### PR TITLE
Close docker networks constructed in tests

### DIFF
--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestingDruidServer.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestingDruidServer.java
@@ -58,6 +58,7 @@ public class TestingDruidServer
     private final GenericContainer<?> middleManager;
     private final GenericContainer<?> zookeeper;
     private final OkHttpClient httpClient;
+    private final Network network;
 
     private static final int DRUID_COORDINATOR_PORT = 8081;
     private static final int DRUID_BROKER_PORT = 8082;
@@ -85,7 +86,7 @@ public class TestingDruidServer
             f.setReadable(true, false);
             f.setExecutable(true, false);
             this.httpClient = new OkHttpClient();
-            Network network = Network.newNetwork();
+            network = Network.newNetwork();
             this.zookeeper = new GenericContainer<>("zookeeper")
                     .withNetwork(network)
                     .withNetworkAliases("zookeeper")
@@ -193,6 +194,7 @@ public class TestingDruidServer
             closer.register(middleManager::stop);
             closer.register(coordinator::stop);
             closer.register(zookeeper::stop);
+            closer.register(network::close);
         }
         catch (FileSystemException e) {
             // Unfortunately, on CI environment, the user running file deletion runs into

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearchBackpressure.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearchBackpressure.java
@@ -31,6 +31,7 @@ public class TestElasticsearchBackpressure
 {
     private static final String image = "elasticsearch:7.0.0";
 
+    private Network network;
     private ElasticsearchServer elasticsearch;
     private ElasticsearchNginxProxy elasticsearchNginxProxy;
 
@@ -38,7 +39,7 @@ public class TestElasticsearchBackpressure
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        Network network = Network.newNetwork();
+        network = Network.newNetwork();
         elasticsearch = new ElasticsearchServer(network, image, ImmutableMap.of());
         elasticsearchNginxProxy = new ElasticsearchNginxProxy(network, 1);
 
@@ -58,6 +59,7 @@ public class TestElasticsearchBackpressure
     {
         elasticsearchNginxProxy.stop();
         elasticsearch.stop();
+        network.close();
     }
 
     @Test


### PR DESCRIPTION
If networks are not closed, eventually docker hits networking limits and docker network prune needs to be manually run

See the comment in this PR for more details:
https://github.com/trinodb/trino/pull/10802#discussion_r792923220