### PR TITLE
Deprecate `@` based syntax for accessing iceberg snapshots

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -61,6 +61,7 @@ public class IcebergConfig
     // to avoid deleting those files if Trino is unable to check.
     private boolean deleteSchemaLocationsFallback;
     private double minimumAssignedSplitWeight = 0.05;
+    private boolean allowLegacySnapshotSyntax;
 
     public CatalogType getCatalogType()
     {
@@ -288,5 +289,19 @@ public class IcebergConfig
     public double getMinimumAssignedSplitWeight()
     {
         return minimumAssignedSplitWeight;
+    }
+
+    @Config("iceberg.allow-legacy-snapshot-syntax")
+    @Deprecated
+    public IcebergConfig setAllowLegacySnapshotSyntax(boolean allowLegacySnapshotSyntax)
+    {
+        this.allowLegacySnapshotSyntax = allowLegacySnapshotSyntax;
+        return this;
+    }
+
+    @Deprecated
+    public boolean isAllowLegacySnapshotSyntax()
+    {
+        return allowLegacySnapshotSyntax;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -169,6 +169,7 @@ import static io.trino.plugin.iceberg.IcebergMetadataColumn.FILE_PATH;
 import static io.trino.plugin.iceberg.IcebergMetadataColumn.isMetadataColumnId;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getExpireSnapshotMinRetention;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getRemoveOrphanFilesMinRetention;
+import static io.trino.plugin.iceberg.IcebergSessionProperties.isAllowLegacySnapshotSyntax;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isProjectionPushdownEnabled;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isStatisticsEnabled;
 import static io.trino.plugin.iceberg.IcebergTableProperties.FILE_FORMAT_PROPERTY;
@@ -309,7 +310,7 @@ public class IcebergMetadata
         }
 
         Optional<Long> snapshotId = endVersion.map(version -> getSnapshotIdFromVersion(table, version))
-                .or(() -> getSnapshotId(table, name.getSnapshotId()));
+                .or(() -> getSnapshotId(table, name.getSnapshotId(), isAllowLegacySnapshotSyntax(session)));
 
         Map<String, String> tableProperties = table.properties();
         String nameMappingJson = tableProperties.get(TableProperties.DEFAULT_NAME_MAPPING);
@@ -406,11 +407,11 @@ public class IcebergMetadata
                 }
                 return Optional.of(new SnapshotsTable(systemTableName, typeManager, table));
             case PARTITIONS:
-                return Optional.of(new PartitionTable(systemTableName, typeManager, table, getSnapshotId(table, name.getSnapshotId())));
+                return Optional.of(new PartitionTable(systemTableName, typeManager, table, getSnapshotId(table, name.getSnapshotId(), isAllowLegacySnapshotSyntax(session))));
             case MANIFESTS:
-                return Optional.of(new ManifestsTable(systemTableName, table, getSnapshotId(table, name.getSnapshotId())));
+                return Optional.of(new ManifestsTable(systemTableName, table, getSnapshotId(table, name.getSnapshotId(), isAllowLegacySnapshotSyntax(session))));
             case FILES:
-                return Optional.of(new FilesTable(systemTableName, typeManager, table, getSnapshotId(table, name.getSnapshotId())));
+                return Optional.of(new FilesTable(systemTableName, typeManager, table, getSnapshotId(table, name.getSnapshotId(), isAllowLegacySnapshotSyntax(session))));
             case PROPERTIES:
                 return Optional.of(new PropertiesTable(systemTableName, table));
         }
@@ -1900,14 +1901,14 @@ public class IcebergMetadata
         catalog.setTablePrincipal(session, tableName, principal);
     }
 
-    private Optional<Long> getSnapshotId(Table table, Optional<Long> snapshotId)
+    private Optional<Long> getSnapshotId(Table table, Optional<Long> snapshotId, boolean allowLegacySnapshotSyntax)
     {
         // table.name() is an encoded version of SchemaTableName
         return snapshotId
                 .map(id ->
                         snapshotIds.computeIfAbsent(
                                 table.name() + "@" + id,
-                                ignored -> IcebergUtil.resolveSnapshotId(table, id)))
+                                ignored -> IcebergUtil.resolveSnapshotId(table, id, allowLegacySnapshotSyntax)))
                 .or(() -> Optional.ofNullable(table.currentSnapshot()).map(Snapshot::snapshotId));
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -76,6 +76,7 @@ public final class IcebergSessionProperties
     private static final String MINIMUM_ASSIGNED_SPLIT_WEIGHT = "minimum_assigned_split_weight";
     public static final String EXPIRE_SNAPSHOTS_MIN_RETENTION = "expire_snapshots_min_retention";
     public static final String REMOVE_ORPHAN_FILES_MIN_RETENTION = "remove_orphan_files_min_retention";
+    private static final String ALLOW_LEGACY_SNAPSHOT_SYNTAX = "allow_legacy_snapshot_syntax";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -245,6 +246,11 @@ public final class IcebergSessionProperties
                         "Minimal retention period for remove_orphan_files procedure",
                         icebergConfig.getRemoveOrphanFilesMinRetention(),
                         false))
+                .add(booleanProperty(
+                        ALLOW_LEGACY_SNAPSHOT_SYNTAX,
+                        "Allow snapshot access based on timestamp and snapshotid",
+                        icebergConfig.isAllowLegacySnapshotSyntax(),
+                        false))
                 .build();
     }
 
@@ -404,5 +410,10 @@ public final class IcebergSessionProperties
     public static double getMinimumAssignedSplitWeight(ConnectorSession session)
     {
         return session.getProperty(MINIMUM_ASSIGNED_SPLIT_WEIGHT, Double.class);
+    }
+
+    public static boolean isAllowLegacySnapshotSyntax(ConnectorSession session)
+    {
+        return session.getProperty(ALLOW_LEGACY_SNAPSHOT_SYNTAX, Boolean.class);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -218,8 +218,20 @@ public final class IcebergUtil
         return properties.buildOrThrow();
     }
 
-    public static long resolveSnapshotId(Table table, long snapshotId)
+    @Deprecated
+    public static long resolveSnapshotId(Table table, long snapshotId, boolean allowLegacySnapshotSyntax)
     {
+        if (!allowLegacySnapshotSyntax) {
+            throw new TrinoException(
+                    NOT_SUPPORTED,
+                    format(
+                            "Failed to access snapshot %s for table %s. This syntax for accessing Iceberg tables is not "
+                                    + "supported. Use the AS OF syntax OR set the catalog session property "
+                                    + "allow_legacy_snapshot_syntax=true for temporarily restoring previous behavior.",
+                            snapshotId,
+                            table.name()));
+        }
+
         if (table.snapshot(snapshotId) != null) {
             return snapshotId;
         }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -4176,24 +4176,27 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testModifyingOldSnapshotIsNotPossible()
     {
+        Session sessionWithLegacySyntaxSupport = Session.builder(getSession())
+                .setCatalogSessionProperty("iceberg", "allow_legacy_snapshot_syntax", "true")
+                .build();
         String tableName = "test_modifying_old_snapshot_" + randomTableSuffix();
         assertUpdate(format("CREATE TABLE %s (col int)", tableName));
         assertUpdate(format("INSERT INTO %s VALUES 1,2,3", tableName), 3);
         long oldSnapshotId = getCurrentSnapshotId(tableName);
         assertUpdate(format("INSERT INTO %s VALUES 4,5,6", tableName), 3);
-        assertQuery(format("SELECT * FROM \"%s@%d\"", tableName, oldSnapshotId), "VALUES 1,2,3");
-        assertThatThrownBy(() -> query(format("INSERT INTO \"%s@%d\" VALUES 7,8,9", tableName, oldSnapshotId)))
+        assertQuery(sessionWithLegacySyntaxSupport, format("SELECT * FROM \"%s@%d\"", tableName, oldSnapshotId), "VALUES 1,2,3");
+        assertThatThrownBy(() -> query(sessionWithLegacySyntaxSupport, format("INSERT INTO \"%s@%d\" VALUES 7,8,9", tableName, oldSnapshotId)))
                 .hasMessage("Modifying old snapshot is not supported in Iceberg.");
-        assertThatThrownBy(() -> query(format("DELETE FROM \"%s@%d\" WHERE col = 5", tableName, oldSnapshotId)))
+        assertThatThrownBy(() -> query(sessionWithLegacySyntaxSupport, format("DELETE FROM \"%s@%d\" WHERE col = 5", tableName, oldSnapshotId)))
                 .hasMessage("Modifying old snapshot is not supported in Iceberg.");
-        assertThatThrownBy(() -> query(format("UPDATE \"%s@%d\" SET col = 50 WHERE col = 5", tableName, oldSnapshotId)))
+        assertThatThrownBy(() -> query(sessionWithLegacySyntaxSupport, format("UPDATE \"%s@%d\" SET col = 50 WHERE col = 5", tableName, oldSnapshotId)))
                 .hasMessage("Modifying old snapshot is not supported in Iceberg.");
-        assertThatThrownBy(() -> query(format("ALTER TABLE \"%s@%d\" EXECUTE OPTIMIZE", tableName, oldSnapshotId)))
+        assertThatThrownBy(() -> query(sessionWithLegacySyntaxSupport, format("ALTER TABLE \"%s@%d\" EXECUTE OPTIMIZE", tableName, oldSnapshotId)))
                 .hasMessage("Modifying old snapshot is not supported in Iceberg.");
-        assertUpdate(format("INSERT INTO \"%s@%d\" VALUES 7,8,9", tableName, getCurrentSnapshotId(tableName)), 3);
-        assertUpdate(format("DELETE FROM \"%s@%d\" WHERE col = 9", tableName, getCurrentSnapshotId(tableName)), 1);
-        assertUpdate(format("UPDATE \"%s@%d\" set col = 50 WHERE col = 5", tableName, getCurrentSnapshotId(tableName)), 1);
-        assertQuerySucceeds(format("ALTER TABLE \"%s@%d\" EXECUTE OPTIMIZE", tableName, getCurrentSnapshotId(tableName)));
+        assertUpdate(sessionWithLegacySyntaxSupport, format("INSERT INTO \"%s@%d\" VALUES 7,8,9", tableName, getCurrentSnapshotId(tableName)), 3);
+        assertUpdate(sessionWithLegacySyntaxSupport, format("DELETE FROM \"%s@%d\" WHERE col = 9", tableName, getCurrentSnapshotId(tableName)), 1);
+        assertUpdate(sessionWithLegacySyntaxSupport, format("UPDATE \"%s@%d\" set col = 50 WHERE col = 5", tableName, getCurrentSnapshotId(tableName)), 1);
+        assertQuerySucceeds(sessionWithLegacySyntaxSupport, format("ALTER TABLE \"%s@%d\" EXECUTE OPTIMIZE", tableName, getCurrentSnapshotId(tableName)));
         assertQuery(format("SELECT * FROM %s", tableName), "VALUES 1,2,3,4,50,6,7,8");
 
         assertUpdate("DROP TABLE " + tableName);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
@@ -56,7 +56,8 @@ public class TestIcebergConfig
                 .setRemoveOrphanFilesMinRetention(new Duration(7, DAYS))
                 .setDeleteSchemaLocationsFallback(false)
                 .setTargetMaxFileSize(DataSize.of(1, GIGABYTE))
-                .setMinimumAssignedSplitWeight(0.05));
+                .setMinimumAssignedSplitWeight(0.05)
+                .setAllowLegacySnapshotSyntax(false));
     }
 
     @Test
@@ -79,6 +80,7 @@ public class TestIcebergConfig
                 .put("iceberg.delete-schema-locations-fallback", "true")
                 .put("iceberg.target-max-file-size", "1MB")
                 .put("iceberg.minimum-assigned-split-weight", "0.01")
+                .put("iceberg.allow-legacy-snapshot-syntax", "true")
                 .buildOrThrow();
 
         IcebergConfig expected = new IcebergConfig()
@@ -97,7 +99,8 @@ public class TestIcebergConfig
                 .setRemoveOrphanFilesMinRetention(new Duration(14, HOURS))
                 .setDeleteSchemaLocationsFallback(true)
                 .setTargetMaxFileSize(DataSize.of(1, MEGABYTE))
-                .setMinimumAssignedSplitWeight(0.01);
+                .setMinimumAssignedSplitWeight(0.01)
+                .setAllowLegacySnapshotSyntax(true);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergReadVersionedTable.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergReadVersionedTable.java
@@ -93,6 +93,14 @@ public class TestIcebergReadVersionedTable
                 "Cannot specify end version both in table name and FOR clause");
     }
 
+    @Test
+    public void testSystemTables()
+    {
+        // TODO https://github.com/trinodb/trino/issues/12920
+        assertQueryFails("SELECT * FROM \"test_iceberg_read_versioned_table$partitions\" FOR VERSION AS OF " + v1SnapshotId,
+                "This connector does not support versioned tables");
+    }
+
     private long getLatestSnapshotId(String tableName)
     {
         return (long) computeActual(format("SELECT snapshot_id FROM \"%s$snapshots\" ORDER BY committed_at DESC LIMIT 1", tableName))

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestLegacySyntaxForIcebergSnapshotAccess.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestLegacySyntaxForIcebergSnapshotAccess.java
@@ -13,18 +13,22 @@
  */
 package io.trino.plugin.iceberg;
 
+import io.trino.Session;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.QueryRunner;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
+import static com.google.common.collect.Iterables.getLast;
 import static io.trino.plugin.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
 import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class TestIcebergSnapshots
+public class TestLegacySyntaxForIcebergSnapshotAccess
         extends AbstractTestQueryFramework
 {
     private static final int ID_FIELD = 0;
@@ -44,8 +48,43 @@ public class TestIcebergSnapshots
         assertUpdate(format("INSERT INTO %s VALUES(1, 1)", tableName), 1);
         List<Long> ids = getSnapshotsIdsByCreationOrder(tableName);
 
-        assertQuery(format("SELECT count(*) FROM \"%s@%d\"", tableName, ids.get(0)), "VALUES(0)");
-        assertQuery(format("SELECT * FROM \"%s@%d\"", tableName, ids.get(1)), "VALUES(1,1)");
+        assertQuery(sessionWithLegacySyntaxSupport(), format("SELECT count(*) FROM \"%s@%d\"", tableName, ids.get(0)), "VALUES(0)");
+        assertQuery(sessionWithLegacySyntaxSupport(), format("SELECT * FROM \"%s@%d\"", tableName, ids.get(1)), "VALUES(1,1)");
+        assertUpdate(format("DROP TABLE %s", tableName));
+    }
+
+    @Test
+    public void testLegacySnapshotSyntaxSupport()
+    {
+        String tableName = "test_legacy_snapshot_access" + randomTableSuffix();
+        assertUpdate(format("CREATE TABLE %s (a BIGINT, b BIGINT)", tableName));
+        assertUpdate(format("INSERT INTO %s VALUES(1, 1)", tableName), 1);
+        List<Long> ids = getSnapshotsIdsByCreationOrder(tableName);
+        // come up with a timestamp value in future that is not an already existing id
+        long futureTimeStamp = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(5);
+        while (ids.contains(futureTimeStamp)) {
+            futureTimeStamp += TimeUnit.MINUTES.toMillis(5);
+        }
+
+        String selectAllFromFutureTimeStamp = format("SELECT * FROM \"%s@%d\"", tableName, futureTimeStamp);
+        String selectAllFromLatestId = format("SELECT * FROM \"%s@%d\"", tableName, getLast(ids));
+        String selectFromPartitionsTable = format("SELECT record_count FROM \"%s$partitions@%d\"", tableName, getLast(ids));
+
+        assertQuery(sessionWithLegacySyntaxSupport(), selectAllFromFutureTimeStamp, "VALUES(1, 1)");
+        assertQuery(sessionWithLegacySyntaxSupport(), selectAllFromLatestId, "VALUES(1, 1)");
+        assertQuery(sessionWithLegacySyntaxSupport(), selectFromPartitionsTable, "VALUES(1)");
+
+        // DISABLED
+        String errorMessage = "Failed to access snapshot .* for table .*. This syntax for accessing Iceberg tables is not "
+                + "supported. Use the AS OF syntax OR set the catalog session property "
+                + "allow_legacy_snapshot_syntax=true for temporarily restoring previous behavior.";
+        assertThatThrownBy(() -> query(getSession(), selectAllFromFutureTimeStamp))
+                .hasMessageMatching(errorMessage);
+        assertThatThrownBy(() -> query(getSession(), selectAllFromLatestId))
+                .hasMessageMatching(errorMessage);
+        assertThatThrownBy(() -> query(getSession(), selectFromPartitionsTable))
+                .hasMessageMatching(errorMessage);
+
         assertUpdate(format("DROP TABLE %s", tableName));
     }
 
@@ -61,6 +100,7 @@ public class TestIcebergSnapshots
 
         assertQuery(format("SELECT * FROM %s", tableName), "SELECT * FROM (VALUES(1,1), (2,2), (3,3))");
         assertQuery(
+                sessionWithLegacySyntaxSupport(),
                 format("SELECT * FROM %1$s EXCEPT (SELECT * FROM \"%1$s@%2$d\" EXCEPT SELECT * FROM \"%1$s@%3$d\")", tableName, ids.get(2), ids.get(1)),
                 "SELECT * FROM (VALUES(1,1), (3,3))");
         assertUpdate(format("DROP TABLE %s", tableName));
@@ -73,5 +113,12 @@ public class TestIcebergSnapshots
                 .getMaterializedRows().stream()
                 .map(row -> (Long) row.getField(ID_FIELD))
                 .collect(toList());
+    }
+
+    private Session sessionWithLegacySyntaxSupport()
+    {
+        return Session.builder(getSession())
+                .setCatalogSessionProperty("iceberg", "allow_legacy_snapshot_syntax", "true")
+                .build();
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

this deprecates `@` based syntax for accessing iceberg snapshots.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

iceberg connector

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

() No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Iceberg
* Deprecate Iceberg snapshot access using mangled table names, in favor of the `AS OF` syntax. The old behavior can be restored by `allow_legacy_snapshot_syntax`  session property or `iceberg.allow-legacy-snapshot-syntax` config property. ({issue}`10768`)
```
