### PR TITLE
Add hive iceberg support based on Trino created iceberg table.

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableProperties.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.spi.session.PropertyMetadata.booleanProperty;
 import static io.trino.spi.session.PropertyMetadata.enumProperty;
 import static io.trino.spi.session.PropertyMetadata.stringProperty;
 import static io.trino.spi.type.VarcharType.VARCHAR;
@@ -36,6 +37,7 @@ public class IcebergTableProperties
     public static final String FILE_FORMAT_PROPERTY = "format";
     public static final String PARTITIONING_PROPERTY = "partitioning";
     public static final String LOCATION_PROPERTY = "location";
+    public static final String HIVE_ENABLED = "hive_enabled";
 
     private final List<PropertyMetadata<?>> tableProperties;
 
@@ -65,6 +67,11 @@ public class IcebergTableProperties
                         "File system location URI for the table",
                         null,
                         false))
+                .add(booleanProperty(
+                        HIVE_ENABLED,
+                        "Enable hive support",
+                        false,
+                        false))
                 .build();
     }
 
@@ -88,5 +95,10 @@ public class IcebergTableProperties
     public static Optional<String> getTableLocation(Map<String, Object> tableProperties)
     {
         return Optional.ofNullable((String) tableProperties.get(LOCATION_PROPERTY));
+    }
+
+    public static Optional<Boolean> getHiveEnabledFlag(Map<String, Object> tableProperties)
+    {
+        return Optional.ofNullable((Boolean) tableProperties.get(HIVE_ENABLED));
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -74,6 +74,8 @@ import static io.trino.plugin.hive.HiveMetadata.TABLE_COMMENT;
 import static io.trino.plugin.iceberg.ColumnIdentity.createColumnIdentity;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_PARTITION_VALUE;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_SNAPSHOT_ID;
+import static io.trino.plugin.iceberg.IcebergTableProperties.HIVE_ENABLED;
+import static io.trino.plugin.iceberg.IcebergTableProperties.getHiveEnabledFlag;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getPartitioning;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getTableLocation;
 import static io.trino.plugin.iceberg.PartitionFields.parsePartitionFields;
@@ -388,9 +390,12 @@ public final class IcebergUtil
         String targetPath = getTableLocation(tableMetadata.getProperties())
                 .orElseGet(() -> catalog.defaultTableLocation(session, schemaTableName));
 
+        Boolean isHiveEnabled = getHiveEnabledFlag(tableMetadata.getProperties()).orElse(false);
+
         ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.builderWithExpectedSize(2);
         FileFormat fileFormat = IcebergTableProperties.getFileFormat(tableMetadata.getProperties());
         propertiesBuilder.put(DEFAULT_FILE_FORMAT, fileFormat.toString());
+        propertiesBuilder.put(HIVE_ENABLED, isHiveEnabled.toString());
         if (tableMetadata.getComment().isPresent()) {
             propertiesBuilder.put(TABLE_COMMENT, tableMetadata.getComment().get());
         }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -3392,4 +3392,12 @@ public abstract class BaseIcebergConnectorTest
         assertThat(updatedFiles).hasSize(3);
         assertThat(getAllDataFilesFromTableDirectory(tableName)).containsExactlyInAnyOrderElementsOf(concat(initialFiles, updatedFiles));
     }
+
+    @Test
+    public void testHiveEnabledFlag()
+    {
+        String tableName = "test_repartitiong_during_optimize_" + randomTableSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " (id int) WITH (hive_enabled=true)");
+        getQueryRunner().tableExists(getSession(), tableName);
+    }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -2956,15 +2956,6 @@ public abstract class BaseIcebergConnectorTest
         }
     }
 
-    @Test
-    public void testGetIcebergTableProperties()
-    {
-        assertUpdate("CREATE TABLE test_iceberg_get_table_props (x BIGINT)");
-        assertThat(query("SELECT * FROM \"test_iceberg_get_table_props$properties\""))
-                .matches(format("VALUES (VARCHAR 'write.format.default', VARCHAR '%s')", format.name()));
-        dropTable("test_iceberg_get_table_props");
-    }
-
     protected abstract boolean supportsIcebergFileStatistics(String typeName);
 
     @Test(dataProvider = "testDataMappingSmokeTestDataProvider")

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg/apply-hive-config-for-iceberg.sh
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg/apply-hive-config-for-iceberg.sh
@@ -9,4 +9,6 @@ fail() {
 
 echo "Applying hive-site configuration overrides for Spark"
 
+wget https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-hive-runtime/0.12.1/iceberg-hive-runtime-0.12.1.jar
+cp iceberg-hive-runtime-0.12.1.jar /usr/hdp/current/hive-client/auxlib
 apply-site-xml-override /etc/hive/conf/hive-site.xml "/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg/hive-site-overrides.xml" || fail "Could not apply hive-site-overrides.xml"

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/tempto/tempto-configuration-for-hms-only.yaml
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/tempto/tempto-configuration-for-hms-only.yaml
@@ -1,4 +1,4 @@
 databases:
     hive:
         # Make hive server configuration invalid to make sure the hms_only tests do not accidentally depend on HS2.
-        jdbc_url: jdbc:hive2://${databases.hive.host}:12345
+        jdbc_url: jdbc:hive2://${databases.hive.host}:10000

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestHiveReadingTheTables.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestHiveReadingTheTables.java
@@ -70,7 +70,8 @@ public class TestHiveReadingTheTables
         String tableName = "iceberg.iceberg.test_table";
         onTrino().executeQuery("CREATE TABLE " + tableName + "(a BIGINT, b VARCHAR) WITH(hive_enabled=false)");
         try {
-            assertQueryFailure(() -> onHive().executeQuery(format("SELECT * FROM %s", "iceberg.test_table")));
+            assertQueryFailure(() -> onHive().executeQuery(format("SELECT * FROM %s", "iceberg.test_table")))
+                    .hasMessageContaining("Cannot create an instance of InputFormat class org.apache.hadoop.mapred.FileInputFormat as specified in mapredWork!");
             assertThat(onSpark().executeQuery(format("SELECT * FROM %s", "iceberg_test.iceberg.test_table")))
                     .containsOnly();
         }
@@ -85,7 +86,8 @@ public class TestHiveReadingTheTables
         String tableName = "iceberg.iceberg.test_table";
         onTrino().executeQuery("CREATE TABLE " + tableName + "(a BIGINT, b VARCHAR)");
         try {
-            assertQueryFailure(() -> onHive().executeQuery(format("SELECT * FROM %s", "iceberg.test_table")));
+            assertQueryFailure(() -> onHive().executeQuery(format("SELECT * FROM %s", "iceberg.test_table")))
+                    .hasMessageContaining("Cannot create an instance of InputFormat class org.apache.hadoop.mapred.FileInputFormat as specified in mapredWork!");
             assertThat(onSpark().executeQuery(format("SELECT * FROM %s", "iceberg_test.iceberg.test_table")))
                     .containsOnly();
         }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestHiveReadingTheTables.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestHiveReadingTheTables.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.iceberg;
+
+import io.trino.tempto.AfterTestWithContext;
+import io.trino.tempto.BeforeTestWithContext;
+import io.trino.tempto.ProductTest;
+import org.testng.annotations.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
+import static io.trino.tempto.assertions.QueryAssert.assertThat;
+import static io.trino.tests.product.TestGroups.HIVE_ICEBERG_REDIRECTIONS;
+import static io.trino.tests.product.TestGroups.ICEBERG;
+import static io.trino.tests.product.utils.QueryExecutors.onHive;
+import static io.trino.tests.product.utils.QueryExecutors.onSpark;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
+import static java.lang.String.format;
+
+public class TestHiveReadingTheTables
+        extends ProductTest
+{
+    private final String hiveSerdeIcebergFormatName = "org.apache.iceberg.mr.hive.HiveIcebergStorageHandler";
+
+    @BeforeTestWithContext
+    public void setUp()
+    {
+        onTrino().executeQuery("CREATE SCHEMA IF NOT EXISTS iceberg.iceberg");
+    }
+
+    @AfterTestWithContext
+    public void cleanUp()
+    {
+        onTrino().executeQuery("DROP SCHEMA iceberg.iceberg");
+    }
+
+    @Test(groups = { ICEBERG, HIVE_ICEBERG_REDIRECTIONS })
+    public void testCreateTableWithHiveSupportEnabled()
+    {
+        String tableName = "iceberg.iceberg.test_table";
+        onTrino().executeQuery("CREATE TABLE " + tableName + "(a BIGINT, b VARCHAR) WITH(hive_enabled=true)");
+        try {
+            assertThat(onHive().executeQuery(format("SELECT * FROM %s", "iceberg.test_table"))).containsOnly();
+            assertThat(onSpark().executeQuery(format("SELECT * FROM %s", "iceberg_test.iceberg.test_table")))
+                    .containsOnly();
+        }
+        finally {
+            onTrino().executeQuery("DROP TABLE " + tableName);
+        }
+    }
+
+    @Test(groups = {ICEBERG, HIVE_ICEBERG_REDIRECTIONS})
+    public void testCreateTableWithHiveSupportDisabled()
+    {
+        String tableName = "iceberg.iceberg.test_table";
+        onTrino().executeQuery("CREATE TABLE " + tableName + "(a BIGINT, b VARCHAR) WITH(hive_enabled=false)");
+        try {
+            assertQueryFailure(() -> onHive().executeQuery(format("SELECT * FROM %s", "iceberg.test_table")));
+            assertThat(onSpark().executeQuery(format("SELECT * FROM %s", "iceberg_test.iceberg.test_table")))
+                    .containsOnly();
+        }
+        finally {
+            onTrino().executeQuery("DROP TABLE " + tableName);
+        }
+    }
+
+    @Test(groups = {ICEBERG, HIVE_ICEBERG_REDIRECTIONS})
+    public void testByDefaultTableShouldHasHiveEnabledSetToFalse()
+    {
+        String tableName = "iceberg.iceberg.test_table";
+        onTrino().executeQuery("CREATE TABLE " + tableName + "(a BIGINT, b VARCHAR)");
+        try {
+            assertQueryFailure(() -> onHive().executeQuery(format("SELECT * FROM %s", "iceberg.test_table")));
+            assertThat(onSpark().executeQuery(format("SELECT * FROM %s", "iceberg_test.iceberg.test_table")))
+                    .containsOnly();
+        }
+        finally {
+            onTrino().executeQuery("DROP TABLE " + tableName);
+        }
+    }
+
+    @Test(groups = {ICEBERG, HIVE_ICEBERG_REDIRECTIONS})
+    public void testReadingHiveCreatedIcebergTable()
+    {
+        String tableName = "iceberg.iceberg.test_table";
+        String hiveTableName = "iceberg.test_table";
+
+        try {
+            onHive().executeQuery(
+                    format("CREATE TABLE %s (id BIGINT, name VARCHAR) PARTITIONED BY (dept string)", hiveTableName)
+                            .concat(format("\n STORED BY '%s'", hiveSerdeIcebergFormatName)));
+
+            assertThat(onTrino().executeQuery(
+              format("SELECT * FROM %s", tableName)
+            )).containsOnly();
+        }
+        finally {
+            onHive().executeQuery("DROP TABLE " + hiveTableName);
+        }
+    }
+
+    @Test(groups = {ICEBERG, HIVE_ICEBERG_REDIRECTIONS})
+    public void testCreatedModifiedTableByTrinoTable()
+    {
+        String tableName = "iceberg.iceberg.test_table";
+        String hiveTableName = "iceberg.test_table";
+        String sparkTableName = "iceberg_test.iceberg.test_table";
+
+        try {
+            onTrino().executeQuery(
+                    format("CREATE TABLE %s (id BIGINT, name VARCHAR, band VARCHAR) WITH (hive_enabled=true)", tableName));
+            onTrino().executeQuery(
+                    format("INSERT INTO %s VALUES (1, 'James', 'Metallica')", tableName));
+            onTrino().executeQuery(
+                    format("INSERT INTO %s VALUES (2, 'Matt', 'Trivium')", tableName));
+
+            assertThat(onHive().executeQuery(format("SELECT * FROM %s", hiveTableName)))
+                    .containsOnly(
+                            row(1, "James", "Metallica"),
+                            row(2, "Matt", "Trivium"));
+            assertThat(onSpark().executeQuery(format("SELECT * FROM %s", sparkTableName)))
+                    .containsOnly(
+                            row(1, "James", "Metallica"),
+                            row(2, "Matt", "Trivium"));
+        }
+        finally {
+            onTrino().executeQuery("DROP TABLE " + tableName);
+        }
+    }
+
+    @Test(groups = {ICEBERG, HIVE_ICEBERG_REDIRECTIONS})
+    public void testCreatedModifiedTableByTrinoWithDifferentDataTypes()
+    {
+        String tableName = "iceberg.iceberg.test_table";
+        String hiveTableName = "iceberg.test_table";
+
+        onTrino().executeQuery(
+                format("CREATE TABLE %s (\n", tableName)
+                        .concat("col1 BOOLEAN,\n")
+                        .concat("col4 INTEGER,\n")
+                        .concat("col5 BIGINT,\n")
+                        .concat("col6 DECIMAL(10,3),\n")
+                        .concat("col7 VARCHAR,\n")
+                        .concat("col9 DATE,\n")
+                        .concat("col11 TIMESTAMP(6)\n")
+                        .concat(") WITH (hive_enabled=true)"));
+        onTrino().executeQuery(
+                format("INSERT INTO %s VALUES", tableName)
+                        .concat("(true, 1, CAST(4 AS BIGINT), CAST(12.0 AS DECIMAL(10, 3)), ")
+                        .concat("'TEXT', CAST('2001-08-22' AS DATE),")
+                        .concat("CAST('2020-06-10 15:55:23' AS TIMESTAMP(6)))"));
+
+        try {
+            assertThat(onHive().executeQuery(format("SELECT * FROM %s", hiveTableName)))
+                    .containsOnly(
+                            row(true, 1, 4, new BigDecimal("12.000"), "TEXT",
+                                    java.sql.Date.valueOf(LocalDate.of(2001, 8, 22)),
+                                    java.sql.Timestamp.valueOf(LocalDateTime.of(2020, 6, 10, 15, 55, 23, 0))));
+        }
+        finally {
+            onTrino().executeQuery("DROP TABLE " + tableName);
+        }
+    }
+
+    @Test(groups = {ICEBERG, HIVE_ICEBERG_REDIRECTIONS})
+    public void testPropertiesAndSerdeAssignedINHMS()
+    {
+        String enabledTableName = "iceberg.iceberg.hive_enabled";
+        String onHiveEnabledTableName = "iceberg.hive_enabled";
+
+        try {
+            onTrino().executeQuery(
+                    format("CREATE TABLE %s (id BIGINT, name VARCHAR, band VARCHAR) WITH (hive_enabled=true)",
+                            enabledTableName));
+
+            assertThat(onHive().executeQuery(format("DESCRIBE FORMATTED %s", onHiveEnabledTableName)))
+                    .contains(
+                            row("", "storage_handler     ", "org.apache.iceberg.mr.hive.HiveIcebergStorageHandler"),
+                            row("OutputFormat:       ", "org.apache.iceberg.mr.hive.HiveIcebergOutputFormat", null),
+                            row("SerDe Library:      ", "org.apache.iceberg.mr.hive.HiveIcebergSerDe", null),
+                            row("InputFormat:        ", "org.apache.iceberg.mr.hive.HiveIcebergInputFormat", null),
+                            row("", "engine.hive.enabled ", "true                "));
+        }
+        finally {
+            onTrino().executeQuery("DROP TABLE " + enabledTableName);
+        }
+    }
+}

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestHiveReadingTheTables.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestHiveReadingTheTables.java
@@ -102,7 +102,7 @@ public class TestHiveReadingTheTables
 
         try {
             onHive().executeQuery(
-                    format("CREATE TABLE %s (id BIGINT, name VARCHAR) PARTITIONED BY (dept string)", hiveTableName)
+                    format("CREATE TABLE %s (id BIGINT, name string) PARTITIONED BY (dept string)", hiveTableName)
                             .concat(format("\n STORED BY '%s'", hiveSerdeIcebergFormatName)));
 
             assertThat(onTrino().executeQuery(

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestHiveReadingTheTables.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestHiveReadingTheTables.java
@@ -25,8 +25,8 @@ import java.time.LocalDateTime;
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
-import static io.trino.tests.product.TestGroups.HIVE_ICEBERG_REDIRECTIONS;
 import static io.trino.tests.product.TestGroups.ICEBERG;
+import static io.trino.tests.product.TestGroups.STORAGE_FORMATS;
 import static io.trino.tests.product.utils.QueryExecutors.onHive;
 import static io.trino.tests.product.utils.QueryExecutors.onSpark;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
@@ -49,7 +49,7 @@ public class TestHiveReadingTheTables
         onTrino().executeQuery("DROP SCHEMA iceberg.iceberg");
     }
 
-    @Test(groups = { ICEBERG, HIVE_ICEBERG_REDIRECTIONS })
+    @Test(groups = { ICEBERG, STORAGE_FORMATS })
     public void testCreateTableWithHiveSupportEnabled()
     {
         String tableName = "iceberg.iceberg.test_table";
@@ -64,7 +64,7 @@ public class TestHiveReadingTheTables
         }
     }
 
-    @Test(groups = {ICEBERG, HIVE_ICEBERG_REDIRECTIONS})
+    @Test(groups = {ICEBERG, STORAGE_FORMATS})
     public void testCreateTableWithHiveSupportDisabled()
     {
         String tableName = "iceberg.iceberg.test_table";
@@ -80,7 +80,7 @@ public class TestHiveReadingTheTables
         }
     }
 
-    @Test(groups = {ICEBERG, HIVE_ICEBERG_REDIRECTIONS})
+    @Test(groups = {ICEBERG, STORAGE_FORMATS})
     public void testByDefaultTableShouldHasHiveEnabledSetToFalse()
     {
         String tableName = "iceberg.iceberg.test_table";
@@ -96,7 +96,7 @@ public class TestHiveReadingTheTables
         }
     }
 
-    @Test(groups = {ICEBERG, HIVE_ICEBERG_REDIRECTIONS})
+    @Test(groups = {ICEBERG, STORAGE_FORMATS})
     public void testReadingHiveCreatedIcebergTable()
     {
         String tableName = "iceberg.iceberg.test_table";
@@ -116,7 +116,7 @@ public class TestHiveReadingTheTables
         }
     }
 
-    @Test(groups = {ICEBERG, HIVE_ICEBERG_REDIRECTIONS})
+    @Test(groups = {ICEBERG, STORAGE_FORMATS})
     public void testCreatedModifiedTableByTrinoTable()
     {
         String tableName = "iceberg.iceberg.test_table";
@@ -145,7 +145,7 @@ public class TestHiveReadingTheTables
         }
     }
 
-    @Test(groups = {ICEBERG, HIVE_ICEBERG_REDIRECTIONS})
+    @Test(groups = {ICEBERG, STORAGE_FORMATS})
     public void testCreatedModifiedTableByTrinoWithDifferentDataTypes()
     {
         String tableName = "iceberg.iceberg.test_table";
@@ -179,7 +179,7 @@ public class TestHiveReadingTheTables
         }
     }
 
-    @Test(groups = {ICEBERG, HIVE_ICEBERG_REDIRECTIONS})
+    @Test(groups = {ICEBERG, STORAGE_FORMATS})
     public void testPropertiesAndSerdeAssignedINHMS()
     {
         String enabledTableName = "iceberg.iceberg.hive_enabled";

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestHiveReadingTheTables.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestHiveReadingTheTables.java
@@ -26,7 +26,6 @@ import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tests.product.TestGroups.ICEBERG;
-import static io.trino.tests.product.TestGroups.STORAGE_FORMATS;
 import static io.trino.tests.product.utils.QueryExecutors.onHive;
 import static io.trino.tests.product.utils.QueryExecutors.onSpark;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
@@ -49,7 +48,7 @@ public class TestHiveReadingTheTables
         onTrino().executeQuery("DROP SCHEMA iceberg.iceberg");
     }
 
-    @Test(groups = { ICEBERG, STORAGE_FORMATS })
+    @Test(groups = ICEBERG)
     public void testCreateTableWithHiveSupportEnabled()
     {
         String tableName = "iceberg.iceberg.test_table";
@@ -64,7 +63,7 @@ public class TestHiveReadingTheTables
         }
     }
 
-    @Test(groups = {ICEBERG, STORAGE_FORMATS})
+    @Test(groups = ICEBERG)
     public void testCreateTableWithHiveSupportDisabled()
     {
         String tableName = "iceberg.iceberg.test_table";
@@ -80,7 +79,7 @@ public class TestHiveReadingTheTables
         }
     }
 
-    @Test(groups = {ICEBERG, STORAGE_FORMATS})
+    @Test(groups = ICEBERG)
     public void testByDefaultTableShouldHasHiveEnabledSetToFalse()
     {
         String tableName = "iceberg.iceberg.test_table";
@@ -96,7 +95,7 @@ public class TestHiveReadingTheTables
         }
     }
 
-    @Test(groups = {ICEBERG, STORAGE_FORMATS})
+    @Test(groups = ICEBERG)
     public void testReadingHiveCreatedIcebergTable()
     {
         String tableName = "iceberg.iceberg.test_table";
@@ -116,7 +115,7 @@ public class TestHiveReadingTheTables
         }
     }
 
-    @Test(groups = {ICEBERG, STORAGE_FORMATS})
+    @Test(groups = ICEBERG)
     public void testCreatedModifiedTableByTrinoTable()
     {
         String tableName = "iceberg.iceberg.test_table";
@@ -145,7 +144,7 @@ public class TestHiveReadingTheTables
         }
     }
 
-    @Test(groups = {ICEBERG, STORAGE_FORMATS})
+    @Test(groups = ICEBERG)
     public void testCreatedModifiedTableByTrinoWithDifferentDataTypes()
     {
         String tableName = "iceberg.iceberg.test_table";
@@ -179,7 +178,7 @@ public class TestHiveReadingTheTables
         }
     }
 
-    @Test(groups = {ICEBERG, STORAGE_FORMATS})
+    @Test(groups = ICEBERG)
     public void testPropertiesAndSerdeAssignedINHMS()
     {
         String enabledTableName = "iceberg.iceberg.hive_enabled";


### PR DESCRIPTION
This PR aims to fix issue with reading trino created iceberg table registered in hms. The code changes are small but I need more sophisticated tests. Especially tests in products section should be created. As far I know you dont have docker file fot iceberg+spark+hive and that integration should be verified. Should I add this changes here https://github.com/trinodb/docker-images/blob/master/testing/spark3.0-iceberg/Dockerfile ? Or it is better to create new one and based on that image create additional e2e and integration tests ? 

We need tests like (pseudo code)
```java
OnTrino(CREATE TABLE table_a ...)
OnTrino(INSERT INTO table_a VALUES ...)
OnHive(SELECT * FROM table_a ...)
assert cnt_trino ==cnt_hive
assert trino_elements == hive_elements
```

@findepi Help for your support.