### PR TITLE
Expire Snapshot and Remove Orphan files for Iceberg together with coordinator-only execute

### DIFF
--- a/lib/trino-plugin-toolkit/pom.xml
+++ b/lib/trino-plugin-toolkit/pom.xml
@@ -90,6 +90,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/util/Procedures.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/util/Procedures.java
@@ -11,16 +11,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.iceberg.procedure;
+package io.trino.plugin.base.util;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.google.errorprone.annotations.FormatMethod;
+import io.trino.spi.TrinoException;
 
-@JsonTypeInfo(
-        use = JsonTypeInfo.Id.NAME,
-        property = "@type")
-@JsonSubTypes({
-        @JsonSubTypes.Type(value = IcebergOptimizeHandle.class, name = "optimize"),
-        @JsonSubTypes.Type(value = IcebergExpireSnapshotsHandle.class, name = "expire_snapshots"),
-})
-public abstract class IcebergProcedureHandle {}
+import static io.trino.spi.StandardErrorCode.INVALID_PROCEDURE_ARGUMENT;
+import static java.lang.String.format;
+
+public final class Procedures
+{
+    private Procedures() {}
+
+    @FormatMethod
+    public static void checkProcedureArgument(boolean condition, String message, Object... args)
+    {
+        if (!condition) {
+            throw new TrinoException(INVALID_PROCEDURE_ARGUMENT, format(message, args));
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -27,12 +27,14 @@ import java.util.Optional;
 import static io.trino.plugin.hive.HiveCompressionCodec.ZSTD;
 import static io.trino.plugin.iceberg.CatalogType.HIVE_METASTORE;
 import static io.trino.plugin.iceberg.IcebergFileFormat.ORC;
+import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class IcebergConfig
 {
     public static final int FORMAT_VERSION_SUPPORT_MIN = 1;
     public static final int FORMAT_VERSION_SUPPORT_MAX = 2;
+    public static final String EXPIRE_SNAPSHOTS_MIN_RETENTION = "iceberg.expire_snapshots.min-retention";
 
     private IcebergFileFormat fileFormat = ORC;
     private HiveCompressionCodec compressionCodec = ZSTD;
@@ -45,6 +47,7 @@ public class IcebergConfig
     private boolean projectionPushdownEnabled = true;
     private Optional<String> hiveCatalogName = Optional.empty();
     private int formatVersion = FORMAT_VERSION_SUPPORT_MIN;
+    private Duration expireSnapshotsMinRetention = new Duration(7, DAYS);
 
     public CatalogType getCatalogType()
     {
@@ -200,6 +203,20 @@ public class IcebergConfig
     public IcebergConfig setFormatVersion(int formatVersion)
     {
         this.formatVersion = formatVersion;
+        return this;
+    }
+
+    @NotNull
+    public Duration getExpireSnapshotsMinRetention()
+    {
+        return expireSnapshotsMinRetention;
+    }
+
+    @Config(EXPIRE_SNAPSHOTS_MIN_RETENTION)
+    @ConfigDescription("Minimal retention period for expire_snapshot procedure")
+    public IcebergConfig setExpireSnapshotsMinRetention(Duration expireSnapshotsMinRetention)
+    {
+        this.expireSnapshotsMinRetention = expireSnapshotsMinRetention;
         return this;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -35,6 +35,7 @@ public class IcebergConfig
     public static final int FORMAT_VERSION_SUPPORT_MIN = 1;
     public static final int FORMAT_VERSION_SUPPORT_MAX = 2;
     public static final String EXPIRE_SNAPSHOTS_MIN_RETENTION = "iceberg.expire_snapshots.min-retention";
+    public static final String DELETE_ORPHAN_FILES_MIN_RETENTION = "iceberg.delete_orphan_files.min-retention";
 
     private IcebergFileFormat fileFormat = ORC;
     private HiveCompressionCodec compressionCodec = ZSTD;
@@ -48,6 +49,7 @@ public class IcebergConfig
     private Optional<String> hiveCatalogName = Optional.empty();
     private int formatVersion = FORMAT_VERSION_SUPPORT_MIN;
     private Duration expireSnapshotsMinRetention = new Duration(7, DAYS);
+    private Duration deleteOrphanFilesMinRetention = new Duration(7, DAYS);
 
     public CatalogType getCatalogType()
     {
@@ -217,6 +219,20 @@ public class IcebergConfig
     public IcebergConfig setExpireSnapshotsMinRetention(Duration expireSnapshotsMinRetention)
     {
         this.expireSnapshotsMinRetention = expireSnapshotsMinRetention;
+        return this;
+    }
+
+    @NotNull
+    public Duration getDeleteOrphanFilesMinRetention()
+    {
+        return deleteOrphanFilesMinRetention;
+    }
+
+    @Config(DELETE_ORPHAN_FILES_MIN_RETENTION)
+    @ConfigDescription("Minimal retention period for delete_orphan_files procedure")
+    public IcebergConfig setDeleteOrphanFilesMinRetention(Duration deleteOrphanFilesMinRetention)
+    {
+        this.deleteOrphanFilesMinRetention = deleteOrphanFilesMinRetention;
         return this;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
@@ -25,6 +25,7 @@ import io.trino.plugin.hive.orc.OrcReaderConfig;
 import io.trino.plugin.hive.orc.OrcWriterConfig;
 import io.trino.plugin.hive.parquet.ParquetReaderConfig;
 import io.trino.plugin.hive.parquet.ParquetWriterConfig;
+import io.trino.plugin.iceberg.procedure.ExpireSnapshotsTableProcedure;
 import io.trino.plugin.iceberg.procedure.OptimizeTableProcedure;
 import io.trino.spi.connector.ConnectorNodePartitioningProvider;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
@@ -80,5 +81,6 @@ public class IcebergModule
 
         Multibinder<TableProcedureMetadata> tableProcedures = newSetBinder(binder, TableProcedureMetadata.class);
         tableProcedures.addBinding().toProvider(OptimizeTableProcedure.class).in(Scopes.SINGLETON);
+        tableProcedures.addBinding().toProvider(ExpireSnapshotsTableProcedure.class).in(Scopes.SINGLETON);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
@@ -25,6 +25,7 @@ import io.trino.plugin.hive.orc.OrcReaderConfig;
 import io.trino.plugin.hive.orc.OrcWriterConfig;
 import io.trino.plugin.hive.parquet.ParquetReaderConfig;
 import io.trino.plugin.hive.parquet.ParquetWriterConfig;
+import io.trino.plugin.iceberg.procedure.DeleteOrphanFilesTableProcedure;
 import io.trino.plugin.iceberg.procedure.ExpireSnapshotsTableProcedure;
 import io.trino.plugin.iceberg.procedure.OptimizeTableProcedure;
 import io.trino.spi.connector.ConnectorNodePartitioningProvider;
@@ -82,5 +83,6 @@ public class IcebergModule
         Multibinder<TableProcedureMetadata> tableProcedures = newSetBinder(binder, TableProcedureMetadata.class);
         tableProcedures.addBinding().toProvider(OptimizeTableProcedure.class).in(Scopes.SINGLETON);
         tableProcedures.addBinding().toProvider(ExpireSnapshotsTableProcedure.class).in(Scopes.SINGLETON);
+        tableProcedures.addBinding().toProvider(DeleteOrphanFilesTableProcedure.class).in(Scopes.SINGLETON);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
@@ -124,8 +124,9 @@ public class IcebergPageSinkProvider
                         optimizeHandle.getFileFormat(),
                         optimizeHandle.getTableStorageProperties(),
                         maxOpenPartitions);
+            case EXPIRE_SNAPSHOTS:
+                // handled via ConnectorMetadata.executeTableExecute
         }
-
         throw new IllegalArgumentException("Unknown procedure: " + executeHandle.getProcedureId());
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
@@ -125,6 +125,7 @@ public class IcebergPageSinkProvider
                         optimizeHandle.getTableStorageProperties(),
                         maxOpenPartitions);
             case EXPIRE_SNAPSHOTS:
+            case DELETE_ORPHAN_FILES:
                 // handled via ConnectorMetadata.executeTableExecute
         }
         throw new IllegalArgumentException("Unknown procedure: " + executeHandle.getProcedureId());

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -75,6 +75,7 @@ public final class IcebergSessionProperties
     private static final String TARGET_MAX_FILE_SIZE = "target_max_file_size";
     private static final String HIVE_CATALOG_NAME = "hive_catalog_name";
     public static final String EXPIRE_SNAPSHOTS_MIN_RETENTION = "expire_snapshots_min_retention";
+    public static final String DELETE_ORPHAN_FILES_MIN_RETENTION = "delete_orphan_files_min_retention";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -235,6 +236,11 @@ public final class IcebergSessionProperties
                         "Minimal retention period for expire_snapshot procedure",
                         icebergConfig.getExpireSnapshotsMinRetention(),
                         false))
+                .add(durationProperty(
+                        DELETE_ORPHAN_FILES_MIN_RETENTION,
+                        "Minimal retention period for delete_orphan_files procedure",
+                        icebergConfig.getDeleteOrphanFilesMinRetention(),
+                        false))
                 .build();
     }
 
@@ -384,5 +390,10 @@ public final class IcebergSessionProperties
     public static Duration getExpireSnapshotMinRetention(ConnectorSession session)
     {
         return session.getProperty(EXPIRE_SNAPSHOTS_MIN_RETENTION, Duration.class);
+    }
+
+    public static Duration getDeleteOrphanFilesMinRetention(ConnectorSession session)
+    {
+        return session.getProperty(DELETE_ORPHAN_FILES_MIN_RETENTION, Duration.class);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -74,6 +74,7 @@ public final class IcebergSessionProperties
     private static final String PROJECTION_PUSHDOWN_ENABLED = "projection_pushdown_enabled";
     private static final String TARGET_MAX_FILE_SIZE = "target_max_file_size";
     private static final String HIVE_CATALOG_NAME = "hive_catalog_name";
+    public static final String EXPIRE_SNAPSHOTS_MIN_RETENTION = "expire_snapshots_min_retention";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -229,6 +230,11 @@ public final class IcebergSessionProperties
                         // Session-level redirections configuration does not work well with views, as view body is analyzed in context
                         // of a session with properties stripped off. Thus, this property is more of a test-only, or at most POC usefulness.
                         true))
+                .add(durationProperty(
+                        EXPIRE_SNAPSHOTS_MIN_RETENTION,
+                        "Minimal retention period for expire_snapshot procedure",
+                        icebergConfig.getExpireSnapshotsMinRetention(),
+                        false))
                 .build();
     }
 
@@ -373,5 +379,10 @@ public final class IcebergSessionProperties
     public static Optional<String> getHiveCatalogName(ConnectorSession session)
     {
         return Optional.ofNullable(session.getProperty(HIVE_CATALOG_NAME, String.class));
+    }
+
+    public static Duration getExpireSnapshotMinRetention(ConnectorSession session)
+    {
+        return session.getProperty(EXPIRE_SNAPSHOTS_MIN_RETENTION, Duration.class);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/DeleteOrphanFilesTableProcedure.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/DeleteOrphanFilesTableProcedure.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.procedure;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.units.Duration;
+import io.trino.spi.connector.TableProcedureMetadata;
+
+import javax.inject.Provider;
+
+import static io.trino.plugin.base.session.PropertyMetadataUtil.durationProperty;
+import static io.trino.plugin.iceberg.procedure.IcebergTableProcedureId.DELETE_ORPHAN_FILES;
+import static io.trino.spi.connector.TableProcedureExecutionMode.coordinatorOnly;
+
+public class DeleteOrphanFilesTableProcedure
+        implements Provider<TableProcedureMetadata>
+{
+    @Override
+    public TableProcedureMetadata get()
+    {
+        return new TableProcedureMetadata(
+                DELETE_ORPHAN_FILES.name(),
+                coordinatorOnly(),
+                ImmutableList.of(
+                        durationProperty(
+                                "retention_threshold",
+                                "Files older than threshold should be removed",
+                                Duration.valueOf("7d"),
+                                false)));
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/ExpireSnapshotsTableProcedure.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/ExpireSnapshotsTableProcedure.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.procedure;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.units.Duration;
+import io.trino.spi.connector.TableProcedureMetadata;
+
+import javax.inject.Provider;
+
+import static io.trino.plugin.base.session.PropertyMetadataUtil.durationProperty;
+import static io.trino.plugin.iceberg.procedure.IcebergTableProcedureId.EXPIRE_SNAPSHOTS;
+import static io.trino.spi.connector.TableProcedureExecutionMode.coordinatorOnly;
+
+public class ExpireSnapshotsTableProcedure
+        implements Provider<TableProcedureMetadata>
+{
+    @Override
+    public TableProcedureMetadata get()
+    {
+        return new TableProcedureMetadata(
+                EXPIRE_SNAPSHOTS.name(),
+                coordinatorOnly(),
+                ImmutableList.of(
+                        durationProperty(
+                                "retention_threshold",
+                                "Only snapshots older than threshold should be removed",
+                                Duration.valueOf("7d"),
+                                false)));
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergDeleteOrphanFilesHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergDeleteOrphanFilesHandle.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.procedure;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.airlift.units.Duration;
+
+import static java.util.Objects.requireNonNull;
+
+public class IcebergDeleteOrphanFilesHandle
+        extends IcebergProcedureHandle
+{
+    private final Duration retentionThreshold;
+
+    @JsonCreator
+    public IcebergDeleteOrphanFilesHandle(Duration retentionThreshold)
+    {
+        this.retentionThreshold = requireNonNull(retentionThreshold, "retentionThreshold is null");
+    }
+
+    @JsonProperty
+    public Duration getRetentionThreshold()
+    {
+        return retentionThreshold;
+    }
+
+    @Override
+    public String toString()
+    {
+        return new StringBuilder()
+                .append("retentionThreshold=").append(retentionThreshold)
+                .toString();
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergExpireSnapshotsHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergExpireSnapshotsHandle.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.procedure;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.airlift.units.Duration;
+
+import static java.util.Objects.requireNonNull;
+
+public class IcebergExpireSnapshotsHandle
+        extends IcebergProcedureHandle
+{
+    private final Duration retentionThreshold;
+
+    @JsonCreator
+    public IcebergExpireSnapshotsHandle(Duration retentionThreshold)
+    {
+        this.retentionThreshold = requireNonNull(retentionThreshold, "retentionThreshold is null");
+    }
+
+    @JsonProperty
+    public Duration getRetentionThreshold()
+    {
+        return retentionThreshold;
+    }
+
+    @Override
+    public String toString()
+    {
+        return new StringBuilder()
+                .append("retentionThreshold:").append(retentionThreshold)
+                .toString();
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergProcedureHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergProcedureHandle.java
@@ -22,5 +22,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonSubTypes({
         @JsonSubTypes.Type(value = IcebergOptimizeHandle.class, name = "optimize"),
         @JsonSubTypes.Type(value = IcebergExpireSnapshotsHandle.class, name = "expire_snapshots"),
+        @JsonSubTypes.Type(value = IcebergDeleteOrphanFilesHandle.class, name = "delete_orphan_files"),
 })
 public abstract class IcebergProcedureHandle {}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergTableExecuteHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergTableExecuteHandle.java
@@ -73,4 +73,14 @@ public class IcebergTableExecuteHandle
                 procedureHandle,
                 tableLocation);
     }
+
+    @Override
+    public String toString()
+    {
+        return new StringBuilder()
+                .append("schemaTableName").append(":").append(schemaTableName)
+                .append(", procedureId").append(":").append(procedureId)
+                .append(", procedureHandle").append(":{").append(procedureHandle).append("}")
+                .toString();
+    }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergTableProcedureId.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergTableProcedureId.java
@@ -16,4 +16,5 @@ package io.trino.plugin.iceberg.procedure;
 public enum IcebergTableProcedureId
 {
     OPTIMIZE,
+    EXPIRE_SNAPSHOTS,
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergTableProcedureId.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergTableProcedureId.java
@@ -17,4 +17,5 @@ public enum IcebergTableProcedureId
 {
     OPTIMIZE,
     EXPIRE_SNAPSHOTS,
+    DELETE_ORPHAN_FILES,
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -54,6 +54,7 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -3351,10 +3352,135 @@ public abstract class BaseIcebergConnectorTest
                 "\\QRetention specified (33.00s) is shorter than the minimum retention configured in the system (7.00d). Minimum retention can be changed with iceberg.expire_snapshots.min-retention configuration property or iceberg.expire_snapshots_min_retention session property");
     }
 
+    @Test
+    public void testDeleteOrphanFiles()
+            throws Exception
+    {
+        String tableName = "test_deleting_orphan_files_unnecessary_files" + randomTableSuffix();
+        Session sessionWithShortRetentionUnlocked = prepareCleanUpSession();
+        assertUpdate("CREATE TABLE " + tableName + " (key varchar, value integer)");
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('one', 1)", 1);
+        Path orphanFile = Files.createFile(Path.of(getIcebergTableDataPath(tableName).toString(), "invalidData." + format));
+        List<String> initialDataFiles = getAllDataFilesFromTableDirectory(tableName);
+
+        assertQuerySucceeds(sessionWithShortRetentionUnlocked, "ALTER TABLE " + tableName + " EXECUTE DELETE_ORPHAN_FILES (retention_threshold => '0s')");
+
+        List<String> updatedDataFiles = getAllDataFilesFromTableDirectory(tableName);
+        assertThat(updatedDataFiles.size()).isLessThan(initialDataFiles.size());
+        assertThat(updatedDataFiles).doesNotContain(orphanFile.toString());
+    }
+
+    @Test
+    public void testIfDeleteOrphanFilesCleansUnnecessaryDataFilesInPartitionedTable()
+            throws Exception
+    {
+        String tableName = "test_deleting_orphan_files_unnecessary_files" + randomTableSuffix();
+        Session sessionWithShortRetentionUnlocked = prepareCleanUpSession();
+        assertUpdate("CREATE TABLE " + tableName + " (key varchar, value integer) WITH (partitioning = ARRAY['key'])");
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('one', 1)", 1);
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('two', 2)", 1);
+        Path orphanFile = Files.createFile(Path.of(getIcebergTableDataPath(tableName) + "/key=one/", "invalidData." + format));
+        List<String> initialDataFiles = getAllDataFilesFromTableDirectory(tableName);
+
+        assertQuerySucceeds(sessionWithShortRetentionUnlocked, "ALTER TABLE " + tableName + " EXECUTE DELETE_ORPHAN_FILES (retention_threshold => '0s')");
+
+        List<String> updatedDataFiles = getAllDataFilesFromTableDirectory(tableName);
+        assertThat(updatedDataFiles.size()).isLessThan(initialDataFiles.size());
+        assertThat(updatedDataFiles).doesNotContain(orphanFile.toString());
+    }
+
+    @Test
+    public void testIfDeleteOrphanFilesCleansUnnecessaryMetadataFilesInPartitionedTable()
+            throws Exception
+    {
+        String tableName = "test_deleting_orphan_files_unnecessary_files" + randomTableSuffix();
+        Session sessionWithShortRetentionUnlocked = prepareCleanUpSession();
+        assertUpdate("CREATE TABLE " + tableName + " (key varchar, value integer) WITH (partitioning = ARRAY['key'])");
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('one', 1)", 1);
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('two', 2)", 1);
+        Path orphanMetadataFile = Files.createFile(Path.of(getIcebergTableMetadataPath(tableName).toString(), "invalidData." + format));
+        List<String> initialMetadataFiles = getAllMetadataFilesFromTableDirectoryForTable(tableName);
+
+        assertQuerySucceeds(sessionWithShortRetentionUnlocked, "ALTER TABLE " + tableName + " EXECUTE DELETE_ORPHAN_FILES (retention_threshold => '0s')");
+
+        List<String> updatedMetadataFiles = getAllMetadataFilesFromTableDirectoryForTable(tableName);
+        assertThat(updatedMetadataFiles.size()).isLessThan(initialMetadataFiles.size());
+        assertThat(updatedMetadataFiles).doesNotContain(orphanMetadataFile.toString());
+    }
+
+    @Test
+    public void testCleaningUpWithTableWithSpecifiedLocationWithSlashAtTheEnd()
+            throws IOException
+    {
+        testCleaningUpWithTableWithSpecifiedLocation("/");
+    }
+
+    @Test
+    public void testCleaningUpWithTableWithSpecifiedLocationWithoutSlashAtTheEnd()
+            throws IOException
+    {
+        testCleaningUpWithTableWithSpecifiedLocation("");
+    }
+
+    private void testCleaningUpWithTableWithSpecifiedLocation(String suffix)
+            throws IOException
+    {
+        File tempDir = getDistributedQueryRunner().getCoordinator().getBaseDataDir().toFile();
+        String tempDirPath = tempDir.toURI().toASCIIString() + randomTableSuffix() + suffix;
+        String tableName = "test_table_cleaning_up_with_location" + randomTableSuffix();
+
+        assertUpdate(format("CREATE TABLE %s (key varchar, value integer) WITH(location = '%s')", tableName, tempDirPath));
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('one', 1)", 1);
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('two', 2)", 1);
+
+        List<String> initialFiles = getAllMetadataFilesFromTableDirectory(tempDirPath);
+        List<Long> initialSnapshots = getSnapshotIds(tableName);
+
+        Session sessionWithShortRetentionUnlocked = prepareCleanUpSession();
+        assertQuerySucceeds(sessionWithShortRetentionUnlocked, "ALTER TABLE " + tableName + " EXECUTE EXPIRE_SNAPSHOTS (retention_threshold => '0s')");
+        assertQuerySucceeds(sessionWithShortRetentionUnlocked, "ALTER TABLE " + tableName + " EXECUTE DELETE_ORPHAN_FILES (retention_threshold => '0s')");
+        List<String> updatedFiles = getAllMetadataFilesFromTableDirectory(tempDirPath);
+        List<Long> updatedSnapshots = getSnapshotIds(tableName);
+        assertThat(updatedFiles.size()).isEqualTo(initialFiles.size() - 1);
+        assertThat(updatedSnapshots.size()).isLessThan(initialSnapshots.size());
+        assertThat(updatedSnapshots.size()).isEqualTo(1);
+        assertThat(initialSnapshots).containsAll(updatedSnapshots);
+    }
+
+    @Test
+    public void testExplainDeleteOrphanFilesOutput()
+    {
+        String tableName = "test_delete_orphan_files_output" + randomTableSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " (key varchar, value integer) WITH (partitioning = ARRAY['key'])");
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('one', 1)", 1);
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('two', 2)", 1);
+
+        assertExplain("EXPLAIN ALTER TABLE " + tableName + " EXECUTE DELETE_ORPHAN_FILES (retention_threshold => '0s')",
+                "SimpleTableExecute\\[iceberg:schemaTableName:tpch.test_delete_orphan_files.*\\{retentionThreshold=0\\.00s}.*");
+    }
+
+    @Test
+    public void testDeleteOrphanFilesParameterValidation()
+    {
+        assertQueryFails(
+                "ALTER TABLE no_such_table_exists EXECUTE DELETE_ORPHAN_FILES",
+                "\\Qline 1:1: Table 'iceberg.tpch.no_such_table_exists' does not exist");
+        assertQueryFails(
+                "ALTER TABLE nation EXECUTE DELETE_ORPHAN_FILES (retention_threshold => '33')",
+                "\\QUnable to set catalog 'iceberg' table procedure 'DELETE_ORPHAN_FILES' property 'retention_threshold' to ['33']: duration is not a valid data duration string: 33");
+        assertQueryFails(
+                "ALTER TABLE nation EXECUTE DELETE_ORPHAN_FILES (retention_threshold => '33mb')",
+                "\\QUnable to set catalog 'iceberg' table procedure 'DELETE_ORPHAN_FILES' property 'retention_threshold' to ['33mb']: Unknown time unit: mb");
+        assertQueryFails(
+                "ALTER TABLE nation EXECUTE DELETE_ORPHAN_FILES (retention_threshold => '33s')",
+                "\\QRetention specified (33.00s) is shorter than the minimum retention configured in the system (7.00d). Minimum retention can be changed with iceberg.delete_orphan_files.min-retention configuration property or iceberg.delete_orphan_files_min_retention session property");
+    }
+
     private Session prepareCleanUpSession()
     {
         return Session.builder(getSession())
                 .setCatalogSessionProperty("iceberg", "expire_snapshots_min_retention", "0s")
+                .setCatalogSessionProperty("iceberg", "delete_orphan_files_min_retention", "0s")
                 .build();
     }
 
@@ -3364,6 +3490,12 @@ public abstract class BaseIcebergConnectorTest
         String schema = getSession().getSchema().orElseThrow();
         Path tableDataDir = getDistributedQueryRunner().getCoordinator().getBaseDataDir().resolve("iceberg_data").resolve(schema).resolve(tableName).resolve("metadata");
         return listAllTableFilesInDirectory(tableDataDir);
+    }
+
+    private List<String> getAllMetadataFilesFromTableDirectory(String tableDataDir)
+            throws IOException
+    {
+        return listAllTableFilesInDirectory(Path.of(URI.create(tableDataDir).getPath()));
     }
 
     private List<String> listAllTableFilesInDirectory(Path tableDataPath)
@@ -3384,5 +3516,21 @@ public abstract class BaseIcebergConnectorTest
                 .getOnlyColumn()
                 .map(Long.class::cast)
                 .collect(toUnmodifiableList());
+    }
+
+    private Path getIcebergTableDataPath(String tableName)
+    {
+        return getIcebergTablePath(tableName, "data");
+    }
+
+    private Path getIcebergTableMetadataPath(String tableName)
+    {
+        return getIcebergTablePath(tableName, "metadata");
+    }
+
+    private Path getIcebergTablePath(String tableName, String suffix)
+    {
+        String schema = getSession().getSchema().orElseThrow();
+        return getDistributedQueryRunner().getCoordinator().getBaseDataDir().resolve("iceberg_data").resolve(schema).resolve(tableName).resolve(suffix);
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
@@ -49,7 +49,8 @@ public class TestIcebergConfig
                 .setProjectionPushdownEnabled(true)
                 .setHiveCatalogName(null)
                 .setFormatVersion(1)
-                .setExpireSnapshotsMinRetention(new Duration(7, DAYS)));
+                .setExpireSnapshotsMinRetention(new Duration(7, DAYS))
+                .setDeleteOrphanFilesMinRetention(new Duration(7, DAYS)));
     }
 
     @Test
@@ -68,6 +69,7 @@ public class TestIcebergConfig
                 .put("iceberg.hive-catalog-name", "hive")
                 .put("iceberg.format-version", "2")
                 .put("iceberg.expire_snapshots.min-retention", "13h")
+                .put("iceberg.delete_orphan_files.min-retention", "14h")
                 .buildOrThrow();
 
         IcebergConfig expected = new IcebergConfig()
@@ -82,7 +84,8 @@ public class TestIcebergConfig
                 .setProjectionPushdownEnabled(false)
                 .setHiveCatalogName("hive")
                 .setFormatVersion(2)
-                .setExpireSnapshotsMinRetention(new Duration(13, HOURS));
+                .setExpireSnapshotsMinRetention(new Duration(13, HOURS))
+                .setDeleteOrphanFilesMinRetention(new Duration(14, HOURS));
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
@@ -28,6 +28,8 @@ import static io.trino.plugin.iceberg.CatalogType.GLUE;
 import static io.trino.plugin.iceberg.CatalogType.HIVE_METASTORE;
 import static io.trino.plugin.iceberg.IcebergFileFormat.ORC;
 import static io.trino.plugin.iceberg.IcebergFileFormat.PARQUET;
+import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class TestIcebergConfig
@@ -46,7 +48,8 @@ public class TestIcebergConfig
                 .setTableStatisticsEnabled(true)
                 .setProjectionPushdownEnabled(true)
                 .setHiveCatalogName(null)
-                .setFormatVersion(1));
+                .setFormatVersion(1)
+                .setExpireSnapshotsMinRetention(new Duration(7, DAYS)));
     }
 
     @Test
@@ -64,6 +67,7 @@ public class TestIcebergConfig
                 .put("iceberg.projection-pushdown-enabled", "false")
                 .put("iceberg.hive-catalog-name", "hive")
                 .put("iceberg.format-version", "2")
+                .put("iceberg.expire_snapshots.min-retention", "13h")
                 .buildOrThrow();
 
         IcebergConfig expected = new IcebergConfig()
@@ -77,7 +81,8 @@ public class TestIcebergConfig
                 .setTableStatisticsEnabled(false)
                 .setProjectionPushdownEnabled(false)
                 .setHiveCatalogName("hive")
-                .setFormatVersion(2);
+                .setFormatVersion(2)
+                .setExpireSnapshotsMinRetention(new Duration(13, HOURS));
 
         assertFullMapping(properties, expected);
     }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
@@ -359,14 +359,14 @@ public class TestIcebergSparkCompatibility
         onTrino().executeQuery(format("CREATE TABLE %s (_string VARCHAR, _varbinary VARBINARY, _bigint BIGINT) WITH (partitioning = ARRAY['_string', '_varbinary'], format = '%s')", trinoTableName, storageFormat));
         onTrino().executeQuery(format("INSERT INTO %s VALUES ('a', X'0ff102f0feff', 1001), ('b', X'0ff102f0fefe', 1002), ('c', X'0ff102fdfeff', 1003)", trinoTableName));
 
-        Row row1 = row("b", new byte[]{15, -15, 2, -16, -2, -2}, 1002);
+        Row row1 = row("b", new byte[] {15, -15, 2, -16, -2, -2}, 1002);
         String selectByString = "SELECT * FROM %s WHERE _string = 'b'";
         assertThat(onTrino().executeQuery(format(selectByString, trinoTableName)))
                 .containsOnly(row1);
         assertThat(onSpark().executeQuery(format(selectByString, sparkTableName)))
                 .containsOnly(row1);
 
-        Row row2 = row("a", new byte[]{15, -15, 2, -16, -2, -1}, 1001);
+        Row row2 = row("a", new byte[] {15, -15, 2, -16, -2, -1}, 1001);
         String selectByVarbinary = "SELECT * FROM %s WHERE _varbinary = X'0ff102f0feff'";
         assertThat(onTrino().executeQuery(format(selectByVarbinary, trinoTableName)))
                 .containsOnly(row2);
@@ -391,14 +391,14 @@ public class TestIcebergSparkCompatibility
                 specVersion));
         onSpark().executeQuery(format("INSERT INTO %s VALUES ('a', X'0ff102f0feff', 1001), ('b', X'0ff102f0fefe', 1002), ('c', X'0ff102fdfeff', 1003)", sparkTableName));
 
-        Row row1 = row("a", new byte[]{15, -15, 2, -16, -2, -1}, 1001);
+        Row row1 = row("a", new byte[] {15, -15, 2, -16, -2, -1}, 1001);
         String select = "SELECT * FROM %s WHERE _string = 'a'";
         assertThat(onSpark().executeQuery(format(select, sparkTableName)))
                 .containsOnly(row1);
         assertThat(onTrino().executeQuery(format(select, trinoTableName)))
                 .containsOnly(row1);
 
-        Row row2 = row("c", new byte[]{15, -15, 2, -3, -2, -1}, 1003);
+        Row row2 = row("c", new byte[] {15, -15, 2, -3, -2, -1}, 1003);
         String selectByVarbinary = "SELECT * FROM %s WHERE _varbinary = X'0ff102fdfeff'";
         assertThat(onTrino().executeQuery(format(selectByVarbinary, trinoTableName)))
                 .containsOnly(row2);
@@ -1065,35 +1065,35 @@ public class TestIcebergSparkCompatibility
             QueryExecutor onTrino = onTrino();
             QueryExecutor onSpark = onSpark();
             List<Row> allInserted = executor.invokeAll(
-                            Stream.of(Engine.TRINO, Engine.SPARK)
-                                    .map(engine -> (Callable<List<Row>>) () -> {
-                                        List<Row> inserted = new ArrayList<>();
-                                        for (int i = 0; i < insertsPerEngine; i++) {
-                                            barrier.await(20, SECONDS);
-                                            String engineName = engine.name().toLowerCase(ENGLISH);
-                                            long value = i;
-                                            switch (engine) {
-                                                case TRINO:
-                                                    try {
-                                                        onTrino.executeQuery(format("INSERT INTO %s VALUES ('%s', %d)", trinoTableName, engineName, value));
-                                                    }
-                                                    catch (QueryExecutionException queryExecutionException) {
-                                                        // failed to insert
-                                                        continue; // next loop iteration
-                                                    }
-                                                    break;
-                                                case SPARK:
-                                                    onSpark.executeQuery(format("INSERT INTO %s VALUES ('%s', %d)", sparkTableName, engineName, value));
-                                                    break;
-                                                default:
-                                                    throw new UnsupportedOperationException("Unexpected engine: " + engine);
+                    Stream.of(Engine.TRINO, Engine.SPARK)
+                            .map(engine -> (Callable<List<Row>>) () -> {
+                                List<Row> inserted = new ArrayList<>();
+                                for (int i = 0; i < insertsPerEngine; i++) {
+                                    barrier.await(20, SECONDS);
+                                    String engineName = engine.name().toLowerCase(ENGLISH);
+                                    long value = i;
+                                    switch (engine) {
+                                        case TRINO:
+                                            try {
+                                                onTrino.executeQuery(format("INSERT INTO %s VALUES ('%s', %d)", trinoTableName, engineName, value));
                                             }
+                                            catch (QueryExecutionException queryExecutionException) {
+                                                // failed to insert
+                                                continue; // next loop iteration
+                                            }
+                                            break;
+                                        case SPARK:
+                                            onSpark.executeQuery(format("INSERT INTO %s VALUES ('%s', %d)", sparkTableName, engineName, value));
+                                            break;
+                                        default:
+                                            throw new UnsupportedOperationException("Unexpected engine: " + engine);
+                                    }
 
-                                            inserted.add(row(engineName, value));
-                                        }
-                                        return inserted;
-                                    })
-                                    .collect(toImmutableList())).stream()
+                                    inserted.add(row(engineName, value));
+                                }
+                                return inserted;
+                            })
+                            .collect(toImmutableList())).stream()
                     .map(MoreFutures::getDone)
                     .flatMap(List::stream)
                     .collect(toImmutableList());
@@ -1537,7 +1537,7 @@ public class TestIcebergSparkCompatibility
         return Stream.of(StorageFormat.values())
                 .filter(StorageFormat::isSupportedInTrino)
                 .flatMap(tableStorageFormat -> Arrays.stream(StorageFormat.values())
-                        .map(deleteFileStorageFormat -> new Object[]{tableStorageFormat, deleteFileStorageFormat}))
+                        .map(deleteFileStorageFormat -> new Object[] {tableStorageFormat, deleteFileStorageFormat}))
                 .toArray(Object[][]::new);
     }
 


### PR DESCRIPTION
Two new procedures are added to Iceberg connector:
1. REMOVE_ORPHAN_FILES - removes files from table folder that don't belong to any tables and that are older than minimum retention
2. EXPIRE_SNAPSHOTS - expires snapshots older than provided minimum retention

Trino lacked infrastructure to run a specific task on a single node tough the necessity for such a behaviour was predicted when table execute was introduced. 
This PR adds necessary changes to run tasks on coordinator only. 