### PR TITLE
Fix UnsupportedOperationException in max_by and min_by aggregation

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/NullableBooleanStateSerializer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/NullableBooleanStateSerializer.java
@@ -13,20 +13,37 @@
  */
 package io.trino.operator.aggregation.state;
 
+import io.trino.annotation.UsedByGeneratedCode;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.function.AccumulatorStateSerializer;
 import io.trino.spi.type.Type;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static java.util.Objects.requireNonNull;
 
 public class NullableBooleanStateSerializer
         implements AccumulatorStateSerializer<NullableBooleanState>
 {
+    private final Type type;
+
+    @UsedByGeneratedCode
+    public NullableBooleanStateSerializer()
+    {
+        this(BOOLEAN);
+    }
+
+    public NullableBooleanStateSerializer(Type type)
+    {
+        this.type = requireNonNull(type, "type is null");
+        checkArgument(type.getJavaType() == boolean.class, "Type must use boolean stack type: " + type);
+    }
+
     @Override
     public Type getSerializedType()
     {
-        return BOOLEAN;
+        return type;
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/NullableDoubleStateSerializer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/NullableDoubleStateSerializer.java
@@ -13,20 +13,37 @@
  */
 package io.trino.operator.aggregation.state;
 
+import io.trino.annotation.UsedByGeneratedCode;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.function.AccumulatorStateSerializer;
 import io.trino.spi.type.Type;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.spi.type.DoubleType.DOUBLE;
+import static java.util.Objects.requireNonNull;
 
 public class NullableDoubleStateSerializer
         implements AccumulatorStateSerializer<NullableDoubleState>
 {
+    private final Type type;
+
+    @UsedByGeneratedCode
+    public NullableDoubleStateSerializer()
+    {
+        this(DOUBLE);
+    }
+
+    public NullableDoubleStateSerializer(Type type)
+    {
+        this.type = requireNonNull(type, "type is null");
+        checkArgument(type.getJavaType() == double.class, "Type must use double stack type: " + type);
+    }
+
     @Override
     public Type getSerializedType()
     {
-        return DOUBLE;
+        return type;
     }
 
     @Override
@@ -36,7 +53,7 @@ public class NullableDoubleStateSerializer
             out.appendNull();
         }
         else {
-            DOUBLE.writeDouble(out, state.getValue());
+            type.writeDouble(out, state.getValue());
         }
     }
 
@@ -48,7 +65,7 @@ public class NullableDoubleStateSerializer
         }
         else {
             state.setNull(false);
-            state.setValue(DOUBLE.getDouble(block, index));
+            state.setValue(type.getDouble(block, index));
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/NullableLongStateSerializer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/NullableLongStateSerializer.java
@@ -13,20 +13,37 @@
  */
 package io.trino.operator.aggregation.state;
 
+import io.trino.annotation.UsedByGeneratedCode;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.function.AccumulatorStateSerializer;
 import io.trino.spi.type.Type;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static java.util.Objects.requireNonNull;
 
 public class NullableLongStateSerializer
         implements AccumulatorStateSerializer<NullableLongState>
 {
+    private final Type type;
+
+    @UsedByGeneratedCode
+    public NullableLongStateSerializer()
+    {
+        this(BIGINT);
+    }
+
+    public NullableLongStateSerializer(Type type)
+    {
+        this.type = requireNonNull(type, "type is null");
+        checkArgument(type.getJavaType() == long.class, "Type must use long stack type: " + type);
+    }
+
     @Override
     public Type getSerializedType()
     {
-        return BIGINT;
+        return type;
     }
 
     @Override
@@ -36,7 +53,7 @@ public class NullableLongStateSerializer
             out.appendNull();
         }
         else {
-            BIGINT.writeLong(out, state.getValue());
+            type.writeLong(out, state.getValue());
         }
     }
 
@@ -48,7 +65,7 @@ public class NullableLongStateSerializer
         }
         else {
             state.setNull(false);
-            state.setValue(BIGINT.getLong(block, index));
+            state.setValue(type.getLong(block, index));
         }
     }
 }

--- a/testing/trino-tests/src/test/java/io/trino/tests/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/AbstractTestEngineOnlyQueries.java
@@ -3409,6 +3409,9 @@ public abstract class AbstractTestEngineOnlyQueries
     public void testMaxBy()
     {
         assertQuery("SELECT MAX_BY(orderkey, totalprice) FROM orders", "SELECT orderkey FROM orders ORDER BY totalprice DESC LIMIT 1");
+        assertQuery(
+                "SELECT clerk, max_by(orderstatus, shippriority) FROM orders WHERE orderstatus = 'O' GROUP BY 1",
+                "SELECT clerk, 'O' FROM orders GROUP BY clerk");
     }
 
     @Test


### PR DESCRIPTION
Change state serializer types to match declared intermediate types

Fixes #10572