### PR TITLE
Allow specifying role session name via S3 security mapping config

### DIFF
--- a/docs/src/main/sphinx/connector/hive-s3.rst
+++ b/docs/src/main/sphinx/connector/hive-s3.rst
@@ -160,6 +160,12 @@ The security mapping must provide one or more configuration settings:
   is allowed to be specified as an extra credential, although specifying it
   explicitly has no effect, as it would be used anyway.
 
+* ``roleSessionName``: Optional role session name to use with ``iamRole``. This can only
+  be used when ``iamRole`` is specified. If ``roleSessionName`` includes the string
+  ``${USER}``, then the ``${USER}`` portion of the string will be replaced with the
+  current session's username. If ``roleSessionName`` is not specified, it defaults
+  to ``trino-session``.
+
 * ``allowedIamRoles``: IAM roles that are allowed to be specified as an extra
   credential. This is useful because a particular AWS account may have permissions
   to use many roles, but a specific user should only be allowed to use a subset

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/S3SecurityMapping.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/S3SecurityMapping.java
@@ -45,6 +45,7 @@ public class S3SecurityMapping
     private final Optional<BasicAWSCredentials> credentials;
     private final boolean useClusterDefault;
     private final Optional<String> endpoint;
+    private final Optional<String> roleSessionName;
 
     @JsonCreator
     public S3SecurityMapping(
@@ -52,6 +53,7 @@ public class S3SecurityMapping
             @JsonProperty("group") Optional<Pattern> group,
             @JsonProperty("prefix") Optional<URI> prefix,
             @JsonProperty("iamRole") Optional<String> iamRole,
+            @JsonProperty("roleSessionName") Optional<String> roleSessionName,
             @JsonProperty("allowedIamRoles") Optional<List<String>> allowedIamRoles,
             @JsonProperty("kmsKeyId") Optional<String> kmsKeyId,
             @JsonProperty("allowedKmsKeyIds") Optional<List<String>> allowedKmsKeyIds,
@@ -72,6 +74,8 @@ public class S3SecurityMapping
                 .orElse(x -> true);
 
         this.iamRole = requireNonNull(iamRole, "iamRole is null");
+        this.roleSessionName = requireNonNull(roleSessionName, "roleSessionName is null");
+        checkArgument(!(iamRole.isEmpty() && roleSessionName.isPresent()), "iamRole must be provided when roleSessionName is provided");
 
         this.allowedIamRoles = ImmutableSet.copyOf(requireNonNull(allowedIamRoles, "allowedIamRoles is null")
                 .orElse(ImmutableList.of()));
@@ -138,6 +142,11 @@ public class S3SecurityMapping
         return endpoint;
     }
 
+    public Optional<String> getRoleSessionName()
+    {
+        return roleSessionName;
+    }
+
     @Override
     public String toString()
     {
@@ -146,6 +155,7 @@ public class S3SecurityMapping
                 .add("group", group)
                 .add("prefix", prefix)
                 .add("iamRole", iamRole)
+                .add("roleSessionName", roleSessionName.orElse(null))
                 .add("allowedIamRoles", allowedIamRoles)
                 .add("kmsKeyId", kmsKeyId)
                 .add("allowedKmsKeyIds", allowedKmsKeyIds)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/S3SecurityMappingConfigurationProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/S3SecurityMappingConfigurationProvider.java
@@ -36,6 +36,7 @@ import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_ACCESS_KEY;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_ENDPOINT;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_IAM_ROLE;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_KMS_KEY_ID;
+import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_ROLE_SESSION_NAME;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_SECRET_KEY;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
@@ -118,6 +119,11 @@ public class S3SecurityMappingConfigurationProvider
         mapping.getEndpoint().ifPresent(endpoint -> {
             configuration.set(S3_ENDPOINT, endpoint);
             hasher.putString(endpoint, UTF_8);
+        });
+
+        mapping.getRoleSessionName().ifPresent(roleSessionName -> {
+            configuration.set(S3_ROLE_SESSION_NAME, roleSessionName.replace("${USER}", context.getIdentity().getUser()));
+            hasher.putString(roleSessionName, UTF_8);
         });
 
         setCacheKey(configuration, hasher.hash().toString());

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/TestS3SecurityMapping.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/TestS3SecurityMapping.java
@@ -41,6 +41,7 @@ import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_ACCESS_KEY;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_ENDPOINT;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_IAM_ROLE;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_KMS_KEY_ID;
+import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_ROLE_SESSION_NAME;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_SECRET_KEY;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -240,6 +241,12 @@ public class TestS3SecurityMapping
                 provider,
                 path("s3://endpointbucket/bar"),
                 credentials("AKIAxxxaccess", "iXbXxxxsecret").withEndpoint("http://localhost:7753"));
+
+        // matches role session name
+        assertMapping(
+                provider,
+                path("s3://somebucket"),
+                role("arn:aws:iam::1234567891012:role/default").withRoleSessionName("iam-trino-session"));
     }
 
     @Test
@@ -290,7 +297,7 @@ public class TestS3SecurityMapping
     public void testMappingWithoutRoleCredentialsFallbackShouldFail()
     {
         assertThatThrownBy(() ->
-                new S3SecurityMapping(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()))
+                new S3SecurityMapping(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("must either allow useClusterDefault role or provide role and/or credentials");
     }
@@ -302,7 +309,7 @@ public class TestS3SecurityMapping
         Optional<Boolean> useClusterDefault = Optional.of(true);
 
         assertThatThrownBy(() ->
-                new S3SecurityMapping(Optional.empty(), Optional.empty(), Optional.empty(), iamRole, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), useClusterDefault, Optional.empty()))
+                new S3SecurityMapping(Optional.empty(), Optional.empty(), Optional.empty(), iamRole, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), useClusterDefault, Optional.empty()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("must either allow useClusterDefault role or provide role and/or credentials");
     }
@@ -314,9 +321,20 @@ public class TestS3SecurityMapping
         Optional<String> kmsKeyId = Optional.of("CLIENT_S3CRT_KEY_ID");
 
         assertThatThrownBy(() ->
-                new S3SecurityMapping(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), kmsKeyId, Optional.empty(), Optional.empty(), Optional.empty(), useClusterDefault, Optional.empty()))
+                new S3SecurityMapping(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), kmsKeyId, Optional.empty(), Optional.empty(), Optional.empty(), useClusterDefault, Optional.empty()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("KMS key ID cannot be provided together with useClusterDefault");
+    }
+
+    @Test
+    public void testMappingWithRoleSessionNameWithoutIamRoleShouldFail()
+    {
+        Optional<String> roleSessionName = Optional.of("iam-trino-session");
+
+        assertThatThrownBy(() ->
+                new S3SecurityMapping(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), roleSessionName, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("iamRole must be provided when roleSessionName is provided");
     }
 
     private static void assertMapping(DynamicConfigurationProvider provider, MappingSelector selector, MappingResult mappingResult)
@@ -335,6 +353,7 @@ public class TestS3SecurityMapping
         assertEquals(configuration.get(S3_IAM_ROLE), mappingResult.getRole().orElse(null));
         assertEquals(configuration.get(S3_KMS_KEY_ID), mappingResult.getKmsKeyId().orElse(null));
         assertEquals(configuration.get(S3_ENDPOINT), mappingResult.getEndpoint().orElse(null));
+        assertEquals(configuration.get(S3_ROLE_SESSION_NAME), mappingResult.getRoleSessionName().orElse(null));
     }
 
     private static void assertMappingFails(DynamicConfigurationProvider provider, MappingSelector selector, String message)
@@ -424,22 +443,22 @@ public class TestS3SecurityMapping
     {
         public static MappingResult credentials(String accessKey, String secretKey)
         {
-            return new MappingResult(Optional.of(accessKey), Optional.of(secretKey), Optional.empty(), Optional.empty(), Optional.empty());
+            return new MappingResult(Optional.of(accessKey), Optional.of(secretKey), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
         }
 
         public static MappingResult role(String role)
         {
-            return new MappingResult(Optional.empty(), Optional.empty(), Optional.of(role), Optional.empty(), Optional.empty());
+            return new MappingResult(Optional.empty(), Optional.empty(), Optional.of(role), Optional.empty(), Optional.empty(), Optional.empty());
         }
 
         public static MappingResult clusterDefaultRole()
         {
-            return new MappingResult(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+            return new MappingResult(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
         }
 
         public static MappingResult endpoint(String endpoint)
         {
-            return new MappingResult(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(endpoint));
+            return new MappingResult(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(endpoint), Optional.empty());
         }
 
         private final Optional<String> accessKey;
@@ -447,24 +466,31 @@ public class TestS3SecurityMapping
         private final Optional<String> role;
         private final Optional<String> kmsKeyId;
         private final Optional<String> endpoint;
+        private final Optional<String> roleSessionName;
 
-        private MappingResult(Optional<String> accessKey, Optional<String> secretKey, Optional<String> role, Optional<String> kmsKeyId, Optional<String> endpoint)
+        private MappingResult(Optional<String> accessKey, Optional<String> secretKey, Optional<String> role, Optional<String> kmsKeyId, Optional<String> endpoint, Optional<String> roleSessionName)
         {
             this.accessKey = requireNonNull(accessKey, "accessKey is null");
             this.secretKey = requireNonNull(secretKey, "secretKey is null");
             this.role = requireNonNull(role, "role is null");
             this.kmsKeyId = requireNonNull(kmsKeyId, "kmsKeyId is null");
             this.endpoint = requireNonNull(endpoint, "endpoint is null");
+            this.roleSessionName = requireNonNull(roleSessionName, "roleSessionName is null");
         }
 
         public MappingResult withEndpoint(String endpoint)
         {
-            return new MappingResult(accessKey, secretKey, role, kmsKeyId, Optional.of(endpoint));
+            return new MappingResult(accessKey, secretKey, role, kmsKeyId, Optional.of(endpoint), Optional.empty());
         }
 
         public MappingResult withKmsKeyId(String kmsKeyId)
         {
-            return new MappingResult(accessKey, secretKey, role, Optional.of(kmsKeyId), endpoint);
+            return new MappingResult(accessKey, secretKey, role, Optional.of(kmsKeyId), endpoint, Optional.empty());
+        }
+
+        public MappingResult withRoleSessionName(String roleSessionName)
+        {
+            return new MappingResult(accessKey, secretKey, role, kmsKeyId, Optional.empty(), Optional.of(roleSessionName));
         }
 
         public Optional<String> getAccessKey()
@@ -490,6 +516,11 @@ public class TestS3SecurityMapping
         public Optional<String> getEndpoint()
         {
             return endpoint;
+        }
+
+        public Optional<String> getRoleSessionName()
+        {
+            return roleSessionName;
         }
     }
 }

--- a/plugin/trino-hive/src/test/resources/io/trino/plugin/hive/s3/security-mapping.json
+++ b/plugin/trino-hive/src/test/resources/io/trino/plugin/hive/s3/security-mapping.json
@@ -68,6 +68,11 @@
       "endpoint": "http://localhost:7753"
     },
     {
+      "prefix": "s3://somebucket",
+      "iamRole": "arn:aws:iam::1234567891012:role/default",
+      "roleSessionName": "iam-trino-session"
+    },
+    {
       "useClusterDefault": "false",
       "iamRole": "arn:aws:iam::123456789101:role/default"
     }


### PR DESCRIPTION
This PR replaces https://github.com/trinodb/trino/pull/8097

The original author's commit has been preserved. 