### PR TITLE
Fix Jwt & OAuth2 authenticators seperation issue

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/jwt/ForJwt.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/jwt/ForJwt.java
@@ -26,6 +26,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Target({FIELD, PARAMETER, METHOD})
 @BindingAnnotation
-public @interface ForJwk
+public @interface ForJwt
 {
 }

--- a/core/trino-main/src/main/java/io/trino/server/security/jwt/JwkService.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/jwt/JwkService.java
@@ -25,7 +25,6 @@ import io.airlift.units.Duration;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.annotation.processing.Generated;
-import javax.inject.Inject;
 
 import java.io.IOException;
 import java.net.URI;
@@ -55,8 +54,7 @@ public final class JwkService
     @Generated("this")
     private Closer closer;
 
-    @Inject
-    public JwkService(@ForJwk URI address, @ForJwk HttpClient httpClient)
+    public JwkService(URI address, HttpClient httpClient)
     {
         this(address, httpClient, new Duration(15, TimeUnit.MINUTES));
     }

--- a/core/trino-main/src/main/java/io/trino/server/security/jwt/JwkSigningKeyResolver.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/jwt/JwkSigningKeyResolver.java
@@ -18,8 +18,6 @@ import io.jsonwebtoken.JwsHeader;
 import io.jsonwebtoken.SigningKeyResolver;
 import io.jsonwebtoken.security.SecurityException;
 
-import javax.inject.Inject;
-
 import java.security.Key;
 
 import static java.util.Objects.requireNonNull;
@@ -29,7 +27,6 @@ public class JwkSigningKeyResolver
 {
     private final JwkService keys;
 
-    @Inject
     public JwkSigningKeyResolver(JwkService keys)
     {
         this.keys = requireNonNull(keys, "keys is null");

--- a/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtAuthenticator.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtAuthenticator.java
@@ -39,7 +39,7 @@ public class JwtAuthenticator
     private final UserMapping userMapping;
 
     @Inject
-    public JwtAuthenticator(JwtAuthenticatorConfig config, SigningKeyResolver signingKeyResolver)
+    public JwtAuthenticator(JwtAuthenticatorConfig config, @ForJwt SigningKeyResolver signingKeyResolver)
     {
         principalField = config.getPrincipalField();
 

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2ServiceModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2ServiceModule.java
@@ -14,13 +14,11 @@
 package io.trino.server.security.oauth2;
 
 import com.google.inject.Binder;
-import com.google.inject.Key;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.airlift.http.client.HttpClient;
 import io.jsonwebtoken.SigningKeyResolver;
-import io.trino.server.security.jwt.ForJwk;
 import io.trino.server.security.jwt.JwkService;
 import io.trino.server.security.jwt.JwkSigningKeyResolver;
 import io.trino.server.ui.OAuth2WebUiInstalled;
@@ -62,18 +60,22 @@ public class OAuth2ServiceModule
                         .setTrustStorePath(null)
                         .setTrustStorePassword(null)
                         .setAutomaticHttpsSharedSecret(null));
-        // Used by JwkService
-        binder.bind(HttpClient.class).annotatedWith(ForJwk.class).to(Key.get(HttpClient.class, ForOAuth2.class));
-        binder.bind(JwkService.class).in(Scopes.SINGLETON);
-        binder.bind(SigningKeyResolver.class).annotatedWith(ForOAuth2.class).to(JwkSigningKeyResolver.class).in(Scopes.SINGLETON);
     }
 
     @Provides
     @Singleton
-    @ForJwk
-    public static URI createJwkAddress(OAuth2Config config)
+    @ForOAuth2
+    public static JwkService createJwkService(OAuth2Config config, @ForOAuth2 HttpClient httpClient)
     {
-        return URI.create(config.getJwksUrl());
+        return new JwkService(URI.create(config.getJwksUrl()), httpClient);
+    }
+
+    @Provides
+    @Singleton
+    @ForOAuth2
+    public static SigningKeyResolver createSigningKeyResolver(@ForOAuth2 JwkService jwkService)
+    {
+        return new JwkSigningKeyResolver(jwkService);
     }
 
     @Override


### PR DESCRIPTION
Jwt & OAuth2 use the same classes in order to resolve JSON Web Keys (JWK)
served over HTTP. Using both authenticators simultaneously resulted in a
duplicated binding error which this commit fixes through a better
binding seperation.