### PR TITLE
Schedule dynamic filtering collecting task immediately

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/FixedSourcePartitionedScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/FixedSourcePartitionedScheduler.java
@@ -323,6 +323,12 @@ public class FixedSourcePartitionedScheduler
         }
 
         @Override
+        public void start()
+        {
+            sourceScheduler.start();
+        }
+
+        @Override
         public ScheduleResult schedule()
         {
             return sourceScheduler.schedule();

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/SourcePartitionedScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/SourcePartitionedScheduler.java
@@ -177,6 +177,12 @@ public class SourcePartitionedScheduler
         return new StageScheduler()
         {
             @Override
+            public void start()
+            {
+                sourcePartitionedScheduler.start();
+            }
+
+            @Override
             public ScheduleResult schedule()
             {
                 ScheduleResult scheduleResult = sourcePartitionedScheduler.schedule();
@@ -249,6 +255,18 @@ public class SourcePartitionedScheduler
         // and the listener should stop waiting.
         whenFinishedOrNewLifespanAdded.set(null);
         whenFinishedOrNewLifespanAdded = SettableFuture.create();
+    }
+
+    @Override
+    public synchronized void start()
+    {
+        // Avoid deadlocks by immediately scheduling a task for collecting dynamic filters because:
+        // * there can be task in other stage blocked waiting for the dynamic filters, or
+        // * connector split source for this stage might be blocked waiting the dynamic filters.
+        if (dynamicFilterService.isCollectingTaskNeeded(stageExecution.getStageId().getQueryId(), stageExecution.getFragment())) {
+            stageExecution.beginScheduling();
+            createTaskOnRandomNode();
+        }
     }
 
     @Override
@@ -406,13 +424,6 @@ public class SourcePartitionedScheduler
             return new ScheduleResult(false, overallNewTasks.build(), overallSplitAssignmentCount);
         }
 
-        if (anyBlockedOnNextSplitBatch
-                && scheduledTasks.isEmpty()
-                && dynamicFilterService.isCollectingTaskNeeded(stageExecution.getStageId().getQueryId(), stageExecution.getFragment())) {
-            // schedule a task for collecting dynamic filters in case probe split generator is waiting for them
-            createTaskOnRandomNode().ifPresent(overallNewTasks::add);
-        }
-
         boolean anySourceTaskBlocked = this.anySourceTaskBlocked.getAsBoolean();
         if (anySourceTaskBlocked) {
             // Dynamic filters might not be collected due to build side source tasks being blocked on full buffer.
@@ -541,13 +552,13 @@ public class SourcePartitionedScheduler
         return newTasks.build();
     }
 
-    private Optional<RemoteTask> createTaskOnRandomNode()
+    private void createTaskOnRandomNode()
     {
         checkState(scheduledTasks.isEmpty(), "Stage task is already scheduled on node");
         List<InternalNode> allNodes = splitPlacementPolicy.allNodes();
         checkState(allNodes.size() > 0, "No nodes available");
         InternalNode node = allNodes.get(ThreadLocalRandom.current().nextInt(0, allNodes.size()));
-        return scheduleTask(node, ImmutableMultimap.of(), ImmutableMultimap.of());
+        scheduleTask(node, ImmutableMultimap.of(), ImmutableMultimap.of());
     }
 
     private Set<RemoteTask> finalizeTaskCreationIfNecessary()

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/SourceScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/SourceScheduler.java
@@ -22,6 +22,8 @@ import java.util.List;
 
 public interface SourceScheduler
 {
+    void start();
+
     ScheduleResult schedule();
 
     void close();

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/SqlQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/SqlQueryScheduler.java
@@ -1543,6 +1543,7 @@ public class SqlQueryScheduler
             checkState(started.compareAndSet(false, true), "already started");
 
             try (SetThreadName ignored = new SetThreadName("Query-%s", queryStateMachine.getQueryId())) {
+                stageSchedulers.values().forEach(StageScheduler::start);
                 while (!executionSchedule.isFinished()) {
                     List<ListenableFuture<Void>> blockedStages = new ArrayList<>();
                     StagesScheduleResult stagesScheduleResult = executionSchedule.getStagesToSchedule();

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/StageScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/StageScheduler.java
@@ -19,6 +19,17 @@ public interface StageScheduler
         extends Closeable
 {
     /**
+     * Called by the query scheduler when the scheduling process begins.
+     * This method is called before the ExecutionSchedule takes a decision
+     * to schedule a stage but after the query scheduling has been fully initialized.
+     * Within this method the scheduler may decide to schedule tasks that
+     * are necessary for query execution to make progress.
+     * For example the scheduler may decide to schedule a task without
+     * assigning any splits to unblock dynamic filter collection.
+     */
+    default void start() {}
+
+    /**
      * Schedules as much work as possible without blocking.
      * The schedule results is a hint to the query scheduler if and
      * when the stage scheduler should be invoked again.  It is

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/policy/PhasedExecutionPolicy.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/policy/PhasedExecutionPolicy.java
@@ -14,15 +14,28 @@
 package io.trino.execution.scheduler.policy;
 
 import io.trino.execution.scheduler.StageExecution;
+import io.trino.server.DynamicFilterService;
+
+import javax.inject.Inject;
 
 import java.util.Collection;
+
+import static java.util.Objects.requireNonNull;
 
 public class PhasedExecutionPolicy
         implements ExecutionPolicy
 {
+    private final DynamicFilterService dynamicFilterService;
+
+    @Inject
+    public PhasedExecutionPolicy(DynamicFilterService dynamicFilterService)
+    {
+        this.dynamicFilterService = requireNonNull(dynamicFilterService, "dynamicFilterService is null");
+    }
+
     @Override
     public ExecutionSchedule createExecutionSchedule(Collection<StageExecution> stages)
     {
-        return PhasedExecutionSchedule.forStages(stages);
+        return PhasedExecutionSchedule.forStages(stages, dynamicFilterService);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/DynamicFilterService.java
+++ b/core/trino-main/src/main/java/io/trino/server/DynamicFilterService.java
@@ -232,7 +232,21 @@ public class DynamicFilterService
             return false;
         }
 
-        return !getSourceStageInnerLazyDynamicFilters(plan).isEmpty();
+        // dynamic filters are collected by additional task only for non-fixed source stage
+        return plan.getPartitioning().equals(SOURCE_DISTRIBUTION) && !getLazyDynamicFilters(plan).isEmpty();
+    }
+
+    public boolean isStageSchedulingNeededToCollectDynamicFilters(QueryId queryId, PlanFragment plan)
+    {
+        DynamicFilterContext context = dynamicFilterContexts.get(queryId);
+        if (context == null) {
+            // query has been removed or not registered (e.g dynamic filtering is disabled)
+            return false;
+        }
+
+        // stage scheduling is not needed to collect dynamic filters for non-fixed source stage, because
+        // for such stage collecting task is created
+        return !plan.getPartitioning().equals(SOURCE_DISTRIBUTION) && !getLazyDynamicFilters(plan).isEmpty();
     }
 
     /**

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveDynamicPartitionPruningTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveDynamicPartitionPruningTest.java
@@ -47,4 +47,27 @@ public class TestHiveDynamicPartitionPruningTest
                 String.join(",", columns));
         getQueryRunner().execute(sql);
     }
+
+    @Override
+    protected void createPartitionedTable(String tableName, List<String> columns, List<String> partitionColumns)
+    {
+        @Language("SQL") String sql = format(
+                "CREATE TABLE %s (%s) WITH (partitioned_by=array[%s])",
+                tableName,
+                String.join(",", columns),
+                partitionColumns.stream().map(column -> "'" + column + "'").collect(joining(",")));
+        getQueryRunner().execute(sql);
+    }
+
+    @Override
+    protected void createPartitionedAndBucketedTable(String tableName, List<String> columns, List<String> partitionColumns, List<String> bucketColumns)
+    {
+        @Language("SQL") String sql = format(
+                "CREATE TABLE %s (%s) WITH (partitioned_by=array[%s], bucketed_by=array[%s], bucket_count=10)",
+                tableName,
+                String.join(",", columns),
+                partitionColumns.stream().map(column -> "'" + column + "'").collect(joining(",")),
+                bucketColumns.stream().map(column -> "'" + column + "'").collect(joining(",")));
+        getQueryRunner().execute(sql);
+    }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergDynamicPartitionPruningTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergDynamicPartitionPruningTest.java
@@ -38,7 +38,7 @@ public class TestIcebergDynamicPartitionPruningTest
     @Override
     protected void createLineitemTable(String tableName, List<String> columns, List<String> partitionColumns)
     {
-        String sql = format(
+        @Language("SQL") String sql = format(
                 "CREATE TABLE %s WITH (partitioning=array[%s]) AS SELECT %s FROM tpch.tiny.lineitem",
                 tableName,
                 partitionColumns.stream().map(column -> "'" + column + "'").collect(joining(",")),

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergDynamicPartitionPruningTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergDynamicPartitionPruningTest.java
@@ -14,8 +14,11 @@
 package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableMap;
+import io.trino.FeaturesConfig.JoinDistributionType;
 import io.trino.testing.BaseDynamicPartitionPruningTest;
 import io.trino.testing.QueryRunner;
+import org.intellij.lang.annotations.Language;
+import org.testng.SkipException;
 
 import java.util.List;
 
@@ -36,6 +39,12 @@ public class TestIcebergDynamicPartitionPruningTest
     }
 
     @Override
+    public void testJoinDynamicFilteringMultiJoinOnBucketedTables(JoinDistributionType joinDistributionType)
+    {
+        throw new SkipException("Iceberg does not support bucketing");
+    }
+
+    @Override
     protected void createLineitemTable(String tableName, List<String> columns, List<String> partitionColumns)
     {
         @Language("SQL") String sql = format(
@@ -44,5 +53,22 @@ public class TestIcebergDynamicPartitionPruningTest
                 partitionColumns.stream().map(column -> "'" + column + "'").collect(joining(",")),
                 String.join(",", columns));
         getQueryRunner().execute(sql);
+    }
+
+    @Override
+    protected void createPartitionedTable(String tableName, List<String> columns, List<String> partitionColumns)
+    {
+        @Language("SQL") String sql = format(
+                "CREATE TABLE %s (%s) WITH (partitioning=array[%s])",
+                tableName,
+                String.join(",", columns),
+                partitionColumns.stream().map(column -> "'" + column + "'").collect(joining(",")));
+        getQueryRunner().execute(sql);
+    }
+
+    @Override
+    protected void createPartitionedAndBucketedTable(String tableName, List<String> columns, List<String> partitionColumns, List<String> bucketColumns)
+    {
+        throw new UnsupportedOperationException();
     }
 }

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseDynamicPartitionPruningTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseDynamicPartitionPruningTest.java
@@ -16,20 +16,25 @@ package io.trino.testing;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.trino.FeaturesConfig.JoinDistributionType;
 import io.trino.Session;
+import io.trino.execution.QueryStats;
 import io.trino.operator.OperatorStats;
 import io.trino.server.DynamicFilterService.DynamicFilterDomainStats;
 import io.trino.server.DynamicFilterService.DynamicFiltersStats;
+import io.trino.spi.QueryId;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.ValueSet;
 import io.trino.tpch.TpchTable;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.FeaturesConfig.JoinDistributionType.PARTITIONED;
@@ -41,11 +46,13 @@ import static io.trino.spi.predicate.Domain.none;
 import static io.trino.spi.predicate.Domain.singleValue;
 import static io.trino.spi.predicate.Range.range;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.testing.DataProviders.toDataProvider;
 import static io.trino.testing.QueryAssertions.assertEqualsIgnoreOrder;
 import static io.trino.tpch.TpchTable.LINE_ITEM;
 import static io.trino.tpch.TpchTable.ORDERS;
 import static io.trino.tpch.TpchTable.SUPPLIER;
 import static io.trino.util.DynamicFiltersTestUtil.getSimplifiedDomainString;
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -72,6 +79,10 @@ public abstract class BaseDynamicPartitionPruningTest
     }
 
     protected abstract void createLineitemTable(String tableName, List<String> columns, List<String> partitionColumns);
+
+    protected abstract void createPartitionedTable(String tableName, List<String> columns, List<String> partitionColumns);
+
+    protected abstract void createPartitionedAndBucketedTable(String tableName, List<String> columns, List<String> partitionColumns, List<String> bucketColumns);
 
     @Override
     protected Session getSession()
@@ -416,9 +427,95 @@ public abstract class BaseDynamicPartitionPruningTest
                 .isEqualTo(getSimplifiedDomainString(1L, 100L, 100, BIGINT));
     }
 
+    @Test(timeOut = 30_000, dataProvider = "joinDistributionTypes")
+    public void testJoinDynamicFilteringMultiJoinOnPartitionedTables(JoinDistributionType joinDistributionType)
+    {
+        assertUpdate("DROP TABLE IF EXISTS t0_part");
+        assertUpdate("DROP TABLE IF EXISTS t1_part");
+        assertUpdate("DROP TABLE IF EXISTS t2_part");
+        createPartitionedTable("t0_part", ImmutableList.of("v0 real", "k0 integer"), ImmutableList.of("k0"));
+        createPartitionedTable("t1_part", ImmutableList.of("v1 real", "i1 integer"), ImmutableList.of());
+        createPartitionedTable("t2_part", ImmutableList.of("v2 real", "i2 integer", "k2 integer"), ImmutableList.of("k2"));
+        assertUpdate("INSERT INTO t0_part VALUES (1.0, 1), (1.0, 2)", 2);
+        assertUpdate("INSERT INTO t1_part VALUES (2.0, 10), (2.0, 20)", 2);
+        assertUpdate("INSERT INTO t2_part VALUES (3.0, 1, 1), (3.0, 2, 2)", 2);
+        testJoinDynamicFilteringMultiJoin(joinDistributionType, "t0_part", "t1_part", "t2_part");
+    }
+
+    @Test(timeOut = 30_000, dataProvider = "joinDistributionTypes")
+    public void testJoinDynamicFilteringMultiJoinOnBucketedTables(JoinDistributionType joinDistributionType)
+    {
+        assertUpdate("DROP TABLE IF EXISTS t0_bucketed");
+        assertUpdate("DROP TABLE IF EXISTS t1_bucketed");
+        assertUpdate("DROP TABLE IF EXISTS t2_bucketed");
+        createPartitionedAndBucketedTable("t0_bucketed", ImmutableList.of("v0 real", "k0 integer"), ImmutableList.of("k0"), ImmutableList.of("v0"));
+        createPartitionedAndBucketedTable("t1_bucketed", ImmutableList.of("v1 real", "i1 integer"), ImmutableList.of(), ImmutableList.of("v1"));
+        createPartitionedAndBucketedTable("t2_bucketed", ImmutableList.of("v2 real", "i2 integer", "k2 integer"), ImmutableList.of("k2"), ImmutableList.of("v2"));
+        assertUpdate("INSERT INTO t0_bucketed VALUES (1.0, 1), (1.0, 2)", 2);
+        assertUpdate("INSERT INTO t1_bucketed VALUES (2.0, 10), (2.0, 20)", 2);
+        assertUpdate("INSERT INTO t2_bucketed VALUES (3.0, 1, 1), (3.0, 2, 2)", 2);
+        testJoinDynamicFilteringMultiJoin(joinDistributionType, "t0_bucketed", "t1_bucketed", "t2_bucketed");
+    }
+
+    private void testJoinDynamicFilteringMultiJoin(JoinDistributionType joinDistributionType, String t0, String t1, String t2)
+    {
+        // queries should not deadlock
+
+        // t0 table scan depends on DFs from t1 and t2
+        assertDynamicFilters(
+                noJoinReordering(joinDistributionType),
+                format("SELECT v0, v1, v2 FROM (%s JOIN %s ON k0 = i2) JOIN %s ON k0 = i1", t0, t2, t1),
+                0);
+
+        // DF evaluation order is: t1 => t2 => t0
+        assertDynamicFilters(
+                noJoinReordering(joinDistributionType),
+                format("SELECT v0, v1, v2 FROM (%s JOIN %s ON k0 = i2) JOIN %s ON k2 = i1", t0, t2, t1),
+                0);
+
+        // t2 table scan depends on t1 DFs, but t0 <-> t2 join is blocked on t2 data
+        // "(k0 * -1) + 2 = i2)" prevents DF to be used on t0
+        assertDynamicFilters(
+                noJoinReordering(joinDistributionType),
+                format("SELECT v0, v1, v2 FROM (%s JOIN %s ON (k0 * -1) + 2 = i2) JOIN %s ON k2 = i1", t0, t2, t1),
+                0);
+    }
+
+    private void assertDynamicFilters(Session session, @Language("SQL") String query, int expectedRowCount)
+    {
+        long filteredInputPositions = getQueryInputPositions(session, query, expectedRowCount);
+        long unfilteredInputPositions = getQueryInputPositions(withDynamicFilteringDisabled(session), query, 0);
+
+        assertThat(filteredInputPositions)
+                .as("filtered input positions")
+                .isLessThan(unfilteredInputPositions);
+    }
+
+    private long getQueryInputPositions(Session session, @Language("SQL") String sql, int expectedRowCount)
+    {
+        DistributedQueryRunner runner = (DistributedQueryRunner) getQueryRunner();
+        ResultWithQueryId<MaterializedResult> result = runner.executeWithQueryId(session, sql);
+        assertThat(result.getResult().getRowCount()).isEqualTo(expectedRowCount);
+        QueryId queryId = result.getQueryId();
+        QueryStats stats = runner.getCoordinator().getQueryManager().getFullQueryInfo(queryId).getQueryStats();
+        return stats.getPhysicalInputPositions();
+    }
+
+    @DataProvider
+    public Object[][] joinDistributionTypes()
+    {
+        return Stream.of(JoinDistributionType.values())
+                .collect(toDataProvider());
+    }
+
     private Session withDynamicFilteringDisabled()
     {
-        return Session.builder(getSession())
+        return withDynamicFilteringDisabled(getSession());
+    }
+
+    private Session withDynamicFilteringDisabled(Session session)
+    {
+        return Session.builder(session)
                 .setSystemProperty("enable_dynamic_filtering", "false")
                 .build();
     }


### PR DESCRIPTION
In case of plan
        J1
       /  \
     J2    S3
    /  \
   S1  S2

It might happen that that dynamic filtering dependencies are:
S3 => S3 => S1

With phased scheduler source stage consisting of
(J1, J2, S1) won't be scheduler until stages with S3 and S2
have finished split enumaration. However, it might happen
that S2 is waiting for dynamic filters for S3. In that case,
S3 will never complete because DFs for S3 are collected in
stage (J1, J2, S1).

This commit makes scheduling of DF collecting task immediately
which will prevent queries from deadlock.