### PR TITLE
Disable ganglia metrics reporter for rubix

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/rubix/RubixInitializer.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/rubix/RubixInitializer.java
@@ -19,6 +19,7 @@ import com.google.common.io.Closer;
 import com.qubole.rubix.bookkeeper.BookKeeper;
 import com.qubole.rubix.bookkeeper.BookKeeperServer;
 import com.qubole.rubix.bookkeeper.LocalDataTransferServer;
+import com.qubole.rubix.common.metrics.MetricsReporterType;
 import com.qubole.rubix.core.CachingFileSystem;
 import com.qubole.rubix.prestosql.CachingPrestoAdlFileSystem;
 import com.qubole.rubix.prestosql.CachingPrestoAzureBlobFileSystem;
@@ -58,6 +59,7 @@ import static com.qubole.rubix.spi.CacheConfig.setCoordinatorHostName;
 import static com.qubole.rubix.spi.CacheConfig.setDataTransferServerPort;
 import static com.qubole.rubix.spi.CacheConfig.setEmbeddedMode;
 import static com.qubole.rubix.spi.CacheConfig.setIsParallelWarmupEnabled;
+import static com.qubole.rubix.spi.CacheConfig.setMetricsReporters;
 import static com.qubole.rubix.spi.CacheConfig.setOnMaster;
 import static com.qubole.rubix.spi.CacheConfig.setPrestoClusterManager;
 import static io.trino.plugin.hive.DynamicConfigurationProvider.setCacheKey;
@@ -299,6 +301,7 @@ public class RubixInitializer
         setCacheDataFullnessPercentage(config, diskUsagePercentage);
         setBookKeeperServerPort(config, bookKeeperServerPort);
         setDataTransferServerPort(config, dataTransferServerPort);
+        setMetricsReporters(config, MetricsReporterType.JMX.name());
 
         setEmbeddedMode(config, true);
         enableHeartbeat(config, false);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
Ganglia metrics reporting does not work with the
custom hostnames generated by Trino. Disabling it
to avoid generating failures in logs.

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Hive cache

> How would you describe this change to a non-technical end user or system administrator?

Avoids cluttering logs with failures about ganglia metrics

## Related issues, pull requests, and links
https://trinodb.slack.com/archives/CGB0QHWSW/p1645125466118919

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
