### PR TITLE
Stop automated removal of `tests:hive` label

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,5 +15,7 @@ jobs:
       - uses: actions/labeler@v3
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          sync-labels: true
+          # Do not sync labels as this reverts manually added "tests:hive" label.
+          # Syncing labels requires that we define "components" labels.
+          sync-labels: false
           configuration-path: .github/config/labeler-config.yml


### PR DESCRIPTION
This label should not be removed automatically.
We can revisit this later, if needed.