### PR TITLE
Increase timeout when testing Docker image

### DIFF
--- a/core/docker/container-test.sh
+++ b/core/docker/container-test.sh
@@ -5,7 +5,7 @@ function cleanup {
 }
 
 function test_trino_starts {
-    local QUERY_PERIOD=5
+    local QUERY_PERIOD=10
     local QUERY_RETRIES=30
 
     CONTAINER_ID=
@@ -21,6 +21,8 @@ function test_trino_starts {
     do
         if [[ $((I++)) -ge ${QUERY_RETRIES} ]]; then
             echo "🚨 Too many retries waiting for Trino to start"
+            echo "Logs from ${CONTAINER_ID} follow..."
+            docker logs "${CONTAINER_ID}"
             break
         fi
         sleep ${QUERY_PERIOD}


### PR DESCRIPTION
The ARM64 Docker image runs under emulation and hence can take time to
start up. The existing timeout of ~150 seconds is too close to the
amount of time it takes for the image to start and hence introduces
occasional flakiness.
    
We also make available the container's logs in timeouts to help debug if
needed.