### PR TITLE
Make close on streaming S3 OutputStream idempotent

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/TrinoS3FileSystem.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/TrinoS3FileSystem.java
@@ -1481,6 +1481,7 @@ public class TrinoS3FileSystem
         private byte[] buffer;
         private int bufferSize;
 
+        private boolean closed;
         private boolean failed;
         // Mutated and read by main thread; mutated just before scheduling upload to background thread (access does not need to be thread safe)
         private boolean multipartUploadStarted;
@@ -1548,6 +1549,11 @@ public class TrinoS3FileSystem
         public void close()
                 throws IOException
         {
+            if (closed) {
+                return;
+            }
+            closed = true;
+
             if (failed) {
                 try {
                     abortUpload();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Make close on streaming S3 OutputStream idempotent.
Apparently it sometimes get called more than once.

Relevant slack conversation https://trinodb.slack.com/archives/CGB0QHWSW/p1645032231001719

> Is this change a fix, improvement, new feature, refactoring, or other?

fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Hive, Iceberg connector

## Related issues, pull requests, and links

We still need https://github.com/trinodb/trino/issues/10797 for test coverage. (cc: @linzebing )

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Hive, Iceberg
* Fix potential query failures for queries writing data to tables backed by S3. ({issue}`11089`)
```
