### PR TITLE
Use valid package name in a test exception assert

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCompatibility.java
@@ -207,7 +207,7 @@ public class TestHiveCompatibility
 
         // Hive expects `FIXED_LEN_BYTE_ARRAY` for decimal values irrespective of the Parquet specification which allows `INT32`, `INT64` for short precision decimal types
         assertQueryFailure(() -> onHive().executeQuery("SELECT a_decimal FROM " + tableName))
-                .hasMessageMatching(".* org.apache.parquet.io.ParquetDecodingException: Can not read value at 1 in block 0 in file .*");
+                .hasMessageMatching(".* parquet.io.ParquetDecodingException: Can not read value at 1 in block 0 in file .*");
 
         onTrino().executeQuery(format("DROP TABLE %s", tableName));
     }


### PR DESCRIPTION
I'm seeing a lot of failures on master in a test that was recently introduced in https://github.com/trinodb/trino/pull/10613/
with the following error:
```
tests               | 2022-01-31 12:13:37 INFO: FAILURE     /    io.trino.tests.product.hive.TestHiveCompatibility.testSmallDecimalFieldWrittenByOptimizedParquetWriterCannotBeReadByHive (Groups: storage_formats_detailed) took 0.7 seconds
tests               | 2022-01-31 12:13:37 SEVERE: Failure cause:
tests               | java.lang.AssertionError: 
tests               | Expecting message:
tests               |   <"java.io.IOException: parquet.io.ParquetDecodingException: Can not read value at 1 in block 0 in file hdfs://hadoop-master:9000/user/hive/warehouse/parquet_table_small_decimal_created_in_trino/20220131_062836_01082_j2ikr_8c200c2a-4add-4f35-a3ed-b70c4732e54b">
tests               | to match regex:
tests               |   <".* org.apache.parquet.io.ParquetDecodingException: Can not read value at 1 in block 0 in file .*">
tests               | but did not.
```
