### PR TITLE
Optimize effectively literal values

### DIFF
--- a/core/trino-main/src/main/java/io/trino/cost/ScalarStatsCalculator.java
+++ b/core/trino-main/src/main/java/io/trino/cost/ScalarStatsCalculator.java
@@ -51,6 +51,7 @@ import java.util.OptionalDouble;
 
 import static io.trino.spi.statistics.StatsUtil.toStatsRepresentation;
 import static io.trino.sql.ExpressionUtils.getExpressionTypes;
+import static io.trino.sql.ExpressionUtils.isEffectivelyLiteral;
 import static io.trino.sql.analyzer.ExpressionAnalyzer.createConstantAnalyzer;
 import static io.trino.sql.planner.LiteralInterpreter.evaluate;
 import static io.trino.util.MoreMath.max;
@@ -140,7 +141,7 @@ public class ScalarStatsCalculator
                 return nullStatsEstimate();
             }
 
-            if (value instanceof Expression && !(value instanceof Literal)) {
+            if (value instanceof Expression && !isEffectivelyLiteral(plannerContext, session, (Expression) value)) {
                 // value is not a constant
                 return SymbolStatsEstimate.unknown();
             }

--- a/core/trino-main/src/main/java/io/trino/sql/ExpressionUtils.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ExpressionUtils.java
@@ -19,24 +19,32 @@ import com.google.common.collect.Iterables;
 import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
+import io.trino.metadata.ResolvedFunction;
 import io.trino.security.AllowAllAccessControl;
 import io.trino.spi.type.Type;
 import io.trino.sql.analyzer.ExpressionAnalyzer;
 import io.trino.sql.analyzer.Scope;
 import io.trino.sql.planner.DeterminismEvaluator;
+import io.trino.sql.planner.ExpressionInterpreter;
+import io.trino.sql.planner.LiteralEncoder;
+import io.trino.sql.planner.NoOpSymbolResolver;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.SymbolsExtractor;
 import io.trino.sql.planner.TypeProvider;
+import io.trino.sql.tree.Cast;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.ExpressionRewriter;
 import io.trino.sql.tree.ExpressionTreeRewriter;
+import io.trino.sql.tree.FunctionCall;
 import io.trino.sql.tree.GenericDataType;
 import io.trino.sql.tree.Identifier;
 import io.trino.sql.tree.IsNullPredicate;
 import io.trino.sql.tree.LambdaExpression;
+import io.trino.sql.tree.Literal;
 import io.trino.sql.tree.LogicalExpression;
 import io.trino.sql.tree.LogicalExpression.Operator;
 import io.trino.sql.tree.NodeRef;
+import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.RowDataType;
 import io.trino.sql.tree.SymbolReference;
 
@@ -51,6 +59,8 @@ import java.util.function.Predicate;
 
 import static com.google.common.base.Predicates.not;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.metadata.LiteralFunction.LITERAL_FUNCTION_NAME;
+import static io.trino.metadata.ResolvedFunction.isResolved;
 import static io.trino.sql.tree.BooleanLiteral.FALSE_LITERAL;
 import static io.trino.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static java.util.Objects.requireNonNull;
@@ -263,6 +273,40 @@ public final class ExpressionUtils
 
             return or(resultDisjunct.build());
         };
+    }
+
+    /**
+     * Returns whether expression is effectively literal. An effectitvely literal expression is a simple constant value, or null,
+     * in either {@link Literal} form, or other form returned by {@link LiteralEncoder}. In particular, other constant expressions
+     * like a deterministic function call with constant arguments are not considered effectitvely literal.
+     */
+    public static boolean isEffectivelyLiteral(PlannerContext plannerContext, Session session, Expression expression)
+    {
+        if (expression instanceof Literal) {
+            return true;
+        }
+        if (expression instanceof Cast) {
+            return ((Cast) expression).getExpression() instanceof Literal
+                    // a Cast(Literal(...)) can fail, so this requires verification
+                    && constantExpressionEvaluatesSuccessfully(plannerContext, session, expression);
+        }
+        if (expression instanceof FunctionCall) {
+            QualifiedName functionName = ((FunctionCall) expression).getName();
+            if (isResolved(functionName)) {
+                ResolvedFunction resolvedFunction = plannerContext.getMetadata().decodeFunction(functionName);
+                return LITERAL_FUNCTION_NAME.equals(resolvedFunction.getSignature().getName());
+            }
+        }
+
+        return false;
+    }
+
+    private static boolean constantExpressionEvaluatesSuccessfully(PlannerContext plannerContext, Session session, Expression constantExpression)
+    {
+        Map<NodeRef<Expression>, Type> types = getExpressionTypes(plannerContext, session, constantExpression, TypeProvider.empty());
+        ExpressionInterpreter interpreter = new ExpressionInterpreter(constantExpression, plannerContext, session, types);
+        Object literalValue = interpreter.optimize(NoOpSymbolResolver.INSTANCE);
+        return !(literalValue instanceof Expression);
     }
 
     /**

--- a/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionInterpreter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionInterpreter.java
@@ -559,11 +559,13 @@ public class ExpressionInterpreter
                         }
                         // This operand can be evaluated to a non-null value. Remaining operands can be skipped.
                         if (nestedOperand instanceof Literal) {
+                            verify(!(nestedOperand instanceof NullLiteral), "Null operand should have been removed by recursive coalesce processing");
                             return newOperands;
                         }
                     }
                 }
                 else if (value instanceof Expression) {
+                    verify(!(value instanceof NullLiteral), "Null value is expected to be represented as null, not NullLiteral");
                     // Skip duplicates unless they are non-deterministic.
                     Expression expression = (Expression) value;
                     if (!isDeterministic(expression, metadata) || uniqueNewOperands.add(expression)) {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionInterpreter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionInterpreter.java
@@ -238,7 +238,7 @@ public class ExpressionInterpreter
 
         // expressionInterpreter/optimizer only understands a subset of expression types
         // TODO: remove this when the new expression tree is implemented
-        Expression canonicalized = canonicalizeExpression(rewrite, analyzer.getExpressionTypes(), plannerContext.getMetadata(), session);
+        Expression canonicalized = canonicalizeExpression(rewrite, analyzer.getExpressionTypes(), plannerContext, session);
 
         // The optimization above may have rewritten the expression tree which breaks all the identity maps, so redo the analysis
         // to re-analyze coercions that might be necessary

--- a/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionInterpreter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionInterpreter.java
@@ -546,7 +546,6 @@ public class ExpressionInterpreter
 
         private List<Object> processOperands(CoalesceExpression node, Object context)
         {
-            Type type = type(node);
             List<Object> newOperands = new ArrayList<>();
             Set<Expression> uniqueNewOperands = new HashSet<>();
             for (Expression operand : node.getOperands()) {
@@ -566,7 +565,7 @@ public class ExpressionInterpreter
                 }
                 else if (value instanceof Expression) {
                     // Skip duplicates unless they are non-deterministic.
-                    Expression expression = toExpression(value, type);
+                    Expression expression = (Expression) value;
                     if (!isDeterministic(expression, metadata) || uniqueNewOperands.add(expression)) {
                         newOperands.add(expression);
                     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -444,7 +444,7 @@ public class PlanOptimizers
                                         new PruneCountAggregationOverScalar(metadata),
                                         new PruneOrderByInAggregation(metadata),
                                         new RewriteSpatialPartitioningAggregation(plannerContext),
-                                        new SimplifyCountOverConstant(metadata)))
+                                        new SimplifyCountOverConstant(plannerContext)))
                                 .build()),
                 new IterativeOptimizer(
                         metadata,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -349,7 +349,7 @@ public class PlanOptimizers
                 statsCalculator,
                 estimatedExchangesCostCalculator,
                 ImmutableSet.of(
-                        new InlineProjections(typeAnalyzer),
+                        new InlineProjections(plannerContext, typeAnalyzer),
                         new RemoveRedundantIdentityProjections()));
 
         Set<Rule<?>> simplifyOptimizerRules = ImmutableSet.<Rule<?>>builder()
@@ -417,7 +417,7 @@ public class PlanOptimizers
                                         new EvaluateEmptyIntersect(),
                                         new RemoveEmptyExceptBranches(),
                                         new MergeFilters(metadata),
-                                        new InlineProjections(typeAnalyzer),
+                                        new InlineProjections(plannerContext, typeAnalyzer),
                                         new RemoveRedundantIdentityProjections(),
                                         new RemoveFullSample(),
                                         new EvaluateZeroSample(),
@@ -534,7 +534,7 @@ public class PlanOptimizers
                         statsCalculator,
                         estimatedExchangesCostCalculator,
                         ImmutableSet.of(
-                                new InlineProjections(typeAnalyzer),
+                                new InlineProjections(plannerContext, typeAnalyzer),
                                 new RemoveRedundantIdentityProjections(),
                                 new TransformCorrelatedSingleRowSubqueryToProject(),
                                 new RemoveAggregationInSemiJoin(),
@@ -697,7 +697,7 @@ public class PlanOptimizers
                         ruleStats,
                         statsCalculator,
                         estimatedExchangesCostCalculator,
-                        ImmutableSet.of(new EliminateCrossJoins(metadata, typeAnalyzer))), // This can pull up Filter and Project nodes from between Joins, so we need to push them down again
+                        ImmutableSet.of(new EliminateCrossJoins(plannerContext, typeAnalyzer))), // This can pull up Filter and Project nodes from between Joins, so we need to push them down again
                 new StatsRecordingPlanOptimizer(
                         optimizerStats,
                         new PredicatePushDown(plannerContext, typeAnalyzer, true, false)),
@@ -750,7 +750,7 @@ public class PlanOptimizers
                         ruleStats,
                         statsCalculator,
                         estimatedExchangesCostCalculator,
-                        ImmutableSet.of(new ReorderJoins(metadata, costComparator, typeAnalyzer))));
+                        ImmutableSet.of(new ReorderJoins(plannerContext, costComparator, typeAnalyzer))));
 
         builder.add(new OptimizeMixedDistinctAggregations(metadata));
         builder.add(new IterativeOptimizer(
@@ -772,7 +772,7 @@ public class PlanOptimizers
                 ImmutableSet.<Rule<?>>builder()
                         .add(new RemoveRedundantIdentityProjections())
                         .addAll(new ExtractSpatialJoins(plannerContext, splitManager, pageSourceManager, typeAnalyzer).rules())
-                        .add(new InlineProjections(typeAnalyzer))
+                        .add(new InlineProjections(plannerContext, typeAnalyzer))
                         .build()));
 
         builder.add(new IterativeOptimizer(
@@ -884,7 +884,7 @@ public class PlanOptimizers
                 ImmutableSet.<Rule<?>>builder()
                         .add(new RemoveRedundantIdentityProjections())
                         .add(new PushRemoteExchangeThroughAssignUniqueId())
-                        .add(new InlineProjections(typeAnalyzer))
+                        .add(new InlineProjections(plannerContext, typeAnalyzer))
                         .build()));
 
         // Optimizers above this don't understand local exchanges, so be careful moving this.

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -358,7 +358,7 @@ public class PlanOptimizers
                 .addAll(new PushCastIntoRow().rules())
                 .addAll(new UnwrapCastInComparison(plannerContext, typeAnalyzer).rules())
                 .addAll(new RemoveDuplicateConditions(metadata).rules())
-                .addAll(new CanonicalizeExpressions(metadata, typeAnalyzer).rules())
+                .addAll(new CanonicalizeExpressions(plannerContext, typeAnalyzer).rules())
                 .add(new RemoveTrivialFilters())
                 .build();
         IterativeOptimizer simplifyOptimizer = new IterativeOptimizer(
@@ -397,7 +397,7 @@ public class PlanOptimizers
                         statsCalculator,
                         estimatedExchangesCostCalculator,
                         ImmutableSet.<Rule<?>>builder()
-                                .addAll(new CanonicalizeExpressions(metadata, typeAnalyzer).rules())
+                                .addAll(new CanonicalizeExpressions(plannerContext, typeAnalyzer).rules())
                                 .add(new OptimizeRowPattern())
                                 .build()),
                 new IterativeOptimizer(

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/CanonicalizeExpressions.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/CanonicalizeExpressions.java
@@ -13,7 +13,7 @@
  */
 package io.trino.sql.planner.iterative.rule;
 
-import io.trino.metadata.Metadata;
+import io.trino.sql.PlannerContext;
 import io.trino.sql.planner.TypeAnalyzer;
 
 import static io.trino.sql.planner.iterative.rule.CanonicalizeExpressionRewriter.rewrite;
@@ -21,8 +21,8 @@ import static io.trino.sql.planner.iterative.rule.CanonicalizeExpressionRewriter
 public class CanonicalizeExpressions
         extends ExpressionRewriteRuleSet
 {
-    public CanonicalizeExpressions(Metadata metadata, TypeAnalyzer typeAnalyzer)
+    public CanonicalizeExpressions(PlannerContext plannerContext, TypeAnalyzer typeAnalyzer)
     {
-        super((expression, context) -> rewrite(expression, context.getSession(), metadata, typeAnalyzer, context.getSymbolAllocator().getTypes()));
+        super((expression, context) -> rewrite(expression, context.getSession(), plannerContext, typeAnalyzer, context.getSymbolAllocator().getTypes()));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/EliminateCrossJoins.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/EliminateCrossJoins.java
@@ -20,7 +20,7 @@ import io.trino.FeaturesConfig.JoinReorderingStrategy;
 import io.trino.Session;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
-import io.trino.metadata.Metadata;
+import io.trino.sql.PlannerContext;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.TypeAnalyzer;
@@ -55,12 +55,12 @@ public class EliminateCrossJoins
         implements Rule<JoinNode>
 {
     private static final Pattern<JoinNode> PATTERN = join();
-    private final Metadata metadata;
+    private final PlannerContext plannerContext;
     private final TypeAnalyzer typeAnalyzer;
 
-    public EliminateCrossJoins(Metadata metadata, TypeAnalyzer typeAnalyzer)
+    public EliminateCrossJoins(PlannerContext plannerContext, TypeAnalyzer typeAnalyzer)
     {
-        this.metadata = metadata;
+        this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
         this.typeAnalyzer = requireNonNull(typeAnalyzer, "typeAnalyzer is null");
     }
 
@@ -81,7 +81,7 @@ public class EliminateCrossJoins
     @Override
     public Result apply(JoinNode node, Captures captures, Context context)
     {
-        JoinGraph joinGraph = JoinGraph.buildFrom(metadata, node, context.getLookup(), context.getIdAllocator(), context.getSession(), typeAnalyzer, context.getSymbolAllocator().getTypes());
+        JoinGraph joinGraph = JoinGraph.buildFrom(plannerContext, node, context.getLookup(), context.getIdAllocator(), context.getSession(), typeAnalyzer, context.getSymbolAllocator().getTypes());
         if (joinGraph.size() < 3 || !joinGraph.isContainsCrossJoin()) {
             return Result.empty();
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushProjectionThroughJoin.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushProjectionThroughJoin.java
@@ -16,7 +16,7 @@ package io.trino.sql.planner.iterative.rule;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
 import io.trino.Session;
-import io.trino.metadata.Metadata;
+import io.trino.sql.PlannerContext;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.SymbolsExtractor;
@@ -48,7 +48,7 @@ import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
 public final class PushProjectionThroughJoin
 {
     public static Optional<PlanNode> pushProjectionThroughJoin(
-            Metadata metadata,
+            PlannerContext plannerContext,
             ProjectNode projectNode,
             Lookup lookup,
             PlanNodeIdAllocator planNodeIdAllocator,
@@ -56,7 +56,7 @@ public final class PushProjectionThroughJoin
             TypeAnalyzer typeAnalyzer,
             TypeProvider types)
     {
-        if (!projectNode.getAssignments().getExpressions().stream().allMatch(expression -> isDeterministic(expression, metadata))) {
+        if (!projectNode.getAssignments().getExpressions().stream().allMatch(expression -> isDeterministic(expression, plannerContext.getMetadata()))) {
             return Optional.empty();
         }
 
@@ -117,12 +117,14 @@ public final class PushProjectionThroughJoin
                 joinNode.getId(),
                 joinNode.getType(),
                 inlineProjections(
+                        plannerContext,
                         new ProjectNode(planNodeIdAllocator.getNextId(), leftChild, leftAssignments),
                         lookup,
                         session,
                         typeAnalyzer,
                         types),
                 inlineProjections(
+                        plannerContext,
                         new ProjectNode(planNodeIdAllocator.getNextId(), rightChild, rightAssignments),
                         lookup,
                         session,
@@ -141,7 +143,13 @@ public final class PushProjectionThroughJoin
                 joinNode.getReorderJoinStatsAndCost()));
     }
 
-    private static PlanNode inlineProjections(ProjectNode parentProjection, Lookup lookup, Session session, TypeAnalyzer typeAnalyzer, TypeProvider types)
+    private static PlanNode inlineProjections(
+            PlannerContext plannerContext,
+            ProjectNode parentProjection,
+            Lookup lookup,
+            Session session,
+            TypeAnalyzer typeAnalyzer,
+            TypeProvider types)
     {
         PlanNode child = lookup.resolve(parentProjection.getSource());
         if (!(child instanceof ProjectNode)) {
@@ -149,8 +157,8 @@ public final class PushProjectionThroughJoin
         }
         ProjectNode childProjection = (ProjectNode) child;
 
-        return InlineProjections.inlineProjections(parentProjection, childProjection, session, typeAnalyzer, types)
-                .map(node -> inlineProjections(node, lookup, session, typeAnalyzer, types))
+        return InlineProjections.inlineProjections(plannerContext, parentProjection, childProjection, session, typeAnalyzer, types)
+                .map(node -> inlineProjections(plannerContext, node, lookup, session, typeAnalyzer, types))
                 .orElse(parentProjection);
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ReorderJoins.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ReorderJoins.java
@@ -33,6 +33,7 @@ import io.trino.cost.StatsProvider;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
 import io.trino.metadata.Metadata;
+import io.trino.sql.PlannerContext;
 import io.trino.sql.planner.EqualityInference;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.Symbol;
@@ -103,17 +104,17 @@ public class ReorderJoins
     private final Pattern<JoinNode> pattern;
     private final TypeAnalyzer typeAnalyzer;
 
-    private final Metadata metadata;
+    private final PlannerContext plannerContext;
     private final CostComparator costComparator;
 
-    public ReorderJoins(Metadata metadata, CostComparator costComparator, TypeAnalyzer typeAnalyzer)
+    public ReorderJoins(PlannerContext plannerContext, CostComparator costComparator, TypeAnalyzer typeAnalyzer)
     {
-        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
         this.costComparator = requireNonNull(costComparator, "costComparator is null");
         this.pattern = join().matching(
                 joinNode -> joinNode.getDistributionType().isEmpty()
                         && joinNode.getType() == INNER
-                        && isDeterministic(joinNode.getFilter().orElse(TRUE_LITERAL), metadata));
+                        && isDeterministic(joinNode.getFilter().orElse(TRUE_LITERAL), plannerContext.getMetadata()));
         this.typeAnalyzer = requireNonNull(typeAnalyzer, "typeAnalyzer is null");
     }
 
@@ -133,7 +134,7 @@ public class ReorderJoins
     public Result apply(JoinNode joinNode, Captures captures, Context context)
     {
         // try reorder joins with projection pushdown first
-        MultiJoinNode multiJoinNode = toMultiJoinNode(metadata, joinNode, context, true, typeAnalyzer);
+        MultiJoinNode multiJoinNode = toMultiJoinNode(plannerContext, joinNode, context, true, typeAnalyzer);
         JoinEnumerationResult resultWithProjectionPushdown = chooseJoinOrder(multiJoinNode, context);
         if (resultWithProjectionPushdown.getPlanNode().isEmpty()) {
             return Result.empty();
@@ -144,7 +145,7 @@ public class ReorderJoins
         }
 
         // try reorder joins without projection pushdown
-        multiJoinNode = toMultiJoinNode(metadata, joinNode, context, false, typeAnalyzer);
+        multiJoinNode = toMultiJoinNode(plannerContext, joinNode, context, false, typeAnalyzer);
         JoinEnumerationResult resultWithoutProjectionPushdown = chooseJoinOrder(multiJoinNode, context);
         if (resultWithoutProjectionPushdown.getPlanNode().isEmpty()
                 || costComparator.compare(context.getSession(), resultWithProjectionPushdown.cost, resultWithoutProjectionPushdown.cost) < 0) {
@@ -157,7 +158,7 @@ public class ReorderJoins
     private JoinEnumerationResult chooseJoinOrder(MultiJoinNode multiJoinNode, Context context)
     {
         JoinEnumerator joinEnumerator = new JoinEnumerator(
-                metadata,
+                plannerContext.getMetadata(),
                 costComparator,
                 multiJoinNode.getFilter(),
                 context);
@@ -549,10 +550,10 @@ public class ReorderJoins
                     && this.pushedProjectionThroughJoin == other.pushedProjectionThroughJoin;
         }
 
-        static MultiJoinNode toMultiJoinNode(Metadata metadata, JoinNode joinNode, Context context, boolean pushProjectionsThroughJoin, TypeAnalyzer typeAnalyzer)
+        static MultiJoinNode toMultiJoinNode(PlannerContext plannerContext, JoinNode joinNode, Context context, boolean pushProjectionsThroughJoin, TypeAnalyzer typeAnalyzer)
         {
             return toMultiJoinNode(
-                    metadata,
+                    plannerContext,
                     joinNode,
                     context.getLookup(),
                     context.getIdAllocator(),
@@ -564,7 +565,7 @@ public class ReorderJoins
         }
 
         static MultiJoinNode toMultiJoinNode(
-                Metadata metadata,
+                PlannerContext plannerContext,
                 JoinNode joinNode,
                 Lookup lookup,
                 PlanNodeIdAllocator planNodeIdAllocator,
@@ -575,13 +576,13 @@ public class ReorderJoins
                 TypeProvider types)
         {
             // the number of sources is the number of joins + 1
-            return new JoinNodeFlattener(metadata, joinNode, lookup, planNodeIdAllocator, joinLimit + 1, pushProjectionsThroughJoin, session, typeAnalyzer, types)
+            return new JoinNodeFlattener(plannerContext, joinNode, lookup, planNodeIdAllocator, joinLimit + 1, pushProjectionsThroughJoin, session, typeAnalyzer, types)
                     .toMultiJoinNode();
         }
 
         private static class JoinNodeFlattener
         {
-            private final Metadata metadata;
+            private final PlannerContext plannerContext;
             private final Session session;
             private final TypeAnalyzer typeAnalyzer;
             private final TypeProvider types;
@@ -597,7 +598,7 @@ public class ReorderJoins
             private boolean pushedProjectionThroughJoin;
 
             JoinNodeFlattener(
-                    Metadata metadata,
+                    PlannerContext plannerContext,
                     JoinNode node,
                     Lookup lookup,
                     PlanNodeIdAllocator planNodeIdAllocator,
@@ -607,7 +608,7 @@ public class ReorderJoins
                     TypeAnalyzer typeAnalyzer,
                     TypeProvider types)
             {
-                this.metadata = requireNonNull(metadata, "metadata is null");
+                this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
                 requireNonNull(node, "node is null");
                 checkState(node.getType() == INNER, "join type must be INNER");
                 this.outputSymbols = node.getOutputSymbols();
@@ -631,7 +632,7 @@ public class ReorderJoins
                         return;
                     }
 
-                    Optional<PlanNode> rewrittenNode = pushProjectionThroughJoin(metadata, (ProjectNode) resolved, lookup, planNodeIdAllocator, session, typeAnalyzer, types);
+                    Optional<PlanNode> rewrittenNode = pushProjectionThroughJoin(plannerContext, (ProjectNode) resolved, lookup, planNodeIdAllocator, session, typeAnalyzer, types);
                     if (rewrittenNode.isEmpty()) {
                         sources.add(node);
                         return;
@@ -649,7 +650,7 @@ public class ReorderJoins
                 }
 
                 JoinNode joinNode = (JoinNode) resolved;
-                if (joinNode.getType() != INNER || !isDeterministic(joinNode.getFilter().orElse(TRUE_LITERAL), metadata) || joinNode.getDistributionType().isPresent()) {
+                if (joinNode.getType() != INNER || !isDeterministic(joinNode.getFilter().orElse(TRUE_LITERAL), plannerContext.getMetadata()) || joinNode.getDistributionType().isPresent()) {
                     sources.add(node);
                     return;
                 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SimplifyCountOverConstant.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SimplifyCountOverConstant.java
@@ -14,11 +14,15 @@
 package io.trino.sql.planner.iterative.rule;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.trino.Session;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
 import io.trino.metadata.BoundSignature;
 import io.trino.metadata.ResolvedFunction;
+import io.trino.security.AllowAllAccessControl;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.Rule;
@@ -26,8 +30,6 @@ import io.trino.sql.planner.plan.AggregationNode;
 import io.trino.sql.planner.plan.Assignments;
 import io.trino.sql.planner.plan.ProjectNode;
 import io.trino.sql.tree.Expression;
-import io.trino.sql.tree.Literal;
-import io.trino.sql.tree.NullLiteral;
 import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.SymbolReference;
 
@@ -36,7 +38,10 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 
+import static com.google.common.base.Verify.verify;
 import static io.trino.matching.Capture.newCapture;
+import static io.trino.sql.ExpressionUtils.isEffectivelyLiteral;
+import static io.trino.sql.planner.ExpressionInterpreter.evaluateConstantExpression;
 import static io.trino.sql.planner.plan.Patterns.aggregation;
 import static io.trino.sql.planner.plan.Patterns.project;
 import static io.trino.sql.planner.plan.Patterns.source;
@@ -77,7 +82,7 @@ public class SimplifyCountOverConstant
             Symbol symbol = entry.getKey();
             AggregationNode.Aggregation aggregation = entry.getValue();
 
-            if (isCountOverConstant(aggregation, child.getAssignments())) {
+            if (isCountOverConstant(context.getSession(), aggregation, child.getAssignments())) {
                 changed = true;
                 aggregations.put(symbol, new AggregationNode.Aggregation(
                         countFunction,
@@ -104,7 +109,7 @@ public class SimplifyCountOverConstant
                 parent.getGroupIdSymbol()));
     }
 
-    private static boolean isCountOverConstant(AggregationNode.Aggregation aggregation, Assignments inputs)
+    private boolean isCountOverConstant(Session session, AggregationNode.Aggregation aggregation, Assignments inputs)
     {
         BoundSignature signature = aggregation.getResolvedFunction().getSignature();
         if (!signature.getName().equals("count") || signature.getArgumentTypes().size() != 1) {
@@ -116,6 +121,20 @@ public class SimplifyCountOverConstant
             argument = inputs.get(Symbol.from(argument));
         }
 
-        return argument instanceof Literal && !(argument instanceof NullLiteral);
+        if (isEffectivelyLiteral(plannerContext, session, argument)) {
+            Object value = evaluateConstantExpression(
+                    argument,
+                    ImmutableMap.of(),
+                    ImmutableSet.of(),
+                    plannerContext,
+                    session,
+                    new AllowAllAccessControl(),
+                    ImmutableSet.of(),
+                    ImmutableMap.of());
+            verify(!(value instanceof Expression));
+            return value != null;
+        }
+
+        return false;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SimplifyCountOverConstant.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SimplifyCountOverConstant.java
@@ -18,8 +18,8 @@ import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
 import io.trino.metadata.BoundSignature;
-import io.trino.metadata.Metadata;
 import io.trino.metadata.ResolvedFunction;
+import io.trino.sql.PlannerContext;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.plan.AggregationNode;
@@ -50,11 +50,11 @@ public class SimplifyCountOverConstant
     private static final Pattern<AggregationNode> PATTERN = aggregation()
             .with(source().matching(project().capturedAs(CHILD)));
 
-    private final Metadata metadata;
+    private final PlannerContext plannerContext;
 
-    public SimplifyCountOverConstant(Metadata metadata)
+    public SimplifyCountOverConstant(PlannerContext plannerContext)
     {
-        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
     }
 
     @Override
@@ -71,7 +71,7 @@ public class SimplifyCountOverConstant
         boolean changed = false;
         Map<Symbol, AggregationNode.Aggregation> aggregations = new LinkedHashMap<>(parent.getAggregations());
 
-        ResolvedFunction countFunction = metadata.resolveFunction(context.getSession(), QualifiedName.of("count"), ImmutableList.of());
+        ResolvedFunction countFunction = plannerContext.getMetadata().resolveFunction(context.getSession(), QualifiedName.of("count"), ImmutableList.of());
 
         for (Entry<Symbol, AggregationNode.Aggregation> entry : parent.getAggregations().entrySet()) {
             Symbol symbol = entry.getKey();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddLocalExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddLocalExchanges.java
@@ -59,7 +59,6 @@ import io.trino.sql.planner.plan.TopNNode;
 import io.trino.sql.planner.plan.TopNRankingNode;
 import io.trino.sql.planner.plan.UnionNode;
 import io.trino.sql.planner.plan.WindowNode;
-import io.trino.sql.tree.Literal;
 import io.trino.sql.tree.SymbolReference;
 
 import java.util.ArrayList;
@@ -77,6 +76,7 @@ import static io.trino.SystemSessionProperties.getTaskConcurrency;
 import static io.trino.SystemSessionProperties.getTaskWriterCount;
 import static io.trino.SystemSessionProperties.isDistributedSortEnabled;
 import static io.trino.SystemSessionProperties.isSpillEnabled;
+import static io.trino.sql.ExpressionUtils.isEffectivelyLiteral;
 import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_ARBITRARY_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
@@ -178,7 +178,7 @@ public class AddLocalExchanges
         {
             // Special handling for trivial projections. Applies to identity and renaming projections, and constants
             // It might be extended to handle other low-cost projections.
-            if (node.getAssignments().getExpressions().stream().allMatch(expression -> expression instanceof SymbolReference || expression instanceof Literal)) {
+            if (node.getAssignments().getExpressions().stream().allMatch(expression -> expression instanceof SymbolReference || isEffectivelyLiteral(plannerContext, session, expression))) {
                 if (parentPreferences.isSingleStreamPreferred()) {
                     // Do not enforce gathering exchange below project:
                     // - if project's source is single stream, no exchanges will be added around project,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
@@ -295,7 +295,7 @@ public class PredicatePushDown
 
             List<Expression> inlinedDeterministicConjuncts = inlineConjuncts.get(true).stream()
                     .map(entry -> inlineSymbols(node.getAssignments().getMap(), entry))
-                    .map(conjunct -> canonicalizeExpression(conjunct, typeAnalyzer.getTypes(session, types, conjunct), metadata, session)) // normalize expressions to a form that unwrapCasts understands
+                    .map(conjunct -> canonicalizeExpression(conjunct, typeAnalyzer.getTypes(session, types, conjunct), plannerContext, session)) // normalize expressions to a form that unwrapCasts understands
                     .map(conjunct -> unwrapCasts(session, plannerContext, typeAnalyzer, types, conjunct))
                     .collect(Collectors.toList());
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
@@ -61,7 +61,6 @@ import io.trino.sql.tree.BetweenPredicate;
 import io.trino.sql.tree.BooleanLiteral;
 import io.trino.sql.tree.ComparisonExpression;
 import io.trino.sql.tree.Expression;
-import io.trino.sql.tree.Literal;
 import io.trino.sql.tree.NodeRef;
 import io.trino.sql.tree.NotExpression;
 import io.trino.sql.tree.NullLiteral;
@@ -97,6 +96,7 @@ import static io.trino.sql.DynamicFilters.createDynamicFilterExpression;
 import static io.trino.sql.ExpressionUtils.combineConjuncts;
 import static io.trino.sql.ExpressionUtils.extractConjuncts;
 import static io.trino.sql.ExpressionUtils.filterDeterministicConjuncts;
+import static io.trino.sql.ExpressionUtils.isEffectivelyLiteral;
 import static io.trino.sql.planner.DeterminismEvaluator.isDeterministic;
 import static io.trino.sql.planner.ExpressionSymbolInliner.inlineSymbols;
 import static io.trino.sql.planner.SymbolsExtractor.extractUnique;
@@ -331,7 +331,7 @@ public class PredicatePushDown
 
             return dependencies.entrySet().stream()
                     .allMatch(entry -> entry.getValue() == 1
-                            || node.getAssignments().get(entry.getKey()) instanceof Literal
+                            || isEffectivelyLiteral(plannerContext, session, node.getAssignments().get(entry.getKey()))
                             || node.getAssignments().get(entry.getKey()) instanceof SymbolReference);
         }
 

--- a/core/trino-main/src/test/java/io/trino/sql/ExpressionTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/sql/ExpressionTestUtils.java
@@ -107,7 +107,7 @@ public final class ExpressionTestUtils
         Expression rewritten = rewriteIdentifiersToSymbolReferences(expression);
         rewritten = DesugarLikeRewriter.rewrite(rewritten, transactionSession, plannerContext.getMetadata(), createTestingTypeAnalyzer(plannerContext), typeProvider);
         rewritten = DesugarArrayConstructorRewriter.rewrite(rewritten, transactionSession, plannerContext.getMetadata(), createTestingTypeAnalyzer(plannerContext), typeProvider);
-        rewritten = CanonicalizeExpressionRewriter.rewrite(rewritten, transactionSession, plannerContext.getMetadata(), createTestingTypeAnalyzer(plannerContext), typeProvider);
+        rewritten = CanonicalizeExpressionRewriter.rewrite(rewritten, transactionSession, plannerContext, createTestingTypeAnalyzer(plannerContext), typeProvider);
         return resolveFunctionCalls(plannerContext, transactionSession, typeProvider, rewritten);
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
@@ -1939,7 +1939,7 @@ public class TestExpressionInterpreter
                     parsedExpression = CanonicalizeExpressionRewriter.rewrite(
                             parsedExpression,
                             transactionSession,
-                            PLANNER_CONTEXT.getMetadata(),
+                            PLANNER_CONTEXT,
                             createTestingTypeAnalyzer(PLANNER_CONTEXT),
                             SYMBOL_TYPES);
                     return parsedExpression;

--- a/core/trino-main/src/test/java/io/trino/sql/TestSqlToRowExpressionTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/TestSqlToRowExpressionTranslator.java
@@ -14,12 +14,8 @@
 package io.trino.sql;
 
 import com.google.common.collect.ImmutableMap;
-import io.trino.execution.warnings.WarningCollector;
-import io.trino.security.AllowAllAccessControl;
 import io.trino.spi.type.Decimals;
 import io.trino.spi.type.Type;
-import io.trino.sql.analyzer.ExpressionAnalyzer;
-import io.trino.sql.analyzer.Scope;
 import io.trino.sql.planner.ExpressionInterpreter;
 import io.trino.sql.planner.LiteralEncoder;
 import io.trino.sql.planner.NoOpSymbolResolver;
@@ -42,7 +38,6 @@ import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
 import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expression;
 import static io.trino.sql.relational.Expressions.constant;
 import static io.trino.testing.assertions.Assert.assertEquals;
-import static java.util.Collections.emptyMap;
 
 public class TestSqlToRowExpressionTranslator
 {
@@ -105,16 +100,6 @@ public class TestSqlToRowExpressionTranslator
 
     private Map<NodeRef<Expression>, Type> getExpressionTypes(Expression expression)
     {
-        ExpressionAnalyzer expressionAnalyzer = ExpressionAnalyzer.createWithoutSubqueries(
-                PLANNER_CONTEXT,
-                new AllowAllAccessControl(),
-                TEST_SESSION,
-                TypeProvider.empty(),
-                emptyMap(),
-                node -> new IllegalStateException("Unexpected node: " + node),
-                WarningCollector.NOOP,
-                false);
-        expressionAnalyzer.analyze(expression, Scope.create());
-        return expressionAnalyzer.getExpressionTypes();
+        return ExpressionUtils.getExpressionTypes(PLANNER_CONTEXT, TEST_SESSION, expression, TypeProvider.empty());
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLiteralEncoder.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLiteralEncoder.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
-import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.BoundSignature;
 import io.trino.metadata.FunctionNullability;
 import io.trino.metadata.LiteralFunction;
@@ -31,8 +30,7 @@ import io.trino.spi.type.TimeZoneKey;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeSignature;
 import io.trino.spi.type.VarcharType;
-import io.trino.sql.analyzer.ExpressionAnalyzer;
-import io.trino.sql.analyzer.Scope;
+import io.trino.sql.ExpressionUtils;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.NodeRef;
 import io.trino.transaction.TestingTransactionManager;
@@ -76,7 +74,6 @@ import static io.trino.type.Re2JRegexpType.RE2J_REGEXP_SIGNATURE;
 import static io.trino.type.UnknownType.UNKNOWN;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Collections.emptyMap;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -301,18 +298,7 @@ public class TestLiteralEncoder
         return transaction(new TestingTransactionManager(), new AllowAllAccessControl())
                 .singleStatement()
                 .execute(TEST_SESSION, transactionSession -> {
-                    ExpressionAnalyzer expressionAnalyzer = ExpressionAnalyzer.createWithoutSubqueries(
-                            PLANNER_CONTEXT,
-                            new AllowAllAccessControl(),
-                            transactionSession,
-                            TypeProvider.empty(),
-                            emptyMap(),
-                            node -> new IllegalStateException("Unexpected node: " + node),
-                            WarningCollector.NOOP,
-                            false);
-                    expressionAnalyzer.analyze(expression, Scope.create());
-                    Map<NodeRef<Expression>, Type> expressionTypes = expressionAnalyzer.getExpressionTypes();
-                    return expressionTypes;
+                    return ExpressionUtils.getExpressionTypes(PLANNER_CONTEXT, transactionSession, expression, TypeProvider.empty());
                 });
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLiteralEncoder.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLiteralEncoder.java
@@ -63,6 +63,7 @@ import static io.trino.spi.type.TypeSignatureParameter.typeVariable;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createVarcharType;
+import static io.trino.sql.ExpressionUtils.isEffectivelyLiteral;
 import static io.trino.sql.SqlFormatter.formatSql;
 import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
 import static io.trino.transaction.TransactionBuilder.transaction;
@@ -266,6 +267,7 @@ public class TestLiteralEncoder
     private void assertEncodeCaseInsensitively(Object value, Type type, String expected)
     {
         Expression expression = encoder.toExpression(TEST_SESSION, value, type);
+        assertTrue(isEffectivelyLiteral(PLANNER_CONTEXT, TEST_SESSION, expression), "isEffectivelyLiteral returned false for: " + expression);
         assertEquals(getExpressionType(expression), type);
         assertEquals(getExpressionValue(expression), value);
         assertEqualsIgnoreCase(formatSql(expression), expected);
@@ -274,6 +276,7 @@ public class TestLiteralEncoder
     private <T> void assertRoundTrip(T value, Type type, BiPredicate<T, T> predicate)
     {
         Expression expression = encoder.toExpression(TEST_SESSION, value, type);
+        assertTrue(isEffectivelyLiteral(PLANNER_CONTEXT, TEST_SESSION, expression), "isEffectivelyLiteral returned false for: " + expression);
         assertEquals(getExpressionType(expression), type);
         @SuppressWarnings("unchecked")
         T decodedValue = (T) getExpressionValue(expression);

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
@@ -995,10 +995,22 @@ public class TestLogicalPlanner
     }
 
     @Test
-    public void testInlineCountOverConstantExpression()
+    public void testInlineCountOverLiteral()
     {
         assertPlan(
                 "SELECT regionkey, count(1) FROM nation GROUP BY regionkey",
+                anyTree(
+                        aggregation(
+                                ImmutableMap.of("count_0", functionCall("count", ImmutableList.of())),
+                                PARTIAL,
+                                tableScan("nation", ImmutableMap.of("regionkey", "regionkey")))));
+    }
+
+    @Test
+    public void testInlineCountOverEffectivelyLiteral()
+    {
+        assertPlan(
+                "SELECT regionkey, count(CAST(DECIMAL '1' AS decimal(8,4))) FROM nation GROUP BY regionkey",
                 anyTree(
                         aggregation(
                                 ImmutableMap.of("count_0", functionCall("count", ImmutableList.of())),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
@@ -72,6 +72,7 @@ import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.Row;
 import io.trino.sql.tree.SortItem;
 import io.trino.sql.tree.WindowFrame;
+import org.intellij.lang.annotations.Language;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -1015,7 +1016,7 @@ public final class PlanMatchPattern
         return new ColumnReference(tableName, columnName);
     }
 
-    public static ExpressionMatcher expression(String expression)
+    public static ExpressionMatcher expression(@Language("SQL") String expression)
     {
         return new ExpressionMatcher(expression);
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestCanonicalizeExpressionRewriter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestCanonicalizeExpressionRewriter.java
@@ -127,7 +127,7 @@ public class TestCanonicalizeExpressionRewriter
                     return rewrite(
                             PlanBuilder.expression(from),
                             transactedSession,
-                            PLANNER_CONTEXT.getMetadata(),
+                            PLANNER_CONTEXT,
                             TYPE_ANALYZER,
                                     TypeProvider.copyOf(ImmutableMap.<Symbol, Type>builder()
                                             .put(new Symbol("x"), BIGINT)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestCanonicalizeExpressions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestCanonicalizeExpressions.java
@@ -25,7 +25,7 @@ public class TestCanonicalizeExpressions
     @Test
     public void testDoesNotFireForExpressionsInCanonicalForm()
     {
-        CanonicalizeExpressions canonicalizeExpressions = new CanonicalizeExpressions(tester().getMetadata(), tester().getTypeAnalyzer());
+        CanonicalizeExpressions canonicalizeExpressions = new CanonicalizeExpressions(tester().getPlannerContext(), tester().getTypeAnalyzer());
         tester().assertThat(canonicalizeExpressions.filterExpressionRewrite())
                 .on(p -> p.filter(FALSE_LITERAL, p.values()))
                 .doesNotFire();
@@ -34,7 +34,7 @@ public class TestCanonicalizeExpressions
     @Test
     public void testDoesNotFireForUnfilteredJoin()
     {
-        CanonicalizeExpressions canonicalizeExpressions = new CanonicalizeExpressions(tester().getMetadata(), tester().getTypeAnalyzer());
+        CanonicalizeExpressions canonicalizeExpressions = new CanonicalizeExpressions(tester().getPlannerContext(), tester().getTypeAnalyzer());
         tester().assertThat(canonicalizeExpressions.joinExpressionRewrite())
                 .on(p -> p.join(INNER, p.values(), p.values()))
                 .doesNotFire();
@@ -43,7 +43,7 @@ public class TestCanonicalizeExpressions
     @Test
     public void testDoesNotFireForCanonicalExpressions()
     {
-        CanonicalizeExpressions canonicalizeExpressions = new CanonicalizeExpressions(tester().getMetadata(), tester().getTypeAnalyzer());
+        CanonicalizeExpressions canonicalizeExpressions = new CanonicalizeExpressions(tester().getPlannerContext(), tester().getTypeAnalyzer());
         tester().assertThat(canonicalizeExpressions.joinExpressionRewrite())
                 .on(p -> p.join(INNER, p.values(), p.values(), FALSE_LITERAL))
                 .doesNotFire();

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestEliminateCrossJoins.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestEliminateCrossJoins.java
@@ -69,7 +69,7 @@ public class TestEliminateCrossJoins
     @Test
     public void testEliminateCrossJoin()
     {
-        tester().assertThat(new EliminateCrossJoins(tester().getMetadata(), tester().getTypeAnalyzer()))
+        tester().assertThat(new EliminateCrossJoins(tester().getPlannerContext(), tester().getTypeAnalyzer()))
                 .setSystemProperty(JOIN_REORDERING_STRATEGY, "ELIMINATE_CROSS_JOINS")
                 .on(crossJoinAndJoin(INNER))
                 .matches(
@@ -85,7 +85,7 @@ public class TestEliminateCrossJoins
     @Test
     public void testRetainOutgoingGroupReferences()
     {
-        tester().assertThat(new EliminateCrossJoins(tester().getMetadata(), tester().getTypeAnalyzer()))
+        tester().assertThat(new EliminateCrossJoins(tester().getPlannerContext(), tester().getTypeAnalyzer()))
                 .setSystemProperty(JOIN_REORDERING_STRATEGY, "ELIMINATE_CROSS_JOINS")
                 .on(crossJoinAndJoin(INNER))
                 .matches(
@@ -99,7 +99,7 @@ public class TestEliminateCrossJoins
     @Test
     public void testDoNotReorderOuterJoin()
     {
-        tester().assertThat(new EliminateCrossJoins(tester().getMetadata(), tester().getTypeAnalyzer()))
+        tester().assertThat(new EliminateCrossJoins(tester().getPlannerContext(), tester().getTypeAnalyzer()))
                 .setSystemProperty(JOIN_REORDERING_STRATEGY, "ELIMINATE_CROSS_JOINS")
                 .on(crossJoinAndJoin(JoinNode.Type.LEFT))
                 .doesNotFire();
@@ -126,7 +126,7 @@ public class TestEliminateCrossJoins
                         "a", "c",
                         "b", "c");
 
-        JoinGraph joinGraph = JoinGraph.buildFrom(tester().getMetadata(), plan, noLookup(), new PlanNodeIdAllocator(), session, createTestingTypeAnalyzer(tester().getPlannerContext()), TypeProvider.empty());
+        JoinGraph joinGraph = JoinGraph.buildFrom(tester().getPlannerContext(), plan, noLookup(), new PlanNodeIdAllocator(), session, createTestingTypeAnalyzer(tester().getPlannerContext()), TypeProvider.empty());
 
         assertEquals(
                 getJoinOrder(joinGraph),
@@ -158,7 +158,7 @@ public class TestEliminateCrossJoins
 
         PlanNode plan = joinNode(leftPlan, rightPlan);
 
-        JoinGraph joinGraph = JoinGraph.buildFrom(tester().getMetadata(), plan, noLookup(), new PlanNodeIdAllocator(), session, createTestingTypeAnalyzer(tester().getPlannerContext()), TypeProvider.empty());
+        JoinGraph joinGraph = JoinGraph.buildFrom(tester().getPlannerContext(), plan, noLookup(), new PlanNodeIdAllocator(), session, createTestingTypeAnalyzer(tester().getPlannerContext()), TypeProvider.empty());
 
         assertEquals(
                 getJoinOrder(joinGraph),
@@ -180,7 +180,7 @@ public class TestEliminateCrossJoins
                         "b1", "c1",
                         "b2", "c2");
 
-        JoinGraph joinGraph = JoinGraph.buildFrom(tester().getMetadata(), plan, noLookup(), new PlanNodeIdAllocator(), session, createTestingTypeAnalyzer(tester().getPlannerContext()), TypeProvider.empty());
+        JoinGraph joinGraph = JoinGraph.buildFrom(tester().getPlannerContext(), plan, noLookup(), new PlanNodeIdAllocator(), session, createTestingTypeAnalyzer(tester().getPlannerContext()), TypeProvider.empty());
 
         assertEquals(
                 getJoinOrder(joinGraph),
@@ -201,7 +201,7 @@ public class TestEliminateCrossJoins
                         values("c"),
                         "b", "c");
 
-        JoinGraph joinGraph = JoinGraph.buildFrom(tester().getMetadata(), plan, noLookup(), new PlanNodeIdAllocator(), session, createTestingTypeAnalyzer(tester().getPlannerContext()), TypeProvider.empty());
+        JoinGraph joinGraph = JoinGraph.buildFrom(tester().getPlannerContext(), plan, noLookup(), new PlanNodeIdAllocator(), session, createTestingTypeAnalyzer(tester().getPlannerContext()), TypeProvider.empty());
 
         assertEquals(
                 getJoinOrder(joinGraph),
@@ -221,7 +221,7 @@ public class TestEliminateCrossJoins
                         values("c"),
                         "b", "c");
 
-        JoinGraph joinGraph = JoinGraph.buildFrom(tester().getMetadata(), plan, noLookup(), new PlanNodeIdAllocator(), session, createTestingTypeAnalyzer(tester().getPlannerContext()), TypeProvider.empty());
+        JoinGraph joinGraph = JoinGraph.buildFrom(tester().getPlannerContext(), plan, noLookup(), new PlanNodeIdAllocator(), session, createTestingTypeAnalyzer(tester().getPlannerContext()), TypeProvider.empty());
 
         assertEquals(
                 getJoinOrder(joinGraph),
@@ -231,7 +231,7 @@ public class TestEliminateCrossJoins
     @Test
     public void testEliminateCrossJoinWithNonIdentityProjections()
     {
-        tester().assertThat(new EliminateCrossJoins(tester().getMetadata(), tester().getTypeAnalyzer()))
+        tester().assertThat(new EliminateCrossJoins(tester().getPlannerContext(), tester().getTypeAnalyzer()))
                 .setSystemProperty(JOIN_REORDERING_STRATEGY, "ELIMINATE_CROSS_JOINS")
                 .on(p -> {
                     Symbol a1 = p.symbol("a1");
@@ -308,7 +308,7 @@ public class TestEliminateCrossJoins
                         "a2", "c",
                         "b", "c");
 
-        assertEquals(JoinGraph.buildFrom(tester().getMetadata(), plan, noLookup(), new PlanNodeIdAllocator(), session, createTestingTypeAnalyzer(tester().getPlannerContext()), TypeProvider.empty()).size(), 2);
+        assertEquals(JoinGraph.buildFrom(tester().getPlannerContext(), plan, noLookup(), new PlanNodeIdAllocator(), session, createTestingTypeAnalyzer(tester().getPlannerContext()), TypeProvider.empty()).size(), 2);
     }
 
     private Function<PlanBuilder, PlanNode> crossJoinAndJoin(JoinNode.Type secondJoinType)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestInlineProjections.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestInlineProjections.java
@@ -37,7 +37,7 @@ public class TestInlineProjections
     @Test
     public void test()
     {
-        tester().assertThat(new InlineProjections(tester().getTypeAnalyzer()))
+        tester().assertThat(new InlineProjections(tester().getPlannerContext(), tester().getTypeAnalyzer()))
                 .on(p ->
                         p.project(
                                 Assignments.builder()
@@ -86,7 +86,7 @@ public class TestInlineProjections
     @Test
     public void testEliminatesIdentityProjection()
     {
-        tester().assertThat(new InlineProjections(tester().getTypeAnalyzer()))
+        tester().assertThat(new InlineProjections(tester().getPlannerContext(), tester().getTypeAnalyzer()))
                 .on(p ->
                         p.project(
                                 Assignments.builder()
@@ -108,7 +108,7 @@ public class TestInlineProjections
     public void testIdentityProjections()
     {
         // projection renaming symbol
-        tester().assertThat(new InlineProjections(tester().getTypeAnalyzer()))
+        tester().assertThat(new InlineProjections(tester().getPlannerContext(), tester().getTypeAnalyzer()))
                 .on(p ->
                         p.project(
                                 Assignments.of(p.symbol("output"), expression("value")),
@@ -118,7 +118,7 @@ public class TestInlineProjections
                 .doesNotFire();
 
         // identity projection
-        tester().assertThat(new InlineProjections(tester().getTypeAnalyzer()))
+        tester().assertThat(new InlineProjections(tester().getPlannerContext(), tester().getTypeAnalyzer()))
                 .on(p ->
                         p.project(
                                 Assignments.identity(p.symbol("x")),
@@ -134,7 +134,7 @@ public class TestInlineProjections
     @Test
     public void testSubqueryProjections()
     {
-        tester().assertThat(new InlineProjections(tester().getTypeAnalyzer()))
+        tester().assertThat(new InlineProjections(tester().getPlannerContext(), tester().getTypeAnalyzer()))
                 .on(p ->
                         p.project(
                                 Assignments.identity(p.symbol("fromOuterScope"), p.symbol("value")),
@@ -147,7 +147,7 @@ public class TestInlineProjections
                                 // ImmutableMap.of("fromOuterScope", PlanMatchPattern.expression("fromOuterScope"), "value", PlanMatchPattern.expression("value")),
                                 values(ImmutableMap.of("value", 0))));
 
-        tester().assertThat(new InlineProjections(tester().getTypeAnalyzer()))
+        tester().assertThat(new InlineProjections(tester().getPlannerContext(), tester().getTypeAnalyzer()))
                 .on(p ->
                         p.project(
                                 Assignments.identity(p.symbol("fromOuterScope"), p.symbol("value_1")),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestJoinNodeFlattener.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestJoinNodeFlattener.java
@@ -103,7 +103,7 @@ public class TestJoinNodeFlattener
                 ImmutableList.of(a1),
                 ImmutableList.of(b1),
                 Optional.empty());
-        assertThatThrownBy(() -> toMultiJoinNode(queryRunner.getMetadata(), outerJoin, noLookup(), planNodeIdAllocator, DEFAULT_JOIN_LIMIT, false, testSessionBuilder().build(), createTestingTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes()))
+        assertThatThrownBy(() -> toMultiJoinNode(queryRunner.getPlannerContext(), outerJoin, noLookup(), planNodeIdAllocator, DEFAULT_JOIN_LIMIT, false, testSessionBuilder().build(), createTestingTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes()))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageMatching("join type must be.*");
     }
@@ -139,7 +139,7 @@ public class TestJoinNodeFlattener
                 .setOutputSymbols(a1, b1, c1)
                 .build();
         assertEquals(
-                toMultiJoinNode(queryRunner.getMetadata(), joinNode, noLookup(), planNodeIdAllocator, DEFAULT_JOIN_LIMIT, false, testSessionBuilder().build(), createTestingTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes()),
+                toMultiJoinNode(queryRunner.getPlannerContext(), joinNode, noLookup(), planNodeIdAllocator, DEFAULT_JOIN_LIMIT, false, testSessionBuilder().build(), createTestingTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes()),
                 expected);
     }
 
@@ -166,7 +166,7 @@ public class TestJoinNodeFlattener
                                 equiJoinClause(a, b))),
                 valuesC,
                 equiJoinClause(d, c));
-        MultiJoinNode actual = toMultiJoinNode(queryRunner.getMetadata(), joinNode, noLookup(), planNodeIdAllocator, DEFAULT_JOIN_LIMIT, true, testSessionBuilder().build(), createTestingTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes());
+        MultiJoinNode actual = toMultiJoinNode(queryRunner.getPlannerContext(), joinNode, noLookup(), planNodeIdAllocator, DEFAULT_JOIN_LIMIT, true, testSessionBuilder().build(), createTestingTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes());
         assertEquals(actual.getOutputSymbols(), ImmutableList.of(d, c));
         assertEquals(actual.getFilter(), and(createEqualsExpression(a, b), createEqualsExpression(d, c)));
         assertTrue(actual.isPushedProjectionThroughJoin());
@@ -212,7 +212,7 @@ public class TestJoinNodeFlattener
                                 equiJoinClause(a, b))),
                 valuesC,
                 equiJoinClause(d, c));
-        MultiJoinNode actual = toMultiJoinNode(queryRunner.getMetadata(), joinNode, noLookup(), planNodeIdAllocator, DEFAULT_JOIN_LIMIT, true, testSessionBuilder().build(), createTestingTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes());
+        MultiJoinNode actual = toMultiJoinNode(queryRunner.getPlannerContext(), joinNode, noLookup(), planNodeIdAllocator, DEFAULT_JOIN_LIMIT, true, testSessionBuilder().build(), createTestingTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes());
         assertEquals(actual.getOutputSymbols(), ImmutableList.of(d, c));
         assertEquals(actual.getFilter(), createEqualsExpression(d, c));
         assertFalse(actual.isPushedProjectionThroughJoin());
@@ -264,7 +264,7 @@ public class TestJoinNodeFlattener
                 .setOutputSymbols(a1, b1)
                 .build();
         assertEquals(
-                toMultiJoinNode(queryRunner.getMetadata(), joinNode, noLookup(), planNodeIdAllocator, DEFAULT_JOIN_LIMIT, false, testSessionBuilder().build(), createTestingTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes()),
+                toMultiJoinNode(queryRunner.getPlannerContext(), joinNode, noLookup(), planNodeIdAllocator, DEFAULT_JOIN_LIMIT, false, testSessionBuilder().build(), createTestingTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes()),
                 expected);
     }
 
@@ -310,7 +310,7 @@ public class TestJoinNodeFlattener
                 ImmutableList.of(a1, b1, b2, c1, c2),
                 false);
         assertEquals(
-                toMultiJoinNode(queryRunner.getMetadata(), joinNode, noLookup(), planNodeIdAllocator, DEFAULT_JOIN_LIMIT, false, testSessionBuilder().build(), createTestingTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes()),
+                toMultiJoinNode(queryRunner.getPlannerContext(), joinNode, noLookup(), planNodeIdAllocator, DEFAULT_JOIN_LIMIT, false, testSessionBuilder().build(), createTestingTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes()),
                 expected);
     }
 
@@ -368,7 +368,7 @@ public class TestJoinNodeFlattener
                 .setOutputSymbols(a1, b1, c1, d1, d2, e1, e2)
                 .build();
         assertEquals(
-                toMultiJoinNode(queryRunner.getMetadata(), joinNode, noLookup(), planNodeIdAllocator, 5, false, testSessionBuilder().build(), createTestingTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes()),
+                toMultiJoinNode(queryRunner.getPlannerContext(), joinNode, noLookup(), planNodeIdAllocator, 5, false, testSessionBuilder().build(), createTestingTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes()),
                 expected);
     }
 
@@ -428,7 +428,7 @@ public class TestJoinNodeFlattener
                 .setOutputSymbols(a1, b1, c1, d1, d2, e1, e2)
                 .build();
         assertEquals(
-                toMultiJoinNode(queryRunner.getMetadata(), joinNode, noLookup(), planNodeIdAllocator, 2, false, testSessionBuilder().build(), createTestingTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes()),
+                toMultiJoinNode(queryRunner.getPlannerContext(), joinNode, noLookup(), planNodeIdAllocator, 2, false, testSessionBuilder().build(), createTestingTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes()),
                 expected);
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushProjectionThroughJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushProjectionThroughJoin.java
@@ -88,7 +88,7 @@ public class TestPushProjectionThroughJoin
                         new JoinNode.EquiJoinClause(a1, b1)));
 
         Session session = testSessionBuilder().build();
-        Optional<PlanNode> rewritten = pushProjectionThroughJoin(PLANNER_CONTEXT.getMetadata(), planNode, noLookup(), idAllocator, session, createTestingTypeAnalyzer(
+        Optional<PlanNode> rewritten = pushProjectionThroughJoin(PLANNER_CONTEXT, planNode, noLookup(), idAllocator, session, createTestingTypeAnalyzer(
                 PLANNER_CONTEXT), p.getTypes());
         assertTrue(rewritten.isPresent());
         assertPlan(
@@ -128,7 +128,7 @@ public class TestPushProjectionThroughJoin
                         INNER,
                         p.values(a),
                         p.values(b)));
-        Optional<PlanNode> rewritten = pushProjectionThroughJoin(PLANNER_CONTEXT.getMetadata(), planNode, noLookup(), new PlanNodeIdAllocator(), testSessionBuilder().build(), createTestingTypeAnalyzer(
+        Optional<PlanNode> rewritten = pushProjectionThroughJoin(PLANNER_CONTEXT, planNode, noLookup(), new PlanNodeIdAllocator(), testSessionBuilder().build(), createTestingTypeAnalyzer(
                 PLANNER_CONTEXT), p.getTypes());
         assertThat(rewritten).isEmpty();
     }
@@ -148,7 +148,7 @@ public class TestPushProjectionThroughJoin
                         LEFT,
                         p.values(a),
                         p.values(b)));
-        Optional<PlanNode> rewritten = pushProjectionThroughJoin(PLANNER_CONTEXT.getMetadata(), planNode, noLookup(), new PlanNodeIdAllocator(), testSessionBuilder().build(), createTestingTypeAnalyzer(
+        Optional<PlanNode> rewritten = pushProjectionThroughJoin(PLANNER_CONTEXT, planNode, noLookup(), new PlanNodeIdAllocator(), testSessionBuilder().build(), createTestingTypeAnalyzer(
                 PLANNER_CONTEXT), p.getTypes());
         assertThat(rewritten).isEmpty();
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestReorderJoins.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestReorderJoins.java
@@ -679,6 +679,6 @@ public class TestReorderJoins
 
     private RuleAssert assertReorderJoins()
     {
-        return tester.assertThat(new ReorderJoins(PLANNER_CONTEXT.getMetadata(), new CostComparator(1, 1, 1), createTestingTypeAnalyzer(PLANNER_CONTEXT)));
+        return tester.assertThat(new ReorderJoins(PLANNER_CONTEXT, new CostComparator(1, 1, 1), createTestingTypeAnalyzer(PLANNER_CONTEXT)));
     }
 }

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueries.java
@@ -225,7 +225,8 @@ public abstract class AbstractTestQueries
         assertQuery("SELECT COUNT(1) FROM orders");
 
         assertQuery("SELECT COUNT(NULLIF(orderstatus, 'F')) FROM orders");
-        assertQuery("SELECT COUNT(CAST(NULL AS BIGINT)) FROM orders"); // todo: make COUNT(null) work
+        assertQuery("SELECT COUNT(NULL) FROM orders", "VALUES 0");
+        assertQuery("SELECT COUNT(CAST(NULL AS BIGINT)) FROM orders", "VALUES 0");
     }
 
     @Test


### PR DESCRIPTION
In many code places, we have special paths for expressions that are
literals. Detecting literals with `instanceof Literal` is not enough, as
some types, or some (value, type) combinations, do not have direct
literal form. The `LiteralEncoder` encodes them as constant, terse
expressions. Throughout the optimizer, the "is literal" detections
should treat them same way.

Follows discussion under https://github.com/trinodb/trino/pull/10499#issuecomment-1009735282 