### PR TITLE
Simplify nesting during elasticsearch query building

### DIFF
--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchQueryBuilder.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchQueryBuilder.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.elasticsearch;
 
+import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.Range;
@@ -29,10 +30,9 @@ import org.elasticsearch.index.query.TermQueryBuilder;
 
 import java.time.Instant;
 import java.time.ZoneOffset;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -65,7 +65,7 @@ public final class ElasticsearchQueryBuilder
 
                 checkArgument(!domain.isNone(), "Unexpected NONE domain for %s", column.getName());
                 if (!domain.isAll()) {
-                    queryBuilder.filter(new BoolQueryBuilder().must(buildPredicate(column.getName(), domain, column.getType())));
+                    addPredicateToQueryBuilder(queryBuilder, column.getName(), domain, column.getType());
                 }
             }
         }
@@ -81,64 +81,69 @@ public final class ElasticsearchQueryBuilder
         return new MatchAllQueryBuilder();
     }
 
-    private static QueryBuilder buildPredicate(String columnName, Domain domain, Type type)
+    private static void addPredicateToQueryBuilder(BoolQueryBuilder queryBuilder, String columnName, Domain domain, Type type)
     {
         checkArgument(domain.getType().isOrderable(), "Domain type must be orderable");
-        BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
 
         if (domain.getValues().isNone()) {
-            boolQueryBuilder.mustNot(new ExistsQueryBuilder(columnName));
-            return boolQueryBuilder;
+            queryBuilder.mustNot(new ExistsQueryBuilder(columnName));
+            return;
         }
 
         if (domain.getValues().isAll()) {
-            boolQueryBuilder.must(new ExistsQueryBuilder(columnName));
-            return boolQueryBuilder;
+            queryBuilder.filter(new ExistsQueryBuilder(columnName));
+            return;
         }
 
-        return buildTermQuery(boolQueryBuilder, columnName, domain, type);
+        List<QueryBuilder> shouldClauses = getShouldClauses(columnName, domain, type);
+        if (shouldClauses.size() == 1) {
+            queryBuilder.filter(getOnlyElement(shouldClauses));
+            return;
+        }
+        else if (shouldClauses.size() > 1) {
+            BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
+            shouldClauses.forEach(boolQueryBuilder::should);
+            queryBuilder.filter(boolQueryBuilder);
+            return;
+        }
+        return;
     }
 
-    private static QueryBuilder buildTermQuery(BoolQueryBuilder queryBuilder, String columnName, Domain domain, Type type)
+    private static List<QueryBuilder> getShouldClauses(String columnName, Domain domain, Type type)
     {
+        ImmutableList.Builder<QueryBuilder> shouldClauses = ImmutableList.builder();
         for (Range range : domain.getValues().getRanges().getOrderedRanges()) {
-            BoolQueryBuilder rangeQueryBuilder = new BoolQueryBuilder();
-            Set<Object> valuesToInclude = new HashSet<>();
             checkState(!range.isAll(), "Invalid range for column: %s", columnName);
             if (range.isSingleValue()) {
-                valuesToInclude.add(range.getSingleValue());
+                shouldClauses.add(new TermQueryBuilder(columnName, getValue(type, range.getSingleValue())));
             }
             else {
+                RangeQueryBuilder rangeQueryBuilder = new RangeQueryBuilder(columnName);
                 if (!range.isLowUnbounded()) {
                     Object lowBound = getValue(type, range.getLowBoundedValue());
                     if (range.isLowInclusive()) {
-                        rangeQueryBuilder.filter(new RangeQueryBuilder(columnName).gte(lowBound));
+                        rangeQueryBuilder.gte(lowBound);
                     }
                     else {
-                        rangeQueryBuilder.filter(new RangeQueryBuilder(columnName).gt(lowBound));
+                        rangeQueryBuilder.gt(lowBound);
                     }
                 }
                 if (!range.isHighUnbounded()) {
                     Object highBound = getValue(type, range.getHighBoundedValue());
                     if (range.isHighInclusive()) {
-                        rangeQueryBuilder.filter(new RangeQueryBuilder(columnName).lte(highBound));
+                        rangeQueryBuilder.lte(highBound);
                     }
                     else {
-                        rangeQueryBuilder.filter(new RangeQueryBuilder(columnName).lt(highBound));
+                        rangeQueryBuilder.lt(highBound);
                     }
                 }
+                shouldClauses.add(rangeQueryBuilder);
             }
-
-            if (valuesToInclude.size() == 1) {
-                rangeQueryBuilder.filter(new TermQueryBuilder(columnName, getValue(type, getOnlyElement(valuesToInclude))));
-            }
-            queryBuilder.should(rangeQueryBuilder);
         }
-
         if (domain.isNullAllowed()) {
-            queryBuilder.should(new BoolQueryBuilder().mustNot(new ExistsQueryBuilder(columnName)));
+            shouldClauses.add(new BoolQueryBuilder().mustNot(new ExistsQueryBuilder(columnName)));
         }
-        return queryBuilder;
+        return shouldClauses.build();
     }
 
     private static Object getValue(Type type, Object value)

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearchQueryBuilder.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearchQueryBuilder.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.elasticsearch;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.elasticsearch.decoders.DoubleDecoder;
+import io.trino.plugin.elasticsearch.decoders.IntegerDecoder;
+import io.trino.plugin.elasticsearch.decoders.VarcharDecoder;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.ExistsQueryBuilder;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.RangeQueryBuilder;
+import org.elasticsearch.index.query.TermQueryBuilder;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.plugin.elasticsearch.ElasticsearchQueryBuilder.buildSearchQuery;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static org.testng.Assert.assertEquals;
+
+public class TestElasticsearchQueryBuilder
+{
+    private static final ElasticsearchColumnHandle NAME = new ElasticsearchColumnHandle("name", VARCHAR, new VarcharDecoder.Descriptor("name"), true);
+    private static final ElasticsearchColumnHandle AGE = new ElasticsearchColumnHandle("age", INTEGER, new IntegerDecoder.Descriptor("age"), true);
+    private static final ElasticsearchColumnHandle SCORE = new ElasticsearchColumnHandle("score", DOUBLE, new DoubleDecoder.Descriptor("score"), true);
+    private static final ElasticsearchColumnHandle LENGTH = new ElasticsearchColumnHandle("length", DOUBLE, new DoubleDecoder.Descriptor("length"), true);
+
+    @Test
+    public void testMatchAll()
+    {
+        assertQueryBuilder(
+                ImmutableMap.of(),
+                new MatchAllQueryBuilder());
+    }
+
+    @Test
+    public void testOneConstraint()
+    {
+        // SingleValue
+        assertQueryBuilder(
+                ImmutableMap.of(AGE, Domain.singleValue(INTEGER, 1L)),
+                new BoolQueryBuilder().filter(new TermQueryBuilder(AGE.getName(), 1L)));
+
+        // Range
+        assertQueryBuilder(
+                ImmutableMap.of(SCORE, Domain.create(ValueSet.ofRanges(Range.range(DOUBLE, 65.0, false, 80.0, true)), false)),
+                new BoolQueryBuilder().filter(new RangeQueryBuilder(SCORE.getName()).gt(65.0).lte(80.0)));
+
+        // List
+        assertQueryBuilder(
+                ImmutableMap.of(NAME, Domain.multipleValues(VARCHAR, ImmutableList.of("alice", "bob"))),
+                new BoolQueryBuilder().filter(
+                        new BoolQueryBuilder()
+                                .should(new TermQueryBuilder(NAME.getName(), "alice"))
+                                .should(new TermQueryBuilder(NAME.getName(), "bob"))));
+        // all
+        assertQueryBuilder(
+                ImmutableMap.of(AGE, Domain.all(INTEGER)),
+                new MatchAllQueryBuilder());
+
+        // notNull
+        assertQueryBuilder(
+                ImmutableMap.of(AGE, Domain.notNull(INTEGER)),
+                new BoolQueryBuilder().filter(new ExistsQueryBuilder(AGE.getName())));
+
+        // isNull
+        assertQueryBuilder(
+                ImmutableMap.of(AGE, Domain.onlyNull(INTEGER)),
+                new BoolQueryBuilder().mustNot(new ExistsQueryBuilder(AGE.getName())));
+
+        // isNullAllowed
+        assertQueryBuilder(
+                ImmutableMap.of(AGE, Domain.singleValue(INTEGER, 1L, true)),
+                new BoolQueryBuilder().filter(
+                        new BoolQueryBuilder()
+                                .should(new TermQueryBuilder(AGE.getName(), 1L))
+                                .should(new BoolQueryBuilder().mustNot(new ExistsQueryBuilder(AGE.getName())))));
+    }
+
+    @Test
+    public void testMultiConstraint()
+    {
+        assertQueryBuilder(
+                ImmutableMap.of(
+                        AGE, Domain.singleValue(INTEGER, 1L),
+                        SCORE, Domain.create(ValueSet.ofRanges(Range.range(DOUBLE, 65.0, false, 80.0, true)), false)),
+                new BoolQueryBuilder()
+                        .filter(new TermQueryBuilder(AGE.getName(), 1L))
+                        .filter(new RangeQueryBuilder(SCORE.getName()).gt(65.0).lte(80.0)));
+
+        assertQueryBuilder(
+                ImmutableMap.of(
+                        LENGTH, Domain.create(ValueSet.ofRanges(Range.range(DOUBLE, 160.0, true, 180.0, true)), false),
+                        SCORE, Domain.create(ValueSet.ofRanges(
+                                Range.range(DOUBLE, 65.0, false, 80.0, true),
+                                Range.equal(DOUBLE, 90.0)), false)),
+                new BoolQueryBuilder()
+                        .filter(new RangeQueryBuilder(LENGTH.getName()).gte(160.0).lte(180.0))
+                        .filter(new BoolQueryBuilder()
+                                .should(new RangeQueryBuilder(SCORE.getName()).gt(65.0).lte(80.0))
+                                .should(new TermQueryBuilder(SCORE.getName(), 90.0))));
+
+        assertQueryBuilder(
+                ImmutableMap.of(
+                        AGE, Domain.singleValue(INTEGER, 10L),
+                        SCORE, Domain.onlyNull(DOUBLE)),
+                new BoolQueryBuilder()
+                        .filter(new TermQueryBuilder(AGE.getName(), 10L))
+                        .mustNot(new ExistsQueryBuilder(SCORE.getName())));
+    }
+
+    private static void assertQueryBuilder(Map<ElasticsearchColumnHandle, Domain> domains, QueryBuilder expected)
+    {
+        QueryBuilder actual = buildSearchQuery(TupleDomain.withColumnDomains(domains), Optional.empty(), Map.of());
+        assertEquals(actual, expected);
+    }
+}


### PR DESCRIPTION
Hi! When we use elasticsearch connector to execute sql, we find current search search query is too deep nesting.
 It will make the query DSL more complex and inefficiency for elasticsearch.
- Bool query should be simplify, not deep nesting.
- Range query of the same field should be merged.

Such as sql
`select * from table where age = 1 and score > 65.0 and score <= 80`

Now query DSL:
```
{
  "bool" : {
    "filter" : [
      {
        "bool" : {
          "must" : [
            {
              "bool" : {
                "should" : [
                  {
                    "bool" : {
                      "filter" : [
                        {
                          "term" : {
                            "age" : {
                              "value" : 1,
                              "boost" : 1.0
                            }
                          }
                        }
                      ],
                      "adjust_pure_negative" : true,
                      "boost" : 1.0
                    }
                  }
                ],
                "adjust_pure_negative" : true,
                "boost" : 1.0
              }
            }
          ],
          "adjust_pure_negative" : true,
          "boost" : 1.0
        }
      },
      {
        "bool" : {
          "must" : [
            {
              "bool" : {
                "should" : [
                  {
                    "bool" : {
                      "filter" : [
                        {
                          "range" : {
                            "score" : {
                              "from" : 65.0,
                              "to" : null,
                              "include_lower" : false,
                              "include_upper" : true,
                              "boost" : 1.0
                            }
                          }
                        },
                        {
                          "range" : {
                            "score" : {
                              "from" : null,
                              "to" : 80.0,
                              "include_lower" : true,
                              "include_upper" : true,
                              "boost" : 1.0
                            }
                          }
                        }
                      ],
                      "adjust_pure_negative" : true,
                      "boost" : 1.0
                    }
                  }
                ],
                "adjust_pure_negative" : true,
                "boost" : 1.0
              }
            }
          ],
          "adjust_pure_negative" : true,
          "boost" : 1.0
        }
      }
    ],
    "adjust_pure_negative" : true,
    "boost" : 1.0
  }
}
```

So we rewrite buildSearchQuery() function to simplify query DSL, the optimize search query:
```
{
  "bool" : {
    "filter" : [
      {
        "term" : {
          "age" : {
            "value" : 1,
            "boost" : 1.0
          }
        }
      },
      {
        "range" : {
          "score" : {
            "from" : 65.0,
            "to" : 80.0,
            "include_lower" : false,
            "include_upper" : true,
            "boost" : 1.0
          }
        }
      }
    ],
    "adjust_pure_negative" : true,
    "boost" : 1.0
  }
}
```