### PR TITLE
Use TupleDomain#intersect for List<TupleDomain> in DynamicFilterService

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/DynamicFilterService.java
+++ b/core/trino-main/src/main/java/io/trino/server/DynamicFilterService.java
@@ -333,9 +333,10 @@ public class DynamicFilterService
                     return currentFilter.getDynamicFilter();
                 }
 
-                TupleDomain<ColumnHandle> dynamicFilter = completedDynamicFilters.stream()
-                        .map(filter -> translateSummaryToTupleDomain(filter, context, symbolsMap, columnHandles, typeProvider))
-                        .reduce(TupleDomain.all(), TupleDomain::intersect);
+                TupleDomain<ColumnHandle> dynamicFilter = TupleDomain.intersect(
+                        completedDynamicFilters.stream()
+                                .map(filter -> translateSummaryToTupleDomain(filter, context, symbolsMap, columnHandles, typeProvider))
+                                .collect(toImmutableList()));
 
                 // It could happen that two threads update currentDynamicFilter concurrently.
                 // In such case, currentDynamicFilter might be set to dynamic filter with less domains.

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/TupleDomain.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/TupleDomain.java
@@ -247,8 +247,12 @@ public final class TupleDomain<T>
 
     public static <T> TupleDomain<T> intersect(List<TupleDomain<T>> domains)
     {
-        if (domains.size() < 2) {
-            throw new IllegalArgumentException("Expected at least 2 elements");
+        if (domains.isEmpty()) {
+            return all();
+        }
+
+        if (domains.size() == 1) {
+            return domains.get(0);
         }
 
         if (domains.stream().anyMatch(TupleDomain::isNone)) {


### PR DESCRIPTION
Allow single element list in TupleDomain#intersect to make it's usage easier.
Using the direct API for intersecting lists can be more efficient than
intersecting two elements at a time.