### PR TITLE
Add a check that JUnit tests are overridden properly

### DIFF
--- a/testing/trino-testing-services/pom.xml
+++ b/testing/trino-testing-services/pom.xml
@@ -49,6 +49,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <!-- it's either on classpath because anyway, or not needed at all. Let's not force the dependency on downstream when not needed. -->
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
         </dependency>
@@ -58,6 +65,12 @@
             <artifactId>testng</artifactId>
             <!-- it's either on classpath because anyway, or not needed at all. Let's not force the dependency on downstream when not needed. -->
             <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-commons</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- testing -->
@@ -70,6 +83,12 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -100,6 +119,14 @@
                         <io.trino.testng.services.FlakyTestRetryAnalyzer.enabled>true</io.trino.testng.services.FlakyTestRetryAnalyzer.enabled>
                     </systemPropertyVariables>
                 </configuration>
+                <dependencies>
+                    <!-- allow only TestNG -->
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>${dep.plugin.surefire.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/testing/trino-testing-services/src/main/java/io/trino/testng/services/ReportImproperlyOverriddenTestMethods.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testng/services/ReportImproperlyOverriddenTestMethods.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testng.services;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.junit.platform.commons.annotation.Testable;
+import org.testng.IClassListener;
+import org.testng.ITestClass;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static com.google.common.base.Throwables.getStackTraceAsString;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.testng.services.Listeners.reportListenerFailure;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static java.util.stream.Collectors.joining;
+import static org.junit.platform.commons.util.AnnotationUtils.isAnnotated;
+
+/**
+ * This checker finds issues in JUnit 5 tests where the test method is overridden in a subclass but
+ * not annotated with {@link org.junit.jupiter.api.Test} or any other {@link Testable}. In addition
+ * to presence of the annotation, this check requires that the overridden method is annotated with the
+ * same annotation with the same parameters, e.g. a {@code @RepeatedTest(5)} method's override needs
+ * to be also annotated with {@link org.junit.jupiter.api.RepeatedTest} with the same number of repeats (5).
+ * <p>
+ * This is only needed for JUnit 5, as TestNG picks up overridden methods just fine.
+ */
+public class ReportImproperlyOverriddenTestMethods
+        implements IClassListener
+{
+    @Override
+    public void onBeforeClass(ITestClass testClass)
+    {
+        try {
+            reportImproperlyOverriddenTestMethods(testClass);
+        }
+        catch (RuntimeException | Error e) {
+            reportListenerFailure(
+                    ReportImproperlyOverriddenTestMethods.class,
+                    "Failed to process %s: \n%s",
+                    testClass,
+                    getStackTraceAsString(e));
+        }
+    }
+
+    private void reportImproperlyOverriddenTestMethods(ITestClass testClass)
+    {
+        Class<?> realClass = testClass.getRealClass();
+
+        if (realClass.getName().startsWith("io.trino.testng.services.TestReportImproperlyOverriddenTestMethods")) {
+            // ignore test of ReportImproperlyOverriddenTestMethods and internal classes
+            return;
+        }
+
+        List<Method> privateTestMethods = findImproperlyOverriddenTestMethods(realClass);
+        if (!privateTestMethods.isEmpty()) {
+            reportListenerFailure(
+                    ReportImproperlyOverriddenTestMethods.class,
+                    "The following methods in the test class %s should be annotated with the same test annotations as in the superclass:%s",
+                    realClass.getName(),
+                    privateTestMethods.stream()
+                            .map(Method::toString)
+                            .collect(joining("\n\t\t", "\n\t\t", "")));
+        }
+    }
+
+    @VisibleForTesting
+    static List<Method> findImproperlyOverriddenTestMethods(Class<?> realClass)
+    {
+        return Arrays.stream(realClass.getDeclaredMethods())
+                .filter(ReportImproperlyOverriddenTestMethods::isImproperlyAnnotated)
+                .filter(method -> !method.isAnnotationPresent(Suppress.class))
+                .collect(toImmutableList());
+    }
+
+    @Override
+    public void onAfterClass(ITestClass testClass) {}
+
+    private static boolean isImproperlyAnnotated(Method method)
+    {
+        return getOverriddenMethod(method)
+                .stream()
+                .map(Method::getAnnotations)
+                .flatMap(Arrays::stream)
+                .anyMatch(overriddenAnnotation -> {
+                    // Junit 5 @Test-like annotations are all annotated with @Testable
+                    if (isAnnotated(overriddenAnnotation.annotationType(), Testable.class)) {
+                        // (There are also associated annotations like @MethodSource, but we can allow changing them in the override)
+                        return !overriddenAnnotation.equals(method.getAnnotation(overriddenAnnotation.annotationType()));
+                    }
+                    return false;
+                });
+    }
+
+    private static Optional<Method> getOverriddenMethod(Method method)
+    {
+        // we can't rely on Class::getMethod to return an inherited method
+        // because in JUnit 5 test methods are not public, and getMethod only returns public
+        // on the other hand Class:getDeclaredMethod does not return inherited methods
+        return inheritanceChain(method.getDeclaringClass().getSuperclass())
+                .map(Class::getDeclaredMethods)
+                .flatMap(Arrays::stream)
+                .filter(overriddenMethod -> overriddenMethod.getName().equals(method.getName()))
+                .filter(overriddenMethod -> Arrays.equals(overriddenMethod.getTypeParameters(), method.getTypeParameters()))
+                .findAny();
+    }
+
+    private static Stream<Class<?>> inheritanceChain(Class<?> mostDerived)
+    {
+        return Stream.iterate(mostDerived, clazz -> clazz.getSuperclass() != null, Class::getSuperclass);
+    }
+
+    @Retention(RUNTIME)
+    @Target(METHOD)
+    public @interface Suppress
+    {
+    }
+}

--- a/testing/trino-testing-services/src/main/resources/META-INF/services/org.testng.ITestNGListener
+++ b/testing/trino-testing-services/src/main/resources/META-INF/services/org.testng.ITestNGListener
@@ -3,6 +3,7 @@ io.trino.testng.services.ReportPrivateMethods
 io.trino.testng.services.ReportUnannotatedMethods
 io.trino.testng.services.ReportIllNamedTest
 io.trino.testng.services.ReportMultiThreadedBeforeOrAfterMethod
+io.trino.testng.services.ReportImproperlyOverriddenTestMethods
 io.trino.testng.services.LogTestDurationListener
 io.trino.testng.services.RetryAnnotationTransformer
 io.trino.testng.services.FlakyAnnotationVerifier

--- a/testing/trino-testing-services/src/test/java/io/trino/testng/services/TestReportImproperlyOverriddenTestMethods.java
+++ b/testing/trino-testing-services/src/test/java/io/trino/testng/services/TestReportImproperlyOverriddenTestMethods.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testng.services;
+
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+
+import static io.trino.testng.services.ReportImproperlyOverriddenTestMethods.findImproperlyOverriddenTestMethods;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestReportImproperlyOverriddenTestMethods
+{
+    @Test
+    public void testTest()
+    {
+        assertThat(findImproperlyOverriddenTestMethods(TestReportImproperlyOverriddenTestMethods.class))
+                .isEmpty();
+    }
+
+    @Test
+    public void testNotOverridden()
+    {
+        assertThat(findImproperlyOverriddenTestMethods(TestNothingOverridden.class))
+                .isEmpty();
+    }
+
+    @Test
+    public void testOverriddenProperly()
+    {
+        assertThat(findImproperlyOverriddenTestMethods(TestOverriddenProperly.class))
+                .isEmpty();
+    }
+
+    @Test
+    public void testOverriddenProperlyViaIntermediate()
+    {
+        assertThat(findImproperlyOverriddenTestMethods(TestOverriddenProperlyViaIntermediate.class))
+                .isEmpty();
+    }
+
+    @Test
+    public void testOverriddenImproperly()
+    {
+        assertThat(findImproperlyOverriddenTestMethods(TestOverriddenImproperly.class))
+                .extracting(Method::getName)
+                .containsExactly("test", "repeatedTest", "factoryTest", "templateTest", "parameterizedTest");
+    }
+
+    @Test
+    public void testOverriddenImproperlyAndSuppressed()
+    {
+        assertThat(findImproperlyOverriddenTestMethods(TestOverriddenImproperlyAndSuppressed.class))
+                .isEmpty();
+    }
+
+    @Test
+    public void testOverriddenImproperlyWithDifferentType()
+    {
+        assertThat(findImproperlyOverriddenTestMethods(TestOverriddenImproperlyWithDifferentType.class))
+                .extracting(Method::getName)
+                .containsExactly("test");
+    }
+
+    @Test
+    public void testOverriddenImproperlyWithSameTypeDifferentParameters()
+    {
+        assertThat(findImproperlyOverriddenTestMethods(TestOverriddenImproperlyWithSameTypeDifferentParameters.class))
+                .extracting(Method::getName)
+                .containsExactly("repeatedTest");
+    }
+
+    private static class BaseTest
+    {
+        @org.junit.jupiter.api.Test
+        void test() {}
+
+        @org.junit.jupiter.api.RepeatedTest(1)
+        void repeatedTest() {}
+
+        @org.junit.jupiter.api.TestFactory
+        void factoryTest() {}
+
+        @org.junit.jupiter.api.TestTemplate
+        void templateTest() {}
+
+        @org.junit.jupiter.params.ParameterizedTest
+        @org.junit.jupiter.params.provider.EmptySource
+        void parameterizedTest() {}
+    }
+
+    private static class TestNothingOverridden
+            extends BaseTest
+    {
+    }
+
+    private static class TestOverriddenProperly
+            extends BaseTest
+    {
+        @Override
+        @org.junit.jupiter.api.Test
+        void test() {}
+
+        @Override
+        @org.junit.jupiter.api.RepeatedTest(1)
+        void repeatedTest() {}
+
+        @Override
+        @org.junit.jupiter.api.TestFactory
+        void factoryTest() {}
+
+        @Override
+        @org.junit.jupiter.api.TestTemplate
+        void templateTest() {}
+
+        @Override
+        @org.junit.jupiter.params.ParameterizedTest
+        // source type changed: this is OK
+        @org.junit.jupiter.params.provider.ValueSource(strings = {})
+        void parameterizedTest() {}
+    }
+
+    private abstract static class TestIntermediate
+            extends BaseTest
+    {
+    }
+
+    private static class TestOverriddenProperlyViaIntermediate
+            extends TestIntermediate
+    {
+        @Override
+        @org.junit.jupiter.api.Test
+        public void test() {}
+    }
+
+    private static class TestOverriddenImproperly
+            extends BaseTest
+    {
+        @Override
+        void test() {}
+
+        @Override
+        void repeatedTest() {}
+
+        @Override
+        void factoryTest() {}
+
+        @Override
+        void templateTest() {}
+
+        @Override
+        void parameterizedTest() {}
+    }
+
+    private static class TestOverriddenImproperlyAndSuppressed
+            extends BaseTest
+    {
+        @Override
+        @ReportImproperlyOverriddenTestMethods.Suppress
+        void test() {}
+    }
+
+    private static class TestOverriddenImproperlyWithDifferentType
+            extends BaseTest
+    {
+        @Override
+        @org.junit.jupiter.api.RepeatedTest(1)
+        public void test() {}
+    }
+
+    private static class TestOverriddenImproperlyWithSameTypeDifferentParameters
+            extends BaseTest
+    {
+        @Override
+        @org.junit.jupiter.api.RepeatedTest(5)
+        public void repeatedTest() {}
+    }
+}


### PR DESCRIPTION
This checker finds issues in JUnit 5 tests where the test method is overridden in a subclass but not annotated with
`org.junit.jupiter.api.Test` or any other `@Testable`. In addition to presence of the annotation, this check requires that the overridden method is annotated with the same annotation with the same parameters, e.g. a `@RepeatedTest(5)` method's override needs to be also annotated with `org.junit.jupiter.api.RepeatedTest` with the same number of repeats (5).

This is only needed for JUnit 5, as TestNG picks up overridden methods just fine.