### PR TITLE
Deny DML commands on Hive bucketed tables created by Spark

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
@@ -177,6 +177,7 @@ public final class HiveUtil
 {
     public static final String SPARK_TABLE_PROVIDER_KEY = "spark.sql.sources.provider";
     public static final String DELTA_LAKE_PROVIDER = "delta";
+    public static final String SPARK_TABLE_BUCKET_NUMBER_KEY = "spark.sql.sources.schema.numBuckets";
 
     public static final String ICEBERG_TABLE_TYPE_NAME = "table_type";
     public static final String ICEBERG_TABLE_TYPE_VALUE = "iceberg";
@@ -1127,5 +1128,11 @@ public final class HiveUtil
     public static boolean isIcebergTable(Table table)
     {
         return ICEBERG_TABLE_TYPE_VALUE.equalsIgnoreCase(table.getParameters().get(ICEBERG_TABLE_TYPE_NAME));
+    }
+
+    public static boolean isSparkBucketedTable(Table table)
+    {
+        return table.getParameters().containsKey(SPARK_TABLE_PROVIDER_KEY)
+                && table.getParameters().containsKey(SPARK_TABLE_BUCKET_NUMBER_KEY);
     }
 }


### PR DESCRIPTION
Apache Spark does not use 'bucketing_version'
parameter while creating Hive tables.

In order to avoid corrupting the bucket files of the
Hive table by using an invalid hashing function for
the bucketing, Trino does not support any DML commands
on Hive bucketed tables created by Spark.