### PR TITLE
Upgrade Error Prone to 2.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <dep.scribejava.version>6.9.0</dep.scribejava.version>
         <dep.tempto.version>187</dep.tempto.version>
         <dep.gcs.version>2.0.0</dep.gcs.version>
-        <dep.errorprone.version>2.10.0</dep.errorprone.version>
+        <dep.errorprone.version>2.11.0</dep.errorprone.version>
         <dep.testcontainers.version>1.16.3</dep.testcontainers.version>
         <dep.docker-java.version>3.2.12</dep.docker-java.version>
         <dep.coral.version>1.0.121</dep.coral.version>
@@ -1822,10 +1822,10 @@
                                     -Xep:InjectOnConstructorOfAbstractClass:ERROR \
                                     -Xep:MissingCasesInEnumSwitch:ERROR \
                                     -Xep:MissingOverride:ERROR \
-                                    -Xep:MutableConstantField:OFF <!-- flags List fields even if initialized with ImmutableList --> \
                                     -Xep:MutablePublicArray:ERROR \
                                     -Xep:NullOptional:ERROR \
                                     -Xep:ObjectToString:ERROR \
+                                    -Xep:PreferredInterfaceType:OFF <!-- flags List fields even if initialized with ImmutableList --> \
                                     -Xep:StreamResourceLeak:ERROR \
                                     -Xep:UnnecessaryMethodReference:ERROR \
                                     -Xep:UnnecessaryOptionalGet:ERROR \


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our
development guide at
https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md
and contact us on #dev in slack. -->
## Description

In version 2.11.0 `MutableConstantField` got replaced with `PreferredInterfaceType`, which has slightly wider scope, but the idea is the same. No other changes needed.


<!--
The following sections are filled in by the maintainer with input from the
contributor:

Use :white_check_mark: or (x) or whatever really to signal selection.
-->
## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text: