### PR TITLE
Track Glue API calls that were untracked

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/AwsSdkUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/AwsSdkUtil.java
@@ -37,7 +37,8 @@ public final class AwsSdkUtil
             Function<Request, Result> submission,
             Request request,
             BiConsumer<Request, String> setNextToken,
-            Function<Result, String> extractNextToken)
+            Function<Result, String> extractNextToken,
+            GlueMetastoreApiStats stats)
     {
         requireNonNull(submission, "submission is null");
         requireNonNull(request, "request is null");
@@ -57,7 +58,7 @@ public final class AwsSdkUtil
                 }
 
                 setNextToken.accept(request, nextToken);
-                Result result = submission.apply(request);
+                Result result = stats.call(() -> submission.apply(request));
                 firstRequest = false;
                 nextToken = extractNextToken.apply(result);
                 return result;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -291,7 +291,7 @@ public class GlueHiveMetastore
     public List<String> getAllDatabases()
     {
         try {
-            return stats.getGetAllDatabases().call(() -> {
+            return stats.getGetDatabases().call(() -> {
                 List<String> databaseNames = getPaginatedResults(
                         glueClient::getDatabases,
                         new GetDatabasesRequest().withCatalogId(catalogId),
@@ -448,7 +448,7 @@ public class GlueHiveMetastore
     public List<String> getAllTables(String databaseName)
     {
         try {
-            return stats.getGetAllTables().call(() -> {
+            return stats.getGetTables().call(() -> {
                 List<String> tableNames = getPaginatedResults(
                         glueClient::getTables,
                         new GetTablesRequest()
@@ -548,7 +548,7 @@ public class GlueHiveMetastore
         }
 
         try {
-            stats.getDropDatabase().call(() ->
+            stats.getDeleteDatabase().call(() ->
                     glueClient.deleteDatabase(new DeleteDatabaseRequest().withCatalogId(catalogId).withName(databaseName)));
         }
         catch (EntityNotFoundException e) {
@@ -569,7 +569,7 @@ public class GlueHiveMetastore
         try {
             Database database = getDatabase(databaseName).orElseThrow(() -> new SchemaNotFoundException(databaseName));
             DatabaseInput renamedDatabase = GlueInputConverter.convertDatabase(database).withName(newDatabaseName);
-            stats.getRenameDatabase().call(() ->
+            stats.getUpdateDatabase().call(() ->
                     glueClient.updateDatabase(new UpdateDatabaseRequest()
                             .withCatalogId(catalogId)
                             .withName(databaseName)
@@ -614,7 +614,7 @@ public class GlueHiveMetastore
         Table table = getExistingTable(databaseName, tableName);
 
         try {
-            stats.getDropTable().call(() ->
+            stats.getDeleteTable().call(() ->
                     glueClient.deleteTable(new DeleteTableRequest()
                             .withCatalogId(catalogId)
                             .withDatabaseName(databaseName)
@@ -651,7 +651,7 @@ public class GlueHiveMetastore
     {
         try {
             TableInput newTableInput = GlueInputConverter.convertTable(newTable);
-            stats.getReplaceTable().call(() ->
+            stats.getUpdateTable().call(() ->
                     glueClient.updateTable(new UpdateTableRequest()
                             .withCatalogId(catalogId)
                             .withDatabaseName(databaseName)
@@ -690,7 +690,7 @@ public class GlueHiveMetastore
             TableInput newTableInput = GlueInputConverter.convertTable(table);
             newTableInput.setOwner(principal.getName());
 
-            stats.getReplaceTable().call(() ->
+            stats.getUpdateTable().call(() ->
                     glueClient.updateTable(new UpdateTableRequest()
                             .withCatalogId(catalogId)
                             .withDatabaseName(databaseName)
@@ -960,7 +960,7 @@ public class GlueHiveMetastore
     public void addPartitions(String databaseName, String tableName, List<PartitionWithStatistics> partitions)
     {
         try {
-            stats.getAddPartitions().call(() -> {
+            stats.getCreatePartitions().call(() -> {
                 List<Future<BatchCreatePartitionResult>> futures = new ArrayList<>();
 
                 for (List<PartitionWithStatistics> partitionBatch : Lists.partition(partitions, BATCH_CREATE_PARTITION_MAX_PAGE_SIZE)) {
@@ -1023,7 +1023,7 @@ public class GlueHiveMetastore
                 .orElseThrow(() -> new PartitionNotFoundException(new SchemaTableName(databaseName, tableName), parts));
 
         try {
-            stats.getDropPartition().call(() ->
+            stats.getDeletePartition().call(() ->
                     glueClient.deletePartition(new DeletePartitionRequest()
                             .withCatalogId(catalogId)
                             .withDatabaseName(databaseName)
@@ -1045,7 +1045,7 @@ public class GlueHiveMetastore
     {
         try {
             PartitionInput newPartition = convertPartition(partition);
-            stats.getAlterPartition().call(() ->
+            stats.getUpdatePartition().call(() ->
                     glueClient.updatePartition(new UpdatePartitionRequest()
                             .withCatalogId(catalogId)
                             .withDatabaseName(databaseName)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -493,7 +493,7 @@ public class GlueHiveMetastore
                             .withDatabaseName(databaseName),
                     GetTablesRequest::setNextToken,
                     GetTablesResult::getNextToken,
-                    stats.getGetAllViews())
+                    stats.getGetTables())
                     .map(GetTablesResult::getTableList)
                     .flatMap(List::stream)
                     .filter(table -> VIRTUAL_VIEW.name().equals(table.getTableType()))
@@ -921,10 +921,10 @@ public class GlueHiveMetastore
                 for (List<PartitionValueList> partitions : Lists.partition(pendingPartitions, BATCH_GET_PARTITION_MAX_PAGE_SIZE)) {
                     long startTimestamp = System.currentTimeMillis();
                     batchGetPartitionFutures.add(glueClient.batchGetPartitionAsync(new BatchGetPartitionRequest()
-                            .withCatalogId(catalogId)
-                            .withDatabaseName(table.getDatabaseName())
-                            .withTableName(table.getTableName())
-                            .withPartitionsToGet(partitions),
+                                    .withCatalogId(catalogId)
+                                    .withDatabaseName(table.getDatabaseName())
+                                    .withTableName(table.getTableName())
+                                    .withPartitionsToGet(partitions),
                             new StatsRecordingAsyncHandler(stats.getGetPartitions(), startTimestamp)));
                 }
                 pendingPartitions.clear();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueMetastoreApiStats.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueMetastoreApiStats.java
@@ -54,6 +54,14 @@ public class GlueMetastoreApiStats
         return totalFailures;
     }
 
+    public void recordCall(long executionTimeInMillis, boolean failure)
+    {
+        time.add(executionTimeInMillis, MILLISECONDS);
+        if (failure) {
+            totalFailures.update(1);
+        }
+    }
+
     public interface ThrowingCallable<V, E extends Exception>
     {
         V call()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueMetastoreStats.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueMetastoreStats.java
@@ -31,7 +31,6 @@ public class GlueMetastoreStats
     private final GlueMetastoreApiStats getDatabase = new GlueMetastoreApiStats();
     private final GlueMetastoreApiStats getTables = new GlueMetastoreApiStats();
     private final GlueMetastoreApiStats getTable = new GlueMetastoreApiStats();
-    private final GlueMetastoreApiStats getAllViews = new GlueMetastoreApiStats();
     private final GlueMetastoreApiStats createDatabase = new GlueMetastoreApiStats();
     private final GlueMetastoreApiStats deleteDatabase = new GlueMetastoreApiStats();
     private final GlueMetastoreApiStats updateDatabase = new GlueMetastoreApiStats();
@@ -91,13 +90,6 @@ public class GlueMetastoreStats
     public GlueMetastoreApiStats getGetTable()
     {
         return getTable;
-    }
-
-    @Managed
-    @Nested
-    public GlueMetastoreApiStats getGetAllViews()
-    {
-        return getAllViews;
     }
 
     @Managed

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueMetastoreStats.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueMetastoreStats.java
@@ -27,24 +27,24 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class GlueMetastoreStats
 {
-    private final GlueMetastoreApiStats getAllDatabases = new GlueMetastoreApiStats();
+    private final GlueMetastoreApiStats getDatabases = new GlueMetastoreApiStats();
     private final GlueMetastoreApiStats getDatabase = new GlueMetastoreApiStats();
-    private final GlueMetastoreApiStats getAllTables = new GlueMetastoreApiStats();
+    private final GlueMetastoreApiStats getTables = new GlueMetastoreApiStats();
     private final GlueMetastoreApiStats getTable = new GlueMetastoreApiStats();
     private final GlueMetastoreApiStats getAllViews = new GlueMetastoreApiStats();
     private final GlueMetastoreApiStats createDatabase = new GlueMetastoreApiStats();
-    private final GlueMetastoreApiStats dropDatabase = new GlueMetastoreApiStats();
-    private final GlueMetastoreApiStats renameDatabase = new GlueMetastoreApiStats();
+    private final GlueMetastoreApiStats deleteDatabase = new GlueMetastoreApiStats();
+    private final GlueMetastoreApiStats updateDatabase = new GlueMetastoreApiStats();
     private final GlueMetastoreApiStats createTable = new GlueMetastoreApiStats();
-    private final GlueMetastoreApiStats dropTable = new GlueMetastoreApiStats();
-    private final GlueMetastoreApiStats replaceTable = new GlueMetastoreApiStats();
+    private final GlueMetastoreApiStats deleteTable = new GlueMetastoreApiStats();
+    private final GlueMetastoreApiStats updateTable = new GlueMetastoreApiStats();
     private final GlueMetastoreApiStats getPartitionNames = new GlueMetastoreApiStats();
     private final GlueMetastoreApiStats getPartitions = new GlueMetastoreApiStats();
     private final GlueMetastoreApiStats getPartition = new GlueMetastoreApiStats();
     private final GlueMetastoreApiStats getPartitionByName = new GlueMetastoreApiStats();
-    private final GlueMetastoreApiStats addPartitions = new GlueMetastoreApiStats();
-    private final GlueMetastoreApiStats dropPartition = new GlueMetastoreApiStats();
-    private final GlueMetastoreApiStats alterPartition = new GlueMetastoreApiStats();
+    private final GlueMetastoreApiStats createPartitions = new GlueMetastoreApiStats();
+    private final GlueMetastoreApiStats deletePartition = new GlueMetastoreApiStats();
+    private final GlueMetastoreApiStats updatePartition = new GlueMetastoreApiStats();
     private final GlueMetastoreApiStats getColumnStatisticsForTable = new GlueMetastoreApiStats();
     private final GlueMetastoreApiStats getColumnStatisticsForPartition = new GlueMetastoreApiStats();
     private final GlueMetastoreApiStats updateColumnStatisticsForTable = new GlueMetastoreApiStats();
@@ -65,9 +65,9 @@ public class GlueMetastoreStats
 
     @Managed
     @Nested
-    public GlueMetastoreApiStats getGetAllDatabases()
+    public GlueMetastoreApiStats getGetDatabases()
     {
-        return getAllDatabases;
+        return getDatabases;
     }
 
     @Managed
@@ -79,9 +79,9 @@ public class GlueMetastoreStats
 
     @Managed
     @Nested
-    public GlueMetastoreApiStats getGetAllTables()
+    public GlueMetastoreApiStats getGetTables()
     {
-        return getAllTables;
+        return getTables;
     }
 
     @Managed
@@ -107,16 +107,16 @@ public class GlueMetastoreStats
 
     @Managed
     @Nested
-    public GlueMetastoreApiStats getDropDatabase()
+    public GlueMetastoreApiStats getDeleteDatabase()
     {
-        return dropDatabase;
+        return deleteDatabase;
     }
 
     @Managed
     @Nested
-    public GlueMetastoreApiStats getRenameDatabase()
+    public GlueMetastoreApiStats getUpdateDatabase()
     {
-        return renameDatabase;
+        return updateDatabase;
     }
 
     @Managed
@@ -128,16 +128,16 @@ public class GlueMetastoreStats
 
     @Managed
     @Nested
-    public GlueMetastoreApiStats getDropTable()
+    public GlueMetastoreApiStats getDeleteTable()
     {
-        return dropTable;
+        return deleteTable;
     }
 
     @Managed
     @Nested
-    public GlueMetastoreApiStats getReplaceTable()
+    public GlueMetastoreApiStats getUpdateTable()
     {
-        return replaceTable;
+        return updateTable;
     }
 
     @Managed
@@ -170,23 +170,23 @@ public class GlueMetastoreStats
 
     @Managed
     @Nested
-    public GlueMetastoreApiStats getAddPartitions()
+    public GlueMetastoreApiStats getCreatePartitions()
     {
-        return addPartitions;
+        return createPartitions;
     }
 
     @Managed
     @Nested
-    public GlueMetastoreApiStats getDropPartition()
+    public GlueMetastoreApiStats getDeletePartition()
     {
-        return dropPartition;
+        return deletePartition;
     }
 
     @Managed
     @Nested
-    public GlueMetastoreApiStats getAlterPartition()
+    public GlueMetastoreApiStats getUpdatePartition()
     {
-        return alterPartition;
+        return updatePartition;
     }
 
     @Managed

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueMetastoreStats.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueMetastoreStats.java
@@ -45,6 +45,8 @@ public class GlueMetastoreStats
     private final GlueMetastoreApiStats createPartitions = new GlueMetastoreApiStats();
     private final GlueMetastoreApiStats deletePartition = new GlueMetastoreApiStats();
     private final GlueMetastoreApiStats updatePartition = new GlueMetastoreApiStats();
+    private final GlueMetastoreApiStats batchUpdatePartition = new GlueMetastoreApiStats();
+    private final GlueMetastoreApiStats batchCreatePartition = new GlueMetastoreApiStats();
     private final GlueMetastoreApiStats getColumnStatisticsForTable = new GlueMetastoreApiStats();
     private final GlueMetastoreApiStats getColumnStatisticsForPartition = new GlueMetastoreApiStats();
     private final GlueMetastoreApiStats updateColumnStatisticsForTable = new GlueMetastoreApiStats();
@@ -187,6 +189,20 @@ public class GlueMetastoreStats
     public GlueMetastoreApiStats getUpdatePartition()
     {
         return updatePartition;
+    }
+
+    @Managed
+    @Nested
+    public GlueMetastoreApiStats getBatchUpdatePartition()
+    {
+        return batchUpdatePartition;
+    }
+
+    @Managed
+    @Nested
+    public GlueMetastoreApiStats getBatchCreatePartition()
+    {
+        return batchCreatePartition;
     }
 
     @Managed

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
@@ -303,12 +303,12 @@ public class TestHiveGlueMetastore
     {
         GlueHiveMetastore metastore = (GlueHiveMetastore) getMetastoreClient();
         GlueMetastoreStats stats = metastore.getStats();
-        double initialCallCount = stats.getGetAllDatabases().getTime().getAllTime().getCount();
-        long initialFailureCount = stats.getGetAllDatabases().getTotalFailures().getTotalCount();
+        double initialCallCount = stats.getGetDatabases().getTime().getAllTime().getCount();
+        long initialFailureCount = stats.getGetDatabases().getTotalFailures().getTotalCount();
         getMetastoreClient().getAllDatabases();
-        assertEquals(stats.getGetAllDatabases().getTime().getAllTime().getCount(), initialCallCount + 1.0);
-        assertTrue(stats.getGetAllDatabases().getTime().getAllTime().getAvg() > 0.0);
-        assertEquals(stats.getGetAllDatabases().getTotalFailures().getTotalCount(), initialFailureCount);
+        assertEquals(stats.getGetDatabases().getTime().getAllTime().getCount(), initialCallCount + 1.0);
+        assertTrue(stats.getGetDatabases().getTime().getAllTime().getAvg() > 0.0);
+        assertEquals(stats.getGetDatabases().getTotalFailures().getTotalCount(), initialFailureCount);
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->
One call to Glue was not being tracked.

Rename GlueMetastoreStats.renameTable to GlueMetastoreStats.updateTable.

## General information

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

a fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

a connector

> How would you describe this change to a non-technical end user or system administrator?

It will allow to more precisely track calls to external api - Glue

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`5678`)
```
