### PR TITLE
Migrate code away from anonymous class using initializers

### DIFF
--- a/plugin/trino-http-event-listener/pom.xml
+++ b/plugin/trino-http-event-listener/pom.xml
@@ -117,7 +117,13 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- TEST -->
+        <!-- for testing -->
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>testing</artifactId>

--- a/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpQueryListener.java
+++ b/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpQueryListener.java
@@ -221,9 +221,7 @@ public class TestHttpQueryListener
         server.enqueue(new MockResponse()
                 .setResponseCode(200));
 
-        EventListener querylogListener = factory.create(new HashMap<>() {{
-                put("http-event-listener.connect-ingest-uri", server.url("/").toString());
-            }});
+        EventListener querylogListener = factory.create(Map.of("http-event-listener.connect-ingest-uri", server.url("/").toString()));
         querylogListener.queryCreated(null);
         querylogListener.queryCompleted(null);
         querylogListener.splitCompleted(null);
@@ -235,12 +233,11 @@ public class TestHttpQueryListener
     public void testAllLoggingEnabledShouldSendCorrectEvent()
             throws Exception
     {
-        EventListener querylogListener = factory.create(new HashMap<>() {{
-                put("http-event-listener.log-created", "true");
-                put("http-event-listener.log-completed", "true");
-                put("http-event-listener.log-split", "true");
-                put("http-event-listener.connect-ingest-uri", server.url("/").toString());
-            }});
+        EventListener querylogListener = factory.create(Map.of(
+                "http-event-listener.log-created", "true",
+                "http-event-listener.log-completed", "true",
+                "http-event-listener.log-split", "true",
+                "http-event-listener.connect-ingest-uri", server.url("/").toString()));
 
         server.enqueue(new MockResponse().setResponseCode(200));
         server.enqueue(new MockResponse().setResponseCode(200));
@@ -260,10 +257,9 @@ public class TestHttpQueryListener
     public void testContentTypeDefaultHeaderShouldAlwaysBeSet()
             throws Exception
     {
-        EventListener querylogListener = factory.create(new HashMap<>(){{
-                put("http-event-listener.connect-ingest-uri", server.url("/").toString());
-                put("http-event-listener.log-completed", "true");
-            }});
+        EventListener querylogListener = factory.create(Map.of(
+                "http-event-listener.connect-ingest-uri", server.url("/").toString(),
+                "http-event-listener.log-completed", "true"));
 
         server.enqueue(new MockResponse().setResponseCode(200));
 
@@ -276,20 +272,18 @@ public class TestHttpQueryListener
     public void testHttpHeadersShouldBePresent()
             throws Exception
     {
-        EventListener querylogListener = factory.create(new HashMap<>(){{
-                put("http-event-listener.connect-ingest-uri", server.url("/").toString());
-                put("http-event-listener.log-completed", "true");
-                put("http-event-listener.connect-http-headers", "Authorization: Trust Me!, Cache-Control: no-cache");
-            }});
+        EventListener querylogListener = factory.create(Map.of(
+                "http-event-listener.connect-ingest-uri", server.url("/").toString(),
+                "http-event-listener.log-completed", "true",
+                "http-event-listener.connect-http-headers", "Authorization: Trust Me!, Cache-Control: no-cache"));
 
         server.enqueue(new MockResponse().setResponseCode(200));
 
         querylogListener.queryCompleted(queryCompleteEvent);
 
-        checkRequest(server.takeRequest(5, TimeUnit.SECONDS), new HashMap<>() {{
-                put("Authorization", "Trust Me!");
-                put("Cache-Control", "no-cache");
-            }}, queryCompleteEvent);
+        checkRequest(server.takeRequest(5, TimeUnit.SECONDS), Map.of(
+                "Authorization", "Trust Me!",
+                "Cache-Control", "no-cache"), queryCompleteEvent);
     }
 
     @Test
@@ -299,12 +293,11 @@ public class TestHttpQueryListener
         setupServerTLSCertificate();
         server.enqueue(new MockResponse().setResponseCode(200));
 
-        EventListener querylogListener = factory.create(new HashMap<>(){{
-                put("http-event-listener.connect-ingest-uri", server.url("/").toString());
-                put("http-event-listener.log-completed", "true");
-                put("http-event-listener.http-client.key-store-path", "src/test/resources/trino-httpquery-test.p12");
-                put("http-event-listener.http-client.key-store-password", "testing-ssl");
-            }});
+        EventListener querylogListener = factory.create(Map.of(
+                "http-event-listener.connect-ingest-uri", server.url("/").toString(),
+                "http-event-listener.log-completed", "true",
+                "http-event-listener.http-client.key-store-path", "src/test/resources/trino-httpquery-test.p12",
+                "http-event-listener.http-client.key-store-password", "testing-ssl"));
         querylogListener.queryCompleted(queryCompleteEvent);
 
         RecordedRequest recordedRequest = server.takeRequest(5, TimeUnit.SECONDS);
@@ -322,12 +315,11 @@ public class TestHttpQueryListener
         setupServerTLSCertificate();
         server.enqueue(new MockResponse().setResponseCode(200));
 
-        EventListener querylogListener = factory.create(new HashMap<>(){{
-                put("http-event-listener.connect-ingest-uri", server.url("/").toString());
-                put("http-event-listener.log-completed", "true");
-                put("http-event-listener.http-client.key-store-path", "src/test/resources/trino-httpquery-test2.p12");
-                put("http-event-listener.http-client.key-store-password", "testing-ssl");
-            }});
+        EventListener querylogListener = factory.create(Map.of(
+                "http-event-listener.connect-ingest-uri", server.url("/").toString(),
+                "http-event-listener.log-completed", "true",
+                "http-event-listener.http-client.key-store-path", "src/test/resources/trino-httpquery-test2.p12",
+                "http-event-listener.http-client.key-store-password", "testing-ssl"));
         querylogListener.queryCompleted(queryCompleteEvent);
 
         RecordedRequest recordedRequest = server.takeRequest(5, TimeUnit.SECONDS);
@@ -341,12 +333,11 @@ public class TestHttpQueryListener
     {
         server.enqueue(new MockResponse().setResponseCode(200));
 
-        EventListener querylogListener = factory.create(new HashMap<>(){{
-                put("http-event-listener.connect-ingest-uri", new URL("https", server.getHostName(), server.getPort(), "/").toString());
-                put("http-event-listener.log-completed", "true");
-                put("http-event-listener.http-client.key-store-path", "src/test/resources/trino-httpquery-test.p12");
-                put("http-event-listener.http-client.key-store-password", "testing-ssl");
-            }});
+        EventListener querylogListener = factory.create(Map.of(
+                "http-event-listener.connect-ingest-uri", new URL("https", server.getHostName(), server.getPort(), "/").toString(),
+                "http-event-listener.log-completed", "true",
+                "http-event-listener.http-client.key-store-path", "src/test/resources/trino-httpquery-test.p12",
+                "http-event-listener.http-client.key-store-password", "testing-ssl"));
         querylogListener.queryCompleted(queryCompleteEvent);
 
         RecordedRequest recordedRequest = server.takeRequest(5, TimeUnit.SECONDS);
@@ -358,11 +349,10 @@ public class TestHttpQueryListener
     public void testServer500ShouldRetry()
             throws Exception
     {
-        EventListener querylogListener = factory.create(new HashMap<>(){{
-                put("http-event-listener.connect-ingest-uri", server.url("/").toString());
-                put("http-event-listener.log-completed", "true");
-                put("http-event-listener.connect-retry-count", "1");
-            }});
+        EventListener querylogListener = factory.create(Map.of(
+                "http-event-listener.connect-ingest-uri", server.url("/").toString(),
+                "http-event-listener.log-completed", "true",
+                "http-event-listener.connect-retry-count", "1"));
 
         server.enqueue(new MockResponse().setResponseCode(500));
         server.enqueue(new MockResponse().setResponseCode(200));
@@ -377,11 +367,10 @@ public class TestHttpQueryListener
     public void testServer400ShouldRetry()
             throws Exception
     {
-        EventListener querylogListener = factory.create(new HashMap<>(){{
-                put("http-event-listener.connect-ingest-uri", server.url("/").toString());
-                put("http-event-listener.log-completed", "true");
-                put("http-event-listener.connect-retry-count", "1");
-            }});
+        EventListener querylogListener = factory.create(Map.of(
+                "http-event-listener.connect-ingest-uri", server.url("/").toString(),
+                "http-event-listener.log-completed", "true",
+                "http-event-listener.connect-retry-count", "1"));
 
         server.enqueue(new MockResponse().setResponseCode(400));
         server.enqueue(new MockResponse().setResponseCode(200));
@@ -396,11 +385,10 @@ public class TestHttpQueryListener
     public void testServerDisconnectShouldRetry()
             throws Exception
     {
-        EventListener querylogListener = factory.create(new HashMap<>(){{
-                put("http-event-listener.connect-ingest-uri", server.url("/").toString());
-                put("http-event-listener.log-completed", "true");
-                put("http-event-listener.connect-retry-count", "1");
-            }});
+        EventListener querylogListener = factory.create(Map.of(
+                "http-event-listener.connect-ingest-uri", server.url("/").toString(),
+                "http-event-listener.log-completed", "true",
+                "http-event-listener.connect-retry-count", "1"));
 
         server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
         server.enqueue(new MockResponse().setResponseCode(200));
@@ -415,10 +403,9 @@ public class TestHttpQueryListener
     public void testServerDelayDoesNotBlock()
             throws Exception
     {
-        EventListener querylogListener = factory.create(new HashMap<>(){{
-                put("http-event-listener.connect-ingest-uri", server.url("/").toString());
-                put("http-event-listener.log-completed", "true");
-            }});
+        EventListener querylogListener = factory.create(Map.of(
+                "http-event-listener.connect-ingest-uri", server.url("/").toString(),
+                "http-event-listener.log-completed", "true"));
 
         server.enqueue(new MockResponse().setResponseCode(200).setHeadersDelay(5, TimeUnit.SECONDS));
 

--- a/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpQueryListener.java
+++ b/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpQueryListener.java
@@ -62,6 +62,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static java.lang.String.format;
 import static java.time.Duration.ofMillis;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -440,16 +441,16 @@ public class TestHttpQueryListener
     private void checkRequest(RecordedRequest recordedRequest, Map<String, String> customHeaders, Object event)
             throws JsonProcessingException
     {
-        assertNotNull(recordedRequest, String.format("No request sent when logging is enabled for %s", event));
+        assertNotNull(recordedRequest, format("No request sent when logging is enabled for %s", event));
         for (String key : customHeaders.keySet()) {
-            assertNotNull(recordedRequest.getHeader(key), String.format("Custom header %s not present in request for %s event", key, event));
+            assertNotNull(recordedRequest.getHeader(key), format("Custom header %s not present in request for %s event", key, event));
             assertEquals(recordedRequest.getHeader(key), customHeaders.get(key),
-                    String.format("Expected value %s for header %s but got %s for %s event", customHeaders.get(key), key, recordedRequest.getHeader(key), event));
+                    format("Expected value %s for header %s but got %s for %s event", customHeaders.get(key), key, recordedRequest.getHeader(key), event));
         }
         String body = recordedRequest.getBody().readUtf8();
-        assertFalse(body.isEmpty(), String.format("Body is empty for %s event", event));
+        assertFalse(body.isEmpty(), format("Body is empty for %s event", event));
         String eventJson = objectMapper.writeValueAsString(event);
-        assertTrue(objectMapper.readTree(eventJson).equals(objectMapper.readTree(body)), String.format("Json value is wrong for event %s, expected %s but found %s", event, eventJson, body));
+        assertTrue(objectMapper.readTree(eventJson).equals(objectMapper.readTree(body)), format("Json value is wrong for event %s, expected %s but found %s", event, eventJson, body));
     }
 
     private void setupServerTLSCertificate()

--- a/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpQueryListener.java
+++ b/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpQueryListener.java
@@ -271,6 +271,7 @@ public class TestHttpQueryListener
         assertEquals(server.takeRequest(5, TimeUnit.SECONDS).getHeader("Content-Type"), "application/json; charset=utf-8");
     }
 
+    @Test
     public void testHttpHeadersShouldBePresent()
             throws Exception
     {

--- a/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpQueryListenerConfig.java
+++ b/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpQueryListenerConfig.java
@@ -16,7 +16,6 @@ package io.trino.plugin.httpquery;
 import io.airlift.units.Duration;
 import org.testng.annotations.Test;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -47,17 +46,16 @@ public class TestHttpQueryListenerConfig
     public void testExplicitPropertyMappings()
             throws Exception
     {
-        Map<String, String> properties = new HashMap<>() {{
-                put("http-event-listener.log-created", "true");
-                put("http-event-listener.log-completed", "true");
-                put("http-event-listener.log-split", "true");
-                put("http-event-listener.connect-ingest-uri", "http://example.com:8080/api");
-                put("http-event-listener.connect-http-headers", "Authorization: Trust Me, Cache-Control: no-cache");
-                put("http-event-listener.connect-retry-count", "2");
-                put("http-event-listener.connect-retry-delay", "101s");
-                put("http-event-listener.connect-backoff-base", "1.5");
-                put("http-event-listener.connect-max-delay", "10m");
-            }};
+        Map<String, String> properties = Map.of(
+                "http-event-listener.log-created", "true",
+                "http-event-listener.log-completed", "true",
+                "http-event-listener.log-split", "true",
+                "http-event-listener.connect-ingest-uri", "http://example.com:8080/api",
+                "http-event-listener.connect-http-headers", "Authorization: Trust Me, Cache-Control: no-cache",
+                "http-event-listener.connect-retry-count", "2",
+                "http-event-listener.connect-retry-delay", "101s",
+                "http-event-listener.connect-backoff-base", "1.5",
+                "http-event-listener.connect-max-delay", "10m");
 
         HttpEventListenerConfig expected = new HttpEventListenerConfig()
                 .setLogCompleted(true)


### PR DESCRIPTION
While it's possible to create a pre-populated collection using `new
CollectionClass() { { ... add elements ... } }`, it is not the idiomatic
way to do it.