### PR TITLE
Revert "Reuse view owner identity"

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -85,7 +85,6 @@ import io.trino.spi.function.InvocationConvention.InvocationArgumentConvention;
 import io.trino.spi.function.OperatorType;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.security.GrantInfo;
-import io.trino.spi.security.GroupProvider;
 import io.trino.spi.security.Identity;
 import io.trino.spi.security.Privilege;
 import io.trino.spi.security.RoleGrant;
@@ -175,7 +174,6 @@ public final class MetadataManager
     private final FunctionRegistry functions;
     private final FunctionResolver functionResolver;
     private final SystemSecurityMetadata systemSecurityMetadata;
-    private final GroupProvider groupProvider;
     private final TransactionManager transactionManager;
     private final TypeManager typeManager;
 
@@ -191,7 +189,6 @@ public final class MetadataManager
             FeaturesConfig featuresConfig,
             SystemSecurityMetadata systemSecurityMetadata,
             TransactionManager transactionManager,
-            GroupProvider groupProvider,
             TypeOperators typeOperators,
             BlockTypeOperators blockTypeOperators,
             TypeManager typeManager,
@@ -204,7 +201,6 @@ public final class MetadataManager
         functionResolver = new FunctionResolver(this, typeManager);
 
         this.systemSecurityMetadata = requireNonNull(systemSecurityMetadata, "systemSecurityMetadata is null");
-        this.groupProvider = requireNonNull(groupProvider, "groupProvider is null");
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
 
         functionDecoder = new ResolvedFunctionDecoder(typeManager::getType);
@@ -242,7 +238,6 @@ public final class MetadataManager
                 featuresConfig,
                 new DisabledSystemSecurityMetadata(),
                 transactionManager,
-                user -> ImmutableSet.of(),
                 typeOperators,
                 new BlockTypeOperators(typeOperators),
                 typeManager,
@@ -1194,16 +1189,9 @@ public final class MetadataManager
         }
 
         Identity runAsIdentity = systemSecurityMetadata.getViewRunAsIdentity(session, viewName.asCatalogSchemaTableName())
-                .or(() -> connectorView.get().getOwner().map(this::createViewOwnerIdentity))
+                .or(() -> connectorView.get().getOwner().map(Identity::ofUser))
                 .orElseThrow(() -> new TrinoException(NOT_SUPPORTED, "Catalog does not support run-as DEFINER views: " + viewName));
         return Optional.of(new ViewDefinition(viewName, connectorView.get(), runAsIdentity));
-    }
-
-    private Identity createViewOwnerIdentity(String user)
-    {
-        return Identity.forUser(user)
-                .withGroups(groupProvider.getGroups(user))
-                .build();
     }
 
     private Optional<ConnectorViewDefinition> getViewInternal(Session session, QualifiedObjectName viewName)

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -64,6 +64,7 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableProcedureMetadata;
 import io.trino.spi.function.OperatorType;
 import io.trino.spi.security.AccessDeniedException;
+import io.trino.spi.security.GroupProvider;
 import io.trino.spi.security.Identity;
 import io.trino.spi.security.ViewExpression;
 import io.trino.spi.type.ArrayType;
@@ -327,6 +328,7 @@ class StatementAnalyzer
     private final TypeCoercion typeCoercion;
     private final Session session;
     private final SqlParser sqlParser;
+    private final GroupProvider groupProvider;
     private final AccessControl accessControl;
     private final TableProceduresRegistry tableProceduresRegistry;
     private final SessionPropertyManager sessionPropertyManager;
@@ -342,6 +344,7 @@ class StatementAnalyzer
             Analysis analysis,
             PlannerContext plannerContext,
             SqlParser sqlParser,
+            GroupProvider groupProvider,
             AccessControl accessControl,
             Session session,
             TableProceduresRegistry tableProceduresRegistry,
@@ -358,6 +361,7 @@ class StatementAnalyzer
         this.metadata = plannerContext.getMetadata();
         this.typeCoercion = new TypeCoercion(plannerContext.getTypeManager()::getType);
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
+        this.groupProvider = requireNonNull(groupProvider, "groupProvider is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.session = requireNonNull(session, "session is null");
         this.tableProceduresRegistry = requireNonNull(tableProceduresRegistry, "tableProceduresRegistry is null");
@@ -3459,7 +3463,9 @@ class StatementAnalyzer
                 Identity identity;
                 AccessControl viewAccessControl;
                 if (owner.isPresent() && !owner.get().getUser().equals(session.getIdentity().getUser())) {
-                    identity = owner.get();
+                    identity = Identity.from(owner.get())
+                            .withGroups(groupProvider.getGroups(owner.get().getUser()))
+                            .build();
                     viewAccessControl = new ViewAccessControl(accessControl, session.getIdentity());
                 }
                 else {

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzerFactory.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzerFactory.java
@@ -13,6 +13,7 @@
  */
 package io.trino.sql.analyzer;
 
+import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.AnalyzePropertyManager;
@@ -21,6 +22,7 @@ import io.trino.metadata.TableProceduresPropertyManager;
 import io.trino.metadata.TableProceduresRegistry;
 import io.trino.metadata.TablePropertyManager;
 import io.trino.security.AccessControl;
+import io.trino.spi.security.GroupProvider;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.parser.SqlParser;
 
@@ -33,6 +35,7 @@ public class StatementAnalyzerFactory
     private final PlannerContext plannerContext;
     private final SqlParser sqlParser;
     private final AccessControl accessControl;
+    private final GroupProvider groupProvider;
     private final TableProceduresRegistry tableProceduresRegistry;
     private final SessionPropertyManager sessionPropertyManager;
     private final TablePropertyManager tablePropertyManager;
@@ -44,6 +47,7 @@ public class StatementAnalyzerFactory
             PlannerContext plannerContext,
             SqlParser sqlParser,
             AccessControl accessControl,
+            GroupProvider groupProvider,
             TableProceduresRegistry tableProceduresRegistry,
             SessionPropertyManager sessionPropertyManager,
             TablePropertyManager tablePropertyManager,
@@ -53,6 +57,7 @@ public class StatementAnalyzerFactory
         this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
+        this.groupProvider = requireNonNull(groupProvider, "groupProvider is null");
         this.tableProceduresRegistry = requireNonNull(tableProceduresRegistry, "tableProceduresRegistry is null");
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
         this.tablePropertyManager = requireNonNull(tablePropertyManager, "tablePropertyManager is null");
@@ -66,6 +71,7 @@ public class StatementAnalyzerFactory
                 plannerContext,
                 sqlParser,
                 accessControl,
+                groupProvider,
                 tableProceduresRegistry,
                 sessionPropertyManager,
                 tablePropertyManager,
@@ -84,6 +90,7 @@ public class StatementAnalyzerFactory
                 analysis,
                 plannerContext,
                 sqlParser,
+                groupProvider,
                 accessControl,
                 session,
                 tableProceduresRegistry,
@@ -105,6 +112,7 @@ public class StatementAnalyzerFactory
                 plannerContext,
                 new SqlParser(),
                 accessControl,
+                user -> ImmutableSet.of(),
                 new TableProceduresRegistry(),
                 new SessionPropertyManager(),
                 tablePropertyManager,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
@@ -16,6 +16,7 @@ package io.trino.sql.planner;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.PeekingIterator;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
@@ -309,6 +310,7 @@ public final class DomainTranslator
                         plannerContext,
                         new SqlParser(),
                         new AllowAllAccessControl(),
+                        user -> ImmutableSet.of(),
                         new TableProceduresRegistry(),
                         new SessionPropertyManager(),
                         new TablePropertyManager(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveUnsupportedDynamicFilters.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveUnsupportedDynamicFilters.java
@@ -95,6 +95,7 @@ public class RemoveUnsupportedDynamicFilters
                         plannerContext,
                         new SqlParser(),
                         new AllowAllAccessControl(),
+                        user -> ImmutableSet.of(),
                         new TableProceduresRegistry(),
                         new SessionPropertyManager(),
                         new TablePropertyManager(),

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -331,7 +331,6 @@ public class LocalQueryRunner
                 catalogManager,
                 notificationExecutor);
         this.nodePartitioningManager = new NodePartitioningManager(nodeScheduler, blockTypeOperators);
-        this.groupProvider = new TestingGroupProvider();
 
         BlockEncodingManager blockEncodingManager = new BlockEncodingManager();
         TypeRegistry typeRegistry = new TypeRegistry(typeOperators, featuresConfig);
@@ -341,7 +340,6 @@ public class LocalQueryRunner
                 featuresConfig,
                 new DisabledSystemSecurityMetadata(),
                 transactionManager,
-                groupProvider,
                 typeOperators,
                 blockTypeOperators,
                 typeManager,
@@ -352,6 +350,7 @@ public class LocalQueryRunner
         this.planFragmenter = new PlanFragmenter(metadata, this.nodePartitioningManager, new QueryManagerConfig());
         this.joinCompiler = new JoinCompiler(typeOperators);
         PageIndexerFactory pageIndexerFactory = new GroupByHashPageIndexerFactory(joinCompiler, blockTypeOperators);
+        this.groupProvider = new TestingGroupProvider();
         this.accessControl = new TestingAccessControlManager(transactionManager, eventListenerManager);
         accessControl.loadSystemAccessControl(AllowAllSystemAccessControl.NAME, ImmutableMap.of());
 
@@ -368,6 +367,7 @@ public class LocalQueryRunner
                 plannerContext,
                 sqlParser,
                 accessControl,
+                groupProvider,
                 tableProceduresRegistry,
                 sessionPropertyManager,
                 tablePropertyManager,

--- a/plugin/trino-ml/src/test/java/io/trino/plugin/ml/TestLearnAggregations.java
+++ b/plugin/trino-ml/src/test/java/io/trino/plugin/ml/TestLearnAggregations.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.ml;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
 import io.trino.FeaturesConfig;
 import io.trino.RowPageBuilder;
@@ -71,7 +70,6 @@ public class TestLearnAggregations
                 new FeaturesConfig(),
                 new DisabledSystemSecurityMetadata(),
                 transactionManager,
-                user -> ImmutableSet.of(),
                 typeOperators,
                 new BlockTypeOperators(typeOperators),
                 typeManager,


### PR DESCRIPTION
Revert "Reuse view owner identity"

This change was not needed as ViewAccessControl was using Identity that
was created by Idenity.from which reuses passed base Identity.

Also that change was incorrect as it was not adding groups to
materialized views.

This reverts commit 3278c8ace96926acdbbd127e5d397909d7542352.
