### PR TITLE
Reuse view owner identity

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -64,7 +64,6 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableProcedureMetadata;
 import io.trino.spi.function.OperatorType;
 import io.trino.spi.security.AccessDeniedException;
-import io.trino.spi.security.GroupProvider;
 import io.trino.spi.security.Identity;
 import io.trino.spi.security.ViewExpression;
 import io.trino.spi.type.ArrayType;
@@ -328,7 +327,6 @@ class StatementAnalyzer
     private final TypeCoercion typeCoercion;
     private final Session session;
     private final SqlParser sqlParser;
-    private final GroupProvider groupProvider;
     private final AccessControl accessControl;
     private final TableProceduresRegistry tableProceduresRegistry;
     private final SessionPropertyManager sessionPropertyManager;
@@ -344,7 +342,6 @@ class StatementAnalyzer
             Analysis analysis,
             PlannerContext plannerContext,
             SqlParser sqlParser,
-            GroupProvider groupProvider,
             AccessControl accessControl,
             Session session,
             TableProceduresRegistry tableProceduresRegistry,
@@ -361,7 +358,6 @@ class StatementAnalyzer
         this.metadata = plannerContext.getMetadata();
         this.typeCoercion = new TypeCoercion(plannerContext.getTypeManager()::getType);
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
-        this.groupProvider = requireNonNull(groupProvider, "groupProvider is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.session = requireNonNull(session, "session is null");
         this.tableProceduresRegistry = requireNonNull(tableProceduresRegistry, "tableProceduresRegistry is null");
@@ -3463,9 +3459,7 @@ class StatementAnalyzer
                 Identity identity;
                 AccessControl viewAccessControl;
                 if (owner.isPresent() && !owner.get().getUser().equals(session.getIdentity().getUser())) {
-                    identity = Identity.from(owner.get())
-                            .withGroups(groupProvider.getGroups(owner.get().getUser()))
-                            .build();
+                    identity = owner.get();
                     viewAccessControl = new ViewAccessControl(accessControl, session.getIdentity());
                 }
                 else {

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzerFactory.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzerFactory.java
@@ -13,7 +13,6 @@
  */
 package io.trino.sql.analyzer;
 
-import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.AnalyzePropertyManager;
@@ -22,7 +21,6 @@ import io.trino.metadata.TableProceduresPropertyManager;
 import io.trino.metadata.TableProceduresRegistry;
 import io.trino.metadata.TablePropertyManager;
 import io.trino.security.AccessControl;
-import io.trino.spi.security.GroupProvider;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.parser.SqlParser;
 
@@ -35,7 +33,6 @@ public class StatementAnalyzerFactory
     private final PlannerContext plannerContext;
     private final SqlParser sqlParser;
     private final AccessControl accessControl;
-    private final GroupProvider groupProvider;
     private final TableProceduresRegistry tableProceduresRegistry;
     private final SessionPropertyManager sessionPropertyManager;
     private final TablePropertyManager tablePropertyManager;
@@ -47,7 +44,6 @@ public class StatementAnalyzerFactory
             PlannerContext plannerContext,
             SqlParser sqlParser,
             AccessControl accessControl,
-            GroupProvider groupProvider,
             TableProceduresRegistry tableProceduresRegistry,
             SessionPropertyManager sessionPropertyManager,
             TablePropertyManager tablePropertyManager,
@@ -57,7 +53,6 @@ public class StatementAnalyzerFactory
         this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
-        this.groupProvider = requireNonNull(groupProvider, "groupProvider is null");
         this.tableProceduresRegistry = requireNonNull(tableProceduresRegistry, "tableProceduresRegistry is null");
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
         this.tablePropertyManager = requireNonNull(tablePropertyManager, "tablePropertyManager is null");
@@ -71,7 +66,6 @@ public class StatementAnalyzerFactory
                 plannerContext,
                 sqlParser,
                 accessControl,
-                groupProvider,
                 tableProceduresRegistry,
                 sessionPropertyManager,
                 tablePropertyManager,
@@ -90,7 +84,6 @@ public class StatementAnalyzerFactory
                 analysis,
                 plannerContext,
                 sqlParser,
-                groupProvider,
                 accessControl,
                 session,
                 tableProceduresRegistry,
@@ -112,7 +105,6 @@ public class StatementAnalyzerFactory
                 plannerContext,
                 new SqlParser(),
                 accessControl,
-                user -> ImmutableSet.of(),
                 new TableProceduresRegistry(),
                 new SessionPropertyManager(),
                 tablePropertyManager,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
@@ -16,7 +16,6 @@ package io.trino.sql.planner;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.PeekingIterator;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
@@ -310,7 +309,6 @@ public final class DomainTranslator
                         plannerContext,
                         new SqlParser(),
                         new AllowAllAccessControl(),
-                        user -> ImmutableSet.of(),
                         new TableProceduresRegistry(),
                         new SessionPropertyManager(),
                         new TablePropertyManager(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveUnsupportedDynamicFilters.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveUnsupportedDynamicFilters.java
@@ -95,7 +95,6 @@ public class RemoveUnsupportedDynamicFilters
                         plannerContext,
                         new SqlParser(),
                         new AllowAllAccessControl(),
-                        user -> ImmutableSet.of(),
                         new TableProceduresRegistry(),
                         new SessionPropertyManager(),
                         new TablePropertyManager(),

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -331,6 +331,7 @@ public class LocalQueryRunner
                 catalogManager,
                 notificationExecutor);
         this.nodePartitioningManager = new NodePartitioningManager(nodeScheduler, blockTypeOperators);
+        this.groupProvider = new TestingGroupProvider();
 
         BlockEncodingManager blockEncodingManager = new BlockEncodingManager();
         TypeRegistry typeRegistry = new TypeRegistry(typeOperators, featuresConfig);
@@ -340,6 +341,7 @@ public class LocalQueryRunner
                 featuresConfig,
                 new DisabledSystemSecurityMetadata(),
                 transactionManager,
+                groupProvider,
                 typeOperators,
                 blockTypeOperators,
                 typeManager,
@@ -350,7 +352,6 @@ public class LocalQueryRunner
         this.planFragmenter = new PlanFragmenter(metadata, this.nodePartitioningManager, new QueryManagerConfig());
         this.joinCompiler = new JoinCompiler(typeOperators);
         PageIndexerFactory pageIndexerFactory = new GroupByHashPageIndexerFactory(joinCompiler, blockTypeOperators);
-        this.groupProvider = new TestingGroupProvider();
         this.accessControl = new TestingAccessControlManager(transactionManager, eventListenerManager);
         accessControl.loadSystemAccessControl(AllowAllSystemAccessControl.NAME, ImmutableMap.of());
 
@@ -367,7 +368,6 @@ public class LocalQueryRunner
                 plannerContext,
                 sqlParser,
                 accessControl,
-                groupProvider,
                 tableProceduresRegistry,
                 sessionPropertyManager,
                 tablePropertyManager,

--- a/plugin/trino-ml/src/test/java/io/trino/plugin/ml/TestLearnAggregations.java
+++ b/plugin/trino-ml/src/test/java/io/trino/plugin/ml/TestLearnAggregations.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.ml;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
 import io.trino.FeaturesConfig;
 import io.trino.RowPageBuilder;
@@ -70,6 +71,7 @@ public class TestLearnAggregations
                 new FeaturesConfig(),
                 new DisabledSystemSecurityMetadata(),
                 transactionManager,
+                user -> ImmutableSet.of(),
                 typeOperators,
                 new BlockTypeOperators(typeOperators),
                 typeManager,


### PR DESCRIPTION
Reuse view owner identity

That way we are using view owner identity that is returned from
SystemSecurityMetadata#getViewRunAsIdentity which may have
much more information than plain user name and groups. For example
getViewRunAsIdentity may return a list of enabled roles.
