### PR TITLE
Remove extraneous parens in single arg lambdas

### DIFF
--- a/client/trino-client/src/test/java/io/trino/client/auth/external/TestExternalAuthentication.java
+++ b/client/trino-client/src/test/java/io/trino/client/auth/external/TestExternalAuthentication.java
@@ -72,7 +72,7 @@ public class TestExternalAuthentication
     {
         RedirectHandler redirectHandler = new MockRedirectHandler();
 
-        TokenPoller poller = MockTokenPoller.onPoll((tokenUri) -> {
+        TokenPoller poller = MockTokenPoller.onPoll(tokenUri -> {
             sleepUninterruptibly(Duration.ofMillis(20));
             return TokenPollResult.pending(TOKEN_URI);
         });

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeAssignmentStats.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeAssignmentStats.java
@@ -47,7 +47,7 @@ public final class NodeAssignmentStats
 
         // pre-populate the assignment counts with zeros
         if (existingTasks.size() < nodeMapSize) {
-            Function<String, PendingSplitInfo> createEmptySplitInfo = (ignored) -> new PendingSplitInfo(PartitionedSplitsInfo.forZeroSplits(), 0);
+            Function<String, PendingSplitInfo> createEmptySplitInfo = ignored -> new PendingSplitInfo(PartitionedSplitsInfo.forZeroSplits(), 0);
             for (InternalNode node : nodeMap.getNodesByHostAndPort().values()) {
                 stageQueuedSplitInfo.computeIfAbsent(node.getNodeIdentifier(), createEmptySplitInfo);
             }

--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionResolver.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionResolver.java
@@ -281,7 +281,7 @@ public class FunctionResolver
     private List<ApplicableFunction> getUnknownOnlyCastFunctions(List<ApplicableFunction> applicableFunction, List<Type> actualParameters)
     {
         return applicableFunction.stream()
-                .filter((function) -> onlyCastsUnknown(function, actualParameters))
+                .filter(function -> onlyCastsUnknown(function, actualParameters))
                 .collect(toImmutableList());
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/DeduplicatingDirectExchangeBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DeduplicatingDirectExchangeBuffer.java
@@ -626,7 +626,7 @@ public class DeduplicatingDirectExchangeBuffer
 
             // Finish ExchangeSink and create ExchangeSource asynchronously to avoid blocking an ExchangeClient thread for potentially substantial amount of time
             ListenableFuture<ExchangeSource> exchangeSourceFuture = FluentFuture.from(toListenableFuture(exchangeSink.finish()))
-                    .transformAsync((ignored) -> {
+                    .transformAsync(ignored -> {
                         exchange.sinkFinished(sinkInstanceHandle);
                         synchronized (this) {
                             exchangeSink = null;

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/PageReference.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/PageReference.java
@@ -75,7 +75,7 @@ final class PageReference
         static PageReleasedListener forLocalExchangeMemoryManager(LocalExchangeMemoryManager memoryManager)
         {
             requireNonNull(memoryManager, "memoryManager is null");
-            return (releasedSizeInBytes) -> memoryManager.updateMemoryUsage(-releasedSizeInBytes);
+            return releasedSizeInBytes -> memoryManager.updateMemoryUsage(-releasedSizeInBytes);
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/PassthroughExchanger.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/PassthroughExchanger.java
@@ -34,7 +34,7 @@ public class PassthroughExchanger
         this.localExchangeSource = requireNonNull(localExchangeSource, "localExchangeSource is null");
         this.memoryTracker = requireNonNull(memoryTracker, "memoryTracker is null");
         bufferMemoryManager = new LocalExchangeMemoryManager(bufferMaxMemory);
-        onPageReleased = (releasedSizeInBytes) -> {
+        onPageReleased = releasedSizeInBytes -> {
             this.bufferMemoryManager.updateMemoryUsage(-releasedSizeInBytes);
             this.memoryTracker.accept(-releasedSizeInBytes);
         };

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -547,7 +547,7 @@ public class ExpressionAnalyzer
         protected Type visitRow(Row node, StackableAstVisitorContext<Context> context)
         {
             List<Type> types = node.getItems().stream()
-                    .map((child) -> process(child, context))
+                    .map(child -> process(child, context))
                     .collect(toImmutableList());
 
             Type type = RowType.anonymous(types);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
@@ -763,7 +763,7 @@ public final class DomainTranslator
             Type valueType = nullableValue.getType();
             Object value = nullableValue.getValue();
             return floorValue(valueType, symbolExpressionType, value)
-                    .map((floorValue) -> rewriteComparisonExpression(symbolExpressionType, symbolExpression, valueType, value, floorValue, comparisonOperator));
+                    .map(floorValue -> rewriteComparisonExpression(symbolExpressionType, symbolExpression, valueType, value, floorValue, comparisonOperator));
         }
 
         private Expression rewriteComparisonExpression(
@@ -833,7 +833,7 @@ public final class DomainTranslator
         private Optional<Object> floorValue(Type fromType, Type toType, Object value)
         {
             return getSaturatedFloorCastOperator(fromType, toType)
-                    .map((operator) -> functionInvoker.invoke(operator, session.toConnectorSession(), value));
+                    .map(operator -> functionInvoker.invoke(operator, session.toConnectorSession(), value));
         }
 
         private Optional<ResolvedFunction> getSaturatedFloorCastOperator(Type fromType, Type toType)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/CanonicalizeExpressionRewriter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/CanonicalizeExpressionRewriter.java
@@ -140,7 +140,7 @@ public final class CanonicalizeExpressionRewriter
             Expression condition = treeRewriter.rewrite(node.getCondition(), context);
             Expression trueValue = treeRewriter.rewrite(node.getTrueValue(), context);
 
-            Optional<Expression> falseValue = node.getFalseValue().map((value) -> treeRewriter.rewrite(value, context));
+            Optional<Expression> falseValue = node.getFalseValue().map(value -> treeRewriter.rewrite(value, context));
 
             return new SearchedCaseExpression(ImmutableList.of(new WhenClause(condition, trueValue)), falseValue);
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ReorderJoins.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ReorderJoins.java
@@ -228,7 +228,7 @@ public class ReorderJoins
                 memo.put(multiJoinKey, bestResult);
             }
 
-            bestResult.planNode.ifPresent((planNode) -> log.debug("Least cost join was: %s", planNode));
+            bestResult.planNode.ifPresent(planNode -> log.debug("Least cost join was: %s", planNode));
             return bestResult;
         }
 
@@ -446,7 +446,7 @@ public class ReorderJoins
 
         private List<JoinEnumerationResult> getPossibleJoinNodes(JoinNode joinNode, DistributionType distributionType)
         {
-            return getPossibleJoinNodes(joinNode, distributionType, (node) -> true);
+            return getPossibleJoinNodes(joinNode, distributionType, node -> true);
         }
 
         private List<JoinEnumerationResult> getPossibleJoinNodes(JoinNode joinNode, DistributionType distributionType, Predicate<JoinNode> isAllowed)

--- a/core/trino-main/src/main/java/io/trino/sql/relational/SqlToRowExpressionTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/relational/SqlToRowExpressionTranslator.java
@@ -577,7 +577,7 @@ public final class SqlToRowExpressionTranslator
 
              */
             RowExpression expression = node.getDefaultValue()
-                    .map((value) -> process(value, context))
+                    .map(value -> process(value, context))
                     .orElse(constantNull(getType(node)));
 
             for (WhenClause clause : Lists.reverse(node.getWhenClauses())) {

--- a/core/trino-main/src/main/java/io/trino/type/DecimalCasts.java
+++ b/core/trino-main/src/main/java/io/trino/type/DecimalCasts.java
@@ -105,7 +105,7 @@ public final class DecimalCasts
                 .choice(choice -> choice
                         .implementation(methodsGroup -> methodsGroup
                                 .methods(methodNames)
-                                .withExtraParameters((context) -> {
+                                .withExtraParameters(context -> {
                                     long precision = context.getLiteral("precision");
                                     long scale = context.getLiteral("scale");
                                     Object tenToScale;
@@ -140,7 +140,7 @@ public final class DecimalCasts
                         .returnConvention(nullableResult ? NULLABLE_RETURN : FAIL_ON_NULL)
                         .implementation(methodsGroup -> methodsGroup
                                 .methods(methodNames)
-                                .withExtraParameters((context) -> {
+                                .withExtraParameters(context -> {
                                     DecimalType resultType = (DecimalType) context.getReturnType();
                                     Object tenToScale;
                                     if (isShortDecimal(resultType)) {
@@ -163,7 +163,7 @@ public final class DecimalCasts
             .choice(choice -> choice
                     .implementation(methodsGroup -> methodsGroup
                             .methods("shortDecimalToVarchar", "longDecimalToVarchar")
-                            .withExtraParameters((context) -> {
+                            .withExtraParameters(context -> {
                                 long scale = context.getLiteral("scale");
                                 VarcharType resultType = (VarcharType) context.getReturnType();
                                 long length;

--- a/core/trino-main/src/main/java/io/trino/type/DecimalSaturatedFloorCasts.java
+++ b/core/trino-main/src/main/java/io/trino/type/DecimalSaturatedFloorCasts.java
@@ -49,7 +49,7 @@ public final class DecimalSaturatedFloorCasts
             .choice(choice -> choice
                     .implementation(methodsGroup -> methodsGroup
                             .methods("shortDecimalToShortDecimal", "shortDecimalToLongDecimal", "longDecimalToShortDecimal", "longDecimalToLongDecimal")
-                            .withExtraParameters((context) -> {
+                            .withExtraParameters(context -> {
                                 int sourcePrecision = toIntExact(context.getLiteral("source_precision"));
                                 int sourceScale = toIntExact(context.getLiteral("source_scale"));
                                 int resultPrecision = toIntExact(context.getLiteral("result_precision"));
@@ -120,7 +120,7 @@ public final class DecimalSaturatedFloorCasts
                 .choice(choice -> choice
                         .implementation(methodsGroup -> methodsGroup
                                 .methods("shortDecimalToGenericIntegerType", "longDecimalToGenericIntegerType")
-                                .withExtraParameters((context) -> {
+                                .withExtraParameters(context -> {
                                     int sourceScale = toIntExact(context.getLiteral("source_scale"));
                                     return ImmutableList.of(sourceScale, minValue, maxValue);
                                 })))
@@ -171,7 +171,7 @@ public final class DecimalSaturatedFloorCasts
                 .choice(choice -> choice
                         .implementation(methodsGroup -> methodsGroup
                                 .methods("genericIntegerTypeToShortDecimal", "genericIntegerTypeToLongDecimal")
-                                .withExtraParameters((context) -> {
+                                .withExtraParameters(context -> {
                                     int resultPrecision = toIntExact(context.getLiteral("result_precision"));
                                     int resultScale = toIntExact(context.getLiteral("result_scale"));
                                     return ImmutableList.of(resultPrecision, resultScale);

--- a/core/trino-main/src/main/java/io/trino/type/DecimalToDecimalCasts.java
+++ b/core/trino-main/src/main/java/io/trino/type/DecimalToDecimalCasts.java
@@ -40,7 +40,7 @@ public final class DecimalToDecimalCasts
             .choice(choice -> choice
                     .implementation(methodsGroup -> methodsGroup
                             .methods("shortToShortCast")
-                            .withExtraParameters((context) -> {
+                            .withExtraParameters(context -> {
                                 DecimalType argumentType = (DecimalType) context.getParameterTypes().get(0);
                                 DecimalType resultType = (DecimalType) context.getReturnType();
                                 long rescale = longTenToNth(Math.abs(resultType.getScale() - argumentType.getScale()));
@@ -51,7 +51,7 @@ public final class DecimalToDecimalCasts
                             }))
                     .implementation(methodsGroup -> methodsGroup
                             .methods("shortToLongCast", "longToShortCast", "longToLongCast")
-                            .withExtraParameters((context) -> {
+                            .withExtraParameters(context -> {
                                 DecimalType argumentType = (DecimalType) context.getParameterTypes().get(0);
                                 DecimalType resultType = (DecimalType) context.getReturnType();
                                 return ImmutableList.of(

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
@@ -328,7 +328,7 @@ public class MockConnectorFactory
         private ListRoleGrants roleGrants = defaultRoleAuthorizations();
         private Grants<String> schemaGrants = new AllowAllGrants<>();
         private Grants<SchemaTableName> tableGrants = new AllowAllGrants<>();
-        private Function<SchemaTableName, ViewExpression> rowFilter = (tableName) -> null;
+        private Function<SchemaTableName, ViewExpression> rowFilter = tableName -> null;
         private BiFunction<SchemaTableName, String, ViewExpression> columnMask = (tableName, columnName) -> null;
         private boolean allowMissingColumnsOnInsert;
 
@@ -603,7 +603,7 @@ public class MockConnectorFactory
 
         public static Function<ConnectorSession, List<String>> defaultListSchemaNames()
         {
-            return (session) -> ImmutableList.of();
+            return session -> ImmutableList.of();
         }
 
         public static ListRoleGrants defaultRoleAuthorizations()

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestStageTaskSourceFactory.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestStageTaskSourceFactory.java
@@ -408,7 +408,7 @@ public class TestStageTaskSourceFactory
                 partitionedExchangeSources,
                 replicatedExchangeSources,
                 splitBatchSize,
-                (getSplitsTime) -> {},
+                getSplitsTime -> {},
                 bucketToPartitionMap,
                 bucketNodeMap,
                 Optional.of(CATALOG));
@@ -625,7 +625,7 @@ public class TestStageTaskSourceFactory
                 new TestingSplitSource(CATALOG, splits),
                 replicatedSources,
                 splitBatchSize,
-                (getSplitsTime) -> {},
+                getSplitsTime -> {},
                 Optional.of(CATALOG),
                 minSplitsPerTask,
                 splitWeightPerTask,
@@ -676,7 +676,7 @@ public class TestStageTaskSourceFactory
 
     private static BucketNodeMap getTestingBucketNodeMap(int bucketCount)
     {
-        return new DynamicBucketNodeMap((split) -> {
+        return new DynamicBucketNodeMap(split -> {
             TestingConnectorSplit testingConnectorSplit = (TestingConnectorSplit) split.getConnectorSplit();
             return testingConnectorSplit.getBucket().getAsInt();
         }, bucketCount);

--- a/core/trino-main/src/test/java/io/trino/metadata/TestFunctionRegistry.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestFunctionRegistry.java
@@ -286,7 +286,7 @@ public class TestFunctionRegistry
     {
         ImmutableSet<String> literalParameters = ImmutableSet.of("p", "s", "p1", "s1", "p2", "s2", "p3", "s3");
         List<TypeSignature> argumentSignatures = arguments.stream()
-                .map((signature) -> parseTypeSignature(signature, literalParameters))
+                .map(signature -> parseTypeSignature(signature, literalParameters))
                 .collect(toImmutableList());
         return new SignatureBuilder()
                 .returnType(parseTypeSignature(returnType, literalParameters))

--- a/core/trino-main/src/test/java/io/trino/operator/TestHttpPageBufferClient.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestHttpPageBufferClient.java
@@ -366,7 +366,7 @@ public class TestHttpPageBufferClient
         TestingTicker ticker = new TestingTicker();
         AtomicReference<Duration> tickerIncrement = new AtomicReference<>(new Duration(0, TimeUnit.SECONDS));
 
-        TestingHttpClient.Processor processor = (input) -> {
+        TestingHttpClient.Processor processor = input -> {
             Duration delta = tickerIncrement.get();
             ticker.increment(delta.toMillis(), TimeUnit.MILLISECONDS);
             throw new RuntimeException("Foo");

--- a/core/trino-main/src/test/java/io/trino/server/TestDynamicFilterService.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestDynamicFilterService.java
@@ -664,7 +664,7 @@ public class TestDynamicFilterService
                 queryId,
                 0,
                 dynamicFilters,
-                (domains) -> domains.forEach((filter, domain) -> assertNull(consumerCollectedFilters.put(filter, domain))));
+                domains -> domains.forEach((filter, domain) -> assertNull(consumerCollectedFilters.put(filter, domain))));
         assertTrue(consumerCollectedFilters.isEmpty());
 
         dynamicFilterService.addTaskDynamicFilters(
@@ -686,7 +686,7 @@ public class TestDynamicFilterService
                 queryId,
                 0,
                 ImmutableSet.of(filterId1),
-                (domains) -> domains.forEach((filter, domain) -> assertNull(secondConsumerCollectedFilters.put(filter, domain))));
+                domains -> domains.forEach((filter, domain) -> assertNull(secondConsumerCollectedFilters.put(filter, domain))));
         assertEquals(secondConsumerCollectedFilters, ImmutableMap.of(filterId1, multipleValues(INTEGER, ImmutableList.of(1L, 3L))));
 
         // complete filterId2
@@ -722,7 +722,7 @@ public class TestDynamicFilterService
                 queryId,
                 0,
                 dynamicFilters,
-                (domains) -> {
+                domains -> {
                     callbackCount.getAndIncrement();
                     domains.forEach((filter, domain) -> assertNull(consumerCollectedFilters.put(filter, domain)));
                 });
@@ -756,7 +756,7 @@ public class TestDynamicFilterService
                 queryId,
                 0,
                 dynamicFilters,
-                (domains) -> {
+                domains -> {
                     secondCallbackCount.getAndIncrement();
                     domains.forEach((filter, domain) -> assertNull(secondConsumerCollectedFilters.put(filter, domain)));
                 });

--- a/core/trino-main/src/test/java/io/trino/server/security/TestHeaderAuthenticatorManager.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/TestHeaderAuthenticatorManager.java
@@ -97,7 +97,7 @@ public class TestHeaderAuthenticatorManager
         @Override
         public HeaderAuthenticator create(Map<String, String> config)
         {
-            return (headers) -> Optional.ofNullable(headers.getHeader(header))
+            return headers -> Optional.ofNullable(headers.getHeader(header))
                     .map(values -> new BasicPrincipal(values.get(0)))
                     .orElseThrow(() -> new AccessDeniedException("You shall not pass!"));
         }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneCountAggregationOverScalar.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneCountAggregationOverScalar.java
@@ -75,7 +75,7 @@ public class TestPruneCountAggregationOverScalar
                                 .globalGrouping()
                                 .step(AggregationNode.Step.SINGLE)
                                 .source(
-                                        p.aggregation((aggregationBuilder) -> aggregationBuilder
+                                        p.aggregation(aggregationBuilder -> aggregationBuilder
                                                 .source(p.tableScan(ImmutableList.of(), ImmutableMap.of()))
                                                 .globalGrouping()
                                                 .step(AggregationNode.Step.SINGLE)))))

--- a/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
@@ -148,7 +148,7 @@ public final class ExpressionFormatter
         protected String visitRow(Row node, Void context)
         {
             return "ROW (" + Joiner.on(", ").join(node.getItems().stream()
-                    .map((child) -> process(child, context))
+                    .map(child -> process(child, context))
                     .collect(toList())) + ")";
         }
 
@@ -613,7 +613,7 @@ public final class ExpressionFormatter
             }
 
             node.getDefaultValue()
-                    .ifPresent((value) -> parts.add("ELSE").add(process(value, context)));
+                    .ifPresent(value -> parts.add("ELSE").add(process(value, context)));
 
             parts.add("END");
 
@@ -633,7 +633,7 @@ public final class ExpressionFormatter
             }
 
             node.getDefaultValue()
-                    .ifPresent((value) -> parts.add("ELSE").add(process(value, context)));
+                    .ifPresent(value -> parts.add("ELSE").add(process(value, context)));
 
             parts.add("END");
 

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -1048,11 +1048,11 @@ public final class SqlFormatter
         {
             builder.append("SHOW FUNCTIONS");
 
-            node.getLikePattern().ifPresent((value) -> builder
+            node.getLikePattern().ifPresent(value -> builder
                     .append(" LIKE ")
                     .append(formatStringLiteral(value)));
 
-            node.getEscape().ifPresent((value) -> builder
+            node.getEscape().ifPresent(value -> builder
                     .append(" ESCAPE ")
                     .append(formatStringLiteral(value)));
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
@@ -622,20 +622,20 @@ public class TupleDomainParquetPredicate
         {
             switch (primitiveType.getPrimitiveTypeName()) {
                 case BOOLEAN:
-                    return (buffer) -> buffer.get(0) != 0;
+                    return buffer -> buffer.get(0) != 0;
                 case INT32:
-                    return (buffer) -> buffer.order(LITTLE_ENDIAN).getInt(0);
+                    return buffer -> buffer.order(LITTLE_ENDIAN).getInt(0);
                 case INT64:
-                    return (buffer) -> buffer.order(LITTLE_ENDIAN).getLong(0);
+                    return buffer -> buffer.order(LITTLE_ENDIAN).getLong(0);
                 case FLOAT:
-                    return (buffer) -> buffer.order(LITTLE_ENDIAN).getFloat(0);
+                    return buffer -> buffer.order(LITTLE_ENDIAN).getFloat(0);
                 case DOUBLE:
-                    return (buffer) -> buffer.order(LITTLE_ENDIAN).getDouble(0);
+                    return buffer -> buffer.order(LITTLE_ENDIAN).getDouble(0);
                 case FIXED_LEN_BYTE_ARRAY:
                 case BINARY:
                 case INT96:
                 default:
-                    return (buffer) -> Binary.fromReusedByteBuffer(buffer);
+                    return buffer -> Binary.fromReusedByteBuffer(buffer);
             }
         }
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -2545,7 +2545,7 @@ public class HiveMetadata
             // Do not create tuple domains for every partition at the same time!
             // There can be a huge number of partitions so use an iterable so
             // all domains do not need to be in memory at the same time.
-            Iterable<TupleDomain<ColumnHandle>> partitionDomains = Iterables.transform(partitions, (hivePartition) -> TupleDomain.fromFixedValues(hivePartition.getKeys()));
+            Iterable<TupleDomain<ColumnHandle>> partitionDomains = Iterables.transform(partitions, hivePartition -> TupleDomain.fromFixedValues(hivePartition.getKeys()));
             discretePredicates = Optional.of(new DiscretePredicates(partitionColumns, partitionDomains));
         }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitWeightProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitWeightProvider.java
@@ -21,6 +21,6 @@ public interface HiveSplitWeightProvider
 
     static HiveSplitWeightProvider uniformStandardWeightProvider()
     {
-        return (splitSizeInBytes) -> SplitWeight.standard();
+        return splitSizeInBytes -> SplitWeight.standard();
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/HiveSecurityModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/HiveSecurityModule.java
@@ -71,7 +71,7 @@ public class HiveSecurityModule
         @Override
         public void configure(Binder binder)
         {
-            binder.bind(AccessControlMetadataFactory.class).toInstance((metastore) -> new AccessControlMetadata() {});
+            binder.bind(AccessControlMetadataFactory.class).toInstance(metastore -> new AccessControlMetadata() {});
         }
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -845,7 +845,7 @@ public abstract class AbstractTestHive
                 ImmutableSet.of(
                         new PartitionsSystemTableProvider(partitionManager, TESTING_TYPE_MANAGER),
                         new PropertiesSystemTableProvider()),
-                (metastore) -> new NoneHiveMaterializedViewMetadata()
+                metastore -> new NoneHiveMaterializedViewMetadata()
                 {
                     @Override
                     public Optional<ConnectorMaterializedViewDefinition> getMaterializedView(ConnectorSession session, SchemaTableName viewName)

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotQueryClient.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotQueryClient.java
@@ -101,7 +101,7 @@ public class PinotQueryClient
         BrokerRequest offlineBrokerRequest = TableNameBuilder.isOfflineTableResource(tableName) ? brokerRequest : null;
         BrokerRequest realtimeBrokerRequest = TableNameBuilder.isRealtimeTableResource(tableName) ? brokerRequest : null;
         AsyncQueryResponse asyncQueryResponse =
-                doWithRetries(pinotRetryCount, (requestId) -> queryRouter.submitQuery(requestId, rawTableName, offlineBrokerRequest, offlineRoutingTable, realtimeBrokerRequest, realtimeRoutingTable, connectionTimeoutInMillis));
+                doWithRetries(pinotRetryCount, requestId -> queryRouter.submitQuery(requestId, rawTableName, offlineBrokerRequest, offlineRoutingTable, realtimeBrokerRequest, realtimeRoutingTable, connectionTimeoutInMillis));
         try {
             Map<ServerRoutingInstance, ServerResponse> response = asyncQueryResponse.getResponse();
             Map<ServerInstance, DataTable> dataTableMap = new HashMap<>();

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotClient.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotClient.java
@@ -35,7 +35,7 @@ public class TestPinotClient
     @Test
     public void testBrokersParsed()
     {
-        HttpClient httpClient = new TestingHttpClient((request) -> TestingResponse.mockResponse(HttpStatus.OK, MediaType.JSON_UTF_8, "{\n" +
+        HttpClient httpClient = new TestingHttpClient(request -> TestingResponse.mockResponse(HttpStatus.OK, MediaType.JSON_UTF_8, "{\n" +
                 "  \"tableName\": \"dummy\",\n" +
                 "  \"brokers\": [\n" +
                 "    {\n" +

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/metadata/DatabaseShardManager.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/metadata/DatabaseShardManager.java
@@ -294,7 +294,7 @@ public class DatabaseShardManager
 
         Map<String, Integer> nodeIds = toNodeIdMap(shards);
 
-        runCommit(transactionId, (handle) -> {
+        runCommit(transactionId, handle -> {
             externalBatchId.ifPresent(shardDaoSupplier.attach(handle)::insertExternalBatch);
             lockTable(handle, tableId);
             insertShardsAndIndex(tableId, columns, shards, nodeIds, handle);
@@ -311,7 +311,7 @@ public class DatabaseShardManager
     {
         Map<String, Integer> nodeIds = toNodeIdMap(newShards);
 
-        runCommit(transactionId, (handle) -> {
+        runCommit(transactionId, handle -> {
             lockTable(handle, tableId);
 
             if (updateTime.isEmpty() && handle.attach(MetadataDao.class).isMaintenanceBlockedLocked(tableId)) {

--- a/plugin/trino-tpch/src/test/java/io/trino/plugin/tpch/statistics/TableStatisticsRecorder.java
+++ b/plugin/trino-tpch/src/test/java/io/trino/plugin/tpch/statistics/TableStatisticsRecorder.java
@@ -59,7 +59,7 @@ class TableStatisticsRecorder
     private <E extends TpchEntity> Map<TpchColumn<E>, ColumnStatisticsRecorder> createStatisticsRecorders(List<TpchColumn<E>> columns)
     {
         return columns.stream()
-                .collect(toImmutableMap(identity(), (column) -> new ColumnStatisticsRecorder(column.getType())));
+                .collect(toImmutableMap(identity(), column -> new ColumnStatisticsRecorder(column.getType())));
     }
 
     private <E extends TpchEntity> Comparable<?> getTpchValue(E row, TpchColumn<E> column)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestTls.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestTls.java
@@ -59,7 +59,7 @@ public class TestTls
         assertThat(activeNodesUrls).hasSize(3);
 
         List<String> hosts = activeNodesUrls.stream()
-                .map((uri) -> URI.create(uri).getHost())
+                .map(uri -> URI.create(uri).getHost())
                 .collect(toList());
 
         for (String host : hosts) {
@@ -87,7 +87,7 @@ public class TestTls
                 .executeQuery("SELECT http_uri FROM system.runtime.nodes");
         return queryResult.rows()
                 .stream()
-                .map((row) -> row.get(0).toString())
+                .map(row -> row.get(0).toString())
                 .collect(toList());
     }
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestCsv.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestCsv.java
@@ -166,7 +166,7 @@ public class TestCsv
     {
         QueryResult expected = onTrino().executeQuery(format(query, "tpch.tiny.nation"));
         List<Row> expectedRows = expected.rows().stream()
-                .map((columns) -> row(columns.toArray()))
+                .map(columns -> row(columns.toArray()))
                 .collect(toImmutableList());
         QueryResult actual = onTrino().executeQuery(format(query, tableName));
         assertThat(actual)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveStorageFormats.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveStorageFormats.java
@@ -949,7 +949,7 @@ public class TestHiveStorageFormats
     {
         QueryResult expected = onTrino().executeQuery(format(query, "tpch." + TPCH_SCHEMA + ".lineitem"));
         List<Row> expectedRows = expected.rows().stream()
-                .map((columns) -> row(columns.toArray()))
+                .map(columns -> row(columns.toArray()))
                 .collect(toImmutableList());
         QueryResult actual = onTrino().executeQuery(format(query, tableName));
         assertThat(actual)

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestJoinQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestJoinQueries.java
@@ -893,7 +893,7 @@ public abstract class AbstractTestJoinQueries
                 condition);
 
         queryTemplate.replaceAll(
-                (query) -> assertQueryFails(query, "line .*: Reference to column 'x' from outer scope not allowed in this context"),
+                query -> assertQueryFails(query, "line .*: Reference to column 'x' from outer scope not allowed in this context"),
                 ImmutableList.of(type.of("left"), type.of("right"), type.of("full")),
                 ImmutableList.of(
                         condition.of("EXISTS(SELECT 1 WHERE x = y)"),

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseFailureRecoveryTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseFailureRecoveryTest.java
@@ -748,17 +748,17 @@ public abstract class BaseFailureRecoveryTest
 
     protected static Function<MaterializedResult, Integer> rootStage()
     {
-        return (result) -> parseInt(getRootStage(result).getStageId());
+        return result -> parseInt(getRootStage(result).getStageId());
     }
 
     protected static Function<MaterializedResult, Integer> boundaryCoordinatorStage()
     {
-        return (result) -> findStageId(result, stage -> stage.isCoordinatorOnly() && stage.getSubStages().stream().noneMatch(StageStats::isCoordinatorOnly));
+        return result -> findStageId(result, stage -> stage.isCoordinatorOnly() && stage.getSubStages().stream().noneMatch(StageStats::isCoordinatorOnly));
     }
 
     protected static Function<MaterializedResult, Integer> boundaryDistributedStage()
     {
-        return (result) -> {
+        return result -> {
             StageStats rootStage = getRootStage(result);
             if (!rootStage.isCoordinatorOnly()) {
                 return parseInt(rootStage.getStageId());
@@ -772,12 +772,12 @@ public abstract class BaseFailureRecoveryTest
 
     protected static Function<MaterializedResult, Integer> intermediateDistributedStage()
     {
-        return (result) -> findStageId(result, stage -> !stage.isCoordinatorOnly() && !stage.getSubStages().isEmpty());
+        return result -> findStageId(result, stage -> !stage.isCoordinatorOnly() && !stage.getSubStages().isEmpty());
     }
 
     protected static Function<MaterializedResult, Integer> leafStage()
     {
-        return (result) -> findStageId(result, stage -> stage.getSubStages().isEmpty());
+        return result -> findStageId(result, stage -> stage.getSubStages().isEmpty());
     }
 
     private static int findStageId(MaterializedResult result, Predicate<StageStats> predicate)


### PR DESCRIPTION
## Description

Remove extraneous parens in single arg lambdas

> Is this change a fix, improvement, new feature, refactoring, or other?

syntactic cleanup

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

varia

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:
