### PR TITLE
Silence QueryRunner startup logs in tests

### DIFF
--- a/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/AccumuloQueryRunner.java
+++ b/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/AccumuloQueryRunner.java
@@ -16,7 +16,6 @@ package io.trino.plugin.accumulo;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedSet;
 import io.airlift.log.Logger;
-import io.airlift.log.Logging;
 import io.trino.Session;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.plugin.accumulo.conf.AccumuloConfig;
@@ -142,7 +141,6 @@ public final class AccumuloQueryRunner
     public static void main(String[] args)
             throws Exception
     {
-        Logging.initialize();
         DistributedQueryRunner queryRunner = createAccumuloQueryRunner(ImmutableMap.of("http-server.http.port", "8080"));
         Thread.sleep(10);
         Logger log = Logger.get(AccumuloQueryRunner.class);

--- a/plugin/trino-bigquery/pom.xml
+++ b/plugin/trino-bigquery/pom.xml
@@ -81,11 +81,6 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
-            <artifactId>log-manager</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
         </dependency>
 

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
@@ -27,7 +27,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import io.airlift.log.Logger;
-import io.airlift.log.Logging;
 import io.trino.Session;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
@@ -181,7 +180,6 @@ public final class BigQueryQueryRunner
     public static void main(String[] args)
             throws Exception
     {
-        Logging.initialize();
         DistributedQueryRunner queryRunner = createQueryRunner(ImmutableMap.of("http-server.http.port", "8080"), ImmutableMap.of());
         Thread.sleep(10);
         Logger log = Logger.get(BigQueryQueryRunner.class);

--- a/plugin/trino-blackhole/src/test/java/io/trino/plugin/blackhole/BlackHoleQueryRunner.java
+++ b/plugin/trino-blackhole/src/test/java/io/trino/plugin/blackhole/BlackHoleQueryRunner.java
@@ -15,7 +15,6 @@ package io.trino.plugin.blackhole;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
-import io.airlift.log.Logging;
 import io.trino.Session;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
@@ -66,7 +65,6 @@ public final class BlackHoleQueryRunner
     public static void main(String[] args)
             throws Exception
     {
-        Logging.initialize();
         DistributedQueryRunner queryRunner = createQueryRunner(ImmutableMap.of("http-server.http.port", "8080"));
         Thread.sleep(10);
         Logger log = Logger.get(BlackHoleQueryRunner.class);

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraQueryRunner.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraQueryRunner.java
@@ -16,7 +16,6 @@ package io.trino.plugin.cassandra;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
-import io.airlift.log.Logging;
 import io.trino.Session;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
@@ -78,8 +77,6 @@ public final class CassandraQueryRunner
     public static void main(String[] args)
             throws Exception
     {
-        Logging.initialize();
-
         DistributedQueryRunner queryRunner = createCassandraQueryRunner(
                 new CassandraServer(),
                 ImmutableMap.of("http-server.http.port", "8080"),

--- a/plugin/trino-clickhouse/pom.xml
+++ b/plugin/trino-clickhouse/pom.xml
@@ -39,11 +39,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>log-manager</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.clickhouse</groupId>
             <artifactId>clickhouse-jdbc</artifactId>
             <classifier>all</classifier>

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/ClickHouseQueryRunner.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/ClickHouseQueryRunner.java
@@ -16,7 +16,6 @@ package io.trino.plugin.clickhouse;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
-import io.airlift.log.Logging;
 import io.trino.Session;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
@@ -85,8 +84,6 @@ public final class ClickHouseQueryRunner
     public static void main(String[] args)
             throws Exception
     {
-        Logging.initialize();
-
         DistributedQueryRunner queryRunner = createClickHouseQueryRunner(
                 new TestingClickHouseServer(),
                 ImmutableMap.of("http-server.http.port", "8080"),

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
@@ -15,7 +15,6 @@ package io.trino.plugin.deltalake;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
-import io.airlift.log.Logging;
 import io.trino.Session;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.plugin.deltalake.util.DockerizedMinioDataLake;
@@ -281,7 +280,6 @@ public final class DeltaLakeQueryRunner
         public static void main(String[] args)
                 throws Exception
         {
-            Logging.initialize();
             DistributedQueryRunner queryRunner = createDeltaLakeQueryRunner(
                     ImmutableMap.of("http-server.http.port", "8080"),
                     ImmutableMap.of("delta.enable-non-concurrent-writes", "true"));
@@ -302,7 +300,6 @@ public final class DeltaLakeQueryRunner
         public static void main(String[] args)
                 throws Exception
         {
-            Logging.initialize();
             String bucketName = "test-bucket";
 
             DockerizedMinioDataLake dockerizedMinioDataLake = createDockerizedMinioDataLakeForDeltaLake(bucketName);

--- a/plugin/trino-druid/pom.xml
+++ b/plugin/trino-druid/pom.xml
@@ -30,11 +30,6 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
-            <artifactId>log-manager</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
         </dependency>
 

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/DruidQueryRunner.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/DruidQueryRunner.java
@@ -16,7 +16,6 @@ package io.trino.plugin.druid;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
-import io.airlift.log.Logging;
 import io.trino.Session;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
@@ -131,8 +130,6 @@ public class DruidQueryRunner
     public static void main(String[] args)
             throws Exception
     {
-        Logging.initialize();
-
         DistributedQueryRunner queryRunner = createDruidQueryRunnerTpch(
                 new TestingDruidServer(),
                 ImmutableMap.of("http-server.http.port", "8080"),

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchExternalQueryRunner.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchExternalQueryRunner.java
@@ -16,7 +16,6 @@ package io.trino.plugin.elasticsearch;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HostAndPort;
 import io.airlift.log.Logger;
-import io.airlift.log.Logging;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.tpch.TpchTable;
 
@@ -36,8 +35,6 @@ public class ElasticsearchExternalQueryRunner
         // Please set hostname and port via VM options. e.g. "-Delasticsearch.host=localhost -Delasticsearch.port=9200"
         // To start Elasticsearch:
         // docker run -p 9200:9200 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.6.2
-        Logging.initialize();
-
         DistributedQueryRunner queryRunner = createElasticsearchQueryRunner(
                 HostAndPort.fromParts(HOSTNAME, PORT),
                 TpchTable.getTables(),

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchQueryRunner.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchQueryRunner.java
@@ -16,7 +16,6 @@ package io.trino.plugin.elasticsearch;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HostAndPort;
 import io.airlift.log.Logger;
-import io.airlift.log.Logging;
 import io.trino.Session;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.plugin.jmx.JmxPlugin;
@@ -128,8 +127,6 @@ public final class ElasticsearchQueryRunner
     public static void main(String[] args)
             throws Exception
     {
-        Logging.initialize();
-
         DistributedQueryRunner queryRunner = createElasticsearchQueryRunner(
                 new ElasticsearchServer(ELASTICSEARCH_7_IMAGE, ImmutableMap.of()).getAddress(),
                 TpchTable.getTables(),

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/GeoQueryRunner.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/GeoQueryRunner.java
@@ -15,7 +15,6 @@ package io.trino.plugin.geospatial;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
-import io.airlift.log.Logging;
 import io.trino.testing.DistributedQueryRunner;
 
 import java.util.Map;
@@ -39,7 +38,6 @@ public final class GeoQueryRunner
     public static void main(String[] args)
             throws Exception
     {
-        Logging.initialize();
         DistributedQueryRunner queryRunner = createQueryRunner(ImmutableMap.of("http-server.http.port", "8080"));
         Logger log = Logger.get(GeoQueryRunner.class);
         log.info("======== SERVER STARTED ========");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
@@ -16,7 +16,6 @@ package io.trino.plugin.iceberg;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
-import io.airlift.log.Logging;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.tpch.TpchTable;
@@ -138,11 +137,10 @@ public final class IcebergQueryRunner
     public static void main(String[] args)
             throws Exception
     {
-        Logging.initialize();
         DistributedQueryRunner queryRunner = null;
         try {
             queryRunner = IcebergQueryRunner.builder()
-                    .setExtraProperties(Map.of("http-server.http.port", "8080"))
+                    .setExtraProperties(ImmutableMap.of("http-server.http.port", "8080"))
                     .setInitialTables(TpchTable.getTables())
                     .build();
         }

--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/MemoryQueryRunner.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/MemoryQueryRunner.java
@@ -16,7 +16,6 @@ package io.trino.plugin.memory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
-import io.airlift.log.Logging;
 import io.trino.Session;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
@@ -104,7 +103,6 @@ public final class MemoryQueryRunner
     public static void main(String[] args)
             throws Exception
     {
-        Logging.initialize();
         DistributedQueryRunner queryRunner = createMemoryQueryRunner(
                 ImmutableMap.of("http-server.http.port", "8080"),
                 TpchTable.getTables());

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoQueryRunner.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoQueryRunner.java
@@ -18,7 +18,6 @@ import com.google.common.collect.ImmutableMap;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import io.airlift.log.Logger;
-import io.airlift.log.Logging;
 import io.trino.Session;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
@@ -87,7 +86,6 @@ public final class MongoQueryRunner
     public static void main(String[] args)
             throws Exception
     {
-        Logging.initialize();
         DistributedQueryRunner queryRunner = createMongoQueryRunner(
                 new MongoServer(),
                 ImmutableMap.of("http-server.http.port", "8080"),

--- a/plugin/trino-mysql/pom.xml
+++ b/plugin/trino-mysql/pom.xml
@@ -40,11 +40,6 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
-            <artifactId>log-manager</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
         </dependency>
 

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/MySqlQueryRunner.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/MySqlQueryRunner.java
@@ -16,7 +16,6 @@ package io.trino.plugin.mysql;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
-import io.airlift.log.Logging;
 import io.trino.Session;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
@@ -86,8 +85,6 @@ public final class MySqlQueryRunner
     public static void main(String[] args)
             throws Exception
     {
-        Logging.initialize();
-
         DistributedQueryRunner queryRunner = createMySqlQueryRunner(
                 new TestingMySqlServer(),
                 ImmutableMap.of("http-server.http.port", "8080"),

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/OracleQueryRunner.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/OracleQueryRunner.java
@@ -15,7 +15,6 @@ package io.trino.plugin.oracle;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
-import io.airlift.log.Logging;
 import io.trino.Session;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
@@ -84,8 +83,6 @@ public final class OracleQueryRunner
     public static void main(String[] args)
             throws Exception
     {
-        Logging.initialize();
-
         TestingOracleServer server = new TestingOracleServer();
         DistributedQueryRunner queryRunner = createOracleQueryRunner(
                 server,

--- a/plugin/trino-phoenix/src/test/java/io/trino/plugin/phoenix/PhoenixQueryRunner.java
+++ b/plugin/trino-phoenix/src/test/java/io/trino/plugin/phoenix/PhoenixQueryRunner.java
@@ -15,7 +15,6 @@ package io.trino.plugin.phoenix;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
-import io.airlift.log.Logging;
 import io.trino.Session;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.plugin.tpch.TpchPlugin;
@@ -140,8 +139,6 @@ public final class PhoenixQueryRunner
     public static void main(String[] args)
             throws Exception
     {
-        Logging.initialize();
-
         DistributedQueryRunner queryRunner = createPhoenixQueryRunner(
                 TestingPhoenixServer.getInstance(),
                 ImmutableMap.of("http-server.http.port", "8080"),

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/PhoenixQueryRunner.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/PhoenixQueryRunner.java
@@ -15,7 +15,6 @@ package io.trino.plugin.phoenix5;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
-import io.airlift.log.Logging;
 import io.trino.Session;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.plugin.tpch.TpchPlugin;
@@ -140,8 +139,6 @@ public final class PhoenixQueryRunner
     public static void main(String[] args)
             throws Exception
     {
-        Logging.initialize();
-
         DistributedQueryRunner queryRunner = createPhoenixQueryRunner(
                 TestingPhoenixServer.getInstance(),
                 ImmutableMap.of("http-server.http.port", "8080"),

--- a/plugin/trino-pinot/pom.xml
+++ b/plugin/trino-pinot/pom.xml
@@ -85,11 +85,6 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
-            <artifactId>log-manager</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.airlift</groupId>
             <artifactId>testing</artifactId>
         </dependency>
 

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/PinotQueryRunner.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/PinotQueryRunner.java
@@ -16,7 +16,6 @@ package io.trino.plugin.pinot;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Module;
 import io.airlift.log.Logger;
-import io.airlift.log.Logging;
 import io.trino.Session;
 import io.trino.connector.CatalogName;
 import io.trino.metadata.SessionPropertyManager;
@@ -65,7 +64,6 @@ public class PinotQueryRunner
     public static void main(String[] args)
             throws Exception
     {
-        Logging.initialize();
         TestingKafka kafka = TestingKafka.createWithSchemaRegistry();
         kafka.start();
         TestingPinotCluster pinot = new TestingPinotCluster(kafka.getNetwork(), false);

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/PostgreSqlQueryRunner.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/PostgreSqlQueryRunner.java
@@ -15,7 +15,6 @@ package io.trino.plugin.postgresql;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
-import io.airlift.log.Logging;
 import io.trino.Session;
 import io.trino.plugin.jmx.JmxPlugin;
 import io.trino.plugin.tpch.TpchPlugin;
@@ -83,8 +82,6 @@ public final class PostgreSqlQueryRunner
     public static void main(String[] args)
             throws Exception
     {
-        Logging.initialize();
-
         DistributedQueryRunner queryRunner = createPostgreSqlQueryRunner(
                 new TestingPostgreSqlServer(),
                 ImmutableMap.of("http-server.http.port", "8080"),

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/PrometheusQueryRunner.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/PrometheusQueryRunner.java
@@ -15,7 +15,6 @@ package io.trino.plugin.prometheus;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
-import io.airlift.log.Logging;
 import io.airlift.units.Duration;
 import io.trino.Session;
 import io.trino.testing.DistributedQueryRunner;
@@ -74,7 +73,6 @@ public final class PrometheusQueryRunner
     public static void main(String[] args)
             throws Exception
     {
-        Logging.initialize();
         DistributedQueryRunner queryRunner = createPrometheusQueryRunner(new PrometheusServer(), ImmutableMap.of("http-server.http.port", "8080"));
         Thread.sleep(10);
         Logger log = Logger.get(PrometheusQueryRunner.class);

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/RaptorQueryRunner.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/RaptorQueryRunner.java
@@ -16,7 +16,6 @@ package io.trino.plugin.raptor.legacy;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
-import io.airlift.log.Logging;
 import io.trino.Session;
 import io.trino.connector.CatalogName;
 import io.trino.metadata.QualifiedObjectName;
@@ -160,7 +159,6 @@ public final class RaptorQueryRunner
     public static void main(String[] args)
             throws Exception
     {
-        Logging.initialize();
         Map<String, String> properties = ImmutableMap.of("http-server.http.port", "8080");
         DistributedQueryRunner queryRunner = createRaptorQueryRunner(properties, ImmutableList.of(), false, ImmutableMap.of());
         Thread.sleep(10);

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/RedisQueryRunner.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/RedisQueryRunner.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.json.JsonCodec;
 import io.airlift.log.Logger;
-import io.airlift.log.Logging;
 import io.trino.Session;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.plugin.redis.util.CodecSupplier;
@@ -135,8 +134,6 @@ public final class RedisQueryRunner
     public static void main(String[] args)
             throws Exception
     {
-        Logging.initialize();
-
         DistributedQueryRunner queryRunner = createRedisQueryRunner(
                 new RedisServer(),
                 ImmutableMap.of("http-server.http.port", "8080"),

--- a/plugin/trino-singlestore/pom.xml
+++ b/plugin/trino-singlestore/pom.xml
@@ -40,11 +40,6 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
-            <artifactId>log-manager</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
         </dependency>
 

--- a/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/SingleStoreQueryRunner.java
+++ b/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/SingleStoreQueryRunner.java
@@ -15,7 +15,6 @@ package io.trino.plugin.singlestore;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
-import io.airlift.log.Logging;
 import io.trino.Session;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
@@ -78,8 +77,6 @@ public class SingleStoreQueryRunner
     public static void main(String[] args)
             throws Exception
     {
-        Logging.initialize();
-
         // You need to set 'memsql.license' to VM options
         DistributedQueryRunner queryRunner = createSingleStoreQueryRunner(
                 new TestingSingleStoreServer(),

--- a/plugin/trino-sqlserver/pom.xml
+++ b/plugin/trino-sqlserver/pom.xml
@@ -50,11 +50,6 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
-            <artifactId>log-manager</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
         </dependency>
 

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/SqlServerQueryRunner.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/SqlServerQueryRunner.java
@@ -15,7 +15,6 @@ package io.trino.plugin.sqlserver;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
-import io.airlift.log.Logging;
 import io.trino.Session;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.spi.security.Identity;
@@ -33,6 +32,8 @@ import static io.trino.testing.TestingSession.testSessionBuilder;
 
 public final class SqlServerQueryRunner
 {
+    private static final Logger log = Logger.get(SqlServerQueryRunner.class);
+
     private SqlServerQueryRunner() {}
 
     private static final String CATALOG = "sqlserver";
@@ -60,6 +61,7 @@ public final class SqlServerQueryRunner
 
             queryRunner.installPlugin(new SqlServerPlugin());
             queryRunner.createCatalog(CATALOG, "sqlserver", connectorProperties);
+            log.info("%s catalog properties: %s", CATALOG, connectorProperties);
 
             copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(testingSqlServer.getUsername()), tables);
 
@@ -83,8 +85,6 @@ public final class SqlServerQueryRunner
     public static void main(String[] args)
             throws Exception
     {
-        Logging.initialize();
-
         TestingSqlServer testingSqlServer = new TestingSqlServer();
 
         // SqlServer is using docker container so in case that shutdown hook is not called, developer can easily clean docker container on their own

--- a/plugin/trino-tpcds/src/test/java/io/trino/plugin/tpcds/TpcdsQueryRunner.java
+++ b/plugin/trino-tpcds/src/test/java/io/trino/plugin/tpcds/TpcdsQueryRunner.java
@@ -15,7 +15,6 @@ package io.trino.plugin.tpcds;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
-import io.airlift.log.Logging;
 import io.trino.Session;
 import io.trino.testing.DistributedQueryRunner;
 
@@ -67,7 +66,6 @@ public final class TpcdsQueryRunner
     public static void main(String[] args)
             throws Exception
     {
-        Logging.initialize();
         DistributedQueryRunner queryRunner = createQueryRunner(ImmutableMap.of("http-server.http.port", "8080"));
         Thread.sleep(10);
         Logger log = Logger.get(TpcdsQueryRunner.class);

--- a/testing/trino-testing/pom.xml
+++ b/testing/trino-testing/pom.xml
@@ -65,6 +65,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>log-manager</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
         </dependency>
 
@@ -151,12 +156,6 @@
                     <artifactId>jmh-core</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>log-manager</artifactId>
-            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
@@ -19,6 +19,7 @@ import com.google.common.io.Closer;
 import com.google.inject.Module;
 import io.airlift.discovery.server.testing.TestingDiscoveryServer;
 import io.airlift.log.Logger;
+import io.airlift.log.Logging;
 import io.airlift.testing.Assertions;
 import io.airlift.units.Duration;
 import io.trino.Session;
@@ -72,6 +73,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.inject.util.Modules.EMPTY_MODULE;
+import static io.airlift.log.Level.ERROR;
+import static io.airlift.log.Level.WARN;
 import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.airlift.units.Duration.nanosSince;
 import static java.util.Objects.requireNonNull;
@@ -118,6 +121,8 @@ public class DistributedQueryRunner
         if (backupCoordinatorProperties.isPresent()) {
             checkArgument(nodeCount >= 2, "the nodeCount must be greater than or equal to two!");
         }
+
+        setupLogging();
 
         try {
             long start = System.nanoTime();
@@ -202,6 +207,14 @@ public class DistributedQueryRunner
             server.addFunctions(AbstractTestQueries.CUSTOM_FUNCTIONS);
         }
         log.info("Added functions in %s", nanosSince(start).convertToMostSuccinctTimeUnit());
+    }
+
+    private static void setupLogging()
+    {
+        Logging logging = Logging.initialize();
+        logging.setLevel("Bootstrap", WARN);
+        logging.setLevel("org.glassfish", ERROR);
+        logging.setLevel("org.eclipse.jetty.server", WARN);
     }
 
     private static TestingTrinoServer createTestingTrinoServer(


### PR DESCRIPTION
Silence QueryRunner startup logs to make it easier to browse logs in case of a failure. For example, the output of the `TestCachingHiveMetastoreWithQueryRunner` test from `trino-hive-hadoop2` module goes down from 2348 to 172 lines. Silenced info should be repetitive across different CI runs and not convey information specific to tests. This includes non-default server configuration properties, which are passed explicitly in the QueryRunner builder.

Silenced logger examples:
`org.glassfish.jersey.internal.inject.Providers` and `org.glassfish.jersey.internal.Errors`:
```
2022-01-19T07:36:49.107-0600 WARNING A provider io.airlift.discovery.server.ServiceResource registered in SERVER runtime does not implement any provider interfaces applicable in the SERVER runtime. Due to constraint configuration problems the provider io.airlift.discovery.server.ServiceResource will be ignored. 
```

`org.eclipse.jetty.server`:
```
2022-01-19T07:36:49.233-0600 INFO Started o.e.j.s.ServletContextHandler@5e0edcd1{/,null,AVAILABLE,@http}
2022-01-19T07:36:49.240-0600 INFO Started http@106b1b81{HTTP/1.1, (http/1.1, h2c)}{127.0.0.1:56868}
2022-01-19T07:36:49.241-0600 INFO Started @5157ms
```

`io.airlift.bootstrap`, `io.trino.server.PluginManager`:
```
2022-01-19T07:36:49.345-0600 INFO Life cycle starting...
2022-01-19T07:36:49.346-0600 INFO Life cycle started
2022-01-19T07:36:53.748-0600 INFO Registering connector tpch
2022-01-19T07:36:53.750-0600 INFO Registering connector tpch
2022-01-19T07:36:53.751-0600 INFO Registering connector tpch
2022-01-19T07:36:53.787-0600 INFO Registering connector clickhouse
2022-01-19T07:36:53.787-0600 INFO Registering connector clickhouse
2022-01-19T07:36:53.788-0600 INFO Registering connector clickhouse
```

`Bootstrap`:
```
2022-01-19T07:36:53.862-0600 INFO PROPERTY                                                   DEFAULT      RUNTIME                             DESCRIPTION
2022-01-19T07:36:53.863-0600 INFO clickhouse.map-string-as-varchar                           false        true                                Map ClickHouse String and FixedString as varchar instead of varbinary
```



Previous failed attempts to reduce amount of logs:
* #10592 - closed because it would require to download artifacts with logs
* #10620 - closed because we run tests in parallel