### PR TITLE
Implement shallowEquals() for SampledRelation

### DIFF
--- a/core/trino-parser/src/main/java/io/trino/sql/tree/SampledRelation.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/SampledRelation.java
@@ -110,4 +110,15 @@ public class SampledRelation
     {
         return Objects.hash(relation, type, samplePercentage);
     }
+
+    @Override
+    public boolean shallowEquals(Node other)
+    {
+        if (!sameClass(this, other)) {
+            return false;
+        }
+
+        SampledRelation otherRelation = (SampledRelation) other;
+        return type == otherRelation.type && Objects.equals(samplePercentage, otherRelation.samplePercentage);
+    }
 }


### PR DESCRIPTION
`TABLESAMPLE` doesn't work inside a subquery.

For instance, the following query fails with `java.lang.UnsupportedOperationException: not yet implemented: io.trino.sql.tree.SampledRelation` on the latest master because [SampledRelation](https://github.com/trinodb/trino/blob/9ab09e99d6c56fe955697a51a95400c367525133/core/trino-parser/src/main/java/io/trino/sql/tree/SampledRelation.java) doesn't implement `shallowEquals()`.

```sql
SELECT * FROM system.runtime.queries WHERE query_id IN (
  SELECT query_id FROM system.runtime.queries TABLESAMPLE BERNOULLI(10)
);
```
Full stacktrace:
```
java.lang.UnsupportedOperationException: not yet implemented: io.trino.sql.tree.SampledRelation
	at io.trino.sql.tree.Node.shallowEquals(Node.java:60)
	at io.trino.sql.planner.ScopeAware.scopeAwareComparison(ScopeAware.java:137)
	at io.trino.sql.util.AstUtils.treeEqual(AstUtils.java:47)
	at io.trino.sql.util.AstUtils.treeEqual(AstUtils.java:61)
	at io.trino.sql.util.AstUtils.treeEqual(AstUtils.java:61)
	at io.trino.sql.util.AstUtils.treeEqual(AstUtils.java:61)
	at io.trino.sql.util.AstUtils.treeEqual(AstUtils.java:61)
	at io.trino.sql.planner.ScopeAware.equals(ScopeAware.java:94)
	at com.google.common.collect.SingletonImmutableBiMap.containsKey(SingletonImmutableBiMap.java:73)
	at io.trino.sql.planner.TranslationMap.canTranslate(TranslationMap.java:151)
	at io.trino.sql.planner.PlanBuilder.canTranslate(PlanBuilder.java:78)
	at io.trino.sql.planner.SubqueryPlanner.lambda$selectSubqueries$0(SubqueryPlanner.java:149)
	at com.google.common.graph.Traverser.validate(Traverser.java:367)
	at com.google.common.graph.Traverser.depthFirstPreOrder(Traverser.java:297)
	at com.google.common.graph.Traverser.depthFirstPreOrder(Traverser.java:283)
	at io.trino.sql.planner.SubqueryPlanner.selectSubqueries(SubqueryPlanner.java:156)
	at io.trino.sql.planner.SubqueryPlanner.handleSubqueries(SubqueryPlanner.java:127)
	at io.trino.sql.planner.QueryPlanner.filter(QueryPlanner.java:630)
	at io.trino.sql.planner.QueryPlanner.plan(QueryPlanner.java:394)
	at io.trino.sql.planner.RelationPlanner.visitQuerySpecification(RelationPlanner.java:983)
	at io.trino.sql.planner.RelationPlanner.visitQuerySpecification(RelationPlanner.java:131)
	at io.trino.sql.tree.QuerySpecification.accept(QuerySpecification.java:155)
	at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)
	at io.trino.sql.planner.QueryPlanner.planQueryBody(QueryPlanner.java:606)
	at io.trino.sql.planner.QueryPlanner.plan(QueryPlanner.java:193)
	at io.trino.sql.planner.RelationPlanner.visitQuery(RelationPlanner.java:976)
	at io.trino.sql.planner.RelationPlanner.visitQuery(RelationPlanner.java:131)
	at io.trino.sql.tree.Query.accept(Query.java:107)
	at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)
	at io.trino.sql.planner.LogicalPlanner.createRelationPlan(LogicalPlanner.java:769)
	at io.trino.sql.planner.LogicalPlanner.planStatementWithoutOutput(LogicalPlanner.java:291)
	at io.trino.sql.planner.LogicalPlanner.planStatement(LogicalPlanner.java:263)
	at io.trino.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:220)
	at io.trino.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:215)
	at io.trino.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:210)
	at io.trino.execution.SqlQueryExecution.doPlanQuery(SqlQueryExecution.java:474)
	at io.trino.execution.SqlQueryExecution.planQuery(SqlQueryExecution.java:455)
	at io.trino.execution.SqlQueryExecution.start(SqlQueryExecution.java:396)
	at io.trino.execution.SqlQueryManager.createQuery(SqlQueryManager.java:243)
	at io.trino.dispatcher.LocalDispatchQuery.lambda$startExecution$7(LocalDispatchQuery.java:143)
	at io.trino.$gen.Trino_dev____20220124_125301_2.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```