### PR TITLE
Define session and catalog session properties

### DIFF
--- a/docs/src/main/sphinx/admin/properties.rst
+++ b/docs/src/main/sphinx/admin/properties.rst
@@ -2,8 +2,10 @@
 Properties reference
 ====================
 
-This section describes the most important config properties, that
-may be used to tune Trino or alter its behavior when required.
+This section describes the most important config properties and (where
+applicable) their corresponding :ref:`session properties
+<session-properties-definition>`, that may be used to tune Trino or alter its
+behavior when required.
 
 .. toctree::
     :titlesonly:

--- a/docs/src/main/sphinx/sql/reset-session.rst
+++ b/docs/src/main/sphinx/sql/reset-session.rst
@@ -13,7 +13,8 @@ Synopsis
 Description
 -----------
 
-Reset a session property value to the default value.
+Reset a :ref:`session property <session-properties-definition>` value to the
+default value.
 
 Examples
 --------

--- a/docs/src/main/sphinx/sql/set-session.rst
+++ b/docs/src/main/sphinx/sql/set-session.rst
@@ -15,10 +15,31 @@ Description
 
 Set a session property value or a catalog session property.
 
+.. _session-properties-definition:
 
-Connectors can provide session properties. They are set separately for each
-catalog by prefixing them with the catalog name. There is no sharing of
-properties across catalogs, even if the catalogs use the same connector.
+Session properties
+------------------
+
+A session property is a :doc:`configuration property </admin/properties>` that
+can be temporarily modified by a user for the duration of the current
+connection session to the Trino cluster. Many configuration properties have a
+corresponding session property that accepts the same values as the config
+property.
+
+There are two types of session properties:
+
+* **System session properties** apply to the whole cluster. Most session
+  properties are system session properties unless specified otherwise.
+* **Catalog session properties** are connector-defined session properties that
+  can be set on a per-catalog basis. These properties can be set separately for
+  each catalog by including the catalog name as a prefix, such as
+  ``catalogname.property_name``.
+
+Session properties are tied to the current session, so a user can have multiple
+connections to a cluster that each have different values for the same session
+properties. Once a session ends, either by disconnecting or creating a new
+session, any changes made to session properties during the previous session are
+lost.
 
 Examples
 --------
@@ -28,15 +49,14 @@ generation::
 
     SET SESSION optimize_hash_generation = true;
 
-An example of the usage of catalog session properties is the :doc:`Accumulo
-connector </connector/accumulo>`, which supports a property named
-``optimize_locality_enabled``. If your Accumulo catalog is named ``data``, you
-would use the following to set the catalog session property::
+The following example sets the ``optimize_locality_enabled`` catalog session
+property for an :doc:`Accumulo catalog </connector/accumulo>` named ``acc01``::
 
-    SET SESSION data.optimize_locality_enabled = false;
+    SET SESSION acc01.optimize_locality_enabled = false;
 
-This catalog session property does not apply to any other catalog, even if it
-also uses the Accumulo connector.
+The example ``acc01.optimize_locality_enabled`` catalog session property
+does not apply to any other catalog, even if another catalog also uses the
+Accumulo connector.
 
 See also
 --------

--- a/docs/src/main/sphinx/sql/show-session.rst
+++ b/docs/src/main/sphinx/sql/show-session.rst
@@ -12,7 +12,7 @@ Synopsis
 Description
 -----------
 
-List the current session properties.
+List the current :ref:`session properties <session-properties-definition>`.
 The ``LIKE`` clause can be used to restrict the list of session properties.
 
 See also


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Add a definition for **session properties** and **catalog session properties** to the `SET SESSION` documentation, and link to that definition from the most relevant pages.

## General information

> Is this change a fix, improvement, new feature, refactoring, or other?

Docs improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Documentation

> How would you describe this change to a non-technical end user or system administrator?

Define session and catalog session properties in the documentation

## Related issues, pull requests, and links

N/A

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) or whatever really to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text
