### PR TITLE
Migrate Kafka to use BaseConnectorTest

### DIFF
--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaConnectorTest.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaConnectorTest.java
@@ -63,7 +63,7 @@ import static org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS
 import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
 
-public class TestKafkaIntegrationSmokeTest
+public class TestKafkaConnectorTest
         // TODO extend BaseConnectorTest
         extends AbstractTestIntegrationSmokeTest
 {


### PR DESCRIPTION
## Description

Migrate Kafka to use BaseConnectorTest

## Related issues, pull requests, and links

* Fixes #7114

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
