### PR TITLE
Fix rendering of list in access control docs

### DIFF
--- a/docs/src/main/sphinx/security/file-system-access-control.rst
+++ b/docs/src/main/sphinx/security/file-system-access-control.rst
@@ -118,8 +118,8 @@ visible. Specifically:
   permissions on any nested table, or has permissions to set session properties
   in the catalog.
 * ``schema``: Visible if the user is the owner of the schema, or has permissions
-  on any nested table. * ``table``: Visible if the user has any permissions on
-  the table.
+  on any nested table.
+* ``table``: Visible if the user has any permissions on the table.
 
 Catalog rules
 ^^^^^^^^^^^^^
@@ -342,7 +342,8 @@ denied. System session property rules are composed of the following fields:
 * ``role`` (optional): regex to match against role names. Defaults to ``.*``.
 * ``group`` (optional): regex to match against group names. Defaults to ``.*``.
 * ``property`` (optional): regex to match against the property name. Defaults to
-  ``.*``. * ``allow`` (required): boolean indicating if the setting the session
+  ``.*``.
+* ``allow`` (required): boolean indicating if the setting the session
   property should be allowed.
 
 The catalog session property rules have the additional field:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Fixes bulleted list at https://trino.io/docs/current/security/file-system-access-control.html#visibility

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
