### PR TITLE
Only mark dictionaries as compacted when they are not nested

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/Page.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/Page.java
@@ -251,7 +251,7 @@ public final class Page
 
             try {
                 Block compactDictionary = dictionaryBlock.getDictionary().copyPositions(dictionaryPositionsToCopy, 0, numberOfIndexes);
-                outputDictionaryBlocks.add(new DictionaryBlock(positionCount, compactDictionary, newIds, true, newDictionaryId));
+                outputDictionaryBlocks.add(new DictionaryBlock(positionCount, compactDictionary, newIds, !(compactDictionary instanceof DictionaryBlock), newDictionaryId));
             }
             catch (UnsupportedOperationException e) {
                 // ignore if copy positions is not supported for the dictionary

--- a/core/trino-spi/src/main/java/io/trino/spi/Page.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/Page.java
@@ -301,7 +301,7 @@ public final class Page
 
     public Page getLoadedPage(int column)
     {
-        return wrapBlocksWithoutCopy(positionCount, new Block[]{this.blocks[column].getLoadedBlock()});
+        return wrapBlocksWithoutCopy(positionCount, new Block[] {this.blocks[column].getLoadedBlock()});
     }
 
     public Page getLoadedPage(int... columns)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fixes https://github.com/trinodb/trino/issues/11080

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# General
Fix certain queries failing due to dictionary compacting error. ({issue}`11080`)
```
