### PR TITLE
Add Pacific/Kanton time zone

### DIFF
--- a/core/trino-spi/src/main/resources/io/trino/spi/type/zone-index.properties
+++ b/core/trino-spi/src/main/resources/io/trino/spi/type/zone-index.properties
@@ -2237,3 +2237,4 @@
 2228 Europe/Saratov
 2229 Asia/Qostanay
 2230 America/Nuuk
+2231 Pacific/Kanton

--- a/core/trino-spi/src/test/java/io/trino/spi/type/TestTimeZoneKey.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/type/TestTimeZoneKey.java
@@ -220,7 +220,7 @@ public class TestTimeZoneKey
             hasher.putString(timeZoneKey.getId(), StandardCharsets.UTF_8);
         }
         // Zone file should not (normally) be changed, so let's make this more difficult
-        assertEquals(hasher.hash().asLong(), 6334606028834602490L, "zone-index.properties file contents changed!");
+        assertEquals(hasher.hash().asLong(), -2665680993684804317L, "zone-index.properties file contents changed!");
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.aws-sdk.version>1.12.85</dep.aws-sdk.version>
         <dep.okhttp.version>3.14.9</dep.okhttp.version>
+        <dep.joda.version>2.10.13</dep.joda.version>
         <dep.jsonwebtoken.version>0.11.2</dep.jsonwebtoken.version>
         <dep.oracle.version>19.3.0.0</dep.oracle.version>
         <dep.drift.version>1.14</dep.drift.version>


### PR DESCRIPTION
Recent JVM versions use tzdata v. 2021b, which includes `Pacific/Kanton`
time zone.

Fixes https://github.com/trinodb/trino/issues/10674