### PR TITLE
[WIP] Remove scope check for symbol reference in EqualityInference to push predicate to table scan

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/EqualityInference.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/EqualityInference.java
@@ -22,7 +22,6 @@ import com.google.common.collect.Multimap;
 import io.trino.metadata.Metadata;
 import io.trino.sql.tree.ComparisonExpression;
 import io.trino.sql.tree.Expression;
-import io.trino.sql.tree.SymbolReference;
 import io.trino.util.DisjointSet;
 
 import java.util.ArrayList;
@@ -306,17 +305,6 @@ public class EqualityInference
         }
 
         Collection<Expression> equivalences = equalitySets.get(canonicalIndex);
-        if (expression instanceof SymbolReference) {
-            boolean inScope = equivalences.stream()
-                    .filter(SymbolReference.class::isInstance)
-                    .map(Symbol::from)
-                    .anyMatch(symbolScope);
-
-            if (!inScope) {
-                return null;
-            }
-        }
-
         return getCanonical(
                 equivalences.stream()
                         .filter(e -> isScoped(e, symbolScope)));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Attempt to fix #10938. I confirmed that this works for #10938 but not sure if this fix is actually valid.

## Related issues, pull requests, and links

* Fixes https://github.com/trinodb/trino/issues/10938
* The behavior change seems to have been introduced in https://github.com/trinodb/trino/pull/1550

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
