### PR TITLE
Remove manual creation of io.trino.metadata.Catalog in tests

### DIFF
--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -258,6 +258,7 @@ public class LocalQueryRunner
     private final ColumnPropertyManager columnPropertyManager;
     private final TablePropertyManager tablePropertyManager;
     private final MaterializedViewPropertyManager materializedViewPropertyManager;
+    private final AnalyzePropertyManager analyzePropertyManager;
 
     private final PageFunctionCompiler pageFunctionCompiler;
     private final ExpressionCompiler expressionCompiler;
@@ -361,7 +362,7 @@ public class LocalQueryRunner
         this.columnPropertyManager = new ColumnPropertyManager();
         this.tablePropertyManager = new TablePropertyManager();
         this.materializedViewPropertyManager = new MaterializedViewPropertyManager();
-        AnalyzePropertyManager analyzePropertyManager = new AnalyzePropertyManager();
+        this.analyzePropertyManager = new AnalyzePropertyManager();
         TableProceduresPropertyManager tableProceduresPropertyManager = new TableProceduresPropertyManager();
 
         this.statementAnalyzerFactory = new StatementAnalyzerFactory(
@@ -560,6 +561,26 @@ public class LocalQueryRunner
     public Metadata getMetadata()
     {
         return plannerContext.getMetadata();
+    }
+
+    public TablePropertyManager getTablePropertyManager()
+    {
+        return tablePropertyManager;
+    }
+
+    public ColumnPropertyManager getColumnPropertyManager()
+    {
+        return columnPropertyManager;
+    }
+
+    public MaterializedViewPropertyManager getMaterializedViewPropertyManager()
+    {
+        return materializedViewPropertyManager;
+    }
+
+    public AnalyzePropertyManager getAnalyzePropertyManager()
+    {
+        return analyzePropertyManager;
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/testing/TestingSession.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingSession.java
@@ -13,28 +13,16 @@
  */
 package io.trino.testing;
 
-import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
 import io.trino.Session.SessionBuilder;
-import io.trino.connector.CatalogName;
-import io.trino.connector.system.StaticSystemTablesProvider;
-import io.trino.connector.system.SystemTablesMetadata;
 import io.trino.execution.QueryIdGenerator;
-import io.trino.metadata.Catalog;
-import io.trino.metadata.Catalog.SecurityManagement;
 import io.trino.metadata.SessionPropertyManager;
-import io.trino.spi.connector.Connector;
-import io.trino.spi.connector.ConnectorMetadata;
-import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.security.Identity;
-import io.trino.spi.transaction.IsolationLevel;
 import io.trino.spi.type.TimeZoneKey;
 import io.trino.sql.SqlPath;
 
 import java.util.Optional;
 
-import static io.trino.connector.CatalogName.createInformationSchemaCatalogName;
-import static io.trino.connector.CatalogName.createSystemTablesCatalogName;
 import static java.util.Locale.ENGLISH;
 
 public final class TestingSession
@@ -72,38 +60,5 @@ public final class TestingSession
                 .setLocale(ENGLISH)
                 .setRemoteUserAddress("address")
                 .setUserAgent("agent");
-    }
-
-    public static Catalog createBogusTestingCatalog(String catalogName)
-    {
-        CatalogName catalog = new CatalogName(catalogName);
-        return new Catalog(
-                catalogName,
-                catalog,
-                "test",
-                createTestSessionConnector(),
-                SecurityManagement.CONNECTOR,
-                createInformationSchemaCatalogName(catalog),
-                createTestSessionConnector(),
-                createSystemTablesCatalogName(catalog),
-                createTestSessionConnector());
-    }
-
-    private static Connector createTestSessionConnector()
-    {
-        return new Connector()
-        {
-            @Override
-            public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly, boolean autoCommit)
-            {
-                return new ConnectorTransactionHandle() {};
-            }
-
-            @Override
-            public ConnectorMetadata getMetadata(ConnectorTransactionHandle transaction)
-            {
-                return new SystemTablesMetadata(new StaticSystemTablesProvider(ImmutableSet.of()));
-            }
-        };
     }
 }

--- a/core/trino-main/src/test/java/io/trino/connector/StaticConnectorFactory.java
+++ b/core/trino-main/src/test/java/io/trino/connector/StaticConnectorFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.connector;
+
+import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorContext;
+import io.trino.spi.connector.ConnectorFactory;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class StaticConnectorFactory
+        implements ConnectorFactory
+{
+    private final String name;
+    private final Connector connector;
+
+    public StaticConnectorFactory(String name, Connector connector)
+    {
+        this.name = requireNonNull(name, "name is null");
+        this.connector = requireNonNull(connector, "connector is null");
+    }
+
+    @Override
+    public String getName()
+    {
+        return name;
+    }
+
+    @Override
+    public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
+    {
+        return connector;
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/eventlistener/TestConnectorEventListener.java
+++ b/core/trino-main/src/test/java/io/trino/eventlistener/TestConnectorEventListener.java
@@ -48,7 +48,7 @@ public class TestConnectorEventListener
                 .build();
         queryRunner.createCatalog(
                 "event_listening",
-                new MockConnectorFactory.Builder()
+                MockConnectorFactory.builder()
                         .withEventListener(listenerFactory)
                         .build(),
                 ImmutableMap.of());

--- a/core/trino-main/src/test/java/io/trino/execution/TestCallTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCallTask.java
@@ -15,11 +15,10 @@ package io.trino.execution;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.trino.FeaturesConfig;
 import io.trino.Session;
 import io.trino.connector.CatalogName;
+import io.trino.connector.MockConnectorFactory;
 import io.trino.execution.warnings.WarningCollector;
-import io.trino.metadata.CatalogManager;
 import io.trino.metadata.MetadataManager;
 import io.trino.metadata.ProcedureRegistry;
 import io.trino.plugin.base.security.AllowAllSystemAccessControl;
@@ -34,6 +33,7 @@ import io.trino.spi.security.AccessDeniedException;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.tree.Call;
 import io.trino.sql.tree.QualifiedName;
+import io.trino.testing.LocalQueryRunner;
 import io.trino.testing.TestingAccessControlManager;
 import io.trino.transaction.TransactionManager;
 import org.testng.annotations.AfterClass;
@@ -48,15 +48,13 @@ import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
-import static io.trino.metadata.MetadataManager.createTestMetadataManager;
+import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.spi.block.MethodHandleUtil.methodHandle;
 import static io.trino.sql.planner.TestingPlannerContext.plannerContextBuilder;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.INSERT_TABLE;
 import static io.trino.testing.TestingAccessControlManager.privilege;
 import static io.trino.testing.TestingEventListenerManager.emptyEventListenerManager;
-import static io.trino.testing.TestingSession.createBogusTestingCatalog;
 import static io.trino.testing.TestingSession.testSessionBuilder;
-import static io.trino.transaction.InMemoryTransactionManager.createTestTransactionManager;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -67,16 +65,22 @@ public class TestCallTask
     private ExecutorService executor;
 
     private static boolean invoked;
+    private LocalQueryRunner queryRunner;
 
     @BeforeClass
     public void init()
     {
+        queryRunner = LocalQueryRunner.builder(TEST_SESSION).build();
+        queryRunner.createCatalog("test", MockConnectorFactory.create(), ImmutableMap.of());
         executor = newCachedThreadPool(daemonThreadsNamed("call-task-test-%s"));
     }
 
     @AfterClass(alwaysRun = true)
     public void close()
     {
+        if (queryRunner != null) {
+            queryRunner.close();
+        }
         executor.shutdownNow();
         executor = null;
     }
@@ -123,8 +127,8 @@ public class TestCallTask
 
     private void executeCallTask(MethodHandle methodHandle, Function<TransactionManager, AccessControl> accessControlProvider)
     {
-        TransactionManager transactionManager = createTransactionManager();
-        MetadataManager metadata = createTestMetadataManager(transactionManager, new FeaturesConfig());
+        TransactionManager transactionManager = queryRunner.getTransactionManager();
+        MetadataManager metadata = (MetadataManager) queryRunner.getMetadata();
         ProcedureRegistry procedureRegistry = createProcedureRegistry(
                 new Procedure(
                         "test",
@@ -140,13 +144,6 @@ public class TestCallTask
                         stateMachine(transactionManager, metadata, accessControl),
                         ImmutableList.of(),
                         WarningCollector.NOOP);
-    }
-
-    private static TransactionManager createTransactionManager()
-    {
-        CatalogManager catalogManager = new CatalogManager();
-        catalogManager.registerCatalog(createBogusTestingCatalog("test"));
-        return createTestTransactionManager(catalogManager);
     }
 
     private static ProcedureRegistry createProcedureRegistry(Procedure procedure)

--- a/core/trino-main/src/test/java/io/trino/execution/TestResetSessionTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestResetSessionTask.java
@@ -14,19 +14,18 @@
 package io.trino.execution;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import io.trino.FeaturesConfig;
 import io.trino.Session;
+import io.trino.connector.MockConnectorFactory;
 import io.trino.execution.warnings.WarningCollector;
-import io.trino.metadata.Catalog;
-import io.trino.metadata.CatalogManager;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.SessionPropertyManager;
 import io.trino.security.AccessControl;
-import io.trino.security.AllowAllAccessControl;
 import io.trino.spi.resourcegroups.ResourceGroupId;
 import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.ResetSession;
+import io.trino.testing.LocalQueryRunner;
 import io.trino.transaction.TransactionManager;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
@@ -38,18 +37,16 @@ import java.util.concurrent.ExecutorService;
 
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
-import static io.trino.metadata.MetadataManager.createTestMetadataManager;
+import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.spi.session.PropertyMetadata.stringProperty;
-import static io.trino.testing.TestingSession.createBogusTestingCatalog;
 import static io.trino.testing.TestingSession.testSessionBuilder;
-import static io.trino.transaction.InMemoryTransactionManager.createTestTransactionManager;
 import static java.util.Collections.emptyList;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static org.testng.Assert.assertEquals;
 
 public class TestResetSessionTask
 {
-    private static final String CATALOG_NAME = "catalog";
+    private static final String CATALOG_NAME = "my_catalog";
     private ExecutorService executor = newCachedThreadPool(daemonThreadsNamed(getClass().getSimpleName() + "-%s"));
     private final TransactionManager transactionManager;
     private final AccessControl accessControl;
@@ -58,26 +55,30 @@ public class TestResetSessionTask
 
     public TestResetSessionTask()
     {
-        CatalogManager catalogManager = new CatalogManager();
-        transactionManager = createTestTransactionManager(catalogManager);
-        accessControl = new AllowAllAccessControl();
+        LocalQueryRunner queryRunner = LocalQueryRunner.builder(TEST_SESSION)
+                .withExtraSystemSessionProperties(ImmutableSet.of(() -> ImmutableList.of(
+                        stringProperty(
+                                "foo",
+                                "test property",
+                                null,
+                                false))))
+                .build();
 
-        metadata = createTestMetadataManager(transactionManager, new FeaturesConfig());
-        sessionPropertyManager = new SessionPropertyManager();
+        queryRunner.createCatalog(
+                CATALOG_NAME,
+                MockConnectorFactory.builder()
+                        .withSessionProperty(stringProperty(
+                                "baz",
+                                "test property",
+                                null,
+                                false))
+                        .build(),
+                ImmutableMap.of());
 
-        sessionPropertyManager.addSystemSessionProperty(stringProperty(
-                "foo",
-                "test property",
-                null,
-                false));
-
-        Catalog bogusTestingCatalog = createBogusTestingCatalog(CATALOG_NAME);
-        sessionPropertyManager.addConnectorSessionProperties(bogusTestingCatalog.getConnectorCatalogName(), ImmutableList.of(stringProperty(
-                "baz",
-                "test property",
-                null,
-                false)));
-        catalogManager.registerCatalog(bogusTestingCatalog);
+        transactionManager = queryRunner.getTransactionManager();
+        accessControl = queryRunner.getAccessControl();
+        metadata = queryRunner.getMetadata();
+        sessionPropertyManager = queryRunner.getSessionPropertyManager();
     }
 
     @AfterClass(alwaysRun = true)
@@ -116,6 +117,6 @@ public class TestResetSessionTask
                 WarningCollector.NOOP));
 
         Set<String> sessionProperties = stateMachine.getResetSessionProperties();
-        assertEquals(sessionProperties, ImmutableSet.of("catalog.baz"));
+        assertEquals(sessionProperties, ImmutableSet.of(CATALOG_NAME + ".baz"));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestMaterializedViews.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestMaterializedViews.java
@@ -16,13 +16,7 @@ package io.trino.sql.planner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
-import io.trino.connector.CatalogName;
-import io.trino.connector.informationschema.InformationSchemaConnector;
-import io.trino.connector.system.SystemConnector;
-import io.trino.metadata.Catalog;
-import io.trino.metadata.Catalog.SecurityManagement;
-import io.trino.metadata.InMemoryNodeManager;
-import io.trino.metadata.InternalNodeManager;
+import io.trino.connector.StaticConnectorFactory;
 import io.trino.metadata.MaterializedViewDefinition;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedObjectName;
@@ -45,8 +39,6 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
-import static io.trino.connector.CatalogName.createInformationSchemaCatalogName;
-import static io.trino.connector.CatalogName.createSystemTablesCatalogName;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
@@ -70,11 +62,10 @@ public class TestMaterializedViews
                 .setSchema(SCHEMA)
                 .setSystemProperty("task_concurrency", "1"); // these tests don't handle exchanges from local parallel
 
-        LocalQueryRunner queryRunner = LocalQueryRunner.create(sessionBuilder.build());
+        TestingMetadata testingConnectorMetadata = new TestingMetadata();
 
-        Catalog testCatalog = createTestingCatalog(CATALOG, new CatalogName(CATALOG), queryRunner);
-        queryRunner.getCatalogManager().registerCatalog(testCatalog);
-        TestingMetadata testingConnectorMetadata = (TestingMetadata) testCatalog.getConnector(new CatalogName(CATALOG)).getMetadata(null);
+        LocalQueryRunner queryRunner = LocalQueryRunner.create(sessionBuilder.build());
+        queryRunner.createCatalog(CATALOG, new StaticConnectorFactory("test", new TestMaterializedViewConnector(testingConnectorMetadata)), ImmutableMap.of());
 
         Metadata metadata = queryRunner.getMetadata();
         SchemaTableName testTable = new SchemaTableName(SCHEMA, "test_table");
@@ -209,43 +200,26 @@ public class TestMaterializedViews
                                 tableScan("storage_table_with_casts", ImmutableMap.of("A", "a", "B", "b")))));
     }
 
-    private Catalog createTestingCatalog(String catalogName, CatalogName catalog, LocalQueryRunner queryRunner)
+    private static class TestMaterializedViewConnector
+            implements Connector
     {
-        CatalogName systemId = createSystemTablesCatalogName(catalog);
-        Connector connector = createTestingConnector();
-        InternalNodeManager nodeManager = new InMemoryNodeManager();
-        return new Catalog(
-                catalogName,
-                catalog,
-                "test",
-                connector,
-                SecurityManagement.CONNECTOR,
-                createInformationSchemaCatalogName(catalog),
-                new InformationSchemaConnector(catalogName, nodeManager, queryRunner.getMetadata(), queryRunner.getAccessControl()),
-                systemId,
-                new SystemConnector(
-                        nodeManager,
-                        connector.getSystemTables(),
-                        transactionId -> queryRunner.getTransactionManager().getConnectorTransaction(transactionId, catalog)));
-    }
+        private final ConnectorMetadata metadata;
 
-    private static Connector createTestingConnector()
-    {
-        return new Connector()
+        public TestMaterializedViewConnector(ConnectorMetadata metadata)
         {
-            private final ConnectorMetadata metadata = new TestingMetadata();
+            this.metadata = metadata;
+        }
 
-            @Override
-            public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly, boolean autoCommit)
-            {
-                return new ConnectorTransactionHandle() {};
-            }
+        @Override
+        public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly, boolean autoCommit)
+        {
+            return new ConnectorTransactionHandle() {};
+        }
 
-            @Override
-            public ConnectorMetadata getMetadata(ConnectorTransactionHandle transaction)
-            {
-                return metadata;
-            }
-        };
+        @Override
+        public ConnectorMetadata getMetadata(ConnectorTransactionHandle transaction)
+        {
+            return metadata;
+        }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestTableScanNodePartitioning.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestTableScanNodePartitioning.java
@@ -196,8 +196,7 @@ public class TestTableScanNodePartitioning
 
     public static MockConnectorFactory createMockFactory()
     {
-        MockConnectorFactory.Builder builder = MockConnectorFactory.builder();
-        builder
+        return MockConnectorFactory.builder()
                 .withGetColumns(schemaTableName -> ImmutableList.of(
                         new ColumnMetadata(COLUMN_A, BIGINT),
                         new ColumnMetadata(COLUMN_B, VARCHAR)))
@@ -227,8 +226,8 @@ public class TestTableScanNodePartitioning
                                 ImmutableList.of());
                     }
                     return new ConnectorTableProperties();
-                });
-        return builder.build();
+                })
+                .build();
     }
 
     public static class TestPartitioningProvider

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestShowQueries.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestShowQueries.java
@@ -15,7 +15,6 @@ package io.trino.sql.query;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.trino.connector.CatalogName;
 import io.trino.connector.MockConnectorFactory;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.SchemaTableName;
@@ -25,10 +24,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
-import java.util.List;
-
 import static io.trino.spi.type.BigintType.BIGINT;
-import static io.trino.testing.TestingSession.createBogusTestingCatalog;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -68,8 +64,7 @@ public class TestShowQueries
                         .withListTables((session, schemaName) -> ImmutableList.of(new SchemaTableName("mockSchema", "mockTable")))
                         .build(),
                 ImmutableMap.of());
-        queryRunner.getCatalogManager().registerCatalog(createBogusTestingCatalog("testing_catalog"));
-        queryRunner.getSessionPropertyManager().addConnectorSessionProperties(new CatalogName("testing_catalog"), List.of());
+        queryRunner.createCatalog("testing_catalog", "mock", ImmutableMap.of());
         assertions = new QueryAssertions(queryRunner);
     }
 

--- a/core/trino-main/src/test/java/io/trino/transaction/TestTransactionManager.java
+++ b/core/trino-main/src/test/java/io/trino/transaction/TestTransactionManager.java
@@ -17,19 +17,10 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.Duration;
 import io.trino.connector.CatalogName;
-import io.trino.connector.informationschema.InformationSchemaConnector;
-import io.trino.connector.system.SystemConnector;
-import io.trino.metadata.Catalog;
-import io.trino.metadata.Catalog.SecurityManagement;
 import io.trino.metadata.CatalogManager;
-import io.trino.metadata.InMemoryNodeManager;
-import io.trino.metadata.InternalNodeManager;
-import io.trino.metadata.Metadata;
 import io.trino.plugin.tpch.TpchConnectorFactory;
-import io.trino.security.AllowAllAccessControl;
-import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorMetadata;
-import io.trino.testing.TestingConnectorContext;
+import io.trino.testing.LocalQueryRunner;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -43,7 +34,6 @@ import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.connector.CatalogName.createInformationSchemaCatalogName;
 import static io.trino.connector.CatalogName.createSystemTablesCatalogName;
-import static io.trino.metadata.MetadataManager.createTestMetadataManager;
 import static io.trino.spi.StandardErrorCode.TRANSACTION_ALREADY_ABORTED;
 import static io.trino.testing.assertions.Assert.assertEventually;
 import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
@@ -71,12 +61,10 @@ public class TestTransactionManager
     @Test
     public void testTransactionWorkflow()
     {
-        try (IdleCheckExecutor executor = new IdleCheckExecutor()) {
-            CatalogManager catalogManager = new CatalogManager();
-            TransactionManager transactionManager = InMemoryTransactionManager.create(new TransactionManagerConfig(), executor.getExecutor(), catalogManager, finishingExecutor);
+        try (LocalQueryRunner queryRunner = LocalQueryRunner.create(TEST_SESSION)) {
+            TransactionManager transactionManager = queryRunner.getTransactionManager();
 
-            Connector c1 = new TpchConnectorFactory().create(CATALOG, ImmutableMap.of(), new TestingConnectorContext());
-            registerConnector(catalogManager, transactionManager, CATALOG, CATALOG_NAME, c1);
+            queryRunner.createCatalog(CATALOG, new TpchConnectorFactory(), ImmutableMap.of());
 
             TransactionId transactionId = transactionManager.beginTransaction(false);
 
@@ -101,12 +89,10 @@ public class TestTransactionManager
     @Test
     public void testAbortedTransactionWorkflow()
     {
-        try (IdleCheckExecutor executor = new IdleCheckExecutor()) {
-            CatalogManager catalogManager = new CatalogManager();
-            TransactionManager transactionManager = InMemoryTransactionManager.create(new TransactionManagerConfig(), executor.getExecutor(), catalogManager, finishingExecutor);
+        try (LocalQueryRunner queryRunner = LocalQueryRunner.create(TEST_SESSION)) {
+            TransactionManager transactionManager = queryRunner.getTransactionManager();
 
-            Connector c1 = new TpchConnectorFactory().create(CATALOG, ImmutableMap.of(), new TestingConnectorContext());
-            registerConnector(catalogManager, transactionManager, CATALOG, CATALOG_NAME, c1);
+            queryRunner.createCatalog(CATALOG, new TpchConnectorFactory(), ImmutableMap.of());
 
             TransactionId transactionId = transactionManager.beginTransaction(false);
 
@@ -131,12 +117,10 @@ public class TestTransactionManager
     @Test
     public void testFailedTransactionWorkflow()
     {
-        try (IdleCheckExecutor executor = new IdleCheckExecutor()) {
-            CatalogManager catalogManager = new CatalogManager();
-            TransactionManager transactionManager = InMemoryTransactionManager.create(new TransactionManagerConfig(), executor.getExecutor(), catalogManager, finishingExecutor);
+        try (LocalQueryRunner queryRunner = LocalQueryRunner.create(TEST_SESSION)) {
+            TransactionManager transactionManager = queryRunner.getTransactionManager();
 
-            Connector c1 = new TpchConnectorFactory().create(CATALOG, ImmutableMap.of(), new TestingConnectorContext());
-            registerConnector(catalogManager, transactionManager, CATALOG, CATALOG_NAME, c1);
+            queryRunner.createCatalog(CATALOG, new TpchConnectorFactory(), ImmutableMap.of());
 
             TransactionId transactionId = transactionManager.beginTransaction(false);
 
@@ -189,32 +173,6 @@ public class TestTransactionManager
             transactionManager.trySetInactive(transactionId);
             assertEventually(new Duration(10, SECONDS), () -> assertTrue(transactionManager.getAllTransactionInfos().isEmpty()));
         }
-    }
-
-    private static void registerConnector(
-            CatalogManager catalogManager,
-            TransactionManager transactionManager,
-            String catalogName,
-            CatalogName catalog,
-            Connector connector)
-    {
-        CatalogName systemId = createSystemTablesCatalogName(catalog);
-        InternalNodeManager nodeManager = new InMemoryNodeManager();
-        Metadata metadata = createTestMetadataManager(catalogManager);
-
-        catalogManager.registerCatalog(new Catalog(
-                catalogName,
-                catalog,
-                "test",
-                connector,
-                SecurityManagement.CONNECTOR,
-                createInformationSchemaCatalogName(catalog),
-                new InformationSchemaConnector(catalogName, nodeManager, metadata, new AllowAllAccessControl()),
-                systemId,
-                new SystemConnector(
-                        nodeManager,
-                        connector.getSystemTables(),
-                        transactionId -> transactionManager.getConnectorTransaction(transactionId, catalog))));
     }
 
     private static class IdleCheckExecutor

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestConnectorEventListener.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestConnectorEventListener.java
@@ -53,7 +53,7 @@ public class TestConnectorEventListener
             @Override
             public Iterable<ConnectorFactory> getConnectorFactories()
             {
-                return ImmutableList.of(new MockConnectorFactory.Builder()
+                return ImmutableList.of(MockConnectorFactory.builder()
                         .withEventListener(new TestingEventListener(generatedEvents))
                         .build());
             }

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestLocalEngineOnlyQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestLocalEngineOnlyQueries.java
@@ -13,13 +13,13 @@
  */
 package io.trino.tests;
 
-import io.trino.connector.CatalogName;
+import com.google.common.collect.ImmutableMap;
+import io.trino.connector.MockConnectorFactory;
 import io.trino.testing.LocalQueryRunner;
 import io.trino.testing.QueryRunner;
 import org.testng.SkipException;
 
 import static io.airlift.testing.Closeables.closeAllSuppress;
-import static io.trino.testing.TestingSession.createBogusTestingCatalog;
 
 public class TestLocalEngineOnlyQueries
         extends AbstractTestEngineOnlyQueries
@@ -31,8 +31,12 @@ public class TestLocalEngineOnlyQueries
         try {
             // for testing session properties
             queryRunner.getSessionPropertyManager().addSystemSessionProperties(TEST_SYSTEM_PROPERTIES);
-            queryRunner.getCatalogManager().registerCatalog(createBogusTestingCatalog(TESTING_CATALOG));
-            queryRunner.getSessionPropertyManager().addConnectorSessionProperties(new CatalogName(TESTING_CATALOG), TEST_CATALOG_PROPERTIES);
+            queryRunner.createCatalog(
+                    TESTING_CATALOG,
+                    MockConnectorFactory.builder()
+                            .withSessionProperties(TEST_CATALOG_PROPERTIES)
+                            .build(),
+                    ImmutableMap.of());
         }
         catch (RuntimeException e) {
             throw closeAllSuppress(e, queryRunner);


### PR DESCRIPTION
Catalog is a deep internal API and use if this interface in tests makes refatoring of the engine difficult.  Instead LocalQueryRunner is used to add catalogs and fetch internal services.