### PR TITLE
Return HTTP OK on token drop for oauth2 authentication

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/auth/external/HttpTokenPoller.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/external/HttpTokenPoller.java
@@ -37,6 +37,7 @@ import static com.google.common.net.HttpHeaders.USER_AGENT;
 import static io.trino.client.JsonCodec.jsonCodec;
 import static io.trino.client.JsonResponse.execute;
 import static java.lang.String.format;
+import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
 import static java.time.temporal.ChronoUnit.MILLIS;
@@ -96,7 +97,7 @@ public class HttpTokenPoller
                     .withMaxAttempts(-1)
                     .withMaxDuration(Duration.ofSeconds(4))
                     .withBackoff(100, 500, MILLIS)
-                    .handleResultIf(code -> code != HTTP_OK))
+                    .handleResultIf(code -> code >= HTTP_INTERNAL_ERROR))
                     .get(() -> {
                         Request request = prepareRequestBuilder(tokenUri)
                                 .delete()

--- a/client/trino-client/src/test/java/io/trino/client/auth/external/TestHttpTokenPoller.java
+++ b/client/trino-client/src/test/java/io/trino/client/auth/external/TestHttpTokenPoller.java
@@ -176,20 +176,16 @@ public class TestHttpTokenPoller
     }
 
     @Test
-    public void testTokenReceivedRetriesUntilHTTP_OK()
+    public void testTokenReceivedRetriesUntilNotErrorReturned()
     {
         server.enqueue(status(HTTP_UNAVAILABLE));
         server.enqueue(status(HTTP_UNAVAILABLE));
         server.enqueue(status(HTTP_UNAVAILABLE));
         server.enqueue(status(202));
-        server.enqueue(status(303));
-        server.enqueue(status(HTTP_OK));
-        server.enqueue(status(HTTP_OK));
-        server.enqueue(status(HTTP_OK));
 
         tokenPoller.tokenReceived(tokenUri());
 
-        assertThat(server.getRequestCount()).isEqualTo(6);
+        assertThat(server.getRequestCount()).isEqualTo(4);
     }
 
     @Test

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2TokenExchangeResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2TokenExchangeResource.java
@@ -114,13 +114,16 @@ public class OAuth2TokenExchangeResource
     @ResourceSecurity(PUBLIC)
     @DELETE
     @Path("{authId}")
-    public void deleteAuthenticationToken(@PathParam("authId") UUID authId)
+    public Response deleteAuthenticationToken(@PathParam("authId") UUID authId)
     {
         if (authId == null) {
             throw new BadRequestException();
         }
 
         tokenExchange.dropToken(authId);
+        return Response
+                .ok()
+                .build();
     }
 
     public static String getTokenUri(UUID authId)


### PR DESCRIPTION
HttpTokenPoller waits 4 seconds for token drop to be acknowledged (checks for HTTP OK). With this small change CLI/JDBC returns token almost immediately upon resolution.