### PR TITLE
Make tests log to files instead of console

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,13 +139,14 @@ jobs:
       - name: Upload test report
         uses: actions/upload-artifact@v2
         # Always upload the test report for the annotate.yml workflow,
-        # but only the single XML file to keep the artifact small
+        # but only the single XML file and some logs to keep the artifact small
         if: always()
         with:
           # Name prefix is checked in the `Annotate checks` workflow
           name: test report ${{ github.job }}
           path: |
             **/surefire-reports/TEST-*.xml
+            /tmp/test-trino-*.log
           retention-days: ${{ env.TEST_REPORT_RETENTION_DAYS }}
 
   hive-tests:
@@ -260,13 +261,14 @@ jobs:
       - name: Upload test report
         uses: actions/upload-artifact@v2
         # Always upload the test report for the annotate.yml workflow,
-        # but only the single XML file to keep the artifact small
+        # but only the single XML file and some logs to keep the artifact small
         if: always()
         with:
           # Name prefix is checked in the `Annotate checks` workflow
           name: test report ${{ github.job }} (${{ matrix.config }})
           path: |
             **/surefire-reports/TEST-*.xml
+            /tmp/test-trino-*.log
           retention-days: ${{ env.TEST_REPORT_RETENTION_DAYS }}
 
   test-other-modules:
@@ -318,13 +320,14 @@ jobs:
       - name: Upload test report
         uses: actions/upload-artifact@v2
         # Always upload the test report for the annotate.yml workflow,
-        # but only the single XML file to keep the artifact small
+        # but only the single XML file and some logs to keep the artifact small
         if: always()
         with:
           # Name prefix is checked in the `Annotate checks` workflow
           name: test report ${{ github.job }}
           path: |
             **/surefire-reports/TEST-*.xml
+            /tmp/test-trino-*.log
           retention-days: ${{ env.TEST_REPORT_RETENTION_DAYS }}
 
   test:
@@ -387,13 +390,14 @@ jobs:
       - name: Upload test report
         uses: actions/upload-artifact@v2
         # Always upload the test report for the annotate.yml workflow,
-        # but only the single XML file to keep the artifact small
+        # but only the single XML file and some logs to keep the artifact small
         if: always()
         with:
           # Name prefix is checked in the `Annotate checks` workflow
           name: test report ${{ github.job }} (${{ env.ARTIFACT_NAME }})
           path: |
             **/surefire-reports/TEST-*.xml
+            /tmp/test-trino-*.log
           retention-days: ${{ env.TEST_REPORT_RETENTION_DAYS }}
 
   test-memsql:
@@ -435,13 +439,14 @@ jobs:
       - name: Upload test report
         uses: actions/upload-artifact@v2
         # Always upload the test report for the annotate.yml workflow,
-        # but only the single XML file to keep the artifact small
+        # but only the single XML file and some logs to keep the artifact small
         if: always()
         with:
           # Name prefix is checked in the `Annotate checks` workflow
           name: test report ${{ github.job }}
           path: |
             **/surefire-reports/TEST-*.xml
+            /tmp/test-trino-*.log
           retention-days: ${{ env.TEST_REPORT_RETENTION_DAYS }}
 
   test-bigquery:
@@ -489,13 +494,14 @@ jobs:
       - name: Upload test report
         uses: actions/upload-artifact@v2
         # Always upload the test report for the annotate.yml workflow,
-        # but only the single XML file to keep the artifact small
+        # but only the single XML file and some logs to keep the artifact small
         if: always()
         with:
           # Name prefix is checked in the `Annotate checks` workflow
           name: test report ${{ github.job }}
           path: |
             **/surefire-reports/TEST-*.xml
+            /tmp/test-trino-*.log
           retention-days: ${{ env.TEST_REPORT_RETENTION_DAYS }}
 
   pt:

--- a/client/trino-cli/src/test/resources/logging.properties
+++ b/client/trino-cli/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-cli-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/client/trino-client/src/test/resources/logging.properties
+++ b/client/trino-client/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-client-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/client/trino-jdbc/src/test/resources/logging.properties
+++ b/client/trino-jdbc/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-jdbc-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/core/trino-main/src/test/resources/logging.properties
+++ b/core/trino-main/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-main-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/core/trino-parser/src/test/resources/logging.properties
+++ b/core/trino-parser/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-parser-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/core/trino-server-main/src/test/resources/logging.properties
+++ b/core/trino-server-main/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-server-main-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/core/trino-server-rpm/src/test/resources/logging.properties
+++ b/core/trino-server-rpm/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-server-rpm-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/core/trino-spi/src/test/resources/logging.properties
+++ b/core/trino-spi/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-spi-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/lib/trino-array/src/test/resources/logging.properties
+++ b/lib/trino-array/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-array-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/lib/trino-geospatial-toolkit/src/test/resources/logging.properties
+++ b/lib/trino-geospatial-toolkit/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-geospatial-toolkit-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/lib/trino-matching/src/test/resources/logging.properties
+++ b/lib/trino-matching/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-matching-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/lib/trino-memory-context/src/test/resources/logging.properties
+++ b/lib/trino-memory-context/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-memory-context-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/lib/trino-orc/src/test/resources/logging.properties
+++ b/lib/trino-orc/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-orc-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/lib/trino-parquet/src/test/resources/logging.properties
+++ b/lib/trino-parquet/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-parquet-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/lib/trino-plugin-toolkit/src/test/resources/logging.properties
+++ b/lib/trino-plugin-toolkit/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-plugin-toolkit-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/lib/trino-rcfile/src/test/resources/logging.properties
+++ b/lib/trino-rcfile/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-rcfile-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/lib/trino-record-decoder/src/test/resources/logging.properties
+++ b/lib/trino-record-decoder/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-record-decoder-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-accumulo-iterators/src/test/resources/logging.properties
+++ b/plugin/trino-accumulo-iterators/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-accumulo-iterators-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-accumulo/src/test/resources/logging.properties
+++ b/plugin/trino-accumulo/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-accumulo-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-atop/src/test/resources/logging.properties
+++ b/plugin/trino-atop/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-atop-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-base-jdbc/src/test/resources/logging.properties
+++ b/plugin/trino-base-jdbc/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-base-jdbc-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-bigquery/src/test/resources/logging.properties
+++ b/plugin/trino-bigquery/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-bigquery-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-blackhole/src/test/resources/logging.properties
+++ b/plugin/trino-blackhole/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-blackhole-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-cassandra/src/test/resources/logging.properties
+++ b/plugin/trino-cassandra/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-cassandra-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-clickhouse/src/test/resources/logging.properties
+++ b/plugin/trino-clickhouse/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-clickhouse-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-druid/src/test/resources/logging.properties
+++ b/plugin/trino-druid/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-druid-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-elasticsearch/src/test/resources/logging.properties
+++ b/plugin/trino-elasticsearch/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-elasticsearch-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-example-http/src/test/resources/logging.properties
+++ b/plugin/trino-example-http/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-example-http-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-geospatial/src/test/resources/logging.properties
+++ b/plugin/trino-geospatial/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-geospatial-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-google-sheets/src/test/resources/logging.properties
+++ b/plugin/trino-google-sheets/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-google-sheets-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-hive-hadoop2/src/test/resources/logging.properties
+++ b/plugin/trino-hive-hadoop2/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-hive-hadoop2-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-hive/src/test/resources/logging.properties
+++ b/plugin/trino-hive/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-hive-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-http-event-listener/src/test/resources/logging.properties
+++ b/plugin/trino-http-event-listener/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-http-event-listener-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-iceberg/src/test/resources/logging.properties
+++ b/plugin/trino-iceberg/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-iceberg-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-jmx/src/test/resources/logging.properties
+++ b/plugin/trino-jmx/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-jmx-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-kafka/src/test/resources/logging.properties
+++ b/plugin/trino-kafka/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-kafka-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-kinesis/pom.xml
+++ b/plugin/trino-kinesis/pom.xml
@@ -184,7 +184,7 @@
                         <exclude>**/TestMinimalFunctionality.java</exclude>
                         <exclude>**/TestS3TableConfigClient.java</exclude>
                     </excludes>
-                    <systemPropertyVariables>
+                    <systemPropertyVariables combine.children="append">
                         <kinesis.awsAccessKey>ACCESS-KEY</kinesis.awsAccessKey>
                         <kinesis.awsSecretKey>SECRET-KEY</kinesis.awsSecretKey>
                         <kinesis.test-table-description-location>s3://S3-LOC</kinesis.test-table-description-location>

--- a/plugin/trino-kinesis/src/test/resources/logging.properties
+++ b/plugin/trino-kinesis/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-kinesis-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-kudu/src/test/resources/logging.properties
+++ b/plugin/trino-kudu/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-kudu-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-local-file/src/test/resources/logging.properties
+++ b/plugin/trino-local-file/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-local-file-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-memory/src/test/resources/logging.properties
+++ b/plugin/trino-memory/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-memory-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-memsql/src/test/resources/logging.properties
+++ b/plugin/trino-memsql/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-memsql-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-ml/src/test/resources/logging.properties
+++ b/plugin/trino-ml/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-ml-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-mongodb/src/test/resources/logging.properties
+++ b/plugin/trino-mongodb/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-mongodb-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-mysql/src/test/resources/logging.properties
+++ b/plugin/trino-mysql/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-mysql-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-oracle/src/test/resources/logging.properties
+++ b/plugin/trino-oracle/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-oracle-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-password-authenticators/src/test/resources/logging.properties
+++ b/plugin/trino-password-authenticators/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-password-authenticators-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-phoenix/src/test/resources/logging.properties
+++ b/plugin/trino-phoenix/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-phoenix-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-phoenix5/src/test/resources/logging.properties
+++ b/plugin/trino-phoenix5/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-phoenix5-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-pinot/src/test/resources/logging.properties
+++ b/plugin/trino-pinot/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-pinot-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-postgresql/src/test/resources/logging.properties
+++ b/plugin/trino-postgresql/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-postgresql-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-prometheus/src/test/resources/logging.properties
+++ b/plugin/trino-prometheus/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-prometheus-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-raptor-legacy/src/test/resources/logging.properties
+++ b/plugin/trino-raptor-legacy/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-raptor-legacy-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-redis/src/test/resources/logging.properties
+++ b/plugin/trino-redis/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-redis-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-redshift/src/test/resources/logging.properties
+++ b/plugin/trino-redshift/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-redshift-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-resource-group-managers/src/test/resources/logging.properties
+++ b/plugin/trino-resource-group-managers/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-resource-group-managers-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-session-property-managers/src/test/resources/logging.properties
+++ b/plugin/trino-session-property-managers/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-session-property-managers-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-sqlserver/src/test/resources/logging.properties
+++ b/plugin/trino-sqlserver/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-sqlserver-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-teradata-functions/src/test/resources/logging.properties
+++ b/plugin/trino-teradata-functions/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-teradata-functions-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-thrift-api/src/test/resources/logging.properties
+++ b/plugin/trino-thrift-api/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-thrift-api-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-thrift-testing-server/src/test/resources/logging.properties
+++ b/plugin/trino-thrift-testing-server/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-thrift-testing-server-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-thrift/src/test/resources/logging.properties
+++ b/plugin/trino-thrift/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-thrift-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-tpcds/src/test/resources/logging.properties
+++ b/plugin/trino-tpcds/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-tpcds-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/plugin/trino-tpch/src/test/resources/logging.properties
+++ b/plugin/trino-tpch/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-tpch-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/pom.xml
+++ b/pom.xml
@@ -1792,6 +1792,9 @@
                         <exclude>**/*jmhTest*.java</exclude>
                         <exclude>**/*jmhType*.java</exclude>
                     </excludes>
+                    <systemPropertyVariables>
+                        <java.util.logging.config.file>src/test/resources/logging.properties</java.util.logging.config.file>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/service/trino-proxy/src/test/resources/logging.properties
+++ b/service/trino-proxy/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-proxy-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/service/trino-verifier/src/test/resources/logging.properties
+++ b/service/trino-verifier/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-verifier-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/testing/trino-benchmark/src/test/resources/logging.properties
+++ b/testing/trino-benchmark/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-benchmark-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/testing/trino-benchto-benchmarks/src/test/resources/logging.properties
+++ b/testing/trino-benchto-benchmarks/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-benchto-benchmarks-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/testing/trino-product-tests-launcher/src/test/resources/logging.properties
+++ b/testing/trino-product-tests-launcher/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-product-tests-launcher-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/testing/trino-server-dev/src/test/resources/logging.properties
+++ b/testing/trino-server-dev/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-server-dev-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/testing/trino-test-jdbc-compatibility-old-driver/src/test/resources/logging.properties
+++ b/testing/trino-test-jdbc-compatibility-old-driver/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-test-jdbc-compatibility-old-driver-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/testing/trino-test-jdbc-compatibility-old-server/src/test/resources/logging.properties
+++ b/testing/trino-test-jdbc-compatibility-old-server/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-test-jdbc-compatibility-old-server-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/testing/trino-testing-services/pom.xml
+++ b/testing/trino-testing-services/pom.xml
@@ -96,7 +96,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <systemPropertyVariables>
+                    <systemPropertyVariables combine.children="append">
                         <io.trino.testng.services.FlakyTestRetryAnalyzer.enabled>true</io.trino.testng.services.FlakyTestRetryAnalyzer.enabled>
                     </systemPropertyVariables>
                 </configuration>

--- a/testing/trino-testing-services/src/test/resources/logging.properties
+++ b/testing/trino-testing-services/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-testing-services-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/testing/trino-testing/src/main/resources/logging.properties
+++ b/testing/trino-testing/src/main/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-testing-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/testing/trino-testing/src/test/resources/logging.properties
+++ b/testing/trino-testing/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-testing-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO

--- a/testing/trino-tests/src/test/resources/logging.properties
+++ b/testing/trino-tests/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+.level= ALL
+
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.pattern = %t/test-trino-tests-%u.log
+# overwrite test log files from previous run
+java.util.logging.FileHandler.append = false
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.trino = INFO
+org.testcontainers = INFO


### PR DESCRIPTION
Make tests log to files instead of console, which should make it easier to find failure messages without having to scroll through tons of output. Logs are available in files and are attached as artifacts in the pipeline.

This does NOT affect product tests. I'll work on them in a separate PR if this idea is accepted.

I created a separate `logging.properties` file in every module since I wanted every module to log to its own file and placeholders in the `pattern` property are very limited. 