### PR TITLE
Fix listTables to include views

### DIFF
--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloMetadata.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloMetadata.java
@@ -309,13 +309,15 @@ public class AccumuloMetadata
         Set<String> schemaNames = filterSchema.<Set<String>>map(ImmutableSet::of)
                 .orElseGet(client::getSchemaNames);
 
-        ImmutableList.Builder<SchemaTableName> builder = ImmutableList.builder();
+        ImmutableSet.Builder<SchemaTableName> builder = ImmutableSet.builder();
         for (String schemaName : schemaNames) {
             for (String tableName : client.getTableNames(schemaName)) {
                 builder.add(new SchemaTableName(schemaName, tableName));
             }
         }
-        return builder.build();
+        builder.addAll(listViews(session, filterSchema));
+        // Deduplicate with set because state may change concurrently
+        return builder.build().asList();
     }
 
     @Override

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorMetadata.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorMetadata.java
@@ -249,7 +249,11 @@ public class RaptorMetadata
     @Override
     public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
     {
-        return dao.listTables(schemaName.orElse(null));
+        // Deduplicate with set because state may change concurrently
+        return ImmutableSet.<SchemaTableName>builder()
+                .addAll(dao.listTables(schemaName.orElse(null)))
+                .addAll(listViews(session, schemaName))
+                .build().asList();
     }
 
     @Override


### PR DESCRIPTION
Per `ConnectorMetadata.listTables` contract, this should include views
and materialized views. Make Iceberg implementation follow the contract.
This fixes `IcebergMetadata`, `AccumuloMetadata` and `RaptorMetadata`.
The `HiveMetadata` was correct and other connectors do not support views
currently.

This also fixes `system.jdbc.tables` and `system.jdbc.columns` --
Iceberg views were not included in these tables.

Fixes https://github.com/trinodb/trino/issues/11060 