### PR TITLE
Support for killing individual task if cluster is out of memory

### DIFF
--- a/core/trino-main/src/main/java/io/trino/TaskMemoryInfo.java
+++ b/core/trino-main/src/main/java/io/trino/TaskMemoryInfo.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.execution.TaskId;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class TaskMemoryInfo
+{
+    private final TaskId taskId;
+    private final long memoryReservation;
+
+    @JsonCreator
+    public TaskMemoryInfo(
+            @JsonProperty("taskId") TaskId taskId,
+            @JsonProperty("memoryReservation") long memoryReservation)
+    {
+        this.taskId = requireNonNull(taskId, "taskId is null");
+        this.memoryReservation = memoryReservation;
+    }
+
+    @JsonProperty
+    public TaskId getTaskId()
+    {
+        return taskId;
+    }
+
+    @JsonProperty
+    public long getMemoryReservation()
+    {
+        return memoryReservation;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("taskId", taskId)
+                .add("memoryReservation", memoryReservation)
+                .toString();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/execution/DataDefinitionExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DataDefinitionExecution.java
@@ -219,6 +219,12 @@ public class DataDefinitionExecution<T extends Statement>
     }
 
     @Override
+    public void failTask(TaskId taskId, Exception reason)
+    {
+        // no-op
+    }
+
+    @Override
     public void recordHeartbeat()
     {
         stateMachine.recordHeartbeat();

--- a/core/trino-main/src/main/java/io/trino/execution/QueryExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryExecution.java
@@ -67,6 +67,8 @@ public interface QueryExecution
 
     void cancelStage(StageId stageId);
 
+    void failTask(TaskId taskId, Exception reason);
+
     void recordHeartbeat();
 
     boolean shouldWaitForMinWorkers();

--- a/core/trino-main/src/main/java/io/trino/execution/RemoteTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RemoteTask.java
@@ -65,6 +65,11 @@ public interface RemoteTask
 
     void fail(Throwable cause);
 
+    /**
+     * Fails task remotely; only transitions to failed state when we recevie confirmation that remote operation is completed
+     */
+    void failRemotely(Throwable cause);
+
     PartitionedSplitsInfo getQueuedPartitionedSplitsInfo();
 
     int getUnacknowledgedPartitionedSplitCount();

--- a/core/trino-main/src/main/java/io/trino/execution/SqlQueryExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlQueryExecution.java
@@ -545,6 +545,19 @@ public class SqlQueryExecution
     }
 
     @Override
+    public void failTask(TaskId taskId, Exception reason)
+    {
+        requireNonNull(taskId, "stageId is null");
+
+        try (SetThreadName ignored = new SetThreadName("Query-%s", stateMachine.getQueryId())) {
+            SqlQueryScheduler scheduler = queryScheduler.get();
+            if (scheduler != null) {
+                scheduler.failTask(taskId, reason);
+            }
+        }
+    }
+
+    @Override
     public void fail(Throwable cause)
     {
         requireNonNull(cause, "cause is null");

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/FaultTolerantStageScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/FaultTolerantStageScheduler.java
@@ -450,6 +450,14 @@ public class FaultTolerantStageScheduler
         }
     }
 
+    public void failTaskRemotely(TaskId taskId, Throwable failureCause)
+    {
+        RemoteTask task = runningTasks.get(taskId);
+        if (task != null) {
+            task.failRemotely(failureCause);
+        }
+    }
+
     private int getNextAttemptIdForPartition(int partition)
     {
         int latestAttemptId = partitionToRemoteTaskMap.get(partition).stream()

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedStageExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedStageExecution.java
@@ -299,6 +299,14 @@ public class PipelinedStageExecution
     }
 
     @Override
+    public synchronized void failTaskRemotely(TaskId taskId, Throwable failureCause)
+    {
+        RemoteTask task = requireNonNull(tasks.get(taskId.getPartitionId()), () -> "task not found: " + taskId);
+        task.failRemotely(failureCause);
+        // not failing stage just yet; it will happen as a result of task failure
+    }
+
+    @Override
     public synchronized Optional<RemoteTask> scheduleTask(
             InternalNode node,
             int partition,

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/StageExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/StageExecution.java
@@ -73,6 +73,8 @@ public interface StageExecution
 
     void failTask(TaskId taskId, Throwable failureCause);
 
+    void failTaskRemotely(TaskId taskId, Throwable failureCause);
+
     List<RemoteTask> getAllTasks();
 
     List<TaskStatus> getTaskStatuses();

--- a/core/trino-main/src/main/java/io/trino/memory/KillTarget.java
+++ b/core/trino-main/src/main/java/io/trino/memory/KillTarget.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.memory;
+
+import com.google.common.collect.ImmutableSet;
+import io.trino.execution.TaskId;
+import io.trino.spi.QueryId;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class KillTarget
+{
+    // Either query id or tasks list must be set
+    // If query id is set then whole query will be killed; individual tasks otherwise.
+
+    private final Optional<QueryId> query;
+    private final Set<TaskId> tasks;
+
+    public static KillTarget wholeQuery(QueryId queryId)
+    {
+        return new KillTarget(Optional.of(queryId), ImmutableSet.of());
+    }
+
+    public static KillTarget selectedTasks(Set<TaskId> tasks)
+    {
+        return new KillTarget(Optional.empty(), tasks);
+    }
+
+    private KillTarget(Optional<QueryId> query, Set<TaskId> tasks)
+    {
+        requireNonNull(query, "query is null");
+        requireNonNull(tasks, "tasks is null");
+        if ((query.isPresent() && !tasks.isEmpty()) || (query.isEmpty() && tasks.isEmpty())) {
+            throw new IllegalArgumentException("either query or tasks must be set");
+        }
+        this.query = query;
+        this.tasks = ImmutableSet.copyOf(tasks);
+    }
+
+    public boolean isWholeQuery()
+    {
+        return query.isPresent();
+    }
+
+    public QueryId getQuery()
+    {
+        return query.orElseThrow(() -> new IllegalStateException("query not set in KillTarget: " + this));
+    }
+
+    public Set<TaskId> getTasks()
+    {
+        checkState(!tasks.isEmpty(), "tasks not set in KillTarget: " + this);
+        return tasks;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        KillTarget that = (KillTarget) o;
+        return Objects.equals(query, that.query) && Objects.equals(tasks, that.tasks);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(query, tasks);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("query", query)
+                .add("tasks", tasks)
+                .toString();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/memory/LowMemoryKiller.java
+++ b/core/trino-main/src/main/java/io/trino/memory/LowMemoryKiller.java
@@ -14,6 +14,7 @@
 
 package io.trino.memory;
 
+import io.trino.execution.TaskId;
 import io.trino.spi.QueryId;
 
 import java.util.List;
@@ -54,6 +55,37 @@ public interface LowMemoryKiller
                     .add("queryId", queryId)
                     .add("memoryReservation", memoryReservation)
                     .toString();
+        }
+
+        public static class TaskMemoryInfo
+        {
+            private final TaskId taskId;
+            private final long memoryReservation;
+
+            public TaskMemoryInfo(TaskId taskId, long memoryReservation)
+            {
+                this.taskId = requireNonNull(taskId, "taskId is null");
+                this.memoryReservation = memoryReservation;
+            }
+
+            public TaskId getTaskId()
+            {
+                return taskId;
+            }
+
+            public long getMemoryReservation()
+            {
+                return memoryReservation;
+            }
+
+            @Override
+            public String toString()
+            {
+                return toStringHelper(this)
+                        .add("taskId", taskId)
+                        .add("memoryReservation", memoryReservation)
+                        .toString();
+            }
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/memory/LowMemoryKiller.java
+++ b/core/trino-main/src/main/java/io/trino/memory/LowMemoryKiller.java
@@ -25,7 +25,7 @@ import static java.util.Objects.requireNonNull;
 
 public interface LowMemoryKiller
 {
-    Optional<QueryId> chooseQueryToKill(List<QueryMemoryInfo> runningQueries, List<MemoryInfo> nodes);
+    Optional<KillTarget> chooseQueryToKill(List<QueryMemoryInfo> runningQueries, List<MemoryInfo> nodes);
 
     class QueryMemoryInfo
     {

--- a/core/trino-main/src/main/java/io/trino/memory/MemoryInfo.java
+++ b/core/trino-main/src/main/java/io/trino/memory/MemoryInfo.java
@@ -15,6 +15,10 @@ package io.trino.memory;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ListMultimap;
+import io.trino.TaskMemoryInfo;
+import io.trino.spi.QueryId;
 import io.trino.spi.memory.MemoryPoolInfo;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -24,14 +28,24 @@ public class MemoryInfo
 {
     private final int availableProcessors;
     private final MemoryPoolInfo pool;
+    private final ListMultimap<QueryId, TaskMemoryInfo> tasksMemoryInfo;
+
+    public MemoryInfo(
+            int availableProcessors,
+            MemoryPoolInfo pool)
+    {
+        this(availableProcessors, pool, ImmutableListMultimap.of());
+    }
 
     @JsonCreator
     public MemoryInfo(
             @JsonProperty("availableProcessors") int availableProcessors,
-            @JsonProperty("pool") MemoryPoolInfo pool)
+            @JsonProperty("pool") MemoryPoolInfo pool,
+            @JsonProperty("tasksMemoryInfo") ListMultimap<QueryId, TaskMemoryInfo> tasksMemoryInfo)
     {
         this.availableProcessors = availableProcessors;
         this.pool = requireNonNull(pool, "pool is null");
+        this.tasksMemoryInfo = ImmutableListMultimap.copyOf(requireNonNull(tasksMemoryInfo, "tasksMemoryInfo is null"));
     }
 
     @JsonProperty
@@ -46,12 +60,24 @@ public class MemoryInfo
         return pool;
     }
 
+    @JsonProperty
+    public ListMultimap<QueryId, TaskMemoryInfo> getTasksMemoryInfo()
+    {
+        return tasksMemoryInfo;
+    }
+
     @Override
     public String toString()
     {
         return toStringHelper(this)
                 .add("availableProcessors", availableProcessors)
                 .add("pool", pool)
+                .add("tasksMemoryInfo", tasksMemoryInfo)
                 .toString();
+    }
+
+    public MemoryInfo withTasksMemoryInfo(ListMultimap<QueryId, TaskMemoryInfo> tasksMemoryInfo)
+    {
+        return new MemoryInfo(availableProcessors, pool, tasksMemoryInfo);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/memory/MemoryResource.java
+++ b/core/trino-main/src/main/java/io/trino/memory/MemoryResource.java
@@ -13,7 +13,12 @@
  */
 package io.trino.memory;
 
+import com.google.common.collect.ListMultimap;
+import io.trino.TaskMemoryInfo;
+import io.trino.execution.SqlTask;
+import io.trino.execution.SqlTaskManager;
 import io.trino.server.security.ResourceSecurity;
+import io.trino.spi.QueryId;
 import io.trino.spi.memory.MemoryPoolInfo;
 
 import javax.inject.Inject;
@@ -23,6 +28,11 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import java.util.List;
+
+import static com.google.common.collect.ImmutableListMultimap.toImmutableListMultimap;
+import static io.trino.SystemSessionProperties.getRetryPolicy;
+import static io.trino.operator.RetryPolicy.TASK;
 import static io.trino.server.security.ResourceSecurity.AccessType.INTERNAL_ONLY;
 import static java.util.Objects.requireNonNull;
 
@@ -33,11 +43,13 @@ import static java.util.Objects.requireNonNull;
 public class MemoryResource
 {
     private final LocalMemoryManager memoryManager;
+    private final SqlTaskManager taskManager;
 
     @Inject
-    public MemoryResource(LocalMemoryManager memoryManager)
+    public MemoryResource(LocalMemoryManager memoryManager, SqlTaskManager taskManager)
     {
         this.memoryManager = requireNonNull(memoryManager, "memoryManager is null");
+        this.taskManager = requireNonNull(taskManager, "taskManager is null");
     }
 
     @ResourceSecurity(INTERNAL_ONLY)
@@ -45,7 +57,26 @@ public class MemoryResource
     @Produces(MediaType.APPLICATION_JSON)
     public MemoryInfo getMemoryInfo()
     {
-        return memoryManager.getInfo();
+        return memoryManager.getInfo().withTasksMemoryInfo(buildTasksMemoryInfo());
+    }
+
+    private ListMultimap<QueryId, TaskMemoryInfo> buildTasksMemoryInfo()
+    {
+        List<SqlTask> tasks = taskManager.getAllTasks();
+        return tasks.stream()
+                .filter(task -> !task.getTaskState().isDone())
+                // we are providing task memory information only for queries which are run with task-level retries.
+                // task memory information is consumed by low memory killer and it does not make sense to kill individual tasks
+                // for queries which does not allow task retries.
+                .filter(task -> task.getTaskContext().map(context -> getRetryPolicy(context.getSession()) == TASK).orElse(false))
+                .collect(toImmutableListMultimap(
+                        task -> task.getTaskId().getQueryId(),
+                        task -> new TaskMemoryInfo(
+                                task.getTaskId(),
+                                task.getTaskContext()
+                                        .map(taskContext -> taskContext.getMemoryReservation().toBytes())
+                                        // task context may no longer be available if task completes
+                                        .orElse(0L))));
     }
 
     private Response toSuccessfulResponse(MemoryPoolInfo memoryInfo)

--- a/core/trino-main/src/main/java/io/trino/memory/NoneLowMemoryKiller.java
+++ b/core/trino-main/src/main/java/io/trino/memory/NoneLowMemoryKiller.java
@@ -14,8 +14,6 @@
 
 package io.trino.memory;
 
-import io.trino.spi.QueryId;
-
 import java.util.List;
 import java.util.Optional;
 
@@ -23,7 +21,7 @@ public class NoneLowMemoryKiller
         implements LowMemoryKiller
 {
     @Override
-    public Optional<QueryId> chooseQueryToKill(List<QueryMemoryInfo> runningQueries, List<MemoryInfo> nodes)
+    public Optional<KillTarget> chooseQueryToKill(List<QueryMemoryInfo> runningQueries, List<MemoryInfo> nodes)
     {
         return Optional.empty();
     }

--- a/core/trino-main/src/main/java/io/trino/memory/TotalReservationLowMemoryKiller.java
+++ b/core/trino-main/src/main/java/io/trino/memory/TotalReservationLowMemoryKiller.java
@@ -23,17 +23,17 @@ public class TotalReservationLowMemoryKiller
         implements LowMemoryKiller
 {
     @Override
-    public Optional<QueryId> chooseQueryToKill(List<QueryMemoryInfo> runningQueries, List<MemoryInfo> nodes)
+    public Optional<KillTarget> chooseQueryToKill(List<QueryMemoryInfo> runningQueries, List<MemoryInfo> nodes)
     {
-        QueryId biggestQuery = null;
+        Optional<QueryId> biggestQuery = Optional.empty();
         long maxMemory = 0;
         for (QueryMemoryInfo query : runningQueries) {
             long bytesUsed = query.getMemoryReservation();
             if (bytesUsed > maxMemory) {
-                biggestQuery = query.getQueryId();
+                biggestQuery = Optional.of(query.getQueryId());
                 maxMemory = bytesUsed;
             }
         }
-        return Optional.ofNullable(biggestQuery);
+        return biggestQuery.map(KillTarget::wholeQuery);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/memory/TotalReservationOnBlockedNodesLowMemoryKiller.java
+++ b/core/trino-main/src/main/java/io/trino/memory/TotalReservationOnBlockedNodesLowMemoryKiller.java
@@ -28,7 +28,7 @@ public class TotalReservationOnBlockedNodesLowMemoryKiller
         implements LowMemoryKiller
 {
     @Override
-    public Optional<QueryId> chooseQueryToKill(List<QueryMemoryInfo> runningQueries, List<MemoryInfo> nodes)
+    public Optional<KillTarget> chooseQueryToKill(List<QueryMemoryInfo> runningQueries, List<MemoryInfo> nodes)
     {
         Map<QueryId, Long> memoryReservationOnBlockedNodes = new HashMap<>();
         for (MemoryInfo node : nodes) {
@@ -47,6 +47,7 @@ public class TotalReservationOnBlockedNodesLowMemoryKiller
 
         return memoryReservationOnBlockedNodes.entrySet().stream()
                 .max(comparingLong(Map.Entry::getValue))
-                .map(Map.Entry::getKey);
+                .map(Map.Entry::getKey)
+                .map(KillTarget::wholeQuery);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
@@ -256,6 +256,7 @@ public class CoordinatorModule
         jsonCodecBinder(binder).bindJsonCodec(TaskInfo.class);
         jsonCodecBinder(binder).bindJsonCodec(TaskStatus.class);
         jsonCodecBinder(binder).bindJsonCodec(TaskUpdateRequest.class);
+        jsonCodecBinder(binder).bindJsonCodec(FailTaskRequest.class);
         jsonCodecBinder(binder).bindJsonCodec(VersionedDynamicFilterDomains.class);
         binder.bind(RemoteTaskFactory.class).to(HttpRemoteTaskFactory.class).in(Scopes.SINGLETON);
         newExporter(binder).export(RemoteTaskFactory.class).withGeneratedName();

--- a/core/trino-main/src/main/java/io/trino/server/FailTaskRequest.java
+++ b/core/trino-main/src/main/java/io/trino/server/FailTaskRequest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.execution.ExecutionFailureInfo;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class FailTaskRequest
+{
+    private final ExecutionFailureInfo failureInfo;
+
+    @JsonCreator
+    public FailTaskRequest(
+            @JsonProperty("failureInfo") ExecutionFailureInfo failureInfo)
+    {
+        this.failureInfo = requireNonNull(failureInfo, "failureInfo is null");
+    }
+
+    @JsonProperty
+    public ExecutionFailureInfo getFailureInfo()
+    {
+        return failureInfo;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("failureInfo", failureInfo)
+                .toString();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/HttpRemoteTaskFactory.java
+++ b/core/trino-main/src/main/java/io/trino/server/HttpRemoteTaskFactory.java
@@ -65,6 +65,7 @@ public class HttpRemoteTaskFactory
     private final JsonCodec<VersionedDynamicFilterDomains> dynamicFilterDomainsCodec;
     private final JsonCodec<TaskInfo> taskInfoCodec;
     private final JsonCodec<TaskUpdateRequest> taskUpdateRequestCodec;
+    private final JsonCodec<FailTaskRequest> failTaskRequestCoded;
     private final Duration maxErrorDuration;
     private final Duration taskStatusRefreshMaxWait;
     private final Duration taskInfoUpdateInterval;
@@ -86,6 +87,7 @@ public class HttpRemoteTaskFactory
             JsonCodec<VersionedDynamicFilterDomains> dynamicFilterDomainsCodec,
             JsonCodec<TaskInfo> taskInfoCodec,
             JsonCodec<TaskUpdateRequest> taskUpdateRequestCodec,
+            JsonCodec<FailTaskRequest> failTaskRequestCoded,
             RemoteTaskStats stats,
             DynamicFilterService dynamicFilterService)
     {
@@ -95,6 +97,7 @@ public class HttpRemoteTaskFactory
         this.dynamicFilterDomainsCodec = dynamicFilterDomainsCodec;
         this.taskInfoCodec = taskInfoCodec;
         this.taskUpdateRequestCodec = taskUpdateRequestCodec;
+        this.failTaskRequestCoded = failTaskRequestCoded;
         this.maxErrorDuration = config.getRemoteTaskMaxErrorDuration();
         this.taskStatusRefreshMaxWait = taskConfig.getStatusRefreshMaxWait();
         this.taskInfoUpdateInterval = taskConfig.getInfoUpdateInterval();
@@ -154,6 +157,7 @@ public class HttpRemoteTaskFactory
                 dynamicFilterDomainsCodec,
                 taskInfoCodec,
                 taskUpdateRequestCodec,
+                failTaskRequestCoded,
                 partitionedSplitCountTracker,
                 stats,
                 dynamicFilterService,

--- a/core/trino-main/src/main/java/io/trino/server/TaskResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/TaskResource.java
@@ -290,6 +290,21 @@ public class TaskResource
     }
 
     @ResourceSecurity(INTERNAL_ONLY)
+    @POST
+    @Path("{taskId}/fail")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public TaskInfo failTask(
+            @PathParam("taskId") TaskId taskId,
+            FailTaskRequest failTaskRequest,
+            @Context UriInfo uriInfo)
+    {
+        requireNonNull(taskId, "taskId is null");
+        requireNonNull(failTaskRequest, "failTaskRequest is null");
+        return taskManager.failTask(taskId, failTaskRequest.getFailureInfo().toException());
+    }
+
+    @ResourceSecurity(INTERNAL_ONLY)
     @GET
     @Path("{taskId}/results/{bufferId}/{token}")
     @Produces(TRINO_PAGES)

--- a/core/trino-main/src/test/java/io/trino/execution/MockRemoteTaskFactory.java
+++ b/core/trino-main/src/test/java/io/trino/execution/MockRemoteTaskFactory.java
@@ -456,6 +456,13 @@ public class MockRemoteTaskFactory
         }
 
         @Override
+        public void failRemotely(Throwable cause)
+        {
+            taskStateMachine.failed(cause);
+            clearSplits();
+        }
+
+        @Override
         public PartitionedSplitsInfo getPartitionedSplitsInfo()
         {
             if (taskStateMachine.getState().isDone()) {

--- a/core/trino-main/src/test/java/io/trino/execution/TestingRemoteTaskFactory.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestingRemoteTaskFactory.java
@@ -279,6 +279,12 @@ public class TestingRemoteTaskFactory
         }
 
         @Override
+        public void failRemotely(Throwable cause)
+        {
+            taskStateMachine.failed(cause);
+        }
+
+        @Override
         public PartitionedSplitsInfo getQueuedPartitionedSplitsInfo()
         {
             return PartitionedSplitsInfo.forZeroSplits();

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/policy/TestPhasedExecutionSchedule.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/policy/TestPhasedExecutionSchedule.java
@@ -355,6 +355,12 @@ public class TestPhasedExecutionSchedule
         }
 
         @Override
+        public void failTaskRemotely(TaskId taskId, Throwable failureCause)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public List<RemoteTask> getAllTasks()
         {
             throw new UnsupportedOperationException();

--- a/core/trino-main/src/test/java/io/trino/memory/TestTotalReservationLowMemoryKiller.java
+++ b/core/trino-main/src/test/java/io/trino/memory/TestTotalReservationLowMemoryKiller.java
@@ -58,6 +58,6 @@ public class TestTotalReservationLowMemoryKiller
                 lowMemoryKiller.chooseQueryToKill(
                         toQueryMemoryInfoList(queries),
                         toNodeMemoryInfoList(memoryPool, queries)),
-                Optional.of(new QueryId("q_2")));
+                Optional.of(KillTarget.wholeQuery(new QueryId("q_2"))));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/memory/TestTotalReservationOnBlockedNodesLowMemoryKiller.java
+++ b/core/trino-main/src/test/java/io/trino/memory/TestTotalReservationOnBlockedNodesLowMemoryKiller.java
@@ -73,6 +73,6 @@ public class TestTotalReservationOnBlockedNodesLowMemoryKiller
                 lowMemoryKiller.chooseQueryToKill(
                         toQueryMemoryInfoList(queries),
                         toNodeMemoryInfoList(memoryPool, queries)),
-                Optional.of(new QueryId("q_1")));
+                Optional.of(KillTarget.wholeQuery(new QueryId("q_1"))));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/server/remotetask/TestHttpRemoteTask.java
+++ b/core/trino-main/src/test/java/io/trino/server/remotetask/TestHttpRemoteTask.java
@@ -54,6 +54,7 @@ import io.trino.metadata.InternalNode;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.Split;
 import io.trino.server.DynamicFilterService;
+import io.trino.server.FailTaskRequest;
 import io.trino.server.HttpRemoteTaskFactory;
 import io.trino.server.TaskUpdateRequest;
 import io.trino.spi.ErrorCode;
@@ -448,6 +449,7 @@ public class TestHttpRemoteTask
                         jsonBinder(binder).addDeserializerBinding(Block.class).to(BlockJsonSerde.Deserializer.class);
                         jsonCodecBinder(binder).bindJsonCodec(TaskInfo.class);
                         jsonCodecBinder(binder).bindJsonCodec(TaskUpdateRequest.class);
+                        jsonCodecBinder(binder).bindJsonCodec(FailTaskRequest.class);
 
                         binder.bind(TypeManager.class).toInstance(TESTING_TYPE_MANAGER);
                         binder.bind(BlockEncodingManager.class).in(SINGLETON);
@@ -460,7 +462,8 @@ public class TestHttpRemoteTask
                             JsonCodec<TaskStatus> taskStatusCodec,
                             JsonCodec<VersionedDynamicFilterDomains> dynamicFilterDomainsCodec,
                             JsonCodec<TaskInfo> taskInfoCodec,
-                            JsonCodec<TaskUpdateRequest> taskUpdateRequestCodec)
+                            JsonCodec<TaskUpdateRequest> taskUpdateRequestCodec,
+                            JsonCodec<FailTaskRequest> failTaskRequestCodec)
                     {
                         JaxrsTestingHttpProcessor jaxrsTestingHttpProcessor = new JaxrsTestingHttpProcessor(URI.create("http://fake.invalid/"), testingTaskResource, jsonMapper);
                         TestingHttpClient testingHttpClient = new TestingHttpClient(jaxrsTestingHttpProcessor.setTrace(TRACE_HTTP));
@@ -474,6 +477,7 @@ public class TestHttpRemoteTask
                                 dynamicFilterDomainsCodec,
                                 taskInfoCodec,
                                 taskUpdateRequestCodec,
+                                failTaskRequestCodec,
                                 new RemoteTaskStats(),
                                 dynamicFilterService);
                     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Support for killing individual task if cluster is out of memory.
Individual tasks will be killed for queries which are run with task-level retries.
Currently only supported if default low memory killer policy is used (total-reservation-on-blocked-nodes).

> Is this change a fix, improvement, new feature, refactoring, or other?

improvement to new feature

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core query engine

> How would you describe this change to a non-technical end user or system administrator?

N/A

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Section
* Add support for killing individual tasks of queries run with ``retry-mode`` set to ``TASK`` low memory killer.
  Requires ``query.low-memory-killer.policy`` config option to be set to ``total-reservation-on-blocked-nodes``. ({issue}`11129`)
```
