### PR TITLE
Remove Block writePositionTo and BlockBuilder appendStructure

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/GroupByIdBlock.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupByIdBlock.java
@@ -136,12 +136,6 @@ public class GroupByIdBlock
     }
 
     @Override
-    public void writePositionTo(int position, BlockBuilder blockBuilder)
-    {
-        block.writePositionTo(position, blockBuilder);
-    }
-
-    @Override
     public boolean equals(int position, int offset, Block otherBlock, int otherPosition, int otherOffset, int length)
     {
         return block.equals(position, offset, otherBlock, otherPosition, otherOffset, length);

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/BlockBuilderCopier.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/BlockBuilderCopier.java
@@ -14,12 +14,13 @@
 package io.trino.operator.aggregation;
 
 import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.type.Type;
 
-public class BlockBuilderCopier
+public final class BlockBuilderCopier
 {
     private BlockBuilderCopier() {}
 
-    public static BlockBuilder copyBlockBuilder(BlockBuilder blockBuilder)
+    public static BlockBuilder copyBlockBuilder(Type type, BlockBuilder blockBuilder)
     {
         if (blockBuilder == null) {
             return null;
@@ -27,7 +28,7 @@ public class BlockBuilderCopier
 
         BlockBuilder copy = blockBuilder.newBlockBuilderLike(null);
         for (int i = 0; i < blockBuilder.getPositionCount(); i++) {
-            copy.appendStructure(blockBuilder.getSingleValueBlock(i));
+            type.appendTo(blockBuilder, i, copy);
         }
 
         return copy;

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/arrayagg/SingleArrayAggregationState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/arrayagg/SingleArrayAggregationState.java
@@ -92,6 +92,6 @@ public class SingleArrayAggregationState
     @Override
     public AccumulatorState copy()
     {
-        return new SingleArrayAggregationState(copyBlockBuilder(blockBuilder), type);
+        return new SingleArrayAggregationState(copyBlockBuilder(type, blockBuilder), type);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/multimapagg/SingleMultimapAggregationState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/multimapagg/SingleMultimapAggregationState.java
@@ -96,6 +96,6 @@ public class SingleMultimapAggregationState
     @Override
     public AccumulatorState copy()
     {
-        return new SingleMultimapAggregationState(keyType, valueType, copyBlockBuilder(keyBlockBuilder), copyBlockBuilder(valueBlockBuilder));
+        return new SingleMultimapAggregationState(keyType, valueType, copyBlockBuilder(keyType, keyBlockBuilder), copyBlockBuilder(valueType, valueBlockBuilder));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/block/BlockAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/block/BlockAssertions.java
@@ -498,33 +498,36 @@ public final class BlockAssertions
                 rowBlockBuilder.appendNull();
                 continue;
             }
+            verify(row.length == fieldTypes.size());
             BlockBuilder singleRowBlockWriter = rowBlockBuilder.beginBlockEntry();
-            for (Object fieldValue : row) {
+            for (int fieldIndex = 0; fieldIndex < fieldTypes.size(); fieldIndex++) {
+                Type fieldType = fieldTypes.get(fieldIndex);
+                Object fieldValue = row[fieldIndex];
                 if (fieldValue == null) {
                     singleRowBlockWriter.appendNull();
                     continue;
                 }
 
                 if (fieldValue instanceof String) {
-                    VARCHAR.writeSlice(singleRowBlockWriter, utf8Slice((String) fieldValue));
+                    fieldType.writeSlice(singleRowBlockWriter, utf8Slice((String) fieldValue));
                 }
                 else if (fieldValue instanceof Slice) {
-                    VARBINARY.writeSlice(singleRowBlockWriter, (Slice) fieldValue);
+                    fieldType.writeSlice(singleRowBlockWriter, (Slice) fieldValue);
                 }
                 else if (fieldValue instanceof Double) {
-                    DOUBLE.writeDouble(singleRowBlockWriter, (Double) fieldValue);
+                    fieldType.writeDouble(singleRowBlockWriter, (Double) fieldValue);
                 }
                 else if (fieldValue instanceof Long) {
-                    BIGINT.writeLong(singleRowBlockWriter, (Long) fieldValue);
+                    fieldType.writeLong(singleRowBlockWriter, (Long) fieldValue);
                 }
                 else if (fieldValue instanceof Boolean) {
-                    BOOLEAN.writeBoolean(singleRowBlockWriter, (Boolean) fieldValue);
+                    fieldType.writeBoolean(singleRowBlockWriter, (Boolean) fieldValue);
                 }
                 else if (fieldValue instanceof Block) {
-                    singleRowBlockWriter.appendStructure((Block) fieldValue);
+                    fieldType.writeObject(singleRowBlockWriter, fieldValue);
                 }
                 else if (fieldValue instanceof Integer) {
-                    INTEGER.writeLong(singleRowBlockWriter, (Integer) fieldValue);
+                    fieldType.writeLong(singleRowBlockWriter, (Integer) fieldValue);
                 }
                 else {
                     throw new IllegalArgumentException();

--- a/core/trino-main/src/test/java/io/trino/block/TestArrayBlock.java
+++ b/core/trino-main/src/test/java/io/trino/block/TestArrayBlock.java
@@ -197,20 +197,20 @@ public class TestArrayBlock
                 blockBuilder.appendNull();
             }
             else {
-                BlockBuilder intermediateBlockBuilder = new ArrayBlockBuilder(BIGINT, null, 100, 100);
+                BlockBuilder intermediateBlockBuilder = blockBuilder.beginBlockEntry();
                 for (int j = 0; j < expectedValue.length; j++) {
                     if (expectedValue[j] == null) {
                         intermediateBlockBuilder.appendNull();
                     }
                     else {
-                        BlockBuilder innerMostBlockBuilder = BIGINT.createBlockBuilder(null, expectedValue.length);
+                        BlockBuilder innerMostBlockBuilder = intermediateBlockBuilder.beginBlockEntry();
                         for (long v : expectedValue[j]) {
                             BIGINT.writeLong(innerMostBlockBuilder, v);
                         }
-                        intermediateBlockBuilder.appendStructure(innerMostBlockBuilder.build());
+                        intermediateBlockBuilder.closeEntry();
                     }
                 }
-                blockBuilder.appendStructure(intermediateBlockBuilder.build());
+                blockBuilder.closeEntry();
             }
         }
         return blockBuilder;
@@ -229,11 +229,11 @@ public class TestArrayBlock
                 blockBuilder.appendNull();
             }
             else {
-                BlockBuilder elementBlockBuilder = BIGINT.createBlockBuilder(null, expectedValue.length);
+                BlockBuilder elementBlockBuilder = blockBuilder.beginBlockEntry();
                 for (long v : expectedValue) {
                     BIGINT.writeLong(elementBlockBuilder, v);
                 }
-                blockBuilder.appendStructure(elementBlockBuilder);
+                blockBuilder.closeEntry();
             }
         }
         return blockBuilder;
@@ -247,11 +247,11 @@ public class TestArrayBlock
                 blockBuilder.appendNull();
             }
             else {
-                BlockBuilder elementBlockBuilder = VARCHAR.createBlockBuilder(null, expectedValue.length);
+                BlockBuilder elementBlockBuilder = blockBuilder.beginBlockEntry();
                 for (Slice v : expectedValue) {
                     VARCHAR.writeSlice(elementBlockBuilder, v);
                 }
-                blockBuilder.appendStructure(elementBlockBuilder.build());
+                blockBuilder.closeEntry();
             }
         }
         return blockBuilder;

--- a/core/trino-main/src/test/java/io/trino/block/TestBlockBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/block/TestBlockBuilder.java
@@ -66,10 +66,9 @@ public class TestBlockBuilder
         for (int i = 0; i < 100; i++) {
             BIGINT.writeLong(bigintBlockBuilder, i);
             VARCHAR.writeSlice(varcharBlockBuilder, Slices.utf8Slice("test" + i));
-            Block longArrayBlock = new ArrayType(BIGINT)
-                    .createBlockBuilder(null, 1)
-                    .appendStructure(BIGINT.createBlockBuilder(null, 2).writeLong(i).closeEntry().writeLong(i * 2).closeEntry().build());
-            arrayBlockBuilder.appendStructure(longArrayBlock);
+            BlockBuilder blockBuilder = longArrayType.createBlockBuilder(null, 1);
+            longArrayType.writeObject(blockBuilder, BIGINT.createBlockBuilder(null, 2).writeLong(i).writeLong(i * 2).build());
+            arrayType.writeObject(arrayBlockBuilder, blockBuilder);
             pageBuilder.declarePosition();
         }
 

--- a/core/trino-main/src/test/java/io/trino/block/TestColumnarArray.java
+++ b/core/trino-main/src/test/java/io/trino/block/TestColumnarArray.java
@@ -15,12 +15,12 @@ package io.trino.block;
 
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
-import io.trino.spi.block.ArrayBlockBuilder;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.ColumnarArray;
 import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.spi.type.ArrayType;
 import org.testng.annotations.Test;
 
 import java.lang.reflect.Array;
@@ -128,7 +128,8 @@ public class TestColumnarArray
 
     public static BlockBuilder createBlockBuilderWithValues(Slice[][] expectedValues)
     {
-        BlockBuilder blockBuilder = new ArrayBlockBuilder(VARCHAR, null, 100, 100);
+        ArrayType arrayType = new ArrayType(VARCHAR);
+        BlockBuilder blockBuilder = arrayType.createBlockBuilder(null, 100, 100);
         for (Slice[] expectedValue : expectedValues) {
             if (expectedValue == null) {
                 blockBuilder.appendNull();
@@ -143,7 +144,7 @@ public class TestColumnarArray
                         VARCHAR.writeSlice(elementBlockBuilder, v);
                     }
                 }
-                blockBuilder.appendStructure(elementBlockBuilder.build());
+                arrayType.writeObject(blockBuilder, elementBlockBuilder.build());
             }
         }
         return blockBuilder;

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkUnnestOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkUnnestOperator.java
@@ -326,7 +326,7 @@ public class BenchmarkUnnestOperator
 
             for (int i = 0; i < entries; i++) {
                 int arrayLength = minNestedCardinality + random.nextInt(maxNestedCardinality - minNestedCardinality);
-                builder.appendStructure(produceBlock(elementType, arrayLength, primitiveNullsRatio, rowNullsRatio));
+                arrayType.writeObject(builder, produceBlock(elementType, arrayLength, primitiveNullsRatio, rowNullsRatio));
             }
             return builder.build();
         }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArrayFilter.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArrayFilter.java
@@ -239,7 +239,7 @@ public class BenchmarkArrayFilter
                     throw new RuntimeException(t);
                 }
                 if (TRUE.equals(keep)) {
-                    block.writePositionTo(position, resultBuilder);
+                    type.appendTo(block, position, resultBuilder);
                 }
             }
             return resultBuilder.build();

--- a/core/trino-main/src/test/java/io/trino/operator/unnest/TestingUnnesterUtil.java
+++ b/core/trino-main/src/test/java/io/trino/operator/unnest/TestingUnnesterUtil.java
@@ -15,9 +15,9 @@ package io.trino.operator.unnest;
 
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
-import io.trino.spi.block.ArrayBlockBuilder;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.RowType;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -46,14 +46,14 @@ public final class TestingUnnesterUtil
 
     public static Block createArrayBlock(Slice[][] values)
     {
-        BlockBuilder blockBuilder = new ArrayBlockBuilder(VARCHAR, null, 100, 100);
+        ArrayType arrayType = new ArrayType(VARCHAR);
+        BlockBuilder blockBuilder = arrayType.createBlockBuilder(null, 100, 100);
         for (Slice[] expectedValue : values) {
             if (expectedValue == null) {
                 blockBuilder.appendNull();
             }
             else {
-                Block elementBlock = createSimpleBlock(expectedValue);
-                blockBuilder.appendStructure(elementBlock);
+                arrayType.writeObject(blockBuilder, createSimpleBlock(expectedValue));
             }
         }
         return blockBuilder.build();
@@ -61,7 +61,8 @@ public final class TestingUnnesterUtil
 
     public static Block createArrayBlockOfRowBlocks(Slice[][][] elements, RowType rowType)
     {
-        BlockBuilder arrayBlockBuilder = new ArrayBlockBuilder(rowType, null, 100, 100);
+        ArrayType arrayType = new ArrayType(rowType);
+        BlockBuilder arrayBlockBuilder = arrayType.createBlockBuilder(null, 100, 100);
         for (int i = 0; i < elements.length; i++) {
             if (elements[i] == null) {
                 arrayBlockBuilder.appendNull();
@@ -86,7 +87,7 @@ public final class TestingUnnesterUtil
                         elementBlockBuilder.closeEntry();
                     }
                 }
-                arrayBlockBuilder.appendStructure(elementBlockBuilder.build());
+                arrayType.writeObject(arrayBlockBuilder, elementBlockBuilder.build());
             }
         }
         return arrayBlockBuilder.build();

--- a/core/trino-spi/src/main/java/io/trino/spi/block/AbstractArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/AbstractArrayBlock.java
@@ -168,13 +168,6 @@ public abstract class AbstractArrayBlock
     }
 
     @Override
-    public void writePositionTo(int position, BlockBuilder blockBuilder)
-    {
-        checkReadablePosition(position);
-        blockBuilder.appendStructureInternal(this, position);
-    }
-
-    @Override
     public Block getSingleValueBlock(int position)
     {
         checkReadablePosition(position);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/AbstractMapBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/AbstractMapBlock.java
@@ -261,13 +261,6 @@ public abstract class AbstractMapBlock
     }
 
     @Override
-    public void writePositionTo(int position, BlockBuilder blockBuilder)
-    {
-        checkReadablePosition(position);
-        blockBuilder.appendStructureInternal(this, position);
-    }
-
-    @Override
     public Block getSingleValueBlock(int position)
     {
         checkReadablePosition(position);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/AbstractRowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/AbstractRowBlock.java
@@ -206,13 +206,6 @@ public abstract class AbstractRowBlock
     }
 
     @Override
-    public void writePositionTo(int position, BlockBuilder blockBuilder)
-    {
-        checkReadablePosition(position);
-        blockBuilder.appendStructureInternal(this, position);
-    }
-
-    @Override
     public Block getSingleValueBlock(int position)
     {
         checkReadablePosition(position);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/AbstractSingleArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/AbstractSingleArrayBlock.java
@@ -115,13 +115,6 @@ public abstract class AbstractSingleArrayBlock
     }
 
     @Override
-    public void writePositionTo(int position, BlockBuilder blockBuilder)
-    {
-        checkReadablePosition(position);
-        getBlock().writePositionTo(position + start, blockBuilder);
-    }
-
-    @Override
     public boolean equals(int position, int offset, Block otherBlock, int otherPosition, int otherOffset, int length)
     {
         checkReadablePosition(position);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/AbstractSingleMapBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/AbstractSingleMapBlock.java
@@ -213,18 +213,6 @@ public abstract class AbstractSingleMapBlock
     }
 
     @Override
-    public void writePositionTo(int position, BlockBuilder blockBuilder)
-    {
-        position = getAbsolutePosition(position);
-        if (position % 2 == 0) {
-            getRawKeyBlock().writePositionTo(position / 2, blockBuilder);
-        }
-        else {
-            getRawValueBlock().writePositionTo(position / 2, blockBuilder);
-        }
-    }
-
-    @Override
     public Block getSingleValueBlock(int position)
     {
         position = getAbsolutePosition(position);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/AbstractSingleRowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/AbstractSingleRowBlock.java
@@ -139,13 +139,6 @@ public abstract class AbstractSingleRowBlock
     }
 
     @Override
-    public void writePositionTo(int position, BlockBuilder blockBuilder)
-    {
-        checkFieldIndex(position);
-        getRawFieldBlock(position).writePositionTo(getRowIndex(), blockBuilder);
-    }
-
-    @Override
     public Block getSingleValueBlock(int position)
     {
         checkFieldIndex(position);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/AbstractVariableWidthBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/AbstractVariableWidthBlock.java
@@ -121,13 +121,6 @@ public abstract class AbstractVariableWidthBlock
     }
 
     @Override
-    public void writePositionTo(int position, BlockBuilder blockBuilder)
-    {
-        writeBytesTo(position, 0, getSliceLength(position), blockBuilder);
-        blockBuilder.closeEntry();
-    }
-
-    @Override
     public Block getSingleValueBlock(int position)
     {
         if (isNull(position)) {

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlockBuilder.java
@@ -147,56 +147,10 @@ public class ArrayBlockBuilder
     }
 
     @Override
-    public BlockBuilder appendStructure(Block block)
-    {
-        if (currentEntryOpened) {
-            throw new IllegalStateException("Expected current entry to be closed but was opened");
-        }
-        currentEntryOpened = true;
-
-        for (int i = 0; i < block.getPositionCount(); i++) {
-            if (block.isNull(i)) {
-                values.appendNull();
-            }
-            else {
-                block.writePositionTo(i, values);
-            }
-        }
-
-        closeEntry();
-        return this;
-    }
-
-    @Override
-    public BlockBuilder appendStructureInternal(Block block, int position)
-    {
-        if (!(block instanceof AbstractArrayBlock)) {
-            throw new IllegalArgumentException();
-        }
-
-        AbstractArrayBlock arrayBlock = (AbstractArrayBlock) block;
-        BlockBuilder entryBuilder = beginBlockEntry();
-
-        int startValueOffset = arrayBlock.getOffset(position);
-        int endValueOffset = arrayBlock.getOffset(position + 1);
-        for (int i = startValueOffset; i < endValueOffset; i++) {
-            if (arrayBlock.getRawElementBlock().isNull(i)) {
-                entryBuilder.appendNull();
-            }
-            else {
-                arrayBlock.getRawElementBlock().writePositionTo(i, entryBuilder);
-            }
-        }
-
-        closeEntry();
-        return this;
-    }
-
-    @Override
     public SingleArrayBlockWriter beginBlockEntry()
     {
         if (currentEntryOpened) {
-            throw new IllegalStateException("Expected current entry to be closed but was closed");
+            throw new IllegalStateException("Expected current entry to be closed but was opened");
         }
         currentEntryOpened = true;
         return new SingleArrayBlockWriter(values, values.getPositionCount());

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Block.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Block.java
@@ -112,11 +112,6 @@ public interface Block
     }
 
     /**
-     * Appends the value at {@code position} to {@code blockBuilder} and close the entry.
-     */
-    void writePositionTo(int position, BlockBuilder blockBuilder);
-
-    /**
      * Is the byte sequences at {@code offset} in the value at {@code position} equal
      * to the byte sequence at {@code otherOffset} in the value at {@code otherPosition}
      * in {@code otherBlock}.

--- a/core/trino-spi/src/main/java/io/trino/spi/block/BlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/BlockBuilder.java
@@ -88,23 +88,6 @@ public interface BlockBuilder
     BlockBuilder appendNull();
 
     /**
-     * Append a struct to the block and close the entry.
-     */
-    default BlockBuilder appendStructure(Block value)
-    {
-        throw new UnsupportedOperationException(getClass().getName());
-    }
-
-    /**
-     * Do not use this interface outside block package.
-     * Instead, use Block.writePositionTo(BlockBuilder, position)
-     */
-    default BlockBuilder appendStructureInternal(Block block, int position)
-    {
-        throw new UnsupportedOperationException(getClass().getName());
-    }
-
-    /**
      * Builds the block. This method can be called multiple times.
      */
     Block build();

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlock.java
@@ -148,14 +148,6 @@ public class ByteArrayBlock
     }
 
     @Override
-    public void writePositionTo(int position, BlockBuilder blockBuilder)
-    {
-        checkReadablePosition(position);
-        blockBuilder.writeByte(values[position + arrayOffset]);
-        blockBuilder.closeEntry();
-    }
-
-    @Override
     public Block getSingleValueBlock(int position)
     {
         checkReadablePosition(position);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlockBuilder.java
@@ -205,14 +205,6 @@ public class ByteArrayBlockBuilder
     }
 
     @Override
-    public void writePositionTo(int position, BlockBuilder blockBuilder)
-    {
-        checkReadablePosition(position);
-        blockBuilder.writeByte(values[position]);
-        blockBuilder.closeEntry();
-    }
-
-    @Override
     public Block getSingleValueBlock(int position)
     {
         checkReadablePosition(position);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
@@ -187,12 +187,6 @@ public class DictionaryBlock
     }
 
     @Override
-    public void writePositionTo(int position, BlockBuilder blockBuilder)
-    {
-        dictionary.writePositionTo(getId(position), blockBuilder);
-    }
-
-    @Override
     public boolean equals(int position, int offset, Block otherBlock, int otherPosition, int otherOffset, int length)
     {
         return dictionary.equals(getId(position), offset, otherBlock, otherPosition, otherOffset, length);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlock.java
@@ -152,15 +152,6 @@ public class Int128ArrayBlock
     }
 
     @Override
-    public void writePositionTo(int position, BlockBuilder blockBuilder)
-    {
-        checkReadablePosition(position);
-        blockBuilder.writeLong(values[(position + positionOffset) * 2]);
-        blockBuilder.writeLong(values[((position + positionOffset) * 2) + 1]);
-        blockBuilder.closeEntry();
-    }
-
-    @Override
     public Block getSingleValueBlock(int position)
     {
         checkReadablePosition(position);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlockBuilder.java
@@ -222,15 +222,6 @@ public class Int128ArrayBlockBuilder
     }
 
     @Override
-    public void writePositionTo(int position, BlockBuilder blockBuilder)
-    {
-        checkReadablePosition(position);
-        blockBuilder.writeLong(values[position * 2]);
-        blockBuilder.writeLong(values[(position * 2) + 1]);
-        blockBuilder.closeEntry();
-    }
-
-    @Override
     public Block getSingleValueBlock(int position)
     {
         checkReadablePosition(position);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Int96ArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Int96ArrayBlock.java
@@ -166,15 +166,6 @@ public class Int96ArrayBlock
     }
 
     @Override
-    public void writePositionTo(int position, BlockBuilder blockBuilder)
-    {
-        checkReadablePosition(position);
-        blockBuilder.writeLong(high[position + positionOffset]);
-        blockBuilder.writeInt(low[position + positionOffset]);
-        blockBuilder.closeEntry();
-    }
-
-    @Override
     public Block getSingleValueBlock(int position)
     {
         checkReadablePosition(position);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Int96ArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Int96ArrayBlockBuilder.java
@@ -255,15 +255,6 @@ public class Int96ArrayBlockBuilder
     }
 
     @Override
-    public void writePositionTo(int position, BlockBuilder blockBuilder)
-    {
-        checkReadablePosition(position);
-        blockBuilder.writeLong(high[position]);
-        blockBuilder.writeInt(low[position]);
-        blockBuilder.closeEntry();
-    }
-
-    @Override
     public Block getSingleValueBlock(int position)
     {
         checkReadablePosition(position);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlock.java
@@ -148,14 +148,6 @@ public class IntArrayBlock
     }
 
     @Override
-    public void writePositionTo(int position, BlockBuilder blockBuilder)
-    {
-        checkReadablePosition(position);
-        blockBuilder.writeInt(values[position + arrayOffset]);
-        blockBuilder.closeEntry();
-    }
-
-    @Override
     public Block getSingleValueBlock(int position)
     {
         checkReadablePosition(position);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlockBuilder.java
@@ -205,14 +205,6 @@ public class IntArrayBlockBuilder
     }
 
     @Override
-    public void writePositionTo(int position, BlockBuilder blockBuilder)
-    {
-        checkReadablePosition(position);
-        blockBuilder.writeInt(values[position]);
-        blockBuilder.closeEntry();
-    }
-
-    @Override
     public Block getSingleValueBlock(int position)
     {
         checkReadablePosition(position);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LazyBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LazyBlock.java
@@ -118,12 +118,6 @@ public class LazyBlock
     }
 
     @Override
-    public void writePositionTo(int position, BlockBuilder blockBuilder)
-    {
-        getBlock().writePositionTo(position, blockBuilder);
-    }
-
-    @Override
     public boolean equals(int position, int offset, Block otherBlock, int otherPosition, int otherOffset, int length)
     {
         return getBlock().equals(

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlock.java
@@ -195,14 +195,6 @@ public class LongArrayBlock
     }
 
     @Override
-    public void writePositionTo(int position, BlockBuilder blockBuilder)
-    {
-        checkReadablePosition(position);
-        blockBuilder.writeLong(values[position + arrayOffset]);
-        blockBuilder.closeEntry();
-    }
-
-    @Override
     public Block getSingleValueBlock(int position)
     {
         checkReadablePosition(position);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlockBuilder.java
@@ -252,14 +252,6 @@ public class LongArrayBlockBuilder
     }
 
     @Override
-    public void writePositionTo(int position, BlockBuilder blockBuilder)
-    {
-        checkReadablePosition(position);
-        blockBuilder.writeLong(values[position]);
-        blockBuilder.closeEntry();
-    }
-
-    @Override
     public Block getSingleValueBlock(int position)
     {
         checkReadablePosition(position);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlockBuilder.java
@@ -233,56 +233,6 @@ public class RowBlockBuilder
     }
 
     @Override
-    public BlockBuilder appendStructure(Block block)
-    {
-        if (!(block instanceof AbstractSingleRowBlock)) {
-            throw new IllegalStateException("Expected AbstractSingleRowBlock");
-        }
-        if (currentEntryOpened) {
-            throw new IllegalStateException("Expected current entry to be closed but was opened");
-        }
-
-        int blockPositionCount = block.getPositionCount();
-        if (blockPositionCount != numFields) {
-            throw new IllegalArgumentException(format("block position count (%s) is not equal to number of fields (%s)", blockPositionCount, numFields));
-        }
-        for (int i = 0; i < blockPositionCount; i++) {
-            if (block.isNull(i)) {
-                fieldBlockBuilders[i].appendNull();
-            }
-            else {
-                block.writePositionTo(i, fieldBlockBuilders[i]);
-            }
-        }
-        entryAdded(false);
-        return this;
-    }
-
-    @Override
-    public BlockBuilder appendStructureInternal(Block block, int position)
-    {
-        if (!(block instanceof AbstractRowBlock)) {
-            throw new IllegalArgumentException();
-        }
-
-        AbstractRowBlock rowBlock = (AbstractRowBlock) block;
-        BlockBuilder entryBuilder = this.beginBlockEntry();
-
-        int fieldBlockOffset = rowBlock.getFieldBlockOffset(position);
-        for (int i = 0; i < rowBlock.numFields; i++) {
-            if (rowBlock.getRawFieldBlocks()[i].isNull(fieldBlockOffset)) {
-                entryBuilder.appendNull();
-            }
-            else {
-                rowBlock.getRawFieldBlocks()[i].writePositionTo(fieldBlockOffset, entryBuilder);
-            }
-        }
-
-        closeEntry();
-        return this;
-    }
-
-    @Override
     public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
     {
         int newSize = calculateBlockResetSize(getPositionCount());

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
@@ -237,13 +237,6 @@ public class RunLengthEncodedBlock
     }
 
     @Override
-    public void writePositionTo(int position, BlockBuilder blockBuilder)
-    {
-        checkReadablePosition(position);
-        value.writePositionTo(0, blockBuilder);
-    }
-
-    @Override
     public boolean equals(int position, int offset, Block otherBlock, int otherPosition, int otherOffset, int length)
     {
         checkReadablePosition(position);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlock.java
@@ -148,14 +148,6 @@ public class ShortArrayBlock
     }
 
     @Override
-    public void writePositionTo(int position, BlockBuilder blockBuilder)
-    {
-        checkReadablePosition(position);
-        blockBuilder.writeShort(values[position + arrayOffset]);
-        blockBuilder.closeEntry();
-    }
-
-    @Override
     public Block getSingleValueBlock(int position)
     {
         checkReadablePosition(position);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlockBuilder.java
@@ -205,14 +205,6 @@ public class ShortArrayBlockBuilder
     }
 
     @Override
-    public void writePositionTo(int position, BlockBuilder blockBuilder)
-    {
-        checkReadablePosition(position);
-        blockBuilder.writeShort(values[position]);
-        blockBuilder.closeEntry();
-    }
-
-    @Override
     public Block getSingleValueBlock(int position)
     {
         checkReadablePosition(position);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/SingleArrayBlockWriter.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/SingleArrayBlockWriter.java
@@ -98,22 +98,6 @@ public class SingleArrayBlockWriter
     }
 
     @Override
-    public BlockBuilder appendStructure(Block block)
-    {
-        blockBuilder.appendStructure(block);
-        entryAdded();
-        return this;
-    }
-
-    @Override
-    public BlockBuilder appendStructureInternal(Block block, int position)
-    {
-        blockBuilder.appendStructureInternal(block, position);
-        entryAdded();
-        return this;
-    }
-
-    @Override
     public BlockBuilder beginBlockEntry()
     {
         return blockBuilder.beginBlockEntry();

--- a/core/trino-spi/src/main/java/io/trino/spi/block/SingleMapBlockWriter.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/SingleMapBlockWriter.java
@@ -149,32 +149,6 @@ public class SingleMapBlockWriter
     }
 
     @Override
-    public BlockBuilder appendStructure(Block block)
-    {
-        if (writeToValueNext) {
-            valueBlockBuilder.appendStructure(block);
-        }
-        else {
-            keyBlockBuilder.appendStructure(block);
-        }
-        entryAdded();
-        return this;
-    }
-
-    @Override
-    public BlockBuilder appendStructureInternal(Block block, int position)
-    {
-        if (writeToValueNext) {
-            valueBlockBuilder.appendStructureInternal(block, position);
-        }
-        else {
-            keyBlockBuilder.appendStructureInternal(block, position);
-        }
-        entryAdded();
-        return this;
-    }
-
-    @Override
     public BlockBuilder beginBlockEntry()
     {
         BlockBuilder result;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/SingleRowBlockWriter.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/SingleRowBlockWriter.java
@@ -147,24 +147,6 @@ public class SingleRowBlockWriter
     }
 
     @Override
-    public BlockBuilder appendStructure(Block block)
-    {
-        checkFieldIndexToWrite();
-        fieldBlockBuilders[currentFieldIndexToWrite].appendStructure(block);
-        entryAdded();
-        return this;
-    }
-
-    @Override
-    public BlockBuilder appendStructureInternal(Block block, int position)
-    {
-        checkFieldIndexToWrite();
-        fieldBlockBuilders[currentFieldIndexToWrite].appendStructureInternal(block, position);
-        entryAdded();
-        return this;
-    }
-
-    @Override
     public BlockBuilder beginBlockEntry()
     {
         checkFieldIndexToWrite();

--- a/core/trino-spi/src/main/java/io/trino/spi/type/ArrayType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ArrayType.java
@@ -219,7 +219,7 @@ public class ArrayType
             blockBuilder.appendNull();
         }
         else {
-            block.writePositionTo(position, blockBuilder);
+            writeObject(blockBuilder, getObject(block, position));
         }
     }
 
@@ -250,7 +250,13 @@ public class ArrayType
     @Override
     public void writeObject(BlockBuilder blockBuilder, Object value)
     {
-        blockBuilder.appendStructure((Block) value);
+        Block arrayBlock = (Block) value;
+
+        BlockBuilder entryBuilder = blockBuilder.beginBlockEntry();
+        for (int i = 0; i < arrayBlock.getPositionCount(); i++) {
+            elementType.appendTo(arrayBlock, i, entryBuilder);
+        }
+        blockBuilder.closeEntry();
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/type/MapType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/MapType.java
@@ -235,7 +235,7 @@ public class MapType
             blockBuilder.appendNull();
         }
         else {
-            block.writePositionTo(position, blockBuilder);
+            writeObject(blockBuilder, getObject(block, position));
         }
     }
 
@@ -251,7 +251,16 @@ public class MapType
         if (!(value instanceof SingleMapBlock)) {
             throw new IllegalArgumentException("Maps must be represented with SingleMapBlock");
         }
-        blockBuilder.appendStructure((Block) value);
+
+        SingleMapBlock singleMapBlock = (SingleMapBlock) value;
+        BlockBuilder entryBuilder = blockBuilder.beginBlockEntry();
+
+        for (int i = 0; i < singleMapBlock.getPositionCount(); i += 2) {
+            keyType.appendTo(singleMapBlock, i, entryBuilder);
+            valueType.appendTo(singleMapBlock, i + 1, entryBuilder);
+        }
+
+        blockBuilder.closeEntry();
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/type/RowType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/RowType.java
@@ -235,7 +235,7 @@ public class RowType
             blockBuilder.appendNull();
         }
         else {
-            block.writePositionTo(position, blockBuilder);
+            writeObject(blockBuilder, getObject(block, position));
         }
     }
 
@@ -248,7 +248,14 @@ public class RowType
     @Override
     public void writeObject(BlockBuilder blockBuilder, Object value)
     {
-        blockBuilder.appendStructure((Block) value);
+        Block rowBlock = (Block) value;
+
+        BlockBuilder entryBuilder = blockBuilder.beginBlockEntry();
+        for (int i = 0; i < rowBlock.getPositionCount(); i++) {
+            fields.get(i).getType().appendTo(rowBlock, i, entryBuilder);
+        }
+
+        blockBuilder.closeEntry();
     }
 
     @Override

--- a/core/trino-spi/src/test/java/io/trino/spi/block/TestArrayBlockBuilder.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/TestArrayBlockBuilder.java
@@ -69,8 +69,7 @@ public class TestArrayBlockBuilder
         BlockBuilder blockBuilder = new ArrayBlockBuilder(BIGINT, null, EXPECTED_ENTRY_COUNT);
         BlockBuilder elementBlockWriter = blockBuilder.beginBlockEntry();
         elementBlockWriter.writeLong(45).closeEntry();
-        Block longArrayBlockBuilder = new LongArrayBlockBuilder(null, 1).writeLong(123).closeEntry().build();
-        assertThatThrownBy(() -> blockBuilder.appendStructure(longArrayBlockBuilder))
+        assertThatThrownBy(blockBuilder::beginBlockEntry)
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("Expected current entry to be closed but was opened");
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestReaderProjectionsAdapter.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestReaderProjectionsAdapter.java
@@ -270,24 +270,7 @@ public class TestReaderProjectionsAdapter
             else {
                 int lastDereference = dereferences.get(dereferences.size() - 1);
 
-                if (currentData.isNull(lastDereference)) {
-                    // Append null if the last dereference is null
-                    builder.appendNull();
-                }
-                else {
-                    // Append actual values otherwise
-                    if (finalType.equals(BIGINT)) {
-                        Long value = currentData.getLong(lastDereference, 0);
-                        builder.writeLong(value);
-                    }
-                    else if (finalType instanceof RowType) {
-                        Block block = currentData.getObject(lastDereference, Block.class);
-                        builder.appendStructure(block);
-                    }
-                    else {
-                        throw new UnsupportedOperationException();
-                    }
-                }
+                finalType.appendTo(currentData, lastDereference, builder);
             }
         }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/BenchmarkProjectionPushdownHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/BenchmarkProjectionPushdownHive.java
@@ -288,7 +288,7 @@ public class BenchmarkProjectionPushdownHive
                 BlockBuilder blockBuilder = type.createBlockBuilder(null, rowCount);
                 for (int i = 0; i < rowCount; i++) {
                     Block elementBlock = createBlock(elementType, DEFAULT_ARRAY_SIZE);
-                    blockBuilder.appendStructure(elementBlock);
+                    type.writeObject(blockBuilder, elementBlock);
                 }
 
                 return blockBuilder.build();


### PR DESCRIPTION
## Description
These methods are used almost exclusively by tests and have a huge footprint in our SPI. Additionally, the methods are dangerous to use because they do not interact with Types. The methods are replaced with the existing Type appendTo or writeObject methods.

## Documentation
- [ ] User facing documentation needed
- [x] Release notes entry needed

## Release notes

## SPI
* Remove unnecessary `Block` `writePositionTo` and `BlockBuilder` `appendStructure` methods.  Use of these methods can be replaced with the existing `Type` `appendTo` or `writeObject` methods. ({issue}`10602 `)
