### PR TITLE
Expose contains_nan in partitions metadata

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -536,8 +536,8 @@ You can retrieve the information about the manifests of the Iceberg table
 .. code-block:: text
 
      path                                                                                                           | length          | partition_spec_id    | added_snapshot_id     |  added_data_files_count  | existing_data_files_count   | deleted_data_files_count    | partitions
-    ----------------------------------------------------------------------------------------------------------------+-----------------+----------------------+-----------------------+--------------------------+-----------------------------+-----------------------------+----------------------------------------------------------------------------------------------------------------------------
-     hdfs://hadoop-master:9000/user/hive/warehouse/test_table/metadata/faa19903-1455-4bb8-855a-61a1bbafbaa7-m0.avro |  6277           |   0                  | 7860805980949777961   |  1                       |   0                         |  0                          |{{contains_null=false, lower_bound=1, upper_bound=1},{contains_null=false, lower_bound=2021-01-12, upper_bound=2021-01-12}}
+    ----------------------------------------------------------------------------------------------------------------+-----------------+----------------------+-----------------------+--------------------------+-----------------------------+-----------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+     hdfs://hadoop-master:9000/user/hive/warehouse/test_table/metadata/faa19903-1455-4bb8-855a-61a1bbafbaa7-m0.avro |  6277           |   0                  | 7860805980949777961   |  1                       |   0                         |  0                          |{{contains_null=false, contains_nan= false, lower_bound=1, upper_bound=1},{contains_null=false, contains_nan= false, lower_bound=2021-01-12, upper_bound=2021-01-12}}
 
 
 The output of the query has the following columns:
@@ -571,7 +571,7 @@ The output of the query has the following columns:
     - ``integer``
     - The number of data files with status ``DELETED`` in the manifest file
   * - ``partitions``
-    - ``array(row(contains_null boolean, lower_bound varchar, upper_bound varchar))``
+    - ``array(row(contains_null boolean, contains_nan boolean, lower_bound varchar, upper_bound varchar))``
     - Partition range metadata
 
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ManifestsTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ManifestsTable.java
@@ -72,6 +72,7 @@ public class ManifestsTable
                         .add(new ColumnMetadata("deleted_data_files_count", INTEGER))
                         .add(new ColumnMetadata("partitions", new ArrayType(RowType.rowType(
                                 RowType.field("contains_null", BOOLEAN),
+                                RowType.field("contains_nan", BOOLEAN),
                                 RowType.field("lower_bound", VARCHAR),
                                 RowType.field("upper_bound", VARCHAR)))))
                         .build());
@@ -136,6 +137,7 @@ public class ManifestsTable
 
             BlockBuilder rowBuilder = singleArrayWriter.beginBlockEntry();
             BOOLEAN.writeBoolean(rowBuilder, summary.containsNull());
+            BOOLEAN.writeBoolean(rowBuilder, summary.containsNaN());
             VARCHAR.writeString(rowBuilder, field.transform().toHumanString(
                     Conversions.fromByteBuffer(nestedType, summary.lowerBound())));
             VARCHAR.writeString(rowBuilder, field.transform().toHumanString(

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSystemTables.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSystemTables.java
@@ -28,6 +28,7 @@ import java.util.function.Function;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.plugin.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
 import static io.trino.testing.MaterializedResult.DEFAULT_PRECISION;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 public class TestIcebergSystemTables
@@ -129,10 +130,17 @@ public class TestIcebergSystemTables
                         "('added_data_files_count', 'integer', '', '')," +
                         "('existing_data_files_count', 'integer', '', '')," +
                         "('deleted_data_files_count', 'integer', '', '')," +
-                        "('partitions', 'array(row(contains_null boolean, lower_bound varchar, upper_bound varchar))', '', '')");
+                        "('partitions', 'array(row(contains_null boolean, contains_nan boolean, lower_bound varchar, upper_bound varchar))', '', '')");
         assertQuerySucceeds("SELECT * FROM test_schema.\"test_table$manifests\"");
+        assertThat(query("SELECT partitions FROM test_schema.\"test_table$manifests\""))
+                .matches("VALUES " +
+                        "    CAST(ARRAY[ROW(false, false, '2019-09-08', '2019-09-09')] AS array(row(contains_null boolean, contains_nan boolean, lower_bound varchar, upper_bound varchar))) , " +
+                        "    CAST(ARRAY[ROW(false, false, '2019-09-09', '2019-09-10')] AS array(row(contains_null boolean, contains_nan boolean, lower_bound varchar, upper_bound varchar)))");
 
         assertQuerySucceeds("SELECT * FROM test_schema.\"test_table_multilevel_partitions$manifests\"");
+        assertThat(query("SELECT partitions FROM test_schema.\"test_table_multilevel_partitions$manifests\""))
+                .matches("VALUES " +
+                        "    CAST(ARRAY[ROW(false, false, '0', '1'), ROW(false, false, '2019-09-08', '2019-09-09')] AS array(row(contains_null boolean, contains_nan boolean, lower_bound varchar, upper_bound varchar)))");
     }
 
     @Test


### PR DESCRIPTION
## Description

Iceberg exposes in the manifests metadata table the column `contains_nan`.
See https://github.com/apache/iceberg/blob/68091037944ff7e9de91e7b619f313a8e98c1adc/core/src/main/java/org/apache/iceberg/ManifestsTable.java#L41

Expose this column in the `$manifests` Iceberg metadata tables.


###Testing scenario

```
CREATE TABLE  iceberg.default.test_iceberg_table (
                                                    c1 integer,
                                                    c2 date,
                                                    c3 double)
    WITH (
        format = 'PARQUET',
        partitioning = ARRAY['c1', 'c2']);

insert into iceberg.default.test_iceberg_table values (1, DATE '2021-01-10',1);

select * from iceberg.default."test_iceberg_table$manifests";
```


exposes `contains_nan` in partitions metadata

```
{{contains_null=false, contains_nan=false, lower_bound=1, upper_bound=1},{contains_null=false, contains_nan=false, lower_bound=2021-01-10, upper_bound=2021-01-10}}
```

## General information

Is this change a fix, improvement, new feature, refactoring, or other?

This is a new feature related to Iceberg table metadata.

Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

This change related to Iceberg connector, specifically to the `$manifests` metadata table exposed by the connector for the Iceberg tables.

How would you describe this change to a non-technical end user or system administrator?

This feature slightly enriches the metadata retrieved for an Iceberg table.

## Related issues, pull requests, and links

N/A
<!-- List any issue that is fixed and provide links to other related PRs, upstream release notes, and other useful resources:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) or whatever really to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

