### PR TITLE
Add redirection awareness for ADD COLUMN, COMMENT, DROP table tasks

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/AddColumnTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/AddColumnTask.java
@@ -19,6 +19,7 @@ import io.trino.connector.CatalogName;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.ColumnPropertyManager;
 import io.trino.metadata.QualifiedObjectName;
+import io.trino.metadata.RedirectionAwareTableHandle;
 import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
 import io.trino.spi.connector.ColumnHandle;
@@ -34,7 +35,6 @@ import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
@@ -81,20 +81,20 @@ public class AddColumnTask
             WarningCollector warningCollector)
     {
         Session session = stateMachine.getSession();
-        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getName());
-        Optional<TableHandle> tableHandle = plannerContext.getMetadata().getTableHandle(session, tableName);
-        if (tableHandle.isEmpty()) {
+        QualifiedObjectName originalTableName = createQualifiedObjectName(session, statement, statement.getName());
+        RedirectionAwareTableHandle redirectionAwareTableHandle = plannerContext.getMetadata().getRedirectionAwareTableHandle(session, originalTableName);
+        if (redirectionAwareTableHandle.getTableHandle().isEmpty()) {
             if (!statement.isTableExists()) {
-                throw semanticException(TABLE_NOT_FOUND, statement, "Table '%s' does not exist", tableName);
+                throw semanticException(TABLE_NOT_FOUND, statement, "Table '%s' does not exist", originalTableName);
             }
             return immediateVoidFuture();
         }
+        TableHandle tableHandle = redirectionAwareTableHandle.getTableHandle().get();
+        CatalogName catalogName = getRequiredCatalogHandle(plannerContext.getMetadata(), session, statement, tableHandle.getCatalogName().getCatalogName());
 
-        CatalogName catalogName = getRequiredCatalogHandle(plannerContext.getMetadata(), session, statement, tableName.getCatalogName());
+        accessControl.checkCanAddColumns(session.toSecurityContext(), redirectionAwareTableHandle.getRedirectedTableName().orElse(originalTableName));
 
-        accessControl.checkCanAddColumns(session.toSecurityContext(), tableName);
-
-        Map<String, ColumnHandle> columnHandles = plannerContext.getMetadata().getColumnHandles(session, tableHandle.get());
+        Map<String, ColumnHandle> columnHandles = plannerContext.getMetadata().getColumnHandles(session, tableHandle);
 
         ColumnDefinition element = statement.getColumn();
         Type type;
@@ -133,7 +133,7 @@ public class AddColumnTask
                 .setProperties(columnProperties)
                 .build();
 
-        plannerContext.getMetadata().addColumn(session, tableHandle.get(), column);
+        plannerContext.getMetadata().addColumn(session, tableHandle, column);
 
         return immediateVoidFuture();
     }

--- a/core/trino-main/src/main/java/io/trino/execution/DropTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropTableTask.java
@@ -18,7 +18,7 @@ import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedObjectName;
-import io.trino.metadata.TableHandle;
+import io.trino.metadata.RedirectionAwareTableHandle;
 import io.trino.security.AccessControl;
 import io.trino.sql.tree.DropTable;
 import io.trino.sql.tree.Expression;
@@ -26,7 +26,6 @@ import io.trino.sql.tree.Expression;
 import javax.inject.Inject;
 
 import java.util.List;
-import java.util.Optional;
 
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
@@ -61,39 +60,38 @@ public class DropTableTask
             WarningCollector warningCollector)
     {
         Session session = stateMachine.getSession();
-        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getTableName());
-
-        if (metadata.isMaterializedView(session, tableName)) {
+        QualifiedObjectName originalTableName = createQualifiedObjectName(session, statement, statement.getTableName());
+        if (metadata.isMaterializedView(session, originalTableName)) {
             if (!statement.isExists()) {
                 throw semanticException(
                         TABLE_NOT_FOUND,
                         statement,
-                        "Table '%s' does not exist, but a materialized view with that name exists. Did you mean DROP MATERIALIZED VIEW %s?", tableName, tableName);
+                        "Table '%s' does not exist, but a materialized view with that name exists. Did you mean DROP MATERIALIZED VIEW %s?", originalTableName, originalTableName);
             }
             return immediateVoidFuture();
         }
 
-        if (metadata.isView(session, tableName)) {
+        if (metadata.isView(session, originalTableName)) {
             if (!statement.isExists()) {
                 throw semanticException(
                         TABLE_NOT_FOUND,
                         statement,
-                        "Table '%s' does not exist, but a view with that name exists. Did you mean DROP VIEW %s?", tableName, tableName);
+                        "Table '%s' does not exist, but a view with that name exists. Did you mean DROP VIEW %s?", originalTableName, originalTableName);
             }
             return immediateVoidFuture();
         }
 
-        Optional<TableHandle> tableHandle = metadata.getTableHandle(session, tableName);
-        if (tableHandle.isEmpty()) {
+        RedirectionAwareTableHandle redirectionAwareTableHandle = metadata.getRedirectionAwareTableHandle(session, originalTableName);
+        if (redirectionAwareTableHandle.getTableHandle().isEmpty()) {
             if (!statement.isExists()) {
-                throw semanticException(TABLE_NOT_FOUND, statement, "Table '%s' does not exist", tableName);
+                throw semanticException(TABLE_NOT_FOUND, statement, "Table '%s' does not exist", originalTableName);
             }
             return immediateVoidFuture();
         }
-
+        QualifiedObjectName tableName = redirectionAwareTableHandle.getRedirectedTableName().orElse(originalTableName);
         accessControl.checkCanDropTable(session.toSecurityContext(), tableName);
 
-        metadata.dropTable(session, tableHandle.get());
+        metadata.dropTable(session, redirectionAwareTableHandle.getTableHandle().get());
 
         return immediateVoidFuture();
     }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveRedirectionToIceberg.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveRedirectionToIceberg.java
@@ -344,9 +344,32 @@ public class TestHiveRedirectionToIceberg
         assertTableComment("hive", "default", tableName).isNull();
         assertTableComment("iceberg", "default", tableName).isNull();
 
-        //TODO restore test assertions after adding redirection awareness to the CommentTask
-        assertQueryFailure(() -> onTrino().executeQuery("COMMENT ON TABLE " + hiveTableName + " IS 'This is my table, there are many like it but this one is mine'"))
-                .hasMessageMatching("\\QQuery failed (#\\E\\S+\\Q): Cannot query Iceberg table 'default." + tableName + "'");
+        String tableComment = "This is my table, there are many like it but this one is mine";
+        onTrino().executeQuery(format("COMMENT ON TABLE " + hiveTableName + " IS '%s'", tableComment));
+
+        assertTableComment("hive", "default", tableName).isEqualTo(tableComment);
+        assertTableComment("iceberg", "default", tableName).isEqualTo(tableComment);
+
+        onTrino().executeQuery("DROP TABLE " + icebergTableName);
+    }
+
+    @Test(groups = {HIVE_ICEBERG_REDIRECTIONS, PROFILE_SPECIFIC_TESTS})
+    public void testCommentColumn()
+    {
+        String tableName = "iceberg_comment_column_" + randomTableSuffix();
+        String hiveTableName = "hive.default." + tableName;
+        String icebergTableName = "iceberg.default." + tableName;
+        String columnName = "nationkey";
+        createIcebergTable(icebergTableName, false);
+
+        assertColumnComment("hive", "default", tableName, columnName).isNull();
+        assertColumnComment("iceberg", "default", tableName, columnName).isNull();
+
+        String columnComment = "Internal identifier for the nation";
+        onTrino().executeQuery(format("COMMENT ON COLUMN %s.%s IS '%s'", hiveTableName, columnName, columnComment));
+
+        assertColumnComment("hive", "default", tableName, columnName).isEqualTo(columnComment);
+        assertColumnComment("iceberg", "default", tableName, columnName).isEqualTo(columnComment);
 
         onTrino().executeQuery("DROP TABLE " + icebergTableName);
     }
@@ -466,6 +489,21 @@ public class TestHiveRedirectionToIceberg
                 param(VARCHAR, catalog),
                 param(VARCHAR, schema),
                 param(VARCHAR, tableName));
+    }
+
+    private static AbstractStringAssert<?> assertColumnComment(String catalog, String schema, String tableName, String columnName)
+    {
+        QueryResult queryResult = readColumnComment(catalog, schema, tableName, columnName);
+        return Assertions.assertThat((String) getOnlyElement(getOnlyElement(queryResult.rows())));
+    }
+
+    private static QueryResult readColumnComment(String catalog, String schema, String tableName, String columnName)
+    {
+        return onTrino().executeQuery(
+                format("SELECT comment FROM %s.information_schema.columns WHERE table_schema = ? AND table_name = ? AND column_name = ?", catalog),
+                param(VARCHAR, schema),
+                param(VARCHAR, tableName),
+                param(VARCHAR, columnName));
     }
 
     private static void assertResultsEqual(QueryResult first, QueryResult second)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveRedirectionToIceberg.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveRedirectionToIceberg.java
@@ -230,9 +230,9 @@ public class TestHiveRedirectionToIceberg
         String icebergTableName = "iceberg.default." + tableName;
 
         createIcebergTable(icebergTableName, false);
-        //TODO restore test assertions after adding redirection awareness to the DropTableTask
-        assertQueryFailure(() -> onTrino().executeQuery("DROP TABLE " + hiveTableName))
-                .hasMessageMatching("\\QQuery failed (#\\E\\S+\\Q): Cannot query Iceberg table 'default." + tableName + "'");
+        onTrino().executeQuery("DROP TABLE " + hiveTableName);
+        assertQueryFailure(() -> onTrino().executeQuery("TABLE " + icebergTableName))
+                .hasMessageMatching("\\QQuery failed (#\\E\\S+\\Q): line 1:1: Table '" + icebergTableName + "' does not exist");
     }
 
     @Test(groups = {HIVE_ICEBERG_REDIRECTIONS, PROFILE_SPECIFIC_TESTS})

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveRedirectionToIceberg.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveRedirectionToIceberg.java
@@ -321,10 +321,14 @@ public class TestHiveRedirectionToIceberg
 
         createIcebergTable(icebergTableName, false);
 
-        //TODO restore test assertions after adding redirection awareness to the AddColumnTask
-        assertQueryFailure(() -> onTrino().executeQuery("ALTER TABLE " + hiveTableName + " ADD COLUMN some_new_column double"))
-                .hasMessageMatching("\\QQuery failed (#\\E\\S+\\Q): Cannot query Iceberg table 'default." + tableName + "'");
+        onTrino().executeQuery("ALTER TABLE " + hiveTableName + " ADD COLUMN some_new_column double");
 
+        Assertions.assertThat(onTrino().executeQuery("DESCRIBE " + icebergTableName).column(1))
+                .containsOnly("nationkey", "name", "regionkey", "comment", "some_new_column");
+
+        assertResultsEqual(
+                onTrino().executeQuery("TABLE " + icebergTableName),
+                onTrino().executeQuery("SELECT * , NULL FROM tpch.tiny.nation"));
         onTrino().executeQuery("DROP TABLE " + icebergTableName);
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

Add redirection awareness for the following tasks:
- ALTER TABLE XXX ADD COLUMN
- COMMENT
- DROP TABLE

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

This is a fix.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

This is a core engine change affecting mainly hive/iceberg connectors.

> How would you describe this change to a non-technical end user or system administrator?

In the context of dealing with a shared Hive Metastore Service where tables of different types can co-exist in the metastore, it is helpful for the end-user to perform automatically table redirections when the user is in the context of a hive schema, but is referencing an iceberg table.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

This is a spin-off from the PR: https://github.com/trinodb/trino/pull/10577

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( x) Release notes entries required with the following suggested text:

```markdown
# Core
* Add redirection awareness for ADD COLUMN, DROP TABLE, COMMENT tasks.
```


Relates to https://github.com/trinodb/trino/issues/11202