### PR TITLE
Make partial aggregation adaptive

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -44,6 +44,7 @@ import static io.trino.spi.session.PropertyMetadata.booleanProperty;
 import static io.trino.spi.session.PropertyMetadata.doubleProperty;
 import static io.trino.spi.session.PropertyMetadata.enumProperty;
 import static io.trino.spi.session.PropertyMetadata.integerProperty;
+import static io.trino.spi.session.PropertyMetadata.longProperty;
 import static io.trino.spi.session.PropertyMetadata.stringProperty;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.TimeZoneKey.getTimeZoneKey;
@@ -156,6 +157,9 @@ public final class SystemSessionProperties
     public static final String FAULT_TOLERANT_EXECUTION_TARGET_TASK_SPLIT_COUNT = "fault_tolerant_execution_target_task_split_count";
     public static final String FAULT_TOLERANT_EXECUTION_MAX_TASK_SPLIT_COUNT = "fault_tolerant_execution_max_task_split_count";
     public static final String FAULT_TOLERANT_EXECUTION_TASK_MEMORY = "fault_tolerant_execution_task_memory";
+    public static final String ADAPTIVE_PARTIAL_AGGREGATION_ENABLED = "adaptive_partial_aggregation_enabled";
+    public static final String ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS = "adaptive_partial_aggregation_min_rows";
+    public static final String ADAPTIVE_PARTIAL_AGGREGATION_UNIQUE_ROWS_RATIO_THRESHOLD = "adaptive_partial_aggregation_unique_rows_ratio_threshold";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -739,6 +743,21 @@ public final class SystemSessionProperties
                         FAULT_TOLERANT_EXECUTION_TASK_MEMORY,
                         "Estimated amount of memory a single task will use when task level retries are used; value is used allocating nodes for tasks execution",
                         memoryManagerConfig.getFaultTolerantTaskMemory(),
+                        false),
+                booleanProperty(
+                        ADAPTIVE_PARTIAL_AGGREGATION_ENABLED,
+                        "When enabled, partial aggregation might be adaptively turned off when it does not provide any performance gain",
+                        optimizerConfig.isAdaptivePartialAggregationEnabled(),
+                        false),
+                longProperty(
+                        ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS,
+                        "Minimum number of processed rows before partial aggregation might be adaptively turned off",
+                        optimizerConfig.getAdaptivePartialAggregationMinRows(),
+                        false),
+                doubleProperty(
+                        ADAPTIVE_PARTIAL_AGGREGATION_UNIQUE_ROWS_RATIO_THRESHOLD,
+                        "Ratio between aggregation output and input rows above which partial aggregation might be adaptively turned off",
+                        optimizerConfig.getAdaptivePartialAggregationUniqueRowsRatioThreshold(),
                         false));
     }
 
@@ -1329,5 +1348,20 @@ public final class SystemSessionProperties
     public static DataSize getFaultTolerantExecutionDefaultTaskMemory(Session session)
     {
         return session.getSystemProperty(FAULT_TOLERANT_EXECUTION_TASK_MEMORY, DataSize.class);
+    }
+
+    public static boolean isAdaptivePartialAggregationEnabled(Session session)
+    {
+        return session.getSystemProperty(ADAPTIVE_PARTIAL_AGGREGATION_ENABLED, Boolean.class);
+    }
+
+    public static long getAdaptivePartialAggregationMinRows(Session session)
+    {
+        return session.getSystemProperty(ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS, Long.class);
+    }
+
+    public static double getAdaptivePartialAggregationUniqueRowsRatioThreshold(Session session)
+    {
+        return session.getSystemProperty(ADAPTIVE_PARTIAL_AGGREGATION_UNIQUE_ROWS_RATIO_THRESHOLD, Double.class);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/CompletedWork.java
+++ b/core/trino-main/src/main/java/io/trino/operator/CompletedWork.java
@@ -13,12 +13,20 @@
  */
 package io.trino.operator;
 
+import javax.annotation.Nullable;
+
 import static java.util.Objects.requireNonNull;
 
 public final class CompletedWork<T>
         implements Work<T>
 {
+    @Nullable
     private final T result;
+
+    public CompletedWork()
+    {
+        this.result = null;
+    }
 
     public CompletedWork(T value)
     {
@@ -31,6 +39,7 @@ public final class CompletedWork<T>
         return true;
     }
 
+    @Nullable
     @Override
     public T getResult()
     {

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/partial/PartialAggregationController.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/partial/PartialAggregationController.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation.partial;
+
+import io.trino.operator.HashAggregationOperator;
+
+/**
+ * Controls whenever partial aggregation is enabled across all {@link HashAggregationOperator}s
+ * for a particular plan node on a single node.
+ * Partial aggregation is disabled once enough rows has been processed ({@link #minNumberOfRowsProcessed})
+ * and the ratio between output(unique) and input rows is too high (> {@link #uniqueRowsRatioThreshold}).
+ * TODO https://github.com/trinodb/trino/issues/11361 add support to adaptively re-enable partial aggregation.
+ * <p>
+ * The class is thread safe and objects of this class are used potentially by multiple threads/drivers simultaneously.
+ * Different threads either:
+ * - modify fields via synchronized {@link #onFlush}.
+ * - read volatile {@link #partialAggregationDisabled} (volatile here gives visibility).
+ */
+public class PartialAggregationController
+{
+    private final long minNumberOfRowsProcessed;
+    private final double uniqueRowsRatioThreshold;
+
+    private volatile boolean partialAggregationDisabled;
+    private long totalRowProcessed;
+    private long totalUniqueRowsProduced;
+
+    public PartialAggregationController(long minNumberOfRowsProcessedToDisable, double uniqueRowsRatioThreshold)
+    {
+        this.minNumberOfRowsProcessed = minNumberOfRowsProcessedToDisable;
+        this.uniqueRowsRatioThreshold = uniqueRowsRatioThreshold;
+    }
+
+    public boolean isPartialAggregationDisabled()
+    {
+        return partialAggregationDisabled;
+    }
+
+    public synchronized void onFlush(long rowsProcessed, long uniqueRowsProduced)
+    {
+        if (partialAggregationDisabled) {
+            return;
+        }
+
+        totalRowProcessed += rowsProcessed;
+        totalUniqueRowsProduced += uniqueRowsProduced;
+        if (shouldDisablePartialAggregation()) {
+            partialAggregationDisabled = true;
+        }
+    }
+
+    private boolean shouldDisablePartialAggregation()
+    {
+        return totalRowProcessed >= minNumberOfRowsProcessed
+                && ((double) totalUniqueRowsProduced / totalRowProcessed) > uniqueRowsRatioThreshold;
+    }
+
+    public PartialAggregationController duplicate()
+    {
+        return new PartialAggregationController(minNumberOfRowsProcessed, uniqueRowsRatioThreshold);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/partial/SkipAggregationBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/partial/SkipAggregationBuilder.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation.partial;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import io.trino.memory.context.LocalMemoryContext;
+import io.trino.operator.CompletedWork;
+import io.trino.operator.GroupByIdBlock;
+import io.trino.operator.HashCollisionsCounter;
+import io.trino.operator.Work;
+import io.trino.operator.WorkProcessor;
+import io.trino.operator.aggregation.AggregatorFactory;
+import io.trino.operator.aggregation.GroupedAggregator;
+import io.trino.operator.aggregation.builder.HashAggregationBuilder;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.LongArrayBlock;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * {@link HashAggregationBuilder} that does not aggregate input rows at all.
+ * It passes the input pages, augmented with initial accumulator state to the output.
+ * It can only be used at the partial aggregation step as it relies on rows be aggregated at the final step.
+ */
+public class SkipAggregationBuilder
+        implements HashAggregationBuilder
+{
+    private final LocalMemoryContext memoryContext;
+    private final List<GroupedAggregator> groupedAggregators;
+    @Nullable
+    private Page currentPage;
+    private final int[] hashChannels;
+
+    public SkipAggregationBuilder(
+            List<Integer> groupByChannels,
+            Optional<Integer> inputHashChannel,
+            List<AggregatorFactory> aggregatorFactories,
+            LocalMemoryContext memoryContext)
+    {
+        this.memoryContext = requireNonNull(memoryContext, "memoryContext is null");
+        this.groupedAggregators = requireNonNull(aggregatorFactories, "aggregatorFactories is null")
+                .stream()
+                .map(AggregatorFactory::createGroupedAggregator)
+                .collect(toImmutableList());
+        this.hashChannels = new int[groupByChannels.size() + (inputHashChannel.isPresent() ? 1 : 0)];
+        for (int i = 0; i < groupByChannels.size(); i++) {
+            hashChannels[i] = groupByChannels.get(i);
+        }
+        inputHashChannel.ifPresent(channelIndex -> hashChannels[groupByChannels.size()] = channelIndex);
+    }
+
+    @Override
+    public Work<?> processPage(Page page)
+    {
+        checkArgument(currentPage == null);
+        currentPage = page;
+        return new CompletedWork<>();
+    }
+
+    @Override
+    public WorkProcessor<Page> buildResult()
+    {
+        if (currentPage == null) {
+            return WorkProcessor.of();
+        }
+
+        Page result = buildOutputPage(currentPage);
+        currentPage = null;
+        return WorkProcessor.of(result);
+    }
+
+    @Override
+    public boolean isFull()
+    {
+        return currentPage != null;
+    }
+
+    @Override
+    public void updateMemory()
+    {
+        if (currentPage != null) {
+            memoryContext.setBytes(currentPage.getSizeInBytes());
+        }
+    }
+
+    @Override
+    public void recordHashCollisions(HashCollisionsCounter hashCollisionsCounter)
+    {
+        // no op
+    }
+
+    @Override
+    public void close()
+    {
+    }
+
+    @Override
+    public ListenableFuture<Void> startMemoryRevoke()
+    {
+        throw new UnsupportedOperationException("startMemoryRevoke not supported for SkipAggregationBuilder");
+    }
+
+    @Override
+    public void finishMemoryRevoke()
+    {
+        throw new UnsupportedOperationException("finishMemoryRevoke not supported for SkipAggregationBuilder");
+    }
+
+    private Page buildOutputPage(Page page)
+    {
+        populateInitialAccumulatorState(page);
+
+        BlockBuilder[] outputBuilders = serializeAccumulatorState(page.getPositionCount());
+
+        return constructOutputPage(page, outputBuilders);
+    }
+
+    private void populateInitialAccumulatorState(Page page)
+    {
+        GroupByIdBlock groupByIdBlock = getGroupByIdBlock(page.getPositionCount());
+        for (GroupedAggregator groupedAggregator : groupedAggregators) {
+            groupedAggregator.processPage(groupByIdBlock, page);
+        }
+    }
+
+    private GroupByIdBlock getGroupByIdBlock(int positionCount)
+    {
+        return new GroupByIdBlock(
+                positionCount,
+                new LongArrayBlock(positionCount, Optional.empty(), consecutive(positionCount)));
+    }
+
+    private BlockBuilder[] serializeAccumulatorState(int positionCount)
+    {
+        BlockBuilder[] outputBuilders = new BlockBuilder[groupedAggregators.size()];
+        for (int i = 0; i < outputBuilders.length; i++) {
+            outputBuilders[i] = groupedAggregators.get(i).getType().createBlockBuilder(null, positionCount);
+        }
+
+        for (int position = 0; position < positionCount; position++) {
+            for (int i = 0; i < groupedAggregators.size(); i++) {
+                GroupedAggregator groupedAggregator = groupedAggregators.get(i);
+                BlockBuilder output = outputBuilders[i];
+                groupedAggregator.evaluate(position, output);
+            }
+        }
+        return outputBuilders;
+    }
+
+    private Page constructOutputPage(Page page, BlockBuilder[] outputBuilders)
+    {
+        Block[] outputBlocks = new Block[hashChannels.length + outputBuilders.length];
+        for (int i = 0; i < hashChannels.length; i++) {
+            outputBlocks[i] = page.getBlock(hashChannels[i]);
+        }
+        for (int i = 0; i < outputBuilders.length; i++) {
+            outputBlocks[hashChannels.length + i] = outputBuilders[i].build();
+        }
+        return new Page(page.getPositionCount(), outputBlocks);
+    }
+
+    private static long[] consecutive(int positionCount)
+    {
+        long[] longs = new long[positionCount];
+        for (int i = 0; i < positionCount; i++) {
+            longs[i] = i;
+        }
+        return longs;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/OptimizerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/OptimizerConfig.java
@@ -77,6 +77,10 @@ public class OptimizerConfig
     private double tableScanNodePartitioningMinBucketToTaskRatio = 0.5;
     private boolean mergeProjectWithValues = true;
     private boolean forceSingleNodeOutput = true;
+    // adaptive partial aggregation
+    private boolean adaptivePartialAggregationEnabled = true;
+    private long adaptivePartialAggregationMinRows = 100_000;
+    private double adaptivePartialAggregationUniqueRowsRatioThreshold = 0.8;
 
     public enum JoinReorderingStrategy
     {
@@ -622,6 +626,44 @@ public class OptimizerConfig
     public OptimizerConfig setForceSingleNodeOutput(boolean value)
     {
         this.forceSingleNodeOutput = value;
+        return this;
+    }
+
+    public boolean isAdaptivePartialAggregationEnabled()
+    {
+        return adaptivePartialAggregationEnabled;
+    }
+
+    @Config("adaptive-partial-aggregation.enabled")
+    public OptimizerConfig setAdaptivePartialAggregationEnabled(boolean adaptivePartialAggregationEnabled)
+    {
+        this.adaptivePartialAggregationEnabled = adaptivePartialAggregationEnabled;
+        return this;
+    }
+
+    public long getAdaptivePartialAggregationMinRows()
+    {
+        return adaptivePartialAggregationMinRows;
+    }
+
+    @Config("adaptive-partial-aggregation.min-rows")
+    @ConfigDescription("Minimum number of processed rows before partial aggregation might be adaptively turned off")
+    public OptimizerConfig setAdaptivePartialAggregationMinRows(long adaptivePartialAggregationMinRows)
+    {
+        this.adaptivePartialAggregationMinRows = adaptivePartialAggregationMinRows;
+        return this;
+    }
+
+    public double getAdaptivePartialAggregationUniqueRowsRatioThreshold()
+    {
+        return adaptivePartialAggregationUniqueRowsRatioThreshold;
+    }
+
+    @Config("adaptive-partial-aggregation.unique-rows-ratio-threshold")
+    @ConfigDescription("Ratio between aggregation output and input rows above which partial aggregation might be adaptively turned off")
+    public OptimizerConfig setAdaptivePartialAggregationUniqueRowsRatioThreshold(double adaptivePartialAggregationUniqueRowsRatioThreshold)
+    {
+        this.adaptivePartialAggregationUniqueRowsRatioThreshold = adaptivePartialAggregationUniqueRowsRatioThreshold;
         return this;
     }
 }

--- a/core/trino-main/src/test/java/io/trino/cost/TestOptimizerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/cost/TestOptimizerConfig.java
@@ -80,7 +80,10 @@ public class TestOptimizerConfig
                 .setUseTableScanNodePartitioning(true)
                 .setTableScanNodePartitioningMinBucketToTaskRatio(0.5)
                 .setMergeProjectWithValues(true)
-                .setForceSingleNodeOutput(true));
+                .setForceSingleNodeOutput(true)
+                .setAdaptivePartialAggregationEnabled(true)
+                .setAdaptivePartialAggregationMinRows(100_000)
+                .setAdaptivePartialAggregationUniqueRowsRatioThreshold(0.8));
     }
 
     @Test
@@ -129,6 +132,9 @@ public class TestOptimizerConfig
                 .put("optimizer.use-table-scan-node-partitioning", "false")
                 .put("optimizer.table-scan-node-partitioning-min-bucket-to-task-ratio", "0.0")
                 .put("optimizer.merge-project-with-values", "false")
+                .put("adaptive-partial-aggregation.enabled", "false")
+                .put("adaptive-partial-aggregation.min-rows", "1")
+                .put("adaptive-partial-aggregation.unique-rows-ratio-threshold", "0.99")
                 .buildOrThrow();
 
         OptimizerConfig expected = new OptimizerConfig()
@@ -173,7 +179,10 @@ public class TestOptimizerConfig
                 .setUseTableScanNodePartitioning(false)
                 .setTableScanNodePartitioningMinBucketToTaskRatio(0.0)
                 .setMergeProjectWithValues(false)
-                .setForceSingleNodeOutput(false);
+                .setForceSingleNodeOutput(false)
+                .setAdaptivePartialAggregationEnabled(false)
+                .setAdaptivePartialAggregationMinRows(1)
+                .setAdaptivePartialAggregationUniqueRowsRatioThreshold(0.99);
         assertFullMapping(properties, expected);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkHashAndStreamingAggregationOperators.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkHashAndStreamingAggregationOperators.java
@@ -266,7 +266,8 @@ public class BenchmarkHashAndStreamingAggregationOperators
                     succinctBytes(Integer.MAX_VALUE),
                     spillerFactory,
                     JOIN_COMPILER,
-                    BLOCK_TYPE_OPERATORS);
+                    BLOCK_TYPE_OPERATORS,
+                    Optional.empty());
         }
 
         private static void repeatToBigintBlock(long value, int count, BlockBuilder blockBuilder)

--- a/core/trino-main/src/test/java/io/trino/operator/TestHashAggregationOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestHashAggregationOperator.java
@@ -27,6 +27,7 @@ import io.trino.operator.HashAggregationOperator.HashAggregationOperatorFactory;
 import io.trino.operator.aggregation.TestingAggregationFunction;
 import io.trino.operator.aggregation.builder.HashAggregationBuilder;
 import io.trino.operator.aggregation.builder.InMemoryHashAggregationBuilder;
+import io.trino.operator.aggregation.partial.PartialAggregationController;
 import io.trino.spi.Page;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.PageBuilderStatus;
@@ -66,6 +67,8 @@ import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.airlift.units.DataSize.succinctBytes;
 import static io.trino.RowPagesBuilder.rowPagesBuilder;
 import static io.trino.SessionTestUtils.TEST_SESSION;
+import static io.trino.block.BlockAssertions.createLongsBlock;
+import static io.trino.block.BlockAssertions.createRLEBlock;
 import static io.trino.operator.GroupByHashYieldAssertion.GroupByHashYieldResult;
 import static io.trino.operator.GroupByHashYieldAssertion.createPagesWithDistinctHashKeys;
 import static io.trino.operator.GroupByHashYieldAssertion.finishOperatorWithYieldingGroupByHash;
@@ -90,6 +93,7 @@ import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true)
@@ -193,7 +197,8 @@ public class TestHashAggregationOperator
                 succinctBytes(memoryLimitForMergeWithMemory),
                 spillerFactory,
                 joinCompiler,
-                blockTypeOperators);
+                blockTypeOperators,
+                Optional.empty());
 
         DriverContext driverContext = createDriverContext(memoryLimitForMerge);
 
@@ -246,7 +251,8 @@ public class TestHashAggregationOperator
                 succinctBytes(memoryLimitForMergeWithMemory),
                 spillerFactory,
                 joinCompiler,
-                blockTypeOperators);
+                blockTypeOperators,
+                Optional.empty());
 
         DriverContext driverContext = createDriverContext(memoryLimitForMerge);
         MaterializedResult expected = resultBuilder(driverContext.getSession(), VARCHAR, BIGINT, BIGINT, BIGINT, DOUBLE, VARCHAR, BIGINT, BIGINT)
@@ -292,7 +298,8 @@ public class TestHashAggregationOperator
                 succinctBytes(memoryLimitForMergeWithMemory),
                 spillerFactory,
                 joinCompiler,
-                blockTypeOperators);
+                blockTypeOperators,
+                Optional.empty());
 
         Operator operator = operatorFactory.createOperator(driverContext);
         toPages(operator, input.iterator(), revokeMemoryWhenAddingPages);
@@ -334,7 +341,8 @@ public class TestHashAggregationOperator
                 100_000,
                 Optional.of(DataSize.of(16, MEGABYTE)),
                 joinCompiler,
-                blockTypeOperators);
+                blockTypeOperators,
+                Optional.empty());
 
         toPages(operatorFactory, driverContext, input);
     }
@@ -374,7 +382,8 @@ public class TestHashAggregationOperator
                 succinctBytes(memoryLimitForMergeWithMemory),
                 spillerFactory,
                 joinCompiler,
-                blockTypeOperators);
+                blockTypeOperators,
+                Optional.empty());
 
         toPages(operatorFactory, driverContext, input, revokeMemoryWhenAddingPages);
     }
@@ -396,7 +405,8 @@ public class TestHashAggregationOperator
                 1,
                 Optional.of(DataSize.of(16, MEGABYTE)),
                 joinCompiler,
-                blockTypeOperators);
+                blockTypeOperators,
+                Optional.empty());
 
         // get result with yield; pick a relatively small buffer for aggregator's memory usage
         GroupByHashYieldResult result;
@@ -448,7 +458,8 @@ public class TestHashAggregationOperator
                 100_000,
                 Optional.of(DataSize.of(16, MEGABYTE)),
                 joinCompiler,
-                blockTypeOperators);
+                blockTypeOperators,
+                Optional.empty());
 
         toPages(operatorFactory, driverContext, input);
     }
@@ -482,7 +493,8 @@ public class TestHashAggregationOperator
                 100_000,
                 Optional.of(DataSize.of(16, MEGABYTE)),
                 joinCompiler,
-                blockTypeOperators);
+                blockTypeOperators,
+                Optional.empty());
 
         assertEquals(toPages(operatorFactory, createDriverContext(), input).size(), 2);
     }
@@ -513,7 +525,8 @@ public class TestHashAggregationOperator
                 100_000,
                 Optional.of(DataSize.of(1, KILOBYTE)),
                 joinCompiler,
-                blockTypeOperators);
+                blockTypeOperators,
+                Optional.empty());
 
         DriverContext driverContext = createDriverContext(1024);
 
@@ -598,7 +611,8 @@ public class TestHashAggregationOperator
                 succinctBytes(Integer.MAX_VALUE),
                 spillerFactory,
                 joinCompiler,
-                blockTypeOperators);
+                blockTypeOperators,
+                Optional.empty());
 
         DriverContext driverContext = createDriverContext(smallPagesSpillThresholdSize);
 
@@ -652,7 +666,8 @@ public class TestHashAggregationOperator
                 succinctBytes(Integer.MAX_VALUE),
                 new FailingSpillerFactory(),
                 joinCompiler,
-                blockTypeOperators);
+                blockTypeOperators,
+                Optional.empty());
 
         assertThatThrownBy(() -> toPages(operatorFactory, driverContext, input))
                 .isInstanceOf(RuntimeException.class)
@@ -681,7 +696,8 @@ public class TestHashAggregationOperator
                 100_000,
                 Optional.of(DataSize.of(16, MEGABYTE)),
                 joinCompiler,
-                blockTypeOperators);
+                blockTypeOperators,
+                Optional.empty());
 
         DriverContext driverContext = createDriverContext(1024);
 
@@ -696,6 +712,115 @@ public class TestHashAggregationOperator
 
         assertEquals(driverContext.getMemoryUsage(), 0);
         assertEquals(driverContext.getRevocableMemoryUsage(), 0);
+    }
+
+    @Test
+    public void testAdaptivePartialAggregation()
+    {
+        List<Integer> hashChannels = Ints.asList(0);
+
+        PartialAggregationController partialAggregationController = new PartialAggregationController(5, 0.8);
+        HashAggregationOperatorFactory operatorFactory = new HashAggregationOperatorFactory(
+                0,
+                new PlanNodeId("test"),
+                ImmutableList.of(BIGINT),
+                hashChannels,
+                ImmutableList.of(),
+                PARTIAL,
+                ImmutableList.of(LONG_MIN.createAggregatorFactory(PARTIAL, ImmutableList.of(0), OptionalInt.empty())),
+                Optional.empty(),
+                Optional.empty(),
+                100,
+                Optional.of(DataSize.ofBytes(1)), // this setting makes operator to flush after each page
+                joinCompiler,
+                blockTypeOperators,
+                // use 5 rows threshold to trigger adaptive partial aggregation after each page flush
+                Optional.of(partialAggregationController));
+
+        // at the start partial aggregation is enabled
+        assertFalse(partialAggregationController.isPartialAggregationDisabled());
+        // First operator will trigger adaptive partial aggregation after the first page
+        List<Page> operator1Input = rowPagesBuilder(false, hashChannels, BIGINT)
+                .addBlocksPage(createLongsBlock(0, 1, 2, 3, 4, 5, 6, 7, 8, 8)) // first page will be hashed but the values are almost unique, so it will trigger adaptation
+                .addBlocksPage(createRLEBlock(1, 10)) // second page would be hashed to existing value 1. but if adaptive PA kicks in, the raw values will be passed on
+                .build();
+        List<Page> operator1Expected = rowPagesBuilder(BIGINT, BIGINT)
+                .addBlocksPage(createLongsBlock(0, 1, 2, 3, 4, 5, 6, 7, 8), createLongsBlock(0, 1, 2, 3, 4, 5, 6, 7, 8)) // the last position was aggregated
+                .addBlocksPage(createRLEBlock(1, 10), createRLEBlock(1, 10)) // we are expecting second page with raw values
+                .build();
+        assertOperatorEquals(operatorFactory, operator1Input, operator1Expected);
+
+        // the first operator flush disables partial aggregation
+        assertTrue(partialAggregationController.isPartialAggregationDisabled());
+        // second operator using the same factory, reuses PartialAggregationControl, so it will only produce raw pages (partial aggregation is disabled at this point)
+        List<Page> operator2Input = rowPagesBuilder(false, hashChannels, BIGINT)
+                .addBlocksPage(createRLEBlock(1, 10))
+                .addBlocksPage(createRLEBlock(2, 10))
+                .build();
+        List<Page> operator2Expected = rowPagesBuilder(BIGINT, BIGINT)
+                .addBlocksPage(createRLEBlock(1, 10), createRLEBlock(1, 10))
+                .addBlocksPage(createRLEBlock(2, 10), createRLEBlock(2, 10))
+                .build();
+
+        assertOperatorEquals(operatorFactory, operator2Input, operator2Expected);
+    }
+
+    @Test
+    public void testAdaptivePartialAggregationTriggeredOnlyOnFlush()
+    {
+        List<Integer> hashChannels = Ints.asList(0);
+
+        PartialAggregationController partialAggregationController = new PartialAggregationController(5, 0.8);
+        HashAggregationOperatorFactory operatorFactory = new HashAggregationOperatorFactory(
+                0,
+                new PlanNodeId("test"),
+                ImmutableList.of(BIGINT),
+                hashChannels,
+                ImmutableList.of(),
+                PARTIAL,
+                ImmutableList.of(LONG_MIN.createAggregatorFactory(PARTIAL, ImmutableList.of(0), OptionalInt.empty())),
+                Optional.empty(),
+                Optional.empty(),
+                10,
+                Optional.of(DataSize.of(16, MEGABYTE)), // this setting makes operator to flush only after all pages
+                joinCompiler,
+                blockTypeOperators,
+                // use 5 rows threshold to trigger adaptive partial aggregation after each page flush
+                Optional.of(partialAggregationController));
+
+        List<Page> operator1Input = rowPagesBuilder(false, hashChannels, BIGINT)
+                .addSequencePage(10, 0) // first page are unique values, so it would trigger adaptation, but it won't because flush is not called
+                .addBlocksPage(createRLEBlock(1, 2)) // second page will be hashed to existing value 1
+                .build();
+        // the total unique ows ratio for the first operator will be 10/12 so > 0.8 (adaptive partial aggregation uniqueRowsRatioThreshold)
+        List<Page> operator1Expected = rowPagesBuilder(BIGINT, BIGINT)
+                .addSequencePage(10, 0, 0) // we are expecting second page to be squashed with the first
+                .build();
+        assertOperatorEquals(operatorFactory, operator1Input, operator1Expected);
+
+        // the first operator flush disables partial aggregation
+        assertTrue(partialAggregationController.isPartialAggregationDisabled());
+
+        // second operator using the same factory, reuses PartialAggregationControl, so it will only produce raw pages (partial aggregation is disabled at this point)
+        List<Page> operator2Input = rowPagesBuilder(false, hashChannels, BIGINT)
+                .addBlocksPage(createRLEBlock(1, 10))
+                .addBlocksPage(createRLEBlock(2, 10))
+                .build();
+        List<Page> operator2Expected = rowPagesBuilder(BIGINT, BIGINT)
+                .addBlocksPage(createRLEBlock(1, 10), createRLEBlock(1, 10))
+                .addBlocksPage(createRLEBlock(2, 10), createRLEBlock(2, 10))
+                .build();
+
+        assertOperatorEquals(operatorFactory, operator2Input, operator2Expected);
+    }
+
+    private void assertOperatorEquals(OperatorFactory operatorFactory, List<Page> input, List<Page> expectedPages)
+    {
+        DriverContext driverContext = createDriverContext(1024);
+        MaterializedResult expected = resultBuilder(driverContext.getSession(), BIGINT, BIGINT)
+                .pages(expectedPages)
+                .build();
+        OperatorAssertion.assertOperatorEquals(operatorFactory, driverContext, input, expected, false, false);
     }
 
     private DriverContext createDriverContext()

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestFilterHideInacessibleColumnsSession.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestFilterHideInacessibleColumnsSession.java
@@ -35,15 +35,7 @@ public class TestFilterHideInacessibleColumnsSession
     {
         FeaturesConfig featuresConfig = new FeaturesConfig();
         featuresConfig.setHideInaccessibleColumns(true);
-        SessionPropertyManager sessionPropertyManager = new SessionPropertyManager(new SystemSessionProperties(
-                new QueryManagerConfig(),
-                new TaskManagerConfig(),
-                new MemoryManagerConfig(),
-                featuresConfig,
-                new OptimizerConfig(),
-                new NodeMemoryConfig(),
-                new DynamicFilterConfig(),
-                new NodeSchedulerConfig()));
+        SessionPropertyManager sessionPropertyManager = createSessionPropertyManager(featuresConfig);
         assertThatThrownBy(() -> sessionPropertyManager.validateSystemSessionProperty(SystemSessionProperties.HIDE_INACCESSIBLE_COLUMNS, "false"))
                 .hasMessage("hide_inaccessible_columns cannot be disabled with session property when it was enabled with configuration");
     }
@@ -53,15 +45,7 @@ public class TestFilterHideInacessibleColumnsSession
     {
         FeaturesConfig featuresConfig = new FeaturesConfig();
         featuresConfig.setHideInaccessibleColumns(true);
-        SessionPropertyManager sessionPropertyManager = new SessionPropertyManager(new SystemSessionProperties(
-                new QueryManagerConfig(),
-                new TaskManagerConfig(),
-                new MemoryManagerConfig(),
-                featuresConfig,
-                new OptimizerConfig(),
-                new NodeMemoryConfig(),
-                new DynamicFilterConfig(),
-                new NodeSchedulerConfig()));
+        SessionPropertyManager sessionPropertyManager = createSessionPropertyManager(featuresConfig);
         assertThatNoException().isThrownBy(() -> sessionPropertyManager.validateSystemSessionProperty(SystemSessionProperties.HIDE_INACCESSIBLE_COLUMNS, "true"));
     }
 
@@ -69,15 +53,7 @@ public class TestFilterHideInacessibleColumnsSession
     public void testDisableWhenAlreadyDisabledByDefault()
     {
         FeaturesConfig featuresConfig = new FeaturesConfig();
-        SessionPropertyManager sessionPropertyManager = new SessionPropertyManager(new SystemSessionProperties(
-                new QueryManagerConfig(),
-                new TaskManagerConfig(),
-                new MemoryManagerConfig(),
-                featuresConfig,
-                new OptimizerConfig(),
-                new NodeMemoryConfig(),
-                new DynamicFilterConfig(),
-                new NodeSchedulerConfig()));
+        SessionPropertyManager sessionPropertyManager = createSessionPropertyManager(featuresConfig);
         assertThatNoException().isThrownBy(() -> sessionPropertyManager.validateSystemSessionProperty(SystemSessionProperties.HIDE_INACCESSIBLE_COLUMNS, "false"));
     }
 
@@ -85,7 +61,13 @@ public class TestFilterHideInacessibleColumnsSession
     public void testEnableWhenDisabledByDefault()
     {
         FeaturesConfig featuresConfig = new FeaturesConfig();
-        SessionPropertyManager sessionPropertyManager = new SessionPropertyManager(new SystemSessionProperties(
+        SessionPropertyManager sessionPropertyManager = createSessionPropertyManager(featuresConfig);
+        assertThatNoException().isThrownBy(() -> sessionPropertyManager.validateSystemSessionProperty(SystemSessionProperties.HIDE_INACCESSIBLE_COLUMNS, "true"));
+    }
+
+    private SessionPropertyManager createSessionPropertyManager(FeaturesConfig featuresConfig)
+    {
+        return new SessionPropertyManager(new SystemSessionProperties(
                 new QueryManagerConfig(),
                 new TaskManagerConfig(),
                 new MemoryManagerConfig(),
@@ -94,6 +76,5 @@ public class TestFilterHideInacessibleColumnsSession
                 new NodeMemoryConfig(),
                 new DynamicFilterConfig(),
                 new NodeSchedulerConfig()));
-        assertThatNoException().isThrownBy(() -> sessionPropertyManager.validateSystemSessionProperty(SystemSessionProperties.HIDE_INACCESSIBLE_COLUMNS, "true"));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestShowQueries.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestShowQueries.java
@@ -90,8 +90,9 @@ public class TestShowQueries
     public void testShowFunctionLike()
     {
         assertThat(assertions.query("SHOW FUNCTIONS LIKE 'split%'"))
+                .skippingTypesCheck()
                 .matches("VALUES " +
-                        "(cast('split' AS VARCHAR(30)), cast('array(varchar(x))' AS VARCHAR(28)), cast('varchar(x), varchar(y)' AS VARCHAR(68)), cast('scalar' AS VARCHAR(9)), true, cast('' AS VARCHAR(131)))," +
+                        "('split', 'array(varchar(x))', 'varchar(x), varchar(y)', 'scalar', true, '')," +
                         "('split', 'array(varchar(x))', 'varchar(x), varchar(y), bigint', 'scalar', true, '')," +
                         "('split_part', 'varchar(x)', 'varchar(x), varchar(y), bigint', 'scalar', true, 'Splits a string by a delimiter and returns the specified field (counting from one)')," +
                         "('split_to_map', 'map(varchar,varchar)', 'varchar, varchar, varchar', 'scalar', true, 'Creates a map using entryDelimiter and keyValueDelimiter')," +
@@ -102,8 +103,9 @@ public class TestShowQueries
     public void testShowFunctionsLikeWithEscape()
     {
         assertThat(assertions.query("SHOW FUNCTIONS LIKE 'split$_to$_%' ESCAPE '$'"))
+                .skippingTypesCheck()
                 .matches("VALUES " +
-                        "(cast('split_to_map' AS VARCHAR(30)), cast('map(varchar,varchar)' AS VARCHAR(28)), cast('varchar, varchar, varchar' AS VARCHAR(68)), cast('scalar' AS VARCHAR(9)), true, cast('Creates a map using entryDelimiter and keyValueDelimiter' AS VARCHAR(131)))," +
+                        "('split_to_map', 'map(varchar,varchar)', 'varchar, varchar, varchar', 'scalar', true, 'Creates a map using entryDelimiter and keyValueDelimiter')," +
                         "('split_to_multimap', 'map(varchar,array(varchar))', 'varchar, varchar, varchar', 'scalar', true, 'Creates a multimap by splitting a string into key/value pairs')");
     }
 
@@ -112,7 +114,8 @@ public class TestShowQueries
     {
         assertThat(assertions.query(
                 "SHOW SESSION LIKE '%page_row_c%'"))
-                .matches("VALUES (cast('filter_and_project_min_output_page_row_count' as VARCHAR(53)), cast('256' as VARCHAR(14)), cast('256' as VARCHAR(14)), 'integer', cast('Experimental: Minimum output page row count for filter and project operators' as VARCHAR(142)))");
+                .skippingTypesCheck()
+                .matches("VALUES ('filter_and_project_min_output_page_row_count', '256', '256', 'integer', 'Experimental: Minimum output page row count for filter and project operators')");
     }
 
     @Test
@@ -124,7 +127,8 @@ public class TestShowQueries
                 .hasMessage("Escape string must be a single character");
         assertThat(assertions.query(
                 "SHOW SESSION LIKE '%page$_row$_c%' ESCAPE '$'"))
-                .matches("VALUES (cast('filter_and_project_min_output_page_row_count' as VARCHAR(53)), cast('256' as VARCHAR(14)), cast('256' as VARCHAR(14)), 'integer', cast('Experimental: Minimum output page row count for filter and project operators' as VARCHAR(142)))");
+                .skippingTypesCheck()
+                .matches("VALUES ('filter_and_project_min_output_page_row_count', '256', '256', 'integer', 'Experimental: Minimum output page row count for filter and project operators')");
     }
 
     @Test

--- a/testing/trino-benchmark/src/main/java/io/trino/benchmark/HandTpchQuery1.java
+++ b/testing/trino-benchmark/src/main/java/io/trino/benchmark/HandTpchQuery1.java
@@ -121,7 +121,8 @@ public class HandTpchQuery1
                 10_000,
                 Optional.of(DataSize.of(16, MEGABYTE)),
                 new JoinCompiler(localQueryRunner.getTypeOperators()),
-                localQueryRunner.getBlockTypeOperators());
+                localQueryRunner.getBlockTypeOperators(),
+                Optional.empty());
 
         return ImmutableList.of(tableScanOperator, tpchQuery1Operator, aggregationOperator);
     }

--- a/testing/trino-benchmark/src/main/java/io/trino/benchmark/HashAggregationBenchmark.java
+++ b/testing/trino-benchmark/src/main/java/io/trino/benchmark/HashAggregationBenchmark.java
@@ -61,7 +61,8 @@ public class HashAggregationBenchmark
                 100_000,
                 Optional.of(DataSize.of(16, MEGABYTE)),
                 new JoinCompiler(localQueryRunner.getTypeOperators()),
-                localQueryRunner.getBlockTypeOperators());
+                localQueryRunner.getBlockTypeOperators(),
+                Optional.empty());
         return ImmutableList.of(tableScanOperator, aggregationOperator);
     }
 

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestAdaptivePartialAggregation.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestAdaptivePartialAggregation.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.AbstractTestAggregations;
+import io.trino.testing.QueryRunner;
+import io.trino.tests.tpch.TpchQueryRunnerBuilder;
+
+public class TestAdaptivePartialAggregation
+        extends AbstractTestAggregations
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return TpchQueryRunnerBuilder.builder()
+                .setExtraProperties(ImmutableMap.of(
+                        "adaptive-partial-aggregation.min-rows", "0",
+                        "task.max-partial-aggregation-memory", "0B"))
+                .build();
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

This is an optimization for the `HashAggregationOperator` that is split into `partial` and `final` steps.
In case when partial aggregation step does not reduce the number of rows too much (e.g. 90 % of rows are unique) this step brings a small benefit in terms of network savings but costs a lot of CPU to do.
In this case, it would be beneficial to skip partial aggregation altogether at the planning time,
but given we don't always have reliable statistics for the number of unique values, especially in the intermediate query stages it is not easy to do.
Instead (although it's complementary to the planner changes) this adds simple runtime adaptation for the `partial aggregation step`, that sends raw, ungrouped rows to the final step if the ratio of unique to input rows is big enough (0.8 by default).

With this change, there is a still significant overhead on the partial step mainly in the `PartitionedOutputOperator` that has to handle the superfluous accumulator state for the raw rows + in the `HashAggregationOperator` that needs to create and populate this state.
There are potential improvements for this in both `HashAggregationOperator` and `PartitionedOutputOperator` that would limit the overhead.
Another possible approach is to have a separate pipe (as it has a different layout) from `partial` to `final` step with only the input pages without the accumulator state. This would eliminate almost all of the overhead but require larger changes in the core engine.

### tpch/tpcds benchmark results for orc sf1000
####  part 
overall ~6% TPCH and 1.5 % tpcds improvement. Most queries are not affected, some gain between 10 to 35%
[adaptive-pa-part-nocode.pdf](https://github.com/trinodb/trino/files/8044205/adaptive-pa-part-nocode.pdf)
#### uppart
overall 3.5% for tpch and 2.5% for tpcds
[adaptive-pa-unpart-nocode.pdf](https://github.com/trinodb/trino/files/8044207/adaptive-pa-unpart-nocode.pdf)

## General information

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

performance improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core query engine (`HashAggregationOperator`)

> How would you describe this change to a non-technical end user or system administrator?

Improves `group by` performance by skipping partial aggregation step

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( x) Release notes entries required with the following suggested text:

Improve performance of `GROUP BY` with a large number of groups.

