### PR TITLE
Upgrade kudu client to 1.15.0

### DIFF
--- a/docs/src/main/sphinx/connector/kudu.rst
+++ b/docs/src/main/sphinx/connector/kudu.rst
@@ -51,9 +51,6 @@ replacing the properties as appropriate:
    ## Default timeout used for user operations
    #kudu.client.default-operation-timeout = 30s
 
-   ## Default timeout to use when waiting on data from a socket
-   #kudu.client.default-socket-read-timeout = 10s
-
    ## Disable Kudu client's collection of statistics.
    #kudu.client.disable-statistics = false
 

--- a/docs/src/main/sphinx/connector/kudu.rst
+++ b/docs/src/main/sphinx/connector/kudu.rst
@@ -11,7 +11,7 @@ Requirements
 
 To connect to Kudu, you need:
 
-* Kudu version 1.10 or higher.
+* Kudu version 1.13.0 or higher.
 * Network access from the Trino coordinator and workers to Kudu. Port 7051 is
   the default port.
 

--- a/plugin/trino-kudu/pom.xml
+++ b/plugin/trino-kudu/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <kudu.version>1.10.0</kudu.version>
+        <kudu.version>1.15.0</kudu.version>
     </properties>
 
     <dependencies>

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduClientConfig.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduClientConfig.java
@@ -17,6 +17,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.DefunctConfig;
 import io.airlift.units.Duration;
 import io.airlift.units.MaxDuration;
 import io.airlift.units.MinDuration;
@@ -32,6 +33,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 /**
  * Configuration read from etc/catalog/kudu.properties
  */
+@DefunctConfig("kudu.client.default-socket-read-timeout")
 public class KuduClientConfig
 {
     private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
@@ -39,7 +41,6 @@ public class KuduClientConfig
     private List<String> masterAddresses;
     private Duration defaultAdminOperationTimeout = new Duration(30, TimeUnit.SECONDS);
     private Duration defaultOperationTimeout = new Duration(30, TimeUnit.SECONDS);
-    private Duration defaultSocketReadTimeout = new Duration(10, TimeUnit.SECONDS);
     private boolean disableStatistics;
     private boolean schemaEmulationEnabled;
     private String schemaEmulationPrefix = "presto::";
@@ -92,20 +93,6 @@ public class KuduClientConfig
     public Duration getDefaultOperationTimeout()
     {
         return defaultOperationTimeout;
-    }
-
-    @Config("kudu.client.default-socket-read-timeout")
-    public KuduClientConfig setDefaultSocketReadTimeout(Duration timeout)
-    {
-        this.defaultSocketReadTimeout = timeout;
-        return this;
-    }
-
-    @MinDuration("1s")
-    @MaxDuration("1h")
-    public Duration getDefaultSocketReadTimeout()
-    {
-        return defaultSocketReadTimeout;
     }
 
     public boolean isDisableStatistics()

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduClientSession.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduClientSession.java
@@ -150,6 +150,8 @@ public class KuduClientSession
         KuduTable table = tableHandle.getTable(this);
         int primaryKeyColumnCount = table.getSchema().getPrimaryKeyColumnCount();
         KuduScanToken.KuduScanTokenBuilder builder = client.newScanTokenBuilder(table);
+        // TODO: remove when kudu client bug is fixed: https://gerrit.cloudera.org/#/c/18166/
+        builder.includeTabletMetadata(false);
 
         TupleDomain<ColumnHandle> constraint = tableHandle.getConstraint()
                 .intersect(dynamicFilter.getCurrentPredicate().simplify(100));

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduModule.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduModule.java
@@ -91,7 +91,6 @@ public class KuduModule
         KuduClient.KuduClientBuilder builder = new KuduClient.KuduClientBuilder(config.getMasterAddresses());
         builder.defaultAdminOperationTimeoutMs(config.getDefaultAdminOperationTimeout().toMillis());
         builder.defaultOperationTimeoutMs(config.getDefaultOperationTimeout().toMillis());
-        builder.defaultSocketReadTimeoutMs(config.getDefaultSocketReadTimeout().toMillis());
         if (config.isDisableStatistics()) {
             builder.disableStatistics();
         }

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduPageSink.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduPageSink.java
@@ -30,7 +30,6 @@ import org.apache.kudu.client.KuduException;
 import org.apache.kudu.client.KuduSession;
 import org.apache.kudu.client.KuduTable;
 import org.apache.kudu.client.PartialRow;
-import org.apache.kudu.client.SessionConfiguration;
 import org.apache.kudu.client.Upsert;
 
 import java.nio.charset.StandardCharsets;
@@ -59,6 +58,7 @@ import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.apache.kudu.client.KuduOperationApplier.applyOperationAndVerifySucceeded;
 
 public class KuduPageSink
         implements ConnectorPageSink
@@ -103,7 +103,6 @@ public class KuduPageSink
 
         this.table = table;
         this.session = clientSession.newSession();
-        this.session.setFlushMode(SessionConfiguration.FlushMode.AUTO_FLUSH_BACKGROUND);
         uuid = UUID.randomUUID().toString();
     }
 
@@ -125,7 +124,7 @@ public class KuduPageSink
             }
 
             try {
-                session.apply(upsert);
+                applyOperationAndVerifySucceeded(session, upsert);
             }
             catch (KuduException e) {
                 throw new RuntimeException(e);

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduUpdatablePageSource.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduUpdatablePageSource.java
@@ -25,11 +25,12 @@ import org.apache.kudu.client.KuduException;
 import org.apache.kudu.client.KuduSession;
 import org.apache.kudu.client.KuduTable;
 import org.apache.kudu.client.PartialRow;
-import org.apache.kudu.client.SessionConfiguration.FlushMode;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
+
+import static org.apache.kudu.client.KuduOperationApplier.applyOperationAndVerifySucceeded;
 
 public class KuduUpdatablePageSource
         implements UpdatablePageSource
@@ -50,7 +51,6 @@ public class KuduUpdatablePageSource
     {
         Schema schema = table.getSchema();
         KuduSession session = clientSession.newSession();
-        session.setFlushMode(FlushMode.AUTO_FLUSH_BACKGROUND);
         try {
             try {
                 for (int i = 0; i < rowIds.getPositionCount(); i++) {
@@ -59,7 +59,7 @@ public class KuduUpdatablePageSource
                     PartialRow row = KeyEncoderAccessor.decodePrimaryKey(schema, slice.getBytes());
                     Delete delete = table.newDelete();
                     RowHelper.copyPrimaryKey(schema, row, delete.getRow());
-                    session.apply(delete);
+                    applyOperationAndVerifySucceeded(session, delete);
                 }
             }
             finally {

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/TypeHelper.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/TypeHelper.java
@@ -122,6 +122,10 @@ public final class TypeHelper
                 return VarbinaryType.VARBINARY;
             case DECIMAL:
                 return DecimalType.createDecimalType(attributes.getPrecision(), attributes.getScale());
+            // TODO: add support for varchar and date types: https://github.com/trinodb/trino/issues/11009
+            case VARCHAR:
+            case DATE:
+                break;
         }
         throw new IllegalStateException("Kudu type not implemented for " + ktype);
     }

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/properties/KuduTableProperties.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/properties/KuduTableProperties.java
@@ -400,6 +400,10 @@ public final class KuduTableProperties
                 return bound.getBoolean(idx);
             case BINARY:
                 return bound.getBinaryCopy(idx);
+            // TODO: add support for varchar and date types: https://github.com/trinodb/trino/issues/11009
+            case VARCHAR:
+            case DATE:
+                break;
         }
         throw new IllegalStateException("Unhandled type " + type + " for range partition");
     }

--- a/plugin/trino-kudu/src/main/java/org/apache/kudu/client/KuduOperationApplier.java
+++ b/plugin/trino-kudu/src/main/java/org/apache/kudu/client/KuduOperationApplier.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kudu.client;
+
+import io.trino.spi.TrinoException;
+
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static java.lang.String.format;
+
+/**
+ * Operation.getChangeType() is package private
+ */
+public final class KuduOperationApplier
+{
+    private KuduOperationApplier()
+    {
+    }
+
+    public static OperationResponse applyOperationAndVerifySucceeded(KuduSession kuduSession, Operation operation)
+            throws KuduException
+    {
+        OperationResponse operationResponse = kuduSession.apply(operation);
+        if (operationResponse != null && operationResponse.hasRowError()) {
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, format("Error while applying kudu operation %s: %s",
+                    operation.getChangeType().toString(), operationResponse.getRowError()));
+        }
+        return operationResponse;
+    }
+}

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/AbstractKuduIntegrationSmokeTest.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/AbstractKuduIntegrationSmokeTest.java
@@ -40,13 +40,15 @@ public abstract class AbstractKuduIntegrationSmokeTest
 {
     private TestingKuduServer kuduServer;
 
+    protected abstract String getKuduServerVersion();
+
     protected abstract Optional<String> getKuduSchemaEmulationPrefix();
 
     @Override
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        kuduServer = new TestingKuduServer();
+        kuduServer = new TestingKuduServer(getKuduServerVersion());
         return createKuduQueryRunnerTpch(kuduServer, getKuduSchemaEmulationPrefix(), CUSTOMER, NATION, ORDERS, REGION);
     }
 

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/AbstractKuduSmokeTestWithDisabledInferSchema.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/AbstractKuduSmokeTestWithDisabledInferSchema.java
@@ -17,20 +17,18 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
-import static org.testng.Assert.assertEquals;
-
-public class TestKuduSmokeTestWithStandardInferSchema
+public abstract class AbstractKuduSmokeTestWithDisabledInferSchema
         extends AbstractKuduIntegrationSmokeTest
 {
     @Override
     protected Optional<String> getKuduSchemaEmulationPrefix()
     {
-        return Optional.of("presto::");
+        return Optional.empty();
     }
 
     @Test
     public void testListingOfTableForDefaultSchema()
     {
-        assertEquals(computeActual("SHOW TABLES FROM default").getRowCount(), 0);
+        assertQuery("SHOW TABLES FROM default", "VALUES ('customer'), ('nation'), ('orders'), ('region')");
     }
 }

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/AbstractKuduSmokeTestWithEmptyInferSchema.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/AbstractKuduSmokeTestWithEmptyInferSchema.java
@@ -17,7 +17,7 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
-public class TestKuduSmokeTestWithEmptyInferSchema
+public abstract class AbstractKuduSmokeTestWithEmptyInferSchema
         extends AbstractKuduIntegrationSmokeTest
 {
     @Override

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/AbstractKuduSmokeTestWithStandardInferSchema.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/AbstractKuduSmokeTestWithStandardInferSchema.java
@@ -17,18 +17,20 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
-public class TestKuduSmokeTestWithDisabledInferSchema
+import static org.testng.Assert.assertEquals;
+
+public abstract class AbstractKuduSmokeTestWithStandardInferSchema
         extends AbstractKuduIntegrationSmokeTest
 {
     @Override
     protected Optional<String> getKuduSchemaEmulationPrefix()
     {
-        return Optional.empty();
+        return Optional.of("presto::");
     }
 
     @Test
     public void testListingOfTableForDefaultSchema()
     {
-        assertQuery("SHOW TABLES FROM default", "VALUES ('customer'), ('nation'), ('orders'), ('region')");
+        assertEquals(computeActual("SHOW TABLES FROM default").getRowCount(), 0);
     }
 }

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/KuduLatestSmokeTests.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/KuduLatestSmokeTests.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kudu;
+
+public class KuduLatestSmokeTests
+{
+    private static final String KUDU_VERSION = "1.15.0";
+
+    public static class TestKuduSmokeTestWithDisabledInferSchema
+            extends AbstractKuduSmokeTestWithDisabledInferSchema
+    {
+        @Override
+        protected String getKuduServerVersion()
+        {
+            return KUDU_VERSION;
+        }
+    }
+
+    public static class TestKuduSmokeTestWithEmptyInferSchema
+            extends AbstractKuduSmokeTestWithEmptyInferSchema
+    {
+        @Override
+        protected String getKuduServerVersion()
+        {
+            return KUDU_VERSION;
+        }
+    }
+
+    public static class TestKuduSmokeTestWithStandardInferSchema
+            extends AbstractKuduSmokeTestWithStandardInferSchema
+    {
+        @Override
+        protected String getKuduServerVersion()
+        {
+            return KUDU_VERSION;
+        }
+    }
+}

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/KuduSmokeTests.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/KuduSmokeTests.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kudu;
+
+public class KuduSmokeTests
+{
+    private static final String KUDU_VERSION = "1.13.0";
+
+    public static class TestKuduSmokeTestWithDisabledInferSchema
+            extends AbstractKuduSmokeTestWithDisabledInferSchema
+    {
+        @Override
+        protected String getKuduServerVersion()
+        {
+            return KUDU_VERSION;
+        }
+    }
+
+    public static class TestKuduSmokeTestWithEmptyInferSchema
+            extends AbstractKuduSmokeTestWithEmptyInferSchema
+    {
+        @Override
+        protected String getKuduServerVersion()
+        {
+            return KUDU_VERSION;
+        }
+    }
+
+    public static class TestKuduSmokeTestWithStandardInferSchema
+            extends AbstractKuduSmokeTestWithStandardInferSchema
+    {
+        @Override
+        protected String getKuduServerVersion()
+        {
+            return KUDU_VERSION;
+        }
+    }
+}


### PR DESCRIPTION
Upgrading the kudu client revealed a few problems:
1. Timeouts to kudu tablets were sometimes occurring during deletes due to this change introduced in the kudu java client in version 1.13.0: https://github.com/apache/kudu/commit/d23ee5d38ddc4317f431dd65df0c825c00cc968a#diff-f1f50409d81052b8f8d7aea7da663c185c704c6206cb0ec901114f4d9ee8c28f
(see here for the reason why that commit broke the client: https://gerrit.cloudera.org/#/c/18166/)

2. Timeouts were *not* failing query execution because the kudu connector was configured to flush operations in the background.

3. The two combined above meant tests that did deletes sometimes actually did not perform deletes and would fail.

The first commit upgrades the kudu client and additionally explicitly fails trino execution when kudu rpcs timeout. This resolves: https://github.com/trinodb/trino/issues/5687

The second commit fixes the problem of one source of kudu timeouts in the 1.15.0 client .