### PR TITLE
Fix race condition in DirectExchangeClient

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/DirectExchangeClient.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DirectExchangeClient.java
@@ -41,7 +41,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Sets.newConcurrentHashSet;
@@ -77,8 +76,8 @@ public class DirectExchangeClient
     private long successfulRequests;
     @GuardedBy("this")
     private long averageBytesPerRequest;
-
-    private final AtomicBoolean closed = new AtomicBoolean();
+    @GuardedBy("this")
+    private boolean closed;
 
     private final LocalMemoryContext memoryContext;
     private final Executor pageBufferClientCallbackExecutor;
@@ -144,7 +143,7 @@ public class DirectExchangeClient
 
         // Ignore new locations after close
         // NOTE: this MUST happen before checking no more locations is checked
-        if (closed.get()) {
+        if (closed) {
             return;
         }
 
@@ -212,19 +211,22 @@ public class DirectExchangeClient
     {
         assertNotHoldsLock();
 
-        if (closed.get()) {
-            return null;
-        }
-
         Slice page = buffer.pollPage();
 
         if (page == null) {
             return null;
         }
 
-        memoryContext.setBytes(buffer.getRetainedSizeInBytes());
-        scheduleRequestIfNecessary();
+        synchronized (this) {
+            if (!closed) {
+                memoryContext.setBytes(buffer.getRetainedSizeInBytes());
+                scheduleRequestIfNecessary();
+            }
+        }
 
+        // Return the page even if the client is closed.
+        // A concurrent thread may have responded to the `isFinished` change
+        // triggered by polling this page and may have closed the client.
         return page;
     }
 
@@ -236,9 +238,10 @@ public class DirectExchangeClient
     @Override
     public synchronized void close()
     {
-        if (!closed.compareAndSet(false, true)) {
+        if (closed) {
             return;
         }
+        closed = true;
 
         for (HttpPageBufferClient client : allClients.values()) {
             closeQuietly(client);
@@ -291,23 +294,23 @@ public class DirectExchangeClient
         checkState(!completedClients.contains(client), "client is already marked as completed");
         // Compute stats before acquiring the lock
         long responseSize = 0;
-        for (Slice page : pages) {
-            responseSize += page.length();
+        if (!pages.isEmpty()) {
+            for (Slice page : pages) {
+                responseSize += page.length();
+            }
+            // Buffer may already be closed at this point. In such situation the buffer is expected to simply ignore this call.
+            buffer.addPages(client.getRemoteTaskId(), pages);
         }
 
         synchronized (this) {
-            if (closed.get() || buffer.isFinished() || buffer.isFailed()) {
+            if (closed || buffer.isFinished() || buffer.isFailed()) {
                 return false;
             }
 
             successfulRequests++;
             // AVG_n = AVG_(n-1) * (n-1)/n + VALUE_n / n
             averageBytesPerRequest = (long) (1.0 * averageBytesPerRequest * (successfulRequests - 1) / successfulRequests + responseSize / successfulRequests);
-        }
 
-        // add pages outside of the lock
-        if (!pages.isEmpty()) {
-            buffer.addPages(client.getRemoteTaskId(), pages);
             memoryContext.setBytes(buffer.getRetainedSizeInBytes());
         }
 


### PR DESCRIPTION


## Description

A race condition can occur when the client is closed while still being
active (e.g.: early termination due to LIMIT). It may happen that the
memory context is updated after close and then never set back to 0.

> Is this change a fix, improvement, new feature, refactoring, or other?

Bug

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core

> How would you describe this change to a non-technical end user or system administrator?

Users may see queries retaining memory after completion

## Related issues, pull requests, and links

https://github.com/trinodb/trino/issues/11030

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Trino Core
* Fix problem when memory wasn't always released after query completion
```
