### PR TITLE
Reduce overheads related to DictionaryBlock#getSizeInBytes()

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/GroupByIdBlock.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupByIdBlock.java
@@ -19,6 +19,7 @@ import io.trino.spi.block.BlockBuilder;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -64,9 +65,15 @@ public class GroupByIdBlock
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public OptionalInt fixedSizeInBytesPerPosition()
     {
-        return block.getPositionsSizeInBytes(positions);
+        return block.fixedSizeInBytesPerPosition();
+    }
+
+    @Override
+    public long getPositionsSizeInBytes(boolean[] positions, int selectedPositionCount)
+    {
+        return block.getPositionsSizeInBytes(positions, selectedPositionCount);
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/block/AbstractTestBlock.java
+++ b/core/trino-main/src/test/java/io/trino/block/AbstractTestBlock.java
@@ -221,11 +221,11 @@ public abstract class AbstractTestBlock
 
         boolean[] positions = new boolean[block.getPositionCount()];
         fill(positions, 0, firstHalf.getPositionCount(), true);
-        assertEquals(block.getPositionsSizeInBytes(positions), expectedFirstHalfSize);
+        assertEquals(block.getPositionsSizeInBytes(positions, firstHalf.getPositionCount()), expectedFirstHalfSize);
         fill(positions, true);
-        assertEquals(block.getPositionsSizeInBytes(positions), expectedBlockSize);
+        assertEquals(block.getPositionsSizeInBytes(positions, positions.length), expectedBlockSize);
         fill(positions, 0, firstHalf.getPositionCount(), false);
-        assertEquals(block.getPositionsSizeInBytes(positions), expectedSecondHalfSize);
+        assertEquals(block.getPositionsSizeInBytes(positions, positions.length - firstHalf.getPositionCount()), expectedSecondHalfSize);
     }
 
     // expectedValueType is required since otherwise the expected value type is unknown when expectedValue is null.

--- a/core/trino-main/src/test/java/io/trino/block/TestDictionaryBlock.java
+++ b/core/trino-main/src/test/java/io/trino/block/TestDictionaryBlock.java
@@ -252,12 +252,12 @@ public class TestDictionaryBlock
 
         assertEquals(
                 dictionary.getSizeInBytes(),
-                valuesBlock.getPositionsSizeInBytes(new boolean[] {true, false, true, false, false, false}) + 4 * Integer.BYTES);
+                valuesBlock.getPositionsSizeInBytes(new boolean[] {true, false, true, false, false, false}, 2) + 4 * Integer.BYTES);
         assertFalse(dictionary.isCompact());
 
         assertEquals(
                 dictionaryWithAllPositionsUsed.getSizeInBytes(),
-                valuesBlock.getPositionsSizeInBytes(new boolean[] {true, true, true, false, true, true}) + 6 * Integer.BYTES);
+                valuesBlock.getPositionsSizeInBytes(new boolean[] {true, true, true, false, true, true}, 5) + 6 * Integer.BYTES);
         // dictionary is not compact (even though all positions were used) because it's unnested
         assertFalse(dictionaryWithAllPositionsUsed.isCompact());
 

--- a/core/trino-main/src/test/java/io/trino/block/TestDictionaryBlock.java
+++ b/core/trino-main/src/test/java/io/trino/block/TestDictionaryBlock.java
@@ -19,9 +19,14 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.block.DictionaryId;
+import io.trino.spi.block.IntArrayBlock;
 import io.trino.spi.block.VariableWidthBlock;
 import io.trino.spi.block.VariableWidthBlockBuilder;
 import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.IntStream;
 
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.testing.Assertions.assertInstanceOf;
@@ -389,6 +394,114 @@ public class TestDictionaryBlock
         DictionaryBlock dictionaryBlock = createDictionaryBlock(expectedValues, dictionaryPositionCount);
         for (int position = 0; position < dictionaryPositionCount; position++) {
             assertEquals(dictionaryBlock.getEstimatedDataSizeForStats(position), expectedValues[position % positionCount].length());
+        }
+    }
+
+    @Test
+    public void testNestedDictionarySizes()
+    {
+        // fixed width block
+        Block fixedWidthBlock = new IntArrayBlock(100, Optional.empty(), IntStream.range(0, 100).toArray());
+        assertDictionarySizeMethods(fixedWidthBlock);
+        assertDictionarySizeMethods(new DictionaryBlock(fixedWidthBlock, IntStream.range(0, 50).toArray()));
+        assertDictionarySizeMethods(
+                new DictionaryBlock(
+                        new DictionaryBlock(fixedWidthBlock, IntStream.range(0, 50).toArray()),
+                        IntStream.range(0, 10).toArray()));
+
+        // variable width block
+        Block variableWidthBlock = createSlicesBlock(createExpectedValues(100));
+        assertDictionarySizeMethods(variableWidthBlock);
+        assertDictionarySizeMethods(new DictionaryBlock(variableWidthBlock, IntStream.range(0, 50).toArray()));
+        assertDictionarySizeMethods(
+                new DictionaryBlock(
+                        new DictionaryBlock(variableWidthBlock, IntStream.range(0, 50).toArray()),
+                        IntStream.range(0, 10).toArray()));
+    }
+
+    private static void assertDictionarySizeMethods(Block block)
+    {
+        int positions = block.getPositionCount();
+
+        int[] allIds = IntStream.range(0, positions).toArray();
+        if (block instanceof DictionaryBlock) {
+            assertEquals(
+                    new DictionaryBlock(block, allIds).getSizeInBytes(),
+                    block.getSizeInBytes(),
+                    "nested dictionary size should not be counted");
+        }
+        else {
+            assertEquals(new DictionaryBlock(block, allIds).getSizeInBytes(), block.getSizeInBytes() + (Integer.BYTES * (long) positions));
+        }
+
+        if (positions > 0) {
+            int firstHalfLength = positions / 2;
+            int secondHalfLength = positions - firstHalfLength;
+            int[] firstHalfIds = IntStream.range(0, firstHalfLength).toArray();
+            int[] secondHalfIds = IntStream.range(firstHalfLength, positions).toArray();
+
+            boolean[] selectedPositions = new boolean[positions];
+            selectedPositions[0] = true;
+            if (block instanceof DictionaryBlock) {
+                assertEquals(
+                        new DictionaryBlock(block, allIds).getPositionsSizeInBytes(selectedPositions, 1),
+                        block.getPositionsSizeInBytes(selectedPositions, 1),
+                        "nested dictionary blocks must not include nested id overhead");
+                assertEquals(
+                        new DictionaryBlock(block, new int[]{0}).getSizeInBytes(),
+                        block.getPositionsSizeInBytes(selectedPositions, 1),
+                        "nested dictionary blocks must not include nested id overhead");
+
+                Arrays.fill(selectedPositions, true);
+                assertEquals(
+                        new DictionaryBlock(block, allIds).getPositionsSizeInBytes(selectedPositions, positions),
+                        block.getSizeInBytes(),
+                        "nested dictionary blocks must not include nested id overhead");
+
+                assertEquals(
+                        new DictionaryBlock(block, firstHalfIds).getSizeInBytes(),
+                        block.getRegionSizeInBytes(0, firstHalfLength),
+                        "nested dictionary blocks must not include nested id overhead");
+                assertEquals(
+                        new DictionaryBlock(block, secondHalfIds).getSizeInBytes(),
+                        block.getRegionSizeInBytes(firstHalfLength, secondHalfLength),
+                        "nested dictionary blocks must not include nested id overhead");
+                assertEquals(
+                        new DictionaryBlock(block, allIds).getRegionSizeInBytes(0, firstHalfLength),
+                        block.getRegionSizeInBytes(0, firstHalfLength),
+                        "nested dictionary blocks must not include nested id overhead");
+                assertEquals(
+                        new DictionaryBlock(block, allIds).getRegionSizeInBytes(firstHalfLength, secondHalfLength),
+                        block.getRegionSizeInBytes(firstHalfLength, secondHalfLength),
+                        "nested dictionary blocks must not include nested id overhead");
+            }
+            else {
+                assertEquals(
+                        new DictionaryBlock(block, allIds).getPositionsSizeInBytes(selectedPositions, 1),
+                        block.getPositionsSizeInBytes(selectedPositions, 1) + Integer.BYTES);
+
+                assertEquals(
+                        new DictionaryBlock(block, new int[]{0}).getSizeInBytes(),
+                        block.getPositionsSizeInBytes(selectedPositions, 1) + Integer.BYTES);
+
+                Arrays.fill(selectedPositions, true);
+                assertEquals(
+                        new DictionaryBlock(block, allIds).getPositionsSizeInBytes(selectedPositions, positions),
+                        block.getSizeInBytes() + (Integer.BYTES * (long) positions));
+
+                assertEquals(
+                        new DictionaryBlock(block, firstHalfIds).getSizeInBytes(),
+                        block.getRegionSizeInBytes(0, firstHalfLength) + (Integer.BYTES * (long) firstHalfLength));
+                assertEquals(
+                        new DictionaryBlock(block, secondHalfIds).getSizeInBytes(),
+                        block.getRegionSizeInBytes(firstHalfLength, secondHalfLength) + (Integer.BYTES * (long) secondHalfLength));
+                assertEquals(
+                        new DictionaryBlock(block, allIds).getRegionSizeInBytes(0, firstHalfLength),
+                        block.getRegionSizeInBytes(0, firstHalfLength) + (Integer.BYTES * (long) firstHalfLength));
+                assertEquals(
+                        new DictionaryBlock(block, allIds).getRegionSizeInBytes(firstHalfLength, secondHalfLength),
+                        block.getRegionSizeInBytes(firstHalfLength, secondHalfLength) + (Integer.BYTES * (long) secondHalfLength));
+            }
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/project/BenchmarkDictionaryBlock.java
+++ b/core/trino-main/src/test/java/io/trino/operator/project/BenchmarkDictionaryBlock.java
@@ -16,6 +16,7 @@ package io.trino.operator.project;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.type.MapType;
 import io.trino.spi.type.StandardTypes;
@@ -43,6 +44,7 @@ import java.util.stream.IntStream;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.block.BlockAssertions.createSlicesBlock;
 import static io.trino.jmh.Benchmarks.benchmark;
+import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
@@ -63,17 +65,30 @@ public class BenchmarkDictionaryBlock
     }
 
     @Benchmark
+    public long getPositionsSizeInBytes(BenchmarkData data)
+    {
+        return data.getAllPositionsDictionaryBlock().getPositionsSizeInBytes(data.getSelectedPositionsMask(), data.getSelectedPositionCount());
+    }
+
+    @Benchmark
+    public long getPositionsThenGetSizeInBytes(BenchmarkData data)
+    {
+        int[] positionIds = data.getPositionsIds();
+        return data.getAllPositionsDictionaryBlock().getPositions(positionIds, 0, positionIds.length).getSizeInBytes();
+    }
+
+    @Benchmark
     public Block copyPositions(BenchmarkData data)
     {
         int[] positionIds = data.getPositionsIds();
-        return data.getAllPositionsDictionaryBlock().copyPositions(data.getPositionsIds(), 0, positionIds.length);
+        return data.getAllPositionsDictionaryBlock().copyPositions(positionIds, 0, positionIds.length);
     }
 
     @Benchmark
     public Block copyPositionsCompactDictionary(BenchmarkData data)
     {
         int[] positionIds = data.getPositionsIds();
-        return data.getAllPositionsCompactDictionaryBlock().copyPositions(data.getPositionsIds(), 0, positionIds.length);
+        return data.getAllPositionsCompactDictionaryBlock().copyPositions(positionIds, 0, positionIds.length);
     }
 
     @State(Scope.Thread)
@@ -83,27 +98,49 @@ public class BenchmarkDictionaryBlock
         @Param({"100", "1000", "10000", "100000"})
         private String selectedPositions = "100";
 
+        @Param({"varchar", "integer"})
+        private String valueType = "integer";
+
         private int[] positionsIds;
         private DictionaryBlock dictionaryBlock;
         private DictionaryBlock allPositionsDictionaryBlock;
         private DictionaryBlock allPositionsCompactDictionaryBlock;
+        private boolean[] selectedPositionsMask;
+        private int selectedPositionCount;
 
-        @Setup(Level.Invocation)
+        @Setup(Level.Trial)
         public void setup()
         {
             positionsIds = generateIds(Integer.parseInt(selectedPositions), POSITIONS);
-            Block mapBlock = createMapBlock(POSITIONS);
+            selectedPositionsMask = new boolean[POSITIONS];
+            for (int position : positionsIds) {
+                if (!selectedPositionsMask[position]) {
+                    selectedPositionsMask[position] = true;
+                    selectedPositionCount++;
+                }
+            }
+            Block mapBlock;
+            switch (valueType) {
+                case "varchar":
+                    mapBlock = createVarcharMapBlock(POSITIONS);
+                    break;
+                case "integer":
+                    mapBlock = createIntMapBlock(POSITIONS);
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unrecognized value type: " + valueType);
+            }
             dictionaryBlock = new DictionaryBlock(mapBlock, positionsIds);
             int[] allPositions = IntStream.range(0, POSITIONS).toArray();
             allPositionsDictionaryBlock = new DictionaryBlock(mapBlock, allPositions);
             allPositionsCompactDictionaryBlock = new DictionaryBlock(POSITIONS, mapBlock, allPositions, true);
         }
 
-        private static Block createMapBlock(int positionCount)
+        private static Block createVarcharMapBlock(int positionCount)
         {
             MapType mapType = (MapType) TESTING_TYPE_MANAGER.getType(new TypeSignature(StandardTypes.MAP, TypeSignatureParameter.typeParameter(VARCHAR.getTypeSignature()), TypeSignatureParameter.typeParameter(VARCHAR.getTypeSignature())));
-            Block keyBlock = createDictionaryBlock(generateList("key", positionCount));
-            Block valueBlock = createDictionaryBlock(generateList("value", positionCount));
+            Block keyBlock = createVarcharDictionaryBlock(generateList("key", positionCount));
+            Block valueBlock = createVarcharDictionaryBlock(generateList("value", positionCount));
             int[] offsets = new int[positionCount + 1];
             int mapSize = keyBlock.getPositionCount() / positionCount;
             for (int i = 0; i < offsets.length; i++) {
@@ -112,7 +149,7 @@ public class BenchmarkDictionaryBlock
             return mapType.createBlockFromKeyValue(Optional.empty(), offsets, keyBlock, valueBlock);
         }
 
-        private static Block createDictionaryBlock(List<String> values)
+        private static Block createVarcharDictionaryBlock(List<String> values)
         {
             Block dictionary = createSliceArrayBlock(values);
             int[] ids = new int[values.size()];
@@ -120,6 +157,38 @@ public class BenchmarkDictionaryBlock
                 ids[i] = i;
             }
             return new DictionaryBlock(dictionary, ids);
+        }
+
+        private static Block createIntMapBlock(int positionCount)
+        {
+            MapType mapType = (MapType) TESTING_TYPE_MANAGER.getType(new TypeSignature(StandardTypes.MAP, TypeSignatureParameter.typeParameter(INTEGER.getTypeSignature()), TypeSignatureParameter.typeParameter(INTEGER.getTypeSignature())));
+            Block keyBlock = createIntDictionaryBlock(positionCount);
+            Block valueBlock = createIntDictionaryBlock(positionCount);
+            int[] offsets = new int[positionCount + 1];
+            int mapSize = keyBlock.getPositionCount() / positionCount;
+            for (int i = 0; i < offsets.length; i++) {
+                offsets[i] = mapSize * i;
+            }
+            return mapType.createBlockFromKeyValue(Optional.empty(), offsets, keyBlock, valueBlock);
+        }
+
+        private static Block createIntDictionaryBlock(int positionCount)
+        {
+            Block dictionary = createIntBlock(positionCount);
+            int[] ids = new int[positionCount];
+            for (int i = 0; i < ids.length; i++) {
+                ids[i] = i;
+            }
+            return new DictionaryBlock(dictionary, ids);
+        }
+
+        private static Block createIntBlock(int positionCount)
+        {
+            BlockBuilder builder = INTEGER.createFixedSizeBlockBuilder(positionCount);
+            for (int i = 0; i < positionCount; i++) {
+                INTEGER.writeLong(builder, i);
+            }
+            return builder.build();
         }
 
         private static Block createSliceArrayBlock(List<String> values)
@@ -151,6 +220,16 @@ public class BenchmarkDictionaryBlock
             return positionsIds;
         }
 
+        public boolean[] getSelectedPositionsMask()
+        {
+            return selectedPositionsMask;
+        }
+
+        public int getSelectedPositionCount()
+        {
+            return selectedPositionCount;
+        }
+
         public DictionaryBlock getDictionaryBlock()
         {
             return dictionaryBlock;
@@ -173,6 +252,22 @@ public class BenchmarkDictionaryBlock
         BenchmarkData data = new BenchmarkData();
         data.setup();
         getSizeInBytes(data);
+    }
+
+    @Test
+    public void testGetPositionsSizeInBytes()
+    {
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        getPositionsSizeInBytes(data);
+    }
+
+    @Test
+    public void testGetPositionsThenGetSizeInBytes()
+    {
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        getPositionsThenGetSizeInBytes(data);
     }
 
     @Test

--- a/core/trino-spi/src/main/java/io/trino/spi/block/AbstractRowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/AbstractRowBlock.java
@@ -16,6 +16,7 @@ package io.trino.spi.block;
 import javax.annotation.Nullable;
 
 import java.util.List;
+import java.util.OptionalInt;
 
 import static io.trino.spi.block.BlockUtil.arraySame;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
@@ -131,6 +132,41 @@ public abstract class AbstractRowBlock
     }
 
     @Override
+    public final OptionalInt fixedSizeInBytesPerPosition()
+    {
+        if (!mayHaveNull()) {
+            // when null rows are present, we can't use the fixed field sizes to infer the correct
+            // size for arbitrary position selection
+            OptionalInt fieldSize = fixedSizeInBytesPerFieldPosition();
+            if (fieldSize.isPresent()) {
+                // must include the row block overhead in addition to the per position size in bytes
+                return OptionalInt.of(fieldSize.getAsInt() + (Integer.BYTES + Byte.BYTES)); // offsets + rowIsNull
+            }
+        }
+        return OptionalInt.empty();
+    }
+
+    /**
+     * Returns the combined {@link Block#fixedSizeInBytesPerPosition()} value for all fields, assuming all
+     * are fixed size. If any field is not fixed size, then no value will be returned. This does <i>not</i>
+     * include the size-per-position overhead associated with the {@link AbstractRowBlock} itself, only of
+     * the constituent field members.
+     */
+    private OptionalInt fixedSizeInBytesPerFieldPosition()
+    {
+        Block[] rawFieldBlocks = getRawFieldBlocks();
+        int fixedSizePerRow = 0;
+        for (int i = 0; i < numFields; i++) {
+            OptionalInt fieldFixedSize = rawFieldBlocks[i].fixedSizeInBytesPerPosition();
+            if (fieldFixedSize.isEmpty()) {
+                return OptionalInt.empty(); // found a block without a single per-position size
+            }
+            fixedSizePerRow += fieldFixedSize.getAsInt();
+        }
+        return OptionalInt.of(fixedSizePerRow);
+    }
+
+    @Override
     public long getRegionSizeInBytes(int position, int length)
     {
         int positionCount = getPositionCount();
@@ -148,27 +184,80 @@ public abstract class AbstractRowBlock
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public final long getPositionsSizeInBytes(boolean[] positions, int selectedRowPositions)
     {
-        checkValidPositions(positions, getPositionCount());
+        int positionCount = getPositionCount();
+        checkValidPositions(positions, positionCount);
+        if (selectedRowPositions == 0) {
+            return 0;
+        }
+        if (selectedRowPositions == positionCount) {
+            return getSizeInBytes();
+        }
 
-        int usedPositionCount = 0;
-        boolean[] fieldPositions = new boolean[getRawFieldBlocks()[0].getPositionCount()];
-        for (int i = 0; i < positions.length; i++) {
-            if (positions[i]) {
-                usedPositionCount++;
-                int startFieldBlockOffset = getFieldBlockOffset(i);
-                int endFieldBlockOffset = getFieldBlockOffset(i + 1);
-                for (int j = startFieldBlockOffset; j < endFieldBlockOffset; j++) {
-                    fieldPositions[j] = true;
+        OptionalInt fixedSizePerFieldPosition = fixedSizeInBytesPerFieldPosition();
+        if (fixedSizePerFieldPosition.isPresent()) {
+            // All field blocks are fixed size per position, no specific position mapping is necessary
+            int selectedFieldPositionCount = selectedRowPositions;
+            boolean[] rowIsNull = getRowIsNull();
+            if (rowIsNull != null) {
+                // Some positions in usedPositions may be null which must be removed from the selectedFieldPositionCount
+                int offsetBase = getOffsetBase();
+                for (int i = 0; i < positions.length; i++) {
+                    if (positions[i] && rowIsNull[i + offsetBase]) {
+                        selectedFieldPositionCount--; // selected row is null, don't include it in the selected field positions
+                    }
+                }
+                if (selectedFieldPositionCount < 0) {
+                    throw new IllegalStateException("Invalid field position selection after nulls removed: " + selectedFieldPositionCount);
+                }
+            }
+            return ((Integer.BYTES + Byte.BYTES) * (long) selectedRowPositions) + (fixedSizePerFieldPosition.getAsInt() * (long) selectedFieldPositionCount);
+        }
+
+        // Fall back to specific position size calculations
+        return getSpecificPositionsSizeInBytes(positions, selectedRowPositions);
+    }
+
+    private long getSpecificPositionsSizeInBytes(boolean[] positions, int selectedRowPositions)
+    {
+        int positionCount = getPositionCount();
+        int offsetBase = getOffsetBase();
+        boolean[] rowIsNull = getRowIsNull();
+        // No fixed width size per row, specific positions used must be tracked
+        int totalFieldPositions = getRawFieldBlocks()[0].getPositionCount();
+        boolean[] fieldPositions;
+        int selectedFieldPositionCount;
+        if (rowIsNull == null) {
+            // No nulls, so the same number of positions are used
+            selectedFieldPositionCount = selectedRowPositions;
+            if (offsetBase == 0 && positionCount == totalFieldPositions) {
+                // No need to adapt the positions array at all, reuse it directly
+                fieldPositions = positions;
+            }
+            else {
+                // no nulls present, so we can just shift the positions array into alignment with the elements block with other positions unused
+                fieldPositions = new boolean[totalFieldPositions];
+                System.arraycopy(positions, 0, fieldPositions, offsetBase, positions.length);
+            }
+        }
+        else {
+            fieldPositions = new boolean[totalFieldPositions];
+            selectedFieldPositionCount = 0;
+            for (int i = 0; i < positions.length; i++) {
+                if (positions[i] && !rowIsNull[offsetBase + i]) {
+                    selectedFieldPositionCount++;
+                    fieldPositions[getFieldBlockOffset(i)] = true;
                 }
             }
         }
-        long sizeInBytes = 0;
+
+        Block[] rawFieldBlocks = getRawFieldBlocks();
+        long sizeInBytes = ((Integer.BYTES + Byte.BYTES) * (long) selectedRowPositions); // offsets + rowIsNull
         for (int j = 0; j < numFields; j++) {
-            sizeInBytes += getRawFieldBlocks()[j].getPositionsSizeInBytes(fieldPositions);
+            sizeInBytes += rawFieldBlocks[j].getPositionsSizeInBytes(fieldPositions, selectedFieldPositionCount);
         }
-        return sizeInBytes + (Integer.BYTES + Byte.BYTES) * (long) usedPositionCount;
+        return sizeInBytes;
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/AbstractSingleArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/AbstractSingleArrayBlock.java
@@ -182,7 +182,7 @@ public abstract class AbstractSingleArrayBlock
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getPositionsSizeInBytes(boolean[] positions, int selectedPositionsCount)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/AbstractSingleMapBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/AbstractSingleMapBlock.java
@@ -243,7 +243,7 @@ public abstract class AbstractSingleMapBlock
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getPositionsSizeInBytes(boolean[] positions, int selectedPositionsCount)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/AbstractSingleRowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/AbstractSingleRowBlock.java
@@ -159,7 +159,7 @@ public abstract class AbstractSingleRowBlock
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getPositionsSizeInBytes(boolean[] positions, int selectedPositionsCount)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Block.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Block.java
@@ -17,6 +17,7 @@ import io.airlift.slice.Slice;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
@@ -188,21 +189,23 @@ public interface Block
     long getRegionSizeInBytes(int position, int length);
 
     /**
-     * Returns the size of all positions marked true in the positions array.
-     * This is equivalent to multiple calls of {@code block.getRegionSizeInBytes(position, length)}
-     * where you mark all positions for the regions first.
+     * Returns the number of bytes (in terms of {@link Block#getSizeInBytes()}) required per position
+     * that this block contains, assuming that the number of bytes required is a known static quantity
+     * and not dependent on any particular specific position. This allows for some complex block wrappings
+     * to potentially avoid having to call {@link Block#getPositionsSizeInBytes(boolean[], int)}  which
+     * would require computing the specific positions selected
+     * @return The size in bytes, per position, if this block type does not require specific position information to compute its size
      */
-    long getPositionsSizeInBytes(boolean[] positions);
+    OptionalInt fixedSizeInBytesPerPosition();
 
     /**
      * Returns the size of all positions marked true in the positions array.
+     * This is equivalent to multiple calls of {@code block.getRegionSizeInBytes(position, length)}
+     * where you mark all positions for the regions first.
      * The 'selectedPositionsCount' variable may be used to skip iterating through
      * the positions array in case this is a fixed-width block
      */
-    default long getPositionsSizeInBytes(boolean[] positions, int selectedPositionsCount)
-    {
-        return getPositionsSizeInBytes(positions);
-    }
+    long getPositionsSizeInBytes(boolean[] positions, int selectedPositionsCount);
 
     /**
      * Returns the retained size of this block in memory, including over-allocations.

--- a/core/trino-spi/src/main/java/io/trino/spi/block/BlockUtil.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/BlockUtil.java
@@ -181,13 +181,29 @@ final class BlockUtil
         return Arrays.copyOfRange(array, index, index + length);
     }
 
-    static int countUsedPositions(boolean[] positions)
+    static int countSelectedPositionsFromOffsets(boolean[] positions, int[] offsets, int offsetBase)
     {
+        checkArrayRange(offsets, offsetBase, positions.length);
         int used = 0;
-        for (boolean position : positions) {
-            // Avoid branching by casting boolean to integer.
-            // This improves CPU utilization by avoiding branch mispredictions.
-            used += position ? 1 : 0;
+        for (int i = 0; i < positions.length; i++) {
+            int offsetStart = offsets[offsetBase + i];
+            int offsetEnd = offsets[offsetBase + i + 1];
+            used += ((positions[i] ? 1 : 0) * (offsetEnd - offsetStart));
+        }
+        return used;
+    }
+
+    static int countAndMarkSelectedPositionsFromOffsets(boolean[] positions, int[] offsets, int offsetBase, boolean[] elementPositions)
+    {
+        checkArrayRange(offsets, offsetBase, positions.length);
+        int used = 0;
+        for (int i = 0; i < positions.length; i++) {
+            int offsetStart = offsets[offsetBase + i];
+            int offsetEnd = offsets[offsetBase + i + 1];
+            if (positions[i]) {
+                used += (offsetEnd - offsetStart);
+                Arrays.fill(elementPositions, offsetStart, offsetEnd, true);
+            }
         }
         return used;
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlock.java
@@ -20,18 +20,19 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.BlockUtil.compactArray;
-import static io.trino.spi.block.BlockUtil.countUsedPositions;
 
 public class ByteArrayBlock
         implements Block
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(ByteArrayBlock.class).instanceSize();
+    public static final int SIZE_IN_BYTES_PER_POSITION = Byte.BYTES + Byte.BYTES;
 
     private final int arrayOffset;
     private final int positionCount;
@@ -79,21 +80,21 @@ public class ByteArrayBlock
     }
 
     @Override
-    public long getRegionSizeInBytes(int position, int length)
+    public OptionalInt fixedSizeInBytesPerPosition()
     {
-        return (Byte.BYTES + Byte.BYTES) * (long) length;
+        return OptionalInt.of(SIZE_IN_BYTES_PER_POSITION);
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getRegionSizeInBytes(int position, int length)
     {
-        return getPositionsSizeInBytes(positions, countUsedPositions(positions));
+        return SIZE_IN_BYTES_PER_POSITION * (long) length;
     }
 
     @Override
     public long getPositionsSizeInBytes(boolean[] positions, int selectedPositionsCount)
     {
-        return (long) (Byte.BYTES + Byte.BYTES) * selectedPositionsCount;
+        return (long) SIZE_IN_BYTES_PER_POSITION * selectedPositionsCount;
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlockBuilder.java
@@ -20,13 +20,13 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.calculateBlockResetSize;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
-import static io.trino.spi.block.BlockUtil.countUsedPositions;
 import static java.lang.Math.max;
 
 public class ByteArrayBlockBuilder
@@ -70,7 +70,7 @@ public class ByteArrayBlockBuilder
         hasNonNullValue = true;
         positionCount++;
         if (blockBuilderStatus != null) {
-            blockBuilderStatus.addBytes(Byte.BYTES + Byte.BYTES);
+            blockBuilderStatus.addBytes(ByteArrayBlock.SIZE_IN_BYTES_PER_POSITION);
         }
         return this;
     }
@@ -93,7 +93,7 @@ public class ByteArrayBlockBuilder
         hasNullValue = true;
         positionCount++;
         if (blockBuilderStatus != null) {
-            blockBuilderStatus.addBytes(Byte.BYTES + Byte.BYTES);
+            blockBuilderStatus.addBytes(ByteArrayBlock.SIZE_IN_BYTES_PER_POSITION);
         }
         return this;
     }
@@ -138,21 +138,27 @@ public class ByteArrayBlockBuilder
     }
 
     @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.of(ByteArrayBlock.SIZE_IN_BYTES_PER_POSITION);
+    }
+
+    @Override
     public long getSizeInBytes()
     {
-        return (Byte.BYTES + Byte.BYTES) * (long) positionCount;
+        return ByteArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
     }
 
     @Override
     public long getRegionSizeInBytes(int position, int length)
     {
-        return (Byte.BYTES + Byte.BYTES) * (long) length;
+        return ByteArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) length;
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getPositionsSizeInBytes(boolean[] positions, int selectedPositionsCount)
     {
-        return (Byte.BYTES + Byte.BYTES) * (long) countUsedPositions(positions);
+        return (long) ByteArrayBlock.SIZE_IN_BYTES_PER_POSITION * selectedPositionsCount;
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
@@ -410,10 +410,19 @@ public class DictionaryBlock
                 used[id] = true;
             }
         }
-        long dictionarySize = dictionary.getPositionsSizeInBytes(used, usedIds);
+
+        long dictionarySize;
         if (usedIds == used.length) {
-            // dictionary is discovered to be compact, store updated size information
-            this.uniqueIds = usedIds;
+            // discovered dictionary is compact
+            dictionarySize = dictionary.getSizeInBytes();
+            if (sizeInBytes < 0) {
+                // save the information about compactness
+                this.uniqueIds = usedIds;
+                this.sizeInBytes = dictionarySize + (Integer.BYTES * (long) positionCount);
+            }
+        }
+        else {
+            dictionarySize = dictionary.getPositionsSizeInBytes(used, usedIds);
         }
         return dictionarySize + (Integer.BYTES * (long) selectedPositionsCount);
     }
@@ -540,20 +549,25 @@ public class DictionaryBlock
 
         int[] newIds = new int[length];
         boolean isCompact = length >= dictionary.getPositionCount() && isCompact();
-        boolean[] seen = null;
-        if (isCompact) {
-            seen = new boolean[dictionary.getPositionCount()];
-        }
+        boolean[] usedIds = isCompact ? new boolean[dictionary.getPositionCount()] : null;
+        int uniqueIds = 0;
         for (int i = 0; i < length; i++) {
-            newIds[i] = getId(positions[offset + i]);
-            if (isCompact) {
-                seen[newIds[i]] = true;
+            int id = getId(positions[offset + i]);
+            newIds[i] = id;
+            if (usedIds != null) {
+                uniqueIds += usedIds[id] ? 0 : 1;
+                usedIds[id] = true;
             }
         }
-        for (int i = 0; i < dictionary.getPositionCount() && isCompact; i++) {
-            isCompact &= seen[i];
+        // All positions must have been referenced in order to be compact
+        isCompact &= (usedIds != null && usedIds.length == uniqueIds);
+        DictionaryBlock result = new DictionaryBlock(newIds.length, dictionary, newIds, isCompact, getDictionarySourceId());
+        if (usedIds != null && !isCompact) {
+            // resulting dictionary is not compact, but we know the number of unique ids and which positions are used
+            result.uniqueIds = uniqueIds;
+            result.sizeInBytes = dictionary.getPositionsSizeInBytes(usedIds, uniqueIds) + (Integer.BYTES * (long) length);
         }
-        return new DictionaryBlock(newIds.length, getDictionary(), newIds, isCompact, getDictionarySourceId());
+        return result;
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlock.java
@@ -20,19 +20,20 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.BlockUtil.compactArray;
-import static io.trino.spi.block.BlockUtil.countUsedPositions;
 
 public class Int128ArrayBlock
         implements Block
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(Int128ArrayBlock.class).instanceSize();
     public static final int INT128_BYTES = Long.BYTES + Long.BYTES;
+    public static final int SIZE_IN_BYTES_PER_POSITION = INT128_BYTES + Byte.BYTES;
 
     private final int positionOffset;
     private final int positionCount;
@@ -69,8 +70,14 @@ public class Int128ArrayBlock
         }
         this.valueIsNull = valueIsNull;
 
-        sizeInBytes = (INT128_BYTES + Byte.BYTES) * (long) positionCount;
+        sizeInBytes = SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
         retainedSizeInBytes = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.of(SIZE_IN_BYTES_PER_POSITION);
     }
 
     @Override
@@ -82,19 +89,13 @@ public class Int128ArrayBlock
     @Override
     public long getRegionSizeInBytes(int position, int length)
     {
-        return (INT128_BYTES + Byte.BYTES) * (long) length;
-    }
-
-    @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
-    {
-        return getPositionsSizeInBytes(positions, countUsedPositions(positions));
+        return SIZE_IN_BYTES_PER_POSITION * (long) length;
     }
 
     @Override
     public long getPositionsSizeInBytes(boolean[] positions, int selectedPositionsCount)
     {
-        return (long) (INT128_BYTES + Byte.BYTES) * selectedPositionsCount;
+        return (long) SIZE_IN_BYTES_PER_POSITION * selectedPositionsCount;
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlockBuilder.java
@@ -20,6 +20,7 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
@@ -28,7 +29,6 @@ import static io.trino.spi.block.BlockUtil.calculateBlockResetSize;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.BlockUtil.compactArray;
-import static io.trino.spi.block.BlockUtil.countUsedPositions;
 import static io.trino.spi.block.Int128ArrayBlock.INT128_BYTES;
 import static java.lang.Math.max;
 
@@ -87,7 +87,7 @@ public class Int128ArrayBlockBuilder
         positionCount++;
         entryPositionCount = 0;
         if (blockBuilderStatus != null) {
-            blockBuilderStatus.addBytes(Byte.BYTES + INT128_BYTES);
+            blockBuilderStatus.addBytes(Int128ArrayBlock.SIZE_IN_BYTES_PER_POSITION);
         }
         return this;
     }
@@ -107,7 +107,7 @@ public class Int128ArrayBlockBuilder
         hasNullValue = true;
         positionCount++;
         if (blockBuilderStatus != null) {
-            blockBuilderStatus.addBytes(Byte.BYTES + INT128_BYTES);
+            blockBuilderStatus.addBytes(Int128ArrayBlock.SIZE_IN_BYTES_PER_POSITION);
         }
         return this;
     }
@@ -152,21 +152,27 @@ public class Int128ArrayBlockBuilder
     }
 
     @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.of(Int128ArrayBlock.SIZE_IN_BYTES_PER_POSITION);
+    }
+
+    @Override
     public long getSizeInBytes()
     {
-        return (INT128_BYTES + Byte.BYTES) * (long) positionCount;
+        return Int128ArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
     }
 
     @Override
     public long getRegionSizeInBytes(int position, int length)
     {
-        return (INT128_BYTES + Byte.BYTES) * (long) length;
+        return Int128ArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) length;
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getPositionsSizeInBytes(boolean[] positions, int selectedPositionsCount)
     {
-        return (INT128_BYTES + Byte.BYTES) * (long) countUsedPositions(positions);
+        return Int128ArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) selectedPositionsCount;
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Int96ArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Int96ArrayBlockBuilder.java
@@ -20,6 +20,7 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
@@ -28,7 +29,6 @@ import static io.trino.spi.block.BlockUtil.calculateBlockResetSize;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.BlockUtil.compactArray;
-import static io.trino.spi.block.BlockUtil.countUsedPositions;
 import static io.trino.spi.block.Int96ArrayBlock.INT96_BYTES;
 import static java.lang.Math.max;
 
@@ -175,21 +175,27 @@ public class Int96ArrayBlockBuilder
     }
 
     @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.of(Int96ArrayBlock.SIZE_IN_BYTES_PER_POSITION);
+    }
+
+    @Override
     public long getSizeInBytes()
     {
-        return (INT96_BYTES + Byte.BYTES) * (long) positionCount;
+        return Int96ArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
     }
 
     @Override
     public long getRegionSizeInBytes(int position, int length)
     {
-        return (INT96_BYTES + Byte.BYTES) * (long) length;
+        return Int96ArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) length;
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getPositionsSizeInBytes(boolean[] positions, int selectedPositionsCount)
     {
-        return (INT96_BYTES + Byte.BYTES) * (long) countUsedPositions(positions);
+        return Int96ArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) selectedPositionsCount;
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlock.java
@@ -20,18 +20,19 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.BlockUtil.compactArray;
-import static io.trino.spi.block.BlockUtil.countUsedPositions;
 
 public class IntArrayBlock
         implements Block
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(IntArrayBlock.class).instanceSize();
+    public static final int SIZE_IN_BYTES_PER_POSITION = Integer.BYTES + Byte.BYTES;
 
     private final int arrayOffset;
     private final int positionCount;
@@ -68,8 +69,14 @@ public class IntArrayBlock
         }
         this.valueIsNull = valueIsNull;
 
-        sizeInBytes = (Integer.BYTES + Byte.BYTES) * (long) positionCount;
+        sizeInBytes = SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
         retainedSizeInBytes = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.of(SIZE_IN_BYTES_PER_POSITION);
     }
 
     @Override
@@ -81,19 +88,13 @@ public class IntArrayBlock
     @Override
     public long getRegionSizeInBytes(int position, int length)
     {
-        return (Integer.BYTES + Byte.BYTES) * (long) length;
-    }
-
-    @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
-    {
-        return getPositionsSizeInBytes(positions, countUsedPositions(positions));
+        return SIZE_IN_BYTES_PER_POSITION * (long) length;
     }
 
     @Override
     public long getPositionsSizeInBytes(boolean[] positions, int selectedPositionsCount)
     {
-        return (long) (Integer.BYTES + Byte.BYTES) * selectedPositionsCount;
+        return (long) SIZE_IN_BYTES_PER_POSITION * selectedPositionsCount;
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlockBuilder.java
@@ -20,13 +20,13 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.calculateBlockResetSize;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
-import static io.trino.spi.block.BlockUtil.countUsedPositions;
 import static java.lang.Math.max;
 
 public class IntArrayBlockBuilder
@@ -70,7 +70,7 @@ public class IntArrayBlockBuilder
         hasNonNullValue = true;
         positionCount++;
         if (blockBuilderStatus != null) {
-            blockBuilderStatus.addBytes(Byte.BYTES + Integer.BYTES);
+            blockBuilderStatus.addBytes(IntArrayBlock.SIZE_IN_BYTES_PER_POSITION);
         }
         return this;
     }
@@ -93,7 +93,7 @@ public class IntArrayBlockBuilder
         hasNullValue = true;
         positionCount++;
         if (blockBuilderStatus != null) {
-            blockBuilderStatus.addBytes(Byte.BYTES + Integer.BYTES);
+            blockBuilderStatus.addBytes(IntArrayBlock.SIZE_IN_BYTES_PER_POSITION);
         }
         return this;
     }
@@ -138,21 +138,27 @@ public class IntArrayBlockBuilder
     }
 
     @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.of(IntArrayBlock.SIZE_IN_BYTES_PER_POSITION);
+    }
+
+    @Override
     public long getSizeInBytes()
     {
-        return (Integer.BYTES + Byte.BYTES) * (long) positionCount;
+        return IntArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
     }
 
     @Override
     public long getRegionSizeInBytes(int position, int length)
     {
-        return (Integer.BYTES + Byte.BYTES) * (long) length;
+        return IntArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) length;
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getPositionsSizeInBytes(boolean[] positions, int selectedPositionsCount)
     {
-        return (Integer.BYTES + Byte.BYTES) * (long) countUsedPositions(positions);
+        return IntArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) selectedPositionsCount;
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LazyBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LazyBlock.java
@@ -21,6 +21,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -155,6 +156,15 @@ public class LazyBlock
     }
 
     @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        if (!isLoaded()) {
+            return OptionalInt.empty();
+        }
+        return getBlock().fixedSizeInBytesPerPosition();
+    }
+
+    @Override
     public long getSizeInBytes()
     {
         if (!isLoaded()) {
@@ -173,12 +183,12 @@ public class LazyBlock
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getPositionsSizeInBytes(boolean[] positions, int selectedPositionsCount)
     {
         if (!isLoaded()) {
             return 0;
         }
-        return getBlock().getPositionsSizeInBytes(positions);
+        return getBlock().getPositionsSizeInBytes(positions, selectedPositionsCount);
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlock.java
@@ -20,19 +20,20 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.BlockUtil.compactArray;
-import static io.trino.spi.block.BlockUtil.countUsedPositions;
 import static java.lang.Math.toIntExact;
 
 public class LongArrayBlock
         implements Block
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(LongArrayBlock.class).instanceSize();
+    public static final int SIZE_IN_BYTES_PER_POSITION = Long.BYTES + Byte.BYTES;
 
     private final int arrayOffset;
     private final int positionCount;
@@ -69,8 +70,14 @@ public class LongArrayBlock
         }
         this.valueIsNull = valueIsNull;
 
-        sizeInBytes = (Long.BYTES + Byte.BYTES) * (long) positionCount;
+        sizeInBytes = SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
         retainedSizeInBytes = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.of(SIZE_IN_BYTES_PER_POSITION);
     }
 
     @Override
@@ -82,19 +89,13 @@ public class LongArrayBlock
     @Override
     public long getRegionSizeInBytes(int position, int length)
     {
-        return (Long.BYTES + Byte.BYTES) * (long) length;
-    }
-
-    @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
-    {
-        return getPositionsSizeInBytes(positions, countUsedPositions(positions));
+        return SIZE_IN_BYTES_PER_POSITION * (long) length;
     }
 
     @Override
     public long getPositionsSizeInBytes(boolean[] positions, int selectedPositionsCount)
     {
-        return (long) (Long.BYTES + Byte.BYTES) * selectedPositionsCount;
+        return (long) SIZE_IN_BYTES_PER_POSITION * selectedPositionsCount;
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlockBuilder.java
@@ -20,13 +20,13 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.calculateBlockResetSize;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
-import static io.trino.spi.block.BlockUtil.countUsedPositions;
 import static java.lang.Math.max;
 import static java.lang.Math.toIntExact;
 
@@ -71,7 +71,7 @@ public class LongArrayBlockBuilder
         hasNonNullValue = true;
         positionCount++;
         if (blockBuilderStatus != null) {
-            blockBuilderStatus.addBytes(Byte.BYTES + Long.BYTES);
+            blockBuilderStatus.addBytes(LongArrayBlock.SIZE_IN_BYTES_PER_POSITION);
         }
         return this;
     }
@@ -94,7 +94,7 @@ public class LongArrayBlockBuilder
         hasNullValue = true;
         positionCount++;
         if (blockBuilderStatus != null) {
-            blockBuilderStatus.addBytes(Byte.BYTES + Long.BYTES);
+            blockBuilderStatus.addBytes(LongArrayBlock.SIZE_IN_BYTES_PER_POSITION);
         }
         return this;
     }
@@ -139,21 +139,27 @@ public class LongArrayBlockBuilder
     }
 
     @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.of(LongArrayBlock.SIZE_IN_BYTES_PER_POSITION);
+    }
+
+    @Override
     public long getSizeInBytes()
     {
-        return (Long.BYTES + Byte.BYTES) * (long) positionCount;
+        return LongArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
     }
 
     @Override
     public long getRegionSizeInBytes(int position, int length)
     {
-        return (Long.BYTES + Byte.BYTES) * (long) length;
+        return LongArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) length;
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getPositionsSizeInBytes(boolean[] positions, int selectedPositionsCount)
     {
-        return (Long.BYTES + Byte.BYTES) * (long) countUsedPositions(positions);
+        return LongArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) selectedPositionsCount;
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
@@ -18,7 +18,10 @@ import io.trino.spi.predicate.Utils;
 import io.trino.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
@@ -81,6 +84,12 @@ public class RunLengthEncodedBlock
     public int getPositionCount()
     {
         return positionCount;
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.empty(); // size does not vary per position selected
     }
 
     @Override
@@ -154,7 +163,7 @@ public class RunLengthEncodedBlock
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getPositionsSizeInBytes(@Nullable boolean[] positions, int selectedPositionCount)
     {
         return value.getSizeInBytes();
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlock.java
@@ -20,18 +20,19 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.BlockUtil.compactArray;
-import static io.trino.spi.block.BlockUtil.countUsedPositions;
 
 public class ShortArrayBlock
         implements Block
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(ShortArrayBlock.class).instanceSize();
+    public static final int SIZE_IN_BYTES_PER_POSITION = Short.BYTES + Byte.BYTES;
 
     private final int arrayOffset;
     private final int positionCount;
@@ -68,8 +69,14 @@ public class ShortArrayBlock
         }
         this.valueIsNull = valueIsNull;
 
-        sizeInBytes = (Short.BYTES + Byte.BYTES) * (long) positionCount;
+        sizeInBytes = SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
         retainedSizeInBytes = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.of(SIZE_IN_BYTES_PER_POSITION);
     }
 
     @Override
@@ -81,19 +88,13 @@ public class ShortArrayBlock
     @Override
     public long getRegionSizeInBytes(int position, int length)
     {
-        return (Short.BYTES + Byte.BYTES) * (long) length;
-    }
-
-    @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
-    {
-        return getPositionsSizeInBytes(positions, countUsedPositions(positions));
+        return SIZE_IN_BYTES_PER_POSITION * (long) length;
     }
 
     @Override
     public long getPositionsSizeInBytes(boolean[] positions, int selectedPositionsCount)
     {
-        return (long) (Short.BYTES + Byte.BYTES) * selectedPositionsCount;
+        return (long) SIZE_IN_BYTES_PER_POSITION * selectedPositionsCount;
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlockBuilder.java
@@ -20,13 +20,13 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.calculateBlockResetSize;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
-import static io.trino.spi.block.BlockUtil.countUsedPositions;
 import static java.lang.Math.max;
 
 public class ShortArrayBlockBuilder
@@ -70,7 +70,7 @@ public class ShortArrayBlockBuilder
         hasNonNullValue = true;
         positionCount++;
         if (blockBuilderStatus != null) {
-            blockBuilderStatus.addBytes(Byte.BYTES + Short.BYTES);
+            blockBuilderStatus.addBytes(ShortArrayBlock.SIZE_IN_BYTES_PER_POSITION);
         }
         return this;
     }
@@ -93,7 +93,7 @@ public class ShortArrayBlockBuilder
         hasNullValue = true;
         positionCount++;
         if (blockBuilderStatus != null) {
-            blockBuilderStatus.addBytes(Byte.BYTES + Short.BYTES);
+            blockBuilderStatus.addBytes(ShortArrayBlock.SIZE_IN_BYTES_PER_POSITION);
         }
         return this;
     }
@@ -138,21 +138,27 @@ public class ShortArrayBlockBuilder
     }
 
     @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.of(ShortArrayBlock.SIZE_IN_BYTES_PER_POSITION);
+    }
+
+    @Override
     public long getSizeInBytes()
     {
-        return (Short.BYTES + Byte.BYTES) * (long) positionCount;
+        return ShortArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
     }
 
     @Override
     public long getRegionSizeInBytes(int position, int length)
     {
-        return (Short.BYTES + Byte.BYTES) * (long) length;
+        return ShortArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) length;
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getPositionsSizeInBytes(boolean[] positions, int selectedPositionCount)
     {
-        return (Short.BYTES + Byte.BYTES) * (long) countUsedPositions(positions);
+        return ShortArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) selectedPositionCount;
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/SingleArrayBlockWriter.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/SingleArrayBlockWriter.java
@@ -16,6 +16,7 @@ package io.trino.spi.block;
 import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static java.lang.String.format;
@@ -41,6 +42,12 @@ public class SingleArrayBlockWriter
     protected Block getBlock()
     {
         return blockBuilder;
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.empty();
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/SingleMapBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/SingleMapBlock.java
@@ -20,6 +20,7 @@ import org.openjdk.jol.info.ClassLayout;
 
 import java.lang.invoke.MethodHandle;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static io.airlift.slice.SizeOf.sizeOfIntArray;
@@ -54,6 +55,12 @@ public class SingleMapBlock
     public int getPositionCount()
     {
         return positionCount;
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.empty();
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/SingleMapBlockWriter.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/SingleMapBlockWriter.java
@@ -16,6 +16,7 @@ package io.trino.spi.block;
 import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static java.lang.String.format;
@@ -66,6 +67,12 @@ public class SingleMapBlockWriter
     Block getRawValueBlock()
     {
         return valueBlockBuilder;
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.empty();
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/SingleRowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/SingleRowBlock.java
@@ -16,6 +16,7 @@ package io.trino.spi.block;
 
 import org.openjdk.jol.info.ClassLayout;
 
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static io.trino.spi.block.BlockUtil.ensureBlocksAreLoaded;
@@ -56,6 +57,12 @@ public class SingleRowBlock
     public int getPositionCount()
     {
         return fieldBlocks.length;
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.empty();
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/SingleRowBlockWriter.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/SingleRowBlockWriter.java
@@ -16,6 +16,7 @@ package io.trino.spi.block;
 import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static java.lang.String.format;
@@ -71,6 +72,12 @@ public class SingleRowBlockWriter
     protected int getRowIndex()
     {
         return rowIndex;
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.empty();
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlock.java
@@ -21,6 +21,7 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static io.airlift.slice.SizeOf.sizeOf;
@@ -113,6 +114,12 @@ public class VariableWidthBlock
     }
 
     @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.empty(); // size varies per element and is not fixed
+    }
+
+    @Override
     public long getSizeInBytes()
     {
         return sizeInBytes;
@@ -125,17 +132,21 @@ public class VariableWidthBlock
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getPositionsSizeInBytes(boolean[] positions, int selectedPositionsCount)
     {
+        if (selectedPositionsCount == 0) {
+            return 0;
+        }
+        if (selectedPositionsCount == positionCount) {
+            return getSizeInBytes();
+        }
         long sizeInBytes = 0;
-        int usedPositionCount = 0;
         for (int i = 0; i < positions.length; ++i) {
             if (positions[i]) {
-                usedPositionCount++;
                 sizeInBytes += offsets[arrayOffset + i + 1] - offsets[arrayOffset + i];
             }
         }
-        return sizeInBytes + (Integer.BYTES + Byte.BYTES) * (long) usedPositionCount;
+        return sizeInBytes + (Integer.BYTES + Byte.BYTES) * (long) selectedPositionsCount;
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlockBuilder.java
@@ -22,6 +22,7 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
@@ -102,6 +103,12 @@ public class VariableWidthBlockBuilder
     }
 
     @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.empty(); // size varies per element and is not fixed
+    }
+
+    @Override
     public long getSizeInBytes()
     {
         long arraysSizeInBytes = (Integer.BYTES + Byte.BYTES) * (long) positions;
@@ -118,18 +125,16 @@ public class VariableWidthBlockBuilder
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getPositionsSizeInBytes(boolean[] positions, int selectedPositionCount)
     {
         checkValidPositions(positions, getPositionCount());
         long sizeInBytes = 0;
-        int usedPositionCount = 0;
         for (int i = 0; i < positions.length; ++i) {
             if (positions[i]) {
-                usedPositionCount++;
                 sizeInBytes += getOffset(i + 1) - getOffset(i);
             }
         }
-        return sizeInBytes + (Integer.BYTES + Byte.BYTES) * (long) usedPositionCount;
+        return sizeInBytes + (Integer.BYTES + Byte.BYTES) * (long) selectedPositionCount;
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
Reduces the overhead of calculating `DictionaryBlock#getSizeInBytes()` by making two changes to the `Block` interface definition:
- Adds a new argument `selectedPositionCount` to `Block#getPositionsSizeInBytes(boolean[] positions, int selectedPositionCount)`. Callers to the previous method `getPositionsSizeInBytes(boolean[] positions)` could trivially calculate and pass the total count of the positions selected, and failing to do so required the called blocks to count the number of `true` values in the positions array- sometimes repeatedly in the case of eg: `RowBlock`.
- Adds a new method `Block#fixedSizeInBytesPerPosition()` that allows blocks to describe whether their `getSizeInBytes()` can be calculated directly from the position count, ie: the size is not variable based on the specific positions selected

Also includes a change to eagerly populate the unique position count and size in bytes on the results of `DictionaryBlock#getPositions` when the result is not compact, since the selected positions array may have already been created  and would otherwise have to be reconstructed in a subsequent call to `DictionaryBlock#getSizeInBytes()`.

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

## General information

Is this change a fix, improvement, new feature, refactoring, or other?

_This is an improvement that reduces the overhead for common scenarios involving `DictionaryBlock#getSizeInBytes()`_

Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

_This change affects the SPI interface of blocks and refactors the implementations of `DictionaryBlock#getPositions` and `Block#getPositionsSizeInBytes` to leverage the new information available._

How would you describe this change to a non-technical end user or system administrator?

_Specifically describing this change to a non-technical audience should not be necessary_

## Related issues, pull requests, and links

<!-- List any issue that is fixed and provide links to other related PRs, upstream release notes, and other useful resources:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) or whatever really to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```
# Section
* Fix some things. ({issue}`5678`)
```
