### PR TITLE
Remove shared mutable state for extra options handling in PTL

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/TestRun.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/TestRun.java
@@ -138,7 +138,7 @@ public final class TestRun
         public Duration timeout;
 
         @Parameters(paramLabel = "<argument>", description = "Test arguments")
-        public List<String> testArguments;
+        public List<String> testArguments = List.of();
 
         public Module toModule()
         {

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/EnvironmentProvider.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/EnvironmentProvider.java
@@ -14,7 +14,6 @@
 package io.trino.tests.product.launcher.env;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.trino.tests.product.launcher.env.common.EnvironmentExtender;
 
@@ -66,22 +65,22 @@ public abstract class EnvironmentProvider
         extender.getDependencies()
                 .forEach(dependencyExtender -> extend(dependencyExtender, builder, extraOptions, seen));
         if (seen.add(extender)) {
+            Map<String, String> extraOptionsForExtender;
             if (extender.getExtraOptionsPrefix().isPresent()) {
                 String prefix = extender.getExtraOptionsPrefix().get();
-                ImmutableMap<String, String> extraOptionsForExtender = extraOptions.entrySet().stream()
+                extraOptionsForExtender = extraOptions.entrySet().stream()
                         .filter(entry -> entry.getKey().startsWith(prefix))
                         .collect(toImmutableMap(
                                 // remove prefix
                                 entry -> entry.getKey().substring(prefix.length()),
                                 Map.Entry::getValue));
-                log.info("Building environment %s with extender: %s; options: %s", builder.getEnvironmentName(), extender.getClass().getSimpleName(), extraOptionsForExtender);
-                extender.setExtraOptions(extraOptionsForExtender);
             }
             else {
-                log.info("Building environment %s with extender: %s", builder.getEnvironmentName(), extender.getClass().getSimpleName());
+                extraOptionsForExtender = Map.of();
             }
 
-            extender.extendEnvironment(builder);
+            log.info("Building environment %s with extender: %s; options: %s", builder.getEnvironmentName(), extender.getClass().getSimpleName(), extraOptionsForExtender);
+            extender.extendEnvironment(builder, extraOptionsForExtender);
         }
     }
 }

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/EnvironmentExtender.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/EnvironmentExtender.java
@@ -24,17 +24,20 @@ import static com.google.common.base.Verify.verify;
 
 public interface EnvironmentExtender
 {
-    void extendEnvironment(Environment.Builder builder);
-
     default Optional<String> getExtraOptionsPrefix()
     {
         return Optional.empty();
     }
 
-    default void setExtraOptions(Map<String, String> extraOptions)
+    default void extendEnvironment(Environment.Builder builder, Map<String, String> extraOptions)
     {
-        verify(getExtraOptionsPrefix().isEmpty(), "getExtraOptionsPrefix is defined but setExtraOptions not overridden");
-        throw new UnsupportedOperationException("Implementations must override this to consume extra options");
+        verify(getExtraOptionsPrefix().isEmpty(), "getExtraOptionsPrefix is defined but extendEnvironment not overridden");
+        extendEnvironment(builder);
+    }
+
+    default void extendEnvironment(Environment.Builder builder)
+    {
+        throw new UnsupportedOperationException("Not implemented");
     }
 
     /**

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeCompatibility.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeCompatibility.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.TESTS;
 import static java.lang.Integer.parseInt;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.containers.wait.strategy.Wait.forHealthcheck;
 import static org.testcontainers.containers.wait.strategy.Wait.forLogMessage;
@@ -121,14 +122,14 @@ public class EnvSinglenodeCompatibility
         return Optional.of("compatibility.");
     }
 
-    public static class Config
+    private static class Config
     {
         private static final String TEST_DOCKER_IMAGE = "testDockerImage";
         private final String compatibilityTestDockerImage;
 
         public Config(Map<String, String> extraOptions)
         {
-            this.compatibilityTestDockerImage = requireNonNull(extraOptions.get(TEST_DOCKER_IMAGE), "Required extra option " + TEST_DOCKER_IMAGE + " is null");
+            this.compatibilityTestDockerImage = requireNonNull(extraOptions.get(TEST_DOCKER_IMAGE), () -> format("Required extra option %s is null", TEST_DOCKER_IMAGE));
         }
 
         public String getCompatibilityTestDockerImage()

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeCompatibility.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeCompatibility.java
@@ -49,8 +49,6 @@ public class EnvSinglenodeCompatibility
     private final DockerFiles.ResourceProvider configDir;
     private final PortBinder portBinder;
 
-    private Config extraConfig;
-
     @Inject
     public EnvSinglenodeCompatibility(Standard standard, Hadoop hadoop, DockerFiles dockerFiles, PortBinder portBinder)
     {
@@ -61,8 +59,9 @@ public class EnvSinglenodeCompatibility
     }
 
     @Override
-    public void extendEnvironment(Environment.Builder builder)
+    public void extendEnvironment(Environment.Builder builder, Map<String, String> extraOptions)
     {
+        Config extraConfig = new Config(extraOptions);
         configureCompatibilityTestContainer(builder, extraConfig);
         configureTestsContainer(builder, extraConfig);
     }
@@ -120,12 +119,6 @@ public class EnvSinglenodeCompatibility
     public Optional<String> getExtraOptionsPrefix()
     {
         return Optional.of("compatibility.");
-    }
-
-    @Override
-    public void setExtraOptions(Map<String, String> extraOptions)
-    {
-        extraConfig = new Config(extraOptions);
     }
 
     public static class Config


### PR DESCRIPTION
Environment and extenders are singletons, so they should be immutable.
Instead of passing the options in separate `setExtraOptions` call, pass
them to `extendEnvironment`.