### PR TITLE
Fully migrate TopNOperator to WorkProcessorOperator

### DIFF
--- a/core/trino-main/src/test/java/io/trino/operator/TestTopNOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestTopNOperator.java
@@ -199,7 +199,8 @@ public class TestTopNOperator
                 ImmutableList.of(0),
                 ImmutableList.of(ASC_NULLS_LAST));
         Operator operator = operatorFactory.createOperator(smallDiverContext);
-        assertThatThrownBy(() -> operator.addInput(input.get(0)))
+        operator.addInput(input.get(0));
+        assertThatThrownBy(() -> operator.getOutput())
                 .isInstanceOf(ExceededMemoryLimitException.class)
                 .hasMessageStartingWith("Query exceeded per-node memory limit of ");
     }


### PR DESCRIPTION
In order to reduce complexity, migrate TopNOperator to WorkProcessorOperator from AdapterWorkProcessorOperator.

No performance implication found.

AdapterWorkProcessorOperator
```
Benchmark (positionsPerPage) (topN) Mode Cnt Score Error Units
BenchmarkTopNOperator.topN 32 1 thrpt 60 16.917 ± 1.182 ops/s
BenchmarkTopNOperator.topN 32 100 thrpt 60 17.369 ± 0.517 ops/s
BenchmarkTopNOperator.topN 32 10000 thrpt 60 5.286 ± 0.058 ops/s
BenchmarkTopNOperator.topN 1024 1 thrpt 60 23.479 ± 0.387 ops/s
BenchmarkTopNOperator.topN 1024 100 thrpt 60 22.266 ± 0.267 ops/s
BenchmarkTopNOperator.topN 1024 10000 thrpt 60 7.306 ± 0.087 ops/s
```

WorkProcessorOperator
```
BenchmarkTopNOperator.topN 32 1 thrpt 60 18.566 ± 0.877 ops/s
BenchmarkTopNOperator.topN 32 100 thrpt 60 17.176 ± 0.400 ops/s
BenchmarkTopNOperator.topN 32 10000 thrpt 60 5.293 ± 0.110 ops/s
BenchmarkTopNOperator.topN 1024 1 thrpt 60 23.134 ± 0.496 ops/s
BenchmarkTopNOperator.topN 1024 100 thrpt 60 22.107 ± 0.410 ops/s
BenchmarkTopNOperator.topN 1024 10000 thrpt 60 7.293 ± 0.151 ops/s
```