### PR TITLE
Document allow-drop-table property in JDBC connectors

### DIFF
--- a/docs/src/main/sphinx/connector/allow-drop-table-config.fragment
+++ b/docs/src/main/sphinx/connector/allow-drop-table-config.fragment
@@ -1,0 +1,11 @@
+DROP TABLE
+^^^^^^^^^^
+
+The connector disables use of :doc:`/sql/drop-table` statements by default.
+To enable these statements, configure the ``allow-drop-table`` catalog
+configuration property:
+
+.. code-block:: properties
+
+    allow-drop-table=true
+

--- a/docs/src/main/sphinx/connector/clickhouse.rst
+++ b/docs/src/main/sphinx/connector/clickhouse.rst
@@ -208,3 +208,5 @@ statements, the connector supports the following features:
 * :ref:`sql-schema-table-management`
 
 .. include:: alter-schema-limitation.fragment
+
+.. include:: allow-drop-table-config.fragment

--- a/docs/src/main/sphinx/connector/jdbc-common-configurations.fragment
+++ b/docs/src/main/sphinx/connector/jdbc-common-configurations.fragment
@@ -47,3 +47,6 @@ connector:
       session property </sql/set-session>` is ``join_pushdown_enabled``.  Enabling
       this may negatively impact performance for some queries.
     - ``false``
+  * - ``allow-drop-table``
+    - Enable :doc:`/sql/drop-table` statements if supported by the connector.
+    - ``false``

--- a/docs/src/main/sphinx/connector/memsql.rst
+++ b/docs/src/main/sphinx/connector/memsql.rst
@@ -138,3 +138,5 @@ statements, the connector supports the following features:
 .. include:: sql-delete-limitation.fragment
 
 .. include:: alter-table-limitation.fragment
+
+.. include:: allow-drop-table-config.fragment

--- a/docs/src/main/sphinx/connector/mysql.rst
+++ b/docs/src/main/sphinx/connector/mysql.rst
@@ -328,3 +328,5 @@ the following statements:
 * :doc:`/sql/drop-schema`
 
 .. include:: sql-delete-limitation.fragment
+
+.. include:: allow-drop-table-config.fragment

--- a/docs/src/main/sphinx/connector/oracle.rst
+++ b/docs/src/main/sphinx/connector/oracle.rst
@@ -457,3 +457,5 @@ supports the following statements:
 .. include:: sql-delete-limitation.fragment
 
 .. include:: alter-table-limitation.fragment
+
+.. include:: allow-drop-table-config.fragment

--- a/docs/src/main/sphinx/connector/phoenix.rst
+++ b/docs/src/main/sphinx/connector/phoenix.rst
@@ -234,3 +234,15 @@ statements, the connector supports the following features:
 * :doc:`/sql/drop-schema`
 
 .. include:: sql-delete-limitation.fragment
+
+DROP TABLE
+^^^^^^^^^^
+
+The connector allows use of :doc:`/sql/drop-table` statements by default.
+To disable these statements, configure the ``allow-drop-table`` catalog
+configuration property:
+
+.. code-block:: properties
+
+    allow-drop-table=false
+

--- a/docs/src/main/sphinx/connector/postgresql.rst
+++ b/docs/src/main/sphinx/connector/postgresql.rst
@@ -169,6 +169,8 @@ statements, the connector supports the following features:
 
 .. include:: alter-schema-limitation.fragment
 
+.. include:: allow-drop-table-config.fragment
+
 .. _postgresql-pushdown:
 
 Pushdown

--- a/docs/src/main/sphinx/connector/redshift.rst
+++ b/docs/src/main/sphinx/connector/redshift.rst
@@ -127,3 +127,5 @@ statements, the connector supports the following features:
 .. include:: alter-table-limitation.fragment
 
 .. include:: alter-schema-limitation.fragment
+
+.. include:: allow-drop-table-config.fragment

--- a/docs/src/main/sphinx/connector/sqlserver.rst
+++ b/docs/src/main/sphinx/connector/sqlserver.rst
@@ -158,6 +158,8 @@ supports the following features:
 
 .. include:: alter-table-limitation.fragment
 
+.. include:: allow-drop-table-config.fragment
+
 .. _sqlserver-pushdown:
 
 Pushdown


### PR DESCRIPTION
As of Trino 368 at least, the `allow-drop-table` property must be enabled to allow `DROP TABLE` statements. This is at least true for JDBC connectors, need clarification if this applies to others.