### PR TITLE
Update stale references to EvictableLoadingCache

### DIFF
--- a/.mvn/modernizer/violations.xml
+++ b/.mvn/modernizer/violations.xml
@@ -46,7 +46,7 @@
     <violation>
         <name>com/google/common/cache/CacheBuilder.build:()Lcom/google/common/cache/Cache;</name>
         <version>1.8</version>
-        <comment>Guava Cache has concurrency issues around invalidation and ongoing loads. Use EvictableCache, EvictableLoadingCache, or SafeCaches to build caches.
+        <comment>Guava Cache has concurrency issues around invalidation and ongoing loads. Use EvictableCacheBuilder or SafeCaches to build caches.
             See https://github.com/trinodb/trino/issues/10512 for more information and see https://github.com/trinodb/trino/issues/10512#issuecomment-1016221168
             for why Caffeine does not solve the problem.</comment>
     </violation>
@@ -54,7 +54,7 @@
     <violation>
         <name>com/google/common/cache/CacheBuilder.build:(Lcom/google/common/cache/CacheLoader;)Lcom/google/common/cache/LoadingCache;</name>
         <version>1.8</version>
-        <comment>Guava LoadingCache has concurrency issues around invalidation and ongoing loads. Use EvictableCache, EvictableLoadingCache, or SafeCaches to build caches.
+        <comment>Guava LoadingCache has concurrency issues around invalidation and ongoing loads. Use EvictableCacheBuilder or SafeCaches to build caches.
             See https://github.com/trinodb/trino/issues/10512 for more information and see https://github.com/trinodb/trino/issues/10512#issuecomment-1016221168
             for why Caffeine does not solve the problem.</comment>
     </violation>

--- a/lib/trino-collect/src/main/java/io/trino/collect/cache/NonEvictableLoadingCache.java
+++ b/lib/trino-collect/src/main/java/io/trino/collect/cache/NonEvictableLoadingCache.java
@@ -20,7 +20,7 @@ public interface NonEvictableLoadingCache<K, V>
         extends NonKeyEvictableLoadingCache<K, V>
 {
     /**
-     * @deprecated Not supported. Use {@link EvictableLoadingCache} cache implementation instead.
+     * @deprecated Not supported. Use {@link EvictableCacheBuilder} to build a cache instead.
      */
     @Deprecated
     @Override

--- a/lib/trino-collect/src/main/java/io/trino/collect/cache/NonEvictableLoadingCacheImpl.java
+++ b/lib/trino-collect/src/main/java/io/trino/collect/cache/NonEvictableLoadingCacheImpl.java
@@ -29,7 +29,7 @@ final class NonEvictableLoadingCacheImpl<K, V>
     public void invalidateAll()
     {
         throw new UnsupportedOperationException("invalidateAll does not invalidate ongoing loads, so a stale value may remain in the cache for ever. " +
-                "Use EvictableLoadingCache if you need invalidation, or use SafeCaches.buildNonEvictableCacheWithWeakInvalidateAll() " +
+                "Use EvictableCacheBuilder if you need invalidation, or use SafeCaches.buildNonEvictableCacheWithWeakInvalidateAll() " +
                 "if invalidateAll is not required for correctness");
     }
 }

--- a/lib/trino-collect/src/main/java/io/trino/collect/cache/NonKeyEvictableLoadingCache.java
+++ b/lib/trino-collect/src/main/java/io/trino/collect/cache/NonKeyEvictableLoadingCache.java
@@ -22,14 +22,14 @@ public interface NonKeyEvictableLoadingCache<K, V>
         extends LoadingCache<K, V>
 {
     /**
-     * @deprecated Not supported. Use {@link EvictableLoadingCache} cache implementation instead.
+     * @deprecated Not supported. Use {@link EvictableCacheBuilder} to build a cache instead.
      */
     @Deprecated
     @Override
     void invalidate(Object key);
 
     /**
-     * @deprecated Not supported. Use {@link EvictableLoadingCache} cache implementation instead.
+     * @deprecated Not supported. Use {@link EvictableCacheBuilder} to build a cache instead.
      */
     @Deprecated
     @Override

--- a/lib/trino-collect/src/main/java/io/trino/collect/cache/NonKeyEvictableLoadingCacheImpl.java
+++ b/lib/trino-collect/src/main/java/io/trino/collect/cache/NonKeyEvictableLoadingCacheImpl.java
@@ -40,13 +40,13 @@ class NonKeyEvictableLoadingCacheImpl<K, V>
     public void invalidate(Object key)
     {
         throw new UnsupportedOperationException("invalidate(key) does not invalidate ongoing loads, so a stale value may remain in the cache for ever. " +
-                "Use EvictableLoadingCache if you need invalidation");
+                "Use EvictableCacheBuilder if you need invalidation");
     }
 
     @Override
     public void invalidateAll(Iterable<?> keys)
     {
         throw new UnsupportedOperationException("invalidateAll(keys) does not invalidate ongoing loads, so a stale value may remain in the cache for ever. " +
-                "Use EvictableLoadingCache if you need invalidation");
+                "Use EvictableCacheBuilder if you need invalidation");
     }
 }

--- a/lib/trino-collect/src/main/java/io/trino/collect/cache/SafeCaches.java
+++ b/lib/trino-collect/src/main/java/io/trino/collect/cache/SafeCaches.java
@@ -21,7 +21,7 @@ import org.gaul.modernizer_maven_annotations.SuppressModernizer;
 
 /**
  * @see EvictableCache
- * @see EvictableLoadingCache
+ * @see EvictableCacheBuilder
  */
 public final class SafeCaches
 {


### PR DESCRIPTION
The class was removed in 39046208f1f96844f8d1bc2984f428af10aca713.
