### PR TITLE
Fix typo in Cassandra doc

### DIFF
--- a/docs/src/main/sphinx/connector/cassandra.rst
+++ b/docs/src/main/sphinx/connector/cassandra.rst
@@ -229,7 +229,7 @@ TUPLE             ROW with anonymous fields
 UUID              UUID
 UDT               ROW with field names
 VARCHAR           VARCHAR
-VARIANT           VARCHAR
+VARINT            VARCHAR
 ================  ======
 
 Any collection (LIST/MAP/SET) can be designated as FROZEN, and the value is


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
Fix typo in cassandra doc, `VARINT` is incorrectly written as `VARIANT`.

We can find the correct name in the [Cassandra doc](https://cassandra.apache.org/doc/trunk/cassandra/cql/types.html#native-types).

```
native_type::= ASCII | BIGINT | BLOB | BOOLEAN | COUNTER | DATE
| DECIMAL | DOUBLE | DURATION | FLOAT | INET | INT |
SMALLINT | TEXT | TIME | TIMESTAMP | TIMEUUID | TINYINT |
UUID | VARCHAR | VARINT
```

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

## General information

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

N/A.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Just Cassandra connector doc.

> How would you describe this change to a non-technical end user or system administrator?

N/A.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

N/A.

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.

