### PR TITLE
Fix Statement leak in Trino JDBC DatabaseMetaData

### DIFF
--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/AbstractTrinoResultSet.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/AbstractTrinoResultSet.java
@@ -190,7 +190,6 @@ abstract class AbstractTrinoResultSet
     private final AtomicReference<List<Object>> row = new AtomicReference<>();
     private final AtomicLong currentRowNumber = new AtomicLong(); // Index into 'rows' of our current row (1-based)
     private final AtomicBoolean wasNull = new AtomicBoolean();
-    protected final AtomicBoolean closed = new AtomicBoolean();
     private final Optional<Statement> statement;
 
     AbstractTrinoResultSet(Optional<Statement> statement, List<Column> columns, Iterator<List<Object>> results)
@@ -1468,11 +1467,8 @@ abstract class AbstractTrinoResultSet
     }
 
     @Override
-    public boolean isClosed()
-            throws SQLException
-    {
-        return closed.get();
-    }
+    public abstract boolean isClosed()
+            throws SQLException;
 
     @Override
     public void updateNString(int columnIndex, String nString)

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/InMemoryTrinoResultSet.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/InMemoryTrinoResultSet.java
@@ -18,12 +18,15 @@ import io.trino.client.Column;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.Objects.requireNonNull;
 
 class InMemoryTrinoResultSet
         extends AbstractTrinoResultSet
 {
+    private final AtomicBoolean closed = new AtomicBoolean();
+
     public InMemoryTrinoResultSet(List<Column> columns, List<List<Object>> results)
     {
         super(Optional.empty(), columns, requireNonNull(results, "results is null").iterator());
@@ -34,5 +37,12 @@ class InMemoryTrinoResultSet
             throws SQLException
     {
         closed.set(true);
+    }
+
+    @Override
+    public boolean isClosed()
+            throws SQLException
+    {
+        return closed.get();
     }
 }

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/InMemoryTrinoResultSet.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/InMemoryTrinoResultSet.java
@@ -32,5 +32,7 @@ class InMemoryTrinoResultSet
     @Override
     public void close()
             throws SQLException
-    {}
+    {
+        closed.set(true);
+    }
 }

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
@@ -782,6 +782,12 @@ public class TrinoConnection
         checkState(statements.remove(statement), "Statement is not registered");
     }
 
+    @VisibleForTesting
+    int activeStatements()
+    {
+        return statements.size();
+    }
+
     private void checkOpen()
             throws SQLException
     {

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoResultSet.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoResultSet.java
@@ -31,6 +31,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
@@ -45,6 +46,8 @@ public class TrinoResultSet
 {
     private final StatementClient client;
     private final String queryId;
+
+    private final AtomicBoolean closed = new AtomicBoolean();
 
     static TrinoResultSet create(Statement statement, StatementClient client, long maxRows, Consumer<QueryStats> progressCallback, WarningsManager warningsManager)
             throws SQLException
@@ -86,6 +89,13 @@ public class TrinoResultSet
             ((AsyncIterator<?>) results).cancel();
             client.close();
         }
+    }
+
+    @Override
+    public boolean isClosed()
+            throws SQLException
+    {
+        return closed.get();
     }
 
     void partialCancel()

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoResultSet.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoResultSet.java
@@ -82,9 +82,10 @@ public class TrinoResultSet
     public void close()
             throws SQLException
     {
-        closed.set(true);
-        ((AsyncIterator<?>) results).cancel();
-        client.close();
+        if (closed.compareAndSet(false, true)) {
+            ((AsyncIterator<?>) results).cancel();
+            client.close();
+        }
     }
 
     void partialCancel()

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/TestTrinoS3FileSystem.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/TestTrinoS3FileSystem.java
@@ -67,7 +67,6 @@ import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Strings.repeat;
 import static com.google.common.io.ByteStreams.toByteArray;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
@@ -736,9 +735,9 @@ public class TestTrinoS3FileSystem
             fs.setS3Client(s3);
             try (FSDataOutputStream stream = fs.create(new Path("s3n://test-bucket/test"))) {
                 stream.write('a');
-                stream.write(repeat("foo", 2).getBytes(US_ASCII));
-                stream.write(repeat("bar", 3).getBytes(US_ASCII));
-                stream.write(repeat("orange", 4).getBytes(US_ASCII), 6, 12);
+                stream.write("foo".repeat(2).getBytes(US_ASCII));
+                stream.write("bar".repeat(3).getBytes(US_ASCII));
+                stream.write("orange".repeat(4).getBytes(US_ASCII), 6, 12);
             }
 
             List<UploadPartRequest> parts = s3.getUploadParts();

--- a/testing/trino-test-jdbc-compatibility-old-driver/src/test/java/io/trino/TestJdbcCompatibility.java
+++ b/testing/trino-test-jdbc-compatibility-old-driver/src/test/java/io/trino/TestJdbcCompatibility.java
@@ -40,7 +40,6 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Consumer;
 
-import static com.google.common.base.Strings.repeat;
 import static io.trino.JdbcDriverCapabilities.correctlyReportsTimestampWithTimeZone;
 import static io.trino.JdbcDriverCapabilities.driverVersion;
 import static io.trino.JdbcDriverCapabilities.hasBrokenParametricTimestampWithTimeZoneSupport;
@@ -112,7 +111,7 @@ public class TestJdbcCompatibility
     public void testLongPreparedStatement()
             throws Exception
     {
-        String sql = format("SELECT '%s' = '%s'", repeat("x", 100_000), repeat("y", 100_000));
+        String sql = format("SELECT '%s' = '%s'", "x".repeat(100_000), "y".repeat(100_000));
 
         try (ResultSet rs = runQuery(sql)) {
             assertThat(rs.next()).isTrue();


### PR DESCRIPTION
Before the change, Trino JDBC's `DatabaseMetaData` implementation
(`TrinoDatabaseMetaData`) would create `Statement` objects that are
never closed. Since `Connection` (`TrinoConnection`) tracks open
statements to be able to close them upon `Connection.close()` (per JDBC
requirements), this created a memory leak where `Statement` objects are
leaked in `Connection.statements` collection.

The commit fixing this, under the condition that `ResultSet` returned
from `TrinoDatabaseMetaData` is correctly closed.

Fixes https://github.com/trinodb/trino/issues/10584 