### PR TITLE
Fix Iceberg dereference pushdown when column has a comment

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1103,6 +1103,9 @@ public class IcebergMetadata
 
     private static IcebergColumnHandle createProjectedColumnHandle(IcebergColumnHandle column, List<Integer> indices, io.trino.spi.type.Type projectedColumnType)
     {
+        if (indices.isEmpty()) {
+            return column;
+        }
         ImmutableList.Builder<Integer> fullPath = ImmutableList.builder();
         fullPath.addAll(column.getPath());
 


### PR DESCRIPTION
When Query iceberg table with predicate column including comments, and deference pushdown enabled. Exception occurred if the predicates containing both nested column and non_nested, for example
`select count(*) from table where col1 = 1 and col2.n1 = 3`
will show exception like
```
Caused by: java.lang.IllegalArgumentException: Multiple entries with same key: .... 
at com.google.common.collect.ImmutableMap.conflictException(ImmutableMap.java:376) 
at com.google.common.collect.ImmutableMap.checkNoConflict(ImmutableMap.java:370) 
at com.google.common.collect.RegularImmutableMap.checkNoConflictInKeyBucket(RegularImmutableMap.java:153) 
at com.google.common.collect.RegularImmutableMap.fromEntryArray(RegularImmutableMap.java:115) 
at com.google.common.collect.ImmutableMap$Builder.buildOrThrow(ImmutableMap.java:574) 
at io.trino.plugin.iceberg.IcebergPageSourceProvider.getParquetTupleDomain(IcebergPageSourceProvider.java:834) 
at io.trino.plugin.iceberg.IcebergPageSourceProvider.createParquetPageSource(IcebergPageSourceProvider.java:646)
```
Also refer the testing cases.