### PR TITLE
Reduce PTL memory consumption

### DIFF
--- a/testing/trino-product-tests-launcher/bin/run-launcher
+++ b/testing/trino-product-tests-launcher/bin/run-launcher
@@ -16,4 +16,5 @@ if ! test -x "${launcher_jar[0]}"; then
     exit 3
 fi
 
+# Run the executable directly to pick memory settings defined in it. Invoking as `java -jar ...` would ignore them.
 exec "${launcher_jar[0]}" "$@"

--- a/testing/trino-product-tests-launcher/bin/run-launcher
+++ b/testing/trino-product-tests-launcher/bin/run-launcher
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-launcher_opts=${LAUNCHER_OPTS:-}
 target="${BASH_SOURCE%/*/*}/target"
 launcher_jar=( "${target}"/trino-product-tests-launcher-*-executable.jar )
 
@@ -17,4 +16,4 @@ if ! test -x "${launcher_jar[0]}"; then
     exit 3
 fi
 
-exec java $launcher_opts -jar "${launcher_jar[0]}" "$@"
+exec "${launcher_jar[0]}" "$@"

--- a/testing/trino-product-tests-launcher/pom.xml
+++ b/testing/trino-product-tests-launcher/pom.xml
@@ -162,7 +162,7 @@
                 <artifactId>really-executable-jar-maven-plugin</artifactId>
                 <configuration>
                     <!-- Force Parallel GC to ensure MaxHeapFreeRatio is respected -->
-                    <flags>-Xmx512m -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=10</flags>
+                    <flags>-Xmx256m -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=10</flags>
                     <classifier>executable</classifier>
                 </configuration>
                 <executions>


### PR DESCRIPTION
This reverts commit 741bb2dd0e5cc9c49054179f58125360826dd731.  "Allow to
pass configuration to launcher process". As a result of this change, the
JVM memory settings defined in launcher's `pom.xml`, and weaved into the
executable jar file, were no longer honored.

Chose to revert over improving `run-launcher` as `LAUNCHER_OPTS` isn't used.