### PR TITLE
Migrate to BaseConnectorTest in BigQuery

### DIFF
--- a/plugin/trino-bigquery/pom.xml
+++ b/plugin/trino-bigquery/pom.xml
@@ -351,7 +351,7 @@
                         <configuration>
                             <excludes>
                                 <!-- If you are adding entry here also add an entry to cloud-tests or cloud-tests-case-insensitive-mapping profile below -->
-                                <exclude>**/TestBigQueryIntegrationSmokeTest.java</exclude>
+                                <exclude>**/TestBigQueryConnectorTest.java</exclude>
                                 <exclude>**/TestBigQueryTypeMapping.java</exclude>
                                 <exclude>**/TestBigQueryMetadata.java</exclude>
                                 <exclude>**/TestBigQueryInstanceCleaner.java</exclude>
@@ -375,7 +375,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <includes>
-                                <include>**/TestBigQueryIntegrationSmokeTest.java</include>
+                                <include>**/TestBigQueryConnectorTest.java</include>
                                 <include>**/TestBigQueryTypeMapping.java</include>
                                 <include>**/TestBigQueryMetadata.java</include>
                                 <include>**/TestBigQueryInstanceCleaner.java</include>

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConnectorTest.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
-public class TestBigQueryIntegrationSmokeTest
+public class TestBigQueryConnectorTest
         // TODO extend BaseConnectorTest
         extends AbstractTestIntegrationSmokeTest
 {

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/AbstractKuduConnectorTest.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/AbstractKuduConnectorTest.java
@@ -432,6 +432,19 @@ public abstract class AbstractKuduConnectorTest
         throw new SkipException("Kudu connector does not support column default values");
     }
 
+    @Override
+    protected String tableDefinitionForQueryLoggingCount()
+    {
+        return "( " +
+                " foo_1 int WITH (primary_key=true), " +
+                " foo_2_4 int " +
+                ") " +
+                "WITH ( " +
+                " partition_by_hash_columns = ARRAY['foo_1'], " +
+                " partition_by_hash_buckets = 2 " +
+                ")";
+    }
+
     private void assertTableProperty(String tableProperties, String key, String regexValue)
     {
         assertTrue(Pattern.compile(key + "\\s*=\\s*" + regexValue + ",?\\s+").matcher(tableProperties).find(),

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/AbstractKuduConnectorTest.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/AbstractKuduConnectorTest.java
@@ -189,17 +189,8 @@ public abstract class AbstractKuduConnectorTest
         assertUpdate("DROP TABLE test_row_delete");
     }
 
-    @Test(dataProvider = "testColumnNameDataProvider")
     @Override
-    public void testColumnName(String columnName)
-    {
-        if (!requiresDelimiting(columnName)) {
-            testColumnName(columnName, false);
-        }
-        testColumnName(columnName, true);
-    }
-
-    private void testColumnName(String columnName, boolean delimited)
+    protected void testColumnName(String columnName, boolean delimited)
     {
         String nameInSql = columnName;
         if (delimited) {

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestDistributedQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestDistributedQueries.java
@@ -1206,7 +1206,7 @@ public abstract class AbstractTestDistributedQueries
         testColumnName(columnName, true);
     }
 
-    private void testColumnName(String columnName, boolean delimited)
+    protected void testColumnName(String columnName, boolean delimited)
     {
         String nameInSql = columnName;
         if (delimited) {

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestDistributedQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestDistributedQueries.java
@@ -771,7 +771,7 @@ public abstract class AbstractTestDistributedQueries
     protected void skipTestUnlessSupportsDeletes()
     {
         skipTestUnless(supportsCreateTable());
-        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_supports_delete", "(col varchar(1))", ImmutableList.of("'a'", "'A'"))) {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_supports_delete", "(col varchar(1))")) {
             if (!supportsDelete()) {
                 assertQueryFails("DELETE FROM " + table.getName(), "This connector does not support deletes");
                 throw new SkipException("This connector does not support deletes");

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestDistributedQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestDistributedQueries.java
@@ -1035,8 +1035,8 @@ public abstract class AbstractTestDistributedQueries
             long beforeCompletedQueriesCount = waitUntilStable(() -> dispatchManager.getStats().getCompletedQueries().getTotalCount(), new Duration(5, SECONDS));
             long beforeSubmittedQueriesCount = dispatchManager.getStats().getSubmittedQueries().getTotalCount();
             String tableName = "test_logging_count" + randomTableSuffix();
-            assertUpdate("CREATE TABLE " + tableName + " AS SELECT 1 foo_1, 2 foo_2_4", 1);
-            assertQuery("SELECT foo_1, foo_2_4 FROM " + tableName, "SELECT 1, 2");
+            assertUpdate("CREATE TABLE " + tableName + tableDefinitionForQueryLoggingCount());
+            assertQueryReturnsEmptyResult("SELECT foo_1, foo_2_4 FROM " + tableName);
             assertUpdate("DROP TABLE " + tableName);
             assertQueryFails("SELECT * FROM " + tableName, ".*Table .* does not exist");
 
@@ -1046,6 +1046,15 @@ public abstract class AbstractTestDistributedQueries
                     () -> assertEquals(dispatchManager.getStats().getCompletedQueries().getTotalCount() - beforeCompletedQueriesCount, 4));
             assertEquals(dispatchManager.getStats().getSubmittedQueries().getTotalCount() - beforeSubmittedQueriesCount, 4);
         });
+    }
+
+    /**
+     * The table must have two columns foo_1 and foo_2_4 of any type.
+     */
+    @Language("SQL")
+    protected String tableDefinitionForQueryLoggingCount()
+    {
+        return "(foo_1 int, foo_2_4 int)";
     }
 
     private <T> T waitUntilStable(Supplier<T> computation, Duration timeout)

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -1296,7 +1296,7 @@ public abstract class BaseConnectorTest
         }
 
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_TABLE));
-        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_supports_delete", "AS SELECT * FROM region")) {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_supports_delete", "(regionkey int)")) {
             assertQueryFails("DELETE FROM " + table.getName(), "This connector does not support deletes");
         }
     }
@@ -1310,7 +1310,7 @@ public abstract class BaseConnectorTest
         }
 
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_TABLE));
-        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_supports_row_level_delete", "AS SELECT * FROM region")) {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_supports_row_level_delete", "(regionkey int)")) {
             assertQueryFails("DELETE FROM " + table.getName() + " WHERE regionkey = 2", "This connector does not support deletes");
         }
     }


### PR DESCRIPTION
## Description

Migrate to BaseConnectorTest in BigQuery

* Fixes #7110

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
