### PR TITLE
Enable gathering of statistics by default for Hive 3 in product tests

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/tempto/tempto-configuration-for-hive3.yaml
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/tempto/tempto-configuration-for-hive3.yaml
@@ -7,5 +7,3 @@ databases:
   hive:
     prepare_statement:
       - USE ${databases.hive.schema}
-      # Hive 3 gathers stats by default. For test purposes we need to disable this behavior.
-      - SET hive.stats.column.autogather=false


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

## General information

This PR is to determine which product tests require Hive stats collection to be disabled, and then to disable this on an individual test level rather than globally. 

## Related issues, pull requests, and links

<!-- List any issue that is fixed and provide links to other related PRs, upstream release notes, and other useful resources:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) or whatever really to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```
# Section
* Fix some things. ({issue}`5678`)
```
