### PR TITLE
Fix compile error due to missing constant

### DIFF
--- a/core/trino-main/src/main/java/io/trino/type/DecimalCasts.java
+++ b/core/trino-main/src/main/java/io/trino/type/DecimalCasts.java
@@ -30,7 +30,6 @@ import io.trino.spi.type.DecimalConversions;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Decimals;
 import io.trino.spi.type.Int128;
-import io.trino.spi.type.Int128Math;
 import io.trino.spi.type.StandardTypes;
 import io.trino.spi.type.TypeSignature;
 import io.trino.spi.type.VarcharType;
@@ -53,6 +52,7 @@ import static io.trino.spi.type.Decimals.overflows;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.Int128.ZERO;
 import static io.trino.spi.type.Int128Math.multiply;
+import static io.trino.spi.type.Int128Math.powerOfTen;
 import static io.trino.spi.type.Int128Math.rescale;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
@@ -113,7 +113,7 @@ public final class DecimalCasts
                                         tenToScale = longTenToNth(DecimalConversions.intScale(scale));
                                     }
                                     else {
-                                        tenToScale = Int128Math.POWERS_OF_TEN[DecimalConversions.intScale(scale)];
+                                        tenToScale = powerOfTen(DecimalConversions.intScale(scale));
                                     }
                                     return ImmutableList.of(precision, scale, tenToScale);
                                 })))
@@ -147,7 +147,7 @@ public final class DecimalCasts
                                         tenToScale = longTenToNth(resultType.getScale());
                                     }
                                     else {
-                                        tenToScale = Int128Math.POWERS_OF_TEN[resultType.getScale()];
+                                        tenToScale = powerOfTen(resultType.getScale());
                                     }
                                     return ImmutableList.of(resultType.getPrecision(), resultType.getScale(), tenToScale);
                                 }))).build();

--- a/core/trino-main/src/main/java/io/trino/type/DecimalSaturatedFloorCasts.java
+++ b/core/trino-main/src/main/java/io/trino/type/DecimalSaturatedFloorCasts.java
@@ -24,10 +24,10 @@ import io.trino.spi.type.TypeSignature;
 
 import static io.trino.spi.function.OperatorType.SATURATED_FLOOR_CAST;
 import static io.trino.spi.type.BigintType.BIGINT;
-import static io.trino.spi.type.Int128Math.POWERS_OF_TEN;
 import static io.trino.spi.type.Int128Math.floorDiv;
 import static io.trino.spi.type.Int128Math.multiply;
 import static io.trino.spi.type.Int128Math.negate;
+import static io.trino.spi.type.Int128Math.powerOfTen;
 import static io.trino.spi.type.Int128Math.subtract;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.SmallintType.SMALLINT;
@@ -86,13 +86,13 @@ public final class DecimalSaturatedFloorCasts
     {
         int scale = resultScale - sourceScale;
         if (scale > 0) {
-            value = multiply(value, POWERS_OF_TEN[scale]);
+            value = multiply(value, powerOfTen(scale));
         }
         else if (scale < 0) {
-            value = floorDiv(value, POWERS_OF_TEN[-scale]);
+            value = floorDiv(value, powerOfTen(-scale));
         }
 
-        Int128 maxUnscaledValue = subtract(POWERS_OF_TEN[resultPrecision], Int128.ONE);
+        Int128 maxUnscaledValue = subtract(powerOfTen(resultPrecision), Int128.ONE);
         if (value.compareTo(maxUnscaledValue) > 0) {
             return maxUnscaledValue;
         }
@@ -142,7 +142,7 @@ public final class DecimalSaturatedFloorCasts
     private static long saturatedCast(Int128 value, int sourceScale, long minValue, long maxValue)
     {
         if (sourceScale > 0) {
-            value = floorDiv(value, POWERS_OF_TEN[sourceScale]);
+            value = floorDiv(value, powerOfTen(sourceScale));
         }
 
         if (value.compareTo(Int128.valueOf(maxValue)) > 0) {


### PR DESCRIPTION
The constant was hidden in a recent change and caused
a logical merge error that resulted in build failures.