### PR TITLE
Not to include the exchange operator stats in input data stat

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
@@ -545,6 +545,13 @@ public class QueryStateMachine
 
                 processedInputDataSize += stageStats.getProcessedInputDataSize().toBytes();
                 processedInputPositions += stageStats.getProcessedInputPositions();
+
+                // Not to include the exchange operator stat to avoid the addition of build-side input data multiple times for broadcast join
+                rawInputDataSize -= stageStats.getRawNonPartitionedInputDataSize().toBytes();
+                rawInputPositions -= stageStats.getRawNonPartitionedInputPositions();
+
+                processedInputDataSize -= stageStats.getProcessedNonPartitionedInputDataSize().toBytes();
+                processedInputPositions -= stageStats.getProcessedNonPartitionedInputPositions();
             }
 
             physicalWrittenDataSize += stageStats.getPhysicalWrittenDataSize().toBytes();

--- a/core/trino-main/src/main/java/io/trino/execution/StageStateMachine.java
+++ b/core/trino-main/src/main/java/io/trino/execution/StageStateMachine.java
@@ -383,10 +383,14 @@ public class StageStateMachine
         long internalNetworkInputPositions = 0;
 
         long rawInputDataSize = 0;
+        long rawNonPartitionedInputDataSize = 0;
         long rawInputPositions = 0;
+        long rawNonPartitionedInputPositions = 0;
 
         long processedInputDataSize = 0;
+        long processedNonPartitionedInputDataSize = 0;
         long processedInputPositions = 0;
+        long processedNonPartitionedInputPositions = 0;
 
         long bufferedDataSize = 0;
         long outputDataSize = 0;
@@ -451,10 +455,14 @@ public class StageStateMachine
             internalNetworkInputPositions += taskStats.getInternalNetworkInputPositions();
 
             rawInputDataSize += taskStats.getRawInputDataSize().toBytes();
+            rawNonPartitionedInputDataSize += taskStats.getRawNonPartitionedInputDataSize().toBytes();
             rawInputPositions += taskStats.getRawInputPositions();
+            rawNonPartitionedInputPositions += taskStats.getRawNonPartitionedInputPositions();
 
             processedInputDataSize += taskStats.getProcessedInputDataSize().toBytes();
+            processedNonPartitionedInputDataSize += taskStats.getProcessedNonPartitionedInputDataSize().toBytes();
             processedInputPositions += taskStats.getProcessedInputPositions();
+            processedNonPartitionedInputPositions += taskStats.getProcessedNonPartitionedInputPositions();
 
             bufferedDataSize += taskInfo.getOutputBuffers().getTotalBufferedBytes();
             outputDataSize += taskStats.getOutputDataSize().toBytes();
@@ -514,10 +522,14 @@ public class StageStateMachine
                 internalNetworkInputPositions,
 
                 succinctBytes(rawInputDataSize),
+                succinctBytes(rawNonPartitionedInputDataSize),
                 rawInputPositions,
+                rawNonPartitionedInputPositions,
 
                 succinctBytes(processedInputDataSize),
+                succinctBytes(processedNonPartitionedInputDataSize),
                 processedInputPositions,
+                processedNonPartitionedInputPositions,
                 succinctBytes(bufferedDataSize),
                 succinctBytes(outputDataSize),
                 outputPositions,

--- a/core/trino-main/src/main/java/io/trino/execution/StageStats.java
+++ b/core/trino-main/src/main/java/io/trino/execution/StageStats.java
@@ -76,10 +76,14 @@ public class StageStats
     private final long internalNetworkInputPositions;
 
     private final DataSize rawInputDataSize;
+    private final DataSize rawNonPartitionedInputDataSize;
     private final long rawInputPositions;
+    private final long rawNonPartitionedInputPositions;
 
     private final DataSize processedInputDataSize;
+    private final DataSize processedNonPartitionedInputDataSize;
     private final long processedInputPositions;
+    private final long processedNonPartitionedInputPositions;
 
     private final DataSize bufferedDataSize;
     private final DataSize outputDataSize;
@@ -130,10 +134,14 @@ public class StageStats
             @JsonProperty("internalNetworkInputPositions") long internalNetworkInputPositions,
 
             @JsonProperty("rawInputDataSize") DataSize rawInputDataSize,
+            @JsonProperty("rawNonPartitionedInputDataSize") DataSize rawNonPartitionedInputDataSize,
             @JsonProperty("rawInputPositions") long rawInputPositions,
+            @JsonProperty("rawNonPartitionedInputPositions") long rawNonPartitionedInputPositions,
 
             @JsonProperty("processedInputDataSize") DataSize processedInputDataSize,
+            @JsonProperty("processedNonPartitionedInputDataSize") DataSize processedNonPartitionedInputDataSize,
             @JsonProperty("processedInputPositions") long processedInputPositions,
+            @JsonProperty("processedNonPartitionedInputPositions") long processedNonPartitionedInputPositions,
 
             @JsonProperty("bufferedDataSize") DataSize bufferedDataSize,
             @JsonProperty("outputDataSize") DataSize outputDataSize,
@@ -193,12 +201,20 @@ public class StageStats
         this.internalNetworkInputPositions = internalNetworkInputPositions;
 
         this.rawInputDataSize = requireNonNull(rawInputDataSize, "rawInputDataSize is null");
+        this.rawNonPartitionedInputDataSize = requireNonNull(rawNonPartitionedInputDataSize, "rawNonPartitionedInputDataSize is null");
+        checkArgument(rawInputDataSize.compareTo(rawNonPartitionedInputDataSize) >= 0, "rawInputDataSize is less than rawNonPartitionedInputDataSize");
         checkArgument(rawInputPositions >= 0, "rawInputPositions is negative");
         this.rawInputPositions = rawInputPositions;
+        checkArgument(rawNonPartitionedInputPositions >= 0, "rawNonPartitionedInputPositions is negative");
+        this.rawNonPartitionedInputPositions = rawNonPartitionedInputPositions;
 
         this.processedInputDataSize = requireNonNull(processedInputDataSize, "processedInputDataSize is null");
         checkArgument(processedInputPositions >= 0, "processedInputPositions is negative");
+        this.processedNonPartitionedInputDataSize = requireNonNull(processedNonPartitionedInputDataSize, "processedNonPartitionedInputDataSize is null");
+        checkArgument(processedInputDataSize.compareTo(processedNonPartitionedInputDataSize) >= 0, "processedInputDataSize is less than processedNonPartitionedInputDataSize");
         this.processedInputPositions = processedInputPositions;
+        checkArgument(processedNonPartitionedInputPositions >= 0, "processedNonPartitionedInputPositions is negative");
+        this.processedNonPartitionedInputPositions = processedNonPartitionedInputPositions;
 
         this.bufferedDataSize = requireNonNull(bufferedDataSize, "bufferedDataSize is null");
         this.outputDataSize = requireNonNull(outputDataSize, "outputDataSize is null");
@@ -387,9 +403,21 @@ public class StageStats
     }
 
     @JsonProperty
+    public DataSize getRawNonPartitionedInputDataSize()
+    {
+        return rawNonPartitionedInputDataSize;
+    }
+
+    @JsonProperty
     public long getRawInputPositions()
     {
         return rawInputPositions;
+    }
+
+    @JsonProperty
+    public long getRawNonPartitionedInputPositions()
+    {
+        return rawNonPartitionedInputPositions;
     }
 
     @JsonProperty
@@ -399,9 +427,21 @@ public class StageStats
     }
 
     @JsonProperty
+    public DataSize getProcessedNonPartitionedInputDataSize()
+    {
+        return processedNonPartitionedInputDataSize;
+    }
+
+    @JsonProperty
     public long getProcessedInputPositions()
     {
         return processedInputPositions;
+    }
+
+    @JsonProperty
+    public long getProcessedNonPartitionedInputPositions()
+    {
+        return processedNonPartitionedInputPositions;
     }
 
     @JsonProperty

--- a/core/trino-main/src/main/java/io/trino/operator/PipelineContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PipelineContext.java
@@ -458,6 +458,7 @@ public class PipelineContext
 
                 inputPipeline,
                 outputPipeline,
+                partitioned,
 
                 totalDrivers,
                 pipelineStatus.getQueuedDrivers(),

--- a/core/trino-main/src/main/java/io/trino/operator/PipelineStats.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PipelineStats.java
@@ -42,6 +42,7 @@ public class PipelineStats
 
     private final boolean inputPipeline;
     private final boolean outputPipeline;
+    private final boolean partitioned;
 
     private final int totalDrivers;
     private final int queuedDrivers;
@@ -97,6 +98,7 @@ public class PipelineStats
 
             @JsonProperty("inputPipeline") boolean inputPipeline,
             @JsonProperty("outputPipeline") boolean outputPipeline,
+            @JsonProperty("partitioned") boolean partitioned,
 
             @JsonProperty("totalDrivers") int totalDrivers,
             @JsonProperty("queuedDrivers") int queuedDrivers,
@@ -150,6 +152,7 @@ public class PipelineStats
 
         this.inputPipeline = inputPipeline;
         this.outputPipeline = outputPipeline;
+        this.partitioned = partitioned;
 
         checkArgument(totalDrivers >= 0, "totalDrivers is negative");
         this.totalDrivers = totalDrivers;
@@ -247,6 +250,12 @@ public class PipelineStats
     public boolean isOutputPipeline()
     {
         return outputPipeline;
+    }
+
+    @JsonProperty
+    public boolean isPartitioned()
+    {
+        return partitioned;
     }
 
     @JsonProperty
@@ -456,6 +465,7 @@ public class PipelineStats
                 lastEndTime,
                 inputPipeline,
                 outputPipeline,
+                partitioned,
                 totalDrivers,
                 queuedDrivers,
                 queuedPartitionedDrivers,

--- a/core/trino-main/src/main/java/io/trino/operator/TaskContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TaskContext.java
@@ -456,10 +456,14 @@ public class TaskContext
         long internalNetworkInputPositions = 0;
 
         long rawInputDataSize = 0;
+        long rawNonPartitionedInputDataSize = 0;
         long rawInputPositions = 0;
+        long rawNonPartitionedInputPositions = 0;
 
         long processedInputDataSize = 0;
+        long processedNonPartitionedInputDataSize = 0;
         long processedInputPositions = 0;
+        long processedNonPartitionedInputPositions = 0;
 
         long outputDataSize = 0;
         long outputPositions = 0;
@@ -508,6 +512,14 @@ public class TaskContext
 
                 processedInputDataSize += pipeline.getProcessedInputDataSize().toBytes();
                 processedInputPositions += pipeline.getProcessedInputPositions();
+
+                if (!pipeline.isPartitioned()) {
+                    rawNonPartitionedInputDataSize += pipeline.getRawInputDataSize().toBytes();
+                    rawNonPartitionedInputPositions += pipeline.getRawInputPositions();
+
+                    processedNonPartitionedInputDataSize += pipeline.getProcessedInputDataSize().toBytes();
+                    processedNonPartitionedInputPositions += pipeline.getProcessedInputPositions();
+                }
             }
 
             if (pipeline.isOutputPipeline()) {
@@ -587,9 +599,13 @@ public class TaskContext
                 succinctBytes(internalNetworkInputDataSize),
                 internalNetworkInputPositions,
                 succinctBytes(rawInputDataSize),
+                succinctBytes(rawNonPartitionedInputDataSize),
                 rawInputPositions,
+                rawNonPartitionedInputPositions,
                 succinctBytes(processedInputDataSize),
+                succinctBytes(processedNonPartitionedInputDataSize),
                 processedInputPositions,
+                processedNonPartitionedInputPositions,
                 succinctBytes(outputDataSize),
                 outputPositions,
                 succinctBytes(physicalWrittenDataSize),

--- a/core/trino-main/src/main/java/io/trino/operator/TaskStats.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TaskStats.java
@@ -71,10 +71,14 @@ public class TaskStats
     private final long internalNetworkInputPositions;
 
     private final DataSize rawInputDataSize;
+    private final DataSize rawNonPartitionedInputDataSize;
     private final long rawInputPositions;
+    private final long rawNonPartitionedInputPositions;
 
     private final DataSize processedInputDataSize;
+    private final DataSize processedNonPartitionedInputDataSize;
     private final long processedInputPositions;
+    private final long processedNonPartitionedInputPositions;
 
     private final DataSize outputDataSize;
     private final long outputPositions;
@@ -120,8 +124,12 @@ public class TaskStats
                 DataSize.ofBytes(0),
                 0,
                 DataSize.ofBytes(0),
+                DataSize.ofBytes(0),
+                0,
                 0,
                 DataSize.ofBytes(0),
+                DataSize.ofBytes(0),
+                0,
                 0,
                 DataSize.ofBytes(0),
                 0,
@@ -171,10 +179,14 @@ public class TaskStats
             @JsonProperty("internalNetworkInputPositions") long internalNetworkInputPositions,
 
             @JsonProperty("rawInputDataSize") DataSize rawInputDataSize,
+            @JsonProperty("rawNonPartitionedInputDataSize") DataSize rawNonPartitionedInputDataSize,
             @JsonProperty("rawInputPositions") long rawInputPositions,
+            @JsonProperty("rawNonPartitionedInputPositions") long rawNonPartitionedInputPositions,
 
             @JsonProperty("processedInputDataSize") DataSize processedInputDataSize,
+            @JsonProperty("processedNonPartitionedInputDataSize") DataSize processedNonPartitionedInputDataSize,
             @JsonProperty("processedInputPositions") long processedInputPositions,
+            @JsonProperty("processedNonPartitionedInputPositions") long processedNonPartitionedInputPositions,
 
             @JsonProperty("outputDataSize") DataSize outputDataSize,
             @JsonProperty("outputPositions") long outputPositions,
@@ -238,12 +250,22 @@ public class TaskStats
         this.internalNetworkInputPositions = internalNetworkInputPositions;
 
         this.rawInputDataSize = requireNonNull(rawInputDataSize, "rawInputDataSize is null");
+        this.rawNonPartitionedInputDataSize = requireNonNull(rawNonPartitionedInputDataSize, "rawNonPartitionedInputDataSize is null");
+        checkArgument(rawInputDataSize.compareTo(rawNonPartitionedInputDataSize) >= 0, "rawInputDataSize is less than rawNonPartitionedInputDataSize");
         checkArgument(rawInputPositions >= 0, "rawInputPositions is negative");
         this.rawInputPositions = rawInputPositions;
+        checkArgument(rawNonPartitionedInputPositions >= 0, "rawNonPartitionedInputPositions is negative");
+        checkArgument(rawInputPositions >= rawNonPartitionedInputPositions, "rawInputPositions is less than rawNonPartitionedInputPositions");
+        this.rawNonPartitionedInputPositions = rawNonPartitionedInputPositions;
 
         this.processedInputDataSize = requireNonNull(processedInputDataSize, "processedInputDataSize is null");
+        this.processedNonPartitionedInputDataSize = requireNonNull(processedNonPartitionedInputDataSize, "processedNonPartitionedInputDataSize is null");
+        checkArgument(processedInputDataSize.compareTo(processedNonPartitionedInputDataSize) >= 0, "processedInputDataSize is less than processedNonPartitionedInputDataSize");
         checkArgument(processedInputPositions >= 0, "processedInputPositions is negative");
         this.processedInputPositions = processedInputPositions;
+        checkArgument(processedNonPartitionedInputPositions >= 0, "processedNonPartitionedInputPositions is negative");
+        checkArgument(processedInputPositions >= processedNonPartitionedInputPositions, "processedInputPositions is less than processedNonPartitionedInputPositions");
+        this.processedNonPartitionedInputPositions = processedNonPartitionedInputPositions;
 
         this.outputDataSize = requireNonNull(outputDataSize, "outputDataSize is null");
         checkArgument(outputPositions >= 0, "outputPositions is negative");
@@ -431,9 +453,21 @@ public class TaskStats
     }
 
     @JsonProperty
+    public DataSize getRawNonPartitionedInputDataSize()
+    {
+        return rawNonPartitionedInputDataSize;
+    }
+
+    @JsonProperty
     public long getRawInputPositions()
     {
         return rawInputPositions;
+    }
+
+    @JsonProperty
+    public long getRawNonPartitionedInputPositions()
+    {
+        return rawNonPartitionedInputPositions;
     }
 
     @JsonProperty
@@ -443,9 +477,21 @@ public class TaskStats
     }
 
     @JsonProperty
+    public DataSize getProcessedNonPartitionedInputDataSize()
+    {
+        return processedNonPartitionedInputDataSize;
+    }
+
+    @JsonProperty
     public long getProcessedInputPositions()
     {
         return processedInputPositions;
+    }
+
+    @JsonProperty
+    public long getProcessedNonPartitionedInputPositions()
+    {
+        return processedNonPartitionedInputPositions;
     }
 
     @JsonProperty
@@ -543,9 +589,13 @@ public class TaskStats
                 internalNetworkInputDataSize,
                 internalNetworkInputPositions,
                 rawInputDataSize,
+                rawNonPartitionedInputDataSize,
                 rawInputPositions,
+                rawNonPartitionedInputPositions,
                 processedInputDataSize,
+                processedNonPartitionedInputDataSize,
                 processedInputPositions,
+                processedNonPartitionedInputPositions,
                 outputDataSize,
                 outputPositions,
                 physicalWrittenDataSize,
@@ -589,9 +639,13 @@ public class TaskStats
                 internalNetworkInputDataSize,
                 internalNetworkInputPositions,
                 rawInputDataSize,
+                rawNonPartitionedInputDataSize,
                 rawInputPositions,
+                rawNonPartitionedInputPositions,
                 processedInputDataSize,
+                processedNonPartitionedInputDataSize,
                 processedInputPositions,
+                processedNonPartitionedInputPositions,
                 outputDataSize,
                 outputPositions,
                 physicalWrittenDataSize,

--- a/core/trino-main/src/test/java/io/trino/execution/TestStageStats.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestStageStats.java
@@ -67,9 +67,13 @@ public class TestStageStats
             202,
 
             DataSize.ofBytes(19),
+            DataSize.ofBytes(19),
+            20,
             20,
 
             DataSize.ofBytes(21),
+            DataSize.ofBytes(21),
+            22,
             22,
 
             DataSize.ofBytes(23),
@@ -137,10 +141,14 @@ public class TestStageStats
         assertEquals(actual.getInternalNetworkInputPositions(), 202);
 
         assertEquals(actual.getRawInputDataSize(), DataSize.ofBytes(19));
+        assertEquals(actual.getRawNonPartitionedInputDataSize(), DataSize.ofBytes(19));
         assertEquals(actual.getRawInputPositions(), 20);
+        assertEquals(actual.getRawNonPartitionedInputPositions(), 20);
 
         assertEquals(actual.getProcessedInputDataSize(), DataSize.ofBytes(21));
+        assertEquals(actual.getProcessedNonPartitionedInputDataSize(), DataSize.ofBytes(21));
         assertEquals(actual.getProcessedInputPositions(), 22);
+        assertEquals(actual.getProcessedNonPartitionedInputPositions(), 22);
 
         assertEquals(actual.getBufferedDataSize(), DataSize.ofBytes(23));
         assertEquals(actual.getOutputDataSize(), DataSize.ofBytes(24));
@@ -157,7 +165,7 @@ public class TestStageStats
         assertEquals(actual.getGcInfo().getAverageFullGcSec(), 107);
     }
 
-    private static DistributionSnapshot getTestDistribution(int count)
+    public static DistributionSnapshot getTestDistribution(int count)
     {
         Distribution distribution = new Distribution();
         for (int i = 0; i < count; i++) {

--- a/core/trino-main/src/test/java/io/trino/operator/TestPipelineStats.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestPipelineStats.java
@@ -40,6 +40,7 @@ public class TestPipelineStats
 
             true,
             false,
+            true,
 
             1,
             2,
@@ -103,6 +104,7 @@ public class TestPipelineStats
         assertEquals(actual.getLastEndTime(), new DateTime(102, UTC));
         assertEquals(actual.isInputPipeline(), true);
         assertEquals(actual.isOutputPipeline(), false);
+        assertEquals(actual.isPartitioned(), true);
 
         assertEquals(actual.getTotalDrivers(), 1);
         assertEquals(actual.getQueuedDrivers(), 2);

--- a/core/trino-main/src/test/java/io/trino/operator/TestTaskStats.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestTaskStats.java
@@ -66,9 +66,13 @@ public class TestTaskStats
             202,
 
             DataSize.ofBytes(19),
+            DataSize.ofBytes(19),
+            20,
             20,
 
             DataSize.ofBytes(21),
+            DataSize.ofBytes(21),
+            22,
             22,
 
             DataSize.ofBytes(23),
@@ -129,10 +133,14 @@ public class TestTaskStats
         assertEquals(actual.getInternalNetworkInputPositions(), 202);
 
         assertEquals(actual.getRawInputDataSize(), DataSize.ofBytes(19));
+        assertEquals(actual.getRawNonPartitionedInputDataSize(), DataSize.ofBytes(19));
         assertEquals(actual.getRawInputPositions(), 20);
+        assertEquals(actual.getRawNonPartitionedInputPositions(), 20);
 
         assertEquals(actual.getProcessedInputDataSize(), DataSize.ofBytes(21));
+        assertEquals(actual.getProcessedNonPartitionedInputDataSize(), DataSize.ofBytes(21));
         assertEquals(actual.getProcessedInputPositions(), 22);
+        assertEquals(actual.getProcessedNonPartitionedInputPositions(), 22);
 
         assertEquals(actual.getOutputDataSize(), DataSize.ofBytes(23));
         assertEquals(actual.getOutputPositions(), 24);


### PR DESCRIPTION
The problem was that this change fixes is that input data is included multiple times for broadcast join in query stat monitoring.

More detail description of the issue:
- In QueryStateMachine#getQueryStats implementation, input data stats are collected only from the stage that contains table scan.
- However, for a broadcast join, the stage where the join is executed contains a probe-side scan operator as well.
- Therefore, the input data stat of exchange operator that comes from the build-side data is added multiple times, which makes the input data size stats bigger.
- 
How to fix:
- Introduce separate stats for input data from non-partitioned source.
- It is adjusted in QueryStateMachine#getQueryStats