### PR TITLE
Support GET method on user info endpoint (oauth)

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Service.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Service.java
@@ -63,7 +63,7 @@ import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.Instant.now;
 import static java.util.Objects.requireNonNull;
-import static javax.ws.rs.HttpMethod.POST;
+import static javax.ws.rs.HttpMethod.GET;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 
 public class OAuth2Service
@@ -316,7 +316,7 @@ public class OAuth2Service
         if (userinfoUri.isPresent()) {
             // validate access token is trusted by remote userinfo endpoint
             Request request = Request.builder()
-                    .setMethod(POST)
+                    .setMethod(GET)
                     .addHeader(AUTHORIZATION, "Bearer " + accessToken)
                     .setUri(userinfoUri.get())
                     .build();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

## General information

> Is this change a fix, improvement, new feature, refactoring, or other?

This is new feature

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

It's a change to the core query engine

> How would you describe this change to a non-technical end user or system administrator?

This feature allows to configure the requests method of the user info endpoint for oauth2 authentication for web ui and jdbc/odbc drivers.

## Related issues, pull requests, and links

* FIxes #11013

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( *) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( *) No release notes entries required.
( ) Release notes entries required with the following suggested text:
