### PR TITLE
Set transactions idle when query completes

### DIFF
--- a/core/trino-main/src/main/java/io/trino/dispatcher/DispatchManager.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/DispatchManager.java
@@ -36,7 +36,6 @@ import io.trino.spi.QueryId;
 import io.trino.spi.TrinoException;
 import io.trino.spi.resourcegroups.SelectionContext;
 import io.trino.spi.resourcegroups.SelectionCriteria;
-import io.trino.transaction.TransactionManager;
 import org.weakref.jmx.Flatten;
 import org.weakref.jmx.Managed;
 
@@ -54,7 +53,6 @@ import static io.trino.execution.QueryState.QUEUED;
 import static io.trino.execution.QueryState.RUNNING;
 import static io.trino.spi.StandardErrorCode.QUERY_TEXT_TOO_LARGE;
 import static io.trino.util.StatementUtils.getQueryType;
-import static io.trino.util.StatementUtils.isTransactionControlStatement;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -65,7 +63,6 @@ public class DispatchManager
     private final ResourceGroupManager<?> resourceGroupManager;
     private final DispatchQueryFactory dispatchQueryFactory;
     private final FailedDispatchQueryFactory failedDispatchQueryFactory;
-    private final TransactionManager transactionManager;
     private final AccessControl accessControl;
     private final SessionSupplier sessionSupplier;
     private final SessionPropertyDefaults sessionPropertyDefaults;
@@ -86,7 +83,6 @@ public class DispatchManager
             ResourceGroupManager<?> resourceGroupManager,
             DispatchQueryFactory dispatchQueryFactory,
             FailedDispatchQueryFactory failedDispatchQueryFactory,
-            TransactionManager transactionManager,
             AccessControl accessControl,
             SessionSupplier sessionSupplier,
             SessionPropertyDefaults sessionPropertyDefaults,
@@ -99,7 +95,6 @@ public class DispatchManager
         this.resourceGroupManager = requireNonNull(resourceGroupManager, "resourceGroupManager is null");
         this.dispatchQueryFactory = requireNonNull(dispatchQueryFactory, "dispatchQueryFactory is null");
         this.failedDispatchQueryFactory = requireNonNull(failedDispatchQueryFactory, "failedDispatchQueryFactory is null");
-        this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.sessionSupplier = requireNonNull(sessionSupplier, "sessionSupplier is null");
         this.sessionPropertyDefaults = requireNonNull(sessionPropertyDefaults, "sessionPropertyDefaults is null");
@@ -198,11 +193,9 @@ public class DispatchManager
             // apply system default session properties (does not override user set properties)
             session = sessionPropertyDefaults.newSessionWithDefaultProperties(session, queryType, selectionContext.getResourceGroupId());
 
-            // mark existing transaction as active
-            transactionManager.activateTransaction(session, isTransactionControlStatement(preparedQuery.getStatement()), accessControl);
-
             DispatchQuery dispatchQuery = dispatchQueryFactory.createDispatchQuery(
                     session,
+                    sessionContext.getTransactionId(),
                     query,
                     preparedQuery,
                     slug,

--- a/core/trino-main/src/main/java/io/trino/dispatcher/DispatchQueryFactory.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/DispatchQueryFactory.java
@@ -17,11 +17,15 @@ import io.trino.Session;
 import io.trino.execution.QueryPreparer.PreparedQuery;
 import io.trino.server.protocol.Slug;
 import io.trino.spi.resourcegroups.ResourceGroupId;
+import io.trino.transaction.TransactionId;
+
+import java.util.Optional;
 
 public interface DispatchQueryFactory
 {
     DispatchQuery createDispatchQuery(
             Session session,
+            Optional<TransactionId> transactionId,
             String query,
             PreparedQuery preparedQuery,
             Slug slug,

--- a/core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQueryFactory.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQueryFactory.java
@@ -33,6 +33,7 @@ import io.trino.server.protocol.Slug;
 import io.trino.spi.TrinoException;
 import io.trino.spi.resourcegroups.ResourceGroupId;
 import io.trino.sql.tree.Statement;
+import io.trino.transaction.TransactionId;
 import io.trino.transaction.TransactionManager;
 
 import javax.inject.Inject;
@@ -93,6 +94,7 @@ public class LocalDispatchQueryFactory
     @Override
     public DispatchQuery createDispatchQuery(
             Session session,
+            Optional<TransactionId> existingTransactionId,
             String query,
             PreparedQuery preparedQuery,
             Slug slug,
@@ -100,6 +102,7 @@ public class LocalDispatchQueryFactory
     {
         WarningCollector warningCollector = warningCollectorFactory.create();
         QueryStateMachine stateMachine = QueryStateMachine.begin(
+                existingTransactionId,
                 query,
                 preparedQuery.getPrepareSql(),
                 session,

--- a/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
@@ -263,7 +263,12 @@ public class QueryStateMachine
                 metadata,
                 warningCollector,
                 queryType);
-        queryStateMachine.addStateChangeListener(newState -> QUERY_STATE_LOG.debug("Query %s is %s", queryStateMachine.getQueryId(), newState));
+        queryStateMachine.addStateChangeListener(newState -> {
+            QUERY_STATE_LOG.debug("Query %s is %s", queryStateMachine.getQueryId(), newState);
+            if (newState.isDone()) {
+                queryStateMachine.getSession().getTransactionId().ifPresent(transactionManager::trySetInactive);
+            }
+        });
 
         return queryStateMachine;
     }

--- a/core/trino-main/src/main/java/io/trino/server/QuerySessionSupplier.java
+++ b/core/trino-main/src/main/java/io/trino/server/QuerySessionSupplier.java
@@ -22,7 +22,6 @@ import io.trino.spi.security.Identity;
 import io.trino.spi.type.TimeZoneKey;
 import io.trino.sql.SqlEnvironmentConfig;
 import io.trino.sql.SqlPath;
-import io.trino.transaction.TransactionManager;
 
 import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
@@ -43,7 +42,6 @@ import static java.util.Objects.requireNonNull;
 public class QuerySessionSupplier
         implements SessionSupplier
 {
-    private final TransactionManager transactionManager;
     private final Metadata metadata;
     private final AccessControl accessControl;
     private final SessionPropertyManager sessionPropertyManager;
@@ -54,13 +52,11 @@ public class QuerySessionSupplier
 
     @Inject
     public QuerySessionSupplier(
-            TransactionManager transactionManager,
             Metadata metadata,
             AccessControl accessControl,
             SessionPropertyManager sessionPropertyManager,
             SqlEnvironmentConfig config)
     {
-        this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
@@ -149,11 +145,6 @@ public class QuerySessionSupplier
             sessionBuilder.setClientTransactionSupport();
         }
 
-        Session session = sessionBuilder.build();
-        if (context.getTransactionId().isPresent()) {
-            session = session.beginTransactionId(context.getTransactionId().get(), transactionManager, accessControl);
-        }
-
-        return session;
+        return sessionBuilder.build();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/transaction/TransactionManager.java
+++ b/core/trino-main/src/main/java/io/trino/transaction/TransactionManager.java
@@ -14,11 +14,9 @@
 package io.trino.transaction;
 
 import com.google.common.util.concurrent.ListenableFuture;
-import io.trino.Session;
 import io.trino.connector.CatalogName;
 import io.trino.metadata.Catalog;
 import io.trino.metadata.CatalogMetadata;
-import io.trino.security.AccessControl;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.transaction.IsolationLevel;
 
@@ -69,20 +67,4 @@ public interface TransactionManager
     ListenableFuture<Void> asyncAbort(TransactionId transactionId);
 
     void fail(TransactionId transactionId);
-
-    default void activateTransaction(Session session, boolean transactionControl, AccessControl accessControl)
-    {
-        if (session.getTransactionId().isEmpty()) {
-            return;
-        }
-
-        // reactivate existing transaction
-        TransactionId transactionId = session.getTransactionId().get();
-        if (transactionControl) {
-            trySetActive(transactionId);
-        }
-        else {
-            checkAndSetActive(transactionId);
-        }
-    }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
+++ b/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
@@ -109,9 +109,7 @@ public abstract class BaseDataDefinitionTaskTest
         transactionManager = queryRunner.getTransactionManager();
         queryRunner.createCatalog(CATALOG_NAME, MockConnectorFactory.create("initial"), ImmutableMap.of());
 
-        testSession = testSessionBuilder()
-                .setTransactionId(transactionManager.beginTransaction(false))
-                .build();
+        testSession = testSessionBuilder().build();
         metadata = new MockMetadata(new CatalogName(CATALOG_NAME));
         plannerContext = plannerContextBuilder().withMetadata(metadata).build();
         materializedViewPropertyManager = new MaterializedViewPropertyManager();
@@ -193,6 +191,7 @@ public abstract class BaseDataDefinitionTaskTest
     private static QueryStateMachine stateMachine(TransactionManager transactionManager, MetadataManager metadata, AccessControl accessControl, Session session)
     {
         return QueryStateMachine.begin(
+                Optional.empty(),
                 "test",
                 Optional.empty(),
                 session,

--- a/core/trino-main/src/test/java/io/trino/execution/TestCallTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCallTask.java
@@ -15,7 +15,6 @@ package io.trino.execution;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.trino.Session;
 import io.trino.connector.CatalogName;
 import io.trino.connector.MockConnectorFactory;
 import io.trino.execution.warnings.WarningCollector;
@@ -156,9 +155,13 @@ public class TestCallTask
     private QueryStateMachine stateMachine(TransactionManager transactionManager, MetadataManager metadata, AccessControl accessControl)
     {
         return QueryStateMachine.begin(
+                Optional.empty(),
                 "CALL testing_procedure()",
                 Optional.empty(),
-                testSession(transactionManager),
+                testSessionBuilder()
+                        .setCatalog("test")
+                        .setSchema("test")
+                        .build(),
                 URI.create("fake://uri"),
                 new ResourceGroupId("test"),
                 false,
@@ -168,15 +171,6 @@ public class TestCallTask
                 metadata,
                 WarningCollector.NOOP,
                 Optional.empty());
-    }
-
-    private Session testSession(TransactionManager transactionManager)
-    {
-        return testSessionBuilder()
-                .setCatalog("test")
-                .setSchema("test")
-                .setTransactionId(transactionManager.beginTransaction(true))
-                .build();
     }
 
     public static void testingMethod()

--- a/core/trino-main/src/test/java/io/trino/execution/TestCommitTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCommitTask.java
@@ -122,6 +122,7 @@ public class TestCommitTask
     private QueryStateMachine createQueryStateMachine(String query, Session session, TransactionManager transactionManager)
     {
         return QueryStateMachine.begin(
+                Optional.empty(),
                 query,
                 Optional.empty(),
                 session,

--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateMaterializedViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateMaterializedViewTask.java
@@ -136,9 +136,7 @@ public class TestCreateMaterializedViewTask
 
         materializedViewPropertyManager = queryRunner.getMaterializedViewPropertyManager();
 
-        testSession = testSessionBuilder()
-                .setTransactionId(transactionManager.beginTransaction(false))
-                .build();
+        testSession = testSessionBuilder().build();
         metadata = new MockMetadata(new CatalogName(CATALOG_NAME));
         plannerContext = plannerContextBuilder().withMetadata(metadata).build();
         parser = queryRunner.getSqlParser();
@@ -266,6 +264,7 @@ public class TestCreateMaterializedViewTask
     private QueryStateMachine stateMachine(TransactionManager transactionManager, MetadataManager metadata, AccessControl accessControl)
     {
         return QueryStateMachine.begin(
+                Optional.empty(),
                 "test",
                 Optional.empty(),
                 testSession,

--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateViewTask.java
@@ -18,12 +18,9 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.AnalyzePropertyManager;
-import io.trino.metadata.MetadataManager;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.TablePropertyManager;
-import io.trino.security.AccessControl;
 import io.trino.security.AllowAllAccessControl;
-import io.trino.spi.resourcegroups.ResourceGroupId;
 import io.trino.sql.analyzer.AnalyzerFactory;
 import io.trino.sql.parser.SqlParser;
 import io.trino.sql.rewrite.StatementRewrite;
@@ -31,14 +28,11 @@ import io.trino.sql.tree.AllColumns;
 import io.trino.sql.tree.CreateView;
 import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.Query;
-import io.trino.transaction.TransactionManager;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.net.URI;
 import java.util.Optional;
 
-import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.trino.spi.StandardErrorCode.TABLE_ALREADY_EXISTS;
 import static io.trino.sql.QueryUtil.selectList;
@@ -127,23 +121,6 @@ public class TestCreateViewTask
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeCreateView(asQualifiedName(viewName), false)))
                 .hasErrorCode(TABLE_ALREADY_EXISTS)
                 .hasMessage("Materialized view already exists: '%s'", viewName);
-    }
-
-    private QueryStateMachine stateMachine(TransactionManager transactionManager, MetadataManager metadata, AccessControl accessControl)
-    {
-        return QueryStateMachine.begin(
-                "test",
-                Optional.empty(),
-                testSession,
-                URI.create("fake://uri"),
-                new ResourceGroupId("test"),
-                false,
-                transactionManager,
-                accessControl,
-                directExecutor(),
-                metadata,
-                WarningCollector.NOOP,
-                Optional.empty());
     }
 
     private ListenableFuture<Void> executeCreateView(QualifiedName viewName, boolean replace)

--- a/core/trino-main/src/test/java/io/trino/execution/TestDeallocateTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestDeallocateTask.java
@@ -82,6 +82,7 @@ public class TestDeallocateTask
         AccessControlManager accessControl = new AccessControlManager(transactionManager, emptyEventListenerManager(), new AccessControlConfig(), DefaultSystemAccessControl.NAME);
         accessControl.setSystemAccessControls(List.of(AllowAllSystemAccessControl.INSTANCE));
         QueryStateMachine stateMachine = QueryStateMachine.begin(
+                Optional.empty(),
                 sqlString,
                 Optional.empty(),
                 session,

--- a/core/trino-main/src/test/java/io/trino/execution/TestPrepareTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestPrepareTask.java
@@ -105,6 +105,7 @@ public class TestPrepareTask
         AccessControlManager accessControl = new AccessControlManager(transactionManager, emptyEventListenerManager(), new AccessControlConfig(), DefaultSystemAccessControl.NAME);
         accessControl.setSystemAccessControls(List.of(AllowAllSystemAccessControl.INSTANCE));
         QueryStateMachine stateMachine = QueryStateMachine.begin(
+                Optional.empty(),
                 sqlString,
                 Optional.empty(),
                 session,

--- a/core/trino-main/src/test/java/io/trino/execution/TestQueryStateMachine.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestQueryStateMachine.java
@@ -516,6 +516,7 @@ public class TestQueryStateMachine
                 DefaultSystemAccessControl.NAME);
         accessControl.setSystemAccessControls(List.of(AllowAllSystemAccessControl.INSTANCE));
         QueryStateMachine stateMachine = QueryStateMachine.beginWithTicker(
+                Optional.empty(),
                 QUERY,
                 Optional.empty(),
                 TEST_SESSION,

--- a/core/trino-main/src/test/java/io/trino/execution/TestResetSessionTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestResetSessionTask.java
@@ -97,6 +97,7 @@ public class TestResetSessionTask
                 .build();
 
         QueryStateMachine stateMachine = QueryStateMachine.begin(
+                Optional.empty(),
                 "reset foo",
                 Optional.empty(),
                 session,

--- a/core/trino-main/src/test/java/io/trino/execution/TestRollbackTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestRollbackTask.java
@@ -115,6 +115,7 @@ public class TestRollbackTask
     private QueryStateMachine createQueryStateMachine(String query, Session session, TransactionManager transactionManager)
     {
         return QueryStateMachine.begin(
+                Optional.empty(),
                 query,
                 Optional.empty(),
                 session,

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetPathTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetPathTask.java
@@ -96,6 +96,7 @@ public class TestSetPathTask
     private QueryStateMachine createQueryStateMachine(String query)
     {
         return QueryStateMachine.begin(
+                Optional.empty(),
                 query,
                 Optional.empty(),
                 TEST_SESSION,

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetRoleTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetRoleTask.java
@@ -146,6 +146,7 @@ public class TestSetRoleTask
     {
         SetRole setRole = (SetRole) parser.createStatement(statement, new ParsingOptions());
         QueryStateMachine stateMachine = QueryStateMachine.begin(
+                Optional.empty(),
                 statement,
                 Optional.empty(),
                 testSessionBuilder()

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetSessionTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetSessionTask.java
@@ -186,6 +186,7 @@ public class TestSetSessionTask
     {
         QualifiedName qualifiedPropName = QualifiedName.of(CATALOG_NAME, property);
         QueryStateMachine stateMachine = QueryStateMachine.begin(
+                Optional.empty(),
                 format("set %s = 'old_value'", qualifiedPropName),
                 Optional.empty(),
                 TEST_SESSION,

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetTimeZoneTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetTimeZoneTask.java
@@ -239,6 +239,7 @@ public class TestSetTimeZoneTask
     private QueryStateMachine createQueryStateMachine(String query)
     {
         return QueryStateMachine.begin(
+                Optional.empty(),
                 query,
                 Optional.empty(),
                 TEST_SESSION,

--- a/core/trino-main/src/test/java/io/trino/execution/TestStartTransactionTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestStartTransactionTask.java
@@ -243,6 +243,7 @@ public class TestStartTransactionTask
     private QueryStateMachine createQueryStateMachine(String query, Session session, TransactionManager transactionManager)
     {
         return QueryStateMachine.begin(
+                Optional.empty(),
                 query,
                 Optional.empty(),
                 session,

--- a/core/trino-main/src/test/java/io/trino/server/TestQuerySessionSupplier.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestQuerySessionSupplier.java
@@ -250,7 +250,6 @@ public class TestQuerySessionSupplier
         TransactionManager transactionManager = createTestTransactionManager();
         Metadata metadata = createTestMetadataManager(transactionManager, new FeaturesConfig());
         return new QuerySessionSupplier(
-                transactionManager,
                 metadata,
                 new AllowAllAccessControl(),
                 new SessionPropertyManager(),


### PR DESCRIPTION
## Description

A few years ago we lost the code that sets transactions idle after a query completes.  

Also this fixes a bug where catalog session properties were dropped when session property defaults are applied to a session in an existing transaction.  The core problem was we were enrolling the session in the transaction before adding the session property defaults.  When a session is enrolled in a transaction we clear the unprocessed catalog properties, process them, and set them in the normal properties field.  Then when session property defaults are applied, we would would merge the new properties into the unprocessed and clears the processed properties, which effectively wipes out the catalog properties.

## Documentation

- (x) No documentation is needed.
- ( ) Sufficient documentation is included in this PR.
- ( ) Documentation PR is available with #prnumber.
- ( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

- ( ) No release notes entries required.
- (x) Release notes entries required with the following suggested text:

```
# General
* Fix transaction idle timeout enforcement. ({issue}``)
* Fix removal of all catalog session properties when using session property defaults with transactions.  ({issue}``)
```