### PR TITLE
Released memory retained by ExchangeSource

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/DeduplicatingDirectExchangeBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DeduplicatingDirectExchangeBuffer.java
@@ -760,7 +760,7 @@ public class DeduplicatingDirectExchangeBuffer
     {
         private final Set<TaskId> selectedTasks;
         private final QueryId queryId;
-        private final ListenableFuture<ExchangeSource> exchangeSourceFuture;
+        private ListenableFuture<ExchangeSource> exchangeSourceFuture;
 
         private ExchangeSource exchangeSource;
         private boolean finished;
@@ -848,6 +848,7 @@ public class DeduplicatingDirectExchangeBuffer
                 return;
             }
             finished = true;
+            exchangeSource = null;
             addCallback(exchangeSourceFuture, new FutureCallback<>()
             {
                 @Override
@@ -868,6 +869,7 @@ public class DeduplicatingDirectExchangeBuffer
                     // It a failure occurred it is expected to be propagated by the getNext method
                 }
             }, directExecutor());
+            exchangeSourceFuture = null;
         }
     }
 }


### PR DESCRIPTION
## Description

Avoid retaining memory used by ExchangeSource more than necessary

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core engine

> How would you describe this change to a non-technical end user or system administrator?

Non user visible improvement

## Related issues, pull requests, and links

-

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:
