### PR TITLE
Ensure ExchangeClient is always properly closed

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResource.java
@@ -118,7 +118,10 @@ public class ExecutingStatementResource
                             }
                             catch (NoSuchElementException e) {
                                 // query is no longer registered
-                                queries.remove(entry.getKey());
+                                Query query = queries.remove(entry.getKey());
+                                if (query != null) {
+                                    query.dispose();
+                                }
                             }
                         }
                     }

--- a/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
@@ -450,6 +450,8 @@ class Query
         }
         else {
             nextToken = OptionalLong.empty();
+            // the client is not coming back, make sure the exchangeClient is closed
+            exchangeClient.close();
         }
 
         URI nextResultsUri = null;
@@ -534,6 +536,9 @@ class Query
                 Page page = serde.deserialize(context, serializedPage);
                 bytes += page.getLogicalSizeInBytes();
                 resultBuilder.addPage(page);
+            }
+            if (exchangeClient.isFinished()) {
+                exchangeClient.close();
             }
         }
         catch (Throwable cause) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our
development guide at
https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md
and contact us on #dev in slack. -->
## Description

The exchange client used to pull query results may not get closed if a
query is abandoned or even when query finished successfully.

## General information

This is a very old problem that didn't manifest itself until https://github.com/trinodb/trino/pull/10507. Now since the `ExchangeClient` may create files when spooling it is required for the temporary data to be properly disposed upon query completion. 

## Related issues, pull requests, and links

https://github.com/trinodb/trino/pull/10507

## Documentation

No documentation is needed.

## Release notes

No release notes entries required.
