### PR TITLE
Document predicate pushdown per types in BigQuery

### DIFF
--- a/docs/src/main/sphinx/connector/bigquery.rst
+++ b/docs/src/main/sphinx/connector/bigquery.rst
@@ -138,24 +138,24 @@ Data types
 With a few exceptions, all BigQuery types are mapped directly to their Trino
 counterparts. Here are all the mappings:
 
-============== =============================== =============================================================================================================
-BigQuery       Trino                           Notes
-============== =============================== =============================================================================================================
-``ARRAY``      ``ARRAY``
-``BOOLEAN``    ``BOOLEAN``
-``BYTES``      ``VARBINARY``
-``DATE``       ``DATE``
-``DATETIME``   ``TIMESTAMP(6)``
-``FLOAT``      ``DOUBLE``
-``GEOGRAPHY``  ``VARCHAR``                     In `Well-known text (WKT) <https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry>`_ format
-``INTEGER``    ``BIGINT``
-``NUMERIC``    ``DECIMAL(P,S)``                Defaults to ``38`` as precision and ``9`` as scale
-``BIGNUMERIC`` ``DECIMAL(P,S)``                Precision > 38 is not supported. Note that the default precision and scale of BIGNUMERIC is ``(77, 38)``.
-``RECORD``     ``ROW``
-``STRING``     ``VARCHAR``
-``TIME``       ``TIME(6)``
-``TIMESTAMP``  ``TIMESTAMP(6) WITH TIME ZONE`` Time zone is UTC
-============== =============================== =============================================================================================================
+============== =============================== =================== =============================================================================================================
+BigQuery       Trino                           Predicate pushdown   Notes
+============== =============================== =================== =============================================================================================================
+``ARRAY``      ``ARRAY``                       No
+``BOOLEAN``    ``BOOLEAN``                     Yes
+``BYTES``      ``VARBINARY``                   Yes
+``DATE``       ``DATE``                        Yes
+``DATETIME``   ``TIMESTAMP(6)``                Yes
+``FLOAT``      ``DOUBLE``                      Yes
+``GEOGRAPHY``  ``VARCHAR``                     No                  In `Well-known text (WKT) <https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry>`_ format
+``INTEGER``    ``BIGINT``                      Yes
+``NUMERIC``    ``DECIMAL(P,S)``                Yes                 Defaults to ``38`` as precision and ``9`` as scale
+``BIGNUMERIC`` ``DECIMAL(P,S)``                Yes                 Precision > 38 is not supported. Note that the default precision and scale of BIGNUMERIC is ``(77, 38)``.
+``RECORD``     ``ROW``                         No
+``STRING``     ``VARCHAR``                     Yes
+``TIME``       ``TIME(6)``                     Yes
+``TIMESTAMP``  ``TIMESTAMP(6) WITH TIME ZONE`` Yes                 Time zone is UTC
+============== =============================== =================== =============================================================================================================
 
 System tables
 -------------


### PR DESCRIPTION
## Description

Document predicate pushdown per types in BigQuery

## Documentation

(x) Sufficient documentation is included in this PR.

## Release notes

(x) No release notes entries required.
