### PR TITLE
Pipeline buffering and upload in S3 multi-upload

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/TrinoS3FileSystem.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/TrinoS3FileSystem.java
@@ -1605,8 +1605,14 @@ public class TrinoS3FileSystem
             if (bufferSize == buffer.length || (finished && bufferSize > 0)) {
                 byte[] data = buffer;
                 int length = bufferSize;
-                this.buffer = new byte[buffer.length];
-                bufferSize = 0;
+
+                if (finished) {
+                    this.buffer = null;
+                }
+                else {
+                    this.buffer = new byte[buffer.length];
+                    bufferSize = 0;
+                }
 
                 inProgressUploadFuture = uploadExecutor.submit(() -> uploadPage(data, length));
             }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/TrinoS3FileSystem.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/TrinoS3FileSystem.java
@@ -1596,6 +1596,7 @@ public class TrinoS3FileSystem
                     return;
                 }
                 catch (AmazonServiceException e) {
+                    failed = true;
                     throw new IOException(e);
                 }
             }


### PR DESCRIPTION
Rework of: https://github.com/trinodb/trino/pull/10180

Original PR desc:

> From discussion in https://github.com/trinodb/trino/pull/6201/files#r762349090, we should only wait for previous upload to finish when we need to flush the buffer.
> 
> Also, adding two minor nits:
> 1. set `failed` to `true` when skip multipart upload and directly upload but failed
> 2. Avoid allocating a new buffer when `finished` is `true`

It turned out that this PR results in corrupted writes to S3 (https://github.com/trinodb/trino/issues/10710).
The problem came from the fact that with `waitForPreviousUploadFinish` call moved from the very beginning of `flushBuffer` method further down, the check:
```
// skip multipart upload if there would only be one part
            if (finished && uploadId.isEmpty()) {
```
was no longer valid.
One call to `flushBuffer` could initiate the multipart upload, but the next call to `flushBuffer` could still observe `uploadId` as not set (there was no memory barrier between setting and reading threads).
Thanks @findepi for chat on this.

Co-authored-by: Łukasz Osipiuk <lukasz@osipuk.net>

Fixes https://github.com/trinodb/trino/issues/10710 