### PR TITLE
Add basic TLS configuration info to JDBC connector docs

### DIFF
--- a/docs/src/main/sphinx/connector/clickhouse.rst
+++ b/docs/src/main/sphinx/connector/clickhouse.rst
@@ -34,6 +34,27 @@ appropriate for your setup:
     connection-user=exampleuser
     connection-password=examplepassword
 
+.. _clickhouse-tls:
+
+Connection security
+^^^^^^^^^^^^^^^^^^^
+
+If you have TLS configured with a globally-trusted certificate installed on your
+data source, you can enable TLS between your cluster and the data
+source by appending a parameter to the JDBC connection string set in the
+``connection-url`` catalog configuration property.
+
+For example, with version 2.6.4 of the ClickHouse JDBC driver, enable TLS by
+appending the ``ssl=true`` parameter to the ``connection-url`` configuration
+property:
+
+.. code-block:: properties
+
+  connection-url=jdbc:clickhouse://host1:8123/?ssl=true
+
+For more information on TLS configuration options, see the `Clickhouse JDBC
+driver documentation <https://clickhouse.com/docs/en/interfaces/jdbc/>`_
+
 Multiple ClickHouse servers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/src/main/sphinx/connector/memsql.rst
+++ b/docs/src/main/sphinx/connector/memsql.rst
@@ -32,6 +32,26 @@ connection properties as appropriate for your setup:
     connection-user=root
     connection-password=secret
 
+.. _singlestore-tls:
+
+Connection security
+^^^^^^^^^^^^^^^^^^^
+
+If you have TLS configured with a globally-trusted certificate installed on your
+data source, you can enable TLS between your cluster and the data
+source by appending a parameter to the JDBC connection string set in the
+``connection-url`` catalog configuration property.
+
+Enable TLS between your cluster and SingleStore by appending the ``useSsl=true``
+parameter to the ``connection-url`` configuration property:
+
+.. code-block:: properties
+
+  connection-url=jdbc:mariadb://example.net:3306/?useSsl=true
+
+For more information on TLS configuration options, see the `JDBC driver
+documentation <https://mariadb.com/kb/en/about-mariadb-connector-j/#tls-parameters>`_.
+
 Multiple SingleStore servers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/src/main/sphinx/connector/mysql.rst
+++ b/docs/src/main/sphinx/connector/mysql.rst
@@ -50,6 +50,32 @@ determine the user credentials for the connection, often a service user. You can
 use :doc:`secrets </security/secrets>` to avoid actual values in the catalog
 properties files.
 
+.. _mysql-tls:
+
+Connection security
+^^^^^^^^^^^^^^^^^^^
+
+If you have TLS configured with a globally-trusted certificate installed on your
+data source, you can enable TLS between your cluster and the data
+source by appending a parameter to the JDBC connection string set in the
+``connection-url`` catalog configuration property.
+
+For example, with version 8.0 of MySQL Connector/J, use the ``sslMode``
+parameter to secure the connection with TLS. By default the parameter is set to
+``PREFERRED`` which secures the connection if enabled by the server. You can
+also set this parameter to ``REQUIRED`` which causes the connection to fail if
+TLS is not established.
+
+You can set the ``sslMode`` paremeter in the catalog configuration file by
+appending it to the ``connection-url`` configuration property:
+
+.. code-block:: properties
+
+  connection-url=jdbc:mysql://example.net:3306/?sslMode=REQUIRED
+
+For more information on TLS configuration options, see the `MySQL JDBC security
+documentation <https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-connp-props-security.html#cj-conn-prop_sslMode>`_.
+
 Multiple MySQL servers
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/src/main/sphinx/connector/postgresql.rst
+++ b/docs/src/main/sphinx/connector/postgresql.rst
@@ -46,6 +46,27 @@ determine the user credentials for the connection, often a service user. You can
 use :doc:`secrets </security/secrets>` to avoid actual values in the catalog
 properties files.
 
+.. _postgresql-tls:
+
+Connection security
+^^^^^^^^^^^^^^^^^^^
+
+If you have TLS configured with a globally-trusted certificate installed on your
+data source, you can enable TLS between your cluster and the data
+source by appending a parameter to the JDBC connection string set in the
+``connection-url`` catalog configuration property.
+
+For example, with version 42 of the PostgreSQL JDBC driver, enable TLS by
+appending the ``ssl=true`` parameter to the ``connection-url`` configuration
+property:
+
+.. code-block:: properties
+
+  connection-url=jdbc:postgresql://example.net:5432/database?ssl=true
+
+For more information on TLS configuration options, see the `PostgreSQL JDBC
+driver documentation <https://jdbc.postgresql.org/documentation/head/connect.html>`_.
+
 Multiple PostgreSQL databases or servers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/src/main/sphinx/connector/redshift.rst
+++ b/docs/src/main/sphinx/connector/redshift.rst
@@ -31,6 +31,28 @@ connection properties as appropriate for your setup:
     connection-user=root
     connection-password=secret
 
+.. _redshift-tls:
+
+Connection security
+^^^^^^^^^^^^^^^^^^^
+
+If you have TLS configured with a globally-trusted certificate installed on your
+data source, you can enable TLS between your cluster and the data
+source by appending a parameter to the JDBC connection string set in the
+``connection-url`` catalog configuration property.
+
+For example, on version 2.1 of the Redshift JDBC driver, TLS/SSL is enabled by
+default with the ``SSL`` parameter. You can disable or further configure TLS
+by appending parameters to the ``connection-url`` configuration property:
+
+.. code-block:: properties
+
+  connection-url=jdbc:redshift://example.net:5439/database;SSL=TRUE;
+
+For more information on TLS configuration options, see the `Redshift JDBC driver
+documentation
+<https://docs.aws.amazon.com/redshift/latest/mgmt/jdbc20-configuration-options.html#jdbc20-ssl-option>`_.
+
 Multiple Redshift databases or clusters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/src/main/sphinx/connector/sqlserver.rst
+++ b/docs/src/main/sphinx/connector/sqlserver.rst
@@ -44,6 +44,26 @@ determine the user credentials for the connection, often a service user. You can
 use :doc:`secrets </security/secrets>` to avoid actual values in the catalog
 properties files.
 
+.. _sqlserver-tls:
+
+Connection security
+^^^^^^^^^^^^^^^^^^^
+
+If you have TLS configured with a globally-trusted certificate installed on your
+data source, you can enable TLS between your cluster and the data
+source by appending a parameter to the JDBC connection string set in the
+``connection-url`` catalog configuration property.
+
+For example, with the JDBC driver for SQL Server 2019, enable TLS by appending
+the ``encrypt=true`` parameter to the ``connection-url`` configuration property:
+
+.. code-block:: properties
+
+  connection-url=jdbc:sqlserver://<host>:<port>;database=<database>;encrypt=true
+
+For more information on TLS configuration options, see the `SQL Server JDBC
+driver documentation <https://docs.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url>`_.
+
 Multiple SQL Server databases or servers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
We have little-to-no information on the connector docs suggesting that you can secure the connection between Trino and the data source. This PR adds some high level information (the main JDBC URL parameter, use with globally-trusted certificates, example `connection-url` property) and links out to the corresponding JDBC driver docs for more information.