### PR TITLE
Disable cache sharing when cache is disabled in JDBC connectors

### DIFF
--- a/lib/trino-collect/src/main/java/io/trino/collect/cache/EmptyCache.java
+++ b/lib/trino-collect/src/main/java/io/trino/collect/cache/EmptyCache.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.collect.cache;
+
+import com.google.common.cache.AbstractLoadingCache;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.CacheStats;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+
+import javax.annotation.CheckForNull;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+
+import static java.util.Objects.requireNonNull;
+
+class EmptyCache<K, V>
+        extends AbstractLoadingCache<K, V>
+{
+    private final CacheLoader<? super K, V> loader;
+    private final StatsCounter statsCounter;
+
+    EmptyCache(CacheLoader<? super K, V> loader, boolean recordStats)
+    {
+        this.loader = requireNonNull(loader, "loader is null");
+        this.statsCounter = recordStats ? new SimpleStatsCounter() : new NoopStatsCounter();
+    }
+
+    @CheckForNull
+    @Override
+    public V getIfPresent(Object key)
+    {
+        statsCounter.recordMisses(1);
+        return null;
+    }
+
+    @Override
+    public V get(K key)
+            throws ExecutionException
+    {
+        return get(key, () -> loader.load(key));
+    }
+
+    @Override
+    public V get(K key, Callable<? extends V> valueLoader)
+            throws ExecutionException
+    {
+        statsCounter.recordMisses(1);
+        try {
+            V value = valueLoader.call();
+            statsCounter.recordLoadSuccess(1);
+            return value;
+        }
+        catch (RuntimeException e) {
+            statsCounter.recordLoadException(1);
+            throw new UncheckedExecutionException(e);
+        }
+        catch (Exception e) {
+            statsCounter.recordLoadException(1);
+            throw new ExecutionException(e);
+        }
+    }
+
+    @Override
+    public void put(K key, V value)
+    {
+        // Cache, even if configured to evict everything immediately, should allow writes.
+    }
+
+    @Override
+    public void refresh(K key) {}
+
+    @Override
+    public void invalidate(Object key) {}
+
+    @Override
+    public void invalidateAll(Iterable<?> keys) {}
+
+    @Override
+    public void invalidateAll() {}
+
+    @Override
+    public long size()
+    {
+        return 0;
+    }
+
+    @Override
+    public CacheStats stats()
+    {
+        return statsCounter.snapshot();
+    }
+
+    @Override
+    public ConcurrentMap<K, V> asMap()
+    {
+        return new ConcurrentMap<K, V>()
+        {
+            @Override
+            public V putIfAbsent(K key, V value)
+            {
+                // Cache, even if configured to evict everything immediately, should allow writes.
+                return value;
+            }
+
+            @Override
+            public boolean remove(Object key, Object value)
+            {
+                return false;
+            }
+
+            @Override
+            public boolean replace(K key, V oldValue, V newValue)
+            {
+                return false;
+            }
+
+            @Override
+            public V replace(K key, V value)
+            {
+                return null;
+            }
+
+            @Override
+            public int size()
+            {
+                return 0;
+            }
+
+            @Override
+            public boolean isEmpty()
+            {
+                return true;
+            }
+
+            @Override
+            public boolean containsKey(Object key)
+            {
+                return false;
+            }
+
+            @Override
+            public boolean containsValue(Object value)
+            {
+                return false;
+            }
+
+            @Override
+            public V get(Object key)
+            {
+                return null;
+            }
+
+            @Override
+            public V put(K key, V value)
+            {
+                // Cache, even if configured to evict everything immediately, should allow writes.
+                return null;
+            }
+
+            @Override
+            public V remove(Object key)
+            {
+                return null;
+            }
+
+            @Override
+            public void putAll(Map<? extends K, ? extends V> m)
+            {
+                // Cache, even if configured to evict everything immediately, should allow writes.
+            }
+
+            @Override
+            public void clear() {}
+
+            @Override
+            public Set<K> keySet()
+            {
+                return ImmutableSet.of();
+            }
+
+            @Override
+            public Collection<V> values()
+            {
+                return ImmutableSet.of();
+            }
+
+            @Override
+            public Set<Entry<K, V>> entrySet()
+            {
+                return ImmutableSet.of();
+            }
+        };
+    }
+
+    private static class NoopStatsCounter
+            implements StatsCounter
+    {
+        private static final CacheStats EMPTY_STATS = new SimpleStatsCounter().snapshot();
+
+        @Override
+        public void recordHits(int count) {}
+
+        @Override
+        public void recordMisses(int count) {}
+
+        @Override
+        public void recordLoadSuccess(long loadTime) {}
+
+        @Override
+        public void recordLoadException(long loadTime) {}
+
+        @Override
+        public void recordEviction() {}
+
+        @Override
+        public CacheStats snapshot()
+        {
+            return EMPTY_STATS;
+        }
+    }
+}

--- a/lib/trino-collect/src/test/java/io/trino/collect/cache/TestEmptyCache.java
+++ b/lib/trino-collect/src/test/java/io/trino/collect/cache/TestEmptyCache.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.collect.cache;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheLoader;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.util.concurrent.Executors.newFixedThreadPool;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestEmptyCache
+{
+    private static final int TEST_TIMEOUT_MILLIS = 10_000;
+
+    @Test(timeOut = TEST_TIMEOUT_MILLIS)
+    public void testLoadFailure()
+            throws Exception
+    {
+        Cache<Integer, String> cache = new EmptyCache<>(
+                CacheLoader.from(() -> {
+                    throw new UnsupportedOperationException();
+                }),
+                false);
+        int key = 10;
+
+        ExecutorService executor = newFixedThreadPool(2);
+        try {
+            AtomicBoolean first = new AtomicBoolean(true);
+            CyclicBarrier barrier = new CyclicBarrier(2);
+
+            List<Future<String>> futures = new ArrayList<>();
+            for (int i = 0; i < 2; i++) {
+                futures.add(executor.submit(() -> {
+                    barrier.await(10, SECONDS);
+                    return cache.get(key, () -> {
+                        if (first.compareAndSet(true, false)) {
+                            // first
+                            Thread.sleep(1); // increase chances that second thread calls cache.get before we return
+                            throw new RuntimeException("first attempt is poised to fail");
+                        }
+                        return "success";
+                    });
+                }));
+            }
+
+            List<String> results = new ArrayList<>();
+            for (Future<String> future : futures) {
+                try {
+                    results.add(future.get());
+                }
+                catch (ExecutionException e) {
+                    results.add(e.getCause().toString());
+                }
+            }
+
+            assertThat(results).containsExactlyInAnyOrder(
+                    "success",
+                    "com.google.common.util.concurrent.UncheckedExecutionException: java.lang.RuntimeException: first attempt is poised to fail");
+        }
+        finally {
+            executor.shutdownNow();
+            executor.awaitTermination(10, SECONDS);
+        }
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -111,6 +111,7 @@ public class CachingJdbcClient
 
         EvictableCacheBuilder<Object, Object> cacheBuilder = EvictableCacheBuilder.newBuilder()
                 .expireAfterWrite(metadataCachingTtl.toMillis(), MILLISECONDS)
+                .shareNothingWhenDisabled()
                 .recordStats();
 
         if (metadataCachingTtl.equals(CACHING_DISABLED)) {

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestCachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestCachingJdbcClient.java
@@ -42,8 +42,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.collect.cache.CacheStatsAssertions.assertCacheStats;
@@ -58,6 +61,7 @@ import static java.util.Collections.emptyList;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -619,6 +623,76 @@ public class TestCachingJdbcClient
         }
 
         futures.forEach(Futures::getUnchecked);
+    }
+
+    @Test(timeOut = 60_000)
+    public void testLoadFailureNotSharedWhenDisabled()
+            throws Exception
+    {
+        AtomicBoolean first = new AtomicBoolean(true);
+        CyclicBarrier barrier = new CyclicBarrier(2);
+
+        CachingJdbcClient cachingJdbcClient = new CachingJdbcClient(
+                new ForwardingJdbcClient()
+                {
+                    private final JdbcClient delegate = database.getJdbcClient();
+
+                    @Override
+                    protected JdbcClient delegate()
+                    {
+                        return delegate;
+                    }
+
+                    @Override
+                    public Optional<JdbcTableHandle> getTableHandle(ConnectorSession session, SchemaTableName schemaTableName)
+                    {
+                        if (first.compareAndSet(true, false)) {
+                            // first
+                            try {
+                                // increase chances that second thread calls cache.get before we return
+                                Thread.sleep(5);
+                            }
+                            catch (InterruptedException e1) {
+                                throw new RuntimeException(e1);
+                            }
+                            throw new RuntimeException("first attempt is poised to fail");
+                        }
+                        return super.getTableHandle(session, schemaTableName);
+                    }
+                },
+                SESSION_PROPERTIES_PROVIDERS,
+                new SingletonIdentityCacheMapping(),
+                // ttl is 0, cache is disabled
+                new Duration(0, DAYS),
+                true,
+                10);
+
+        SchemaTableName tableName = new SchemaTableName(schema, "test_load_failure_not_shared");
+        createTable(tableName);
+        ConnectorSession session = createSession("session");
+
+        List<Future<JdbcTableHandle>> futures = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            futures.add(executor.submit(() -> {
+                barrier.await(10, SECONDS);
+                return cachingJdbcClient.getTableHandle(session, tableName).orElseThrow();
+            }));
+        }
+
+        List<String> results = new ArrayList<>();
+        for (Future<JdbcTableHandle> future : futures) {
+            try {
+                results.add(future.get().toString());
+            }
+            catch (ExecutionException e) {
+                results.add(e.getCause().toString());
+            }
+        }
+
+        assertThat(results)
+                .containsExactlyInAnyOrder(
+                        "example.test_load_failure_not_shared " + database.getDatabaseName() + ".EXAMPLE.TEST_LOAD_FAILURE_NOT_SHARED",
+                        "com.google.common.util.concurrent.UncheckedExecutionException: java.lang.RuntimeException: first attempt is poised to fail");
     }
 
     private JdbcTableHandle getAnyTable(String schema)


### PR DESCRIPTION
This disables opportunistic sharing of results (and failures) between
threads when cache is disabled.

This fixes usages going through `EvictableCacheBuilder`. Other cache
usages are to be addressed later.

Relates to: https://github.com/trinodb/trino/issues/11067