### PR TITLE
Fix typo in `hideInaccesibleColumns`

### DIFF
--- a/core/trino-main/src/main/java/io/trino/FeaturesConfig.java
+++ b/core/trino-main/src/main/java/io/trino/FeaturesConfig.java
@@ -148,7 +148,7 @@ public class FeaturesConfig
     private boolean incrementalHashArrayLoadFactorEnabled = true;
     private boolean allowSetViewAuthorization;
 
-    private boolean hideInaccesibleColumns;
+    private boolean hideInaccessibleColumns;
 
     public enum JoinReorderingStrategy
     {
@@ -1088,16 +1088,16 @@ public class FeaturesConfig
         return this;
     }
 
-    public boolean isHideInaccesibleColumns()
+    public boolean isHideInaccessibleColumns()
     {
-        return hideInaccesibleColumns;
+        return hideInaccessibleColumns;
     }
 
     @Config("hide-inaccessible-columns")
     @ConfigDescription("When enabled non-accessible columns are silently filtered from results from SELECT * statements")
-    public FeaturesConfig setHideInaccesibleColumns(boolean hideInaccesibleColumns)
+    public FeaturesConfig setHideInaccessibleColumns(boolean hideInaccessibleColumns)
     {
-        this.hideInaccesibleColumns = hideInaccesibleColumns;
+        this.hideInaccessibleColumns = hideInaccessibleColumns;
         return this;
     }
 

--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -687,8 +687,8 @@ public final class SystemSessionProperties
                 booleanProperty(
                         HIDE_INACCESSIBLE_COLUMNS,
                         "When enabled non-accessible columns are silently filtered from results from SELECT * statements",
-                        featuresConfig.isHideInaccesibleColumns(),
-                        value -> validateHideInaccesibleColumns(value, featuresConfig.isHideInaccesibleColumns()),
+                        featuresConfig.isHideInaccessibleColumns(),
+                        value -> validateHideInaccessibleColumns(value, featuresConfig.isHideInaccessibleColumns()),
                         false),
                 dataSizeProperty(
                         FAULT_TOLERANT_EXECUTION_TARGET_TASK_INPUT_SIZE,
@@ -1027,7 +1027,7 @@ public final class SystemSessionProperties
         return session.getSystemProperty(MAX_GROUPING_SETS, Integer.class);
     }
 
-    private static void validateHideInaccesibleColumns(boolean value, boolean defaultValue)
+    private static void validateHideInaccessibleColumns(boolean value, boolean defaultValue)
     {
         if (defaultValue == true && value == false) {
             throw new TrinoException(INVALID_SESSION_PROPERTY, format("%s cannot be disabled with session property when it was enabled with configuration", HIDE_INACCESSIBLE_COLUMNS));
@@ -1251,7 +1251,7 @@ public final class SystemSessionProperties
         return session.getSystemProperty(RETRY_MAX_DELAY, Duration.class);
     }
 
-    public static boolean isHideInaccesibleColumns(Session session)
+    public static boolean isHideInaccessibleColumns(Session session)
     {
         return session.getSystemProperty(HIDE_INACCESSIBLE_COLUMNS, Boolean.class);
     }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -3219,7 +3219,7 @@ class StatementAnalyzer
 
         private List<Field> filterInaccessibleFields(List<Field> fields)
         {
-            if (!SystemSessionProperties.isHideInaccesibleColumns(session)) {
+            if (!SystemSessionProperties.isHideInaccessibleColumns(session)) {
                 return fields;
             }
 

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestFeaturesConfig.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestFeaturesConfig.java
@@ -114,7 +114,7 @@ public class TestFeaturesConfig
                 .setLegacyCatalogRoles(false)
                 .setDisableSetPropertiesSecurityCheckForCreateDdl(false)
                 .setIncrementalHashArrayLoadFactorEnabled(true)
-                .setHideInaccesibleColumns(false)
+                .setHideInaccessibleColumns(false)
                 .setAllowSetViewAuthorization(false));
     }
 
@@ -269,7 +269,7 @@ public class TestFeaturesConfig
                 .setLegacyCatalogRoles(true)
                 .setDisableSetPropertiesSecurityCheckForCreateDdl(true)
                 .setIncrementalHashArrayLoadFactorEnabled(false)
-                .setHideInaccesibleColumns(true)
+                .setHideInaccessibleColumns(true)
                 .setAllowSetViewAuthorization(true);
         assertFullMapping(properties, expected);
     }

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestFilterHideInacessibleColumnsSession.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestFilterHideInacessibleColumnsSession.java
@@ -33,7 +33,7 @@ public class TestFilterHideInacessibleColumnsSession
     public void testDisableWhenEnabledByDefault()
     {
         FeaturesConfig featuresConfig = new FeaturesConfig();
-        featuresConfig.setHideInaccesibleColumns(true);
+        featuresConfig.setHideInaccessibleColumns(true);
         SessionPropertyManager sessionPropertyManager = new SessionPropertyManager(new SystemSessionProperties(
                 new QueryManagerConfig(),
                 new TaskManagerConfig(),
@@ -50,7 +50,7 @@ public class TestFilterHideInacessibleColumnsSession
     public void testEnableWhenAlreadyEnabledByDefault()
     {
         FeaturesConfig featuresConfig = new FeaturesConfig();
-        featuresConfig.setHideInaccesibleColumns(true);
+        featuresConfig.setHideInaccessibleColumns(true);
         SessionPropertyManager sessionPropertyManager = new SessionPropertyManager(new SystemSessionProperties(
                 new QueryManagerConfig(),
                 new TaskManagerConfig(),

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestFilterInaccessibleColumns.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestFilterInaccessibleColumns.java
@@ -57,7 +57,7 @@ public class TestFilterInaccessibleColumns
     public void init()
     {
         LocalQueryRunner runner = LocalQueryRunner.builder(SESSION)
-                .withFeaturesConfig(new FeaturesConfig().setHideInaccesibleColumns(true))
+                .withFeaturesConfig(new FeaturesConfig().setHideInaccessibleColumns(true))
                 .build();
 
         runner.createCatalog(CATALOG, new TpchConnectorFactory(1), ImmutableMap.of());


### PR DESCRIPTION
This spans config class field and config/session accessors, but not the
config and session property names, as they are correct.