### PR TITLE
Return exception message in HTTP header

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/ThrowableMapper.java
+++ b/core/trino-main/src/main/java/io/trino/server/ThrowableMapper.java
@@ -13,6 +13,7 @@
  */
 package io.trino.server;
 
+import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import io.airlift.log.Logger;
 
@@ -54,6 +55,11 @@ public class ThrowableMapper
 
         ResponseBuilder responseBuilder = Response.serverError()
                 .header(CONTENT_TYPE, TEXT_PLAIN);
+
+        if (!Strings.isNullOrEmpty(throwable.getMessage())) {
+            responseBuilder.header("X-Trino-Error-Message", throwable.getMessage());
+        }
+
         if (includeExceptionInResponse) {
             responseBuilder.entity(Throwables.getStackTraceAsString(throwable));
         }


### PR DESCRIPTION
For better UI experience it would be nice to have an access to human readable error message without a full stack trace.
The idea is to return it in a HTTP header `X-Trino-Error-Message` - not sure about naming.
