### PR TITLE
Document support for ALTER TABLE SET PROPERTIES

### DIFF
--- a/docs/src/main/sphinx/sql/alter-table.rst
+++ b/docs/src/main/sphinx/sql/alter-table.rst
@@ -29,6 +29,22 @@ The optional ``IF EXISTS`` (when used before the column name) clause causes the 
 
 The optional ``IF NOT EXISTS`` clause causes the error to be suppressed if the column already exists.
 
+.. _alter-table-set-properties:
+
+SET PROPERTIES
+^^^^^^^^^^^^^^
+
+The ``ALTER TABLE SET PROPERTIES``  statement followed by some number
+of ``property_name`` and ``expression`` pairs applies the specified properties
+and values to a table. Ommitting an already-set property from this
+statement leaves that property unchanged in the table.
+
+A property in a ``SET PROPERTIES`` statement can be set to ``DEFAULT``, which
+reverts its value back to the default in that table.
+
+Support for ``ALTER TABLE SET PROPERTIES`` varies between
+connectors, as not all connectors support modifying table properties.
+
 .. _alter-table-execute:
 
 EXECUTE
@@ -87,9 +103,19 @@ Allow everyone with role public to drop and alter table ``people``::
 
     ALTER TABLE people SET AUTHORIZATION ROLE PUBLIC
 
-Set table properties (``x=y``) to table ``users``::
+Set table properties (``x = y``) in table ``people``::
 
-    ALTER TABLE people SET PROPERTIES x = 'y'
+    ALTER TABLE people SET PROPERTIES x = 'y';
+
+Set multiple table properties (``foo = 123`` and ``foo bar = 456``) in
+table ``people``::
+
+    ALTER TABLE people SET PROPERTIES foo = 123, "foo bar" = 456;
+
+Set table property ``x`` to its default value in table``people``::
+
+    ALTER TABLE people SET PROPERTIES x = DEFAULT;
+
 
 Collapse files in a table that are over 10 megabytes in size, as supported by
 the Hive connector::


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

`ALTER TABLE SET PROPERTIES` has been supported for a while, but has been missing practical details such as detailed examples, use of the DEFAULT keyword, and what connectors (don't) support it.

## General information

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Documentation

> How would you describe this change to a non-technical end user or system administrator?

Further document support and use of ALTER TABLE SET PROPERTIES

## Related issues, pull requests, and links

* Fixes https://github.com/trinodb/trino/issues/10936
* Some details gathered from https://github.com/trinodb/trino/issues/10774
* Follow up to https://github.com/trinodb/trino/pull/10835#issuecomment-1026513422

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```
# Section
* Fix some things. ({issue}`5678`)
```
