### PR TITLE
Use IcebergFileFormat enum for better validation

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -17,7 +17,6 @@ import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.units.Duration;
 import io.trino.plugin.hive.HiveCompressionCodec;
-import org.apache.iceberg.FileFormat;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -52,9 +51,9 @@ public class IcebergConfig
     }
 
     @NotNull
-    public FileFormat getFileFormat()
+    public IcebergFileFormat getFileFormat()
     {
-        return FileFormat.valueOf(fileFormat.name());
+        return fileFormat;
     }
 
     @Config("iceberg.file-format")

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileFormat.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileFormat.java
@@ -13,8 +13,38 @@
  */
 package io.trino.plugin.iceberg;
 
+import com.google.common.base.VerifyException;
+import io.trino.spi.TrinoException;
+import org.apache.iceberg.FileFormat;
+
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+
 public enum IcebergFileFormat
 {
     ORC,
     PARQUET,
+    /**/;
+
+    public FileFormat toIceberg()
+    {
+        switch (this) {
+            case ORC:
+                return FileFormat.ORC;
+            case PARQUET:
+                return FileFormat.PARQUET;
+        }
+        throw new VerifyException("Unhandled type: " + this);
+    }
+
+    public static IcebergFileFormat fromIceberg(FileFormat format)
+    {
+        switch (format) {
+            case ORC:
+                return ORC;
+            case PARQUET:
+                return PARQUET;
+            default:
+                throw new TrinoException(NOT_SUPPORTED, "File format not supported for Iceberg: " + format);
+        }
+    }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
@@ -35,7 +35,6 @@ import io.trino.spi.type.TypeManager;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.JobConf;
-import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.types.Types;
@@ -111,7 +110,7 @@ public class IcebergFileWriterFactory
             JobConf jobConf,
             ConnectorSession session,
             HdfsContext hdfsContext,
-            FileFormat fileFormat,
+            IcebergFileFormat fileFormat,
             MetricsConfig metricsConfig)
     {
         switch (fileFormat) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -531,7 +531,7 @@ public class IcebergMetadata
             DataFiles.Builder builder = DataFiles.builder(icebergTable.spec())
                     .withPath(task.getPath())
                     .withFileSizeInBytes(task.getFileSizeInBytes())
-                    .withFormat(table.getFileFormat())
+                    .withFormat(table.getFileFormat().toIceberg())
                     .withMetrics(task.getMetrics().metrics());
 
             if (!icebergTable.spec().fields().isEmpty()) {
@@ -687,7 +687,7 @@ public class IcebergMetadata
             DataFiles.Builder builder = DataFiles.builder(icebergTable.spec())
                     .withPath(task.getPath())
                     .withFileSizeInBytes(task.getFileSizeInBytes())
-                    .withFormat(optimizeHandle.getFileFormat())
+                    .withFormat(optimizeHandle.getFileFormat().toIceberg())
                     .withMetrics(task.getMetrics().metrics());
 
             if (!icebergTable.spec().fields().isEmpty()) {
@@ -1114,7 +1114,7 @@ public class IcebergMetadata
             DataFiles.Builder builder = DataFiles.builder(icebergTable.spec())
                     .withPath(task.getPath())
                     .withFileSizeInBytes(task.getFileSizeInBytes())
-                    .withFormat(table.getFileFormat())
+                    .withFormat(table.getFileFormat().toIceberg())
                     .withMetrics(task.getMetrics().metrics());
 
             if (!icebergTable.spec().fields().isEmpty()) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
@@ -41,7 +41,6 @@ import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.JobConf;
-import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
@@ -95,7 +94,7 @@ public class IcebergPageSink
     private final JobConf jobConf;
     private final JsonCodec<CommitTaskData> jsonCodec;
     private final ConnectorSession session;
-    private final FileFormat fileFormat;
+    private final IcebergFileFormat fileFormat;
     private final MetricsConfig metricsConfig;
     private final PagePartitioner pagePartitioner;
 
@@ -116,7 +115,7 @@ public class IcebergPageSink
             List<IcebergColumnHandle> inputColumns,
             JsonCodec<CommitTaskData> jsonCodec,
             ConnectorSession session,
-            FileFormat fileFormat,
+            IcebergFileFormat fileFormat,
             Map<String, String> storageProperties,
             int maxOpenWriters)
     {
@@ -306,7 +305,7 @@ public class IcebergPageSink
 
     private WriteContext createWriter(Optional<PartitionData> partitionData)
     {
-        String fileName = fileFormat.addExtension(randomUUID().toString());
+        String fileName = fileFormat.toIceberg().addExtension(randomUUID().toString());
         Path outputPath = partitionData.map(partition -> new Path(locationProvider.newDataLocation(partitionSpec, partition, fileName)))
                 .orElse(new Path(locationProvider.newDataLocation(fileName)));
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -74,7 +74,6 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.BlockMissingException;
-import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.mapping.MappedField;
 import org.apache.iceberg.mapping.MappedFields;
 import org.apache.iceberg.mapping.NameMapping;
@@ -224,7 +223,7 @@ public class IcebergPageSourceProvider
             long start,
             long length,
             long fileSize,
-            FileFormat fileFormat,
+            IcebergFileFormat fileFormat,
             List<IcebergColumnHandle> dataColumns,
             TupleDomain<IcebergColumnHandle> predicate,
             Optional<NameMapping> nameMapping)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplit.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplit.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.SizeOf;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
-import org.apache.iceberg.FileFormat;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
@@ -41,7 +40,7 @@ public class IcebergSplit
     private final long start;
     private final long length;
     private final long fileSize;
-    private final FileFormat fileFormat;
+    private final IcebergFileFormat fileFormat;
     private final List<HostAddress> addresses;
     private final Map<Integer, Optional<String>> partitionKeys;
 
@@ -51,7 +50,7 @@ public class IcebergSplit
             @JsonProperty("start") long start,
             @JsonProperty("length") long length,
             @JsonProperty("fileSize") long fileSize,
-            @JsonProperty("fileFormat") FileFormat fileFormat,
+            @JsonProperty("fileFormat") IcebergFileFormat fileFormat,
             @JsonProperty("addresses") List<HostAddress> addresses,
             @JsonProperty("partitionKeys") Map<Integer, Optional<String>> partitionKeys)
     {
@@ -102,7 +101,7 @@ public class IcebergSplit
     }
 
     @JsonProperty
-    public FileFormat getFileFormat()
+    public IcebergFileFormat getFileFormat()
     {
         return fileFormat;
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
@@ -378,7 +378,7 @@ public class IcebergSplitSource
                 task.start(),
                 task.length(),
                 task.file().fileSizeInBytes(),
-                task.file().format(),
+                IcebergFileFormat.fromIceberg(task.file().format()),
                 ImmutableList.of(),
                 getPartitionKeys(task));
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableProperties.java
@@ -16,7 +16,6 @@ package io.trino.plugin.iceberg;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.type.ArrayType;
-import org.apache.iceberg.FileFormat;
 
 import javax.inject.Inject;
 
@@ -46,7 +45,7 @@ public class IcebergTableProperties
                 .add(enumProperty(
                         FILE_FORMAT_PROPERTY,
                         "File format for the table",
-                        FileFormat.class,
+                        IcebergFileFormat.class,
                         icebergConfig.getFileFormat(),
                         false))
                 .add(new PropertyMetadata<>(
@@ -73,9 +72,9 @@ public class IcebergTableProperties
         return tableProperties;
     }
 
-    public static FileFormat getFileFormat(Map<String, Object> tableProperties)
+    public static IcebergFileFormat getFileFormat(Map<String, Object> tableProperties)
     {
-        return (FileFormat) tableProperties.get(FILE_FORMAT_PROPERTY);
+        return (IcebergFileFormat) tableProperties.get(FILE_FORMAT_PROPERTY);
     }
 
     @SuppressWarnings("unchecked")

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -220,11 +220,11 @@ public final class IcebergUtil
         throw new IllegalStateException("Unsupported field type: " + nestedField);
     }
 
-    public static FileFormat getFileFormat(Table table)
+    public static IcebergFileFormat getFileFormat(Table table)
     {
-        return FileFormat.valueOf(table.properties()
+        return IcebergFileFormat.fromIceberg(FileFormat.valueOf(table.properties()
                 .getOrDefault(DEFAULT_FILE_FORMAT, DEFAULT_FILE_FORMAT_DEFAULT)
-                .toUpperCase(Locale.ENGLISH));
+                .toUpperCase(Locale.ENGLISH)));
     }
 
     public static Optional<String> getTableComment(Table table)
@@ -395,8 +395,8 @@ public final class IcebergUtil
                 .orElseGet(() -> catalog.defaultTableLocation(session, schemaTableName));
 
         ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.builderWithExpectedSize(2);
-        FileFormat fileFormat = IcebergTableProperties.getFileFormat(tableMetadata.getProperties());
-        propertiesBuilder.put(DEFAULT_FILE_FORMAT, fileFormat.toString());
+        IcebergFileFormat fileFormat = IcebergTableProperties.getFileFormat(tableMetadata.getProperties());
+        propertiesBuilder.put(DEFAULT_FILE_FORMAT, fileFormat.toIceberg().toString());
         if (tableMetadata.getComment().isPresent()) {
             propertiesBuilder.put(TABLE_COMMENT, tableMetadata.getComment().get());
         }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergWritableTableHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergWritableTableHandle.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.connector.ConnectorInsertTableHandle;
 import io.trino.spi.connector.ConnectorOutputTableHandle;
-import org.apache.iceberg.FileFormat;
 
 import java.util.List;
 import java.util.Map;
@@ -34,7 +33,7 @@ public class IcebergWritableTableHandle
     private final String partitionSpecAsJson;
     private final List<IcebergColumnHandle> inputColumns;
     private final String outputPath;
-    private final FileFormat fileFormat;
+    private final IcebergFileFormat fileFormat;
     private final Map<String, String> storageProperties;
 
     @JsonCreator
@@ -45,7 +44,7 @@ public class IcebergWritableTableHandle
             @JsonProperty("partitionSpecAsJson") String partitionSpecAsJson,
             @JsonProperty("inputColumns") List<IcebergColumnHandle> inputColumns,
             @JsonProperty("outputPath") String outputPath,
-            @JsonProperty("fileFormat") FileFormat fileFormat,
+            @JsonProperty("fileFormat") IcebergFileFormat fileFormat,
             @JsonProperty("properties") Map<String, String> storageProperties)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
@@ -95,7 +94,7 @@ public class IcebergWritableTableHandle
     }
 
     @JsonProperty
-    public FileFormat getFileFormat()
+    public IcebergFileFormat getFileFormat()
     {
         return fileFormat;
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergOptimizeHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergOptimizeHandle.java
@@ -19,7 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 import io.trino.plugin.iceberg.IcebergColumnHandle;
-import org.apache.iceberg.FileFormat;
+import io.trino.plugin.iceberg.IcebergFileFormat;
 
 import java.util.List;
 import java.util.Map;
@@ -32,7 +32,7 @@ public class IcebergOptimizeHandle
     private final String schemaAsJson;
     private final String partitionSpecAsJson;
     private final List<IcebergColumnHandle> tableColumns;
-    private final FileFormat fileFormat;
+    private final IcebergFileFormat fileFormat;
     private final Map<String, String> tableStorageProperties;
     private final DataSize maxScannedFileSize;
 
@@ -41,7 +41,7 @@ public class IcebergOptimizeHandle
             String schemaAsJson,
             String partitionSpecAsJson,
             List<IcebergColumnHandle> tableColumns,
-            FileFormat fileFormat,
+            IcebergFileFormat fileFormat,
             Map<String, String> tableStorageProperties,
             DataSize maxScannedFileSize)
     {
@@ -72,7 +72,7 @@ public class IcebergOptimizeHandle
     }
 
     @JsonProperty
-    public FileFormat getFileFormat()
+    public IcebergFileFormat getFileFormat()
     {
         return fileFormat;
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -50,7 +50,6 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.iceberg.FileFormat;
 import org.intellij.lang.annotations.Language;
 import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
@@ -87,6 +86,8 @@ import static io.trino.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static io.trino.SystemSessionProperties.PREFERRED_WRITE_PARTITIONING_MIN_NUMBER_OF_PARTITIONS;
 import static io.trino.plugin.hive.HdfsEnvironment.HdfsContext;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
+import static io.trino.plugin.iceberg.IcebergFileFormat.ORC;
+import static io.trino.plugin.iceberg.IcebergFileFormat.PARQUET;
 import static io.trino.plugin.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static io.trino.plugin.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
 import static io.trino.plugin.iceberg.IcebergSplitManager.ICEBERG_DOMAIN_COMPACTION_THRESHOLD;
@@ -109,8 +110,6 @@ import static java.util.Collections.nCopies;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.IntStream.range;
-import static org.apache.iceberg.FileFormat.ORC;
-import static org.apache.iceberg.FileFormat.PARQUET;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertFalse;
@@ -122,9 +121,9 @@ public abstract class BaseIcebergConnectorTest
 {
     private static final Pattern WITH_CLAUSE_EXTRACTOR = Pattern.compile(".*(WITH\\s*\\([^)]*\\))\\s*$", Pattern.DOTALL);
 
-    private final FileFormat format;
+    private final IcebergFileFormat format;
 
-    protected BaseIcebergConnectorTest(FileFormat format)
+    protected BaseIcebergConnectorTest(IcebergFileFormat format)
     {
         this.format = requireNonNull(format, "format is null");
     }
@@ -1078,11 +1077,11 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testCreateTableLike()
     {
-        FileFormat otherFormat = format == PARQUET ? ORC : PARQUET;
+        IcebergFileFormat otherFormat = (format == PARQUET) ? ORC : PARQUET;
         testCreateTableLikeForFormat(otherFormat);
     }
 
-    private void testCreateTableLikeForFormat(FileFormat otherFormat)
+    private void testCreateTableLikeForFormat(IcebergFileFormat otherFormat)
     {
         File tempDir = getDistributedQueryRunner().getCoordinator().getBaseDataDir().toFile();
         String tempDirPath = tempDir.toURI().toASCIIString() + randomTableSuffix();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcConnectorTest.java
@@ -15,7 +15,7 @@ package io.trino.plugin.iceberg;
 
 import io.trino.Session;
 
-import static org.apache.iceberg.FileFormat.ORC;
+import static io.trino.plugin.iceberg.IcebergFileFormat.ORC;
 
 public class TestIcebergOrcConnectorTest
         extends BaseIcebergConnectorTest

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetConnectorTest.java
@@ -21,7 +21,7 @@ import org.testng.annotations.Test;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.apache.iceberg.FileFormat.PARQUET;
+import static io.trino.plugin.iceberg.IcebergFileFormat.PARQUET;
 import static org.testng.Assert.assertEquals;
 
 public class TestIcebergParquetConnectorTest


### PR DESCRIPTION
The Iceberg enum has the METADATA type which is not valid for users.
