### PR TITLE
Remove reflective access from KuduRecordCursor

### DIFF
--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduRecordCursor.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduRecordCursor.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
-import io.trino.spi.TrinoException;
 import io.trino.spi.connector.RecordCursor;
 import io.trino.spi.type.Type;
 import org.apache.kudu.client.KeyEncoderAccessor;
@@ -28,29 +27,15 @@ import org.apache.kudu.client.KuduTable;
 import org.apache.kudu.client.PartialRow;
 import org.apache.kudu.client.RowResult;
 
-import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 
 import static io.trino.plugin.kudu.KuduColumnHandle.ROW_ID_POSITION;
-import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static java.util.Objects.requireNonNull;
 
 public class KuduRecordCursor
         implements RecordCursor
 {
-    private static final Field ROW_DATA_FIELD;
-
-    static {
-        try {
-            ROW_DATA_FIELD = RowResult.class.getDeclaredField("rowData");
-            ROW_DATA_FIELD.setAccessible(true);
-        }
-        catch (NoSuchFieldException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     private final KuduScanner scanner;
     private final List<Type> columnTypes;
     private final KuduTable table;
@@ -107,26 +92,9 @@ public class KuduRecordCursor
         return true;
     }
 
-    private org.apache.kudu.util.Slice getCurrentRowRawData()
-    {
-        if (currentRow != null) {
-            try {
-                return (org.apache.kudu.util.Slice) ROW_DATA_FIELD.get(currentRow);
-            }
-            catch (IllegalAccessException e) {
-                throw new TrinoException(GENERIC_INTERNAL_ERROR, e);
-            }
-        }
-        return null;
-    }
-
     private int getRowLength()
     {
-        org.apache.kudu.util.Slice rawData = getCurrentRowRawData();
-        if (rawData != null) {
-            return rawData.length();
-        }
-        return columnTypes.size();
+        return currentRow.getSchema().getRowSize();
     }
 
     @Override


### PR DESCRIPTION
Functionality can be accomplished with the public API of RowResult

Commit broken out from this PR since it is unrelated to the client upgrade:
https://github.com/trinodb/trino/pull/10940/files#r801750233 (https://github.com/trinodb/trino/pull/10940)
