### PR TITLE
Fix parquet data page offset calculation in parquet writer

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
@@ -210,7 +210,7 @@ public class ParquetWriter
         List<BufferData> bufferDataList = builder.build();
 
         // update stats
-        long stripeStartOffset = outputStream.size();
+        long stripeStartOffset = outputStream.longSize();
         List<ColumnMetaData> metadatas = bufferDataList.stream()
                 .map(BufferData::getMetaData)
                 .collect(toImmutableList());


### PR DESCRIPTION
The `ParquetWriter::flush` method calls `int OutputStreamSliceOutput::size()` to get the data page offset which is a long, thus flushing fails trying to write files larger than ~2 GB with an integer overflow exception (originating [here](https://github.com/airlift/slice/blob/f29d1b2e5e526cc4f381a793373ef4654418d04c/src/main/java/io/airlift/slice/OutputStreamSliceOutput.java#L104)).