### PR TITLE
Delete Iceberg table data on DROP

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -524,12 +524,10 @@ public class FileHiveMetastore
 
         Path tableMetadataDirectory = getTableMetadataDirectory(databaseName, tableName);
 
-        // It is safe to delete the whole meta directory for external tables and views
-        if (!table.getTableType().equals(MANAGED_TABLE.name()) || deleteData) {
+        if (deleteData) {
             deleteDirectoryAndSchema(TABLE, tableMetadataDirectory);
         }
         else {
-            // in this case we only want to delete the metadata of a managed table
             deleteSchemaFile(TABLE, tableMetadataDirectory);
             deleteTablePrivileges(table);
         }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/DataFileRecord.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/DataFileRecord.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.MaterializedRow;
+
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+
+public class DataFileRecord
+{
+    private final int content;
+    private final String filePath;
+    private final String fileFormat;
+    private final long recordCount;
+    private final long fileSizeInBytes;
+    private final Map<Integer, Long> columnSizes;
+    private final Map<Integer, Long> valueCounts;
+    private final Map<Integer, Long> nullValueCounts;
+    private final Map<Integer, Long> nanValueCounts;
+    private final Map<Integer, String> lowerBounds;
+    private final Map<Integer, String> upperBounds;
+
+    public static DataFileRecord toDataFileRecord(MaterializedRow row)
+    {
+        assertEquals(row.getFieldCount(), 14);
+        return new DataFileRecord(
+                (int) row.getField(0),
+                (String) row.getField(1),
+                (String) row.getField(2),
+                (long) row.getField(3),
+                (long) row.getField(4),
+                row.getField(5) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(5)) : null,
+                row.getField(6) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(6)) : null,
+                row.getField(7) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(7)) : null,
+                row.getField(8) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(8)) : null,
+                row.getField(9) != null ? ImmutableMap.copyOf((Map<Integer, String>) row.getField(9)) : null,
+                row.getField(10) != null ? ImmutableMap.copyOf((Map<Integer, String>) row.getField(10)) : null);
+    }
+
+    private DataFileRecord(
+            int content,
+            String filePath,
+            String fileFormat,
+            long recordCount,
+            long fileSizeInBytes,
+            Map<Integer, Long> columnSizes,
+            Map<Integer, Long> valueCounts,
+            Map<Integer, Long> nullValueCounts,
+            Map<Integer, Long> nanValueCounts,
+            Map<Integer, String> lowerBounds,
+            Map<Integer, String> upperBounds)
+    {
+        this.content = content;
+        this.filePath = filePath;
+        this.fileFormat = fileFormat;
+        this.recordCount = recordCount;
+        this.fileSizeInBytes = fileSizeInBytes;
+        this.columnSizes = columnSizes;
+        this.valueCounts = valueCounts;
+        this.nullValueCounts = nullValueCounts;
+        this.nanValueCounts = nanValueCounts;
+        this.lowerBounds = lowerBounds;
+        this.upperBounds = upperBounds;
+    }
+
+    public int getContent()
+    {
+        return content;
+    }
+
+    public String getFilePath()
+    {
+        return filePath;
+    }
+
+    public String getFileFormat()
+    {
+        return fileFormat;
+    }
+
+    public long getRecordCount()
+    {
+        return recordCount;
+    }
+
+    public long getFileSizeInBytes()
+    {
+        return fileSizeInBytes;
+    }
+
+    public Map<Integer, Long> getColumnSizes()
+    {
+        return columnSizes;
+    }
+
+    public Map<Integer, Long> getValueCounts()
+    {
+        return valueCounts;
+    }
+
+    public Map<Integer, Long> getNullValueCounts()
+    {
+        return nullValueCounts;
+    }
+
+    public Map<Integer, Long> getNanValueCounts()
+    {
+        return nanValueCounts;
+    }
+
+    public Map<Integer, String> getLowerBounds()
+    {
+        return lowerBounds;
+    }
+
+    public Map<Integer, String> getUpperBounds()
+    {
+        return upperBounds;
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcMetricsCollection.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcMetricsCollection.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.iceberg;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
 import io.trino.plugin.hive.HdfsConfig;
@@ -49,7 +48,7 @@ import java.util.Optional;
 import static io.trino.SystemSessionProperties.MAX_DRIVERS_PER_TASK;
 import static io.trino.SystemSessionProperties.TASK_CONCURRENCY;
 import static io.trino.SystemSessionProperties.TASK_WRITER_COUNT;
-import static io.trino.plugin.iceberg.TestIcebergOrcMetricsCollection.DataFileRecord.toDataFileRecord;
+import static io.trino.plugin.iceberg.DataFileRecord.toDataFileRecord;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
@@ -408,118 +407,5 @@ public class TestIcebergOrcMetricsCollection
         assertQuery("SELECT max(_timestamp) FROM test_timestamp", "VALUES '2021-01-31 00:00:00.333333'");
 
         assertUpdate("DROP TABLE test_timestamp");
-    }
-
-    public static class DataFileRecord
-    {
-        private final int content;
-        private final String filePath;
-        private final String fileFormat;
-        private final long recordCount;
-        private final long fileSizeInBytes;
-        private final Map<Integer, Long> columnSizes;
-        private final Map<Integer, Long> valueCounts;
-        private final Map<Integer, Long> nullValueCounts;
-        private final Map<Integer, Long> nanValueCounts;
-        private final Map<Integer, String> lowerBounds;
-        private final Map<Integer, String> upperBounds;
-
-        public static DataFileRecord toDataFileRecord(MaterializedRow row)
-        {
-            assertEquals(row.getFieldCount(), 14);
-            return new DataFileRecord(
-                    (int) row.getField(0),
-                    (String) row.getField(1),
-                    (String) row.getField(2),
-                    (long) row.getField(3),
-                    (long) row.getField(4),
-                    row.getField(5) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(5)) : null,
-                    row.getField(6) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(6)) : null,
-                    row.getField(7) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(7)) : null,
-                    row.getField(8) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(8)) : null,
-                    row.getField(9) != null ? ImmutableMap.copyOf((Map<Integer, String>) row.getField(9)) : null,
-                    row.getField(10) != null ? ImmutableMap.copyOf((Map<Integer, String>) row.getField(10)) : null);
-        }
-
-        private DataFileRecord(
-                int content,
-                String filePath,
-                String fileFormat,
-                long recordCount,
-                long fileSizeInBytes,
-                Map<Integer, Long> columnSizes,
-                Map<Integer, Long> valueCounts,
-                Map<Integer, Long> nullValueCounts,
-                Map<Integer, Long> nanValueCounts,
-                Map<Integer, String> lowerBounds,
-                Map<Integer, String> upperBounds)
-        {
-            this.content = content;
-            this.filePath = filePath;
-            this.fileFormat = fileFormat;
-            this.recordCount = recordCount;
-            this.fileSizeInBytes = fileSizeInBytes;
-            this.columnSizes = columnSizes;
-            this.valueCounts = valueCounts;
-            this.nullValueCounts = nullValueCounts;
-            this.nanValueCounts = nanValueCounts;
-            this.lowerBounds = lowerBounds;
-            this.upperBounds = upperBounds;
-        }
-
-        public int getContent()
-        {
-            return content;
-        }
-
-        public String getFilePath()
-        {
-            return filePath;
-        }
-
-        public String getFileFormat()
-        {
-            return fileFormat;
-        }
-
-        public long getRecordCount()
-        {
-            return recordCount;
-        }
-
-        public long getFileSizeInBytes()
-        {
-            return fileSizeInBytes;
-        }
-
-        public Map<Integer, Long> getColumnSizes()
-        {
-            return columnSizes;
-        }
-
-        public Map<Integer, Long> getValueCounts()
-        {
-            return valueCounts;
-        }
-
-        public Map<Integer, Long> getNullValueCounts()
-        {
-            return nullValueCounts;
-        }
-
-        public Map<Integer, Long> getNanValueCounts()
-        {
-            return nanValueCounts;
-        }
-
-        public Map<Integer, String> getLowerBounds()
-        {
-            return lowerBounds;
-        }
-
-        public Map<Integer, String> getUpperBounds()
-        {
-            return upperBounds;
-        }
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergTableWithExternalLocation.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergTableWithExternalLocation.java
@@ -47,14 +47,14 @@ import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.trino.plugin.iceberg.DataFileRecord.toDataFileRecord;
 import static io.trino.plugin.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
+import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 
-public class TestIcebergTableWithCustomLocation
+public class TestIcebergTableWithExternalLocation
         extends AbstractTestQueryFramework
 {
     private FileHiveMetastore metastore;
@@ -82,7 +82,7 @@ public class TestIcebergTableWithCustomLocation
 
         return createIcebergQueryRunner(
                 ImmutableMap.of(),
-                ImmutableMap.of("iceberg.unique-table-location", "true"),
+                ImmutableMap.of(),
                 ImmutableList.of(),
                 Optional.of(metastoreDir));
     }
@@ -95,79 +95,28 @@ public class TestIcebergTableWithCustomLocation
     }
 
     @Test
-    public void testTableHasUuidSuffixInLocation()
-    {
-        String tableName = "table_with_uuid";
-        assertQuerySucceeds(format("CREATE TABLE %s as select 1 as val", tableName));
-        Optional<Table> table = metastore.getTable("tpch", tableName);
-        assertTrue(table.isPresent(), "Table should exists");
-        String location = table.get().getStorage().getLocation();
-        assertThat(location).matches(format(".*%s-[0-9a-f]{32}", tableName));
-    }
-
-    @Test
     public void testCreateAndDrop()
             throws IOException
     {
-        String tableName = "test_create_and_drop";
-        assertQuerySucceeds(format("CREATE TABLE %s as select 1 as val", tableName));
+        String tableName = "test_table_external_create_and_drop";
+        File tempDir = getDistributedQueryRunner().getCoordinator().getBaseDataDir().toFile();
+        String tempDirPath = tempDir.toURI().toASCIIString() + randomTableSuffix();
+        assertQuerySucceeds(format("CREATE TABLE %s ( x bigint) WITH (location = '%s')", tableName, tempDirPath));
+        assertQuerySucceeds(format("INSERT INTO %s VALUES (1), (2), (3)", tableName));
+
         Table table = metastore.getTable("tpch", tableName).orElseThrow();
         assertThat(table.getTableType()).isEqualTo(TableType.EXTERNAL_TABLE.name());
-
         Path tableLocation = new Path(table.getStorage().getLocation());
         FileSystem fileSystem = hdfsEnvironment.getFileSystem(hdfsContext, tableLocation);
         assertTrue(fileSystem.exists(tableLocation), "The directory corresponding to the table storage location should exist");
-        MaterializedResult materializedResult = computeActual("SELECT * FROM \"test_create_and_drop$files\"");
+        MaterializedResult materializedResult = computeActual("SELECT * FROM \"test_table_external_create_and_drop$files\"");
         assertEquals(materializedResult.getRowCount(), 1);
         DataFileRecord dataFile = toDataFileRecord(materializedResult.getMaterializedRows().get(0));
         assertTrue(fileSystem.exists(new Path(dataFile.getFilePath())), "The data file should exist");
+
         assertQuerySucceeds(format("DROP TABLE %s", tableName));
         assertFalse(metastore.getTable("tpch", tableName).isPresent(), "Table should be dropped");
         assertFalse(fileSystem.exists(new Path(dataFile.getFilePath())), "The data file should have been removed");
         assertFalse(fileSystem.exists(tableLocation), "The directory corresponding to the dropped Iceberg table should not be removed because it may be shared with other tables");
-    }
-
-    @Test
-    public void testCreateRenameDrop()
-    {
-        String tableName = "test_create_rename_drop";
-        String renamedName = "test_create_rename_drop_renamed";
-        assertQuerySucceeds(format("CREATE TABLE %s as select 1 as val", tableName));
-        Optional<Table> table = metastore.getTable("tpch", tableName);
-        assertTrue(table.isPresent(), "Table should exist");
-        String tableInitialLocation = table.get().getStorage().getLocation();
-
-        assertQuerySucceeds(format("ALTER TABLE %s RENAME TO %s", tableName, renamedName));
-        Optional<Table> renamedTable = metastore.getTable("tpch", renamedName);
-        assertTrue(renamedTable.isPresent(), "Table should exist");
-        String renamedTableLocation = renamedTable.get().getStorage().getLocation();
-        assertEquals(renamedTableLocation, tableInitialLocation, "Location should not be changed");
-
-        assertQuerySucceeds(format("DROP TABLE %s", renamedName));
-        assertFalse(metastore.getTable("tpch", tableName).isPresent(), "Initial table should not exists");
-        assertFalse(metastore.getTable("tpch", renamedName).isPresent(), "Renamed table should be dropped");
-    }
-
-    @Test
-    public void testCreateRenameCreate()
-    {
-        String tableName = "test_create_rename_create";
-        String renamedName = "test_create_rename_create_renamed";
-        assertQuerySucceeds(format("CREATE TABLE %s as select 1 as val", tableName));
-        Optional<Table> table = metastore.getTable("tpch", tableName);
-        assertTrue(table.isPresent(), "Table should exist");
-        String tableInitialLocation = table.get().getStorage().getLocation();
-
-        assertQuerySucceeds(format("ALTER TABLE %s RENAME TO %s", tableName, renamedName));
-        Optional<Table> renamedTable = metastore.getTable("tpch", renamedName);
-        assertTrue(renamedTable.isPresent(), "Table should exist");
-        String renamedTableLocation = renamedTable.get().getStorage().getLocation();
-        assertEquals(renamedTableLocation, tableInitialLocation, "Location should not be changed");
-
-        assertQuerySucceeds(format("CREATE TABLE %s as select 1 as val", tableName));
-        Optional<Table> recreatedTableWithInitialName = metastore.getTable("tpch", tableName);
-        assertTrue(recreatedTableWithInitialName.isPresent(), "Table should exist");
-        String recreatedTableLocation = recreatedTableWithInitialName.get().getStorage().getLocation();
-        assertNotEquals(tableInitialLocation, recreatedTableLocation, "Location should be different");
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkDropTableCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkDropTableCompatibility.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.iceberg;
+
+import com.google.inject.name.Named;
+import io.trino.tempto.BeforeTestWithContext;
+import io.trino.tempto.ProductTest;
+import io.trino.tempto.hadoop.hdfs.HdfsClient;
+import io.trino.tests.product.hive.Engine;
+import org.assertj.core.api.Assertions;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import javax.inject.Inject;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static io.trino.tests.product.TestGroups.ICEBERG;
+import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static io.trino.tests.product.hive.Engine.SPARK;
+import static io.trino.tests.product.hive.Engine.TRINO;
+import static io.trino.tests.product.hive.util.TemporaryHiveTable.randomTableSuffix;
+import static io.trino.tests.product.utils.QueryExecutors.onSpark;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
+import static java.lang.String.format;
+
+/**
+ * Tests drop table compatibility between Iceberg connector and Spark Iceberg.
+ */
+public class TestIcebergSparkDropTableCompatibility
+        extends ProductTest
+{
+    @Inject
+    @Named("databases.hive.warehouse_directory_path")
+    private String warehouseDirectory;
+
+    @Inject
+    private HdfsClient hdfsClient;
+
+    @BeforeTestWithContext
+    public void useIceberg()
+    {
+        onTrino().executeQuery("USE iceberg.default");
+        // see spark-defaults.conf
+        onSpark().executeQuery("USE iceberg_test.default");
+    }
+
+    @DataProvider
+    public static Object[][] tableCleanupEngineConfigurations()
+    {
+        return new Object[][] {
+                {TRINO, TRINO},
+                {TRINO, SPARK},
+                {SPARK, SPARK},
+                {SPARK, TRINO},
+        };
+    }
+
+    @Test(groups = {ICEBERG, PROFILE_SPECIFIC_TESTS}, dataProvider = "tableCleanupEngineConfigurations")
+    public void testCleanupOnDropTable(Engine tableCreatorEngine, Engine tableDropperEngine)
+    {
+        String tableName = "test_cleanup_on_drop_table" + randomTableSuffix();
+
+        tableCreatorEngine.queryExecutor().executeQuery("CREATE TABLE " + tableName + "(col0 INT, col1 INT)");
+        onTrino().executeQuery("INSERT INTO " + tableName + " VALUES (1, 2)");
+
+        String tableDirectory = format("%s/%s", warehouseDirectory, tableName);
+        assertFileExistence(tableDirectory, true, "The table directory exists after creating the table");
+        List<String> dataFilePaths = getDataFilePaths(tableName);
+
+        tableDropperEngine.queryExecutor().executeQuery("DROP TABLE " + tableName);
+        assertFileExistence(tableDirectory, false, format("The table directory %s should be removed after dropping the table", tableDirectory));
+        dataFilePaths.forEach(dataFilePath -> assertFileExistence(dataFilePath, false, format("The data file %s removed after dropping the table", dataFilePath)));
+    }
+
+    private void assertFileExistence(String path, boolean exists, String description)
+    {
+        Assertions.assertThat(hdfsClient.exist(path)).as(description).isEqualTo(exists);
+    }
+
+    private static List<String> getDataFilePaths(String icebergTableName)
+    {
+        List<String> filePaths = onTrino().executeQuery(format("SELECT file_path FROM \"%s$files\"", icebergTableName)).column(1);
+        return filePaths.stream().map(TestIcebergSparkDropTableCompatibility::getPath).collect(Collectors.toList());
+    }
+
+    private static String getPath(String uri)
+    {
+        if (uri.startsWith("hdfs://")) {
+            try {
+                return new URI(uri).getPath();
+            }
+            catch (URISyntaxException e) {
+                throw new RuntimeException("Invalid syntax for the URI: " + uri, e);
+            }
+        }
+
+        return uri;
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

Delegate the responsibility of deleting the data files
of the table to Iceberg because the data files
of the Iceberg table may be located in different locations.

The DROP statement deletes the Iceberg table data irrespective
of the fact that the `location` parameter has been specified
explicitly on the table, or it was implicitly derived from
the schema location.

It is important to note that the DROP functionality can be currently 
performed only for Iceberg tables that do not contain path overrides
(`write.object-storage.path`, `write.folder-storage.path`, `write.metadata.path`).

## General information

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

This is a fix.
Previously the data of the Iceberg table was not removed by HMS because Iceberg tables are marked implicitly as EXTERNAL, reason why the data of the table is not deleted by HMS on DROP.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

This change relates solely to the Iceberg connector.

> How would you describe this change to a non-technical end user or system administrator?

This feature brings the ability to delete the data files while performing a DROP statements.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->
Fixes #5616
Related PR: [#6063](https://github.com/trinodb/trino/pull/6063)
Depends on PR: [#11032](https://github.com/trinodb/trino/pull/11032)
<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Iceberg
* Delete data files on DROP for managed tables. ({issue}`5616`)
```

