### PR TITLE
Expose data files rows statistics fields in $manifests table

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -775,9 +775,9 @@ You can retrieve the information about the manifests of the Iceberg table
 
 .. code-block:: text
 
-     path                                                                                                           | length          | partition_spec_id    | added_snapshot_id     |  added_data_files_count  | existing_data_files_count   | deleted_data_files_count    | partitions
-    ----------------------------------------------------------------------------------------------------------------+-----------------+----------------------+-----------------------+--------------------------+-----------------------------+-----------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
-     hdfs://hadoop-master:9000/user/hive/warehouse/test_table/metadata/faa19903-1455-4bb8-855a-61a1bbafbaa7-m0.avro |  6277           |   0                  | 7860805980949777961   |  1                       |   0                         |  0                          |{{contains_null=false, contains_nan= false, lower_bound=1, upper_bound=1},{contains_null=false, contains_nan= false, lower_bound=2021-01-12, upper_bound=2021-01-12}}
+     path                                                                                                           | length          | partition_spec_id    | added_snapshot_id     | added_data_files_count  | added_rows_count | existing_data_files_count   | existing_rows_count | deleted_data_files_count    | deleted_rows_count | partitions
+    ----------------------------------------------------------------------------------------------------------------+-----------------+----------------------+-----------------------+-------------------------+------------------+-----------------------------+---------------------+-----------------------------+--------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+     hdfs://hadoop-master:9000/user/hive/warehouse/test_table/metadata/faa19903-1455-4bb8-855a-61a1bbafbaa7-m0.avro |  6277           |   0                  | 7860805980949777961   | 1                       | 100              | 0                           | 0                   | 0                           | 0                  | {{contains_null=false, contains_nan= false, lower_bound=1, upper_bound=1},{contains_null=false, contains_nan= false, lower_bound=2021-01-12, upper_bound=2021-01-12}}
 
 
 The output of the query has the following columns:
@@ -804,12 +804,21 @@ The output of the query has the following columns:
   * - ``added_data_files_count``
     - ``integer``
     - The number of data files with status ``ADDED`` in the manifest file
+  * - ``added_rows_count``
+    - ``bigint``
+    - The total number of rows in all data files with status ``ADDED`` in the manifest file.
   * - ``existing_data_files_count``
     - ``integer``
     - The number of data files with status ``EXISTING`` in the manifest file
+  * - ``existing_rows_count``
+    - ``bigint``
+    - The total number of rows in all data files with status ``EXISTING`` in the manifest file.
   * - ``deleted_data_files_count``
     - ``integer``
     - The number of data files with status ``DELETED`` in the manifest file
+  * - ``deleted_rows_count``
+    - ``bigint``
+    - The total number of rows in all data files with status ``DELETED`` in the manifest file.
   * - ``partitions``
     - ``array(row(contains_null boolean, contains_nan boolean, lower_bound varchar, upper_bound varchar))``
     - Partition range metadata

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ManifestsTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ManifestsTable.java
@@ -68,8 +68,11 @@ public class ManifestsTable
                         .add(new ColumnMetadata("partition_spec_id", INTEGER))
                         .add(new ColumnMetadata("added_snapshot_id", BIGINT))
                         .add(new ColumnMetadata("added_data_files_count", INTEGER))
+                        .add(new ColumnMetadata("added_rows_count", BIGINT))
                         .add(new ColumnMetadata("existing_data_files_count", INTEGER))
+                        .add(new ColumnMetadata("existing_rows_count", BIGINT))
                         .add(new ColumnMetadata("deleted_data_files_count", INTEGER))
+                        .add(new ColumnMetadata("deleted_rows_count", BIGINT))
                         .add(new ColumnMetadata("partitions", new ArrayType(RowType.rowType(
                                 RowType.field("contains_null", BOOLEAN),
                                 RowType.field("contains_nan", BOOLEAN),
@@ -118,8 +121,11 @@ public class ManifestsTable
             pagesBuilder.appendInteger(file.partitionSpecId());
             pagesBuilder.appendBigint(file.snapshotId());
             pagesBuilder.appendInteger(file.addedFilesCount());
+            pagesBuilder.appendBigint(file.addedRowsCount());
             pagesBuilder.appendInteger(file.existingFilesCount());
+            pagesBuilder.appendBigint(file.existingRowsCount());
             pagesBuilder.appendInteger(file.deletedFilesCount());
+            pagesBuilder.appendBigint(file.deletedRowsCount());
             writePartitionSummaries(pagesBuilder.nextColumn(), file.partitions(), partitionSpecsById.get(file.partitionSpecId()));
             pagesBuilder.endRow();
         });


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

Expose `org.apache.iceberg.ManifestFile` data files rows fields  which are not yet exposed in the `$manifests` metadata table.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Iceberg connector

> How would you describe this change to a non-technical end user or system administrator?

Expose further fields in the `$manifests` Iceberg metadata table.


## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Iceberg
* Add `added_rows_count`, `existing_rows_count` and `deleted_rows_count` columns to `$manifests` table
```


