### PR TITLE
Expose `nan_count` in $partitions metadata table

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -659,9 +659,9 @@ You can retrieve the information about the partitions of the Iceberg table
 .. code-block:: text
 
      partition             | record_count  | file_count    | total_size    |  data
-    -----------------------+---------------+---------------+---------------+--------------------------------------
-    {c1=1, c2=2021-01-12}  |  2            | 2             |  884          | {c3={min=1.0, max=2.0, null_count=0}}
-    {c1=1, c2=2021-01-13}  |  1            | 1             |  442          | {c3={min=1.0, max=1.0, null_count=0}}
+    -----------------------+---------------+---------------+---------------+------------------------------------------------------
+    {c1=1, c2=2021-01-12}  |  2            | 2             |  884          | {c3={min=1.0, max=2.0, null_count=0, nan_count=NULL}}
+    {c1=1, c2=2021-01-13}  |  1            | 1             |  442          | {c3={min=1.0, max=1.0, null_count=0, nan_count=NULL}}
 
 
 The output of the query has the following columns:
@@ -686,7 +686,7 @@ The output of the query has the following columns:
     - ``bigint``
     - The size of all the files in the partition
   * - ``data``
-    - ``row(... row (min ..., max ... , null_count bigint))``
+    - ``row(... row (min ..., max ... , null_count bigint, nan_count bigint))``
     - Partition range metadata
 
 ``$files`` table

--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcWriteValidation.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcWriteValidation.java
@@ -560,7 +560,7 @@ public class OrcWriteValidation
                 return Optional.empty();
             }
             ImmutableList.Builder<ColumnStatistics> statisticsBuilders = ImmutableList.builder();
-            statisticsBuilders.add(new ColumnStatistics(rowCount, 0, null, null, null, null, null, null, null, null, null));
+            statisticsBuilders.add(new ColumnStatistics(rowCount, 0, null, null, null, null, null, null, null, null, null, null));
             columnStatisticsValidations.forEach(validation -> validation.build(statisticsBuilders));
             return Optional.of(new ColumnMetadata<>(statisticsBuilders.build()));
         }
@@ -752,7 +752,7 @@ public class OrcWriteValidation
         @Override
         public ColumnStatistics buildColumnStatistics()
         {
-            return new ColumnStatistics(rowCount, 0, null, null, null, null, null, null, null, null, null);
+            return new ColumnStatistics(rowCount, 0, null, null, null, null, null, null, null, null, null, null);
         }
     }
 

--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcWriter.java
@@ -433,7 +433,7 @@ public final class OrcWriter
 
         // the 0th column is a struct column for the whole row
         columnEncodings.put(ROOT_COLUMN, new ColumnEncoding(DIRECT, 0));
-        columnStatistics.put(ROOT_COLUMN, new ColumnStatistics((long) stripeRowCount, 0, null, null, null, null, null, null, null, null, null));
+        columnStatistics.put(ROOT_COLUMN, new ColumnStatistics((long) stripeRowCount, 0, null, null, null, null, null, null, null, null, null, null));
 
         // add footer
         StripeFooter stripeFooter = new StripeFooter(allStreams, toColumnMetadata(columnEncodings, orcTypes.size()), ZoneId.of("UTC"));

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/OrcMetadataReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/OrcMetadataReader.java
@@ -294,7 +294,7 @@ public class OrcMetadataReader
         // is set to 1, but the value is wrongly set to default 0 which implies there is something wrong with
         // the stats. Drop the column statistics altogether.
         if (statistics.hasHasNull() && statistics.getNumberOfValues() == 0 && !statistics.getHasNull()) {
-            return new ColumnStatistics(null, 0, null, null, null, null, null, null, null, null, null);
+            return new ColumnStatistics(null, 0, null, null, null, null, null, null, null, null, null, null);
         }
 
         return new ColumnStatistics(
@@ -303,6 +303,7 @@ public class OrcMetadataReader
                 statistics.hasBucketStatistics() ? toBooleanStatistics(statistics.getBucketStatistics()) : null,
                 statistics.hasIntStatistics() ? toIntegerStatistics(statistics.getIntStatistics()) : null,
                 statistics.hasDoubleStatistics() ? toDoubleStatistics(statistics.getDoubleStatistics()) : null,
+                null,
                 statistics.hasStringStatistics() ? toStringStatistics(hiveWriterVersion, statistics.getStringStatistics(), isRowGroup) : null,
                 statistics.hasDateStatistics() ? toDateStatistics(hiveWriterVersion, statistics.getDateStatistics(), isRowGroup) : null,
                 statistics.hasTimestampStatistics() ? toTimestampStatistics(hiveWriterVersion, statistics.getTimestampStatistics(), isRowGroup) : null,

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/BinaryStatisticsBuilder.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/BinaryStatisticsBuilder.java
@@ -68,6 +68,7 @@ public class BinaryStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 binaryStatistics.orElse(null),
                 null);
     }

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/BooleanStatisticsBuilder.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/BooleanStatisticsBuilder.java
@@ -77,6 +77,7 @@ public class BooleanStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 null);
     }
 

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/ColumnStatistics.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/ColumnStatistics.java
@@ -40,6 +40,7 @@ public class ColumnStatistics
     private final BooleanStatistics booleanStatistics;
     private final IntegerStatistics integerStatistics;
     private final DoubleStatistics doubleStatistics;
+    private final long numberOfNanValues;
     private final StringStatistics stringStatistics;
     private final DateStatistics dateStatistics;
     private final TimestampStatistics timestampStatistics;
@@ -53,6 +54,7 @@ public class ColumnStatistics
             BooleanStatistics booleanStatistics,
             IntegerStatistics integerStatistics,
             DoubleStatistics doubleStatistics,
+            Long numberOfNanValues,
             StringStatistics stringStatistics,
             DateStatistics dateStatistics,
             TimestampStatistics timestampStatistics,
@@ -66,6 +68,7 @@ public class ColumnStatistics
         this.booleanStatistics = booleanStatistics;
         this.integerStatistics = integerStatistics;
         this.doubleStatistics = doubleStatistics;
+        this.numberOfNanValues = numberOfNanValues != null ? numberOfNanValues : 0;
         this.stringStatistics = stringStatistics;
         this.dateStatistics = dateStatistics;
         this.timestampStatistics = timestampStatistics;
@@ -115,6 +118,11 @@ public class ColumnStatistics
         return doubleStatistics;
     }
 
+    public long getNumberOfNanValues()
+    {
+        return numberOfNanValues;
+    }
+
     public IntegerStatistics getIntegerStatistics()
     {
         return integerStatistics;
@@ -153,6 +161,7 @@ public class ColumnStatistics
                 booleanStatistics,
                 integerStatistics,
                 doubleStatistics,
+                numberOfNanValues,
                 stringStatistics,
                 dateStatistics,
                 timestampStatistics,
@@ -280,12 +289,17 @@ public class ColumnStatistics
                     .sum() / numberOfRows;
         }
 
+        long numberOfNanValues = stats.stream()
+                .mapToLong(ColumnStatistics::getNumberOfNanValues)
+                .sum();
+
         return new ColumnStatistics(
                 numberOfRows,
                 minAverageValueBytes,
                 mergeBooleanStatistics(stats).orElse(null),
                 mergeIntegerStatistics(stats).orElse(null),
                 mergeDoubleStatistics(stats).orElse(null),
+                numberOfNanValues,
                 mergeStringStatistics(stats).orElse(null),
                 mergeDateStatistics(stats).orElse(null),
                 mergeTimestampStatistics(stats).orElse(null),

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/DateStatisticsBuilder.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/DateStatisticsBuilder.java
@@ -74,6 +74,7 @@ public class DateStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 dateStatistics.orElse(null),
                 null,
                 null,

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/DoubleStatisticsBuilder.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/DoubleStatisticsBuilder.java
@@ -27,7 +27,7 @@ public class DoubleStatisticsBuilder
         implements StatisticsBuilder
 {
     private long nonNullValueCount;
-    private boolean hasNan;
+    private long nanValueCount;
     private double minimum = Double.POSITIVE_INFINITY;
     private double maximum = Double.NEGATIVE_INFINITY;
 
@@ -71,7 +71,7 @@ public class DoubleStatisticsBuilder
     {
         nonNullValueCount++;
         if (Double.isNaN(value)) {
-            hasNan = true;
+            nanValueCount++;
         }
         else {
             minimum = Math.min(value, minimum);
@@ -93,7 +93,7 @@ public class DoubleStatisticsBuilder
     private Optional<DoubleStatistics> buildDoubleStatistics()
     {
         // if there are NaN values we cannot say anything about the data
-        if (nonNullValueCount == 0 || hasNan) {
+        if (nonNullValueCount == 0 || nanValueCount > 0) {
             return Optional.empty();
         }
         return Optional.of(new DoubleStatistics(minimum, maximum));
@@ -109,6 +109,7 @@ public class DoubleStatisticsBuilder
                 null,
                 null,
                 doubleStatistics.orElse(null),
+                nanValueCount,
                 null,
                 null,
                 null,

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/IntegerStatisticsBuilder.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/IntegerStatisticsBuilder.java
@@ -103,6 +103,7 @@ public class IntegerStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 bloomFilterBuilder.buildBloomFilter());
     }
 

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/LongDecimalStatisticsBuilder.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/LongDecimalStatisticsBuilder.java
@@ -102,6 +102,7 @@ public class LongDecimalStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 decimalStatistics.orElse(null),
                 null,
                 null);

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/ShortDecimalStatisticsBuilder.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/ShortDecimalStatisticsBuilder.java
@@ -68,6 +68,7 @@ public class ShortDecimalStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 decimalStatistics.orElse(null),
                 null,
                 null);

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/StringStatisticsBuilder.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/StringStatisticsBuilder.java
@@ -133,6 +133,7 @@ public class StringStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 stringStatistics.orElse(null),
                 null,
                 null,

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/TimestampStatisticsBuilder.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/TimestampStatisticsBuilder.java
@@ -99,6 +99,7 @@ public class TimestampStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 timestampStatistics.orElse(null),
                 null,
                 null,

--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/ByteColumnWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/ByteColumnWriter.java
@@ -113,7 +113,7 @@ public class ByteColumnWriter
     public Map<OrcColumnId, ColumnStatistics> finishRowGroup()
     {
         checkState(!closed);
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
         return ImmutableMap.of(columnId, statistics);

--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/ListColumnWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/ListColumnWriter.java
@@ -135,7 +135,7 @@ public class ListColumnWriter
     {
         checkState(!closed);
 
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
 

--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/MapColumnWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/MapColumnWriter.java
@@ -142,7 +142,7 @@ public class MapColumnWriter
     {
         checkState(!closed);
 
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
 

--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/StructColumnWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/StructColumnWriter.java
@@ -135,7 +135,7 @@ public class StructColumnWriter
     public Map<OrcColumnId, ColumnStatistics> finishRowGroup()
     {
         checkState(!closed);
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
 

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestOrcBloomFilters.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestOrcBloomFilters.java
@@ -241,6 +241,7 @@ public class TestOrcBloomFilters
                 null,
                 null,
                 null,
+                null,
                 new Utf8BloomFilterBuilder(1000, 0.01)
                         .addLong(1234L)
                         .buildBloomFilter())));
@@ -256,6 +257,7 @@ public class TestOrcBloomFilters
                 null,
                 null,
                 null,
+                null,
                 new Utf8BloomFilterBuilder(1000, 0.01)
                         .buildBloomFilter())));
 
@@ -264,6 +266,7 @@ public class TestOrcBloomFilters
                 0,
                 null,
                 new IntegerStatistics(10L, 2000L, null),
+                null,
                 null,
                 null,
                 null,
@@ -299,6 +302,7 @@ public class TestOrcBloomFilters
                 null,
                 null,
                 null,
+                null,
                 new Utf8BloomFilterBuilder(1000, 0.01)
                         .addLong(1234L)
                         .buildBloomFilter())));
@@ -308,6 +312,7 @@ public class TestOrcBloomFilters
                 0,
                 null,
                 new IntegerStatistics(10L, 2000L, null),
+                null,
                 null,
                 null,
                 null,
@@ -330,6 +335,7 @@ public class TestOrcBloomFilters
                 0,
                 null,
                 new IntegerStatistics(10L, 2000L, null),
+                null,
                 null,
                 null,
                 null,

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestTupleDomainOrcPredicate.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestTupleDomainOrcPredicate.java
@@ -101,7 +101,7 @@ public class TestTupleDomainOrcPredicate
         if (trueValueCount != null) {
             booleanStatistics = new BooleanStatistics(trueValueCount);
         }
-        return new ColumnStatistics(numberOfValues, 2L, booleanStatistics, null, null, null, null, null, null, null, null);
+        return new ColumnStatistics(numberOfValues, 2L, booleanStatistics, null, null, null, null, null, null, null, null, null);
     }
 
     @Test
@@ -130,7 +130,7 @@ public class TestTupleDomainOrcPredicate
 
     private static ColumnStatistics integerColumnStats(Long numberOfValues, Long minimum, Long maximum)
     {
-        return new ColumnStatistics(numberOfValues, 9L, null, new IntegerStatistics(minimum, maximum, null), null, null, null, null, null, null, null);
+        return new ColumnStatistics(numberOfValues, 9L, null, new IntegerStatistics(minimum, maximum, null), null, null, null, null, null, null, null, null);
     }
 
     @Test
@@ -159,7 +159,7 @@ public class TestTupleDomainOrcPredicate
 
     private static ColumnStatistics doubleColumnStats(Long numberOfValues, Double minimum, Double maximum)
     {
-        return new ColumnStatistics(numberOfValues, 9L, null, null, new DoubleStatistics(minimum, maximum), null, null, null, null, null, null);
+        return new ColumnStatistics(numberOfValues, 9L, null, null, new DoubleStatistics(minimum, maximum), null, null, null, null, null, null, null);
     }
 
     @Test
@@ -249,7 +249,7 @@ public class TestTupleDomainOrcPredicate
         Slice minimumSlice = minimum == null ? null : utf8Slice(minimum);
         Slice maximumSlice = maximum == null ? null : utf8Slice(maximum);
         // sum and minAverageValueSizeInBytes are not used in this test; they could be arbitrary numbers
-        return new ColumnStatistics(numberOfValues, 10L, null, null, null, new StringStatistics(minimumSlice, maximumSlice, 100L), null, null, null, null, null);
+        return new ColumnStatistics(numberOfValues, 10L, null, null, null, null, new StringStatistics(minimumSlice, maximumSlice, 100L), null, null, null, null, null);
     }
 
     @Test
@@ -278,7 +278,7 @@ public class TestTupleDomainOrcPredicate
 
     private static ColumnStatistics dateColumnStats(Long numberOfValues, Integer minimum, Integer maximum)
     {
-        return new ColumnStatistics(numberOfValues, 5L, null, null, null, null, new DateStatistics(minimum, maximum), null, null, null, null);
+        return new ColumnStatistics(numberOfValues, 5L, null, null, null, null, null, new DateStatistics(minimum, maximum), null, null, null, null);
     }
 
     @Test
@@ -530,7 +530,7 @@ public class TestTupleDomainOrcPredicate
 
     private static ColumnStatistics timeStampColumnStats(Long numberOfValues, Long minimum, Long maximum)
     {
-        return new ColumnStatistics(numberOfValues, 5L, null, null, null, null, null, new TimestampStatistics(minimum, maximum), null, null, null);
+        return new ColumnStatistics(numberOfValues, 5L, null, null, null, null, null, null, new TimestampStatistics(minimum, maximum), null, null, null);
     }
 
     @Test
@@ -586,7 +586,7 @@ public class TestTupleDomainOrcPredicate
     {
         BigDecimal minimumDecimal = minimum == null ? null : new BigDecimal(minimum);
         BigDecimal maximumDecimal = maximum == null ? null : new BigDecimal(maximum);
-        return new ColumnStatistics(numberOfValues, 9L, null, null, null, null, null, null, new DecimalStatistics(minimumDecimal, maximumDecimal, SHORT_DECIMAL_VALUE_BYTES), null, null);
+        return new ColumnStatistics(numberOfValues, 9L, null, null, null, null, null, null, null, new DecimalStatistics(minimumDecimal, maximumDecimal, SHORT_DECIMAL_VALUE_BYTES), null, null);
     }
 
     @Test
@@ -608,7 +608,7 @@ public class TestTupleDomainOrcPredicate
     private static ColumnStatistics binaryColumnStats(Long numberOfValues)
     {
         // sum and minAverageValueSizeInBytes are not used in this test; they could be arbitrary numbers
-        return new ColumnStatistics(numberOfValues, 10L, null, null, null, null, null, null, null, new BinaryStatistics(100L), null);
+        return new ColumnStatistics(numberOfValues, 10L, null, null, null, null, null, null, null, null, new BinaryStatistics(100L), null);
     }
 
     private static Long shortDecimal(String value)

--- a/lib/trino-orc/src/test/java/io/trino/orc/metadata/statistics/AbstractStatisticsBuilderTest.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/metadata/statistics/AbstractStatisticsBuilderTest.java
@@ -142,6 +142,12 @@ public abstract class AbstractStatisticsBuilderTest<B extends StatisticsBuilder,
         assertNull(columnStatistics.getBloomFilter());
     }
 
+    protected static void assertNoColumnStatistics(ColumnStatistics columnStatistics, int expectedNumberOfValues, int expectedNumberOfNanValues)
+    {
+        assertNoColumnStatistics(columnStatistics, expectedNumberOfValues);
+        assertEquals(columnStatistics.getNumberOfNanValues(), expectedNumberOfNanValues);
+    }
+
     private void assertColumnStatistics(
             ColumnStatistics columnStatistics,
             int expectedNumberOfValues,
@@ -171,7 +177,7 @@ public abstract class AbstractStatisticsBuilderTest<B extends StatisticsBuilder,
     static List<ColumnStatistics> insertEmptyColumnStatisticsAt(List<ColumnStatistics> statisticsList, int index, long numberOfValues)
     {
         List<ColumnStatistics> newStatisticsList = new ArrayList<>(statisticsList);
-        newStatisticsList.add(index, new ColumnStatistics(numberOfValues, 0, null, null, null, null, null, null, null, null, null));
+        newStatisticsList.add(index, new ColumnStatistics(numberOfValues, 0, null, null, null, null, null, null, null, null, null, null));
         return newStatisticsList;
     }
 

--- a/lib/trino-orc/src/test/java/io/trino/orc/metadata/statistics/TestDoubleStatisticsBuilder.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/metadata/statistics/TestDoubleStatisticsBuilder.java
@@ -26,6 +26,7 @@ import static io.trino.orc.metadata.statistics.DoubleStatistics.DOUBLE_VALUE_BYT
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
 import static java.lang.Double.POSITIVE_INFINITY;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -71,19 +72,21 @@ public class TestDoubleStatisticsBuilder
     {
         DoubleStatisticsBuilder statisticsBuilder = new DoubleStatisticsBuilder(new NoOpBloomFilterBuilder());
         statisticsBuilder.addValue(NaN);
-        assertNoColumnStatistics(statisticsBuilder.buildColumnStatistics(), 1);
+        assertNoColumnStatistics(statisticsBuilder.buildColumnStatistics(), 1, 1);
         statisticsBuilder.addValue(NaN);
-        assertNoColumnStatistics(statisticsBuilder.buildColumnStatistics(), 2);
+        assertNoColumnStatistics(statisticsBuilder.buildColumnStatistics(), 2, 2);
         statisticsBuilder.addValue(42.42);
-        assertNoColumnStatistics(statisticsBuilder.buildColumnStatistics(), 3);
+        assertNoColumnStatistics(statisticsBuilder.buildColumnStatistics(), 3, 2);
 
         statisticsBuilder = new DoubleStatisticsBuilder(new NoOpBloomFilterBuilder());
         statisticsBuilder.addValue(42.42);
-        assertColumnStatistics(statisticsBuilder.buildColumnStatistics(), 1, 42.42, 42.42);
+        ColumnStatistics columnStatistics = statisticsBuilder.buildColumnStatistics();
+        assertColumnStatistics(columnStatistics, 1, 42.42, 42.42);
+        assertEquals(columnStatistics.getNumberOfNanValues(), 0);
         statisticsBuilder.addValue(NaN);
-        assertNoColumnStatistics(statisticsBuilder.buildColumnStatistics(), 2);
+        assertNoColumnStatistics(statisticsBuilder.buildColumnStatistics(), 2, 1);
         statisticsBuilder.addValue(42.42);
-        assertNoColumnStatistics(statisticsBuilder.buildColumnStatistics(), 3);
+        assertNoColumnStatistics(statisticsBuilder.buildColumnStatistics(), 3, 1);
     }
 
     @Test

--- a/lib/trino-orc/src/test/java/io/trino/orc/metadata/statistics/TestStringStatisticsBuilder.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/metadata/statistics/TestStringStatisticsBuilder.java
@@ -297,6 +297,7 @@ public class TestStringStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 minimum == null && maximum == null ? null : new StringStatistics(minimum, maximum, 100),
                 null,
                 null,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergOrcFileWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergOrcFileWriter.java
@@ -114,6 +114,7 @@ public class IcebergOrcFileWriter
 
         ImmutableMap.Builder<Integer, Long> valueCountsBuilder = ImmutableMap.builder();
         ImmutableMap.Builder<Integer, Long> nullCountsBuilder = ImmutableMap.builder();
+        ImmutableMap.Builder<Integer, Long> nanCountsBuilder = ImmutableMap.builder();
         ImmutableMap.Builder<Integer, ByteBuffer> lowerBoundsBuilder = ImmutableMap.builder();
         ImmutableMap.Builder<Integer, ByteBuffer> upperBoundsBuilder = ImmutableMap.builder();
 
@@ -136,6 +137,9 @@ public class IcebergOrcFileWriter
             if (orcColumnStats.hasNumberOfValues()) {
                 nullCountsBuilder.put(icebergId, fileRowCount - orcColumnStats.getNumberOfValues());
             }
+            if (orcColumnStats.getNumberOfNanValues() > 0) {
+                nanCountsBuilder.put(icebergId, orcColumnStats.getNumberOfNanValues());
+            }
 
             if (!metricsMode.equals(MetricsModes.Counts.get())) {
                 toIcebergMinMax(orcColumnStats, icebergField.type(), metricsMode).ifPresent(minMax -> {
@@ -146,6 +150,7 @@ public class IcebergOrcFileWriter
         }
         Map<Integer, Long> valueCounts = valueCountsBuilder.buildOrThrow();
         Map<Integer, Long> nullCounts = nullCountsBuilder.buildOrThrow();
+        Map<Integer, Long> nanCounts = nanCountsBuilder.buildOrThrow();
         Map<Integer, ByteBuffer> lowerBounds = lowerBoundsBuilder.buildOrThrow();
         Map<Integer, ByteBuffer> upperBounds = upperBoundsBuilder.buildOrThrow();
         return new Metrics(
@@ -153,7 +158,7 @@ public class IcebergOrcFileWriter
                 null, // TODO: Add column size accounting to ORC column writers
                 valueCounts.isEmpty() ? null : valueCounts,
                 nullCounts.isEmpty() ? null : nullCounts,
-                null, // TODO: Add nanValueCounts to ORC writer
+                nanCounts.isEmpty() ? null : nanCounts,
                 lowerBounds.isEmpty() ? null : lowerBounds,
                 upperBounds.isEmpty() ? null : upperBounds);
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergStatistics.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergStatistics.java
@@ -55,6 +55,7 @@ final class IcebergStatistics
     private final Map<Integer, Object> minValues;
     private final Map<Integer, Object> maxValues;
     private final Map<Integer, Long> nullCounts;
+    private final Map<Integer, Long> nanCounts;
     private final Map<Integer, Long> columnSizes;
 
     private IcebergStatistics(
@@ -64,6 +65,7 @@ final class IcebergStatistics
             Map<Integer, Object> minValues,
             Map<Integer, Object> maxValues,
             Map<Integer, Long> nullCounts,
+            Map<Integer, Long> nanCounts,
             Map<Integer, Long> columnSizes)
     {
         this.recordCount = recordCount;
@@ -72,6 +74,7 @@ final class IcebergStatistics
         this.minValues = ImmutableMap.copyOf(requireNonNull(minValues, "minValues is null"));
         this.maxValues = ImmutableMap.copyOf(requireNonNull(maxValues, "maxValues is null"));
         this.nullCounts = ImmutableMap.copyOf(requireNonNull(nullCounts, "nullCounts is null"));
+        this.nanCounts = ImmutableMap.copyOf(requireNonNull(nanCounts, "nanCounts is null"));
         this.columnSizes = ImmutableMap.copyOf(requireNonNull(columnSizes, "columnSizes is null"));
     }
 
@@ -105,6 +108,11 @@ final class IcebergStatistics
         return nullCounts;
     }
 
+    public Map<Integer, Long> getNanCounts()
+    {
+        return nanCounts;
+    }
+
     public Map<Integer, Long> getColumnSizes()
     {
         return columnSizes;
@@ -115,6 +123,7 @@ final class IcebergStatistics
         private final List<Types.NestedField> columns;
         private final TypeManager typeManager;
         private final Map<Integer, Optional<Long>> nullCounts = new HashMap<>();
+        private final Map<Integer, Optional<Long>> nanCounts = new HashMap<>();
         private final Map<Integer, ColumnStatistics> columnStatistics = new HashMap<>();
         private final Map<Integer, Long> columnSizes = new HashMap<>();
         private final Map<Integer, io.trino.spi.type.Type> fieldIdToTrinoType;
@@ -156,9 +165,11 @@ final class IcebergStatistics
                     .map(PartitionField::sourceId)
                     .collect(toImmutableSet());
             Map<Integer, Optional<String>> partitionValues = getPartitionKeys(dataFile.partition(), partitionSpec);
+            Optional<Map<Integer, Long>> nanValueCounts = Optional.ofNullable(dataFile.nanValueCounts());
             for (Types.NestedField column : partitionSpec.schema().columns()) {
                 int id = column.fieldId();
                 io.trino.spi.type.Type trinoType = fieldIdToTrinoType.get(id);
+                updateNanCountStats(id, nanValueCounts.map(map -> map.get(id)));
                 if (identityPartitionFieldIds.contains(id)) {
                     verify(partitionValues.containsKey(id), "Unable to find value for partition column with field id " + id);
                     Optional<String> partitionValue = partitionValues.get(id);
@@ -211,6 +222,10 @@ final class IcebergStatistics
                     .filter(entry -> entry.getValue().isPresent())
                     .collect(toImmutableMap(Map.Entry::getKey, entry -> entry.getValue().orElseThrow()));
 
+            Map<Integer, Long> nanCounts = this.nanCounts.entrySet().stream()
+                    .filter(entry -> entry.getValue().isPresent())
+                    .collect(toImmutableMap(Map.Entry::getKey, entry -> entry.getValue().orElseThrow()));
+
             return new IcebergStatistics(
                     recordCount,
                     fileCount,
@@ -218,6 +233,7 @@ final class IcebergStatistics
                     minValues.buildOrThrow(),
                     maxValues.buildOrThrow(),
                     nullCounts,
+                    nanCounts,
                     ImmutableMap.copyOf(columnSizes));
         }
 
@@ -226,6 +242,13 @@ final class IcebergStatistics
             // If one file is missing nullCounts for a column, invalidate the estimate
             nullCounts.merge(id, nullCount, (existingCount, newCount) ->
                     existingCount.isPresent() && newCount.isPresent() ? Optional.of(existingCount.get() + newCount.get()) : Optional.empty());
+        }
+
+        private void updateNanCountStats(int id, Optional<Long> nanCount)
+        {
+            // If one file is missing nanCounts for a column, invalidate the estimate
+            nanCounts.merge(id, nanCount, (existingCount, newCount) ->
+                    (existingCount.isPresent() && newCount.isPresent()) ? Optional.of(existingCount.get() + newCount.get()) : Optional.empty());
         }
 
         private void updateMinMaxStats(

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -530,7 +530,7 @@ public abstract class BaseIcebergConnectorTest
         else {
             assertThat(query(format("SELECT record_count, file_count, data._timestamptz FROM \"%s$partitions\"", tableName)))
                     .matches(format(
-                            "VALUES (BIGINT '3', BIGINT '3', CAST(ROW(%s, %s, 0) AS row(min timestamp(6) with time zone, max timestamp(6) with time zone, null_count bigint)))",
+                            "VALUES (BIGINT '3', BIGINT '3', CAST(ROW(%s, %s, 0, NULL) AS row(min timestamp(6) with time zone, max timestamp(6) with time zone, null_count bigint, nan_count bigint)))",
                             instant1Utc,
                             format == ORC ? "TIMESTAMP '2021-10-31 00:30:00.007999 UTC'" : instant3Utc));
         }
@@ -1766,8 +1766,8 @@ public abstract class BaseIcebergConnectorTest
 
         assertQuery("SELECT COUNT(*) FROM \"test_void_transform$partitions\"", "SELECT 1");
         assertQuery(
-                "SELECT partition.d_null, record_count, file_count, data.d.min, data.d.max, data.d.null_count, data.b.min, data.b.max, data.b.null_count FROM \"test_void_transform$partitions\"",
-                "VALUES (NULL, 7, 1, 'Warsaw', 'mommy', 2, 1, 7, 0)");
+                "SELECT partition.d_null, record_count, file_count, data.d.min, data.d.max, data.d.null_count, data.d.nan_count, data.b.min, data.b.max, data.b.null_count, data.b.nan_count FROM \"test_void_transform$partitions\"",
+                "VALUES (NULL, 7, 1, 'Warsaw', 'mommy', 2, NULL, 1, 7, 0, NULL)");
 
         assertQuery(
                 "SELECT d, b FROM test_void_transform WHERE d IS NOT NULL",
@@ -2159,18 +2159,18 @@ public abstract class BaseIcebergConnectorTest
                         "(SELECT total_size FROM \"test_partitions_with_conflict$partitions\"), " +
                         "CAST(" +
                         "  ROW (" +
-                        (partitioned ? "" : "  ROW(11, 11, 0), ") +
-                        "    ROW(12, 12, 0), " +
-                        "    ROW(13, 13, 0), " +
-                        "    ROW(14, 14, 0), " +
-                        "    ROW(15, 15, 0) " +
+                        (partitioned ? "" : "  ROW(11, 11, 0, NULL), ") +
+                        "    ROW(12, 12, 0, NULL), " +
+                        "    ROW(13, 13, 0, NULL), " +
+                        "    ROW(14, 14, 0, NULL), " +
+                        "    ROW(15, 15, 0, NULL) " +
                         "  ) " +
                         "  AS row(" +
-                        (partitioned ? "" : "    p row(min integer, max integer, null_count bigint), ") +
-                        "    row_count row(min integer, max integer, null_count bigint), " +
-                        "    record_count row(min integer, max integer, null_count bigint), " +
-                        "    file_count row(min integer, max integer, null_count bigint), " +
-                        "    total_size row(min integer, max integer, null_count bigint) " +
+                        (partitioned ? "" : "    p row(min integer, max integer, null_count bigint, nan_count bigint), ") +
+                        "    row_count row(min integer, max integer, null_count bigint, nan_count bigint), " +
+                        "    record_count row(min integer, max integer, null_count bigint, nan_count bigint), " +
+                        "    file_count row(min integer, max integer, null_count bigint, nan_count bigint), " +
+                        "    total_size row(min integer, max integer, null_count bigint, nan_count bigint) " +
                         "  )" +
                         ")");
 
@@ -2695,28 +2695,28 @@ public abstract class BaseIcebergConnectorTest
                         "VALUES (" +
                                 "  BIGINT '2', " +
                                 "  BIGINT '2', " +
-                                "  CAST(ROW(true, true, 1) AS ROW(min boolean, max boolean, null_count bigint)), " +
-                                "  CAST(ROW(1, 1, 1) AS ROW(min integer, max integer, null_count bigint)), " +
-                                "  CAST(ROW(1, 1, 1) AS ROW(min bigint, max bigint, null_count bigint)), " +
-                                "  CAST(ROW(1, 1, 1) AS ROW(min real, max real, null_count bigint)), " +
-                                "  CAST(ROW(1, 1, 1) AS ROW(min double, max double, null_count bigint)), " +
-                                "  CAST(ROW(1, 1, 1) AS ROW(min decimal(5,2), max decimal(5,2), null_count bigint)), " +
-                                "  CAST(ROW(11, 11, 1) AS ROW(min decimal(38,20), max decimal(38,20), null_count bigint)), " +
-                                "  CAST(ROW('onefsadfdsf', 'onefsadfdsf', 1) AS ROW(min varchar, max varchar, null_count bigint)), " +
+                                "  CAST(ROW(true, true, 1, NULL) AS ROW(min boolean, max boolean, null_count bigint, nan_count bigint)), " +
+                                "  CAST(ROW(1, 1, 1, NULL) AS ROW(min integer, max integer, null_count bigint, nan_count bigint)), " +
+                                "  CAST(ROW(1, 1, 1, NULL) AS ROW(min bigint, max bigint, null_count bigint, nan_count bigint)), " +
+                                "  CAST(ROW(1, 1, 1, NULL) AS ROW(min real, max real, null_count bigint, nan_count bigint)), " +
+                                "  CAST(ROW(1, 1, 1, NULL) AS ROW(min double, max double, null_count bigint, nan_count bigint)), " +
+                                "  CAST(ROW(1, 1, 1, NULL) AS ROW(min decimal(5,2), max decimal(5,2), null_count bigint, nan_count bigint)), " +
+                                "  CAST(ROW(11, 11, 1, NULL) AS ROW(min decimal(38,20), max decimal(38,20), null_count bigint, nan_count bigint)), " +
+                                "  CAST(ROW('onefsadfdsf', 'onefsadfdsf', 1, NULL) AS ROW(min varchar, max varchar, null_count bigint, nan_count bigint)), " +
                                 (format == ORC ?
-                                        "  CAST(ROW(NULL, NULL, 1) AS ROW(min varbinary, max varbinary, null_count bigint)), " :
-                                        "  CAST(ROW(X'000102f0feff', X'000102f0feff', 1) AS ROW(min varbinary, max varbinary, null_count bigint)), ") +
-                                "  CAST(ROW(DATE '2021-07-24', DATE '2021-07-24', 1) AS ROW(min date, max date, null_count bigint)), " +
-                                "  CAST(ROW(TIME '02:43:57.987654', TIME '02:43:57.987654', 1) AS ROW(min time(6), max time(6), null_count bigint)), " +
+                                        "  CAST(ROW(NULL, NULL, 1, NULL) AS ROW(min varbinary, max varbinary, null_count bigint, nan_count bigint)), " :
+                                        "  CAST(ROW(X'000102f0feff', X'000102f0feff', 1, NULL) AS ROW(min varbinary, max varbinary, null_count bigint, nan_count bigint)), ") +
+                                "  CAST(ROW(DATE '2021-07-24', DATE '2021-07-24', 1, NULL) AS ROW(min date, max date, null_count bigint, nan_count bigint)), " +
+                                "  CAST(ROW(TIME '02:43:57.987654', TIME '02:43:57.987654', 1, NULL) AS ROW(min time(6), max time(6), null_count bigint, nan_count bigint)), " +
                                 (format == ORC ?
-                                        "  CAST(ROW(TIMESTAMP '2021-07-24 03:43:57.987000', TIMESTAMP '2021-07-24 03:43:57.987999', 1) AS ROW(min timestamp(6), max timestamp(6), null_count bigint)), " :
-                                        "  CAST(ROW(TIMESTAMP '2021-07-24 03:43:57.987654', TIMESTAMP '2021-07-24 03:43:57.987654', 1) AS ROW(min timestamp(6), max timestamp(6), null_count bigint)), ") +
+                                        "  CAST(ROW(TIMESTAMP '2021-07-24 03:43:57.987000', TIMESTAMP '2021-07-24 03:43:57.987999', 1, NULL) AS ROW(min timestamp(6), max timestamp(6), null_count bigint, nan_count bigint)), " :
+                                        "  CAST(ROW(TIMESTAMP '2021-07-24 03:43:57.987654', TIMESTAMP '2021-07-24 03:43:57.987654', 1, NULL) AS ROW(min timestamp(6), max timestamp(6), null_count bigint, nan_count bigint)), ") +
                                 (format == ORC ?
-                                        "  CAST(ROW(TIMESTAMP '2021-07-24 04:43:57.987000 UTC', TIMESTAMP '2021-07-24 04:43:57.987999 UTC', 1) AS ROW(min timestamp(6) with time zone, max timestamp(6) with time zone, null_count bigint)), " :
-                                        "  CAST(ROW(TIMESTAMP '2021-07-24 04:43:57.987654 UTC', TIMESTAMP '2021-07-24 04:43:57.987654 UTC', 1) AS ROW(min timestamp(6) with time zone, max timestamp(6) with time zone, null_count bigint)), ") +
+                                        "  CAST(ROW(TIMESTAMP '2021-07-24 04:43:57.987000 UTC', TIMESTAMP '2021-07-24 04:43:57.987999 UTC', 1, NULL) AS ROW(min timestamp(6) with time zone, max timestamp(6) with time zone, null_count bigint, nan_count bigint)), " :
+                                        "  CAST(ROW(TIMESTAMP '2021-07-24 04:43:57.987654 UTC', TIMESTAMP '2021-07-24 04:43:57.987654 UTC', 1, NULL) AS ROW(min timestamp(6) with time zone, max timestamp(6) with time zone, null_count bigint, nan_count bigint)), ") +
                                 (format == ORC ?
-                                        "  CAST(ROW(NULL, NULL, 1) AS ROW(min uuid, max uuid, null_count bigint)) " :
-                                        "  CAST(ROW(UUID '20050910-1330-11e9-ffff-2a86e4085a59', UUID '20050910-1330-11e9-ffff-2a86e4085a59', 1) AS ROW(min uuid, max uuid, null_count bigint)) "
+                                        "  CAST(ROW(NULL, NULL, 1, NULL) AS ROW(min uuid, max uuid, null_count bigint, nan_count bigint)) " :
+                                        "  CAST(ROW(UUID '20050910-1330-11e9-ffff-2a86e4085a59', UUID '20050910-1330-11e9-ffff-2a86e4085a59', 1, NULL) AS ROW(min uuid, max uuid, null_count bigint, nan_count bigint)) "
                                 ) +
                                 ")");
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcMetricsCollection.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcMetricsCollection.java
@@ -341,8 +341,11 @@ public class TestIcebergOrcMetricsCollection
         // Check per-column value count
         datafile.getValueCounts().values().forEach(valueCount -> assertEquals(valueCount, (Long) 3L));
 
-        // TODO: add more checks after NaN info is collected
-        assertNull(datafile.getNanValueCounts());
+        // Check per-column nan value count
+        assertEquals(datafile.getNanValueCounts().size(), 2);
+        assertEquals(datafile.getNanValueCounts().get(2), (Long) 1L);
+        assertEquals(datafile.getNanValueCounts().get(3), (Long) 1L);
+
         assertNull(datafile.getLowerBounds().get(2));
         assertNull(datafile.getLowerBounds().get(3));
         assertNull(datafile.getUpperBounds().get(2));

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergPartitionEvolution.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergPartitionEvolution.java
@@ -80,8 +80,8 @@ public class TestIcebergPartitionEvolution
                         row("total_size", "bigint"),
                         row("data", "row(" +
                                 // A/B is now partitioning column in the first partitioning spec, and non-partitioning in new one
-                                (dropFirst ? "a" : "b") + " row(min varchar, max varchar, null_count bigint), " +
-                                "c row(min varchar, max varchar, null_count bigint))"));
+                                (dropFirst ? "a" : "b") + " row(min varchar, max varchar, null_count bigint, nan_count bigint), " +
+                                "c row(min varchar, max varchar, null_count bigint, nan_count bigint))"));
         assertThat(onTrino().executeQuery("SELECT partition, record_count, file_count, data FROM \"test_dropped_partition_field$partitions\""))
                 .containsOnly(
                         row(
@@ -92,7 +92,7 @@ public class TestIcebergPartitionEvolution
                                         .addField(
                                                 dropFirst ? "a" : "b",
                                                 dropFirst ? singletonMetrics("one") : singletonMetrics("small"))
-                                        .addField("c", dataMetrics("rabbit", "snake", 0))
+                                        .addField("c", dataMetrics("rabbit", "snake", 0, null))
                                         .build()),
                         row(
                                 rowBuilder().addField("a", "one").addField("b", "big").build(),
@@ -129,7 +129,7 @@ public class TestIcebergPartitionEvolution
                                 1L,
                                 1L,
                                 rowBuilder()
-                                        .addField(dropFirst ? "a" : "b", dataMetrics(null, null, 1))
+                                        .addField(dropFirst ? "a" : "b", dataMetrics(null, null, 1, null))
                                         .addField("c", singletonMetrics("nothing"))
                                         .build()));
 
@@ -153,15 +153,16 @@ public class TestIcebergPartitionEvolution
 
     private static io.trino.jdbc.Row singletonMetrics(Object value)
     {
-        return dataMetrics(value, value, 0);
+        return dataMetrics(value, value, 0, null);
     }
 
-    private static io.trino.jdbc.Row dataMetrics(Object min, Object max, long nullCount)
+    private static io.trino.jdbc.Row dataMetrics(Object min, Object max, long nullCount, Long nanCount)
     {
         return rowBuilder()
                 .addField("min", min)
                 .addField("max", max)
                 .addField("null_count", nullCount)
+                .addField("nan_count", nanCount)
                 .build();
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

Expose `nan_count` partition metadata information in the `$partitions` metadata table.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

This is a new feature added to be consistent with the information exposed by Iceberg partitions table.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

This change is targeted primarily at the Iceberg connector.
However, because this change requires exposing new information from `trino-orc` module, it may (although it shouldn't) affect other Trino functionality which reads/writes ORC files.

> How would you describe this change to a non-technical end user or system administrator?

This change adds new metadata information about REAL, DOUBLE columns in Iceberg $partitions metadata table.
## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x ) Release notes entries required with the following suggested text:

```markdown
# Iceberg
* Expose `nan_count` in `$partitions` metadata table. ({pr}`10709`)
```
