### PR TITLE
Remove redundant error-checking from bash script

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hdp3/apply-hdp3-config.sh
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hdp3/apply-hdp3-config.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
 set -exuo pipefail
 
-fail() {
-  echo "$(basename "$0"): $*" >&2
-  exit 1
-}
-
 echo "Applying HDP3 hive-site configuration overrides"
-
-apply-site-xml-override /etc/hive/conf/hive-site.xml "/docker/presto-product-tests/conf/environment/singlenode-hdp3/hive-site-overrides.xml" || fail "Could not apply hive-site-overrides.xml"
+apply-site-xml-override /etc/hive/conf/hive-site.xml "/docker/presto-product-tests/conf/environment/singlenode-hdp3/hive-site-overrides.xml"

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg/apply-hive-config-for-iceberg.sh
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg/apply-hive-config-for-iceberg.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
 set -exuo pipefail
 
-fail() {
-  echo "$(basename "$0"): $*" >&2
-  exit 1
-}
-
 echo "Applying hive-site configuration overrides for Spark"
-
-apply-site-xml-override /etc/hive/conf/hive-site.xml "/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg/hive-site-overrides.xml" || fail "Could not apply hive-site-overrides.xml"
+apply-site-xml-override /etc/hive/conf/hive-site.xml "/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg/hive-site-overrides.xml"


### PR DESCRIPTION
The script is run with `-e`, so manual error handling is redundant. It's
run with `-x`, so in case of error, we know what failed.