### PR TITLE
Update SQL Server JDBC driver to 10.2.0

### DIFF
--- a/docs/src/main/sphinx/connector/sqlserver.rst
+++ b/docs/src/main/sphinx/connector/sqlserver.rst
@@ -30,7 +30,7 @@ appropriate for your setup:
 .. code-block:: properties
 
     connector.name=sqlserver
-    connection-url=jdbc:sqlserver://<host>:<port>;database=<database>
+    connection-url=jdbc:sqlserver://<host>:<port>;database=<database>;encrypt=false
     connection-user=root
     connection-password=secret
 
@@ -49,20 +49,21 @@ properties files.
 Connection security
 ^^^^^^^^^^^^^^^^^^^
 
-If you have TLS configured with a globally-trusted certificate installed on your
-data source, you can enable TLS between your cluster and the data
-source by appending a parameter to the JDBC connection string set in the
-``connection-url`` catalog configuration property.
+The JDBC driver, and therefore the connector, automatically use Transport Layer
+Security (TLS) encryption and certificate validation. This requires a suitable
+TLS certificate configured on your SQL Server database host.
 
-For example, with the JDBC driver for SQL Server 2019, enable TLS by appending
-the ``encrypt=true`` parameter to the ``connection-url`` configuration property:
+If you do not have the necessary configuration established, you can disable
+encryption in the connection string with the ``encrypt`` property:
 
 .. code-block:: properties
 
-  connection-url=jdbc:sqlserver://<host>:<port>;database=<database>;encrypt=true
+  connection-url=jdbc:sqlserver://<host>:<port>;database=<database>;encrypt=false
 
-For more information on TLS configuration options, see the `SQL Server JDBC
-driver documentation <https://docs.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url>`_.
+Further parameters like ``trustServerCertificate``, ``hostNameInCertificate``,
+``trustStore``, and ``trustStorePassword`` are details in the `TLS section of
+SQL Server JDBC driver documentation
+<https://docs.microsoft.com/en-us/sql/connect/jdbc/using-ssl-encryption>`_.
 
 Multiple SQL Server databases or servers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestingSqlServer.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestingSqlServer.java
@@ -135,6 +135,10 @@ public final class TestingSqlServer
         // enable case sensitive (see the CS below) collation for SQL identifiers
         container.addEnv("MSSQL_COLLATION", "Latin1_General_CS_AS");
 
+        // TLS and certificate validation are on by default, and need
+        // to be disabled for tests.
+        container.withUrlParam("encrypt", "false");
+
         Closeable cleanup = startOrReuse(container);
         try {
             setUpDatabase(sqlExecutorForContainer(container), databaseName, databaseSetUp);

--- a/pom.xml
+++ b/pom.xml
@@ -1100,7 +1100,7 @@
             <dependency>
                 <groupId>com.microsoft.sqlserver</groupId>
                 <artifactId>mssql-jdbc</artifactId>
-                <version>9.4.1.jre11</version>
+                <version>10.2.0.jre11</version>
             </dependency>
 
             <dependency>

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-sqlserver/sqlserver.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-sqlserver/sqlserver.properties
@@ -1,5 +1,5 @@
 connector.name=sqlserver
-connection-url=jdbc:sqlserver://sqlserver
+connection-url=jdbc:sqlserver://sqlserver;encrypt=false
 connection-user=sa
 connection-password=SQLServerPass1
 allow-drop-table=true

--- a/testing/trino-product-tests/src/main/resources/tempto-configuration.yaml
+++ b/testing/trino-product-tests/src/main/resources/tempto-configuration.yaml
@@ -134,7 +134,7 @@ databases:
 
   sqlserver:
     jdbc_driver_class: com.microsoft.sqlserver.jdbc.SQLServerDriver
-    jdbc_url: jdbc:sqlserver://sqlserver
+    jdbc_url: jdbc:sqlserver://sqlserver;encrypt=false
     jdbc_user: sa
     jdbc_password: SQLServerPass1
     jdbc_pooling: true

--- a/testing/trino-server-dev/etc/catalog/sqlserver.properties
+++ b/testing/trino-server-dev/etc/catalog/sqlserver.properties
@@ -1,4 +1,4 @@
 connector.name=sqlserver
-connection-url=jdbc:sqlserver://sqlserver
+connection-url=jdbc:sqlserver://sqlserver;encrypt=false
 connection-user=sa
 connection-password=SQLServerPass1


### PR DESCRIPTION
## Description

Update the JDBC driver to the new major release version. Using the Java 11 version. A Java 17 one is also available if desired. This enables a simpler upgrade to the Java 17 version in the future when we update Trino to use 17.

See release notes for the new version for details. https://docs.microsoft.com/en-us/sql/connect/jdbc/release-notes-for-the-jdbc-driver?view=sql-server-ver15#94

## General information

Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

Is this a change to the core query engine, a connector, client library, or the SPI interfaces (be specific)?

SQL Server connector only

How would you describe this change to a non-technical end user or system administrator?

Using the new JDBC driver enables us to switch to the Java 17 version soon. The old version does not have Java 17 support. 

## Related issues and pull requests

* Potentially enables update to Java 17 since this is the first version of the JDBC driver with Java 17 support, see #9876
* Related issue in upstream https://github.com/microsoft/mssql-jdbc/issues/1732

## Documentation

( ) No documentation is needed.
(✅ ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(✅ ) Release notes entries required with the following suggested text:

```
## SQL Server connector

* Update JDBC driver to 10.2.0. Upgrade requires catalog configuration changes since the new version automatically enables encryption.  ({issue}`10898`)
```

Release notes should link to the updated section in the docs about the `Connection security`.
