### PR TITLE
Skip PTs if the WIP label is applied

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,6 +515,8 @@ jobs:
 
   pt:
     runs-on: ubuntu-latest
+    # skip all PTs if the WIP label is applied
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'WIP') }}
     # explicitly define the name to avoid adding the value of the `ignore exclusion if` matrix item
     name: pt (${{ matrix.config }}, ${{ matrix.suite }}, ${{ matrix.jdk }})
     strategy:


### PR DESCRIPTION
PTs are the most time consuming tests - so sometimes during development it helps to disable them since for most changes we add integration tests.

Also this has low chance of someone not noticing skipped tests since instead of appearing "green" they are explicitly shown as "skipped".

Just an idea - we don't have to go through with this if there isn't consensus. We might want to revert this once the impact based tests are merged in (#10323 and #10895)