### PR TITLE
Support guessing BinData type as varbinary in MongoDB 

### DIFF
--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
@@ -53,6 +53,7 @@ import io.trino.spi.type.TypeSignature;
 import io.trino.spi.type.TypeSignatureParameter;
 import io.trino.spi.type.VarcharType;
 import org.bson.Document;
+import org.bson.types.Binary;
 import org.bson.types.ObjectId;
 
 import java.util.ArrayList;
@@ -80,6 +81,7 @@ import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.lang.Math.toIntExact;
@@ -599,6 +601,9 @@ public class MongoSession
         TypeSignature typeSignature = null;
         if (value instanceof String) {
             typeSignature = createUnboundedVarcharType().getTypeSignature();
+        }
+        if (value instanceof Binary) {
+            typeSignature = VARBINARY.getTypeSignature();
         }
         else if (value instanceof Integer || value instanceof Long) {
             typeSignature = BIGINT.getTypeSignature();

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorTest.java
@@ -283,6 +283,7 @@ public abstract class BaseMongoConnectorTest
     {
         return new Object[][] {
                 {"String type", "varchar 'String type'", "varchar"},
+                {"BinData".getBytes(UTF_8), "to_utf8('BinData')", "varbinary"},
                 {1234567890, "bigint '1234567890'", "bigint"},
                 {true, "true", "boolean"},
                 {12.3f, "double '12.3'", "double"},

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorTest.java
@@ -34,6 +34,7 @@ import org.testng.annotations.Test;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Date;
 
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -281,6 +282,12 @@ public abstract class BaseMongoConnectorTest
     public Object[][] dbRefProvider()
     {
         return new Object[][] {
+                {"String type", "varchar 'String type'", "varchar"},
+                {1234567890, "bigint '1234567890'", "bigint"},
+                {true, "true", "boolean"},
+                {12.3f, "double '12.3'", "double"},
+                {new Date(0), "timestamp '1970-01-01 00:00:00.000'", "timestamp(3)"},
+                {ImmutableList.of(1), "array[bigint '1']", "array(bigint)"},
                 {new ObjectId("5126bc054aed4daf9e2ab772"), "ObjectId('5126bc054aed4daf9e2ab772')", "ObjectId"},
         };
     }


### PR DESCRIPTION
## Description

Support guessing BinData type as varbinary in MongoDB 

## Documentation

(x) Documentation issue #11121 is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# MongoDB
* Support guessing MongoDB `bindata` type as Trino `varbinary` type . ({issue}`11122`)
```
