### PR TITLE
Fix expression predicate pushdown not firing before AddExchanges

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/DynamicFilters.java
+++ b/core/trino-main/src/main/java/io/trino/sql/DynamicFilters.java
@@ -362,7 +362,7 @@ public final class DynamicFilters
     {
         private Function() {}
 
-        private static final String NAME = "$internal$dynamic_filter_function";
+        public static final String NAME = "$internal$dynamic_filter_function";
 
         @TypeParameter("T")
         @SqlType(BOOLEAN)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/ConnectorExpressionTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ConnectorExpressionTranslator.java
@@ -33,6 +33,7 @@ import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeSignature;
 import io.trino.spi.type.VarcharType;
+import io.trino.sql.DynamicFilters;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.analyzer.TypeSignatureProvider;
 import io.trino.sql.tree.AstVisitor;
@@ -58,6 +59,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.slice.SliceUtf8.countCodePoints;
@@ -239,6 +241,7 @@ public final class ConnectorExpressionTranslator
             }
 
             String functionName = ResolvedFunction.extractFunctionName(node.getName());
+            checkArgument(!DynamicFilters.Function.NAME.equals(functionName), "Dynamic filter has no meaning for a connector, it should not be translated into ConnectorExpression");
 
             if (LiteralFunction.LITERAL_FUNCTION_NAME.equalsIgnoreCase(functionName)) {
                 Object value = evaluateConstant(node);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPredicateIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPredicateIntoTableScan.java
@@ -214,7 +214,10 @@ public class PushPredicateIntoTableScan
         }
 
         // check if new domain is wider than domain already provided by table scan
-        if (constraint.predicate().isEmpty() && newDomain.contains(node.getEnforcedConstraint())) {
+        if (constraint.predicate().isEmpty() &&
+                // TODO do we need to track enforced ConnectorExpression in TableScanNode?
+                TRUE.equals(connectorExpression.orElse(TRUE)) &&
+                newDomain.contains(node.getEnforcedConstraint())) {
             Expression resultingPredicate = createResultingPredicate(
                     plannerContext,
                     session,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveRedundantPredicateAboveTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveRedundantPredicateAboveTableScan.java
@@ -141,6 +141,7 @@ public class RemoveRedundantPredicateAboveTableScan
                 session,
                 context.getSymbolAllocator(),
                 typeAnalyzer,
+                TRUE_LITERAL, // Dynamic filters are included in decomposedPredicate.getRemainingExpression()
                 new DomainTranslator(plannerContext).toPredicate(session, unenforcedDomain.transformKeys(assignments::get)),
                 nonDeterministicPredicate,
                 decomposedPredicate.getRemainingExpression());

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
@@ -222,10 +222,8 @@ public abstract class BaseJdbcConnectorTest
         assertConditionallyPushedDown(
                 getSession(),
                 "SELECT regionkey, sum(nationkey) FROM nation WHERE name LIKE '%N%' GROUP BY regionkey",
-                false, // TODO: hasBehavior(SUPPORTS_PREDICATE_EXPRESSION_PUSHDOWN_WITH_LIKE), --  currently, applyAggregation is not invoked after applyFilter with expression
-                hasBehavior(SUPPORTS_PREDICATE_EXPRESSION_PUSHDOWN_WITH_LIKE)
-                        ? node(AggregationNode.class, node(TableScanNode.class))
-                        : node(FilterNode.class, node(TableScanNode.class)));
+                hasBehavior(SUPPORTS_PREDICATE_EXPRESSION_PUSHDOWN_WITH_LIKE),
+                node(FilterNode.class, node(TableScanNode.class)));
         // aggregation on varchar column
         assertThat(query("SELECT count(name) FROM nation")).isFullyPushedDown();
         // aggregation on varchar column with GROUPING

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraMetadata.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraMetadata.java
@@ -202,6 +202,10 @@ public class CassandraMetadata
     public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle tableHandle, Constraint constraint)
     {
         CassandraTableHandle handle = (CassandraTableHandle) tableHandle;
+        if (handle.getPartitions().isPresent() || !handle.getClusteringKeyPredicates().isEmpty()) {
+            // TODO support repeated applyFilter
+            return Optional.empty();
+        }
 
         CassandraPartitionResult partitionResult = partitionManager.getPartitions(handle, constraint.getSummary());
 
@@ -232,6 +236,7 @@ public class CassandraMetadata
                         handle.getSchemaName(),
                         handle.getTableName(),
                         Optional.of(partitionResult.getPartitions()),
+                        // TODO this should probably be AND-ed with handle.getClusteringKeyPredicates()
                         clusteringKeyPredicates),
                         unenforcedConstraint,
                         false));

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraPartitionManager.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraPartitionManager.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Predicates.in;
 import static com.google.common.base.Predicates.not;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -53,6 +54,9 @@ public class CassandraPartitionManager
 
     public CassandraPartitionResult getPartitions(CassandraTableHandle cassandraTableHandle, TupleDomain<ColumnHandle> tupleDomain)
     {
+        // TODO support repeated applyFilter
+        checkArgument(cassandraTableHandle.getPartitions().isEmpty(), "getPartitions() currently does not take into account table handle's partitions");
+
         CassandraTable table = cassandraSession.getTable(cassandraTableHandle.getSchemaTableName());
 
         // fetch the partitions

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraType.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraType.java
@@ -78,6 +78,7 @@ import static io.trino.spi.type.UuidType.trinoUuidToJavaUuid;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class CassandraType
@@ -681,5 +682,16 @@ public class CassandraType
     public int hashCode()
     {
         return Objects.hash(kind, trinoType, argumentTypes);
+    }
+
+    @Override
+    public String toString()
+    {
+        String string = format("%s(%s", kind, trinoType);
+        if (!argumentTypes.isEmpty()) {
+            string += "; " + argumentTypes;
+        }
+        string += ")";
+        return string;
     }
 }

--- a/testing/trino-server-dev/etc/catalog/cassandra.properties
+++ b/testing/trino-server-dev/etc/catalog/cassandra.properties
@@ -1,0 +1,4 @@
+connector.name=cassandra
+# Can be used with `bin/ptl env up --environment singlenode-cassandra --without-trino`
+cassandra.contact-points=localhost
+cassandra.allow-drop-table=true

--- a/testing/trino-server-dev/etc/config.properties
+++ b/testing/trino-server-dev/etc/config.properties
@@ -32,6 +32,7 @@ plugin.bundles=\
   ../../plugin/trino-password-authenticators/pom.xml, \
   ../../plugin/trino-iceberg/pom.xml,\
   ../../plugin/trino-blackhole/pom.xml,\
+  ../../plugin/trino-cassandra/pom.xml,\
   ../../plugin/trino-memory/pom.xml,\
   ../../plugin/trino-jmx/pom.xml,\
   ../../plugin/trino-raptor-legacy/pom.xml,\


### PR DESCRIPTION
Before the change, the pushdown of `ConnectorExpression` was fired only
when
- there was some other `TupleDomain` constraint to be pushed down, OR
- during `AddExchanges`, because functional predicate is created there.

This commit enables expression-based pushdown early, allowing further
pushdowns -- like aggregation or join pushdown -- to happen. These need
to happen before `AddExchanges`.

Extracted from  https://github.com/trinodb/trino/pull/11045
Relates to https://github.com/trinodb/trino/issues/18