### PR TITLE
Allow reading Zstandard compressed Avro files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -595,7 +595,7 @@
             <dependency>
                 <groupId>io.trino.hive</groupId>
                 <artifactId>hive-apache</artifactId>
-                <version>3.1.2-17</version>
+                <version>3.1.2-18</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -607,7 +607,7 @@
             <dependency>
                 <groupId>io.trino.orc</groupId>
                 <artifactId>orc-protobuf</artifactId>
-                <version>11</version>
+                <version>13</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Related issues, pull requests, and links

* See stack trace in https://github.com/trinodb/trino-hive-apache/pull/39

## Documentation

(x) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# Hive connector
* Allow reading Zstandard compressed Avro files. ({issue}`this`)
```
