### PR TITLE
Include less details in the query failure messsage matching

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCompatibility.java
@@ -207,7 +207,7 @@ public class TestHiveCompatibility
 
         // Hive expects `FIXED_LEN_BYTE_ARRAY` for decimal values irrespective of the Parquet specification which allows `INT32`, `INT64` for short precision decimal types
         assertQueryFailure(() -> onHive().executeQuery("SELECT a_decimal FROM " + tableName))
-                .hasMessageMatching(".* org.apache.parquet.io.ParquetDecodingException: Can not read value at 1 in block 0 in file .*");
+                .hasMessageMatching(".*ParquetDecodingException: Can not read value at 1 in block 0 in file .*");
 
         onTrino().executeQuery(format("DROP TABLE %s", tableName));
     }


### PR DESCRIPTION
Some  older Hive distributions have apparently a different full class name for `ParquetDecodingException`.
Relax the failure message matching to be able to apply this test on more Hive distributions.


```
 Expecting message:
tests               |   <"java.io.IOException: parquet.io.ParquetDecodingException: Can not read value at 1 in block 0 in file hdfs://hadoop-master:9000/user/hive/warehouse/parquet_table_small_decimal_created_in_trino/20220128_164310_01082_rxiyb_3ecc49f0-f52f-4955-8f2f-0e2db8beeff7">
tests               | to match regex:
tests               |   <".* org.apache.parquet.io.ParquetDecodingException: Can not read value at 1 in block 0 in file .*">
tests               | but did not.
```