### PR TITLE
Cleanup new symbol allocation logic

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/SymbolAllocator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/SymbolAllocator.java
@@ -24,6 +24,8 @@ import io.trino.sql.tree.GroupingOperation;
 import io.trino.sql.tree.Identifier;
 import io.trino.sql.tree.SymbolReference;
 
+import javax.annotation.Nullable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -67,7 +69,7 @@ public class SymbolAllocator
         return newSymbol("$hashValue", BigintType.BIGINT);
     }
 
-    public Symbol newSymbol(String nameHint, Type type, String suffix)
+    public Symbol newSymbol(String nameHint, Type type, @Nullable String suffix)
     {
         requireNonNull(nameHint, "nameHint is null");
         requireNonNull(type, "type is null");
@@ -92,13 +94,11 @@ public class SymbolAllocator
             unique = unique + "$" + suffix;
         }
 
-        String attempt = unique;
-        while (symbols.containsKey(new Symbol(attempt))) {
-            attempt = unique + "_" + nextId();
+        Symbol symbol = new Symbol(unique);
+        while (symbols.putIfAbsent(symbol, type) != null) {
+            symbol = new Symbol(unique + "_" + nextId());
         }
 
-        Symbol symbol = new Symbol(attempt);
-        symbols.put(symbol, type);
         return symbol;
     }
 


### PR DESCRIPTION
Avoids extra hash table probes and allocations when creating new symbols in `SymbolAllocator`.