### PR TITLE
Flexible TupleDomain.intersect type

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/TupleDomain.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/TupleDomain.java
@@ -240,19 +240,19 @@ public final class TupleDomain<T>
      * The resulting TupleDomain represents the set of tuples that would be valid
      * in both TupleDomains.
      */
-    public TupleDomain<T> intersect(TupleDomain<T> other)
+    public <U extends T> TupleDomain<T> intersect(TupleDomain<U> other)
     {
         return intersect(List.of(this, other));
     }
 
-    public static <T> TupleDomain<T> intersect(List<TupleDomain<T>> domains)
+    public static <T> TupleDomain<T> intersect(List<? extends TupleDomain<? extends T>> domains)
     {
         if (domains.isEmpty()) {
             return all();
         }
 
         if (domains.size() == 1) {
-            return domains.get(0);
+            return upcast(domains.get(0));
         }
 
         if (domains.stream().anyMatch(TupleDomain::isNone)) {
@@ -260,10 +260,10 @@ public final class TupleDomain<T>
         }
 
         if (domains.stream().allMatch(domain -> domain.equals(domains.get(0)))) {
-            return domains.get(0);
+            return upcast(domains.get(0));
         }
 
-        List<TupleDomain<T>> candidates = domains.stream()
+        List<TupleDomain<? extends T>> candidates = domains.stream()
                 .filter(domain -> !domain.isAll())
                 .collect(toList());
 
@@ -272,12 +272,12 @@ public final class TupleDomain<T>
         }
 
         if (candidates.size() == 1) {
-            return candidates.get(0);
+            return upcast(candidates.get(0));
         }
 
         Map<T, Domain> intersected = new LinkedHashMap<>(candidates.get(0).getDomains().get());
         for (int i = 1; i < candidates.size(); i++) {
-            for (Map.Entry<T, Domain> entry : candidates.get(i).getDomains().get().entrySet()) {
+            for (Map.Entry<? extends T, Domain> entry : candidates.get(i).getDomains().get().entrySet()) {
                 Domain intersectionDomain = intersected.get(entry.getKey());
                 if (intersectionDomain == null) {
                     intersected.put(entry.getKey(), entry.getValue());
@@ -293,6 +293,13 @@ public final class TupleDomain<T>
         }
 
         return withColumnDomains(intersected);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <U, T extends U> TupleDomain<U> upcast(TupleDomain<T> domain)
+    {
+        // TupleDomain<T> is covariant with respect to T (because it's immutable), so it's a safe operation
+        return (TupleDomain<U>) domain;
     }
 
     @SafeVarargs

--- a/core/trino-spi/src/test/java/io/trino/spi/predicate/TestTupleDomain.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/predicate/TestTupleDomain.java
@@ -165,6 +165,21 @@ public class TestTupleDomain
     }
 
     @Test
+    public void testIntersectResultType()
+    {
+        TupleDomain<Number> numberDomain = TupleDomain.withColumnDomains(Map.of(10, Domain.singleValue(BIGINT, 42L)));
+        TupleDomain<Integer> integerDomain = TupleDomain.withColumnDomains(Map.of(10, Domain.multipleValues(BIGINT, List.of(41L, 42L, 42L))));
+        // Declare explicit variable to verify assignability from the derived type of TupleDomain.intersect
+        TupleDomain<Number> intersection = numberDomain.intersect(integerDomain);
+        assertEquals(intersection, numberDomain);
+        // Sadly, this cannot be made to work:
+        //   intersection = integerDomain.intersect(numberDomain)
+        // but this can:
+        intersection = TupleDomain.intersect(List.of(integerDomain, numberDomain));
+        assertEquals(intersection, numberDomain);
+    }
+
+    @Test
     public void testColumnWiseUnion()
     {
         TupleDomain<ColumnHandle> tupleDomain1 = TupleDomain.withColumnDomains(


### PR DESCRIPTION
Allow `TupleDomain.intersect` to operate on objects with different (but
related) key types.
