### PR TITLE
Support overriding  splits reading properties for Iceberg connector.

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -15,6 +15,7 @@ package io.trino.plugin.iceberg;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.plugin.hive.HiveCompressionCodec;
 
@@ -37,6 +38,10 @@ public class IcebergConfig
     private Duration dynamicFilteringWaitTimeout = new Duration(0, SECONDS);
     private boolean tableStatisticsEnabled = true;
     private boolean projectionPushdownEnabled = true;
+    private DataSize splitTargetSize = DataSize.of(128, DataSize.Unit.MEGABYTE);
+    private DataSize splitMetadataTargetSize = DataSize.of(32, DataSize.Unit.MEGABYTE);
+    private int splitPlanningLookback = 10;
+    private DataSize splitOpenFileCost = DataSize.of(4, DataSize.Unit.MEGABYTE);
 
     public CatalogType getCatalogType()
     {
@@ -164,6 +169,61 @@ public class IcebergConfig
     public IcebergConfig setProjectionPushdownEnabled(boolean projectionPushdownEnabled)
     {
         this.projectionPushdownEnabled = projectionPushdownEnabled;
+        return this;
+    }
+
+    @NotNull
+    public DataSize getSplitTargetSize()
+    {
+        return splitTargetSize;
+    }
+
+    @Config("iceberg.split-target-size")
+    @ConfigDescription("The target size of a data file split.")
+    public IcebergConfig setSplitTargetSize(DataSize splitTargetSize)
+    {
+        this.splitTargetSize = splitTargetSize;
+        return this;
+    }
+
+    @NotNull
+    public DataSize getSplitMetadataTargetSize()
+    {
+        return splitMetadataTargetSize;
+    }
+
+    @Config("iceberg.split-metadata-target-size")
+    @ConfigDescription("The target size of a metadata file split.")
+    public IcebergConfig setSplitMetadataTargetSize(DataSize splitMetadataTargetSize)
+    {
+        this.splitMetadataTargetSize = splitMetadataTargetSize;
+        return this;
+    }
+
+    public int getSplitPlanningLookback()
+    {
+        return splitPlanningLookback;
+    }
+
+    @Config("iceberg.split-planning-lookback")
+    @ConfigDescription("The number of bins considered when trying to pack the next file split into a scan task.")
+    public IcebergConfig setSplitPlanningLookback(int splitPlanningLookback)
+    {
+        this.splitPlanningLookback = splitPlanningLookback;
+        return this;
+    }
+
+    @NotNull
+    public DataSize getSplitOpenFileCost()
+    {
+        return splitOpenFileCost;
+    }
+
+    @Config("iceberg.split-open-file-cost")
+    @ConfigDescription("The cost of opening a file that will be taken into account during planning scan tasks.")
+    public IcebergConfig setSplitOpenFileCost(DataSize splitOpenFileCost)
+    {
+        this.splitOpenFileCost = splitOpenFileCost;
         return this;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -71,6 +71,10 @@ public final class IcebergSessionProperties
     private static final String STATISTICS_ENABLED = "statistics_enabled";
     private static final String PROJECTION_PUSHDOWN_ENABLED = "projection_pushdown_enabled";
     private static final String TARGET_MAX_FILE_SIZE = "target_max_file_size";
+    private static final String SPLIT_SIZE = "split_size";
+    private static final String METADATA_SPLIT_SIZE = "metadata_split_size";
+    private static final String SPLIT_LOOKBACK = "split_lookback";
+    private static final String SPLIT_OPEN_FILE_COST = "split_open_file_cost";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -219,6 +223,28 @@ public final class IcebergSessionProperties
                         "Target maximum size of written files; the actual size may be larger",
                         hiveConfig.getTargetMaxFileSize(),
                         false))
+                .add(dataSizeProperty(
+                        SPLIT_SIZE,
+                        "Maximum split size read on data file",
+                        icebergConfig.getSplitTargetSize(),
+                        false))
+                .add(dataSizeProperty(
+                        METADATA_SPLIT_SIZE,
+                        "Maximum split size read on metadata file",
+                        icebergConfig.getSplitMetadataTargetSize(),
+                        false))
+                .add(integerProperty(
+                        SPLIT_LOOKBACK,
+                        "The number of bins considered when trying to pack the next file split into " +
+                                "a task. Increasing this usually makes tasks a bit more even by considering " +
+                                "more ways to pack file regions into a single task with extra planning cost.",
+                        icebergConfig.getSplitPlanningLookback(),
+                        false))
+                .add(dataSizeProperty(
+                        SPLIT_OPEN_FILE_COST,
+                        "The minimum memory cost to open a file.",
+                        icebergConfig.getSplitOpenFileCost(),
+                        false))
                 .build();
     }
 
@@ -358,5 +384,25 @@ public final class IcebergSessionProperties
     public static long getTargetMaxFileSize(ConnectorSession session)
     {
         return session.getProperty(TARGET_MAX_FILE_SIZE, DataSize.class).toBytes();
+    }
+
+    public static DataSize getSplitSize(ConnectorSession session)
+    {
+        return session.getProperty(SPLIT_SIZE, DataSize.class);
+    }
+
+    public static DataSize getMetadataSplitSize(ConnectorSession session)
+    {
+        return session.getProperty(METADATA_SPLIT_SIZE, DataSize.class);
+    }
+
+    public static int getSplitLookback(ConnectorSession session)
+    {
+        return session.getProperty(SPLIT_LOOKBACK, Integer.class);
+    }
+
+    public static DataSize getSplitOpenFileCost(ConnectorSession session)
+    {
+        return session.getProperty(SPLIT_OPEN_FILE_COST, DataSize.class);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitManager.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitManager.java
@@ -26,11 +26,16 @@ import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.connector.FixedSplitSource;
 import io.trino.spi.type.TypeManager;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableScan;
 
 import javax.inject.Inject;
 
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getDynamicFilteringWaitTimeout;
+import static io.trino.plugin.iceberg.IcebergSessionProperties.getMetadataSplitSize;
+import static io.trino.plugin.iceberg.IcebergSessionProperties.getSplitLookback;
+import static io.trino.plugin.iceberg.IcebergSessionProperties.getSplitOpenFileCost;
+import static io.trino.plugin.iceberg.IcebergSessionProperties.getSplitSize;
 import static java.util.Objects.requireNonNull;
 
 public class IcebergSplitManager
@@ -70,6 +75,10 @@ public class IcebergSplitManager
         Duration dynamicFilteringWaitTimeout = getDynamicFilteringWaitTimeout(session);
 
         TableScan tableScan = icebergTable.newScan()
+                .option(TableProperties.SPLIT_SIZE, String.valueOf(getSplitSize(session).toBytes()))
+                .option(TableProperties.METADATA_SPLIT_SIZE, String.valueOf(getMetadataSplitSize(session).toBytes()))
+                .option(TableProperties.SPLIT_LOOKBACK, String.valueOf(getSplitLookback(session)))
+                .option(TableProperties.SPLIT_OPEN_FILE_COST, String.valueOf(getSplitOpenFileCost(session).toBytes()))
                 .useSnapshot(table.getSnapshotId().get());
         IcebergSplitSource splitSource = new IcebergSplitSource(
                 table,

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableMap;
+import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.plugin.hive.HiveCompressionCodec;
 import org.testng.annotations.Test;
@@ -44,7 +45,11 @@ public class TestIcebergConfig
                 .setCatalogType(HIVE_METASTORE)
                 .setDynamicFilteringWaitTimeout(new Duration(0, MINUTES))
                 .setTableStatisticsEnabled(true)
-                .setProjectionPushdownEnabled(true));
+                .setProjectionPushdownEnabled(true)
+                .setSplitTargetSize(DataSize.of(128, DataSize.Unit.MEGABYTE))
+                .setSplitMetadataTargetSize(DataSize.of(32, DataSize.Unit.MEGABYTE))
+                .setSplitPlanningLookback(10)
+                .setSplitOpenFileCost(DataSize.of(4, DataSize.Unit.MEGABYTE)));
     }
 
     @Test
@@ -60,6 +65,10 @@ public class TestIcebergConfig
                 .put("iceberg.dynamic-filtering.wait-timeout", "1h")
                 .put("iceberg.table-statistics-enabled", "false")
                 .put("iceberg.projection-pushdown-enabled", "false")
+                .put("iceberg.split-target-size", "1kB")
+                .put("iceberg.split-metadata-target-size", "2MB")
+                .put("iceberg.split-planning-lookback", "3")
+                .put("iceberg.split-open-file-cost", "3GB")
                 .buildOrThrow();
 
         IcebergConfig expected = new IcebergConfig()
@@ -71,7 +80,11 @@ public class TestIcebergConfig
                 .setCatalogType(GLUE)
                 .setDynamicFilteringWaitTimeout(Duration.valueOf("1h"))
                 .setTableStatisticsEnabled(false)
-                .setProjectionPushdownEnabled(false);
+                .setProjectionPushdownEnabled(false)
+                .setSplitTargetSize(DataSize.of(1, DataSize.Unit.KILOBYTE))
+                .setSplitMetadataTargetSize(DataSize.of(2, DataSize.Unit.MEGABYTE))
+                .setSplitPlanningLookback(3)
+                .setSplitOpenFileCost(DataSize.of(3, DataSize.Unit.GIGABYTE));
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

This PR will change Iceberg SPI interfaces, mainly effecting  on  reading/writing table metadata and planning splits.

> How would you describe this change to a non-technical end user or system administrator?

Users can dynamically override reading splits properties in table and session level for Iceberg connector.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Support overriding Iceberg splits planning properties. ({issue}`10874`)
```

Fixes https://github.com/trinodb/trino/issues/10874 