### PR TITLE
Fix incorrect type mapping in Cassandra documentation

### DIFF
--- a/docs/src/main/sphinx/connector/cassandra.rst
+++ b/docs/src/main/sphinx/connector/cassandra.rst
@@ -214,7 +214,7 @@ BOOLEAN           BOOLEAN
 DATE              DATE
 DECIMAL           DOUBLE
 DOUBLE            DOUBLE
-FLOAT             DOUBLE
+FLOAT             REAL
 INET              VARCHAR(45)
 INT               INTEGER
 LIST<?>           VARCHAR


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Cassandra documentation incorrectly maps Cassandra FLOAT to Trino DOUBLE,
the correct mapping relationship is: Cassandra FLOAT <-> Trino REAL.

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

## General information

Is this change a fix, improvement, new feature, refactoring, or other?

docs.

Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Just Cassandra connector doc.

How would you describe this change to a non-technical end user or system administrator?

Not applicable.

## Related issues, pull requests, and links
Fixes #10988

<!-- List any issue that is fixed and provide links to other related PRs, upstream release notes, and other useful resources:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) or whatever really to signal selection.
-->

## Documentation

Sufficient documentation is included in this PR.

## Release notes

No release notes entries required.
