### PR TITLE
Implement renameSchema for ClickHouse

### DIFF
--- a/docs/src/main/sphinx/connector/clickhouse.rst
+++ b/docs/src/main/sphinx/connector/clickhouse.rst
@@ -189,3 +189,6 @@ statements, the connector supports the following features:
 * :doc:`/sql/drop-table`
 * :doc:`/sql/create-schema`
 * :doc:`/sql/drop-schema`
+* :doc:`/sql/alter-schema`
+
+.. include:: alter-schema-limitation.fragment

--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
@@ -278,10 +278,9 @@ public class ClickHouseClient
     }
 
     @Override
-    public void renameSchema(ConnectorSession session, String schemaName, String newSchemaName)
+    protected String renameSchemaSql(String remoteSchemaName, String newRemoteSchemaName)
     {
-        // TODO: https://github.com/trinodb/trino/issues/10558
-        throw new TrinoException(NOT_SUPPORTED, "This connector does not support renaming schemas");
+        return "RENAME DATABASE " + quoted(remoteSchemaName) + " TO " + quoted(newRemoteSchemaName);
     }
 
     @Override

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseConnectorSmokeTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseConnectorSmokeTest.java
@@ -23,7 +23,6 @@ public abstract class BaseClickHouseConnectorSmokeTest
     protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
     {
         switch (connectorBehavior) {
-            case SUPPORTS_RENAME_SCHEMA:
             case SUPPORTS_DELETE:
                 return false;
             default:

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
@@ -87,9 +87,6 @@ public class TestClickHouseConnectorTest
             case SUPPORTS_DELETE:
                 return false;
 
-            case SUPPORTS_RENAME_SCHEMA:
-                return false;
-
             default:
                 return super.hasBehavior(connectorBehavior);
         }
@@ -100,6 +97,25 @@ public class TestClickHouseConnectorTest
     public void testColumnName(String columnName)
     {
         throw new SkipException("TODO: test not implemented yet");
+    }
+
+    @Test
+    @Override
+    public void testRenameSchema()
+    {
+        // Override because the default database engine in version < v20.10.2.20-stable doesn't allow renaming schemas
+        assertThatThrownBy(super::testRenameSchema)
+                .hasMessageMatching("ClickHouse exception, code: 48,.* Ordinary: RENAME DATABASE is not supported .*\\n");
+
+        String schemaName = "test_rename_schema_" + randomTableSuffix();
+        try {
+            onRemoteDatabase().execute("CREATE DATABASE " + schemaName + " ENGINE = Atomic");
+            assertUpdate("ALTER SCHEMA " + schemaName + " RENAME TO " + schemaName + "_renamed");
+        }
+        finally {
+            assertUpdate("DROP SCHEMA IF EXISTS " + schemaName);
+            assertUpdate("DROP SCHEMA IF EXISTS " + schemaName + "_renamed");
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes: #10558 

The current implementation checks if it is an ATOMIC
database in ClickHouseClient when RENAME SCHEMA