### PR TITLE
Dont use row block field block offsets if not needed

### DIFF
--- a/core/trino-main/src/test/java/io/trino/execution/buffer/BenchmarkDataGenerator.java
+++ b/core/trino-main/src/test/java/io/trino/execution/buffer/BenchmarkDataGenerator.java
@@ -13,8 +13,10 @@
  */
 package io.trino.execution.buffer;
 
+import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.LongTimestamp;
 import io.trino.spi.type.SqlDecimal;
+import io.trino.spi.type.Type;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -23,7 +25,9 @@ import java.util.List;
 import java.util.Random;
 import java.util.function.Function;
 
+import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 
 public class BenchmarkDataGenerator
 {
@@ -92,5 +96,25 @@ public class BenchmarkDataGenerator
     public static byte randomByte(Random random)
     {
         return (byte) random.nextInt();
+    }
+
+    public static List<Object> randomRow(List<Type> fieldTypes, Random random)
+    {
+        List<Object> row = new ArrayList<>(fieldTypes.size());
+        for (Type type : fieldTypes) {
+            if (type == VARCHAR) {
+                row.add(randomAsciiString(random));
+            }
+            else if (type == BIGINT) {
+                row.add(random.nextLong());
+            }
+            else if (type instanceof DecimalType) {
+                row.add(randomLongDecimal(random));
+            }
+            else {
+                throw new UnsupportedOperationException(String.format("The %s is not supported", type));
+            }
+        }
+        return row;
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
@@ -46,15 +46,10 @@ public class RowBlock
     public static Block fromFieldBlocks(int positionCount, Optional<boolean[]> rowIsNullOptional, Block[] fieldBlocks)
     {
         boolean[] rowIsNull = rowIsNullOptional.orElse(null);
-        int[] fieldBlockOffsets = new int[positionCount + 1];
-        if (rowIsNull == null) {
-            // Fast-path create identity field block offsets from position only
-            for (int position = 0; position < fieldBlockOffsets.length; position++) {
-                fieldBlockOffsets[position] = position;
-            }
-        }
-        else {
+        int[] fieldBlockOffsets = null;
+        if (rowIsNull != null) {
             // Check for nulls when computing field block offsets
+            fieldBlockOffsets = new int[positionCount + 1];
             fieldBlockOffsets[0] = 0;
             for (int position = 0; position < positionCount; position++) {
                 fieldBlockOffsets[position + 1] = fieldBlockOffsets[position] + (rowIsNull[position] ? 0 : 1);
@@ -63,6 +58,7 @@ public class RowBlock
             if (fieldBlockOffsets[positionCount] == positionCount) {
                 // No nulls encountered, discard the null mask
                 rowIsNull = null;
+                fieldBlockOffsets = null;
             }
         }
 
@@ -73,13 +69,13 @@ public class RowBlock
     /**
      * Create a row block directly without per element validations.
      */
-    static RowBlock createRowBlockInternal(int startOffset, int positionCount, @Nullable boolean[] rowIsNull, int[] fieldBlockOffsets, Block[] fieldBlocks)
+    static RowBlock createRowBlockInternal(int startOffset, int positionCount, @Nullable boolean[] rowIsNull, @Nullable int[] fieldBlockOffsets, Block[] fieldBlocks)
     {
         validateConstructorArguments(startOffset, positionCount, rowIsNull, fieldBlockOffsets, fieldBlocks);
         return new RowBlock(startOffset, positionCount, rowIsNull, fieldBlockOffsets, fieldBlocks);
     }
 
-    private static void validateConstructorArguments(int startOffset, int positionCount, @Nullable boolean[] rowIsNull, int[] fieldBlockOffsets, Block[] fieldBlocks)
+    private static void validateConstructorArguments(int startOffset, int positionCount, @Nullable boolean[] rowIsNull, @Nullable int[] fieldBlockOffsets, Block[] fieldBlocks)
     {
         if (startOffset < 0) {
             throw new IllegalArgumentException("arrayOffset is negative");
@@ -93,8 +89,11 @@ public class RowBlock
             throw new IllegalArgumentException("rowIsNull length is less than positionCount");
         }
 
-        requireNonNull(fieldBlockOffsets, "fieldBlockOffsets is null");
-        if (fieldBlockOffsets.length - startOffset < positionCount + 1) {
+        if ((rowIsNull == null) != (fieldBlockOffsets == null)) {
+            throw new IllegalArgumentException("When rowIsNull is (non) null then fieldBlockOffsets should be (non) null as well");
+        }
+
+        if (fieldBlockOffsets != null && fieldBlockOffsets.length - startOffset < positionCount + 1) {
             throw new IllegalArgumentException("fieldBlockOffsets length is less than positionCount");
         }
 
@@ -116,7 +115,7 @@ public class RowBlock
      * Use createRowBlockInternal or fromFieldBlocks instead of this method.  The caller of this method is assumed to have
      * validated the arguments with validateConstructorArguments.
      */
-    private RowBlock(int startOffset, int positionCount, @Nullable boolean[] rowIsNull, int[] fieldBlockOffsets, Block[] fieldBlocks)
+    private RowBlock(int startOffset, int positionCount, @Nullable boolean[] rowIsNull, @Nullable int[] fieldBlockOffsets, Block[] fieldBlocks)
     {
         super(fieldBlocks.length);
 
@@ -136,6 +135,7 @@ public class RowBlock
     }
 
     @Override
+    @Nullable
     protected int[] getFieldBlockOffsets()
     {
         return fieldBlockOffsets;
@@ -176,8 +176,8 @@ public class RowBlock
         long sizeInBytes = getBaseSizeInBytes();
         boolean hasUnloadedBlocks = false;
 
-        int startFieldBlockOffset = fieldBlockOffsets[startOffset];
-        int endFieldBlockOffset = fieldBlockOffsets[startOffset + positionCount];
+        int startFieldBlockOffset = fieldBlockOffsets != null ? fieldBlockOffsets[startOffset] : startOffset;
+        int endFieldBlockOffset = fieldBlockOffsets != null ? fieldBlockOffsets[startOffset + positionCount] : startOffset + positionCount;
         int fieldBlockLength = endFieldBlockOffset - startFieldBlockOffset;
 
         for (Block fieldBlock : fieldBlocks) {

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlockBuilder.java
@@ -85,9 +85,10 @@ public class RowBlockBuilder
     }
 
     @Override
+    @Nullable
     protected int[] getFieldBlockOffsets()
     {
-        return fieldBlockOffsets;
+        return hasNullRow ? fieldBlockOffsets : null;
     }
 
     @Override
@@ -223,7 +224,7 @@ public class RowBlockBuilder
         for (int i = 0; i < numFields; i++) {
             fieldBlocks[i] = fieldBlockBuilders[i].build();
         }
-        return createRowBlockInternal(0, positionCount, hasNullRow ? rowIsNull : null, fieldBlockOffsets, fieldBlocks);
+        return createRowBlockInternal(0, positionCount, hasNullRow ? rowIsNull : null, hasNullRow ? fieldBlockOffsets : null, fieldBlocks);
     }
 
     @Override

--- a/core/trino-spi/src/test/java/io/trino/spi/block/TestRowBlock.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/TestRowBlock.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.spi.block;
+
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+public class TestRowBlock
+{
+    @Test
+    public void testFieldBlockOffsetsIsNullWhenThereIsNoNullRow()
+    {
+        Block fieldBlock = new ByteArrayBlock(1, Optional.empty(), new byte[]{10});
+        AbstractRowBlock rowBlock = (RowBlock) RowBlock.fromFieldBlocks(1, Optional.empty(), new Block[] {fieldBlock});
+        // Blocks should discard the offset mask during creation if no values are null
+        assertNull(rowBlock.getFieldBlockOffsets());
+    }
+
+    @Test
+    public void testFieldBlockOffsetsIsNotNullWhenThereIsNullRow()
+    {
+        Block fieldBlock = new ByteArrayBlock(1, Optional.empty(), new byte[]{10});
+        AbstractRowBlock rowBlock = (RowBlock) RowBlock.fromFieldBlocks(1, Optional.of(new boolean[] {true}), new Block[] {fieldBlock});
+        // Blocks should not discard the offset mask during creation if no values are null
+        assertNotNull(rowBlock.getFieldBlockOffsets());
+    }
+}

--- a/core/trino-spi/src/test/java/io/trino/spi/block/TestRowBlockEncoding.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/TestRowBlockEncoding.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.spi.block;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+
+import java.nio.charset.Charset;
+import java.util.Random;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+
+public class TestRowBlockEncoding
+        extends BaseBlockEncodingTest<Object[]>
+{
+    @Override
+    protected Type getType()
+    {
+        return RowType.anonymous(ImmutableList.of(BIGINT, VARCHAR));
+    }
+
+    @Override
+    protected void write(BlockBuilder blockBuilder, Object[] value)
+    {
+        BlockBuilder row = blockBuilder.beginBlockEntry();
+        BIGINT.writeLong(row, (long) value[0]);
+        VARCHAR.writeSlice(row, utf8Slice((String) value[1]));
+        blockBuilder.closeEntry();
+    }
+
+    @Override
+    protected Object[] randomValue(Random random)
+    {
+        byte[] data = new byte[random.nextInt(256)];
+        random.nextBytes(data);
+        return new Object[] {random.nextLong(), new String(data, Charset.defaultCharset()), null};
+    }
+}

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerWithSplits.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerWithSplits.java
@@ -164,7 +164,7 @@ public class TestEventListenerWithSplits
         // Deterministic statistics
         assertEquals(statistics.getPhysicalInputBytes(), 0);
         assertEquals(statistics.getPhysicalInputRows(), expectedCompletedPositions);
-        assertEquals(statistics.getInternalNetworkBytes(), 405);
+        assertEquals(statistics.getInternalNetworkBytes(), 381);
         assertEquals(statistics.getInternalNetworkRows(), 3);
         assertEquals(statistics.getTotalBytes(), 0);
         assertEquals(statistics.getOutputBytes(), 9);


### PR DESCRIPTION
*  Add support for RowType to BenchmarkDataGenerator and benchmarks
* Do not use/serialize/deserialize fieldBlockOffset when not needed
  * When there are no null rows within RowBlock then it's not needed to store fieldBlockOffsets.
This improves performance and reduces network traffic as fieldBlockOffsets array is not serialized or deserialized.
```
Benchmark  (before/after)                      (nullChance)  Mode  Cnt  Score   Error  Units
(before)   BenchmarkBlockSerde.deserializeRow  0             avgt  60   17.348  ±      0.109  ns/op
(after)    BenchmarkBlockSerde.deserializeRow  0             avgt  60   15.205  ±      0.084  ns/op
(before)   BenchmarkBlockSerde.deserializeRow  .01           avgt  60   18.020  ±      0.104  ns/op
(after)    BenchmarkBlockSerde.deserializeRow  .01           avgt  60   18.279  ±      0.113  ns/op
(before)   BenchmarkBlockSerde.deserializeRow  .10           avgt  60   16.859  ±      0.140  ns/op
(after)    BenchmarkBlockSerde.deserializeRow  .10           avgt  60   16.494  ±      0.157  ns/op
(before)   BenchmarkBlockSerde.deserializeRow  .50           avgt  60   10.273  ±      0.044  ns/op
(after)    BenchmarkBlockSerde.deserializeRow  .50           avgt  60   10.491  ±      0.063  ns/op
(before)   BenchmarkBlockSerde.deserializeRow  .90           avgt  60   4.351   ±      0.020  ns/op
(after)    BenchmarkBlockSerde.deserializeRow  .90           avgt  60   4.311   ±      0.013  ns/op
(before)   BenchmarkBlockSerde.deserializeRow  .99           avgt  60   2.919   ±      0.027  ns/op
(after)    BenchmarkBlockSerde.deserializeRow  .99           avgt  60   2.851   ±      0.008  ns/op
(before)   BenchmarkBlockSerde.serializeRow    0             avgt  60   20.862  ±      0.117  ns/op
(after)    BenchmarkBlockSerde.serializeRow    0             avgt  60   16.941  ±      0.089  ns/op
(before)   BenchmarkBlockSerde.serializeRow    .01           avgt  60   21.588  ±      0.097  ns/op
(after)    BenchmarkBlockSerde.serializeRow    .01           avgt  60   20.045  ±      0.102  ns/op
(before)   BenchmarkBlockSerde.serializeRow    .10           avgt  60   20.667  ±      0.068  ns/op
(after)    BenchmarkBlockSerde.serializeRow    .10           avgt  60   19.448  ±      0.126  ns/op
(before)   BenchmarkBlockSerde.serializeRow    .50           avgt  60   13.217  ±      0.090  ns/op
(after)    BenchmarkBlockSerde.serializeRow    .50           avgt  60   11.839  ±      0.042  ns/op
(before)   BenchmarkBlockSerde.serializeRow    .90           avgt  60   7.404   ±      0.017  ns/op
(after)    BenchmarkBlockSerde.serializeRow    .90           avgt  60   5.615   ±      0.009  ns/op
(before)   BenchmarkBlockSerde.serializeRow    .99           avgt  60   5.517   ±      0.007  ns/op
(after)    BenchmarkBlockSerde.serializeRow    .99           avgt  60   3.534   ±      0.009  ns/op

```