### PR TITLE
Fix Iceberg metadata listing failure when materialized view dropped

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/system/TableCommentSystemTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/TableCommentSystemTable.java
@@ -121,7 +121,7 @@ public class TableCommentSystemTable
                 try {
                     comment = getComment(session, prefix, name, views, materializedViews);
                 }
-                catch (TrinoException e) {
+                catch (RuntimeException e) {
                     // getTableHandle may throw an exception (e.g. Cassandra connector doesn't allow case insensitive column names)
                     LOG.warn(e, "Failed to get metadata for table: %s", name);
                 }

--- a/core/trino-main/src/main/java/io/trino/connector/system/TableCommentSystemTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/TableCommentSystemTable.java
@@ -113,7 +113,7 @@ public class TableCommentSystemTable
             }
             catch (TrinoException e) {
                 // listTables throws an exception if cannot connect the database
-                LOG.debug(e, "Failed to get tables for catalog: %s", catalog);
+                LOG.warn(e, "Failed to get tables for catalog: %s", catalog);
             }
 
             for (SchemaTableName name : names) {
@@ -123,7 +123,7 @@ public class TableCommentSystemTable
                 }
                 catch (TrinoException e) {
                     // getTableHandle may throw an exception (e.g. Cassandra connector doesn't allow case insensitive column names)
-                    LOG.debug(e, "Failed to get metadata for table: %s", name);
+                    LOG.warn(e, "Failed to get metadata for table: %s", name);
                 }
                 table.addRow(prefix.getCatalogName(), name.getSchemaName(), name.getTableName(), comment.orElse(null));
             }
@@ -153,7 +153,7 @@ public class TableCommentSystemTable
                 .map(metadata -> metadata.getMetadata().getComment())
                 .orElseGet(() -> {
                     // A previously listed table might have been dropped concurrently
-                    LOG.debug("Failed to get metadata for table: %s", name);
+                    LOG.warn("Failed to get metadata for table: %s", name);
                     return Optional.empty();
                 });
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.hive.metastore.cache;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
@@ -579,8 +578,7 @@ public class CachingHiveMetastore
         }
     }
 
-    @VisibleForTesting
-    void invalidateTable(String databaseName, String tableName)
+    public void invalidateTable(String databaseName, String tableName)
     {
         invalidateTableCache(databaseName, tableName);
         tableNamesCache.invalidate(databaseName);

--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -125,6 +125,11 @@
             <artifactId>joda-time</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>net.jodah</groupId>
+            <artifactId>failsafe</artifactId>
+        </dependency>
+
         <!-- Iceberg -->
         <dependency>
             <groupId>org.apache.iceberg</groupId>

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TrinoHiveCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TrinoHiveCatalog.java
@@ -347,6 +347,15 @@ class TrinoHiveCatalog
     }
 
     @Override
+    public void updateColumnComment(ConnectorSession session, SchemaTableName schemaTableName, ColumnIdentity columnIdentity, Optional<String> comment)
+    {
+        metastore.commentColumn(schemaTableName.getSchemaName(), schemaTableName.getTableName(), columnIdentity.getName(), comment);
+
+        Table icebergTable = loadTable(session, schemaTableName);
+        icebergTable.updateSchema().updateColumnDoc(columnIdentity.getName(), comment.orElse(null)).commit();
+    }
+
+    @Override
     public String defaultTableLocation(ConnectorSession session, SchemaTableName schemaTableName)
     {
         Database database = metastore.getDatabase(schemaTableName.getSchemaName())
@@ -692,15 +701,6 @@ class TrinoHiveCatalog
             return ImmutableList.of(namespace.get());
         }
         return listNamespaces(session);
-    }
-
-    @Override
-    public void updateColumnComment(ConnectorSession session, SchemaTableName schemaTableName, ColumnIdentity columnIdentity, Optional<String> comment)
-    {
-        metastore.commentColumn(schemaTableName.getSchemaName(), schemaTableName.getTableName(), columnIdentity.getName(), comment);
-
-        Table icebergTable = loadTable(session, schemaTableName);
-        icebergTable.updateSchema().updateColumnDoc(columnIdentity.getName(), comment.orElse(null)).commit();
     }
 
     private static class MaterializedViewMayBeBeingRemovedException

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractMetastoreTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractMetastoreTableOperations.java
@@ -279,6 +279,7 @@ public abstract class AbstractMetastoreTableOperations
         Tasks.foreach(newLocation)
                 .retry(20)
                 .exponentialBackoff(100, 5000, 600000, 4.0)
+                .stopRetryOn(org.apache.iceberg.exceptions.NotFoundException.class) // qualified name, as this is NOT the io.trino.spi.connector.NotFoundException
                 .run(metadataLocation -> newMetadata.set(
                         TableMetadataParser.read(fileIo, io().newInputFile(metadataLocation))));
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -42,7 +42,6 @@ import io.trino.testing.QueryRunner;
 import io.trino.testing.ResultWithQueryId;
 import io.trino.testing.TestingConnectorBehavior;
 import io.trino.testing.sql.TestTable;
-import io.trino.testng.services.Flaky;
 import io.trino.tpch.TpchTable;
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileReader;
@@ -283,31 +282,12 @@ public abstract class BaseIcebergConnectorTest
                         ")");
     }
 
-    @Test
-    @Flaky(
-            issue = "https://github.com/trinodb/trino/issues/10976",
-            // Due to the nature of the problem, actual failure can vary greatly
-            match = "^")
-    @Override
-    public void testSelectInformationSchemaColumns()
-    {
-        super.testSelectInformationSchemaColumns();
-    }
-
     @Override
     protected void checkInformationSchemaViewsForMaterializedView(String schemaName, String viewName)
     {
         // TODO should probably return materialized view, as it's also a view -- to be double checked
         assertThatThrownBy(() -> super.checkInformationSchemaViewsForMaterializedView(schemaName, viewName))
                 .hasMessageFindingMatch("(?s)Expecting.*to contain:.*\\Q[(" + viewName + ")]");
-    }
-
-    @Test(enabled = false) // TODO fails
-    @Override
-    public void testReadMetadataWithRelationsConcurrentModifications()
-            throws Exception
-    {
-        super.testReadMetadataWithRelationsConcurrentModifications();
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -302,6 +302,14 @@ public abstract class BaseIcebergConnectorTest
                 .hasMessageFindingMatch("(?s)Expecting.*to contain:.*\\Q[(" + viewName + ")]");
     }
 
+    @Test(enabled = false) // TODO fails
+    @Override
+    public void testReadMetadataWithRelationsConcurrentModifications()
+            throws Exception
+    {
+        super.testReadMetadataWithRelationsConcurrentModifications();
+    }
+
     @Test
     public void testDecimal()
     {

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/AbstractKuduConnectorTest.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/AbstractKuduConnectorTest.java
@@ -355,6 +355,13 @@ public abstract class AbstractKuduConnectorTest
         throw new SkipException("TODO");
     }
 
+    @Override
+    public void testReadMetadataWithRelationsConcurrentModifications()
+    {
+        // TODO Support these test once kudu connector can create tables with default partitions
+        throw new SkipException("TODO");
+    }
+
     @Test
     @Override
     public void testCreateTableAsSelectNegativeDate()

--- a/plugin/trino-phoenix/pom.xml
+++ b/plugin/trino-phoenix/pom.xml
@@ -187,6 +187,12 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-testing-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-tpch</artifactId>
             <scope>test</scope>
         </dependency>

--- a/plugin/trino-phoenix/src/test/java/io/trino/plugin/phoenix/TestPhoenixConnectorTest.java
+++ b/plugin/trino-phoenix/src/test/java/io/trino/plugin/phoenix/TestPhoenixConnectorTest.java
@@ -22,6 +22,7 @@ import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
 import io.trino.testing.sql.SqlExecutor;
 import io.trino.testing.sql.TestTable;
+import io.trino.testng.services.Flaky;
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
@@ -218,6 +219,30 @@ public class TestPhoenixConnectorTest
                         "   rowkeys = 'ROWKEY',\n" +
                         "   salt_buckets = 10\n" +
                         ")");
+    }
+
+    // TODO (https://github.com/trinodb/trino/issues/10904): Test is flaky because tests execute in parallel
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/10904", match = "\\QERROR 1012 (42M03): Table undefined. tableName=")
+    @Test
+    @Override
+    public void testSelectInformationSchemaColumns()
+    {
+        super.testSelectInformationSchemaColumns();
+    }
+
+    @Override
+    public void testReadMetadataWithRelationsConcurrentModifications()
+    {
+        try {
+            super.testReadMetadataWithRelationsConcurrentModifications();
+        }
+        catch (Exception expected) {
+            // The test failure is not guaranteed
+            // TODO (https://github.com/trinodb/trino/issues/10904): shouldn't fail
+            assertThat(expected)
+                    .hasMessageContaining("ERROR 1012 (42M03): Table undefined. tableName=");
+            throw new SkipException("to be fixed");
+        }
     }
 
     @Override

--- a/plugin/trino-phoenix5/pom.xml
+++ b/plugin/trino-phoenix5/pom.xml
@@ -192,6 +192,12 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-testing-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-tpch</artifactId>
             <scope>test</scope>
         </dependency>

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
@@ -24,6 +24,7 @@ import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
 import io.trino.testing.sql.SqlExecutor;
 import io.trino.testing.sql.TestTable;
+import io.trino.testng.services.Flaky;
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
@@ -236,6 +237,30 @@ public class TestPhoenixConnectorTest
                         "   rowkeys = 'ROWKEY',\n" +
                         "   salt_buckets = 10\n" +
                         ")");
+    }
+
+    // TODO (https://github.com/trinodb/trino/issues/10904): Test is flaky because tests execute in parallel
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/10904", match = "\\QERROR 1012 (42M03): Table undefined. tableName=")
+    @Test
+    @Override
+    public void testSelectInformationSchemaColumns()
+    {
+        super.testSelectInformationSchemaColumns();
+    }
+
+    @Override
+    public void testReadMetadataWithRelationsConcurrentModifications()
+    {
+        try {
+            super.testReadMetadataWithRelationsConcurrentModifications();
+        }
+        catch (Exception expected) {
+            // The test failure is not guaranteed
+            // TODO (https://github.com/trinodb/trino/issues/10904): shouldn't fail
+            assertThat(expected)
+                    .hasMessageContaining("ERROR 1012 (42M03): Table undefined. tableName=");
+            throw new SkipException("to be fixed");
+        }
     }
 
     @Override

--- a/plugin/trino-sqlserver/pom.xml
+++ b/plugin/trino-sqlserver/pom.xml
@@ -142,6 +142,12 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-testing-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-tpch</artifactId>
             <scope>test</scope>
         </dependency>

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
@@ -25,6 +25,8 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.sql.planner.plan.FilterNode;
 import io.trino.testing.TestingConnectorBehavior;
 import io.trino.testing.sql.TestTable;
+import io.trino.testng.services.Flaky;
+import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -133,6 +135,35 @@ public abstract class BaseSqlServerConnectorTest
         assertTrue(getQueryRunner().tableExists(getSession(), "test_view"));
         assertQuery("SELECT orderkey FROM test_view", "SELECT orderkey FROM orders");
         onRemoteDatabase().execute("DROP VIEW IF EXISTS test_view");
+    }
+
+    // TODO (https://github.com/trinodb/trino/issues/10846): Test is expected to be flaky because tests execute in parallel
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/10846", match = "was deadlocked on lock resources with another process and has been chosen as the deadlock victim")
+    @Test
+    @Override
+    public void testSelectInformationSchemaColumns()
+    {
+        super.testSelectInformationSchemaColumns();
+    }
+
+    @Test
+    @Override
+    public void testReadMetadataWithRelationsConcurrentModifications()
+    {
+        try {
+            super.testReadMetadataWithRelationsConcurrentModifications();
+        }
+        catch (Exception expected) {
+            // The test failure is not guaranteed
+            // TODO (https://github.com/trinodb/trino/issues/10846): shouldn't fail
+            assertThat(expected)
+                    .hasMessageMatching("(?s).*(" +
+                            "No task completed before timeout|" +
+                            "was deadlocked on lock resources with another process and has been chosen as the deadlock victim|" +
+                            // E.g. system.metadata.table_comments can return empty results, when underlying metadata list tables call fails
+                            "Expecting actual not to be empty).*");
+            throw new SkipException("to be fixed");
+        }
     }
 
     @Test

--- a/testing/trino-testing-services/src/main/java/io/trino/testng/services/LogTestDurationListener.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testng/services/LogTestDurationListener.java
@@ -260,6 +260,7 @@ public class LogTestDurationListener
 
     private static String getName(IInvokedMethod method)
     {
-        return format("%s::%s", method.getTestMethod().getTestClass().getName(), method.getTestMethod().getMethodName());
+        // See ProgressLoggingListener.formatTestName
+        return format("%s.%s", method.getTestMethod().getTestClass().getName(), method.getTestMethod().getMethodName());
     }
 }

--- a/testing/trino-testing-services/src/main/java/io/trino/testng/services/ProgressLoggingListener.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testng/services/ProgressLoggingListener.java
@@ -108,6 +108,7 @@ public class ProgressLoggingListener
 
     private String formatTestName(ITestResult testCase)
     {
+        // See LogTestDurationListener.getName
         return format("%s.%s%s", testCase.getTestClass().getName(), testCase.getName(), formatTestParameters(testCase));
     }
 


### PR DESCRIPTION
Fix `SHOW TABLES` and `information_schema.tables` read failure when
materialized view is concurrently dropped

Fixes https://github.com/trinodb/trino/issues/10976 