### PR TITLE
Run HttpRemoteTask#sendUpdate in separate thread

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
@@ -578,7 +578,7 @@ public final class HttpRemoteTask
     {
         // synchronized so that needsUpdate is not cleared in sendUpdate before actual request is sent
         needsUpdate.set(true);
-        sendUpdate();
+        scheduleUpdate();
     }
 
     private synchronized void sendUpdate()


### PR DESCRIPTION
Sending update is potentially expensive operation
therefore it should be run from separate thread.
This fixes bug introduced by
https://github.com/trinodb/trino/commit/613bd2f3feb42cc4aedf637260a2bc6672f323d4