### PR TITLE
Support async commit for ExchangeSink

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
@@ -182,7 +182,7 @@ public class SqlTask
             if (newState == FAILED || newState == ABORTED) {
                 // don't close buffers for a failed query
                 // closed buffers signal to upstream tasks that everything finished cleanly
-                outputBuffer.fail();
+                outputBuffer.abort();
             }
             else {
                 outputBuffer.destroy();

--- a/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
@@ -488,12 +488,12 @@ public class SqlTask
         outputBuffer.acknowledge(bufferId, sequenceId);
     }
 
-    public TaskInfo abortTaskResults(OutputBufferId bufferId)
+    public TaskInfo destroyTaskResults(OutputBufferId bufferId)
     {
         requireNonNull(bufferId, "bufferId is null");
 
         log.debug("Aborting task %s output %s", taskId, bufferId);
-        outputBuffer.abort(bufferId);
+        outputBuffer.destroy(bufferId);
 
         return getTaskInfo();
     }

--- a/core/trino-main/src/main/java/io/trino/execution/SqlTaskExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTaskExecution.java
@@ -639,8 +639,8 @@ public class SqlTaskExecution
         // no more output will be created
         outputBuffer.setNoMorePages();
 
-        // are there still pages in the output buffer
-        if (!outputBuffer.isFinished()) {
+        BufferState bufferState = outputBuffer.getState();
+        if (bufferState != BufferState.FINISHED) {
             taskStateMachine.transitionToFlushing();
             return;
         }

--- a/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
@@ -448,12 +448,12 @@ public class SqlTaskManager
     }
 
     @Override
-    public TaskInfo abortTaskResults(TaskId taskId, OutputBufferId bufferId)
+    public TaskInfo destroyTaskResults(TaskId taskId, OutputBufferId bufferId)
     {
         requireNonNull(taskId, "taskId is null");
         requireNonNull(bufferId, "bufferId is null");
 
-        return tasks.getUnchecked(taskId).abortTaskResults(bufferId);
+        return tasks.getUnchecked(taskId).destroyTaskResults(bufferId);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/execution/TaskManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TaskManager.java
@@ -137,7 +137,7 @@ public interface TaskManager
      * NOTE: this design assumes that only tasks and buffers that will
      * eventually exist are queried.
      */
-    TaskInfo abortTaskResults(TaskId taskId, OutputBufferId bufferId);
+    TaskInfo destroyTaskResults(TaskId taskId, OutputBufferId bufferId);
 
     /**
      * Adds a state change listener to the specified task.

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/ArbitraryOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/ArbitraryOutputBuffer.java
@@ -105,12 +105,6 @@ public class ArbitraryOutputBuffer
     }
 
     @Override
-    public boolean isFinished()
-    {
-        return stateMachine.getState() == FINISHED;
-    }
-
-    @Override
     public double getUtilization()
     {
         return memoryManager.getUtilization();
@@ -157,6 +151,12 @@ public class ArbitraryOutputBuffer
                 totalRowsAdded.get(),
                 totalPagesAdded.get(),
                 infos.build());
+    }
+
+    @Override
+    public BufferState getState()
+    {
+        return stateMachine.getState();
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/ArbitraryOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/ArbitraryOutputBuffer.java
@@ -282,9 +282,9 @@ public class ArbitraryOutputBuffer
     }
 
     @Override
-    public void abort(OutputBufferId bufferId)
+    public void destroy(OutputBufferId bufferId)
     {
-        checkState(!Thread.holdsLock(this), "Cannot abort while holding a lock on this");
+        checkState(!Thread.holdsLock(this), "Cannot destroy while holding a lock on this");
         requireNonNull(bufferId, "bufferId is null");
 
         getBuffer(bufferId).destroy();

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/ArbitraryOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/ArbitraryOutputBuffer.java
@@ -20,7 +20,6 @@ import com.google.common.collect.Sets.SetView;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.slice.Slice;
 import io.airlift.units.DataSize;
-import io.trino.execution.StateMachine;
 import io.trino.execution.StateMachine.StateChangeListener;
 import io.trino.execution.buffer.ClientBuffer.PagesSupplier;
 import io.trino.execution.buffer.OutputBuffers.OutputBufferId;
@@ -45,12 +44,9 @@ import java.util.function.Supplier;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static io.trino.execution.buffer.BufferState.FAILED;
 import static io.trino.execution.buffer.BufferState.FINISHED;
 import static io.trino.execution.buffer.BufferState.FLUSHING;
-import static io.trino.execution.buffer.BufferState.NO_MORE_BUFFERS;
 import static io.trino.execution.buffer.BufferState.NO_MORE_PAGES;
-import static io.trino.execution.buffer.BufferState.OPEN;
 import static io.trino.execution.buffer.OutputBuffers.BufferType.ARBITRARY;
 import static io.trino.execution.buffer.OutputBuffers.createInitialEmptyOutputBuffers;
 import static io.trino.execution.buffer.PagesSerde.getSerializedPagePositionCount;
@@ -77,7 +73,7 @@ public class ArbitraryOutputBuffer
     //  The index of the first client buffer that should be polled
     private final AtomicInteger nextClientBufferIndex = new AtomicInteger(0);
 
-    private final StateMachine<BufferState> state;
+    private final OutputBufferStateMachine stateMachine;
     private final String taskInstanceId;
 
     private final AtomicLong totalPagesAdded = new AtomicLong();
@@ -85,13 +81,13 @@ public class ArbitraryOutputBuffer
 
     public ArbitraryOutputBuffer(
             String taskInstanceId,
-            StateMachine<BufferState> state,
+            OutputBufferStateMachine stateMachine,
             DataSize maxBufferSize,
             Supplier<LocalMemoryContext> memoryContextSupplier,
             Executor notificationExecutor)
     {
         this.taskInstanceId = requireNonNull(taskInstanceId, "taskInstanceId is null");
-        this.state = requireNonNull(state, "state is null");
+        this.stateMachine = requireNonNull(stateMachine, "stateMachine is null");
         requireNonNull(maxBufferSize, "maxBufferSize is null");
         checkArgument(maxBufferSize.toBytes() > 0, "maxBufferSize must be at least 1");
         this.memoryManager = new OutputBufferMemoryManager(
@@ -105,13 +101,13 @@ public class ArbitraryOutputBuffer
     @Override
     public void addStateChangeListener(StateChangeListener<BufferState> stateChangeListener)
     {
-        state.addStateChangeListener(stateChangeListener);
+        stateMachine.addStateChangeListener(stateChangeListener);
     }
 
     @Override
     public boolean isFinished()
     {
-        return state.get() == FINISHED;
+        return stateMachine.getState() == FINISHED;
     }
 
     @Override
@@ -123,7 +119,7 @@ public class ArbitraryOutputBuffer
     @Override
     public boolean isOverutilized()
     {
-        return (memoryManager.getUtilization() >= 0.5) || !state.get().canAddPages();
+        return (memoryManager.getUtilization() >= 0.5) || !stateMachine.getState().canAddPages();
     }
 
     @Override
@@ -134,7 +130,7 @@ public class ArbitraryOutputBuffer
         //
 
         // always get the state first before any other stats
-        BufferState state = this.state.get();
+        BufferState state = stateMachine.getState();
 
         // buffers it a concurrent collection so it is safe to access out side of guard
         // in this case we only want a snapshot of the current buffers
@@ -172,7 +168,7 @@ public class ArbitraryOutputBuffer
         synchronized (this) {
             // ignore buffers added after query finishes, which can happen when a query is canceled
             // also ignore old versions, which is normal
-            BufferState state = this.state.get();
+            BufferState state = stateMachine.getState();
             if (state.isTerminal() || outputBuffers.getVersion() >= newOutputBuffers.getVersion()) {
                 return;
             }
@@ -190,12 +186,11 @@ public class ArbitraryOutputBuffer
 
             // update state if no more buffers is set
             if (outputBuffers.isNoMoreBufferIds()) {
-                this.state.compareAndSet(OPEN, NO_MORE_BUFFERS);
-                this.state.compareAndSet(NO_MORE_PAGES, FLUSHING);
+                stateMachine.noMoreBuffers();
             }
         }
 
-        if (!state.get().canAddBuffers()) {
+        if (!stateMachine.getState().canAddBuffers()) {
             noMoreBuffers();
         }
 
@@ -216,7 +211,7 @@ public class ArbitraryOutputBuffer
 
         // ignore pages after "no more pages" is set
         // this can happen with a limit query
-        if (!state.get().canAddPages()) {
+        if (!stateMachine.getState().canAddPages()) {
             return;
         }
 
@@ -301,8 +296,7 @@ public class ArbitraryOutputBuffer
     public void setNoMorePages()
     {
         checkState(!Thread.holdsLock(this), "Cannot set no more pages while holding a lock on this");
-        state.compareAndSet(OPEN, NO_MORE_PAGES);
-        state.compareAndSet(NO_MORE_BUFFERS, FLUSHING);
+        stateMachine.noMorePages();
         memoryManager.setNoBlockOnFull();
 
         masterBuffer.setNoMorePages();
@@ -321,7 +315,7 @@ public class ArbitraryOutputBuffer
         checkState(!Thread.holdsLock(this), "Cannot destroy while holding a lock on this");
 
         // ignore destroy if the buffer already in a terminal state.
-        if (state.setIf(FINISHED, oldState -> !oldState.isTerminal())) {
+        if (stateMachine.finish()) {
             noMoreBuffers();
 
             masterBuffer.destroy();
@@ -337,7 +331,7 @@ public class ArbitraryOutputBuffer
     public void fail()
     {
         // ignore fail if the buffer already in a terminal state.
-        if (state.setIf(FAILED, oldState -> !oldState.isTerminal())) {
+        if (stateMachine.fail()) {
             memoryManager.setNoBlockOnFull();
             forceFreeMemory();
             // DO NOT destroy buffers or set no more pages.  The coordinator manages the teardown of failed queries.
@@ -366,14 +360,14 @@ public class ArbitraryOutputBuffer
         // NOTE: buffers are allowed to be created in the FINISHED state because destroy() can move to the finished state
         // without a clean "no-more-buffers" message from the scheduler.  This happens with limit queries and is ok because
         // the buffer will be immediately destroyed.
-        checkState(state.get().canAddBuffers() || !outputBuffers.isNoMoreBufferIds(), "No more buffers already set");
+        checkState(stateMachine.getState().canAddBuffers() || !outputBuffers.isNoMoreBufferIds(), "No more buffers already set");
 
         // NOTE: buffers are allowed to be created before they are explicitly declared by setOutputBuffers
         // When no-more-buffers is set, we verify that all created buffers have been declared
         buffer = new ClientBuffer(taskInstanceId, id, onPagesReleased);
 
         // buffer may have finished immediately before calling this method
-        if (state.get() == FINISHED) {
+        if (stateMachine.getState() == FINISHED) {
             buffer.destroy();
         }
 
@@ -400,7 +394,7 @@ public class ArbitraryOutputBuffer
         // This buffer type assigns each page to a single, arbitrary reader,
         // so we don't need to wait for no-more-buffers to finish the buffer.
         // Any readers added after finish will simply receive no data.
-        BufferState state = this.state.get();
+        BufferState state = stateMachine.getState();
         if ((state == FLUSHING) || ((state == NO_MORE_PAGES) && masterBuffer.isEmpty())) {
             if (safeGetBuffersSnapshot().stream().allMatch(ClientBuffer::isDestroyed)) {
                 destroy();

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/ArbitraryOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/ArbitraryOutputBuffer.java
@@ -344,6 +344,12 @@ public class ArbitraryOutputBuffer
         return memoryManager.getPeakMemoryUsage();
     }
 
+    @Override
+    public Optional<Throwable> getFailureCause()
+    {
+        return stateMachine.getFailureCause();
+    }
+
     @VisibleForTesting
     void forceFreeMemory()
     {

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/ArbitraryOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/ArbitraryOutputBuffer.java
@@ -328,10 +328,10 @@ public class ArbitraryOutputBuffer
     }
 
     @Override
-    public void fail()
+    public void abort()
     {
-        // ignore fail if the buffer already in a terminal state.
-        if (stateMachine.fail()) {
+        // ignore abort if the buffer already in a terminal state.
+        if (stateMachine.abort()) {
             memoryManager.setNoBlockOnFull();
             forceFreeMemory();
             // DO NOT destroy buffers or set no more pages.  The coordinator manages the teardown of failed queries.

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/BroadcastOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/BroadcastOutputBuffer.java
@@ -418,7 +418,8 @@ public class BroadcastOutputBuffer
 
     private void checkFlushComplete()
     {
-        if (stateMachine.getState() != FLUSHING && stateMachine.getState() != NO_MORE_BUFFERS) {
+        BufferState state = stateMachine.getState();
+        if (state != FLUSHING && state != NO_MORE_BUFFERS) {
             return;
         }
 

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/BroadcastOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/BroadcastOutputBuffer.java
@@ -20,7 +20,6 @@ import com.google.common.collect.Sets.SetView;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.slice.Slice;
 import io.airlift.units.DataSize;
-import io.trino.execution.StateMachine;
 import io.trino.execution.StateMachine.StateChangeListener;
 import io.trino.execution.buffer.OutputBuffers.OutputBufferId;
 import io.trino.execution.buffer.SerializedPageReference.PagesReleasedListener;
@@ -46,8 +45,6 @@ import static io.trino.execution.buffer.BufferState.FAILED;
 import static io.trino.execution.buffer.BufferState.FINISHED;
 import static io.trino.execution.buffer.BufferState.FLUSHING;
 import static io.trino.execution.buffer.BufferState.NO_MORE_BUFFERS;
-import static io.trino.execution.buffer.BufferState.NO_MORE_PAGES;
-import static io.trino.execution.buffer.BufferState.OPEN;
 import static io.trino.execution.buffer.OutputBuffers.BufferType.BROADCAST;
 import static io.trino.execution.buffer.PagesSerde.getSerializedPagePositionCount;
 import static io.trino.execution.buffer.SerializedPageReference.dereferencePages;
@@ -57,7 +54,7 @@ public class BroadcastOutputBuffer
         implements OutputBuffer
 {
     private final String taskInstanceId;
-    private final StateMachine<BufferState> state;
+    private final OutputBufferStateMachine stateMachine;
     private final OutputBufferMemoryManager memoryManager;
     private final PagesReleasedListener onPagesReleased;
 
@@ -79,14 +76,14 @@ public class BroadcastOutputBuffer
 
     public BroadcastOutputBuffer(
             String taskInstanceId,
-            StateMachine<BufferState> state,
+            OutputBufferStateMachine stateMachine,
             DataSize maxBufferSize,
             Supplier<LocalMemoryContext> memoryContextSupplier,
             Executor notificationExecutor,
             Runnable notifyStatusChanged)
     {
         this.taskInstanceId = requireNonNull(taskInstanceId, "taskInstanceId is null");
-        this.state = requireNonNull(state, "state is null");
+        this.stateMachine = requireNonNull(stateMachine, "stateMachine is null");
         this.memoryManager = new OutputBufferMemoryManager(
                 requireNonNull(maxBufferSize, "maxBufferSize is null").toBytes(),
                 requireNonNull(memoryContextSupplier, "memoryContextSupplier is null"),
@@ -101,13 +98,13 @@ public class BroadcastOutputBuffer
     @Override
     public void addStateChangeListener(StateChangeListener<BufferState> stateChangeListener)
     {
-        state.addStateChangeListener(stateChangeListener);
+        stateMachine.addStateChangeListener(stateChangeListener);
     }
 
     @Override
     public boolean isFinished()
     {
-        return state.get() == FINISHED;
+        return stateMachine.getState() == FINISHED;
     }
 
     @Override
@@ -119,7 +116,7 @@ public class BroadcastOutputBuffer
     @Override
     public boolean isOverutilized()
     {
-        return (getUtilization() > 0.5) && state.get().canAddPages();
+        return (getUtilization() > 0.5) && stateMachine.getState().canAddPages();
     }
 
     @Override
@@ -130,7 +127,7 @@ public class BroadcastOutputBuffer
         //
 
         // always get the state first before any other stats
-        BufferState state = this.state.get();
+        BufferState state = stateMachine.getState();
 
         // buffer it a concurrent collection so it is safe to access out side of guard
         // in this case we only want a snapshot of the current buffers
@@ -160,7 +157,7 @@ public class BroadcastOutputBuffer
         synchronized (this) {
             // ignore buffers added after query finishes, which can happen when a query is canceled
             // also ignore old versions, which is normal
-            BufferState state = this.state.get();
+            BufferState state = stateMachine.getState();
             if (state.isTerminal() || outputBuffers.getVersion() >= newOutputBuffers.getVersion()) {
                 return;
             }
@@ -181,12 +178,11 @@ public class BroadcastOutputBuffer
 
             // update state if no more buffers is set
             if (outputBuffers.isNoMoreBufferIds()) {
-                this.state.compareAndSet(OPEN, NO_MORE_BUFFERS);
-                this.state.compareAndSet(NO_MORE_PAGES, FLUSHING);
+                stateMachine.noMoreBuffers();
             }
         }
 
-        if (!state.get().canAddBuffers()) {
+        if (!stateMachine.getState().canAddBuffers()) {
             noMoreBuffers();
         }
 
@@ -207,7 +203,7 @@ public class BroadcastOutputBuffer
 
         // ignore pages after "no more pages" is set
         // this can happen with a limit query
-        if (!state.get().canAddPages()) {
+        if (!stateMachine.getState().canAddPages()) {
             return;
         }
 
@@ -234,7 +230,7 @@ public class BroadcastOutputBuffer
         // if we can still add buffers, remember the pages for the future buffers
         Collection<ClientBuffer> buffers;
         synchronized (this) {
-            if (state.get().canAddBuffers()) {
+            if (stateMachine.getState().canAddBuffers()) {
                 serializedPageReferences.forEach(SerializedPageReference::addReference);
                 initialPagesForNewBuffers.addAll(serializedPageReferences);
             }
@@ -252,7 +248,7 @@ public class BroadcastOutputBuffer
         // if the buffer is full for first time and more clients are expected, update the task status
         // notifying a status change will lead to the SourcePartitionedScheduler sending 'no-more-buffers' to unblock
         if (!hasBlockedBefore.get()
-                && state.get().canAddBuffers()
+                && stateMachine.getState().canAddBuffers()
                 && !isFull().isDone()
                 && hasBlockedBefore.compareAndSet(false, true)) {
             notifyStatusChanged.run();
@@ -300,8 +296,7 @@ public class BroadcastOutputBuffer
     public void setNoMorePages()
     {
         checkState(!Thread.holdsLock(this), "Cannot set no more pages while holding a lock on this");
-        state.compareAndSet(OPEN, NO_MORE_PAGES);
-        state.compareAndSet(NO_MORE_BUFFERS, FLUSHING);
+        stateMachine.noMorePages();
         memoryManager.setNoBlockOnFull();
 
         safeGetBuffersSnapshot().forEach(ClientBuffer::setNoMorePages);
@@ -315,7 +310,7 @@ public class BroadcastOutputBuffer
         checkState(!Thread.holdsLock(this), "Cannot destroy while holding a lock on this");
 
         // ignore destroy if the buffer already in a terminal state.
-        if (state.setIf(FINISHED, oldState -> !oldState.isTerminal())) {
+        if (stateMachine.finish()) {
             noMoreBuffers();
 
             safeGetBuffersSnapshot().forEach(ClientBuffer::destroy);
@@ -329,7 +324,7 @@ public class BroadcastOutputBuffer
     public void fail()
     {
         // ignore fail if the buffer already in a terminal state.
-        if (state.setIf(FAILED, oldState -> !oldState.isTerminal())) {
+        if (stateMachine.fail()) {
             memoryManager.setNoBlockOnFull();
             forceFreeMemory();
             // DO NOT destroy buffers or set no more pages.  The coordinator manages the teardown of failed queries.
@@ -358,7 +353,7 @@ public class BroadcastOutputBuffer
         // NOTE: buffers are allowed to be created in the FINISHED state because destroy() can move to the finished state
         // without a clean "no-more-buffers" message from the scheduler.  This happens with limit queries and is ok because
         // the buffer will be immediately destroyed.
-        BufferState state = this.state.get();
+        BufferState state = stateMachine.getState();
         checkState(state.canAddBuffers() || !outputBuffers.isNoMoreBufferIds(), "No more buffers already set");
 
         // NOTE: buffers are allowed to be created before they are explicitly declared by setOutputBuffers
@@ -412,7 +407,7 @@ public class BroadcastOutputBuffer
 
     private void checkFlushComplete()
     {
-        if (state.get() != FLUSHING && state.get() != NO_MORE_BUFFERS) {
+        if (stateMachine.getState() != FLUSHING && stateMachine.getState() != NO_MORE_BUFFERS) {
             return;
         }
 

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/BroadcastOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/BroadcastOutputBuffer.java
@@ -102,12 +102,6 @@ public class BroadcastOutputBuffer
     }
 
     @Override
-    public boolean isFinished()
-    {
-        return stateMachine.getState() == FINISHED;
-    }
-
-    @Override
     public double getUtilization()
     {
         return memoryManager.getUtilization();
@@ -146,6 +140,12 @@ public class BroadcastOutputBuffer
                 buffers.stream()
                         .map(ClientBuffer::getInfo)
                         .collect(toImmutableList()));
+    }
+
+    @Override
+    public BufferState getState()
+    {
+        return stateMachine.getState();
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/BroadcastOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/BroadcastOutputBuffer.java
@@ -41,7 +41,7 @@ import java.util.function.Supplier;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.trino.execution.buffer.BufferState.FAILED;
+import static io.trino.execution.buffer.BufferState.ABORTED;
 import static io.trino.execution.buffer.BufferState.FINISHED;
 import static io.trino.execution.buffer.BufferState.FLUSHING;
 import static io.trino.execution.buffer.BufferState.NO_MORE_BUFFERS;
@@ -321,10 +321,10 @@ public class BroadcastOutputBuffer
     }
 
     @Override
-    public void fail()
+    public void abort()
     {
-        // ignore fail if the buffer already in a terminal state.
-        if (stateMachine.fail()) {
+        // ignore abort if the buffer already in a terminal state.
+        if (stateMachine.abort()) {
             memoryManager.setNoBlockOnFull();
             forceFreeMemory();
             // DO NOT destroy buffers or set no more pages.  The coordinator manages the teardown of failed queries.
@@ -360,8 +360,8 @@ public class BroadcastOutputBuffer
         // When no-more-buffers is set, we verify that all created buffers have been declared
         buffer = new ClientBuffer(taskInstanceId, id, onPagesReleased);
 
-        // do not setup the new buffer if we are already failed
-        if (state != FAILED) {
+        // do not setup the new buffer if we are already aborted
+        if (state != ABORTED) {
             // add initial pages
             buffer.enqueuePages(initialPagesForNewBuffers);
 

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/BroadcastOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/BroadcastOutputBuffer.java
@@ -282,9 +282,9 @@ public class BroadcastOutputBuffer
     }
 
     @Override
-    public void abort(OutputBufferId bufferId)
+    public void destroy(OutputBufferId bufferId)
     {
-        checkState(!Thread.holdsLock(this), "Cannot abort while holding a lock on this");
+        checkState(!Thread.holdsLock(this), "Cannot destroy while holding a lock on this");
         requireNonNull(bufferId, "bufferId is null");
 
         getBuffer(bufferId).destroy();

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/BufferState.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/BufferState.java
@@ -52,7 +52,13 @@ public enum BufferState
      * assumed that the reader will be cleaned up elsewhere.
      * This is the terminal state.
      */
-    ABORTED(false, false, true);
+    ABORTED(false, false, true),
+
+    /**
+     * Buffer is failed. No more buffers or pages can be added. The task will be failed.
+     * This is the terminal state.
+     */
+    FAILED(false, false, true);
 
     public static final Set<BufferState> TERMINAL_BUFFER_STATES = Stream.of(BufferState.values()).filter(BufferState::isTerminal).collect(toImmutableSet());
 

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/BufferState.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/BufferState.java
@@ -47,12 +47,12 @@ public enum BufferState
      */
     FINISHED(false, false, true),
     /**
-     * Buffer has failed.  No more buffers or pages can be added.  Readers
+     * Buffer has been aborted.  No more buffers or pages can be added.  Readers
      * will be blocked, as to not communicate a finished state.  It is
      * assumed that the reader will be cleaned up elsewhere.
      * This is the terminal state.
      */
-    FAILED(false, false, true);
+    ABORTED(false, false, true);
 
     public static final Set<BufferState> TERMINAL_BUFFER_STATES = Stream.of(BufferState.values()).filter(BufferState::isTerminal).collect(toImmutableSet());
 

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/LazyOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/LazyOutputBuffer.java
@@ -34,6 +34,7 @@ import javax.annotation.concurrent.GuardedBy;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.function.Supplier;
@@ -335,6 +336,12 @@ public class LazyOutputBuffer
             return outputBuffer.getPeakMemoryUsage();
         }
         return 0;
+    }
+
+    @Override
+    public Optional<Throwable> getFailureCause()
+    {
+        return stateMachine.getFailureCause();
     }
 
     @Nullable

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/LazyOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/LazyOutputBuffer.java
@@ -96,12 +96,6 @@ public class LazyOutputBuffer
     }
 
     @Override
-    public boolean isFinished()
-    {
-        return stateMachine.getState() == FINISHED;
-    }
-
-    @Override
     public double getUtilization()
     {
         OutputBuffer outputBuffer = getDelegateOutputBuffer();
@@ -145,6 +139,12 @@ public class LazyOutputBuffer
                     ImmutableList.of());
         }
         return outputBuffer.getInfo();
+    }
+
+    @Override
+    public BufferState getState()
+    {
+        return stateMachine.getState();
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/LazyOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/LazyOutputBuffer.java
@@ -308,14 +308,14 @@ public class LazyOutputBuffer
     }
 
     @Override
-    public void fail()
+    public void abort()
     {
         OutputBuffer outputBuffer = delegate;
         if (outputBuffer == null) {
             synchronized (this) {
                 if (delegate == null) {
-                    // ignore fail if the buffer already in a terminal state.
-                    stateMachine.fail();
+                    // ignore abort if the buffer already in a terminal state.
+                    stateMachine.abort();
 
                     // Do not free readers on fail
                     return;
@@ -323,7 +323,7 @@ public class LazyOutputBuffer
                 outputBuffer = delegate;
             }
         }
-        outputBuffer.fail();
+        outputBuffer.abort();
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/OutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/OutputBuffer.java
@@ -105,10 +105,10 @@ public interface OutputBuffer
     void destroy();
 
     /**
-     * Fail the buffer, discarding all pages, but blocking readers.  It is expected that
+     * Abort the buffer, discarding all pages, but blocking readers.  It is expected that
      * readers will be unblocked when the failed query is cleaned up.
      */
-    void fail();
+    void abort();
 
     /**
      * @return the peak memory usage of this output buffer.

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/OutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/OutputBuffer.java
@@ -30,10 +30,9 @@ public interface OutputBuffer
     OutputBufferInfo getInfo();
 
     /**
-     * A buffer is finished once no-more-pages has been set and all buffers have been closed
-     * with an abort call.
+     * Get buffer state
      */
-    boolean isFinished();
+    BufferState getState();
 
     /**
      * Get the memory utilization percentage.

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/OutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/OutputBuffer.java
@@ -72,9 +72,9 @@ public interface OutputBuffer
     void acknowledge(OutputBufferId bufferId, long token);
 
     /**
-     * Closes the specified output buffer.
+     * Destroys the specified output buffer, discarding all pages.
      */
-    void abort(OutputBufferId bufferId);
+    void destroy(OutputBufferId bufferId);
 
     /**
      * Get a future that will be completed when the buffer is not full.

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/OutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/OutputBuffer.java
@@ -20,6 +20,7 @@ import io.trino.execution.StateMachine.StateChangeListener;
 import io.trino.execution.buffer.OutputBuffers.OutputBufferId;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface OutputBuffer
 {
@@ -114,4 +115,9 @@ public interface OutputBuffer
      * @return the peak memory usage of this output buffer.
      */
     long getPeakMemoryUsage();
+
+    /**
+     * Returns non empty failure cause if the buffer is in state {@link BufferState#FAILED}
+     */
+    Optional<Throwable> getFailureCause();
 }

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/OutputBufferStateMachine.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/OutputBufferStateMachine.java
@@ -18,7 +18,7 @@ import io.trino.execution.TaskId;
 
 import java.util.concurrent.Executor;
 
-import static io.trino.execution.buffer.BufferState.FAILED;
+import static io.trino.execution.buffer.BufferState.ABORTED;
 import static io.trino.execution.buffer.BufferState.FINISHED;
 import static io.trino.execution.buffer.BufferState.FLUSHING;
 import static io.trino.execution.buffer.BufferState.NO_MORE_BUFFERS;
@@ -66,8 +66,8 @@ public class OutputBufferStateMachine
         return state.setIf(FINISHED, oldState -> !oldState.isTerminal());
     }
 
-    public boolean fail()
+    public boolean abort()
     {
-        return state.setIf(FAILED, oldState -> !oldState.isTerminal());
+        return state.setIf(ABORTED, oldState -> !oldState.isTerminal());
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/OutputBufferStateMachine.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/OutputBufferStateMachine.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.buffer;
+
+import io.trino.execution.StateMachine;
+import io.trino.execution.TaskId;
+
+import java.util.concurrent.Executor;
+
+import static io.trino.execution.buffer.BufferState.FAILED;
+import static io.trino.execution.buffer.BufferState.FINISHED;
+import static io.trino.execution.buffer.BufferState.FLUSHING;
+import static io.trino.execution.buffer.BufferState.NO_MORE_BUFFERS;
+import static io.trino.execution.buffer.BufferState.NO_MORE_PAGES;
+import static io.trino.execution.buffer.BufferState.OPEN;
+import static io.trino.execution.buffer.BufferState.TERMINAL_BUFFER_STATES;
+
+public class OutputBufferStateMachine
+{
+    private final StateMachine<BufferState> state;
+
+    public OutputBufferStateMachine(TaskId taskId, Executor executor)
+    {
+        state = new StateMachine<>(taskId + "-buffer", executor, OPEN, TERMINAL_BUFFER_STATES);
+    }
+
+    public BufferState getState()
+    {
+        return state.get();
+    }
+
+    public void addStateChangeListener(StateMachine.StateChangeListener<BufferState> stateChangeListener)
+    {
+        state.addStateChangeListener(stateChangeListener);
+    }
+
+    public boolean noMoreBuffers()
+    {
+        if (state.compareAndSet(OPEN, NO_MORE_BUFFERS)) {
+            return true;
+        }
+        return state.compareAndSet(NO_MORE_PAGES, FLUSHING);
+    }
+
+    public boolean noMorePages()
+    {
+        if (state.compareAndSet(OPEN, NO_MORE_PAGES)) {
+            return true;
+        }
+        return state.compareAndSet(NO_MORE_BUFFERS, FLUSHING);
+    }
+
+    public boolean finish()
+    {
+        return state.setIf(FINISHED, oldState -> !oldState.isTerminal());
+    }
+
+    public boolean fail()
+    {
+        return state.setIf(FAILED, oldState -> !oldState.isTerminal());
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/PartitionedOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/PartitionedOutputBuffer.java
@@ -281,7 +281,8 @@ public class PartitionedOutputBuffer
 
     private void checkFlushComplete()
     {
-        if (stateMachine.getState() != FLUSHING && stateMachine.getState() != NO_MORE_BUFFERS) {
+        BufferState state = stateMachine.getState();
+        if (state != FLUSHING && state != NO_MORE_BUFFERS) {
             return;
         }
 

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/PartitionedOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/PartitionedOutputBuffer.java
@@ -250,10 +250,10 @@ public class PartitionedOutputBuffer
     }
 
     @Override
-    public void fail()
+    public void abort()
     {
-        // ignore fail if the buffer already in a terminal state.
-        if (stateMachine.fail()) {
+        // ignore abort if the buffer already in a terminal state.
+        if (stateMachine.abort()) {
             memoryManager.setNoBlockOnFull();
             forceFreeMemory();
             // DO NOT destroy buffers or set no more pages.  The coordinator manages the teardown of failed queries.

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/PartitionedOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/PartitionedOutputBuffer.java
@@ -24,6 +24,7 @@ import io.trino.execution.buffer.SerializedPageReference.PagesReleasedListener;
 import io.trino.memory.context.LocalMemoryContext;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
@@ -264,6 +265,12 @@ public class PartitionedOutputBuffer
     public long getPeakMemoryUsage()
     {
         return memoryManager.getPeakMemoryUsage();
+    }
+
+    @Override
+    public Optional<Throwable> getFailureCause()
+    {
+        return stateMachine.getFailureCause();
     }
 
     @VisibleForTesting

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/PartitionedOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/PartitionedOutputBuffer.java
@@ -30,7 +30,6 @@ import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static io.trino.execution.buffer.BufferState.FINISHED;
 import static io.trino.execution.buffer.BufferState.FLUSHING;
 import static io.trino.execution.buffer.BufferState.NO_MORE_BUFFERS;
 import static io.trino.execution.buffer.OutputBuffers.BufferType.PARTITIONED;
@@ -89,12 +88,6 @@ public class PartitionedOutputBuffer
     }
 
     @Override
-    public boolean isFinished()
-    {
-        return stateMachine.getState() == FINISHED;
-    }
-
-    @Override
     public double getUtilization()
     {
         return memoryManager.getUtilization();
@@ -134,6 +127,12 @@ public class PartitionedOutputBuffer
                 totalRowsAdded.get(),
                 totalPagesAdded.get(),
                 infos.build());
+    }
+
+    @Override
+    public BufferState getState()
+    {
+        return stateMachine.getState();
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/PartitionedOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/PartitionedOutputBuffer.java
@@ -218,7 +218,7 @@ public class PartitionedOutputBuffer
     }
 
     @Override
-    public void abort(OutputBufferId bufferId)
+    public void destroy(OutputBufferId bufferId)
     {
         requireNonNull(bufferId, "bufferId is null");
 

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/SpoolingExchangeOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/SpoolingExchangeOutputBuffer.java
@@ -28,7 +28,6 @@ import java.util.function.Supplier;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.concurrent.MoreFutures.asVoid;
 import static io.airlift.concurrent.MoreFutures.toListenableFuture;
-import static io.trino.execution.buffer.BufferState.FINISHED;
 import static io.trino.execution.buffer.OutputBuffers.BufferType.SPOOL;
 import static io.trino.execution.buffer.PagesSerde.getSerializedPagePositionCount;
 import static java.util.Objects.requireNonNull;
@@ -77,9 +76,9 @@ public class SpoolingExchangeOutputBuffer
     }
 
     @Override
-    public boolean isFinished()
+    public BufferState getState()
     {
-        return stateMachine.getState() == FINISHED;
+        return stateMachine.getState();
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/SpoolingExchangeOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/SpoolingExchangeOutputBuffer.java
@@ -184,9 +184,9 @@ public class SpoolingExchangeOutputBuffer
     }
 
     @Override
-    public void fail()
+    public void abort()
     {
-        if (stateMachine.fail()) {
+        if (stateMachine.abort()) {
             try {
                 exchangeSink.abort();
             }

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/SpoolingExchangeOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/SpoolingExchangeOutputBuffer.java
@@ -127,7 +127,7 @@ public class SpoolingExchangeOutputBuffer
     }
 
     @Override
-    public void abort(OutputBuffers.OutputBufferId bufferId)
+    public void destroy(OutputBuffers.OutputBufferId bufferId)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-main/src/main/java/io/trino/operator/DeduplicatingDirectExchangeBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DeduplicatingDirectExchangeBuffer.java
@@ -134,7 +134,7 @@ public class DeduplicatingDirectExchangeBuffer
     }
 
     @Override
-    public ListenableFuture<Void> isBlocked()
+    public synchronized ListenableFuture<Void> isBlocked()
     {
         if (failure != null || closed) {
             return immediateVoidFuture();

--- a/core/trino-main/src/main/java/io/trino/operator/HttpPageBufferClient.java
+++ b/core/trino-main/src/main/java/io/trino/operator/HttpPageBufferClient.java
@@ -268,10 +268,10 @@ public final class HttpPageBufferClient
     @Override
     public void close()
     {
-        boolean shouldSendDelete;
+        boolean shouldDestroyTaskResults;
         Future<?> future;
         synchronized (this) {
-            shouldSendDelete = !closed;
+            shouldDestroyTaskResults = !closed;
 
             closed = true;
 
@@ -286,9 +286,9 @@ public final class HttpPageBufferClient
             future.cancel(true);
         }
 
-        // abort the output buffer on the remote node; response of delete is ignored
-        if (shouldSendDelete) {
-            sendDelete();
+        // destroy task results on the remote node; response is ignored
+        if (shouldDestroyTaskResults) {
+            destroyTaskResults();
         }
     }
 
@@ -325,7 +325,7 @@ public final class HttpPageBufferClient
         }
 
         if (completed) {
-            sendDelete();
+            destroyTaskResults();
         }
         else {
             sendGetResults();
@@ -478,7 +478,7 @@ public final class HttpPageBufferClient
         }, pageBufferClientCallbackExecutor);
     }
 
-    private synchronized void sendDelete()
+    private synchronized void destroyTaskResults()
     {
         HttpResponseFuture<StatusResponse> resultFuture = httpClient.executeAsync(prepareDelete().setUri(location).build(), createStatusResponseHandler());
         future = resultFuture;

--- a/core/trino-main/src/main/java/io/trino/server/TaskResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/TaskResource.java
@@ -375,7 +375,7 @@ public class TaskResource
     @ResourceSecurity(INTERNAL_ONLY)
     @DELETE
     @Path("{taskId}/results/{bufferId}")
-    public void abortResults(
+    public void destroyTaskResults(
             @PathParam("taskId") TaskId taskId,
             @PathParam("bufferId") OutputBufferId bufferId,
             @Context UriInfo uriInfo,
@@ -384,11 +384,11 @@ public class TaskResource
         requireNonNull(taskId, "taskId is null");
         requireNonNull(bufferId, "bufferId is null");
 
-        if (injectFailure(taskManager.getTraceToken(taskId), taskId, RequestType.ABORT_RESULTS, asyncResponse)) {
+        if (injectFailure(taskManager.getTraceToken(taskId), taskId, RequestType.DESTROY_RESULTS, asyncResponse)) {
             return;
         }
 
-        taskManager.abortTaskResults(taskId, bufferId);
+        taskManager.destroyTaskResults(taskId, bufferId);
         asyncResponse.resume(Response.noContent().build());
     }
 
@@ -461,7 +461,7 @@ public class TaskResource
         GET_TASK_STATUS(true),
         ACKNOWLEDGE_AND_GET_NEW_DYNAMIC_FILTER_DOMAINS(true),
         GET_RESULTS(false),
-        ABORT_RESULTS(false);
+        DESTROY_RESULTS(false);
 
         private final boolean taskManagement;
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTask.java
@@ -173,8 +173,8 @@ public class TestSqlTask
         }
         assertEquals(results.getSerializedPages().size(), 0);
 
-        // complete the task by calling abort on it
-        TaskInfo info = sqlTask.abortTaskResults(OUT);
+        // complete the task by calling destroy on it
+        TaskInfo info = sqlTask.destroyTaskResults(OUT);
         assertEquals(info.getOutputBuffers().getState(), BufferState.FINISHED);
 
         taskInfo = sqlTask.getTaskInfo(info.getTaskStatus().getVersion()).get();
@@ -233,7 +233,7 @@ public class TestSqlTask
         assertEquals(taskInfo.getTaskStatus().getState(), TaskState.FLUSHING);
         assertEquals(taskInfo.getTaskStatus().getVersion(), STARTING_VERSION + 1);
 
-        sqlTask.abortTaskResults(OUT);
+        sqlTask.destroyTaskResults(OUT);
 
         taskInfo = sqlTask.getTaskInfo(taskInfo.getTaskStatus().getVersion()).get();
         assertEquals(taskInfo.getTaskStatus().getState(), TaskState.FINISHED);
@@ -258,7 +258,7 @@ public class TestSqlTask
         updateTask(sqlTask, ImmutableList.of(new SplitAssignment(TABLE_SCAN_NODE_ID, ImmutableSet.of(), true)), outputBuffers);
 
         // finish the task by calling abort on it
-        sqlTask.abortTaskResults(OUT);
+        sqlTask.destroyTaskResults(OUT);
 
         // buffer will be closed by cancel event (wait for event to fire)
         bufferResult.get(1, SECONDS);

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskExecution.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskExecution.java
@@ -684,7 +684,7 @@ public class TestSqlTaskExecution
 
         public void abort()
         {
-            outputBuffer.abort(outputBufferId);
+            outputBuffer.destroy(outputBufferId);
             assertEquals(outputBuffer.getInfo().getState(), BufferState.FINISHED);
         }
     }

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskExecution.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskExecution.java
@@ -29,6 +29,7 @@ import io.trino.connector.CatalogName;
 import io.trino.execution.buffer.BufferResult;
 import io.trino.execution.buffer.BufferState;
 import io.trino.execution.buffer.OutputBuffer;
+import io.trino.execution.buffer.OutputBufferStateMachine;
 import io.trino.execution.buffer.OutputBuffers.OutputBufferId;
 import io.trino.execution.buffer.PagesSerdeFactory;
 import io.trino.execution.buffer.PartitionedOutputBuffer;
@@ -95,8 +96,6 @@ import static io.trino.execution.TaskState.FLUSHING;
 import static io.trino.execution.TaskState.RUNNING;
 import static io.trino.execution.TaskTestUtils.TABLE_SCAN_NODE_ID;
 import static io.trino.execution.TaskTestUtils.createTestSplitMonitor;
-import static io.trino.execution.buffer.BufferState.OPEN;
-import static io.trino.execution.buffer.BufferState.TERMINAL_BUFFER_STATES;
 import static io.trino.execution.buffer.OutputBuffers.BufferType.PARTITIONED;
 import static io.trino.execution.buffer.OutputBuffers.createInitialEmptyOutputBuffers;
 import static io.trino.execution.buffer.PagesSerde.getSerializedPagePositionCount;
@@ -612,7 +611,7 @@ public class TestSqlTaskExecution
     {
         return new PartitionedOutputBuffer(
                 TASK_ID.toString(),
-                new StateMachine<>("bufferState", taskNotificationExecutor, OPEN, TERMINAL_BUFFER_STATES),
+                new OutputBufferStateMachine(TASK_ID, taskNotificationExecutor),
                 createInitialEmptyOutputBuffers(PARTITIONED)
                         .withBuffer(OUTPUT_BUFFER_ID, 0)
                         .withNoMoreBufferIds(),

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskManager.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskManager.java
@@ -135,8 +135,8 @@ public class TestSqlTaskManager
             assertTrue(results.isBufferComplete());
             assertEquals(results.getSerializedPages().size(), 0);
 
-            // complete the task by calling abort on it
-            TaskInfo info = sqlTaskManager.abortTaskResults(taskId, OUT);
+            // complete the task by calling destroy on it
+            TaskInfo info = sqlTaskManager.destroyTaskResults(taskId, OUT);
             assertEquals(info.getOutputBuffers().getState(), BufferState.FINISHED);
 
             taskInfo = sqlTaskManager.getTaskInfo(taskId, taskInfo.getTaskStatus().getVersion()).get();
@@ -203,7 +203,7 @@ public class TestSqlTaskManager
             TaskInfo taskInfo = sqlTaskManager.getTaskInfo(taskId, TaskStatus.STARTING_VERSION).get();
             assertEquals(taskInfo.getTaskStatus().getState(), TaskState.FLUSHING);
 
-            sqlTaskManager.abortTaskResults(taskId, OUT);
+            sqlTaskManager.destroyTaskResults(taskId, OUT);
 
             taskInfo = sqlTaskManager.getTaskInfo(taskId, taskInfo.getTaskStatus().getVersion()).get();
             assertEquals(taskInfo.getTaskStatus().getState(), TaskState.FINISHED);

--- a/core/trino-main/src/test/java/io/trino/execution/buffer/BufferTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/execution/buffer/BufferTestUtils.java
@@ -30,6 +30,7 @@ import java.util.concurrent.Future;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.concurrent.MoreFutures.tryGetFutureValue;
+import static io.trino.execution.buffer.BufferState.FINISHED;
 import static io.trino.execution.buffer.TestingPagesSerdeFactory.testingPagesSerde;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -229,7 +230,7 @@ public final class BufferTestUtils
 
     static void assertFinished(OutputBuffer buffer)
     {
-        assertTrue(buffer.isFinished());
+        assertEquals(buffer.getState(), FINISHED);
         for (BufferInfo bufferInfo : buffer.getInfo().getBuffers()) {
             assertTrue(bufferInfo.isFinished());
             assertEquals(bufferInfo.getBufferedPages(), 0);

--- a/core/trino-main/src/test/java/io/trino/execution/buffer/TestArbitraryOutputBuffer.java
+++ b/core/trino-main/src/test/java/io/trino/execution/buffer/TestArbitraryOutputBuffer.java
@@ -217,7 +217,7 @@ public class TestArbitraryOutputBuffer
         assertEquals(buffer.getState(), FLUSHING);
 
         // finish first queue
-        buffer.abort(FIRST);
+        buffer.destroy(FIRST);
         assertQueueClosed(buffer, 0, FIRST, 6);
         assertQueueState(buffer, 0, SECOND, 1, 10);
         assertEquals(buffer.getState(), FLUSHING);
@@ -228,7 +228,7 @@ public class TestArbitraryOutputBuffer
         assertEquals(buffer.getState(), FLUSHING);
 
         // finish second queue
-        buffer.abort(SECOND);
+        buffer.destroy(SECOND);
         assertQueueClosed(buffer, 0, FIRST, 6);
         assertQueueClosed(buffer, 0, SECOND, 11);
         assertFinished(buffer);
@@ -496,8 +496,8 @@ public class TestArbitraryOutputBuffer
         ListenableFuture<BufferResult> future = buffer.get(FIRST, 0L, sizeOfPages(1));
         assertFalse(future.isDone());
 
-        // abort that buffer, and verify the future is finishd
-        buffer.abort(FIRST);
+        // destroy that buffer, and verify the future is finished
+        buffer.destroy(FIRST);
         assertBufferResultEquals(TYPES, getFuture(future, NO_WAIT), emptyResults(TASK_INSTANCE_ID, 0, false));
         assertBufferResultEquals(TYPES, getBufferResult(buffer, FIRST, 0, sizeOfPages(10), NO_WAIT), emptyResults(TASK_INSTANCE_ID, 0, true));
 
@@ -545,17 +545,17 @@ public class TestArbitraryOutputBuffer
         // read a page from the first buffer
         assertBufferResultEquals(TYPES, getBufferResult(buffer, FIRST, 0, sizeOfPages(1), NO_WAIT), bufferResult(0, createPage(0)));
 
-        // abort buffer, and verify page cannot be acknowledged
-        buffer.abort(FIRST);
+        // destroy buffer, and verify page cannot be acknowledged
+        buffer.destroy(FIRST);
         assertQueueClosed(buffer, 9, FIRST, 0);
         assertBufferResultEquals(TYPES, getBufferResult(buffer, FIRST, 1, sizeOfPages(1), NO_WAIT), emptyResults(TASK_INSTANCE_ID, 0, true));
 
         outputBuffers = outputBuffers.withBuffer(SECOND, 0).withNoMoreBufferIds();
         buffer.setOutputBuffers(outputBuffers);
 
-        // first page is lost because the first buffer was aborted
+        // first page is lost because the first buffer was destroyed
         assertBufferResultEquals(TYPES, getBufferResult(buffer, SECOND, 0, sizeOfPages(1), NO_WAIT), bufferResult(0, createPage(1)));
-        buffer.abort(SECOND);
+        buffer.destroy(SECOND);
         assertQueueClosed(buffer, 0, SECOND, 0);
         assertFinished(buffer);
         assertBufferResultEquals(TYPES, getBufferResult(buffer, SECOND, 1, sizeOfPages(1), NO_WAIT), emptyResults(TASK_INSTANCE_ID, 0, true));
@@ -577,8 +577,8 @@ public class TestArbitraryOutputBuffer
         assertQueueState(buffer, 0, FIRST, 0, 0);
         assertQueueState(buffer, 0, SECOND, 0, 0);
 
-        buffer.abort(FIRST);
-        buffer.abort(SECOND);
+        buffer.destroy(FIRST);
+        buffer.destroy(SECOND);
 
         assertQueueClosed(buffer, 0, FIRST, 0);
         assertQueueClosed(buffer, 0, SECOND, 0);
@@ -607,8 +607,8 @@ public class TestArbitraryOutputBuffer
         future = buffer.get(FIRST, 1, sizeOfPages(10));
         assertFalse(future.isDone());
 
-        // abort the buffer
-        buffer.abort(FIRST);
+        // destroy the buffer
+        buffer.destroy(FIRST);
         assertQueueClosed(buffer, 0, FIRST, 1);
 
         // verify the future completed
@@ -640,7 +640,7 @@ public class TestArbitraryOutputBuffer
 
         // finish the buffer
         assertQueueState(buffer, 0, FIRST, 0, 1);
-        buffer.abort(FIRST);
+        buffer.destroy(FIRST);
         assertQueueClosed(buffer, 0, FIRST, 1);
 
         // verify the future completed
@@ -690,7 +690,7 @@ public class TestArbitraryOutputBuffer
         assertEquals(buffer.getState(), FLUSHING);
 
         // finish the queue
-        buffer.abort(FIRST);
+        buffer.destroy(FIRST);
 
         // verify finished
         assertFinished(buffer);
@@ -908,7 +908,7 @@ public class TestArbitraryOutputBuffer
         assertEquals(buffer.getState(), FLUSHING);
 
         // ask the buffer to finish
-        buffer.abort(FIRST);
+        buffer.destroy(FIRST);
 
         // verify that the buffer is finished
         assertEquals(buffer.getState(), FINISHED);
@@ -957,7 +957,7 @@ public class TestArbitraryOutputBuffer
         assertEquals(buffer.getState(), NO_MORE_PAGES);
 
         // finish first queue
-        buffer.abort(FIRST);
+        buffer.destroy(FIRST);
         assertQueueClosed(buffer, 0, FIRST, 3);
         assertFinished(buffer);
 

--- a/core/trino-main/src/test/java/io/trino/execution/buffer/TestArbitraryOutputBuffer.java
+++ b/core/trino-main/src/test/java/io/trino/execution/buffer/TestArbitraryOutputBuffer.java
@@ -17,10 +17,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
-import io.trino.execution.StateMachine;
+import io.trino.execution.StageId;
+import io.trino.execution.TaskId;
 import io.trino.execution.buffer.OutputBuffers.OutputBufferId;
 import io.trino.memory.context.SimpleLocalMemoryContext;
 import io.trino.spi.Page;
+import io.trino.spi.QueryId;
 import io.trino.spi.type.BigintType;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -35,8 +37,6 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.execution.buffer.BufferResult.emptyResults;
-import static io.trino.execution.buffer.BufferState.OPEN;
-import static io.trino.execution.buffer.BufferState.TERMINAL_BUFFER_STATES;
 import static io.trino.execution.buffer.BufferTestUtils.MAX_WAIT;
 import static io.trino.execution.buffer.BufferTestUtils.NO_WAIT;
 import static io.trino.execution.buffer.BufferTestUtils.acknowledgeBufferResult;
@@ -1063,7 +1063,7 @@ public class TestArbitraryOutputBuffer
     {
         ArbitraryOutputBuffer buffer = new ArbitraryOutputBuffer(
                 TASK_INSTANCE_ID,
-                new StateMachine<>("bufferState", stateNotificationExecutor, OPEN, TERMINAL_BUFFER_STATES),
+                new OutputBufferStateMachine(new TaskId(new StageId(new QueryId("query"), 0), 0, 0), stateNotificationExecutor),
                 dataSize,
                 () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
                 stateNotificationExecutor);

--- a/core/trino-main/src/test/java/io/trino/execution/buffer/TestArbitraryOutputBuffer.java
+++ b/core/trino-main/src/test/java/io/trino/execution/buffer/TestArbitraryOutputBuffer.java
@@ -37,7 +37,7 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.execution.buffer.BufferResult.emptyResults;
-import static io.trino.execution.buffer.BufferState.FAILED;
+import static io.trino.execution.buffer.BufferState.ABORTED;
 import static io.trino.execution.buffer.BufferState.FINISHED;
 import static io.trino.execution.buffer.BufferState.FLUSHING;
 import static io.trino.execution.buffer.BufferState.NO_MORE_BUFFERS;
@@ -790,8 +790,8 @@ public class TestArbitraryOutputBuffer
         future = buffer.get(FIRST, 1, sizeOfPages(10));
         assertFalse(future.isDone());
 
-        // fail the buffer
-        buffer.fail();
+        // abort the buffer
+        buffer.abort();
 
         // future should have not finished
         assertFalse(future.isDone());
@@ -828,9 +828,9 @@ public class TestArbitraryOutputBuffer
         assertFalse(firstEnqueuePage.isDone());
         assertFalse(secondEnqueuePage.isDone());
 
-        // fail the buffer (i.e., cancel the query)
-        buffer.fail();
-        assertEquals(buffer.getState(), FAILED);
+        // abort the buffer (i.e., fail the query)
+        buffer.abort();
+        assertEquals(buffer.getState(), ABORTED);
 
         // verify the futures are completed
         assertFutureIsDone(firstEnqueuePage);
@@ -857,8 +857,8 @@ public class TestArbitraryOutputBuffer
         // verify we got one page
         assertBufferResultEquals(TYPES, getFuture(future, NO_WAIT), bufferResult(0, createPage(0)));
 
-        // fail the buffer
-        buffer.fail();
+        // abort the buffer
+        buffer.abort();
 
         // add a buffer
         outputBuffers = outputBuffers.withBuffer(SECOND, BROADCAST_PARTITION_ID);

--- a/core/trino-main/src/test/java/io/trino/execution/buffer/TestBroadcastOutputBuffer.java
+++ b/core/trino-main/src/test/java/io/trino/execution/buffer/TestBroadcastOutputBuffer.java
@@ -17,12 +17,14 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.units.DataSize;
-import io.trino.execution.StateMachine;
+import io.trino.execution.StageId;
+import io.trino.execution.TaskId;
 import io.trino.execution.buffer.OutputBuffers.OutputBufferId;
 import io.trino.memory.context.AggregatedMemoryContext;
 import io.trino.memory.context.MemoryReservationHandler;
 import io.trino.memory.context.SimpleLocalMemoryContext;
 import io.trino.spi.Page;
+import io.trino.spi.QueryId;
 import io.trino.spi.type.BigintType;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -37,8 +39,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.execution.buffer.BufferResult.emptyResults;
-import static io.trino.execution.buffer.BufferState.OPEN;
-import static io.trino.execution.buffer.BufferState.TERMINAL_BUFFER_STATES;
 import static io.trino.execution.buffer.BufferTestUtils.MAX_WAIT;
 import static io.trino.execution.buffer.BufferTestUtils.NO_WAIT;
 import static io.trino.execution.buffer.BufferTestUtils.acknowledgeBufferResult;
@@ -1143,7 +1143,7 @@ public class TestBroadcastOutputBuffer
     {
         BroadcastOutputBuffer buffer = new BroadcastOutputBuffer(
                 TASK_INSTANCE_ID,
-                new StateMachine<>("bufferState", stateNotificationExecutor, OPEN, TERMINAL_BUFFER_STATES),
+                new OutputBufferStateMachine(new TaskId(new StageId(new QueryId("query"), 0), 0, 0), stateNotificationExecutor),
                 dataSize,
                 () -> memoryContext.newLocalMemoryContext("test"),
                 notificationExecutor,
@@ -1209,7 +1209,7 @@ public class TestBroadcastOutputBuffer
     {
         BroadcastOutputBuffer buffer = new BroadcastOutputBuffer(
                 TASK_INSTANCE_ID,
-                new StateMachine<>("bufferState", stateNotificationExecutor, OPEN, TERMINAL_BUFFER_STATES),
+                new OutputBufferStateMachine(new TaskId(new StageId(new QueryId("query"), 0), 0, 0), stateNotificationExecutor),
                 dataSize,
                 () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
                 stateNotificationExecutor,

--- a/core/trino-main/src/test/java/io/trino/execution/buffer/TestBroadcastOutputBuffer.java
+++ b/core/trino-main/src/test/java/io/trino/execution/buffer/TestBroadcastOutputBuffer.java
@@ -39,7 +39,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.execution.buffer.BufferResult.emptyResults;
-import static io.trino.execution.buffer.BufferState.FAILED;
+import static io.trino.execution.buffer.BufferState.ABORTED;
 import static io.trino.execution.buffer.BufferState.FINISHED;
 import static io.trino.execution.buffer.BufferState.FLUSHING;
 import static io.trino.execution.buffer.BufferState.NO_MORE_BUFFERS;
@@ -879,8 +879,8 @@ public class TestBroadcastOutputBuffer
         future = buffer.get(FIRST, 1, sizeOfPages(10));
         assertFalse(future.isDone());
 
-        // fail the buffer
-        buffer.fail();
+        // abort the buffer
+        buffer.abort();
 
         // future should have not finished
         assertFalse(future.isDone());
@@ -917,9 +917,9 @@ public class TestBroadcastOutputBuffer
         assertFalse(firstEnqueuePage.isDone());
         assertFalse(secondEnqueuePage.isDone());
 
-        // fail the buffer (i.e., cancel the query)
-        buffer.fail();
-        assertEquals(buffer.getState(), FAILED);
+        // abort the buffer (i.e., fail the query)
+        buffer.abort();
+        assertEquals(buffer.getState(), ABORTED);
 
         // verify the futures are completed
         assertFutureIsDone(firstEnqueuePage);
@@ -946,8 +946,8 @@ public class TestBroadcastOutputBuffer
         // verify we got one page
         assertBufferResultEquals(TYPES, getFuture(future, NO_WAIT), bufferResult(0, createPage(0)));
 
-        // fail the buffer
-        buffer.fail();
+        // abort the buffer
+        buffer.abort();
 
         // add a buffer
         outputBuffers = outputBuffers.withBuffer(SECOND, BROADCAST_PARTITION_ID);

--- a/core/trino-main/src/test/java/io/trino/execution/buffer/TestBroadcastOutputBuffer.java
+++ b/core/trino-main/src/test/java/io/trino/execution/buffer/TestBroadcastOutputBuffer.java
@@ -234,7 +234,7 @@ public class TestBroadcastOutputBuffer
         assertBufferResultEquals(TYPES, getBufferResult(buffer, FIRST, 14, sizeOfPages(10), NO_WAIT), emptyResults(TASK_INSTANCE_ID, 14, true));
 
         // finish first queue
-        buffer.abort(FIRST);
+        buffer.destroy(FIRST);
         assertQueueClosed(buffer, FIRST, 14);
         assertQueueState(buffer, SECOND, 4, 10);
         assertEquals(buffer.getState(), FLUSHING);
@@ -246,7 +246,7 @@ public class TestBroadcastOutputBuffer
                 createPage(13)));
         assertQueueState(buffer, SECOND, 4, 10);
         assertBufferResultEquals(TYPES, getBufferResult(buffer, SECOND, 14, sizeOfPages(10), NO_WAIT), emptyResults(TASK_INSTANCE_ID, 14, true));
-        buffer.abort(SECOND);
+        buffer.destroy(SECOND);
         assertQueueClosed(buffer, FIRST, 14);
         assertQueueClosed(buffer, SECOND, 14);
         assertFinished(buffer);
@@ -520,7 +520,7 @@ public class TestBroadcastOutputBuffer
 
         // acknowledge the page and verify we are finished
         assertBufferResultEquals(TYPES, getBufferResult(buffer, FIRST, 1, sizeOfPages(10), NO_WAIT), emptyResults(TASK_INSTANCE_ID, 1, true));
-        buffer.abort(FIRST);
+        buffer.destroy(FIRST);
 
         // set final buffers to a set that does not contain the buffer, which will fail
         assertThatThrownBy(() -> buffer.setOutputBuffers(createInitialEmptyOutputBuffers(BROADCAST).withNoMoreBufferIds()))
@@ -554,8 +554,8 @@ public class TestBroadcastOutputBuffer
         ListenableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(1));
         assertFalse(future.isDone());
 
-        // abort that buffer, and verify the future is complete and buffer is finished
-        buffer.abort(FIRST);
+        // destroy that buffer, and verify the future is complete and buffer is finished
+        buffer.destroy(FIRST);
         assertTrue(future.isDone());
         assertBufferResultEquals(TYPES, getBufferResult(buffer, FIRST, 0, sizeOfPages(10), NO_WAIT), emptyResults(TASK_INSTANCE_ID, 0, true));
     }
@@ -630,12 +630,12 @@ public class TestBroadcastOutputBuffer
         bufferedBuffer.setNoMorePages();
 
         assertBufferResultEquals(TYPES, getBufferResult(bufferedBuffer, FIRST, 0, sizeOfPages(1), NO_WAIT), bufferResult(0, createPage(0)));
-        bufferedBuffer.abort(FIRST);
+        bufferedBuffer.destroy(FIRST);
         assertQueueClosed(bufferedBuffer, FIRST, 0);
         assertBufferResultEquals(TYPES, getBufferResult(bufferedBuffer, FIRST, 1, sizeOfPages(1), NO_WAIT), emptyResults(TASK_INSTANCE_ID, 0, true));
 
         assertBufferResultEquals(TYPES, getBufferResult(bufferedBuffer, SECOND, 0, sizeOfPages(1), NO_WAIT), bufferResult(0, createPage(0)));
-        bufferedBuffer.abort(SECOND);
+        bufferedBuffer.destroy(SECOND);
         assertQueueClosed(bufferedBuffer, SECOND, 0);
         assertFinished(bufferedBuffer);
         assertBufferResultEquals(TYPES, getBufferResult(bufferedBuffer, SECOND, 1, sizeOfPages(1), NO_WAIT), emptyResults(TASK_INSTANCE_ID, 0, true));
@@ -657,8 +657,8 @@ public class TestBroadcastOutputBuffer
         assertQueueState(buffer, FIRST, 0, 0);
         assertQueueState(buffer, SECOND, 0, 0);
 
-        buffer.abort(FIRST);
-        buffer.abort(SECOND);
+        buffer.destroy(FIRST);
+        buffer.destroy(SECOND);
 
         assertQueueClosed(buffer, FIRST, 0);
         assertQueueClosed(buffer, SECOND, 0);
@@ -692,8 +692,8 @@ public class TestBroadcastOutputBuffer
         future = buffer.get(FIRST, 1, sizeOfPages(10));
         assertFalse(future.isDone());
 
-        // abort the buffer
-        buffer.abort(FIRST);
+        // destroy the buffer
+        buffer.destroy(FIRST);
 
         // verify the future completed
         // broadcast buffer does not return a "complete" result in this case, but it doesn't mapper
@@ -777,7 +777,7 @@ public class TestBroadcastOutputBuffer
                 bufferResult(1, createPage(1), createPage(2), createPage(3), createPage(4), createPage(5), createPage(6)));
         assertBufferResultEquals(TYPES, getBufferResult(buffer, FIRST, 7, sizeOfPages(100), NO_WAIT), emptyResults(TASK_INSTANCE_ID, 7, true));
 
-        buffer.abort(FIRST);
+        buffer.destroy(FIRST);
 
         // verify finished
         assertFinished(buffer);
@@ -998,7 +998,7 @@ public class TestBroadcastOutputBuffer
         assertEquals(buffer.getState(), FLUSHING);
 
         // ask the buffer to finish
-        buffer.abort(FIRST);
+        buffer.destroy(FIRST);
 
         // verify that the buffer is finished
         assertEquals(buffer.getState(), FINISHED);
@@ -1172,13 +1172,13 @@ public class TestBroadcastOutputBuffer
         }
 
         // the buffer is in the NO_MORE_BUFFERS state now
-        // and if we abort all the buffers it should destroy itself
+        // and if we destroy all the buffers it should destroy itself
         // and move to the FINISHED state
-        buffer.abort(FIRST);
+        buffer.destroy(FIRST);
         assertEquals(buffer.getState(), NO_MORE_BUFFERS);
-        buffer.abort(SECOND);
+        buffer.destroy(SECOND);
         assertEquals(buffer.getState(), NO_MORE_BUFFERS);
-        buffer.abort(THIRD);
+        buffer.destroy(THIRD);
         assertEquals(buffer.getState(), FINISHED);
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/buffer/TestBroadcastOutputBuffer.java
+++ b/core/trino-main/src/test/java/io/trino/execution/buffer/TestBroadcastOutputBuffer.java
@@ -39,6 +39,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.execution.buffer.BufferResult.emptyResults;
+import static io.trino.execution.buffer.BufferState.FAILED;
+import static io.trino.execution.buffer.BufferState.FINISHED;
+import static io.trino.execution.buffer.BufferState.FLUSHING;
+import static io.trino.execution.buffer.BufferState.NO_MORE_BUFFERS;
+import static io.trino.execution.buffer.BufferState.OPEN;
 import static io.trino.execution.buffer.BufferTestUtils.MAX_WAIT;
 import static io.trino.execution.buffer.BufferTestUtils.NO_WAIT;
 import static io.trino.execution.buffer.BufferTestUtils.acknowledgeBufferResult;
@@ -201,19 +206,19 @@ public class TestBroadcastOutputBuffer
 
         //
         // finish the buffer
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), NO_MORE_BUFFERS);
         buffer.setNoMorePages();
         assertQueueState(buffer, FIRST, 10, 4);
         assertQueueState(buffer, SECOND, 4, 10);
 
         // not fully finished until all pages are consumed
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), FLUSHING);
 
         // remove a page, not finished
         assertBufferResultEquals(TYPES, getBufferResult(buffer, FIRST, 5, sizeOfPages(1), NO_WAIT), bufferResult(5, createPage(5)));
         assertQueueState(buffer, FIRST, 9, 5);
         assertQueueState(buffer, SECOND, 4, 10);
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), FLUSHING);
 
         // remove all remaining pages from first queue, should not be finished
         BufferResult x = getBufferResult(buffer, FIRST, 6, sizeOfPages(10), NO_WAIT);
@@ -232,7 +237,7 @@ public class TestBroadcastOutputBuffer
         buffer.abort(FIRST);
         assertQueueClosed(buffer, FIRST, 14);
         assertQueueState(buffer, SECOND, 4, 10);
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), FLUSHING);
 
         // remove all remaining pages from second queue, should be finished
         assertBufferResultEquals(TYPES, getBufferResult(buffer, SECOND, 10, sizeOfPages(10), NO_WAIT), bufferResult(10, createPage(10),
@@ -422,7 +427,7 @@ public class TestBroadcastOutputBuffer
                         .withNoMoreBufferIds(),
                 sizeOfPages(10));
 
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), NO_MORE_BUFFERS);
 
         assertThatThrownBy(() -> buffer.setOutputBuffers(createInitialEmptyOutputBuffers(BROADCAST)
                 .withBuffer(FIRST, BROADCAST_PARTITION_ID)
@@ -450,19 +455,19 @@ public class TestBroadcastOutputBuffer
     public void testAddQueueAfterNoMoreQueues()
     {
         BroadcastOutputBuffer buffer = createBroadcastBuffer(createInitialEmptyOutputBuffers(BROADCAST), sizeOfPages(10));
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), OPEN);
 
         // tell buffer no more queues will be added
         buffer.setOutputBuffers(createInitialEmptyOutputBuffers(BROADCAST).withNoMoreBufferIds());
-        assertTrue(buffer.isFinished());
+        assertEquals(buffer.getState(), FINISHED);
 
         // set no more queues a second time to assure that we don't get an exception or such
         buffer.setOutputBuffers(createInitialEmptyOutputBuffers(BROADCAST).withNoMoreBufferIds());
-        assertTrue(buffer.isFinished());
+        assertEquals(buffer.getState(), FINISHED);
 
         // set no more queues a third time to assure that we don't get an exception or such
         buffer.setOutputBuffers(createInitialEmptyOutputBuffers(BROADCAST).withNoMoreBufferIds());
-        assertTrue(buffer.isFinished());
+        assertEquals(buffer.getState(), FINISHED);
     }
 
     @Test
@@ -483,7 +488,7 @@ public class TestBroadcastOutputBuffer
     public void testGetBeforeCreate()
     {
         BroadcastOutputBuffer buffer = createBroadcastBuffer(createInitialEmptyOutputBuffers(BROADCAST), sizeOfPages(10));
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), OPEN);
 
         // get a page from a buffer that doesn't exist yet
         ListenableFuture<BufferResult> future = buffer.get(FIRST, 0L, sizeOfPages(1));
@@ -499,7 +504,7 @@ public class TestBroadcastOutputBuffer
     public void testSetFinalBuffersWihtoutDeclaringUsedBuffer()
     {
         BroadcastOutputBuffer buffer = createBroadcastBuffer(createInitialEmptyOutputBuffers(BROADCAST), sizeOfPages(10));
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), OPEN);
 
         // get a page from a buffer that doesn't exist yet
         ListenableFuture<BufferResult> future = buffer.get(FIRST, 0L, sizeOfPages(1));
@@ -531,7 +536,7 @@ public class TestBroadcastOutputBuffer
                         .withBuffer(FIRST, BROADCAST_PARTITION_ID)
                         .withNoMoreBufferIds(),
                 sizeOfPages(10));
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), NO_MORE_BUFFERS);
 
         // get a page from a buffer that was not declared, which will fail
         assertThatThrownBy(() -> buffer.get(SECOND, 0L, sizeOfPages(1)))
@@ -543,7 +548,7 @@ public class TestBroadcastOutputBuffer
     public void testAbortBeforeCreate()
     {
         BroadcastOutputBuffer buffer = createBroadcastBuffer(createInitialEmptyOutputBuffers(BROADCAST), sizeOfPages(2));
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), OPEN);
 
         // get a page from a buffer that doesn't exist yet
         ListenableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(1));
@@ -668,7 +673,7 @@ public class TestBroadcastOutputBuffer
                         .withBuffer(SECOND, BROADCAST_PARTITION_ID)
                         .withNoMoreBufferIds(),
                 sizeOfPages(5));
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), NO_MORE_BUFFERS);
 
         // attempt to get a page
         ListenableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(10));
@@ -706,7 +711,7 @@ public class TestBroadcastOutputBuffer
                         .withBuffer(FIRST, BROADCAST_PARTITION_ID)
                         .withNoMoreBufferIds(),
                 sizeOfPages(5));
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), NO_MORE_BUFFERS);
 
         // attempt to get a page
         ListenableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(10));
@@ -740,7 +745,7 @@ public class TestBroadcastOutputBuffer
                         .withBuffer(FIRST, BROADCAST_PARTITION_ID)
                         .withNoMoreBufferIds(),
                 sizeOfPages(5));
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), NO_MORE_BUFFERS);
 
         // fill the buffer
         for (int i = 0; i < 5; i++) {
@@ -761,7 +766,7 @@ public class TestBroadcastOutputBuffer
 
         // finish the query
         buffer.setNoMorePages();
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), FLUSHING);
 
         // verify futures are complete
         assertFutureIsDone(firstEnqueuePage);
@@ -786,7 +791,7 @@ public class TestBroadcastOutputBuffer
                         .withBuffer(FIRST, BROADCAST_PARTITION_ID)
                         .withNoMoreBufferIds(),
                 sizeOfPages(5));
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), NO_MORE_BUFFERS);
 
         // attempt to get a page
         ListenableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(10));
@@ -820,7 +825,7 @@ public class TestBroadcastOutputBuffer
                         .withBuffer(FIRST, BROADCAST_PARTITION_ID)
                         .withNoMoreBufferIds(),
                 sizeOfPages(5));
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), NO_MORE_BUFFERS);
 
         // fill the buffer
         for (int i = 0; i < 5; i++) {
@@ -856,7 +861,7 @@ public class TestBroadcastOutputBuffer
                         .withBuffer(FIRST, BROADCAST_PARTITION_ID)
                         .withNoMoreBufferIds(),
                 sizeOfPages(5));
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), NO_MORE_BUFFERS);
 
         // attempt to get a page
         ListenableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(10));
@@ -893,7 +898,7 @@ public class TestBroadcastOutputBuffer
                         .withBuffer(FIRST, BROADCAST_PARTITION_ID)
                         .withNoMoreBufferIds(),
                 sizeOfPages(5));
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), NO_MORE_BUFFERS);
 
         // fill the buffer
         for (int i = 0; i < 5; i++) {
@@ -914,7 +919,7 @@ public class TestBroadcastOutputBuffer
 
         // fail the buffer (i.e., cancel the query)
         buffer.fail();
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), FAILED);
 
         // verify the futures are completed
         assertFutureIsDone(firstEnqueuePage);
@@ -927,7 +932,7 @@ public class TestBroadcastOutputBuffer
         OutputBuffers outputBuffers = createInitialEmptyOutputBuffers(BROADCAST)
                 .withBuffer(FIRST, BROADCAST_PARTITION_ID);
         BroadcastOutputBuffer buffer = createBroadcastBuffer(outputBuffers, sizeOfPages(5));
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), OPEN);
 
         // attempt to get a page
         ListenableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(10));
@@ -974,7 +979,7 @@ public class TestBroadcastOutputBuffer
                         .withNoMoreBufferIds(),
                 sizeOfPages(5));
 
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), NO_MORE_BUFFERS);
 
         // fill the buffer
         List<Page> pages = new ArrayList<>();
@@ -989,17 +994,14 @@ public class TestBroadcastOutputBuffer
         // get and acknowledge 5 pages
         assertBufferResultEquals(TYPES, getBufferResult(buffer, FIRST, 0, sizeOfPages(5), MAX_WAIT), createBufferResult(TASK_INSTANCE_ID, 0, pages));
 
-        // buffer is not finished
-        assertFalse(buffer.isFinished());
-
         // there are no more pages and no more buffers, but buffer is not finished because it didn't receive an acknowledgement yet
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), FLUSHING);
 
         // ask the buffer to finish
         buffer.abort(FIRST);
 
         // verify that the buffer is finished
-        assertTrue(buffer.isFinished());
+        assertEquals(buffer.getState(), FINISHED);
     }
 
     @Test
@@ -1173,11 +1175,11 @@ public class TestBroadcastOutputBuffer
         // and if we abort all the buffers it should destroy itself
         // and move to the FINISHED state
         buffer.abort(FIRST);
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), NO_MORE_BUFFERS);
         buffer.abort(SECOND);
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), NO_MORE_BUFFERS);
         buffer.abort(THIRD);
-        assertTrue(buffer.isFinished());
+        assertEquals(buffer.getState(), FINISHED);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/execution/buffer/TestPartitionedOutputBuffer.java
+++ b/core/trino-main/src/test/java/io/trino/execution/buffer/TestPartitionedOutputBuffer.java
@@ -16,10 +16,12 @@ package io.trino.execution.buffer;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.DataSize;
-import io.trino.execution.StateMachine;
+import io.trino.execution.StageId;
+import io.trino.execution.TaskId;
 import io.trino.execution.buffer.OutputBuffers.OutputBufferId;
 import io.trino.memory.context.SimpleLocalMemoryContext;
 import io.trino.spi.Page;
+import io.trino.spi.QueryId;
 import io.trino.spi.type.BigintType;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -31,8 +33,6 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.execution.buffer.BufferResult.emptyResults;
-import static io.trino.execution.buffer.BufferState.OPEN;
-import static io.trino.execution.buffer.BufferState.TERMINAL_BUFFER_STATES;
 import static io.trino.execution.buffer.BufferTestUtils.MAX_WAIT;
 import static io.trino.execution.buffer.BufferTestUtils.NO_WAIT;
 import static io.trino.execution.buffer.BufferTestUtils.acknowledgeBufferResult;
@@ -830,7 +830,7 @@ public class TestPartitionedOutputBuffer
     {
         return new PartitionedOutputBuffer(
                 TASK_INSTANCE_ID,
-                new StateMachine<>("bufferState", stateNotificationExecutor, OPEN, TERMINAL_BUFFER_STATES),
+                new OutputBufferStateMachine(new TaskId(new StageId(new QueryId("query"), 0), 0, 0), stateNotificationExecutor),
                 buffers,
                 dataSize,
                 () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),

--- a/core/trino-main/src/test/java/io/trino/execution/buffer/TestPartitionedOutputBuffer.java
+++ b/core/trino-main/src/test/java/io/trino/execution/buffer/TestPartitionedOutputBuffer.java
@@ -33,7 +33,7 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.execution.buffer.BufferResult.emptyResults;
-import static io.trino.execution.buffer.BufferState.FAILED;
+import static io.trino.execution.buffer.BufferState.ABORTED;
 import static io.trino.execution.buffer.BufferState.FINISHED;
 import static io.trino.execution.buffer.BufferState.FLUSHING;
 import static io.trino.execution.buffer.BufferState.NO_MORE_BUFFERS;
@@ -682,8 +682,8 @@ public class TestPartitionedOutputBuffer
         future = buffer.get(FIRST, 1, sizeOfPages(10));
         assertFalse(future.isDone());
 
-        // fail the buffer
-        buffer.fail();
+        // abort the buffer
+        buffer.abort();
 
         // future should have not finished
         assertFalse(future.isDone());
@@ -720,9 +720,9 @@ public class TestPartitionedOutputBuffer
         assertFalse(firstEnqueuePage.isDone());
         assertFalse(secondEnqueuePage.isDone());
 
-        // fail the buffer (i.e., cancel the query)
-        buffer.fail();
-        assertEquals(buffer.getState(), FAILED);
+        // abort the buffer (i.e., fail the query)
+        buffer.abort();
+        assertEquals(buffer.getState(), ABORTED);
 
         // verify the futures are completed
         assertFutureIsDone(firstEnqueuePage);

--- a/core/trino-main/src/test/java/io/trino/execution/buffer/TestPartitionedOutputBuffer.java
+++ b/core/trino-main/src/test/java/io/trino/execution/buffer/TestPartitionedOutputBuffer.java
@@ -200,7 +200,7 @@ public class TestPartitionedOutputBuffer
         buffer.setNoMorePages();
         assertQueueState(buffer, FIRST, 12, 4);
         assertQueueState(buffer, SECOND, 0, 10);
-        buffer.abort(SECOND);
+        buffer.destroy(SECOND);
         assertQueueClosed(buffer, SECOND, 10);
 
         // not fully finished until all pages are consumed
@@ -228,7 +228,7 @@ public class TestPartitionedOutputBuffer
         assertQueueState(buffer, FIRST, 10, 6);
         // acknowledge all pages from the first partition, should transition to finished state
         assertBufferResultEquals(TYPES, getBufferResult(buffer, FIRST, 16, sizeOfPages(10), NO_WAIT), emptyResults(TASK_INSTANCE_ID, 16, true));
-        buffer.abort(FIRST);
+        buffer.destroy(FIRST);
         assertQueueClosed(buffer, FIRST, 16);
         assertFinished(buffer);
     }
@@ -434,12 +434,12 @@ public class TestPartitionedOutputBuffer
         buffer.setNoMorePages();
 
         assertBufferResultEquals(TYPES, getBufferResult(buffer, FIRST, 0, sizeOfPages(1), NO_WAIT), bufferResult(0, createPage(0)));
-        buffer.abort(FIRST);
+        buffer.destroy(FIRST);
         assertQueueClosed(buffer, FIRST, 0);
         assertBufferResultEquals(TYPES, getBufferResult(buffer, FIRST, 1, sizeOfPages(1), NO_WAIT), emptyResults(TASK_INSTANCE_ID, 0, true));
 
         assertBufferResultEquals(TYPES, getBufferResult(buffer, SECOND, 0, sizeOfPages(1), NO_WAIT), bufferResult(0, createPage(0)));
-        buffer.abort(SECOND);
+        buffer.destroy(SECOND);
         assertQueueClosed(buffer, SECOND, 0);
         assertFinished(buffer);
         assertBufferResultEquals(TYPES, getBufferResult(buffer, SECOND, 1, sizeOfPages(1), NO_WAIT), emptyResults(TASK_INSTANCE_ID, 0, true));
@@ -461,8 +461,8 @@ public class TestPartitionedOutputBuffer
         assertQueueState(buffer, FIRST, 0, 0);
         assertQueueState(buffer, SECOND, 0, 0);
 
-        buffer.abort(FIRST);
-        buffer.abort(SECOND);
+        buffer.destroy(FIRST);
+        buffer.destroy(SECOND);
 
         assertQueueClosed(buffer, FIRST, 0);
         assertQueueClosed(buffer, SECOND, 0);
@@ -495,8 +495,8 @@ public class TestPartitionedOutputBuffer
         future = buffer.get(FIRST, 1, sizeOfPages(10));
         assertFalse(future.isDone());
 
-        // abort the buffer
-        buffer.abort(FIRST);
+        // destroy the buffer
+        buffer.destroy(FIRST);
 
         // verify the future completed
         // partitioned buffer does not return a "complete" result in this case, but it doesn't matter
@@ -580,7 +580,7 @@ public class TestPartitionedOutputBuffer
                 bufferResult(1, createPage(1), createPage(2), createPage(3), createPage(4), createPage(5), createPage(6)));
         assertBufferResultEquals(TYPES, getBufferResult(buffer, FIRST, 7, sizeOfPages(100), NO_WAIT), emptyResults(TASK_INSTANCE_ID, 7, true));
 
-        buffer.abort(FIRST);
+        buffer.destroy(FIRST);
 
         // verify finished
         assertFinished(buffer);
@@ -757,7 +757,7 @@ public class TestPartitionedOutputBuffer
         assertEquals(buffer.getState(), FLUSHING);
 
         // ask the buffer to finish
-        buffer.abort(FIRST);
+        buffer.destroy(FIRST);
 
         // verify that the buffer is finished
         assertEquals(buffer.getState(), FINISHED);
@@ -781,13 +781,13 @@ public class TestPartitionedOutputBuffer
         }
 
         // the buffer is in the NO_MORE_BUFFERS state now
-        // and if we abort all the buffers it should destroy itself
+        // and if we destroy all the buffers it should destroy itself
         // and move to the FINISHED state
-        buffer.abort(FIRST);
+        buffer.destroy(FIRST);
         assertEquals(buffer.getState(), NO_MORE_BUFFERS);
-        buffer.abort(SECOND);
+        buffer.destroy(SECOND);
         assertEquals(buffer.getState(), NO_MORE_BUFFERS);
-        buffer.abort(THIRD);
+        buffer.destroy(THIRD);
         assertEquals(buffer.getState(), FINISHED);
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/buffer/TestPartitionedOutputBuffer.java
+++ b/core/trino-main/src/test/java/io/trino/execution/buffer/TestPartitionedOutputBuffer.java
@@ -33,6 +33,10 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.execution.buffer.BufferResult.emptyResults;
+import static io.trino.execution.buffer.BufferState.FAILED;
+import static io.trino.execution.buffer.BufferState.FINISHED;
+import static io.trino.execution.buffer.BufferState.FLUSHING;
+import static io.trino.execution.buffer.BufferState.NO_MORE_BUFFERS;
 import static io.trino.execution.buffer.BufferTestUtils.MAX_WAIT;
 import static io.trino.execution.buffer.BufferTestUtils.NO_WAIT;
 import static io.trino.execution.buffer.BufferTestUtils.acknowledgeBufferResult;
@@ -192,7 +196,7 @@ public class TestPartitionedOutputBuffer
 
         //
         // finish the buffer
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), NO_MORE_BUFFERS);
         buffer.setNoMorePages();
         assertQueueState(buffer, FIRST, 12, 4);
         assertQueueState(buffer, SECOND, 0, 10);
@@ -200,12 +204,12 @@ public class TestPartitionedOutputBuffer
         assertQueueClosed(buffer, SECOND, 10);
 
         // not fully finished until all pages are consumed
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), FLUSHING);
 
         // remove a page, not finished
         assertBufferResultEquals(TYPES, getBufferResult(buffer, FIRST, 5, sizeOfPages(1), NO_WAIT), bufferResult(5, createPage(5)));
         assertQueueState(buffer, FIRST, 11, 5);
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), FLUSHING);
 
         // remove all remaining pages from first queue, should not be finished
         BufferResult x = getBufferResult(buffer, FIRST, 6, sizeOfPages(30), NO_WAIT);
@@ -321,7 +325,7 @@ public class TestPartitionedOutputBuffer
                         .withNoMoreBufferIds(),
                 sizeOfPages(10));
 
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), NO_MORE_BUFFERS);
 
         assertThatThrownBy(() -> buffer.setOutputBuffers(createInitialEmptyOutputBuffers(PARTITIONED)
                 .withBuffer(FIRST, 0)
@@ -472,7 +476,7 @@ public class TestPartitionedOutputBuffer
                         .withBuffer(FIRST, 0)
                         .withNoMoreBufferIds(),
                 sizeOfPages(5));
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), NO_MORE_BUFFERS);
 
         // attempt to get a page
         ListenableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(10));
@@ -510,7 +514,7 @@ public class TestPartitionedOutputBuffer
                         .withBuffer(FIRST, 0)
                         .withNoMoreBufferIds(),
                 sizeOfPages(5));
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), NO_MORE_BUFFERS);
 
         // attempt to get a page
         ListenableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(10));
@@ -544,7 +548,7 @@ public class TestPartitionedOutputBuffer
                         .withBuffer(FIRST, 0)
                         .withNoMoreBufferIds(),
                 sizeOfPages(5));
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), NO_MORE_BUFFERS);
 
         // fill the buffer
         for (int i = 0; i < 5; i++) {
@@ -565,7 +569,7 @@ public class TestPartitionedOutputBuffer
 
         // finish the query
         buffer.setNoMorePages();
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), FLUSHING);
 
         // verify futures are complete
         assertFutureIsDone(firstEnqueuePage);
@@ -590,7 +594,7 @@ public class TestPartitionedOutputBuffer
                         .withBuffer(FIRST, 0)
                         .withNoMoreBufferIds(),
                 sizeOfPages(5));
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), NO_MORE_BUFFERS);
 
         // attempt to get a page
         ListenableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(10));
@@ -624,7 +628,7 @@ public class TestPartitionedOutputBuffer
                         .withBuffer(FIRST, 0)
                         .withNoMoreBufferIds(),
                 sizeOfPages(5));
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), NO_MORE_BUFFERS);
 
         // fill the buffer
         for (int i = 0; i < 5; i++) {
@@ -660,7 +664,7 @@ public class TestPartitionedOutputBuffer
                         .withBuffer(FIRST, 0)
                         .withNoMoreBufferIds(),
                 sizeOfPages(5));
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), NO_MORE_BUFFERS);
 
         // attempt to get a page
         ListenableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(10));
@@ -697,7 +701,7 @@ public class TestPartitionedOutputBuffer
                         .withBuffer(FIRST, 0)
                         .withNoMoreBufferIds(),
                 sizeOfPages(5));
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), NO_MORE_BUFFERS);
 
         // fill the buffer
         for (int i = 0; i < 5; i++) {
@@ -718,7 +722,7 @@ public class TestPartitionedOutputBuffer
 
         // fail the buffer (i.e., cancel the query)
         buffer.fail();
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), FAILED);
 
         // verify the futures are completed
         assertFutureIsDone(firstEnqueuePage);
@@ -734,7 +738,7 @@ public class TestPartitionedOutputBuffer
                         .withNoMoreBufferIds(),
                 sizeOfPages(5));
 
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), NO_MORE_BUFFERS);
 
         // fill the buffer
         List<Page> pages = new ArrayList<>();
@@ -749,17 +753,14 @@ public class TestPartitionedOutputBuffer
         // get and acknowledge 5 pages
         assertBufferResultEquals(TYPES, getBufferResult(buffer, FIRST, 0, sizeOfPages(5), MAX_WAIT), createBufferResult(TASK_INSTANCE_ID, 0, pages));
 
-        // buffer is not finished
-        assertFalse(buffer.isFinished());
-
         // there are no more pages and no more buffers, but buffer is not finished because it didn't receive an acknowledgement yet
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), FLUSHING);
 
         // ask the buffer to finish
         buffer.abort(FIRST);
 
         // verify that the buffer is finished
-        assertTrue(buffer.isFinished());
+        assertEquals(buffer.getState(), FINISHED);
     }
 
     @Test
@@ -783,11 +784,11 @@ public class TestPartitionedOutputBuffer
         // and if we abort all the buffers it should destroy itself
         // and move to the FINISHED state
         buffer.abort(FIRST);
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), NO_MORE_BUFFERS);
         buffer.abort(SECOND);
-        assertFalse(buffer.isFinished());
+        assertEquals(buffer.getState(), NO_MORE_BUFFERS);
         buffer.abort(THIRD);
-        assertTrue(buffer.isFinished());
+        assertEquals(buffer.getState(), FINISHED);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/execution/buffer/TestSpoolingExchangeOutputBuffer.java
+++ b/core/trino-main/src/test/java/io/trino/execution/buffer/TestSpoolingExchangeOutputBuffer.java
@@ -1,0 +1,403 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.buffer;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ListMultimap;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.slice.Slice;
+import io.trino.execution.StageId;
+import io.trino.execution.TaskId;
+import io.trino.memory.context.LocalMemoryContext;
+import io.trino.spi.QueryId;
+import io.trino.spi.exchange.ExchangeSink;
+import io.trino.spi.exchange.ExchangeSinkInstanceHandle;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.execution.buffer.BufferState.ABORTED;
+import static io.trino.execution.buffer.BufferState.FAILED;
+import static io.trino.execution.buffer.BufferState.FINISHED;
+import static io.trino.execution.buffer.BufferState.FLUSHING;
+import static io.trino.execution.buffer.BufferState.NO_MORE_BUFFERS;
+import static io.trino.execution.buffer.OutputBuffers.createSpoolingExchangeOutputBuffers;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestSpoolingExchangeOutputBuffer
+{
+    @Test
+    public void testIsFull()
+    {
+        TestingExchangeSink exchangeSink = new TestingExchangeSink();
+        OutputBuffer outputBuffer = createSpoolingExchangeOutputBuffer(exchangeSink);
+        assertEquals(outputBuffer.getState(), NO_MORE_BUFFERS);
+        assertNotBlocked(outputBuffer.isFull());
+
+        CompletableFuture<?> blocked = new CompletableFuture<>();
+        exchangeSink.setBlocked(blocked);
+
+        ListenableFuture<Void> full = outputBuffer.isFull();
+        assertBlocked(full);
+
+        blocked.complete(null);
+        assertNotBlocked(full);
+    }
+
+    @Test
+    public void testFinishSuccess()
+    {
+        TestingExchangeSink exchangeSink = new TestingExchangeSink();
+        CompletableFuture<?> finish = new CompletableFuture<>();
+        exchangeSink.setFinish(finish);
+
+        OutputBuffer outputBuffer = createSpoolingExchangeOutputBuffer(exchangeSink);
+        assertEquals(outputBuffer.getState(), NO_MORE_BUFFERS);
+
+        outputBuffer.setNoMorePages();
+        // call it for the second time to verify that the buffer handles it correctly
+        outputBuffer.setNoMorePages();
+        assertEquals(outputBuffer.getState(), FLUSHING);
+
+        finish.complete(null);
+        assertEquals(outputBuffer.getState(), FINISHED);
+    }
+
+    @Test
+    public void testFinishFailure()
+    {
+        TestingExchangeSink exchangeSink = new TestingExchangeSink();
+        CompletableFuture<?> finish = new CompletableFuture<>();
+        exchangeSink.setFinish(finish);
+
+        OutputBuffer outputBuffer = createSpoolingExchangeOutputBuffer(exchangeSink);
+        assertEquals(outputBuffer.getState(), NO_MORE_BUFFERS);
+
+        outputBuffer.setNoMorePages();
+        // call it for the second time to verify that the buffer handles it correctly
+        outputBuffer.setNoMorePages();
+        assertEquals(outputBuffer.getState(), FLUSHING);
+
+        RuntimeException failure = new RuntimeException("failure");
+        finish.completeExceptionally(failure);
+        assertEquals(outputBuffer.getState(), FAILED);
+        assertEquals(outputBuffer.getFailureCause(), Optional.of(failure));
+    }
+
+    @Test
+    public void testDestroyAfterFinishCompletion()
+    {
+        TestingExchangeSink exchangeSink = new TestingExchangeSink();
+        CompletableFuture<?> finish = new CompletableFuture<>();
+        exchangeSink.setFinish(finish);
+
+        OutputBuffer outputBuffer = createSpoolingExchangeOutputBuffer(exchangeSink);
+        assertEquals(outputBuffer.getState(), NO_MORE_BUFFERS);
+
+        outputBuffer.setNoMorePages();
+        // call it for the second time to verify that the buffer handles it correctly
+        outputBuffer.setNoMorePages();
+        assertEquals(outputBuffer.getState(), FLUSHING);
+
+        finish.complete(null);
+        assertEquals(outputBuffer.getState(), FINISHED);
+
+        outputBuffer.destroy();
+        assertEquals(outputBuffer.getState(), FINISHED);
+    }
+
+    @Test
+    public void testDestroyBeforeFinishCompletion()
+    {
+        TestingExchangeSink exchangeSink = new TestingExchangeSink();
+        CompletableFuture<?> finish = new CompletableFuture<>();
+        exchangeSink.setFinish(finish);
+
+        OutputBuffer outputBuffer = createSpoolingExchangeOutputBuffer(exchangeSink);
+        assertEquals(outputBuffer.getState(), NO_MORE_BUFFERS);
+
+        outputBuffer.setNoMorePages();
+        assertEquals(outputBuffer.getState(), FLUSHING);
+
+        outputBuffer.destroy();
+        assertEquals(outputBuffer.getState(), ABORTED);
+
+        finish.complete(null);
+        assertEquals(outputBuffer.getState(), ABORTED);
+    }
+
+    @Test
+    public void testAbortBeforeNoMorePages()
+    {
+        TestingExchangeSink exchangeSink = new TestingExchangeSink();
+
+        OutputBuffer outputBuffer = createSpoolingExchangeOutputBuffer(exchangeSink);
+        assertEquals(outputBuffer.getState(), NO_MORE_BUFFERS);
+
+        outputBuffer.abort();
+        assertEquals(outputBuffer.getState(), ABORTED);
+        outputBuffer.setNoMorePages();
+        assertEquals(outputBuffer.getState(), ABORTED);
+    }
+
+    @Test
+    public void testAbortBeforeFinishCompletion()
+    {
+        TestingExchangeSink exchangeSink = new TestingExchangeSink();
+        CompletableFuture<?> finish = new CompletableFuture<>();
+        exchangeSink.setFinish(finish);
+        CompletableFuture<?> abort = new CompletableFuture<>();
+        exchangeSink.setAbort(abort);
+
+        OutputBuffer outputBuffer = createSpoolingExchangeOutputBuffer(exchangeSink);
+        assertEquals(outputBuffer.getState(), NO_MORE_BUFFERS);
+
+        outputBuffer.setNoMorePages();
+        // call it for the second time to verify that the buffer handles it correctly
+        outputBuffer.setNoMorePages();
+        assertEquals(outputBuffer.getState(), FLUSHING);
+
+        // if abort is called before finish completes it should abort the buffer
+        outputBuffer.abort();
+        assertEquals(outputBuffer.getState(), ABORTED);
+
+        // abort failure shouldn't impact the buffer state
+        abort.completeExceptionally(new RuntimeException("failure"));
+        assertEquals(outputBuffer.getState(), ABORTED);
+    }
+
+    @Test
+    public void testAbortAfterFinishCompletion()
+    {
+        TestingExchangeSink exchangeSink = new TestingExchangeSink();
+        CompletableFuture<?> finish = new CompletableFuture<>();
+        exchangeSink.setFinish(finish);
+        CompletableFuture<?> abort = new CompletableFuture<>();
+        exchangeSink.setAbort(abort);
+
+        OutputBuffer outputBuffer = createSpoolingExchangeOutputBuffer(exchangeSink);
+        assertEquals(outputBuffer.getState(), NO_MORE_BUFFERS);
+
+        outputBuffer.setNoMorePages();
+        // call it for the second time to verify that the buffer handles it correctly
+        outputBuffer.setNoMorePages();
+        assertEquals(outputBuffer.getState(), FLUSHING);
+
+        finish.complete(null);
+        assertEquals(outputBuffer.getState(), FINISHED);
+
+        // abort is no op
+        outputBuffer.abort();
+        assertEquals(outputBuffer.getState(), FINISHED);
+
+        // abort success doesn't change the buffer state
+        abort.complete(null);
+        assertEquals(outputBuffer.getState(), FINISHED);
+    }
+
+    @Test
+    public void testEnqueueAfterFinish()
+    {
+        TestingExchangeSink exchangeSink = new TestingExchangeSink();
+        CompletableFuture<?> finish = new CompletableFuture<>();
+        exchangeSink.setFinish(finish);
+
+        OutputBuffer outputBuffer = createSpoolingExchangeOutputBuffer(exchangeSink);
+        assertEquals(outputBuffer.getState(), NO_MORE_BUFFERS);
+
+        outputBuffer.enqueue(0, ImmutableList.of(utf8Slice("page1")));
+        outputBuffer.enqueue(1, ImmutableList.of(utf8Slice("page2"), utf8Slice("page3")));
+
+        ImmutableListMultimap<Integer, Slice> expectedDataBufferState = ImmutableListMultimap.<Integer, Slice>builder()
+                .put(0, utf8Slice("page1"))
+                .put(1, utf8Slice("page2"))
+                .put(1, utf8Slice("page3"))
+                .build();
+
+        assertEquals(exchangeSink.getDataBuffer(), expectedDataBufferState);
+
+        outputBuffer.setNoMorePages();
+        assertEquals(outputBuffer.getState(), FLUSHING);
+        // the buffer is flushing, this page is expected to be rejected
+        outputBuffer.enqueue(0, ImmutableList.of(utf8Slice("page4")));
+        assertEquals(exchangeSink.getDataBuffer(), expectedDataBufferState);
+
+        finish.complete(null);
+        assertEquals(outputBuffer.getState(), FINISHED);
+        outputBuffer.enqueue(0, ImmutableList.of(utf8Slice("page5")));
+        assertEquals(exchangeSink.getDataBuffer(), expectedDataBufferState);
+    }
+
+    @Test
+    public void testEnqueueAfterAbort()
+    {
+        TestingExchangeSink exchangeSink = new TestingExchangeSink();
+        CompletableFuture<?> abort = new CompletableFuture<>();
+        exchangeSink.setAbort(abort);
+
+        OutputBuffer outputBuffer = createSpoolingExchangeOutputBuffer(exchangeSink);
+        assertEquals(outputBuffer.getState(), NO_MORE_BUFFERS);
+
+        outputBuffer.enqueue(0, ImmutableList.of(utf8Slice("page1")));
+        outputBuffer.enqueue(1, ImmutableList.of(utf8Slice("page2"), utf8Slice("page3")));
+
+        ImmutableListMultimap<Integer, Slice> expectedDataBufferState = ImmutableListMultimap.<Integer, Slice>builder()
+                .put(0, utf8Slice("page1"))
+                .put(1, utf8Slice("page2"))
+                .put(1, utf8Slice("page3"))
+                .build();
+
+        assertEquals(exchangeSink.getDataBuffer(), expectedDataBufferState);
+
+        outputBuffer.abort();
+        assertEquals(outputBuffer.getState(), ABORTED);
+        // the buffer is flushing, this page is expected to be rejected
+        outputBuffer.enqueue(0, ImmutableList.of(utf8Slice("page4")));
+        assertEquals(exchangeSink.getDataBuffer(), expectedDataBufferState);
+
+        abort.complete(null);
+        assertEquals(outputBuffer.getState(), ABORTED);
+        outputBuffer.enqueue(0, ImmutableList.of(utf8Slice("page5")));
+        assertEquals(exchangeSink.getDataBuffer(), expectedDataBufferState);
+    }
+
+    private static SpoolingExchangeOutputBuffer createSpoolingExchangeOutputBuffer(ExchangeSink exchangeSink)
+    {
+        return new SpoolingExchangeOutputBuffer(
+                new OutputBufferStateMachine(new TaskId(new StageId(new QueryId("query"), 0), 0, 0), directExecutor()),
+                createSpoolingExchangeOutputBuffers(TestingExchangeSinkInstanceHandle.INSTANCE),
+                exchangeSink,
+                TestingLocalMemoryContext::new);
+    }
+
+    private static void assertNotBlocked(ListenableFuture<Void> blocked)
+    {
+        assertTrue(blocked.isDone());
+    }
+
+    private static void assertBlocked(ListenableFuture<Void> blocked)
+    {
+        assertFalse(blocked.isDone());
+    }
+
+    private static class TestingExchangeSink
+            implements ExchangeSink
+    {
+        private final ListMultimap<Integer, Slice> dataBuffer = ArrayListMultimap.create();
+        private CompletableFuture<?> blocked = CompletableFuture.completedFuture(null);
+        private CompletableFuture<?> finish = CompletableFuture.completedFuture(null);
+        private CompletableFuture<?> abort = CompletableFuture.completedFuture(null);
+
+        private boolean finishCalled;
+        private boolean abortCalled;
+
+        @Override
+        public CompletableFuture<?> isBlocked()
+        {
+            return blocked;
+        }
+
+        public void setBlocked(CompletableFuture<?> blocked)
+        {
+            this.blocked = requireNonNull(blocked, "blocked is null");
+        }
+
+        @Override
+        public void add(int partitionId, Slice data)
+        {
+            this.dataBuffer.put(partitionId, data);
+        }
+
+        public ListMultimap<Integer, Slice> getDataBuffer()
+        {
+            return dataBuffer;
+        }
+
+        @Override
+
+        public long getMemoryUsage()
+        {
+            return 0;
+        }
+
+        @Override
+        public CompletableFuture<?> finish()
+        {
+            assertFalse(abortCalled);
+            assertFalse(finishCalled);
+            finishCalled = true;
+            return finish;
+        }
+
+        public void setFinish(CompletableFuture<?> finish)
+        {
+            this.finish = requireNonNull(finish, "finish is null");
+        }
+
+        @Override
+        public CompletableFuture<?> abort()
+        {
+            assertFalse(abortCalled);
+            abortCalled = true;
+            return abort;
+        }
+
+        public void setAbort(CompletableFuture<?> abort)
+        {
+            this.abort = requireNonNull(abort, "abort is null");
+        }
+    }
+
+    private enum TestingExchangeSinkInstanceHandle
+            implements ExchangeSinkInstanceHandle
+    {
+        INSTANCE
+    }
+
+    private static class TestingLocalMemoryContext
+            implements LocalMemoryContext
+    {
+        @Override
+        public long getBytes()
+        {
+            return 0;
+        }
+
+        @Override
+        public ListenableFuture<Void> setBytes(long bytes)
+        {
+            return immediateVoidFuture();
+        }
+
+        @Override
+        public boolean trySetBytes(long bytes)
+        {
+            return true;
+        }
+
+        @Override
+        public void close()
+        {
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPartitionedOutputOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPartitionedOutputOperator.java
@@ -661,7 +661,7 @@ public class TestPartitionedOutputOperator
         }
 
         @Override
-        public void fail()
+        public void abort()
         {
         }
 

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPartitionedOutputOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPartitionedOutputOperator.java
@@ -670,6 +670,12 @@ public class TestPartitionedOutputOperator
         {
             return 0;
         }
+
+        @Override
+        public Optional<Throwable> getFailureCause()
+        {
+            return Optional.empty();
+        }
     }
 
     private static class SumModuloPartitionFunction

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPartitionedOutputOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPartitionedOutputOperator.java
@@ -635,7 +635,7 @@ public class TestPartitionedOutputOperator
         }
 
         @Override
-        public void abort(OutputBuffers.OutputBufferId bufferId)
+        public void destroy(OutputBuffers.OutputBufferId bufferId)
         {
         }
 

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPartitionedOutputOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPartitionedOutputOperator.java
@@ -596,9 +596,9 @@ public class TestPartitionedOutputOperator
         }
 
         @Override
-        public boolean isFinished()
+        public BufferState getState()
         {
-            return false;
+            return BufferState.NO_MORE_BUFFERS;
         }
 
         @Override

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestExchangeManager.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestExchangeManager.java
@@ -37,6 +37,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.trino.spi.exchange.ExchangeId.createRandomExchangeId;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertTrue;
@@ -165,10 +166,10 @@ public abstract class AbstractTestExchangeManager
             sink.add(key, Slices.utf8Slice(value));
         });
         if (finish) {
-            sink.finish();
+            getFutureValue(sink.finish());
         }
         else {
-            sink.abort();
+            getFutureValue(sink.abort());
         }
     }
 


### PR DESCRIPTION
This came up during a discussion with @linzebing . It looks like currently the `noMorePages` and `destroy` methods could be called from a tiny thread pool designed to handle lightweight task notifications, for example:

https://github.com/trinodb/trino/blob/master/core/trino-main/src/main/java/io/trino/execution/SqlTaskExecution.java#L640
https://github.com/trinodb/trino/blob/master/core/trino-main/src/main/java/io/trino/execution/SqlTaskExecution.java#L568
https://github.com/trinodb/trino/blob/master/core/trino-main/src/main/java/io/trino/execution/SqlTaskExecution.java#L602

Where the `notificationExecutor` is shared between all tasks and by default only has 5 threads in the pool: https://github.com/trinodb/trino/blob/master/core/trino-main/src/main/java/io/trino/execution/TaskManagerConfig.java#L79

The commit operation on `ExchangeSink` could be quite time consuming (as it may require to flush existing buffers, create files and so on). So it looks like it is better to provide a non blocking `ExchangeSink` interface.

I will update the commit message.