### PR TITLE
External token ack hang

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/auth/external/HttpTokenPoller.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/external/HttpTokenPoller.java
@@ -96,7 +96,7 @@ public class HttpTokenPoller
                     .withMaxAttempts(-1)
                     .withMaxDuration(Duration.ofSeconds(4))
                     .withBackoff(100, 500, MILLIS)
-                    .handleResultIf(code -> code != HTTP_OK))
+                    .handleResultIf(code -> code >= 500))
                     .get(() -> {
                         Request request = prepareRequestBuilder(tokenUri)
                                 .delete()

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2TokenExchangeResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2TokenExchangeResource.java
@@ -48,6 +48,7 @@ import static io.trino.server.security.oauth2.OAuth2TokenExchange.MAX_POLL_TIME;
 import static io.trino.server.security.oauth2.OAuth2TokenExchange.hashAuthId;
 import static java.util.Objects.requireNonNull;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
 
 @Path(OAuth2TokenExchangeResource.TOKEN_ENDPOINT)
 public class OAuth2TokenExchangeResource
@@ -114,13 +115,15 @@ public class OAuth2TokenExchangeResource
     @ResourceSecurity(PUBLIC)
     @DELETE
     @Path("{authId}")
-    public void deleteAuthenticationToken(@PathParam("authId") UUID authId)
+    public Response deleteAuthenticationToken(@PathParam("authId") UUID authId)
     {
         if (authId == null) {
             throw new BadRequestException();
         }
 
         tokenExchange.dropToken(authId);
+        return Response.ok("Authentication deleted", TEXT_PLAIN_TYPE)
+                .build();
     }
 
     public static String getTokenUri(UUID authId)


### PR DESCRIPTION
It's a bug in a client, as it's too restrictive expecting for the server to return `200 OK` Http Code to be returned on ack token, when in reality the endpoint returns ` 204 NO_CONTENT`. This causes token mechanism to hang for 4s before it finishes. 
Fix tries to handle this from both sides: 
- it improves client code to react only on server and connectivity errors
- it makes the `/oauth2/token/{authId} DELETE` response to return 200 with body, to meet the expectations of older and different clients 