### PR TITLE
Remove line breaks in pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,39 +1,29 @@
-<!-- Thank you for submitting a pull request! Find more information in our
-development guide at
-https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md
-and contact us on #dev in slack. -->
-## Description
-<!-- Elaborate beyond the title of the PR as necessary to help the reviewers
-and maintainers.-->
+<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
 
+## Description
+
+<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->
 
 ## General information
 
 Is this change a fix, improvement, new feature, refactoring, or other?
 
+Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
 
-Is this a change to the core query engine, a connector, client library, or the
-SPI interfaces (be specific)?
-
-
-How would you describe this change to a non-technical end user or system
-administrator?
+How would you describe this change to a non-technical end user or system administrator?
 
 ## Related issues, pull requests, and links
-<!-- List any issue that is fixed and provide links to other related PRs,
-upstream release notes, and other useful resources:
+
+<!-- List any issue that is fixed and provide links to other related PRs, upstream release notes, and other useful resources:
 * Fixes #issuenumber
 * Related documentation in #issuenumber
 * [Some release notes](http://usefulinfo.example.com)
 -->
 
-
-<!--
-The following sections are filled in by the maintainer with input from the
-contributor:
-
+<!-- The following sections are filled in by the maintainer with input from the contributor:
 Use :white_check_mark: or (x) or whatever really to signal selection.
 -->
+
 ## Documentation
 
 ( ) No documentation is needed.


### PR DESCRIPTION
These artificial line breaks look bad when the template is rendered in the GitHub edit box.

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
