### PR TITLE
Fix out-of-date links in Cassandra connector doc

### DIFF
--- a/docs/src/main/sphinx/connector/cassandra.rst
+++ b/docs/src/main/sphinx/connector/cassandra.rst
@@ -83,7 +83,7 @@ Property Name                                      Description
         If authorization is enabled, ``cassandra.username`` must have enough permissions to perform ``SELECT`` queries on
         the ``system.size_estimates`` table.
 
-.. _Cassandra consistency: http://www.datastax.com/documentation/cassandra/2.0/cassandra/dml/dml_config_consistency_c.html
+.. _Cassandra consistency: https://docs.datastax.com/en/cassandra-oss/2.2/cassandra/dml/dmlConfigConsistency.html
 
 The following advanced configuration properties are available:
 
@@ -169,7 +169,7 @@ The ``users`` table is an example Cassandra table from the Cassandra
 `Getting Started`_ guide. It can be created along with the ``mykeyspace``
 keyspace using Cassandra's cqlsh (CQL interactive terminal):
 
-.. _Getting Started: https://wiki.apache.org/cassandra/GettingStarted
+.. _Getting Started: https://cassandra.apache.org/doc/latest/cassandra/getting_started/index.html
 
 .. code-block:: text
 


### PR DESCRIPTION
## Related issues, pull requests, and links

<!-- List any issue that is fixed and provide links to other related PRs, upstream release notes, and other useful resources:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->
Fixes #10966

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) or whatever really to signal selection.
-->

## Documentation

(✅) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(✅) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```
# Section
* Fix some things. ({issue}`5678`)
```
