### PR TITLE
Wait for reserved pool to become free

### DIFF
--- a/testing/trino-tests/src/test/java/io/trino/memory/TestMemoryManager.java
+++ b/testing/trino-tests/src/test/java/io/trino/memory/TestMemoryManager.java
@@ -324,7 +324,9 @@ public class TestMemoryManager
             for (TestingTrinoServer worker : queryRunner.getServers()) {
                 Optional<MemoryPool> reserved = worker.getLocalMemoryManager().getReservedPool();
                 assertTrue(reserved.isPresent());
-                assertEquals(reserved.get().getMaxBytes(), reserved.get().getFreeBytes());
+                while (reserved.get().getMaxBytes() != reserved.get().getFreeBytes()) {
+                    MILLISECONDS.sleep(10);
+                }
                 MemoryPool general = worker.getLocalMemoryManager().getGeneralPool();
                 // Free up the memory we reserved earlier
                 general.free(fakeQueryId, "test", general.getMaxBytes());


### PR DESCRIPTION
Attempt to fix https://github.com/trinodb/trino/issues/10684
Certain operators will only release memory on close rather than finish (https://github.com/trinodb/trino/issues/10596), so perhaps there is a lag between query finished and memory being freed.

Fixes: https://github.com/trinodb/trino/issues/10684