### PR TITLE
Default to TEXTFILE for LazySimpleSerDe and SymlinkTextInputFormat

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestHiveUtil.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestHiveUtil.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat;
 import org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat;
 import org.apache.hadoop.hive.serde2.thrift.ThriftDeserializer;
 import org.apache.hadoop.hive.serde2.thrift.test.IntString;
+import org.apache.hadoop.mapred.TextInputFormat;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -35,6 +36,7 @@ import java.util.Properties;
 import static io.airlift.testing.Assertions.assertInstanceOf;
 import static io.trino.plugin.hive.HiveStorageFormat.AVRO;
 import static io.trino.plugin.hive.HiveStorageFormat.PARQUET;
+import static io.trino.plugin.hive.HiveStorageFormat.SEQUENCEFILE;
 import static io.trino.plugin.hive.util.HiveUtil.getDeserializer;
 import static io.trino.plugin.hive.util.HiveUtil.getInputFormat;
 import static io.trino.plugin.hive.util.HiveUtil.parseHiveTimestamp;
@@ -86,6 +88,14 @@ public class TestHiveUtil
     public void testGetInputFormat()
     {
         Configuration configuration = new Configuration(false);
+
+        // LazySimpleSerDe is used by TEXTFILE and SEQUENCEFILE. getInputFormat should default to TEXTFILE
+        // per Hive spec.
+        Properties sequenceFileSchema = new Properties();
+        sequenceFileSchema.setProperty(FILE_INPUT_FORMAT, SymlinkTextInputFormat.class.getName());
+        sequenceFileSchema.setProperty(SERIALIZATION_LIB, SEQUENCEFILE.getSerde());
+        assertInstanceOf(getInputFormat(configuration, sequenceFileSchema, false), SymlinkTextInputFormat.class);
+        assertInstanceOf(getInputFormat(configuration, sequenceFileSchema, true), TextInputFormat.class);
 
         Properties avroSymlinkSchema = new Properties();
         avroSymlinkSchema.setProperty(FILE_INPUT_FORMAT, SymlinkTextInputFormat.class.getName());


### PR DESCRIPTION
Per Hive spec symlinks should default to TEXTFILE
(https://hive.apache.org/javadocs/r2.1.1/api/org/apache/hadoop/hive/ql/io/SymlinkTextInputFormat.html).
However Databricks Delta uses symlinks to point to Parquet files.
Snowflake and Redshift Spectrum now also support the same non-standard use of Parquet+Symlink.
Hence this PR defaults symlinks to TEXTFILE only for LazySimpleSerDe
which is used by both TEXTFILE and SEQUENCEFILE.

Fixes: https://github.com/trinodb/trino/issues/10910
