### PR TITLE
Enable ClickHouse smoke tests except for Altinity 20.3.12

### DIFF
--- a/plugin/trino-clickhouse/pom.xml
+++ b/plugin/trino-clickhouse/pom.xml
@@ -203,8 +203,6 @@
                             <excludes>
                                 <!-- TODO (https://github.com/trinodb/trino/issues/10752) Enable after resolving flaky test issues -->
                                 <exclude>**/TestAltinityConnectorSmokeTest.java</exclude>
-                                <exclude>**/TestAltinityLatestConnectorSmokeTest.java</exclude>
-                                <exclude>**/TestClickHouseLatestConnectorSmokeTest.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
100 stress tests passed in #10675. Altinity 20.3.12 still has the flaky issue and we need to wait the driver improvement. 