### PR TITLE
Ensure caches are not used unsafely

### DIFF
--- a/.mvn/modernizer/violations.xml
+++ b/.mvn/modernizer/violations.xml
@@ -44,6 +44,22 @@
     </violation>
 
     <violation>
+        <name>com/google/common/cache/CacheBuilder.build:()Lcom/google/common/cache/Cache;</name>
+        <version>1.8</version>
+        <comment>Guava Cache has concurrency issues around invalidation and ongoing loads. Use EvictableCache, EvictableLoadingCache, or SafeCaches to build caches.
+            See https://github.com/trinodb/trino/issues/10512 for more information and see https://github.com/trinodb/trino/issues/10512#issuecomment-1016221168
+            for why Caffeine does not solve the problem.</comment>
+    </violation>
+
+    <violation>
+        <name>com/google/common/cache/CacheBuilder.build:(Lcom/google/common/cache/CacheLoader;)Lcom/google/common/cache/LoadingCache;</name>
+        <version>1.8</version>
+        <comment>Guava LoadingCache has concurrency issues around invalidation and ongoing loads. Use EvictableCache, EvictableLoadingCache, or SafeCaches to build caches.
+            See https://github.com/trinodb/trino/issues/10512 for more information and see https://github.com/trinodb/trino/issues/10512#issuecomment-1016221168
+            for why Caffeine does not solve the problem.</comment>
+    </violation>
+
+    <violation>
         <name>org/testng/Assert.assertEquals:(Ljava/lang/Iterable;Ljava/lang/Iterable;)V</name>
         <version>1.8</version>
         <comment>Use io.trino.testing.assertions.Assert.assertEquals due to TestNG #543</comment>

--- a/client/trino-cli/pom.xml
+++ b/client/trino-cli/pom.xml
@@ -77,6 +77,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.gaul</groupId>
+            <artifactId>modernizer-maven-annotations</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline-reader</artifactId>
             <version>${dep.jline.version}</version>

--- a/client/trino-cli/src/main/java/io/trino/cli/TableNameCompleter.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/TableNameCompleter.java
@@ -56,7 +56,7 @@ public class TableNameCompleter
                 .build(asyncReloading(CacheLoader.from(this::listTables), executor));
 
         functionCache = CacheBuilder.newBuilder()
-                .build(asyncReloading(CacheLoader.from(this::listFunctions), executor));
+                .build(CacheLoader.from(this::listFunctions));
     }
 
     private List<String> listTables(String schemaName)

--- a/client/trino-cli/src/main/java/io/trino/cli/TableNameCompleter.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/TableNameCompleter.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.trino.client.QueryData;
 import io.trino.client.StatementClient;
+import org.gaul.modernizer_maven_annotations.SuppressModernizer;
 import org.jline.reader.Candidate;
 import org.jline.reader.Completer;
 import org.jline.reader.LineReader;
@@ -51,12 +52,21 @@ public class TableNameCompleter
     {
         this.queryRunner = requireNonNull(queryRunner, "queryRunner session was null!");
 
-        tableCache = CacheBuilder.newBuilder()
-                .refreshAfterWrite(RELOAD_TIME_MINUTES, TimeUnit.MINUTES)
-                .build(asyncReloading(CacheLoader.from(this::listTables), executor));
+        tableCache = buildUnsafeCache(
+                CacheBuilder.newBuilder()
+                        .refreshAfterWrite(RELOAD_TIME_MINUTES, TimeUnit.MINUTES),
+                asyncReloading(CacheLoader.from(this::listTables), executor));
 
-        functionCache = CacheBuilder.newBuilder()
-                .build(CacheLoader.from(this::listFunctions));
+        functionCache = buildUnsafeCache(
+                CacheBuilder.newBuilder(),
+                CacheLoader.from(this::listFunctions));
+    }
+
+    // TODO extract safe caches implementations to a new module and use SafeCaches.buildNonEvictableCache hereAsyncCache
+    @SuppressModernizer
+    private static <K, V> LoadingCache<K, V> buildUnsafeCache(CacheBuilder<? super K, ? super V> cacheBuilder, CacheLoader<? super K, V> cacheLoader)
+    {
+        return cacheBuilder.build(cacheLoader);
     }
 
     private List<String> listTables(String schemaName)

--- a/core/trino-main/pom.xml
+++ b/core/trino-main/pom.xml
@@ -300,6 +300,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.gaul</groupId>
+            <artifactId>modernizer-maven-annotations</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jgrapht</groupId>
             <artifactId>jgrapht-core</artifactId>
         </dependency>

--- a/core/trino-main/src/main/java/io/trino/execution/FailureInjector.java
+++ b/core/trino-main/src/main/java/io/trino/execution/FailureInjector.java
@@ -13,9 +13,9 @@
  */
 package io.trino.execution;
 
-import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import io.airlift.units.Duration;
+import io.trino.plugin.base.cache.NonEvictableCache;
 import io.trino.spi.ErrorCode;
 import io.trino.spi.ErrorCodeSupplier;
 import io.trino.spi.ErrorType;
@@ -29,6 +29,7 @@ import java.util.Optional;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.execution.FailureInjector.InjectedFailureType.TASK_FAILURE;
+import static io.trino.plugin.base.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.spi.ErrorType.EXTERNAL;
 import static io.trino.spi.ErrorType.INSUFFICIENT_RESOURCES;
 import static io.trino.spi.ErrorType.INTERNAL_ERROR;
@@ -40,7 +41,7 @@ public class FailureInjector
 {
     public static final String FAILURE_INJECTION_MESSAGE = "This error is injected by the failure injection service";
 
-    private final Cache<Key, InjectedFailure> failures;
+    private final NonEvictableCache<Key, InjectedFailure> failures;
     private final Duration requestTimeout;
 
     @Inject
@@ -53,9 +54,8 @@ public class FailureInjector
 
     public FailureInjector(Duration expirationPeriod, Duration requestTimeout)
     {
-        failures = CacheBuilder.newBuilder()
-                .expireAfterWrite(expirationPeriod.toMillis(), MILLISECONDS)
-                .build();
+        failures = buildNonEvictableCache(CacheBuilder.newBuilder()
+                .expireAfterWrite(expirationPeriod.toMillis(), MILLISECONDS));
         this.requestTimeout = requireNonNull(requestTimeout, "requestTimeout is null");
     }
 

--- a/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
@@ -485,7 +485,8 @@ public class SqlTaskManager
         return tasks.getUnchecked(taskId).failed(failure);
     }
 
-    public void removeOldTasks()
+    @VisibleForTesting
+    void removeOldTasks()
     {
         DateTime oldestAllowedTask = DateTime.now().minus(infoCacheTime.toMillis());
         tasks.asMap().values().stream()

--- a/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
@@ -497,6 +497,8 @@ public class SqlTaskManager
                     try {
                         DateTime endTime = taskInfo.getStats().getEndTime();
                         if (endTime != null && endTime.isBefore(oldestAllowedTask)) {
+                            // The removal here is concurrency safe with respect to any concurrent loads: the cache has no expiration,
+                            // the taskId is in the cache, so there mustn't be an ongoing load.
                             tasks.asMap().remove(taskId);
                         }
                     }

--- a/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
@@ -16,7 +16,6 @@ package io.trino.execution;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.concurrent.ThreadPoolExecutorMBean;
@@ -40,6 +39,7 @@ import io.trino.memory.MemoryPoolAssignment;
 import io.trino.memory.MemoryPoolAssignmentsRequest;
 import io.trino.memory.NodeMemoryConfig;
 import io.trino.memory.QueryContext;
+import io.trino.plugin.base.cache.NonEvictableLoadingCache;
 import io.trino.spi.QueryId;
 import io.trino.spi.TrinoException;
 import io.trino.spi.VersionEmbedder;
@@ -80,6 +80,7 @@ import static io.trino.SystemSessionProperties.resourceOvercommit;
 import static io.trino.execution.SqlTask.createSqlTask;
 import static io.trino.memory.LocalMemoryManager.GENERAL_POOL;
 import static io.trino.memory.LocalMemoryManager.RESERVED_POOL;
+import static io.trino.plugin.base.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.spi.StandardErrorCode.ABANDONED_TASK;
 import static io.trino.spi.StandardErrorCode.SERVER_SHUTTING_DOWN;
 import static java.lang.Math.min;
@@ -104,8 +105,8 @@ public class SqlTaskManager
     private final Duration clientTimeout;
 
     private final LocalMemoryManager localMemoryManager;
-    private final LoadingCache<QueryId, QueryContext> queryContexts;
-    private final LoadingCache<TaskId, SqlTask> tasks;
+    private final NonEvictableLoadingCache<QueryId, QueryContext> queryContexts;
+    private final NonEvictableLoadingCache<TaskId, SqlTask> tasks;
 
     private final SqlTaskIoStats cachedStats = new SqlTaskIoStats();
     private final SqlTaskIoStats finishedTaskStats = new SqlTaskIoStats();
@@ -163,10 +164,10 @@ public class SqlTaskManager
         queryMaxMemoryPerNode = maxQueryMemoryPerNode.toBytes();
         queryMaxTotalMemoryPerNode = maxQueryTotalMemoryPerNode.toBytes();
 
-        queryContexts = CacheBuilder.newBuilder().weakValues().build(CacheLoader.from(
+        queryContexts = buildNonEvictableCache(CacheBuilder.newBuilder().weakValues(), CacheLoader.from(
                 queryId -> createQueryContext(queryId, localMemoryManager, localSpillManager, gcMonitor, maxQueryMemoryPerNode, maxQueryTotalMemoryPerNode, queryMaxMemoryPerTask, maxQuerySpillPerNode)));
 
-        tasks = CacheBuilder.newBuilder().build(CacheLoader.from(
+        tasks = buildNonEvictableCache(CacheBuilder.newBuilder(), CacheLoader.from(
                 taskId -> createSqlTask(
                         taskId,
                         locationFactory.createLocalTaskLocation(taskId),

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/TopologyAwareNodeSelectorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/TopologyAwareNodeSelectorFactory.java
@@ -14,7 +14,6 @@
 package io.trino.execution.scheduler;
 
 import com.google.common.base.Suppliers;
-import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
@@ -27,6 +26,7 @@ import io.trino.connector.CatalogName;
 import io.trino.execution.NodeTaskMap;
 import io.trino.metadata.InternalNode;
 import io.trino.metadata.InternalNodeManager;
+import io.trino.plugin.base.cache.NonEvictableCache;
 import io.trino.spi.HostAddress;
 import io.trino.spi.SplitWeight;
 
@@ -46,6 +46,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.SystemSessionProperties.getMaxUnacknowledgedSplitsPerTask;
 import static io.trino.metadata.NodeState.ACTIVE;
+import static io.trino.plugin.base.cache.SafeCaches.buildNonEvictableCache;
 import static java.util.Objects.requireNonNull;
 
 public class TopologyAwareNodeSelectorFactory
@@ -53,9 +54,9 @@ public class TopologyAwareNodeSelectorFactory
 {
     private static final Logger LOG = Logger.get(TopologyAwareNodeSelectorFactory.class);
 
-    private final Cache<InternalNode, Object> inaccessibleNodeLogCache = CacheBuilder.newBuilder()
-            .expireAfterWrite(30, TimeUnit.SECONDS)
-            .build();
+    private final NonEvictableCache<InternalNode, Object> inaccessibleNodeLogCache = buildNonEvictableCache(
+            CacheBuilder.newBuilder()
+                    .expireAfterWrite(30, TimeUnit.SECONDS));
 
     private final NetworkTopology networkTopology;
     private final InternalNodeManager nodeManager;

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/UniformNodeSelectorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/UniformNodeSelectorFactory.java
@@ -15,7 +15,6 @@ package io.trino.execution.scheduler;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
-import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableSetMultimap;
 import io.airlift.log.Logger;
@@ -25,6 +24,7 @@ import io.trino.connector.CatalogName;
 import io.trino.execution.NodeTaskMap;
 import io.trino.metadata.InternalNode;
 import io.trino.metadata.InternalNodeManager;
+import io.trino.plugin.base.cache.NonEvictableCache;
 import io.trino.spi.HostAddress;
 import io.trino.spi.SplitWeight;
 
@@ -42,6 +42,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.SystemSessionProperties.getMaxUnacknowledgedSplitsPerTask;
 import static io.trino.metadata.NodeState.ACTIVE;
+import static io.trino.plugin.base.cache.SafeCaches.buildNonEvictableCache;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -51,9 +52,9 @@ public class UniformNodeSelectorFactory
 {
     private static final Logger LOG = Logger.get(UniformNodeSelectorFactory.class);
 
-    private final Cache<InternalNode, Object> inaccessibleNodeLogCache = CacheBuilder.newBuilder()
-            .expireAfterWrite(30, TimeUnit.SECONDS)
-            .build();
+    private final NonEvictableCache<InternalNode, Object> inaccessibleNodeLogCache = buildNonEvictableCache(
+            CacheBuilder.newBuilder()
+                    .expireAfterWrite(30, TimeUnit.SECONDS));
 
     private final InternalNodeManager nodeManager;
     private final int minCandidates;

--- a/core/trino-main/src/main/java/io/trino/metadata/AbstractTypedJacksonModule.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/AbstractTypedJacksonModule.java
@@ -34,8 +34,9 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.BeanSerializerFactory;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.fasterxml.jackson.databind.type.TypeFactory;
-import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import io.trino.plugin.base.cache.NonEvictableCache;
+import io.trino.plugin.base.cache.SafeCaches;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
@@ -92,7 +93,7 @@ public abstract class AbstractTypedJacksonModule<T>
             extends StdSerializer<T>
     {
         private final TypeSerializer typeSerializer;
-        private final Cache<Class<?>, JsonSerializer<T>> serializerCache = CacheBuilder.newBuilder().build();
+        private final NonEvictableCache<Class<?>, JsonSerializer<T>> serializerCache = SafeCaches.buildNonEvictableCache(CacheBuilder.newBuilder());
 
         public InternalTypeSerializer(Class<T> baseClass, TypeIdResolver typeIdResolver)
         {

--- a/core/trino-main/src/main/java/io/trino/sql/gen/PageFunctionCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/PageFunctionCompiler.java
@@ -16,7 +16,6 @@ package io.trino.sql.gen;
 import com.google.common.base.Throwables;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -42,6 +41,7 @@ import io.trino.operator.project.PageFieldsToInputParametersRewriter;
 import io.trino.operator.project.PageFilter;
 import io.trino.operator.project.PageProjection;
 import io.trino.operator.project.SelectedPositions;
+import io.trino.plugin.base.cache.NonEvictableLoadingCache;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
@@ -88,6 +88,7 @@ import static io.airlift.bytecode.expression.BytecodeExpressions.lessThan;
 import static io.airlift.bytecode.expression.BytecodeExpressions.newArray;
 import static io.airlift.bytecode.expression.BytecodeExpressions.not;
 import static io.trino.operator.project.PageFieldsToInputParametersRewriter.rewritePageFieldsToInputParameters;
+import static io.trino.plugin.base.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.spi.StandardErrorCode.COMPILER_ERROR;
 import static io.trino.sql.gen.BytecodeUtils.generateWrite;
 import static io.trino.sql.gen.BytecodeUtils.invoke;
@@ -102,8 +103,8 @@ public class PageFunctionCompiler
 {
     private final Metadata metadata;
 
-    private final LoadingCache<RowExpression, Supplier<PageProjection>> projectionCache;
-    private final LoadingCache<RowExpression, Supplier<PageFilter>> filterCache;
+    private final NonEvictableLoadingCache<RowExpression, Supplier<PageProjection>> projectionCache;
+    private final NonEvictableLoadingCache<RowExpression, Supplier<PageFilter>> filterCache;
 
     private final CacheStatsMBean projectionCacheStats;
     private final CacheStatsMBean filterCacheStats;
@@ -119,10 +120,11 @@ public class PageFunctionCompiler
         this.metadata = requireNonNull(metadata, "metadata is null");
 
         if (expressionCacheSize > 0) {
-            projectionCache = CacheBuilder.newBuilder()
-                    .recordStats()
-                    .maximumSize(expressionCacheSize)
-                    .build(CacheLoader.from(projection -> compileProjectionInternal(projection, Optional.empty())));
+            projectionCache = buildNonEvictableCache(
+                    CacheBuilder.newBuilder()
+                            .recordStats()
+                            .maximumSize(expressionCacheSize),
+                    CacheLoader.from(projection -> compileProjectionInternal(projection, Optional.empty())));
             projectionCacheStats = new CacheStatsMBean(projectionCache);
         }
         else {
@@ -131,10 +133,11 @@ public class PageFunctionCompiler
         }
 
         if (expressionCacheSize > 0) {
-            filterCache = CacheBuilder.newBuilder()
-                    .recordStats()
-                    .maximumSize(expressionCacheSize)
-                    .build(CacheLoader.from(filter -> compileFilterInternal(filter, Optional.empty())));
+            filterCache = buildNonEvictableCache(
+                    CacheBuilder.newBuilder()
+                            .recordStats()
+                            .maximumSize(expressionCacheSize),
+                    CacheLoader.from(filter -> compileFilterInternal(filter, Optional.empty())));
             filterCacheStats = new CacheStatsMBean(filterCache);
         }
         else {

--- a/core/trino-main/src/main/java/io/trino/type/BlockTypeOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/BlockTypeOperators.java
@@ -13,9 +13,9 @@
  */
 package io.trino.type;
 
-import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import io.trino.plugin.base.cache.NonKeyEvictableCache;
 import io.trino.spi.block.Block;
 import io.trino.spi.connector.SortOrder;
 import io.trino.spi.function.InvocationConvention;
@@ -34,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Throwables.throwIfUnchecked;
+import static io.trino.plugin.base.cache.SafeCaches.buildNonEvictableCacheWithWeakInvalidateAll;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
@@ -54,7 +55,7 @@ public final class BlockTypeOperators
     private static final InvocationConvention ORDERING_CONVENTION = simpleConvention(FAIL_ON_NULL, BLOCK_POSITION, BLOCK_POSITION);
     private static final InvocationConvention LESS_THAN_CONVENTION = simpleConvention(FAIL_ON_NULL, BLOCK_POSITION, BLOCK_POSITION);
 
-    private final Cache<GeneratedBlockOperatorKey<?>, GeneratedBlockOperator<?>> generatedBlockOperatorCache;
+    private final NonKeyEvictableCache<GeneratedBlockOperatorKey<?>, GeneratedBlockOperator<?>> generatedBlockOperatorCache;
     private final TypeOperators typeOperators;
 
     public BlockTypeOperators()
@@ -66,10 +67,10 @@ public final class BlockTypeOperators
     public BlockTypeOperators(TypeOperators typeOperators)
     {
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
-        this.generatedBlockOperatorCache = CacheBuilder.newBuilder()
-                .maximumSize(10_000)
-                .expireAfterWrite(2, TimeUnit.HOURS)
-                .build();
+        this.generatedBlockOperatorCache = buildNonEvictableCacheWithWeakInvalidateAll(
+                CacheBuilder.newBuilder()
+                        .maximumSize(10_000)
+                        .expireAfterWrite(2, TimeUnit.HOURS));
     }
 
     public BlockPositionEqual getEqualOperator(Type type)

--- a/core/trino-main/src/main/java/io/trino/type/TypeOperatorsCache.java
+++ b/core/trino-main/src/main/java/io/trino/type/TypeOperatorsCache.java
@@ -13,9 +13,9 @@
  */
 package io.trino.type;
 
-import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import io.trino.plugin.base.cache.NonKeyEvictableCache;
 import org.weakref.jmx.Managed;
 
 import java.util.concurrent.ExecutionException;
@@ -23,13 +23,14 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Throwables.throwIfUnchecked;
+import static io.trino.plugin.base.cache.SafeCaches.buildNonEvictableCacheWithWeakInvalidateAll;
 
 public class TypeOperatorsCache
         implements BiFunction<Object, Supplier<Object>, Object>
 {
-    private final Cache<Object, Object> cache = CacheBuilder.newBuilder()
-            .maximumSize(10_000)
-            .build();
+    private final NonKeyEvictableCache<Object, Object> cache = buildNonEvictableCacheWithWeakInvalidateAll(
+            CacheBuilder.newBuilder()
+                    .maximumSize(10_000));
 
     @Override
     public Object apply(Object operatorConvention, Supplier<Object> supplier)

--- a/core/trino-main/src/main/java/io/trino/util/FastutilSetHelper.java
+++ b/core/trino-main/src/main/java/io/trino/util/FastutilSetHelper.java
@@ -13,9 +13,9 @@
  */
 package io.trino.util;
 
-import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import io.trino.plugin.base.cache.NonEvictableCache;
 import io.trino.spi.type.Type;
 import it.unimi.dsi.fastutil.Hash;
 import it.unimi.dsi.fastutil.booleans.BooleanOpenHashSet;
@@ -36,6 +36,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.base.Verify.verifyNotNull;
+import static io.trino.plugin.base.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.util.SingleAccessMethodCompiler.compileSingleAccessMethod;
 import static java.lang.Boolean.TRUE;
 import static java.lang.invoke.MethodType.methodType;
@@ -238,10 +239,10 @@ public final class FastutilSetHelper
 
     private static class MethodGenerator
     {
-        private static final Cache<MethodKey<?>, GeneratedMethod<?>> generatedMethodCache = CacheBuilder.newBuilder()
-                .maximumSize(1_000)
-                .expireAfterWrite(2, TimeUnit.HOURS)
-                .build();
+        private static final NonEvictableCache<MethodKey<?>, GeneratedMethod<?>> generatedMethodCache = buildNonEvictableCache(
+                CacheBuilder.newBuilder()
+                        .maximumSize(1_000)
+                        .expireAfterWrite(2, TimeUnit.HOURS));
 
         private static <T> T getGeneratedMethod(Type type, Class<T> operatorInterface, MethodHandle methodHandle)
         {

--- a/core/trino-main/src/test/java/io/trino/operator/MockExchangeRequestProcessor.java
+++ b/core/trino-main/src/test/java/io/trino/operator/MockExchangeRequestProcessor.java
@@ -45,6 +45,7 @@ import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static io.trino.TrinoMediaTypes.TRINO_PAGES;
 import static io.trino.execution.buffer.PagesSerdeUtil.calculateChecksum;
 import static io.trino.execution.buffer.TestingPagesSerdeFactory.testingPagesSerde;
+import static io.trino.plugin.base.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.server.InternalHeaders.TRINO_BUFFER_COMPLETE;
 import static io.trino.server.InternalHeaders.TRINO_PAGE_NEXT_TOKEN;
 import static io.trino.server.InternalHeaders.TRINO_PAGE_TOKEN;
@@ -60,7 +61,7 @@ public class MockExchangeRequestProcessor
     private static final String TASK_INSTANCE_ID = "task-instance-id";
     private static final PagesSerde PAGES_SERDE = testingPagesSerde();
 
-    private final LoadingCache<URI, MockBuffer> buffers = CacheBuilder.newBuilder().build(CacheLoader.from(MockBuffer::new));
+    private final LoadingCache<URI, MockBuffer> buffers = buildNonEvictableCache(CacheBuilder.newBuilder(), CacheLoader.from(MockBuffer::new));
 
     private final DataSize expectedMaxSize;
 

--- a/core/trino-main/src/test/java/io/trino/operator/TestExchangeOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestExchangeOperator.java
@@ -52,6 +52,7 @@ import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.operator.ExchangeOperator.REMOTE_CONNECTOR_ID;
 import static io.trino.operator.PageAssertions.assertPageEquals;
 import static io.trino.operator.TestingTaskBuffer.PAGE;
+import static io.trino.plugin.base.cache.SafeCaches.buildNonEvictableCacheWithWeakInvalidateAll;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.testing.TestingTaskContext.createTaskContext;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
@@ -69,7 +70,8 @@ public class TestExchangeOperator
     private static final TaskId TASK_2_ID = new TaskId(new StageId("query", 0), 1, 0);
     private static final TaskId TASK_3_ID = new TaskId(new StageId("query", 0), 2, 0);
 
-    private final LoadingCache<TaskId, TestingTaskBuffer> taskBuffers = CacheBuilder.newBuilder().build(CacheLoader.from(TestingTaskBuffer::new));
+    private final LoadingCache<TaskId, TestingTaskBuffer> taskBuffers = buildNonEvictableCacheWithWeakInvalidateAll(
+            CacheBuilder.newBuilder(), CacheLoader.from(TestingTaskBuffer::new));
 
     private ScheduledExecutorService scheduler;
     private ScheduledExecutorService scheduledExecutor;
@@ -120,6 +122,7 @@ public class TestExchangeOperator
     @BeforeMethod
     public void setUpMethod()
     {
+        // the test class is single-threaded, so there should be no ongoing loads and invalidation should be effective
         taskBuffers.invalidateAll();
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/TestMergeOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestMergeOperator.java
@@ -51,6 +51,7 @@ import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.operator.OperatorAssertion.assertOperatorIsBlocked;
 import static io.trino.operator.OperatorAssertion.assertOperatorIsUnblocked;
 import static io.trino.operator.PageAssertions.assertPageEquals;
+import static io.trino.plugin.base.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.spi.connector.SortOrder.ASC_NULLS_FIRST;
 import static io.trino.spi.connector.SortOrder.DESC_NULLS_FIRST;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -84,7 +85,7 @@ public class TestMergeOperator
         executor = newSingleThreadScheduledExecutor(daemonThreadsNamed("test-merge-operator-%s"));
         serdeFactory = new TestingPagesSerdeFactory();
 
-        taskBuffers = CacheBuilder.newBuilder().build(CacheLoader.from(TestingTaskBuffer::new));
+        taskBuffers = buildNonEvictableCache(CacheBuilder.newBuilder(), CacheLoader.from(TestingTaskBuffer::new));
         httpClient = new TestingHttpClient(new TestingExchangeHttpClientHandler(taskBuffers), executor);
         exchangeClientFactory = new ExchangeClientFactory(new NodeInfo("test"), new FeaturesConfig(), new ExchangeClientConfig(), httpClient, executor);
         orderingCompiler = new OrderingCompiler(new TypeOperators());

--- a/docs/src/main/sphinx/connector/bigquery.rst
+++ b/docs/src/main/sphinx/connector/bigquery.rst
@@ -130,11 +130,6 @@ Property                                              Description               
 ``bigquery.credentials-key``                          The base64 encoded credentials key                             None. See the `requirements <#requirements>`_ section.
 ``bigquery.credentials-file``                         The path to the JSON credentials file                          None. See the `requirements <#requirements>`_ section.
 ``bigquery.case-insensitive-name-matching``           Match dataset and table names case-insensitively               ``false``
-``bigquery.case-insensitive-name-matching.cache-ttl`` Duration for which remote dataset and table names will be      ``1m``
-                                                      cached. Higher values reduce the number of API calls to
-                                                      BigQuery but can cause newly created dataset or tables to not
-                                                      be visible until the configured duration. Set to ``0ms`` to
-                                                      disable the cache.
 ===================================================== ============================================================== ======================================================
 
 Data types

--- a/lib/trino-plugin-toolkit/pom.xml
+++ b/lib/trino-plugin-toolkit/pom.xml
@@ -115,6 +115,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.gaul</groupId>
+            <artifactId>modernizer-maven-annotations</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.weakref</groupId>
             <artifactId>jmxutils</artifactId>
         </dependency>
@@ -143,13 +148,6 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.gaul</groupId>
-            <artifactId>modernizer-maven-annotations</artifactId>
-            <version>2.1.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/cache/EvictableCache.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/cache/EvictableCache.java
@@ -18,6 +18,7 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheStats;
 import com.google.common.util.concurrent.SettableFuture;
+import org.gaul.modernizer_maven_annotations.SuppressModernizer;
 
 import javax.annotation.CheckForNull;
 
@@ -61,7 +62,13 @@ public class EvictableCache<K, V>
     private EvictableCache(CacheBuilder<? super K, Object> cacheBuilder)
     {
         requireNonNull(cacheBuilder, "cacheBuilder is null");
-        this.delegate = cacheBuilder.build();
+        this.delegate = buildUnsafeCache(cacheBuilder);
+    }
+
+    @SuppressModernizer // CacheBuilder.build() is forbidden, advising to use this class as a safety-adding wrapper.
+    private static <K, V> Cache<K, V> buildUnsafeCache(CacheBuilder<? super K, ? super V> cacheBuilder)
+    {
+        return cacheBuilder.build();
     }
 
     @CheckForNull

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/cache/EvictableLoadingCache.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/cache/EvictableLoadingCache.java
@@ -23,6 +23,7 @@ import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListenableFuture;
+import org.gaul.modernizer_maven_annotations.SuppressModernizer;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -77,7 +78,13 @@ public class EvictableLoadingCache<K, V>
 
         return new EvictableLoadingCache<>(
                 EvictableCache.buildWith(tokenCache),
-                dataCache.build(new TokenCacheLoader<>(cacheLoader)));
+                buildUnsafeCache(dataCache, new TokenCacheLoader<>(cacheLoader)));
+    }
+
+    @SuppressModernizer // CacheBuilder.build(CacheLoader) is forbidden, advising to use this class as a safety-adding wrapper.
+    private static <K, V> LoadingCache<K, V> buildUnsafeCache(CacheBuilder<? super K, ? super V> cacheBuilder, CacheLoader<? super K, V> cacheLoader)
+    {
+        return cacheBuilder.build(cacheLoader);
     }
 
     // Token<K> is a freshness marker. tokenCache keeps the fresh token for given key.

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/cache/NonEvictableCache.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/cache/NonEvictableCache.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.cache;
+
+import com.google.common.cache.Cache;
+
+/**
+ * A {@link com.google.common.cache.Cache} that does not support eviction.
+ */
+public interface NonEvictableCache<K, V>
+        extends Cache<K, V>
+{
+    /**
+     * @deprecated Not supported. Use {@link EvictableCache} cache implementation instead.
+     */
+    @Deprecated
+    @Override
+    void invalidate(Object key);
+
+    /**
+     * @deprecated Not supported. Use {@link EvictableCache} cache implementation instead.
+     */
+    @Deprecated
+    @Override
+    void invalidateAll(Iterable<?> keys);
+
+    /**
+     * @deprecated Not supported. Use {@link EvictableCache} cache implementation instead.
+     */
+    @Deprecated
+    @Override
+    void invalidateAll();
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/cache/NonEvictableCacheImpl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/cache/NonEvictableCacheImpl.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.cache;
+
+import com.google.common.cache.Cache;
+
+// package-private. The interface provides deprecation and javadoc to help at call sites
+final class NonEvictableCacheImpl<K, V>
+        extends NonKeyEvictableCacheImpl<K, V>
+        implements NonEvictableCache<K, V>
+{
+    NonEvictableCacheImpl(Cache<K, V> delegate)
+    {
+        super(delegate);
+    }
+
+    @Override
+    public void invalidateAll()
+    {
+        throw new UnsupportedOperationException("invalidateAll does not invalidate ongoing loads, so a stale value may remain in the cache for ever. " +
+                "Use EvictableCache if you need invalidation, or use SafeCaches.buildNonEvictableCacheWithWeakInvalidateAll() " +
+                "if invalidateAll is not required for correctness");
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/cache/NonEvictableLoadingCache.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/cache/NonEvictableLoadingCache.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.cache;
+
+/**
+ * A {@link com.google.common.cache.LoadingCache} that does not support eviction.
+ */
+public interface NonEvictableLoadingCache<K, V>
+        extends NonKeyEvictableLoadingCache<K, V>
+{
+    /**
+     * @deprecated Not supported. Use {@link EvictableLoadingCache} cache implementation instead.
+     */
+    @Deprecated
+    @Override
+    void invalidateAll();
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/cache/NonEvictableLoadingCacheImpl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/cache/NonEvictableLoadingCacheImpl.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.cache;
+
+import com.google.common.cache.LoadingCache;
+
+// package-private. The interface provides deprecation and javadoc to help at call sites
+final class NonEvictableLoadingCacheImpl<K, V>
+        extends NonKeyEvictableLoadingCacheImpl<K, V>
+        implements NonEvictableLoadingCache<K, V>
+{
+    NonEvictableLoadingCacheImpl(LoadingCache<K, V> delegate)
+    {
+        super(delegate);
+    }
+
+    @Override
+    public void invalidateAll()
+    {
+        throw new UnsupportedOperationException("invalidateAll does not invalidate ongoing loads, so a stale value may remain in the cache for ever. " +
+                "Use EvictableLoadingCache if you need invalidation, or use SafeCaches.buildNonEvictableCacheWithWeakInvalidateAll() " +
+                "if invalidateAll is not required for correctness");
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/cache/NonKeyEvictableCache.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/cache/NonKeyEvictableCache.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.cache;
+
+import com.google.common.cache.Cache;
+
+/**
+ * A {@link com.google.common.cache.Cache} that does not support key-based eviction.
+ */
+public interface NonKeyEvictableCache<K, V>
+        extends Cache<K, V>
+{
+    /**
+     * @deprecated Not supported. Use {@link EvictableCache} cache implementation instead.
+     */
+    @Deprecated
+    @Override
+    void invalidate(Object key);
+
+    /**
+     * @deprecated Not supported. Use {@link EvictableCache} cache implementation instead.
+     */
+    @Deprecated
+    @Override
+    void invalidateAll(Iterable<?> keys);
+
+    /**
+     * Invalidates all live entries in the cache. Ongoing loads may not be invalidated, so subsequent
+     * get from the cache is not guaranteed to return fresh state. Must not be relied on for correctness,
+     * but can be used for manual intervention, e.g. as a method exposed over JMX.
+     */
+    @Override
+    void invalidateAll();
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/cache/NonKeyEvictableCacheImpl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/cache/NonKeyEvictableCacheImpl.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.cache;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.ForwardingCache;
+
+import static java.util.Objects.requireNonNull;
+
+// package-private. The interface provides deprecation and javadoc to help at call sites
+class NonKeyEvictableCacheImpl<K, V>
+        extends ForwardingCache<K, V>
+        implements NonKeyEvictableCache<K, V>
+{
+    private final Cache<K, V> delegate;
+
+    NonKeyEvictableCacheImpl(Cache<K, V> delegate)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+    }
+
+    @Override
+    protected Cache<K, V> delegate()
+    {
+        return delegate;
+    }
+
+    @Override
+    public void invalidate(Object key)
+    {
+        throw new UnsupportedOperationException("invalidate(key) does not invalidate ongoing loads, so a stale value may remain in the cache for ever. " +
+                "Use EvictableCache if you need invalidation");
+    }
+
+    @Override
+    public void invalidateAll(Iterable<?> keys)
+    {
+        throw new UnsupportedOperationException("invalidateAll(keys) does not invalidate ongoing loads, so a stale value may remain in the cache for ever. " +
+                "Use EvictableCache if you need invalidation");
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/cache/NonKeyEvictableLoadingCache.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/cache/NonKeyEvictableLoadingCache.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.cache;
+
+import com.google.common.cache.LoadingCache;
+
+/**
+ * A {@link com.google.common.cache.LoadingCache} that does not support key-based eviction.
+ */
+public interface NonKeyEvictableLoadingCache<K, V>
+        extends LoadingCache<K, V>
+{
+    /**
+     * @deprecated Not supported. Use {@link EvictableLoadingCache} cache implementation instead.
+     */
+    @Deprecated
+    @Override
+    void invalidate(Object key);
+
+    /**
+     * @deprecated Not supported. Use {@link EvictableLoadingCache} cache implementation instead.
+     */
+    @Deprecated
+    @Override
+    void invalidateAll(Iterable<?> keys);
+
+    /**
+     * Invalidates all live entries in the cache. Ongoing loads may not be invalidated, so subsequent
+     * get from the cache is not guaranteed to return fresh state. Must not be relied on for correctness,
+     * but can be used for manual intervention, e.g. as a method exposed over JMX.
+     */
+    @Override
+    void invalidateAll();
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/cache/NonKeyEvictableLoadingCacheImpl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/cache/NonKeyEvictableLoadingCacheImpl.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.cache;
+
+import com.google.common.cache.ForwardingLoadingCache;
+import com.google.common.cache.LoadingCache;
+
+import static java.util.Objects.requireNonNull;
+
+// package-private. The interface provides deprecation and javadoc to help at call sites
+class NonKeyEvictableLoadingCacheImpl<K, V>
+        extends ForwardingLoadingCache<K, V>
+        implements NonKeyEvictableLoadingCache<K, V>
+{
+    private final LoadingCache<K, V> delegate;
+
+    NonKeyEvictableLoadingCacheImpl(LoadingCache<K, V> delegate)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+    }
+
+    @Override
+    protected LoadingCache<K, V> delegate()
+    {
+        return delegate;
+    }
+
+    @Override
+    public void invalidate(Object key)
+    {
+        throw new UnsupportedOperationException("invalidate(key) does not invalidate ongoing loads, so a stale value may remain in the cache for ever. " +
+                "Use EvictableLoadingCache if you need invalidation");
+    }
+
+    @Override
+    public void invalidateAll(Iterable<?> keys)
+    {
+        throw new UnsupportedOperationException("invalidateAll(keys) does not invalidate ongoing loads, so a stale value may remain in the cache for ever. " +
+                "Use EvictableLoadingCache if you need invalidation");
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/cache/SafeCaches.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/cache/SafeCaches.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.cache;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import org.gaul.modernizer_maven_annotations.SuppressModernizer;
+
+/**
+ * @see EvictableCache
+ * @see EvictableLoadingCache
+ */
+public final class SafeCaches
+{
+    private SafeCaches() {}
+
+    public static <K, V> NonEvictableCache<K, V> buildNonEvictableCache(CacheBuilder<? super K, ? super V> cacheBuilder)
+    {
+        return new NonEvictableCacheImpl<>(buildUnsafeCache(cacheBuilder));
+    }
+
+    /**
+     * Builds a cache that supports {@link Cache#invalidateAll()} with best-effort semantics:
+     * there is no guarantee that cache is empty after {@code invalidateAll()} returns, or that
+     * subsequent read will not see stale state.
+     */
+    public static <K, V> NonKeyEvictableCache<K, V> buildNonEvictableCacheWithWeakInvalidateAll(CacheBuilder<? super K, ? super V> cacheBuilder)
+    {
+        return new NonKeyEvictableCacheImpl<>(buildUnsafeCache(cacheBuilder));
+    }
+
+    public static <K, V> NonEvictableLoadingCache<K, V> buildNonEvictableCache(CacheBuilder<? super K, ? super V> cacheBuilder, CacheLoader<? super K, V> cacheLoader)
+    {
+        return new NonEvictableLoadingCacheImpl<>(buildUnsafeCache(cacheBuilder, cacheLoader));
+    }
+
+    /**
+     * Builds a cache that supports {@link Cache#invalidateAll()} with best-effort semantics:
+     * there is no guarantee that cache is empty after {@code invalidateAll()} returns, or that
+     * subsequent read will not see stale state.
+     */
+    public static <K, V> NonKeyEvictableLoadingCache<K, V> buildNonEvictableCacheWithWeakInvalidateAll(
+            CacheBuilder<? super K, ? super V> cacheBuilder,
+            CacheLoader<? super K, V> cacheLoader)
+    {
+        return new NonKeyEvictableLoadingCacheImpl<>(buildUnsafeCache(cacheBuilder, cacheLoader));
+    }
+
+    @SuppressModernizer // CacheBuilder.build() is forbidden, advising to use this class as a safety-adding wrapper.
+    private static <K, V> Cache<K, V> buildUnsafeCache(CacheBuilder<? super K, ? super V> cacheBuilder)
+    {
+        return cacheBuilder.build();
+    }
+
+    @SuppressModernizer // CacheBuilder.build(CacheLoader) is forbidden, advising to use this class as a safety-adding wrapper.
+    private static <K, V> LoadingCache<K, V> buildUnsafeCache(CacheBuilder<? super K, ? super V> cacheBuilder, CacheLoader<? super K, V> cacheLoader)
+    {
+        return cacheBuilder.build(cacheLoader);
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/mapping/CachingIdentifierMapping.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/mapping/CachingIdentifierMapping.java
@@ -14,11 +14,11 @@
 package io.trino.plugin.jdbc.mapping;
 
 import com.google.common.base.CharMatcher;
-import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.trino.plugin.base.cache.NonKeyEvictableCache;
 import io.trino.plugin.jdbc.BaseJdbcClient;
 import io.trino.plugin.jdbc.mapping.IdentifierMappingModule.ForCachingIdentifierMapping;
 import io.trino.spi.TrinoException;
@@ -43,6 +43,7 @@ import java.util.function.Function;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
+import static io.trino.plugin.base.cache.SafeCaches.buildNonEvictableCacheWithWeakInvalidateAll;
 import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -50,8 +51,8 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public final class CachingIdentifierMapping
         implements IdentifierMapping
 {
-    private final Cache<ConnectorIdentity, Mapping> remoteSchemaNames;
-    private final Cache<RemoteTableNameCacheKey, Mapping> remoteTableNames;
+    private final NonKeyEvictableCache<ConnectorIdentity, Mapping> remoteSchemaNames;
+    private final NonKeyEvictableCache<RemoteTableNameCacheKey, Mapping> remoteTableNames;
     private final IdentifierMapping identifierMapping;
     private final Provider<BaseJdbcClient> baseJdbcClient;
 
@@ -64,8 +65,8 @@ public final class CachingIdentifierMapping
         requireNonNull(mappingConfig, "mappingConfig is null");
         CacheBuilder<Object, Object> remoteNamesCacheBuilder = CacheBuilder.newBuilder()
                 .expireAfterWrite(mappingConfig.getCaseInsensitiveNameMatchingCacheTtl().toMillis(), MILLISECONDS);
-        this.remoteSchemaNames = remoteNamesCacheBuilder.build();
-        this.remoteTableNames = remoteNamesCacheBuilder.build();
+        this.remoteSchemaNames = buildNonEvictableCacheWithWeakInvalidateAll(remoteNamesCacheBuilder);
+        this.remoteTableNames = buildNonEvictableCacheWithWeakInvalidateAll(remoteNamesCacheBuilder);
 
         this.identifierMapping = requireNonNull(identifierMapping, "identifierMapping is null");
         this.baseJdbcClient = requireNonNull(baseJdbcClient, "baseJdbcClient is null");

--- a/plugin/trino-bigquery/pom.xml
+++ b/plugin/trino-bigquery/pom.xml
@@ -55,6 +55,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-plugin-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>bootstrap</artifactId>
         </dependency>

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClientFactory.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClientFactory.java
@@ -18,8 +18,8 @@ import com.google.auth.Credentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
-import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import io.trino.plugin.base.cache.NonEvictableCache;
 import io.trino.spi.connector.ConnectorSession;
 
 import javax.inject.Inject;
@@ -27,6 +27,7 @@ import javax.inject.Inject;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
+import static io.trino.plugin.base.cache.SafeCaches.buildNonEvictableCache;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -37,7 +38,7 @@ public class BigQueryClientFactory
     private final BigQueryConfig bigQueryConfig;
     private final ViewMaterializationCache materializationCache;
     private final HeaderProvider headerProvider;
-    private final Cache<IdentityCacheMapping.IdentityCacheKey, BigQueryClient> clientCache;
+    private final NonEvictableCache<IdentityCacheMapping.IdentityCacheKey, BigQueryClient> clientCache;
 
     @Inject
     public BigQueryClientFactory(
@@ -56,7 +57,7 @@ public class BigQueryClientFactory
         CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder()
                 .expireAfterWrite(bigQueryConfig.getServiceCacheTtl().toMillis(), MILLISECONDS);
 
-        clientCache = cacheBuilder.build();
+        clientCache = buildNonEvictableCache(cacheBuilder);
     }
 
     public BigQueryClient create(ConnectorSession session)

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConfig.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConfig.java
@@ -16,6 +16,7 @@ package io.trino.plugin.bigquery;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.ConfigHidden;
+import io.airlift.configuration.DefunctConfig;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDuration;
 
@@ -27,6 +28,7 @@ import java.util.Optional;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
+@DefunctConfig("bigquery.case-insensitive-name-matching.cache-ttl")
 public class BigQueryConfig
 {
     public static final int DEFAULT_MAX_READ_ROWS_RETRIES = 3;
@@ -40,7 +42,6 @@ public class BigQueryConfig
     private Optional<String> viewMaterializationDataset = Optional.empty();
     private int maxReadRowsRetries = DEFAULT_MAX_READ_ROWS_RETRIES;
     private boolean caseInsensitiveNameMatching;
-    private Duration caseInsensitiveNameMatchingCacheTtl = new Duration(1, MINUTES);
     private Duration viewsCacheTtl = new Duration(15, MINUTES);
     private Duration serviceCacheTtl = new Duration(3, MINUTES);
 
@@ -152,21 +153,6 @@ public class BigQueryConfig
     public BigQueryConfig setCaseInsensitiveNameMatching(boolean caseInsensitiveNameMatching)
     {
         this.caseInsensitiveNameMatching = caseInsensitiveNameMatching;
-        return this;
-    }
-
-    @NotNull
-    @MinDuration("0ms")
-    public Duration getCaseInsensitiveNameMatchingCacheTtl()
-    {
-        return caseInsensitiveNameMatchingCacheTtl;
-    }
-
-    @Config("bigquery.case-insensitive-name-matching.cache-ttl")
-    @ConfigDescription("Duration for which remote dataset and table names will be cached")
-    public BigQueryConfig setCaseInsensitiveNameMatchingCacheTtl(Duration caseInsensitiveNameMatchingCacheTtl)
-    {
-        this.caseInsensitiveNameMatchingCacheTtl = caseInsensitiveNameMatchingCacheTtl;
         return this;
     }
 

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConfig.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConfig.java
@@ -24,7 +24,6 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDe
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.MINUTES;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class TestBigQueryConfig
 {
@@ -39,7 +38,6 @@ public class TestBigQueryConfig
                 .setViewMaterializationDataset(null)
                 .setMaxReadRowsRetries(3)
                 .setCaseInsensitiveNameMatching(false)
-                .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, MINUTES))
                 .setViewsCacheTtl(new Duration(15, MINUTES))
                 .setServiceCacheTtl(new Duration(3, MINUTES))
                 .setViewsEnabled(false));
@@ -57,7 +55,6 @@ public class TestBigQueryConfig
                 .put("bigquery.view-materialization-dataset", "vmdataset")
                 .put("bigquery.max-read-rows-retries", "10")
                 .put("bigquery.case-insensitive-name-matching", "true")
-                .put("bigquery.case-insensitive-name-matching.cache-ttl", "1s")
                 .put("bigquery.views-cache-ttl", "1m")
                 .put("bigquery.service-cache-ttl", "10d")
                 .buildOrThrow();
@@ -71,7 +68,6 @@ public class TestBigQueryConfig
                 .setViewMaterializationDataset("vmdataset")
                 .setMaxReadRowsRetries(10)
                 .setCaseInsensitiveNameMatching(true)
-                .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, SECONDS))
                 .setViewsCacheTtl(new Duration(1, MINUTES))
                 .setServiceCacheTtl(new Duration(10, DAYS));
 

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsClient.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsClient.java
@@ -21,13 +21,13 @@ import com.google.api.services.sheets.v4.Sheets;
 import com.google.api.services.sheets.v4.SheetsScopes;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.airlift.json.JsonCodec;
 import io.airlift.log.Logger;
+import io.trino.plugin.base.cache.NonEvictableLoadingCache;
 import io.trino.spi.TrinoException;
 import io.trino.spi.type.VarcharType;
 
@@ -46,8 +46,8 @@ import java.util.Set;
 
 import static com.google.api.client.googleapis.javanet.GoogleNetHttpTransport.newTrustedTransport;
 import static com.google.common.base.Throwables.throwIfInstanceOf;
-import static com.google.common.cache.CacheLoader.from;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.base.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.plugin.google.sheets.SheetsErrorCode.SHEETS_BAD_CREDENTIALS_ERROR;
 import static io.trino.plugin.google.sheets.SheetsErrorCode.SHEETS_METASTORE_ERROR;
 import static io.trino.plugin.google.sheets.SheetsErrorCode.SHEETS_TABLE_LOAD_ERROR;
@@ -65,8 +65,8 @@ public class SheetsClient
 
     private static final List<String> SCOPES = ImmutableList.of(SheetsScopes.SPREADSHEETS_READONLY);
 
-    private final LoadingCache<String, Optional<String>> tableSheetMappingCache;
-    private final LoadingCache<String, List<List<Object>>> sheetDataCache;
+    private final NonEvictableLoadingCache<String, Optional<String>> tableSheetMappingCache;
+    private final NonEvictableLoadingCache<String, List<List<Object>>> sheetDataCache;
 
     private final String metadataSheetId;
     private final String credentialsFilePath;
@@ -91,8 +91,9 @@ public class SheetsClient
         long expiresAfterWriteMillis = config.getSheetsDataExpireAfterWrite().toMillis();
         long maxCacheSize = config.getSheetsDataMaxCacheSize();
 
-        this.tableSheetMappingCache = newCacheBuilder(expiresAfterWriteMillis, maxCacheSize)
-                .build(new CacheLoader<>()
+        this.tableSheetMappingCache = buildNonEvictableCache(
+                newCacheBuilder(expiresAfterWriteMillis, maxCacheSize),
+                new CacheLoader<>()
                 {
                     @Override
                     public Optional<String> load(String tableName)
@@ -107,7 +108,9 @@ public class SheetsClient
                     }
                 });
 
-        this.sheetDataCache = newCacheBuilder(expiresAfterWriteMillis, maxCacheSize).build(from(this::readAllValuesFromSheetExpression));
+        this.sheetDataCache = buildNonEvictableCache(
+                newCacheBuilder(expiresAfterWriteMillis, maxCacheSize),
+                CacheLoader.from(this::readAllValuesFromSheetExpression));
     }
 
     public Optional<SheetsTable> getTable(String tableName)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/CachingDirectoryLister.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/CachingDirectoryLister.java
@@ -13,11 +13,11 @@
  */
 package io.trino.plugin.hive;
 
-import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.Weigher;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.Duration;
+import io.trino.plugin.base.cache.NonKeyEvictableCache;
 import io.trino.plugin.hive.metastore.Table;
 import io.trino.spi.connector.SchemaTablePrefix;
 import org.apache.hadoop.fs.FileSystem;
@@ -36,11 +36,13 @@ import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.base.cache.SafeCaches.buildNonEvictableCacheWithWeakInvalidateAll;
 
 public class CachingDirectoryLister
         implements DirectoryLister
 {
-    private final Cache<Path, List<LocatedFileStatus>> cache;
+    // TODO (https://github.com/trinodb/trino/issues/10621) this cache lacks invalidation
+    private final NonKeyEvictableCache<Path, List<LocatedFileStatus>> cache;
     private final List<SchemaTablePrefix> tablePrefixes;
 
     @Inject
@@ -51,12 +53,11 @@ public class CachingDirectoryLister
 
     public CachingDirectoryLister(Duration expireAfterWrite, long maxSize, List<String> tables)
     {
-        this.cache = CacheBuilder.newBuilder()
+        this.cache = buildNonEvictableCacheWithWeakInvalidateAll(CacheBuilder.newBuilder()
                 .maximumWeight(maxSize)
                 .weigher((Weigher<Path, List<LocatedFileStatus>>) (key, value) -> value.size())
                 .expireAfterWrite(expireAfterWrite.toMillis(), TimeUnit.MILLISECONDS)
-                .recordStats()
-                .build();
+                .recordStats());
         this.tablePrefixes = tables.stream()
                 .map(CachingDirectoryLister::parseTableName)
                 .collect(toImmutableList());

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/RecordingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/RecordingHiveMetastore.java
@@ -20,6 +20,7 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import io.airlift.json.JsonCodec;
 import io.airlift.units.Duration;
+import io.trino.plugin.base.cache.NonEvictableCache;
 import io.trino.plugin.hive.ForRecordingHiveMetastore;
 import io.trino.plugin.hive.HiveType;
 import io.trino.plugin.hive.PartitionStatistics;
@@ -51,6 +52,7 @@ import java.util.function.Supplier;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.trino.plugin.base.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.plugin.hive.metastore.HivePartitionName.hivePartitionName;
 import static io.trino.plugin.hive.metastore.HiveTableName.hiveTableName;
 import static io.trino.plugin.hive.metastore.PartitionFilter.partitionFilter;
@@ -70,21 +72,21 @@ public class RecordingHiveMetastore
     private volatile Optional<List<String>> allDatabases = Optional.empty();
     private volatile Optional<Set<String>> allRoles = Optional.empty();
 
-    private final Cache<String, Optional<Database>> databaseCache;
-    private final Cache<HiveTableName, Optional<Table>> tableCache;
-    private final Cache<String, Set<ColumnStatisticType>> supportedColumnStatisticsCache;
-    private final Cache<HiveTableName, PartitionStatistics> tableStatisticsCache;
-    private final Cache<Set<HivePartitionName>, Map<String, PartitionStatistics>> partitionStatisticsCache;
-    private final Cache<String, List<String>> allTablesCache;
-    private final Cache<TablesWithParameterCacheKey, List<String>> tablesWithParameterCache;
-    private final Cache<String, List<String>> allViewsCache;
-    private final Cache<HivePartitionName, Optional<Partition>> partitionCache;
-    private final Cache<HiveTableName, Optional<List<String>>> partitionNamesCache;
-    private final Cache<PartitionFilter, Optional<List<String>>> partitionNamesByPartsCache;
-    private final Cache<Set<HivePartitionName>, Map<String, Optional<Partition>>> partitionsByNamesCache;
-    private final Cache<UserTableKey, Set<HivePrivilegeInfo>> tablePrivilegesCache;
-    private final Cache<HivePrincipal, Set<RoleGrant>> roleGrantsCache;
-    private final Cache<String, Set<RoleGrant>> grantedPrincipalsCache;
+    private final NonEvictableCache<String, Optional<Database>> databaseCache;
+    private final NonEvictableCache<HiveTableName, Optional<Table>> tableCache;
+    private final NonEvictableCache<String, Set<ColumnStatisticType>> supportedColumnStatisticsCache;
+    private final NonEvictableCache<HiveTableName, PartitionStatistics> tableStatisticsCache;
+    private final NonEvictableCache<Set<HivePartitionName>, Map<String, PartitionStatistics>> partitionStatisticsCache;
+    private final NonEvictableCache<String, List<String>> allTablesCache;
+    private final NonEvictableCache<TablesWithParameterCacheKey, List<String>> tablesWithParameterCache;
+    private final NonEvictableCache<String, List<String>> allViewsCache;
+    private final NonEvictableCache<HivePartitionName, Optional<Partition>> partitionCache;
+    private final NonEvictableCache<HiveTableName, Optional<List<String>>> partitionNamesCache;
+    private final NonEvictableCache<PartitionFilter, Optional<List<String>>> partitionNamesByPartsCache;
+    private final NonEvictableCache<Set<HivePartitionName>, Map<String, Optional<Partition>>> partitionsByNamesCache;
+    private final NonEvictableCache<UserTableKey, Set<HivePrivilegeInfo>> tablePrivilegesCache;
+    private final NonEvictableCache<HivePrincipal, Set<RoleGrant>> roleGrantsCache;
+    private final NonEvictableCache<String, Set<RoleGrant>> grantedPrincipalsCache;
 
     @Inject
     public RecordingHiveMetastore(@ForRecordingHiveMetastore HiveMetastore delegate, RecordingMetastoreConfig config, JsonCodec<RecordingHiveMetastore.Recording> recordingCodec)
@@ -143,16 +145,14 @@ public class RecordingHiveMetastore
         grantedPrincipalsCache.putAll(toMap(recording.getGrantedPrincipals()));
     }
 
-    private static <K, V> Cache<K, V> createCache(boolean reply, Duration recordingDuration)
+    private static <K, V> NonEvictableCache<K, V> createCache(boolean reply, Duration recordingDuration)
     {
         if (reply) {
-            return CacheBuilder.newBuilder()
-                    .build();
+            return buildNonEvictableCache(CacheBuilder.newBuilder());
         }
 
-        return CacheBuilder.newBuilder()
-                .expireAfterWrite(recordingDuration.toMillis(), MILLISECONDS)
-                .build();
+        return buildNonEvictableCache(CacheBuilder.newBuilder()
+                .expireAfterWrite(recordingDuration.toMillis(), MILLISECONDS));
     }
 
     @Managed

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -15,7 +15,6 @@ package io.trino.plugin.hive.metastore.thrift;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -23,6 +22,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
+import io.trino.plugin.base.cache.NonEvictableLoadingCache;
 import io.trino.plugin.hive.HdfsEnvironment;
 import io.trino.plugin.hive.HdfsEnvironment.HdfsContext;
 import io.trino.plugin.hive.HiveBasicStatistics;
@@ -127,10 +127,10 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Sets.difference;
+import static io.trino.plugin.base.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_TABLE_LOCK_NOT_ACQUIRED;
 import static io.trino.plugin.hive.ViewReaderUtil.PRESTO_VIEW_FLAG;
-import static io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege;
 import static io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege.OWNERSHIP;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.partitionKeyFilterToStringList;
 import static io.trino.plugin.hive.metastore.thrift.ThriftMetastoreUtil.createMetastoreColumnStatistics;
@@ -180,7 +180,7 @@ public class ThriftHiveMetastore
     private final int maxRetries;
     private final boolean impersonationEnabled;
     private final boolean authenticationEnabled;
-    private final LoadingCache<String, String> delegationTokenCache;
+    private final NonEvictableLoadingCache<String, String> delegationTokenCache;
     private final boolean deleteFilesOnDrop;
     private final boolean translateHiveViews;
 
@@ -238,10 +238,11 @@ public class ThriftHiveMetastore
         this.maxWaitForLock = thriftConfig.getMaxWaitForTransactionLock();
         this.authenticationEnabled = authenticationEnabled;
 
-        this.delegationTokenCache = CacheBuilder.newBuilder()
-                .expireAfterWrite(thriftConfig.getDelegationTokenCacheTtl().toMillis(), MILLISECONDS)
-                .maximumSize(thriftConfig.getDelegationTokenCacheMaximumSize())
-                .build(CacheLoader.from(this::loadDelegationToken));
+        this.delegationTokenCache = buildNonEvictableCache(
+                CacheBuilder.newBuilder()
+                        .expireAfterWrite(thriftConfig.getDelegationTokenCacheTtl().toMillis(), MILLISECONDS)
+                        .maximumSize(thriftConfig.getDelegationTokenCacheMaximumSize()),
+                CacheLoader.from(this::loadDelegationToken));
         this.assumeCanonicalPartitionKeys = thriftConfig.isAssumeCanonicalPartitionKeys();
     }
 

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentAvroReaderSupplier.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentAvroReaderSupplier.java
@@ -15,10 +15,10 @@ package io.trino.plugin.kafka.schema.confluent;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.trino.decoder.avro.AvroReaderSupplier;
+import io.trino.plugin.base.cache.NonEvictableLoadingCache;
 import io.trino.spi.TrinoException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import static com.google.common.base.Preconditions.checkState;
+import static io.trino.plugin.base.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -39,15 +40,15 @@ public class ConfluentAvroReaderSupplier<T>
 {
     private final Schema targetSchema;
     private final SchemaRegistryClient schemaRegistryClient;
-    private final LoadingCache<Integer, GenericDatumReader<T>> avroRecordReaderCache;
+    private final NonEvictableLoadingCache<Integer, GenericDatumReader<T>> avroRecordReaderCache;
 
     private ConfluentAvroReaderSupplier(Schema targetSchema, SchemaRegistryClient schemaRegistryClient)
     {
         this.targetSchema = requireNonNull(targetSchema, "targetSchema is null");
         this.schemaRegistryClient = requireNonNull(schemaRegistryClient, "schemaRegistryClient is null");
-        avroRecordReaderCache = CacheBuilder.newBuilder()
-                .maximumSize(1000)
-                .build(CacheLoader.from(this::lookupReader));
+        avroRecordReaderCache = buildNonEvictableCache(
+                CacheBuilder.newBuilder().maximumSize(1000),
+                CacheLoader.from(this::lookupReader));
     }
 
     private GenericDatumReader<T> lookupReader(int id)

--- a/plugin/trino-local-file/pom.xml
+++ b/plugin/trino-local-file/pom.xml
@@ -19,6 +19,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-plugin-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>bootstrap</artifactId>
         </dependency>

--- a/plugin/trino-ml/pom.xml
+++ b/plugin/trino-ml/pom.xml
@@ -23,6 +23,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-plugin-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>concurrent</artifactId>
         </dependency>

--- a/plugin/trino-ml/src/main/java/io/trino/plugin/ml/MLFunctions.java
+++ b/plugin/trino-ml/src/main/java/io/trino/plugin/ml/MLFunctions.java
@@ -13,11 +13,11 @@
  */
 package io.trino.plugin.ml;
 
-import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.hash.HashCode;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import io.trino.plugin.base.cache.NonEvictableCache;
 import io.trino.plugin.ml.type.RegressorType;
 import io.trino.spi.block.Block;
 import io.trino.spi.function.ScalarFunction;
@@ -27,13 +27,14 @@ import io.trino.spi.type.StandardTypes;
 import java.util.concurrent.ExecutionException;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.plugin.base.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.plugin.ml.type.ClassifierType.BIGINT_CLASSIFIER;
 import static io.trino.plugin.ml.type.ClassifierType.VARCHAR_CLASSIFIER;
 import static io.trino.plugin.ml.type.RegressorType.REGRESSOR;
 
 public final class MLFunctions
 {
-    private static final Cache<HashCode, Model> MODEL_CACHE = CacheBuilder.newBuilder().maximumSize(5).build();
+    private static final NonEvictableCache<HashCode, Model> MODEL_CACHE = buildNonEvictableCache(CacheBuilder.newBuilder().maximumSize(5));
     private static final String MAP_BIGINT_DOUBLE = "map(bigint,double)";
 
     private MLFunctions()

--- a/plugin/trino-password-authenticators/pom.xml
+++ b/plugin/trino-password-authenticators/pom.xml
@@ -19,6 +19,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-plugin-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>bootstrap</artifactId>
         </dependency>

--- a/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/file/PasswordStore.java
+++ b/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/file/PasswordStore.java
@@ -17,8 +17,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.base.cache.NonEvictableLoadingCache;
 import io.trino.plugin.password.Credential;
 import io.trino.spi.TrinoException;
 
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static io.trino.plugin.base.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.plugin.password.file.EncryptionUtil.doesBCryptPasswordMatch;
 import static io.trino.plugin.password.file.EncryptionUtil.doesPBKDF2PasswordMatch;
 import static io.trino.plugin.password.file.EncryptionUtil.getHashingAlgorithm;
@@ -41,7 +42,7 @@ public class PasswordStore
     private static final Splitter LINE_SPLITTER = Splitter.on(":").limit(2);
 
     private final Map<String, HashedPassword> credentials;
-    private final LoadingCache<Credential, Boolean> cache;
+    private final NonEvictableLoadingCache<Credential, Boolean> cache;
 
     public PasswordStore(File file, int cacheMaxSize)
     {
@@ -52,9 +53,9 @@ public class PasswordStore
     public PasswordStore(List<String> lines, int cacheMaxSize)
     {
         credentials = loadPasswordFile(lines);
-        cache = CacheBuilder.newBuilder()
-                .maximumSize(cacheMaxSize)
-                .build(CacheLoader.from(this::matches));
+        cache = buildNonEvictableCache(
+                CacheBuilder.newBuilder().maximumSize(cacheMaxSize),
+                CacheLoader.from(this::matches));
     }
 
     public boolean authenticate(String user, String password)

--- a/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/salesforce/SalesforceBasicAuthenticator.java
+++ b/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/salesforce/SalesforceBasicAuthenticator.java
@@ -15,7 +15,6 @@ package io.trino.plugin.password.salesforce;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.escape.Escaper;
 import com.google.common.util.concurrent.UncheckedExecutionException;
@@ -23,6 +22,8 @@ import io.airlift.http.client.HttpClient;
 import io.airlift.http.client.Request;
 import io.airlift.http.client.StringResponseHandler;
 import io.airlift.log.Logger;
+import io.trino.plugin.base.cache.NonEvictableLoadingCache;
+import io.trino.plugin.base.cache.SafeCaches;
 import io.trino.plugin.password.Credential;
 import io.trino.spi.security.AccessDeniedException;
 import io.trino.spi.security.BasicPrincipal;
@@ -71,7 +72,7 @@ public class SalesforceBasicAuthenticator
     // Set of Salesforce orgs, which users must belong to in order to authN.
     private final Set<String> allowedOrganizations;
     private final HttpClient httpClient;
-    private final LoadingCache<Credential, Principal> userCache;
+    private final NonEvictableLoadingCache<Credential, Principal> userCache;
 
     @Inject
     public SalesforceBasicAuthenticator(SalesforceConfig config, @SalesforceAuthenticationClient HttpClient httpClient)
@@ -79,10 +80,11 @@ public class SalesforceBasicAuthenticator
         this.allowedOrganizations = ImmutableSet.copyOf(config.getOrgSet());
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
 
-        this.userCache = CacheBuilder.newBuilder()
-                .maximumSize(config.getCacheSize())
-                .expireAfterWrite(config.getCacheExpireDuration().toMillis(), MILLISECONDS)
-                .build(CacheLoader.from(this::doLogin));
+        this.userCache = SafeCaches.buildNonEvictableCache(
+                CacheBuilder.newBuilder()
+                        .maximumSize(config.getCacheSize())
+                        .expireAfterWrite(config.getCacheExpireDuration().toMillis(), MILLISECONDS),
+                CacheLoader.from(this::doLogin));
     }
 
     @Override

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotMetadata.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotMetadata.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.log.Logger;
+import io.trino.plugin.base.cache.NonEvictableLoadingCache;
 import io.trino.plugin.base.expression.AggregateFunctionRewriter;
 import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.pinot.client.PinotClient;
@@ -74,6 +75,7 @@ import static com.google.common.cache.CacheLoader.asyncReloading;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.plugin.base.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.plugin.pinot.PinotColumnHandle.getPinotColumnsForPinotSchema;
 import static io.trino.plugin.pinot.PinotSessionProperties.isAggregationPushdownEnabled;
 import static io.trino.plugin.pinot.query.AggregateExpression.replaceIdentifier;
@@ -90,8 +92,8 @@ public class PinotMetadata
     private static final String SCHEMA_NAME = "default";
     private static final String PINOT_COLUMN_NAME_PROPERTY = "pinotColumnName";
 
-    private final LoadingCache<String, List<PinotColumnHandle>> pinotTableColumnCache;
-    private final LoadingCache<Object, List<String>> allTablesCache;
+    private final NonEvictableLoadingCache<String, List<PinotColumnHandle>> pinotTableColumnCache;
+    private final NonEvictableLoadingCache<Object, List<String>> allTablesCache;
     private final int maxRowsPerBrokerQuery;
     private final AggregateFunctionRewriter<AggregateExpression> aggregateFunctionRewriter;
     private final ImplementCountDistinct implementCountDistinct;
@@ -106,22 +108,23 @@ public class PinotMetadata
         requireNonNull(pinotConfig, "pinot config");
         this.pinotClient = requireNonNull(pinotClient, "pinotClient is null");
         long metadataCacheExpiryMillis = pinotConfig.getMetadataCacheExpiry().roundTo(TimeUnit.MILLISECONDS);
-        this.allTablesCache = CacheBuilder.newBuilder()
-                .refreshAfterWrite(metadataCacheExpiryMillis, TimeUnit.MILLISECONDS)
-                .build(asyncReloading(CacheLoader.from(pinotClient::getAllTables), executor));
-        this.pinotTableColumnCache =
+        this.allTablesCache = buildNonEvictableCache(
                 CacheBuilder.newBuilder()
-                        .refreshAfterWrite(metadataCacheExpiryMillis, TimeUnit.MILLISECONDS)
-                        .build(asyncReloading(new CacheLoader<>()
-                        {
-                            @Override
-                            public List<PinotColumnHandle> load(String tableName)
-                                    throws Exception
-                            {
-                                Schema tablePinotSchema = pinotClient.getTableSchema(tableName);
-                                return getPinotColumnsForPinotSchema(tablePinotSchema);
-                            }
-                        }, executor));
+                        .refreshAfterWrite(metadataCacheExpiryMillis, TimeUnit.MILLISECONDS),
+                asyncReloading(CacheLoader.from(pinotClient::getAllTables), executor));
+        this.pinotTableColumnCache = buildNonEvictableCache(
+                CacheBuilder.newBuilder()
+                        .refreshAfterWrite(metadataCacheExpiryMillis, TimeUnit.MILLISECONDS),
+                asyncReloading(new CacheLoader<>()
+                {
+                    @Override
+                    public List<PinotColumnHandle> load(String tableName)
+                            throws Exception
+                    {
+                        Schema tablePinotSchema = pinotClient.getTableSchema(tableName);
+                        return getPinotColumnsForPinotSchema(tablePinotSchema);
+                    }
+                }, executor));
 
         executor.execute(() -> this.allTablesCache.refresh(ALL_TABLES_CACHE_KEY));
         this.maxRowsPerBrokerQuery = pinotConfig.getMaxRowsForBrokerQueries();

--- a/plugin/trino-raptor-legacy/pom.xml
+++ b/plugin/trino-raptor-legacy/pom.xml
@@ -152,6 +152,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.gaul</groupId>
+            <artifactId>modernizer-maven-annotations</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-core</artifactId>
         </dependency>

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/metadata/DatabaseShardManager.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/metadata/DatabaseShardManager.java
@@ -17,7 +17,6 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Ticker;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -25,6 +24,7 @@ import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
+import io.trino.plugin.base.cache.NonEvictableLoadingCache;
 import io.trino.plugin.raptor.legacy.NodeSupplier;
 import io.trino.plugin.raptor.legacy.RaptorColumnHandle;
 import io.trino.plugin.raptor.legacy.storage.organization.ShardOrganizerDao;
@@ -64,6 +64,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.Iterables.partition;
+import static io.trino.plugin.base.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.plugin.raptor.legacy.RaptorErrorCode.RAPTOR_ERROR;
 import static io.trino.plugin.raptor.legacy.RaptorErrorCode.RAPTOR_EXTERNAL_BATCH_ALREADY_EXISTS;
 import static io.trino.plugin.raptor.legacy.storage.ColumnIndexStatsUtils.jdbcType;
@@ -111,13 +112,13 @@ public class DatabaseShardManager
     private final Duration startupGracePeriod;
     private final long startTime;
 
-    private final LoadingCache<String, Integer> nodeIdCache = CacheBuilder.newBuilder()
-            .maximumSize(10_000)
-            .build(CacheLoader.from(this::loadNodeId));
+    private final NonEvictableLoadingCache<String, Integer> nodeIdCache = buildNonEvictableCache(
+            CacheBuilder.newBuilder().maximumSize(10_000),
+            CacheLoader.from(this::loadNodeId));
 
-    private final LoadingCache<Long, List<String>> bucketAssignmentsCache = CacheBuilder.newBuilder()
-            .expireAfterWrite(1, SECONDS)
-            .build(CacheLoader.from(this::loadBucketAssignments));
+    private final NonEvictableLoadingCache<Long, List<String>> bucketAssignmentsCache = buildNonEvictableCache(
+            CacheBuilder.newBuilder().expireAfterWrite(1, SECONDS),
+            CacheLoader.from(this::loadBucketAssignments));
 
     @Inject
     public DatabaseShardManager(

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
@@ -16,13 +16,13 @@ package io.trino.plugin.sqlserver;
 import com.google.common.base.Enums;
 import com.google.common.base.Joiner;
 import com.google.common.base.Throwables;
-import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.microsoft.sqlserver.jdbc.SQLServerException;
 import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
+import io.trino.plugin.base.cache.NonEvictableCache;
 import io.trino.plugin.base.expression.AggregateFunctionRewriter;
 import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.BaseJdbcClient;
@@ -97,6 +97,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.microsoft.sqlserver.jdbc.SQLServerConnection.TRANSACTION_SNAPSHOT;
 import static io.airlift.slice.Slices.wrappedBuffer;
+import static io.trino.plugin.base.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static io.trino.plugin.jdbc.PredicatePushdownController.DISABLE_PUSHDOWN;
 import static io.trino.plugin.jdbc.StandardColumnMappings.bigintColumnMapping;
@@ -183,10 +184,10 @@ public class SqlServerClient
     private static final Joiner DOT_JOINER = Joiner.on(".");
 
     private final boolean snapshotIsolationDisabled;
-    private final Cache<SnapshotIsolationEnabledCacheKey, Boolean> snapshotIsolationEnabled = CacheBuilder.newBuilder()
-            .maximumSize(1)
-            .expireAfterWrite(ofMinutes(5))
-            .build();
+    private final NonEvictableCache<SnapshotIsolationEnabledCacheKey, Boolean> snapshotIsolationEnabled = buildNonEvictableCache(
+            CacheBuilder.newBuilder()
+                    .maximumSize(1)
+                    .expireAfterWrite(ofMinutes(5)));
 
     private final AggregateFunctionRewriter<JdbcExpression> aggregateFunctionRewriter;
 

--- a/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftMetadata.java
+++ b/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftMetadata.java
@@ -15,12 +15,12 @@ package io.trino.plugin.thrift;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.drift.TException;
 import io.airlift.drift.client.DriftClient;
 import io.airlift.units.Duration;
+import io.trino.plugin.base.cache.NonEvictableLoadingCache;
 import io.trino.plugin.thrift.annotations.ForMetadataRefresh;
 import io.trino.plugin.thrift.api.TrinoThriftNullableSchemaName;
 import io.trino.plugin.thrift.api.TrinoThriftNullableTableMetadata;
@@ -59,6 +59,7 @@ import java.util.concurrent.Executor;
 import static com.google.common.cache.CacheLoader.asyncReloading;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.trino.plugin.base.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.plugin.thrift.ThriftErrorCode.THRIFT_SERVICE_INVALID_RESPONSE;
 import static io.trino.plugin.thrift.util.ThriftExceptions.toTrinoException;
 import static java.util.Objects.requireNonNull;
@@ -75,7 +76,7 @@ public class ThriftMetadata
     private final DriftClient<TrinoThriftService> client;
     private final ThriftHeaderProvider thriftHeaderProvider;
     private final TypeManager typeManager;
-    private final LoadingCache<SchemaTableName, Optional<ThriftTableMetadata>> tableCache;
+    private final NonEvictableLoadingCache<SchemaTableName, Optional<ThriftTableMetadata>> tableCache;
 
     @Inject
     public ThriftMetadata(
@@ -87,10 +88,11 @@ public class ThriftMetadata
         this.client = requireNonNull(client, "client is null");
         this.thriftHeaderProvider = requireNonNull(thriftHeaderProvider, "thriftHeaderProvider is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
-        this.tableCache = CacheBuilder.newBuilder()
-                .expireAfterWrite(EXPIRE_AFTER_WRITE.toMillis(), MILLISECONDS)
-                .refreshAfterWrite(REFRESH_AFTER_WRITE.toMillis(), MILLISECONDS)
-                .build(asyncReloading(CacheLoader.from(this::getTableMetadataInternal), metadataRefreshExecutor));
+        this.tableCache = buildNonEvictableCache(
+                CacheBuilder.newBuilder()
+                        .expireAfterWrite(EXPIRE_AFTER_WRITE.toMillis(), MILLISECONDS)
+                        .refreshAfterWrite(REFRESH_AFTER_WRITE.toMillis(), MILLISECONDS),
+                asyncReloading(CacheLoader.from(this::getTableMetadataInternal), metadataRefreshExecutor));
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -1454,6 +1454,13 @@
                 <version>7.15.0</version>
             </dependency>
 
+            <dependency>
+                <!-- TODO remove once we upgrade to airbase with https://github.com/airlift/airbase/pull/298 -->
+                <groupId>org.gaul</groupId>
+                <artifactId>modernizer-maven-annotations</artifactId>
+                <version>2.3.0</version>
+            </dependency>
+
             <!-- force newer version to be used for dependencies -->
             <dependency>
                 <groupId>org.javassist</groupId>


### PR DESCRIPTION
Guava's `Cache` and `LoadingCache` have concurrency issues around
invalidation and ongoing loads.

Ensure that
- code uses `EvictableCache` or `EvictableLoadingCache` which fix the
  probem, or
- code uses safety wrappers, `NonEvictableCache`,
  `NonEvictableLoadingCache`, which fail when unsafe invalidation is
  called. Additionally, the interfaces have the unimplemented methods
  marked as `@Deprecated`, to signal the problem as early as possible.

Follows https://github.com/trinodb/trino/issues/10512 