### PR TITLE
Recover commentary about ReentrantBoundedExecutor use

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastoreModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastoreModule.java
@@ -85,6 +85,9 @@ public class CachingHiveMetastoreModule
 
         return Optional.of(cachingHiveMetastore(
                 delegate,
+                // Loading of cache entry in CachingHiveMetastore might trigger loading of another cache entry for different object type
+                // In case there are no empty executor slots, such operation would deadlock. Therefore, a reentrant executor needs to be
+                // used.
                 new ReentrantBoundedExecutor(
                         newCachedThreadPool(daemonThreadsNamed("hive-metastore-" + catalogName + "-%s")),
                         config.getMaxMetastoreRefreshThreads()),


### PR DESCRIPTION
The wording comes from 2d3074e1dfaaa4d75e80485f27b77d0fada13469 (https://github.com/trinodb/trino/pull/2984) which
added the usage. The code has been refactored since then, so the commit
message is not easy to be found.

<!-- Thank you for submitting a pull request! Find more information in our
development guide at
https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md
and contact us on #dev in slack. -->
## Description
<!-- Elaborate beyond the title of the PR as necessary to help the reviewers
and maintainers.-->


## General information

Is this change a fix, improvement, new feature, refactoring, or other?


Is this a change to the core query engine, a connector, client library, or the
SPI interfaces (be specific)?


How would you describe this change to a non-technical end user or system
administrator?

## Related issues, pull requests, and links
<!-- List any issue that is fixed and provide links to other related PRs,
upstream release notes, and other useful resources:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->


<!--
The following sections are filled in by the maintainer with input from the
contributor:

Use :white_check_mark: or (x) or whatever really to signal selection.
-->
## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```
# Section
* Fix some things. ({issue}`5678`)
```
