### PR TITLE
Add system.metadata.plugins table

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/PluginSystemTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/PluginSystemTable.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.connector;
+
+import io.trino.metadata.Metadata;
+import io.trino.server.PluginManager;
+import io.trino.server.PluginMetadata;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.InMemoryRecordSet;
+import io.trino.spi.connector.InMemoryRecordSet.Builder;
+import io.trino.spi.connector.RecordCursor;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.SystemTable;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.ArrayType;
+
+import javax.inject.Inject;
+
+import java.util.List;
+
+import static io.trino.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
+import static io.trino.spi.connector.SystemTable.Distribution.SINGLE_COORDINATOR;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static java.util.Objects.requireNonNull;
+
+public class PluginSystemTable
+        implements SystemTable
+{
+    public static final SchemaTableName TABLE_NAME = new SchemaTableName("metadata", "plugins");
+
+    public static final ConnectorTableMetadata TABLE = tableMetadataBuilder(TABLE_NAME)
+            .column("plugin_name", createUnboundedVarcharType())
+            .column("connectors", new ArrayType(createUnboundedVarcharType()))
+            .column("functions", new ArrayType(createUnboundedVarcharType()))
+            .column("event_listeners", new ArrayType(createUnboundedVarcharType()))
+            .build();
+    private final PluginManager pluginManager;
+
+    @Inject
+    public PluginSystemTable(Metadata metadata, PluginManager pluginManager)
+    {
+        this.pluginManager = requireNonNull(pluginManager, "pluginManager is null");
+    }
+
+    @Override
+    public Distribution getDistribution()
+    {
+        return SINGLE_COORDINATOR;
+    }
+
+    @Override
+    public ConnectorTableMetadata getTableMetadata()
+    {
+        return TABLE;
+    }
+
+    @Override
+    public RecordCursor cursor(ConnectorTransactionHandle transactionHandle, ConnectorSession connectorSession, TupleDomain<Integer> constraint)
+    {
+        Builder table = InMemoryRecordSet.builder(TABLE);
+        for (PluginMetadata plugin : pluginManager.getPluginsMetadata()) {
+            table.addRow(
+                    plugin.getName(),
+                    getStringsBlock(plugin.getConnectors()),
+                    getStringsBlock(plugin.getFunctions()),
+                    getStringsBlock(plugin.getEventListeners()));
+        }
+        return table.build().cursor();
+    }
+
+    private static Block getStringsBlock(List<String> input)
+    {
+        BlockBuilder builder = VARCHAR.createBlockBuilder(null, input.size());
+        input.forEach(name -> VARCHAR.writeString(builder, name));
+        return builder.build();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/connector/system/SystemConnectorModule.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/SystemConnectorModule.java
@@ -20,6 +20,7 @@ import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.multibindings.ProvidesIntoSet;
 import io.trino.connector.ConnectorManager;
+import io.trino.connector.PluginSystemTable;
 import io.trino.connector.system.jdbc.AttributeJdbcTable;
 import io.trino.connector.system.jdbc.CatalogJdbcTable;
 import io.trino.connector.system.jdbc.ColumnJdbcTable;
@@ -49,6 +50,7 @@ public class SystemConnectorModule
         globalTableBinder.addBinding().to(QuerySystemTable.class).in(Scopes.SINGLETON);
         globalTableBinder.addBinding().to(TaskSystemTable.class).in(Scopes.SINGLETON);
         globalTableBinder.addBinding().to(CatalogSystemTable.class).in(Scopes.SINGLETON);
+        globalTableBinder.addBinding().to(PluginSystemTable.class).in(Scopes.SINGLETON);
         globalTableBinder.addBinding().to(TableCommentSystemTable.class).in(Scopes.SINGLETON);
         globalTableBinder.addBinding().to(SchemaPropertiesSystemTable.class).in(Scopes.SINGLETON);
         globalTableBinder.addBinding().to(TablePropertiesSystemTable.class).in(Scopes.SINGLETON);

--- a/core/trino-main/src/main/java/io/trino/server/PluginMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/server/PluginMetadata.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server;
+
+import java.util.List;
+
+public final class PluginMetadata
+{
+    private final String name;
+    private final List<String> connectors;
+    private final List<String> functions;
+    private final List<String> eventListeners;
+
+    public PluginMetadata(String name, List<String> connectors, List<String> functions, List<String> eventListeners)
+    {
+        this.name = name;
+        this.connectors = connectors;
+        this.functions = functions;
+        this.eventListeners = eventListeners;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public List<String> getConnectors()
+    {
+        return connectors;
+    }
+
+    public List<String> getFunctions()
+    {
+        return functions;
+    }
+
+    public List<String> getEventListeners()
+    {
+        return eventListeners;
+    }
+}

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestSystemConnector.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestSystemConnector.java
@@ -17,6 +17,8 @@ import com.google.common.collect.ImmutableList;
 import io.trino.tempto.ProductTest;
 import org.testng.annotations.Test;
 
+import java.util.List;
+
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tests.product.TestGroups.JDBC;
@@ -121,5 +123,34 @@ public class TestSystemConnector
                                 row("jmx", "jmx", "jmx"),
                                 row("system", "system", "system"),
                                 row("tpch", "tpch", "tpch")));
+    }
+
+    @Test(groups = {SYSTEM_CONNECTOR, JDBC})
+    public void selectMetadataPlugins()
+    {
+        String sql = "select plugin_name, connectors, functions, event_listeners from system.metadata.plugins where plugin_name like 'jmx' or plugin_name like 'httpquery' or plugin_name like 'mongodb'";
+        assertThat(onTrino().executeQuery(sql))
+                .hasColumns(VARCHAR, ARRAY, ARRAY, ARRAY)
+                .contains(
+                        ImmutableList.of(
+                                row(
+                                        "io.trino.plugin.httpquery.HttpEventListenerPlugin",
+                                        List.of(),
+                                        List.of(),
+                                        List.of("http")),
+                                row(
+                                        "io.trino.plugin.jmx.JmxPlugin",
+                                        List.of("jmx"),
+                                        List.of(),
+                                        List.of()),
+                                row(
+                                        "io.trino.plugin.mongodb.MongoPlugin",
+                                        List.of("mongodb"),
+                                        List.of("objectid",
+                                                "objectid",
+                                                "timestamp_objectid",
+                                                "objectid_timestamp",
+                                                "$operator$CAST"),
+                                        List.of())));
     }
 }

--- a/testing/trino-product-tests/src/main/resources/sql-tests/testcases/system/selectInformationSchemaColumns.result
+++ b/testing/trino-product-tests/src/main/resources/sql-tests/testcases/system/selectInformationSchemaColumns.result
@@ -47,6 +47,10 @@ system| metadata| analyze_properties| description| varchar| YES| null| null|
 system| metadata| catalogs| catalog_name| varchar| YES| null| null|
 system| metadata| catalogs| connector_id| varchar| YES| null| null|
 system| metadata| catalogs| connector_name| varchar| YES| null| null|
+system| metadata| plugins| plugin_name| varchar| YES| null| null|
+system| metadata| plugins| catalogs| array(varchar)| YES| null| null|
+system| metadata| plugins| functions| array(varchar)| YES| null| null|
+system| metadata| plugins| event_listeners| array(varchar)| YES| null| null|
 system| metadata| column_properties| catalog_name| varchar| YES| null| null|
 system| metadata| column_properties| property_name| varchar| YES| null| null|
 system| metadata| column_properties| default_value| varchar| YES| null| null|

--- a/testing/trino-product-tests/src/main/resources/sql-tests/testcases/system/showTablesSystemMetadata.result
+++ b/testing/trino-product-tests/src/main/resources/sql-tests/testcases/system/showTablesSystemMetadata.result
@@ -1,5 +1,6 @@
 -- delimiter: |; ignoreOrder: true;
 catalogs|
+plugins|
 analyze_properties|
 schema_properties|
 table_properties|


### PR DESCRIPTION
Add the `system.metadata.plugins` table that lists all loaded plugins and various features they provide. This gives a nice overview of where does specific features come from.

Right now I only added connectors, functions, and event listeners as a showcase, but I can add all remaining features if we agree this is a good idea.