### PR TITLE
Fix incorrect project version in trino-collect

### DIFF
--- a/lib/trino-collect/pom.xml
+++ b/lib/trino-collect/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>370-SNAPSHOT</version>
+        <version>371-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
<!--
The following sections are filled in by the maintainer with input from the
contributor:

Use :white_check_mark: or (x) or whatever really to signal selection.
-->
## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```
# Section
* Fix some things. ({issue}`5678`)
```
