### PR TITLE
Use airlift json codec in http event listener, fixing airlift/airlift#983

### DIFF
--- a/plugin/trino-http-event-listener/pom.xml
+++ b/plugin/trino-http-event-listener/pom.xml
@@ -45,6 +45,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>log</artifactId>
         </dependency>
 
@@ -61,16 +66,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jdk8</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
 
         <dependency>
@@ -118,6 +113,12 @@
         </dependency>
 
         <!-- for testing -->
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-testing-services</artifactId>

--- a/plugin/trino-http-event-listener/src/main/java/io/trino/plugin/httpquery/HttpEventListener.java
+++ b/plugin/trino-http-event-listener/src/main/java/io/trino/plugin/httpquery/HttpEventListener.java
@@ -144,12 +144,17 @@ public class HttpEventListener
                                                 result.getStatusCode(), nextDelay.roundTo(TimeUnit.SECONDS));
 
                                         attemptToSend(request, nextAttempt, nextDelay, queryId);
-                                        return;
+                                    }
+                                    else {
+                                        log.error("QueryId = \"%s\", attempt = %d/%d, URL = %s | Ingest server responded with code %d, fatal error",
+                                                queryId, attempt + 1, config.getRetryCount() + 1, request.getUri().toString(),
+                                                result.getStatusCode());
                                     }
                                 }
-
-                                log.debug("QueryId = \"%s\", attempt = %d/%d, URL = %s | Query event delivered successfully",
-                                        queryId, attempt + 1, config.getRetryCount() + 1, request.getUri().toString());
+                                else {
+                                    log.debug("QueryId = \"%s\", attempt = %d/%d, URL = %s | Query event delivered successfully",
+                                            queryId, attempt + 1, config.getRetryCount() + 1, request.getUri().toString());
+                                }
                             }
 
                             @Override
@@ -164,11 +169,11 @@ public class HttpEventListener
                                             nextDelay.roundTo(TimeUnit.SECONDS));
 
                                     attemptToSend(request, nextAttempt, nextDelay, queryId);
-                                    return;
                                 }
-
-                                log.error(t, "QueryId = \"%s\", attempt = %d/%d, URL = %s | Error sending HTTP request",
-                                        queryId, attempt + 1, config.getRetryCount() + 1, request.getUri().toString());
+                                else {
+                                    log.error(t, "QueryId = \"%s\", attempt = %d/%d, URL = %s | Error sending HTTP request",
+                                            queryId, attempt + 1, config.getRetryCount() + 1, request.getUri().toString());
+                                }
                             }
                         }, executor),
                 (long) delay.getValue(), delay.getUnit());

--- a/plugin/trino-http-event-listener/src/main/java/io/trino/plugin/httpquery/HttpEventListenerFactory.java
+++ b/plugin/trino-http-event-listener/src/main/java/io/trino/plugin/httpquery/HttpEventListenerFactory.java
@@ -15,13 +15,18 @@ package io.trino.plugin.httpquery;
 import com.google.inject.Injector;
 import com.google.inject.Scopes;
 import io.airlift.bootstrap.Bootstrap;
+import io.airlift.json.JsonModule;
 import io.trino.spi.eventlistener.EventListener;
 import io.trino.spi.eventlistener.EventListenerFactory;
+import io.trino.spi.eventlistener.QueryCompletedEvent;
+import io.trino.spi.eventlistener.QueryCreatedEvent;
+import io.trino.spi.eventlistener.SplitCompletedEvent;
 
 import java.util.Map;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
+import static io.airlift.json.JsonCodecBinder.jsonCodecBinder;
 
 public class HttpEventListenerFactory
         implements EventListenerFactory
@@ -36,7 +41,11 @@ public class HttpEventListenerFactory
     public EventListener create(Map<String, String> config)
     {
         Bootstrap app = new Bootstrap(
+                new JsonModule(),
                 binder -> {
+                    jsonCodecBinder(binder).bindJsonCodec(QueryCompletedEvent.class);
+                    jsonCodecBinder(binder).bindJsonCodec(QueryCreatedEvent.class);
+                    jsonCodecBinder(binder).bindJsonCodec(SplitCompletedEvent.class);
                     configBinder(binder).bindConfig(HttpEventListenerConfig.class);
                     httpClientBinder(binder).bindHttpClient("http-event-listener", ForHttpEventListener.class);
                     binder.bind(HttpEventListener.class).in(Scopes.SINGLETON);

--- a/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpEventListenerConfig.java
+++ b/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpEventListenerConfig.java
@@ -24,7 +24,7 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertFullMappin
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 
-public class TestHttpQueryListenerConfig
+public class TestHttpEventListenerConfig
 {
     @Test
     public void testDefaults()


### PR DESCRIPTION
A bug in airlift described in this issue airlift/airlift#983 affects the event listener, causing it to leak threads and timeout all requests. This fixes the effect of the issue by not using the dangerous class but not the source of the issue.

I also changed the `testServerDisconnectShouldRetry` to cover the issue above. With the old setup, this would fail because the http-client's threads would go into deadlock. 

Other changes: replace the name `querylog` with `httpeventlistener` or `eventlistener` in tests, cleanup logs.