### PR TITLE
Schedule coordinator stage after creating distributed stages scheduler

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/SqlQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/SqlQueryScheduler.java
@@ -289,9 +289,9 @@ public class SqlQueryScheduler
             queryStateMachine.updateQueryInfo(Optional.ofNullable(getStageInfo()));
         });
 
-        coordinatorStagesScheduler.schedule();
-
         Optional<DistributedStagesScheduler> distributedStagesScheduler = createDistributedStagesScheduler(currentAttempt.get());
+
+        coordinatorStagesScheduler.schedule();
         distributedStagesScheduler.ifPresent(scheduler -> distributedStagesSchedulingTask = executor.submit(scheduler::schedule, null));
     }
 


### PR DESCRIPTION
If coordinator stage is running and fails while distributed stages scheduler
is being created we can get unexpected failures from the latter routine.
The race between handling failure of coordinator stage and code run from
createDistributedStagesScheduler may result in the failures of SPI
calls called by the latter; and propagating those failures as top-level
query failure.

E.g. for queries which read Hive we observed the exceptions from
HiveSplitManager.getSplits() to be set as top-level query failures after
coordinator stage failure, because `currentQueryId` was unset in
SemiTransactionalHiveMetastore as part of coordinator failure handling.

Defering start of coordinator stage does not solve the problem totally
but changes the probability of occurence.