### PR TITLE
Describe allow-* properties in Hive and Cassandra 

### DIFF
--- a/docs/src/main/sphinx/connector/cassandra.rst
+++ b/docs/src/main/sphinx/connector/cassandra.rst
@@ -62,8 +62,7 @@ Property Name                                      Description
                                                    ``EACH_QUORUM``, ``QUORUM``, ``LOCAL_QUORUM``, ``ONE``, ``TWO``,
                                                    ``THREE``, ``LOCAL_ONE``, ``ANY``, ``SERIAL``, ``LOCAL_SERIAL``.
 
-``cassandra.allow-drop-table``                     Set to ``true`` to allow dropping Cassandra tables from Trino
-                                                   via :doc:`/sql/drop-table`, defaults to ``false``.
+``cassandra.allow-drop-table``                     Enables :doc:`/sql/drop-table` operations. Defaults to ``false``.
 
 ``cassandra.username``                             Username used for authentication to the Cassandra cluster.
                                                    This is a global setting used for all connections, regardless
@@ -277,6 +276,18 @@ statements, the connector supports the following features:
 * :doc:`/sql/create-table`
 * :doc:`/sql/create-table-as`
 * :doc:`/sql/drop-table`
+
+DROP TABLE
+^^^^^^^^^^
+
+By default, ``DROP TABLE`` operations are disabled on Cassandra catalogs. To
+enable ``DROP TABLE``, set the ``cassandra.allow-drop-table`` catalog
+configuration property to ``true``:
+
+.. code-block:: properties
+
+  cassandra.allow-drop-table=true
+
 
 .. _sql-delete-limitation:
 

--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -678,6 +678,11 @@ features:
 * :ref:`sql-security-operations`, see also :ref:`hive-sql-standard-based-authorization`
 * :ref:`sql-transactions`
 
+Some :ref:`sql-data-management` statements may be affected by the
+Hive catalog's authorization check policy. In the default ``legacy`` policy,
+some statements are disabled by default. See :doc:`hive-security` for more
+information.
+
 Refer to :doc:`the migration guide </appendix/from-hive>` for practical advice on migrating from Hive to Trino.
 
 .. include:: alter-mv-set-properties-unsupported.fragment


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Though https://github.com/trinodb/trino/pull/588 removed the `allow-drop-table` property from JDBC connectors, the property still exists in the Cassandra connector, and it + similar properties are in the Hive connector for legacy security. This PR completes the corresponding documentation in those connector pages.

## General information

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix - adding missing documentation

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Hive and Cassandra connector documentation

> How would you describe this change to a non-technical end user or system administrator?

`DROP TABLE` statements are disabled by default on Cassandra catalogs and several table/column statements are disabled with the default legacy security on Hive catalogs, so we need to document why and how to enable them.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

* Follow-up to https://github.com/trinodb/trino/pull/588
* and https://github.com/trinodb/trino/pull/10795

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```
# Section
* Fix some things. ({issue}`5678`)
```
