### PR TITLE
Abstain from overriding @BeforeClass init method

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestFailureRecovery.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestFailureRecovery.java
@@ -107,11 +107,9 @@ public abstract class AbstractTestFailureRecovery
             throws Exception;
 
     @BeforeClass
-    @Override
-    public void init()
+    public void initTables()
             throws Exception
     {
-        super.init();
         // setup partitioned fact table for dynamic partition pruning
         createPartitionedLineitemTable(PARTITIONED_LINEITEM, ImmutableList.of("orderkey", "partkey", "suppkey"), "suppkey");
     }

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseDynamicPartitionPruningTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseDynamicPartitionPruningTest.java
@@ -64,11 +64,9 @@ public abstract class BaseDynamicPartitionPruningTest
             "optimizer.rewrite-filtering-semi-join-to-inner-join", "false");
 
     @BeforeClass
-    @Override
-    public void init()
+    public void initTables()
             throws Exception
     {
-        super.init();
         // setup partitioned fact table for dynamic partition pruning
         createLineitemTable(PARTITIONED_LINEITEM, ImmutableList.of("orderkey", "partkey", "suppkey"), ImmutableList.of("suppkey"));
     }


### PR DESCRIPTION
There is no need for that, and thus it should be avoided, as it
introduces unnecessary flow dependencies, or ordering of events. Regular
`@BeforeClass` should be used instead.