### PR TITLE
Remove redundant TupleDomain conversions

### DIFF
--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/CountQueryPageSource.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/CountQueryPageSource.java
@@ -42,7 +42,7 @@ class CountQueryPageSource
         long count = client.count(
                 split.getIndex(),
                 split.getShard(),
-                buildSearchQuery(table.getConstraint().transformKeys(ElasticsearchColumnHandle.class::cast), table.getQuery()));
+                buildSearchQuery(table.getConstraint(), table.getQuery()));
         readTimeNanos = System.nanoTime() - start;
 
         if (table.getLimit().isPresent()) {

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
@@ -504,7 +504,7 @@ public class ElasticsearchMetadata
             return Optional.empty();
         }
 
-        Map<ColumnHandle, Domain> supported = new HashMap<>();
+        Map<ElasticsearchColumnHandle, Domain> supported = new HashMap<>();
         Map<ColumnHandle, Domain> unsupported = new HashMap<>();
         if (constraint.getSummary().getDomains().isPresent()) {
             for (Map.Entry<ColumnHandle, Domain> entry : constraint.getSummary().getDomains().get().entrySet()) {
@@ -519,8 +519,8 @@ public class ElasticsearchMetadata
             }
         }
 
-        TupleDomain<ColumnHandle> oldDomain = handle.getConstraint();
-        TupleDomain<ColumnHandle> newDomain = oldDomain.intersect(TupleDomain.withColumnDomains(supported));
+        TupleDomain<ElasticsearchColumnHandle> oldDomain = handle.getConstraint();
+        TupleDomain<ElasticsearchColumnHandle> newDomain = oldDomain.intersect(TupleDomain.withColumnDomains(supported));
         if (oldDomain.equals(newDomain)) {
             return Optional.empty();
         }

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchTableHandle.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchTableHandle.java
@@ -15,7 +15,6 @@ package io.trino.plugin.elasticsearch;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.predicate.TupleDomain;
 
@@ -36,7 +35,7 @@ public final class ElasticsearchTableHandle
     private final Type type;
     private final String schema;
     private final String index;
-    private final TupleDomain<ColumnHandle> constraint;
+    private final TupleDomain<ElasticsearchColumnHandle> constraint;
     private final Optional<String> query;
     private final OptionalLong limit;
 
@@ -56,7 +55,7 @@ public final class ElasticsearchTableHandle
             @JsonProperty("type") Type type,
             @JsonProperty("schema") String schema,
             @JsonProperty("index") String index,
-            @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint,
+            @JsonProperty("constraint") TupleDomain<ElasticsearchColumnHandle> constraint,
             @JsonProperty("query") Optional<String> query,
             @JsonProperty("limit") OptionalLong limit)
     {
@@ -87,7 +86,7 @@ public final class ElasticsearchTableHandle
     }
 
     @JsonProperty
-    public TupleDomain<ColumnHandle> getConstraint()
+    public TupleDomain<ElasticsearchColumnHandle> getConstraint()
     {
         return constraint;
     }

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ScanQueryPageSource.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ScanQueryPageSource.java
@@ -111,7 +111,7 @@ public class ScanQueryPageSource
         SearchResponse searchResponse = client.beginSearch(
                 split.getIndex(),
                 split.getShard(),
-                buildSearchQuery(table.getConstraint().transformKeys(ElasticsearchColumnHandle.class::cast), table.getQuery()),
+                buildSearchQuery(table.getConstraint(), table.getQuery()),
                 needAllFields ? Optional.empty() : Optional.of(requiredFields),
                 documentFields,
                 sort,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
@@ -38,7 +38,6 @@ import io.trino.plugin.hive.util.InternalHiveSplitFactory;
 import io.trino.plugin.hive.util.ResumableTask;
 import io.trino.plugin.hive.util.ResumableTasks;
 import io.trino.spi.TrinoException;
-import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.predicate.TupleDomain;
@@ -147,7 +146,7 @@ public class BackgroundHiveSplitLoader
 
     private final Table table;
     private final AcidTransaction transaction;
-    private final TupleDomain<? extends ColumnHandle> compactEffectivePredicate;
+    private final TupleDomain<HiveColumnHandle> compactEffectivePredicate;
     private final DynamicFilter dynamicFilter;
     private final long dynamicFilteringWaitTimeoutMillis;
     private final TypeManager typeManager;
@@ -192,7 +191,7 @@ public class BackgroundHiveSplitLoader
             Table table,
             AcidTransaction transaction,
             Iterable<HivePartitionMetadata> partitions,
-            TupleDomain<? extends ColumnHandle> compactEffectivePredicate,
+            TupleDomain<HiveColumnHandle> compactEffectivePredicate,
             DynamicFilter dynamicFilter,
             Duration dynamicFilteringWaitTimeout,
             TypeManager typeManager,
@@ -371,7 +370,6 @@ public class BackgroundHiveSplitLoader
         String partitionName = hivePartition.getPartitionId();
         Properties schema = getPartitionSchema(table, partition.getPartition());
         List<HivePartitionKey> partitionKeys = getPartitionKeys(table, partition.getPartition());
-        TupleDomain<HiveColumnHandle> effectivePredicate = compactEffectivePredicate.transformKeys(HiveColumnHandle.class::cast);
 
         List<HiveColumnHandle> partitionColumns = getPartitionKeyColumnHandles(table, typeManager);
         BooleanSupplier partitionMatchSupplier =
@@ -412,7 +410,7 @@ public class BackgroundHiveSplitLoader
                         partitionName,
                         schema,
                         partitionKeys,
-                        effectivePredicate,
+                        compactEffectivePredicate,
                         partitionMatchSupplier,
                         s3SelectPushdownEnabled,
                         partition.getTableToPartitionMapping(),
@@ -429,7 +427,7 @@ public class BackgroundHiveSplitLoader
                     targetInputFormat,
                     schema,
                     partitionKeys,
-                    effectivePredicate,
+                    compactEffectivePredicate,
                     partitionMatchSupplier,
                     s3SelectPushdownEnabled,
                     partition.getTableToPartitionMapping(),
@@ -467,7 +465,7 @@ public class BackgroundHiveSplitLoader
                 inputFormat,
                 schema,
                 partitionKeys,
-                effectivePredicate,
+                compactEffectivePredicate,
                 partitionMatchSupplier,
                 partition.getTableToPartitionMapping(),
                 bucketConversionRequiresWorkerParticipation ? bucketConversion : Optional.empty(),


### PR DESCRIPTION
Remove redundant `TupleDomain.transformKeys` invocations used to change
`TupleDomain` type only.
