### PR TITLE
Fix duplicate headers in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 <!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->
 
-## Description
+## General information
 
 <!-- Answer the following questions to help reviewers and maintainers
 understand this PR's scope at a glance:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Fix the duplicate "Description" header (see immediately below this line)

## Description

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

GitHub template

> How would you describe this change to a non-technical end user or system administrator?

Fix a duplicate header that may be confusing to contributors

## Related issues, pull requests, and links

* Follow-up to https://github.com/trinodb/trino/pull/10999

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```
# Section
* Fix some things. ({issue}`5678`)
```
