### PR TITLE
Disallow mutable array use as a constant

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/type/Decimals.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/Decimals.java
@@ -27,8 +27,8 @@ import java.util.regex.Pattern;
 
 import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.type.DecimalType.createDecimalType;
-import static io.trino.spi.type.Int128Math.POWERS_OF_TEN;
 import static io.trino.spi.type.Int128Math.absExact;
+import static io.trino.spi.type.Int128Math.powerOfTen;
 import static java.lang.Math.abs;
 import static java.lang.Math.pow;
 import static java.lang.Math.round;
@@ -339,6 +339,6 @@ public final class Decimals
             return overflows(value.getHigh(), value.getLow());
         }
 
-        return absExact(value).compareTo(POWERS_OF_TEN[precision]) >= 0;
+        return absExact(value).compareTo(powerOfTen(precision)) >= 0;
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/Int128Math.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/Int128Math.java
@@ -31,7 +31,7 @@ public final class Int128Math
     private static final int NUMBER_OF_LONGS = 2;
     private static final int NUMBER_OF_INTS = 2 * NUMBER_OF_LONGS;
 
-    public static final Int128[] POWERS_OF_TEN = new Int128[38]; // 10^38 is the largest value < Int128.MAX_VALUE
+    private static final Int128[] POWERS_OF_TEN = new Int128[38]; // 10^38 is the largest value < Int128.MAX_VALUE
     private static final Int128[] POWERS_OF_FIVE = new Int128[54]; // 5^54 is the largest value < Int128.MAX_VALUE
 
     private static final long ALL_BITS_SET_64 = 0xFFFFFFFFFFFFFFFFL;
@@ -96,6 +96,11 @@ public final class Int128Math
         if (!ByteOrder.nativeOrder().equals(ByteOrder.LITTLE_ENDIAN)) {
             throw new IllegalStateException("UnsignedDecimal128Arithmetic is supported on little-endian machines only");
         }
+    }
+
+    public static Int128 powerOfTen(int exponent)
+    {
+        return POWERS_OF_TEN[exponent];
     }
 
     public static void rescale(long high, long low, int factor, long[] result, int offset)

--- a/lib/trino-rcfile/src/main/java/io/trino/rcfile/text/TextRcFileEncoding.java
+++ b/lib/trino-rcfile/src/main/java/io/trino/rcfile/text/TextRcFileEncoding.java
@@ -20,13 +20,14 @@ import io.trino.rcfile.RcFileEncoding;
 import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.Type;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class TextRcFileEncoding
         implements RcFileEncoding
 {
-    public static final byte[] DEFAULT_SEPARATORS = new byte[] {
+    private static final byte[] DEFAULT_SEPARATORS = new byte[] {
             1,  // Start of Heading
             2,  // Start of text
             3,  // End of Text
@@ -70,7 +71,7 @@ public class TextRcFileEncoding
     {
         this(
                 DEFAULT_NULL_SEQUENCE,
-                DEFAULT_SEPARATORS,
+                DEFAULT_SEPARATORS.clone(),
                 null,
                 false);
     }
@@ -81,6 +82,11 @@ public class TextRcFileEncoding
         this.separators = separators;
         this.escapeByte = escapeByte;
         this.lastColumnTakesRest = lastColumnTakesRest;
+    }
+
+    public static byte[] getDefaultSeparators(int nestingLevels)
+    {
+        return Arrays.copyOf(DEFAULT_SEPARATORS, nestingLevels);
     }
 
     @Override

--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/serializers/BooleanLexicoder.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/serializers/BooleanLexicoder.java
@@ -21,13 +21,10 @@ import org.apache.accumulo.core.client.lexicoder.Lexicoder;
 public class BooleanLexicoder
         implements Lexicoder<Boolean>
 {
-    public static final byte[] TRUE = new byte[] {1};
-    public static final byte[] FALSE = new byte[] {0};
-
     @Override
     public byte[] encode(Boolean v)
     {
-        return v ? TRUE : FALSE;
+        return new byte[] {v ? (byte) 1 : 0};
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/rcfile/RcFilePageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/rcfile/RcFilePageSourceFactory.java
@@ -59,7 +59,6 @@ import javax.inject.Inject;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -76,7 +75,7 @@ import static io.trino.plugin.hive.HiveSessionProperties.getTimestampPrecision;
 import static io.trino.plugin.hive.ReaderPageSource.noProjectionAdaptation;
 import static io.trino.plugin.hive.util.HiveUtil.getDeserializerClassName;
 import static io.trino.rcfile.text.TextRcFileEncoding.DEFAULT_NULL_SEQUENCE;
-import static io.trino.rcfile.text.TextRcFileEncoding.DEFAULT_SEPARATORS;
+import static io.trino.rcfile.text.TextRcFileEncoding.getDefaultSeparators;
 import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
@@ -238,14 +237,14 @@ public class RcFilePageSourceFactory
         else {
             nestingLevels = TEXT_EXTENDED_NESTING_LEVELS;
         }
-        byte[] separators = Arrays.copyOf(DEFAULT_SEPARATORS, nestingLevels);
+        byte[] separators = getDefaultSeparators(nestingLevels);
 
         // the first three separators are set by old-old properties
-        separators[0] = getByte(schema.getProperty(FIELD_DELIM, schema.getProperty(SERIALIZATION_FORMAT)), DEFAULT_SEPARATORS[0]);
+        separators[0] = getByte(schema.getProperty(FIELD_DELIM, schema.getProperty(SERIALIZATION_FORMAT)), separators[0]);
         // for map field collection delimiter, Hive 1.x uses "colelction.delim" but Hive 3.x uses "collection.delim"
         // https://issues.apache.org/jira/browse/HIVE-16922
-        separators[1] = getByte(schema.getProperty(COLLECTION_DELIM, schema.getProperty("colelction.delim")), DEFAULT_SEPARATORS[1]);
-        separators[2] = getByte(schema.getProperty(MAPKEY_DELIM), DEFAULT_SEPARATORS[2]);
+        separators[1] = getByte(schema.getProperty(COLLECTION_DELIM, schema.getProperty("colelction.delim")), separators[1]);
+        separators[2] = getByte(schema.getProperty(MAPKEY_DELIM), separators[2]);
 
         // null sequence
         Slice nullSequence;

--- a/pom.xml
+++ b/pom.xml
@@ -1825,6 +1825,7 @@
                                     -Xep:InjectOnConstructorOfAbstractClass:ERROR \
                                     -Xep:MissingCasesInEnumSwitch:ERROR \
                                     -Xep:MissingOverride:ERROR \
+                                    -Xep:MutablePublicArray:ERROR \
                                     -Xep:NullOptional:ERROR \
                                     -Xep:ObjectToString:ERROR \
                                     -Xep:UnnecessaryMethodReference:ERROR \

--- a/pom.xml
+++ b/pom.xml
@@ -1817,14 +1817,17 @@
                                     -Xep:BoxedPrimitiveConstructor:ERROR \
                                     -Xep:ClassCanBeStatic:ERROR \
                                     -Xep:CompareToZero:ERROR \
+                                    -Xep:EqualsGetClass:OFF <!-- we would rather want the opposite check --> \
                                     -Xep:EqualsIncompatibleType:ERROR \
                                     -Xep:FallThrough:ERROR \
                                     -Xep:GuardedBy:OFF <!-- needs some careful inspection --> \
+                                    -Xep:ImmutableEnumChecker:OFF <!-- flags enums with List fields even if initialized with ImmutableList, and other false positives --> \
                                     -Xep:ImmutableSetForContains:ERROR \
                                     -Xep:InconsistentHashCode:ERROR \
                                     -Xep:InjectOnConstructorOfAbstractClass:ERROR \
                                     -Xep:MissingCasesInEnumSwitch:ERROR \
                                     -Xep:MissingOverride:ERROR \
+                                    -Xep:MutableConstantField:OFF <!-- flags List fields even if initialized with ImmutableList --> \
                                     -Xep:MutablePublicArray:ERROR \
                                     -Xep:NullOptional:ERROR \
                                     -Xep:ObjectToString:ERROR \

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/SuiteRun.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/SuiteRun.java
@@ -241,7 +241,7 @@ public class SuiteRun
         private void printTestRunsSummary(List<TestRunResult> results)
         {
             ConsoleTable table = new ConsoleTable();
-            table.addHeader(HEADER);
+            table.addHeader(HEADER.toArray());
             results.forEach(result -> table.addRow(result.toRow()));
             table.addSeparator();
             log.info("Suite tests results:\n%s", table.render());
@@ -350,9 +350,7 @@ public class SuiteRun
 
     static class TestRunResult
     {
-        public static final Object[] HEADER = {
-                "id", "suite", "environment", "config", "options", "status", "elapsed", "error"
-        };
+        public static final List<String> HEADER = List.of("id", "suite", "environment", "config", "options", "status", "elapsed", "error");
 
         private final String runId;
         private final SuiteTestRun suiteRun;

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/EnvironmentListener.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/EnvironmentListener.java
@@ -260,7 +260,7 @@ public interface EnvironmentListener
             private void printContainerStats()
             {
                 ConsoleTable statistics = new ConsoleTable();
-                statistics.addHeader(HEADER);
+                statistics.addHeader(HEADER.toArray());
                 fetchers.entrySet().forEach(entry -> statistics.addRow(entry.getValue().get().toRow(entry.getKey())));
                 statistics.addSeparator();
 

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/StatisticsFetcher.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/StatisticsFetcher.java
@@ -183,7 +183,7 @@ public class StatisticsFetcher
 
     public static class Stats
     {
-        public static final String[] HEADER = {
+        public static final List<String> HEADER = List.of(
                 "container",
                 "cpu",
                 "mem",
@@ -191,8 +191,7 @@ public class StatisticsFetcher
                 "mem %",
                 "pids",
                 "net in",
-                "net out"
-        };
+                "net out");
 
         private long systemCpuUsage = -1;
         private long totalCpuUsage = -1;


### PR DESCRIPTION
Arrays are mutable, so are not suitable for public static fields.