### PR TITLE
Introduce TrinoToClickHouseWriteChecker in ClickHouse

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/StandardColumnMappings.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/StandardColumnMappings.java
@@ -574,7 +574,7 @@ public final class StandardColumnMappings
         return (resultSet, columnIndex) -> toTrinoTimestamp(timestampType, resultSet.getObject(columnIndex, LocalDateTime.class));
     }
 
-    private static ObjectReadFunction longTimestampReadFunction(TimestampType timestampType)
+    public static ObjectReadFunction longTimestampReadFunction(TimestampType timestampType)
     {
         checkArgument(timestampType.getPrecision() > TimestampType.MAX_SHORT_PRECISION && timestampType.getPrecision() <= MAX_LOCAL_DATE_TIME_PRECISION,
                 "Precision is out of range: %s", timestampType.getPrecision());

--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
@@ -104,6 +104,7 @@ import static io.trino.plugin.clickhouse.ClickHouseTableProperties.PARTITION_BY_
 import static io.trino.plugin.clickhouse.ClickHouseTableProperties.PRIMARY_KEY_PROPERTY;
 import static io.trino.plugin.clickhouse.ClickHouseTableProperties.SAMPLE_BY_PROPERTY;
 import static io.trino.plugin.clickhouse.TrinoToClickHouseWriteChecker.UINT16;
+import static io.trino.plugin.clickhouse.TrinoToClickHouseWriteChecker.UINT32;
 import static io.trino.plugin.clickhouse.TrinoToClickHouseWriteChecker.UINT8;
 import static io.trino.plugin.jdbc.DecimalConfig.DecimalMapping.ALLOW_OVERFLOW;
 import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalDefaultScale;
@@ -172,9 +173,6 @@ public class ClickHouseClient
         extends BaseJdbcClient
 {
     private static final Splitter TABLE_PROPERTY_SPLITTER = Splitter.on(',').omitEmptyStrings().trimResults();
-
-    private static final long UINT32_MIN_VALUE = 0L;
-    private static final long UINT32_MAX_VALUE = 4294967295L;
 
     private static final DecimalType UINT64_TYPE = createDecimalType(20, 0);
     private static final BigDecimal UINT64_MIN_VALUE = BigDecimal.ZERO;
@@ -514,7 +512,7 @@ public class ClickHouseClient
             case UInt16:
                 return Optional.of(ColumnMapping.longMapping(INTEGER, ResultSet::getInt, uInt16WriteFunction(getClickHouseServerVersion(session))));
             case UInt32:
-                return Optional.of(ColumnMapping.longMapping(BIGINT, ResultSet::getLong, uInt32WriteFunction()));
+                return Optional.of(ColumnMapping.longMapping(BIGINT, ResultSet::getLong, uInt32WriteFunction(getClickHouseServerVersion(session))));
             case UInt64:
                 return Optional.of(ColumnMapping.objectMapping(
                         UINT64_TYPE,
@@ -726,13 +724,11 @@ public class ClickHouseClient
         };
     }
 
-    private static LongWriteFunction uInt32WriteFunction()
+    private static LongWriteFunction uInt32WriteFunction(ClickHouseVersion version)
     {
         return (preparedStatement, parameterIndex, value) -> {
             // ClickHouse stores incorrect results when the values are out of supported range.
-            if (value < UINT32_MIN_VALUE || value > UINT32_MAX_VALUE) {
-                throw new TrinoException(INVALID_ARGUMENTS, format("Value must be between %s and %s in ClickHouse: %s", UINT32_MIN_VALUE, UINT32_MAX_VALUE, value));
-            }
+            UINT32.validate(version, value);
             preparedStatement.setLong(parameterIndex, value);
         };
     }

--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
@@ -103,6 +103,7 @@ import static io.trino.plugin.clickhouse.ClickHouseTableProperties.ORDER_BY_PROP
 import static io.trino.plugin.clickhouse.ClickHouseTableProperties.PARTITION_BY_PROPERTY;
 import static io.trino.plugin.clickhouse.ClickHouseTableProperties.PRIMARY_KEY_PROPERTY;
 import static io.trino.plugin.clickhouse.ClickHouseTableProperties.SAMPLE_BY_PROPERTY;
+import static io.trino.plugin.clickhouse.TrinoToClickHouseWriteChecker.UINT16;
 import static io.trino.plugin.clickhouse.TrinoToClickHouseWriteChecker.UINT8;
 import static io.trino.plugin.jdbc.DecimalConfig.DecimalMapping.ALLOW_OVERFLOW;
 import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalDefaultScale;
@@ -171,9 +172,6 @@ public class ClickHouseClient
         extends BaseJdbcClient
 {
     private static final Splitter TABLE_PROPERTY_SPLITTER = Splitter.on(',').omitEmptyStrings().trimResults();
-
-    private static final long UINT16_MIN_VALUE = 0L;
-    private static final long UINT16_MAX_VALUE = 65535L;
 
     private static final long UINT32_MIN_VALUE = 0L;
     private static final long UINT32_MAX_VALUE = 4294967295L;
@@ -514,7 +512,7 @@ public class ClickHouseClient
             case UInt8:
                 return Optional.of(ColumnMapping.longMapping(SMALLINT, ResultSet::getShort, uInt8WriteFunction(getClickHouseServerVersion(session))));
             case UInt16:
-                return Optional.of(ColumnMapping.longMapping(INTEGER, ResultSet::getInt, uInt16WriteFunction()));
+                return Optional.of(ColumnMapping.longMapping(INTEGER, ResultSet::getInt, uInt16WriteFunction(getClickHouseServerVersion(session))));
             case UInt32:
                 return Optional.of(ColumnMapping.longMapping(BIGINT, ResultSet::getLong, uInt32WriteFunction()));
             case UInt64:
@@ -719,13 +717,11 @@ public class ClickHouseClient
         };
     }
 
-    private static LongWriteFunction uInt16WriteFunction()
+    private static LongWriteFunction uInt16WriteFunction(ClickHouseVersion version)
     {
         return (statement, index, value) -> {
             // ClickHouse stores incorrect results when the values are out of supported range.
-            if (value < UINT16_MIN_VALUE || value > UINT16_MAX_VALUE) {
-                throw new TrinoException(INVALID_ARGUMENTS, format("Value must be between %s and %s in ClickHouse: %s", UINT16_MIN_VALUE, UINT16_MAX_VALUE, value));
-            }
+            UINT16.validate(version, value);
             statement.setInt(index, toIntExact(value));
         };
     }

--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
@@ -15,6 +15,7 @@ package io.trino.plugin.clickhouse;
 
 import com.clickhouse.client.ClickHouseColumn;
 import com.clickhouse.client.ClickHouseDataType;
+import com.clickhouse.client.ClickHouseVersion;
 import com.google.common.base.Enums;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
@@ -87,6 +88,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -197,6 +199,7 @@ public class ClickHouseClient
     private final AggregateFunctionRewriter<JdbcExpression, String> aggregateFunctionRewriter;
     private final Type uuidType;
     private final Type ipAddressType;
+    private final AtomicReference<ClickHouseVersion> clickHouseVersion = new AtomicReference<>();
 
     @Inject
     public ClickHouseClient(
@@ -667,6 +670,27 @@ public class ClickHouseClient
             return WriteMapping.sliceMapping("UUID", uuidWriteFunction());
         }
         throw new TrinoException(NOT_SUPPORTED, "Unsupported column type: " + type);
+    }
+
+    private ClickHouseVersion getClickHouseServerVersion(ConnectorSession session)
+    {
+        return clickHouseVersion.updateAndGet(current -> {
+            if (current != null) {
+                return current;
+            }
+
+            try (Connection connection = connectionFactory.openConnection(session);
+                    PreparedStatement statement = connection.prepareStatement("SELECT version()");
+                    ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    current = ClickHouseVersion.of(resultSet.getString(1));
+                }
+                return current;
+            }
+            catch (SQLException e) {
+                throw new TrinoException(JDBC_ERROR, e);
+            }
+        });
     }
 
     /**

--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
@@ -81,7 +81,6 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -103,6 +102,7 @@ import static io.trino.plugin.clickhouse.ClickHouseTableProperties.ORDER_BY_PROP
 import static io.trino.plugin.clickhouse.ClickHouseTableProperties.PARTITION_BY_PROPERTY;
 import static io.trino.plugin.clickhouse.ClickHouseTableProperties.PRIMARY_KEY_PROPERTY;
 import static io.trino.plugin.clickhouse.ClickHouseTableProperties.SAMPLE_BY_PROPERTY;
+import static io.trino.plugin.clickhouse.TrinoToClickHouseWriteChecker.DATETIME;
 import static io.trino.plugin.clickhouse.TrinoToClickHouseWriteChecker.UINT16;
 import static io.trino.plugin.clickhouse.TrinoToClickHouseWriteChecker.UINT32;
 import static io.trino.plugin.clickhouse.TrinoToClickHouseWriteChecker.UINT64;
@@ -139,7 +139,6 @@ import static io.trino.plugin.jdbc.StandardColumnMappings.varcharWriteFunction;
 import static io.trino.plugin.jdbc.TypeHandlingJdbcSessionProperties.getUnsupportedTypeHandling;
 import static io.trino.plugin.jdbc.UnsupportedTypeHandling.CONVERT_TO_VARCHAR;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
-import static io.trino.spi.StandardErrorCode.INVALID_ARGUMENTS;
 import static io.trino.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -176,11 +175,6 @@ public class ClickHouseClient
     private static final Splitter TABLE_PROPERTY_SPLITTER = Splitter.on(',').omitEmptyStrings().trimResults();
 
     private static final DecimalType UINT64_TYPE = createDecimalType(20, 0);
-
-    private static final LocalDateTime MIN_SUPPORTED_TIMESTAMP = LocalDateTime.parse("1970-01-01T00:00:00");
-    private static final LocalDateTime MAX_SUPPORTED_TIMESTAMP = LocalDateTime.parse("2105-12-31T23:59:59");
-    private static final long MIN_SUPPORTED_TIMESTAMP_EPOCH = MIN_SUPPORTED_TIMESTAMP.toEpochSecond(UTC);
-    private static final long MAX_SUPPORTED_TIMESTAMP_EPOCH = MAX_SUPPORTED_TIMESTAMP.toEpochSecond(UTC);
 
     // An empty character means that the table doesn't have a comment in ClickHouse
     private static final String NO_COMMENT = "";
@@ -596,7 +590,7 @@ public class ClickHouseClient
                     return Optional.of(ColumnMapping.longMapping(
                             TIMESTAMP_SECONDS,
                             timestampReadFunction(TIMESTAMP_SECONDS),
-                            timestampSecondsWriteFunction()));
+                            timestampSecondsWriteFunction(getClickHouseServerVersion(session))));
                 }
                 // TODO (https://github.com/trinodb/trino/issues/10537) Add support for Datetime64 type
                 return Optional.of(timestampColumnMappingUsingSqlTimestampWithRounding(TIMESTAMP_MILLIS));
@@ -654,7 +648,7 @@ public class ClickHouseClient
             return WriteMapping.longMapping("Date", dateWriteFunctionUsingLocalDate(getClickHouseServerVersion(session)));
         }
         if (type == TIMESTAMP_SECONDS) {
-            return WriteMapping.longMapping("DateTime", timestampSecondsWriteFunction());
+            return WriteMapping.longMapping("DateTime", timestampSecondsWriteFunction(getClickHouseServerVersion(session)));
         }
         if (type.equals(uuidType)) {
             return WriteMapping.sliceMapping("UUID", uuidWriteFunction());
@@ -760,23 +754,17 @@ public class ClickHouseClient
         };
     }
 
-    private static LongWriteFunction timestampSecondsWriteFunction()
+    private static LongWriteFunction timestampSecondsWriteFunction(ClickHouseVersion version)
     {
         return (statement, index, value) -> {
             long epochSecond = floorDiv(value, MICROSECONDS_PER_SECOND);
             int nanoFraction = floorMod(value, MICROSECONDS_PER_SECOND) * NANOSECONDS_PER_MICROSECOND;
             verify(nanoFraction == 0, "Nanos of second must be zero: '%s'", value);
-            verifySupportedTimestamp(epochSecond);
-            statement.setObject(index, LocalDateTime.ofEpochSecond(epochSecond, 0, UTC));
+            LocalDateTime timestamp = LocalDateTime.ofEpochSecond(epochSecond, 0, UTC);
+            // ClickHouse stores incorrect results when the values are out of supported range.
+            DATETIME.validate(version, timestamp);
+            statement.setObject(index, timestamp);
         };
-    }
-
-    private static void verifySupportedTimestamp(long epochSecond)
-    {
-        if (epochSecond < MIN_SUPPORTED_TIMESTAMP_EPOCH || epochSecond > MAX_SUPPORTED_TIMESTAMP_EPOCH) {
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss");
-            throw new TrinoException(INVALID_ARGUMENTS, format("Timestamp must be between %s and %s in ClickHouse: %s", MIN_SUPPORTED_TIMESTAMP.format(formatter), MAX_SUPPORTED_TIMESTAMP.format(formatter), LocalDateTime.ofEpochSecond(epochSecond, 0, UTC).format(formatter)));
-        }
     }
 
     private ColumnMapping ipAddressColumnMapping(String writeBindExpression)

--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
@@ -105,6 +105,7 @@ import static io.trino.plugin.clickhouse.ClickHouseTableProperties.PRIMARY_KEY_P
 import static io.trino.plugin.clickhouse.ClickHouseTableProperties.SAMPLE_BY_PROPERTY;
 import static io.trino.plugin.clickhouse.TrinoToClickHouseWriteChecker.UINT16;
 import static io.trino.plugin.clickhouse.TrinoToClickHouseWriteChecker.UINT32;
+import static io.trino.plugin.clickhouse.TrinoToClickHouseWriteChecker.UINT64;
 import static io.trino.plugin.clickhouse.TrinoToClickHouseWriteChecker.UINT8;
 import static io.trino.plugin.jdbc.DecimalConfig.DecimalMapping.ALLOW_OVERFLOW;
 import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalDefaultScale;
@@ -175,8 +176,6 @@ public class ClickHouseClient
     private static final Splitter TABLE_PROPERTY_SPLITTER = Splitter.on(',').omitEmptyStrings().trimResults();
 
     private static final DecimalType UINT64_TYPE = createDecimalType(20, 0);
-    private static final BigDecimal UINT64_MIN_VALUE = BigDecimal.ZERO;
-    private static final BigDecimal UINT64_MAX_VALUE = new BigDecimal("18446744073709551615");
 
     private static final long MIN_SUPPORTED_DATE_EPOCH = LocalDate.parse("1970-01-01").toEpochDay();
     private static final long MAX_SUPPORTED_DATE_EPOCH = LocalDate.parse("2106-02-07").toEpochDay(); // The max date is '2148-12-31' in new ClickHouse version
@@ -517,7 +516,7 @@ public class ClickHouseClient
                 return Optional.of(ColumnMapping.objectMapping(
                         UINT64_TYPE,
                         longDecimalReadFunction(UINT64_TYPE, UNNECESSARY),
-                        uInt64WriteFunction()));
+                        uInt64WriteFunction(getClickHouseServerVersion(session))));
             case IPv4:
                 return Optional.of(ipAddressColumnMapping("IPv4StringToNum(?)"));
             case IPv6:
@@ -733,7 +732,7 @@ public class ClickHouseClient
         };
     }
 
-    private static ObjectWriteFunction uInt64WriteFunction()
+    private static ObjectWriteFunction uInt64WriteFunction(ClickHouseVersion version)
     {
         return ObjectWriteFunction.of(
                 Int128.class,
@@ -741,9 +740,7 @@ public class ClickHouseClient
                     BigInteger unscaledValue = value.toBigInteger();
                     BigDecimal bigDecimal = new BigDecimal(unscaledValue, UINT64_TYPE.getScale(), new MathContext(UINT64_TYPE.getPrecision()));
                     // ClickHouse stores incorrect results when the values are out of supported range.
-                    if (bigDecimal.compareTo(UINT64_MIN_VALUE) < 0 || bigDecimal.compareTo(UINT64_MAX_VALUE) > 0) {
-                        throw new TrinoException(INVALID_ARGUMENTS, format("Value must be between %s and %s in ClickHouse: %s", UINT64_MIN_VALUE, UINT64_MAX_VALUE, bigDecimal));
-                    }
+                    UINT64.validate(version, bigDecimal);
                     statement.setBigDecimal(index, bigDecimal);
                 });
     }

--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/TrinoToClickHouseWriteChecker.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/TrinoToClickHouseWriteChecker.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.clickhouse;
+
+import com.clickhouse.client.ClickHouseVersion;
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.TrinoException;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+import java.util.List;
+import java.util.function.Predicate;
+
+import static com.google.common.base.Predicates.alwaysTrue;
+import static io.trino.spi.StandardErrorCode.INVALID_ARGUMENTS;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class TrinoToClickHouseWriteChecker<T>
+{
+    // Different versions of ClickHouse may support different min/max values for the
+    // same data type, you can refer to the table below:
+    //
+    // | version | column type | min value           | max value            |
+    // |---------|-------------|---------------------|----------------------|
+    // | any     | UInt8       | 0                   | 255                  |
+    // | any     | UInt16      | 0                   | 65535                |
+    // | any     | UInt32      | 0                   | 4294967295           |
+    // | any     | UInt64      | 0                   | 18446744073709551615 |
+    // | < 21.4  | Date        | 1970-01-01          | 2106-02-07           |
+    // | < 21.4  | DateTime    | 1970-01-01 00:00:00 | 2106-02-06 06:28:15  |
+    // | >= 21.4 | Date        | 1970-01-01          | 2149-06-06           |
+    // | >= 21.4 | DateTime    | 1970-01-01 00:00:00 | 2106-02-07 06:28:15  |
+    //
+    // And when the value written to ClickHouse is out of range, ClickHouse will store
+    // the incorrect result, so we need to check the range of the written value to
+    // prevent ClickHouse from storing the incorrect value.
+
+    public static final TrinoToClickHouseWriteChecker<Long> UINT8 = new TrinoToClickHouseWriteChecker<>(ImmutableList.of(new LongWriteValueChecker(alwaysTrue(), new Range<>(0L, 255L))));
+    public static final TrinoToClickHouseWriteChecker<Long> UINT16 = new TrinoToClickHouseWriteChecker<>(ImmutableList.of(new LongWriteValueChecker(alwaysTrue(), new Range<>(0L, 65535L))));
+    public static final TrinoToClickHouseWriteChecker<Long> UINT32 = new TrinoToClickHouseWriteChecker<>(ImmutableList.of(new LongWriteValueChecker(alwaysTrue(), new Range<>(0L, 4294967295L))));
+    public static final TrinoToClickHouseWriteChecker<BigDecimal> UINT64 = new TrinoToClickHouseWriteChecker<>(
+            ImmutableList.of(new BigDecimalWriteValueChecker(alwaysTrue(), new Range<>(BigDecimal.ZERO, new BigDecimal("18446744073709551615")))));
+    public static final TrinoToClickHouseWriteChecker<LocalDate> DATE = new TrinoToClickHouseWriteChecker<>(
+            ImmutableList.of(
+                    new DateWriteValueChecker(version -> version.isOlderThan("21.4"), new Range<>(LocalDate.parse("1970-01-01"), LocalDate.parse("2106-02-07"))),
+                    new DateWriteValueChecker(version -> version.isNewerOrEqualTo("21.4"), new Range<>(LocalDate.parse("1970-01-01"), LocalDate.parse("2149-06-06")))));
+    public static final TrinoToClickHouseWriteChecker<LocalDateTime> DATETIME = new TrinoToClickHouseWriteChecker<>(
+            ImmutableList.of(
+                    new TimestampWriteValueChecker(
+                            version -> version.isOlderThan("21.4"),
+                            new Range<>(LocalDateTime.parse("1970-01-01T00:00:00"), LocalDateTime.parse("2106-02-06T06:28:15"))),
+                    new TimestampWriteValueChecker(
+                            version -> version.isNewerOrEqualTo("21.4"),
+                            new Range<>(LocalDateTime.parse("1970-01-01T00:00:00"), LocalDateTime.parse("2106-02-07T06:28:15")))));
+
+    private final List<Checker<T>> checkers;
+
+    private TrinoToClickHouseWriteChecker(List<Checker<T>> checkers)
+    {
+        this.checkers = ImmutableList.copyOf(requireNonNull(checkers, "checkers is null"));
+    }
+
+    public void validate(ClickHouseVersion version, T value)
+    {
+        for (Checker<T> checker : checkers) {
+            checker.validate(version, value);
+        }
+    }
+
+    private interface Checker<T>
+    {
+        void validate(ClickHouseVersion version, T value);
+    }
+
+    private static class LongWriteValueChecker
+            implements Checker<Long>
+    {
+        private final Predicate<ClickHouseVersion> predicate;
+        private final Range<Long> range;
+
+        public LongWriteValueChecker(Predicate<ClickHouseVersion> predicate, Range<Long> range)
+        {
+            this.predicate = requireNonNull(predicate, "predicate is null");
+            this.range = requireNonNull(range, "range is null");
+        }
+
+        @Override
+        public void validate(ClickHouseVersion version, Long value)
+        {
+            if (!predicate.test(version)) {
+                return;
+            }
+
+            if (value >= range.getMin() && value <= range.getMax()) {
+                return;
+            }
+
+            throw new TrinoException(INVALID_ARGUMENTS, format("Value must be between %d and %d in ClickHouse: %d", range.getMin(), range.getMax(), value));
+        }
+    }
+
+    private static class BigDecimalWriteValueChecker
+            implements Checker<BigDecimal>
+    {
+        private final Predicate<ClickHouseVersion> predicate;
+        private final Range<BigDecimal> range;
+
+        public BigDecimalWriteValueChecker(Predicate<ClickHouseVersion> predicate, Range<BigDecimal> range)
+        {
+            this.predicate = requireNonNull(predicate, "predicate is null");
+            this.range = requireNonNull(range, "range is null");
+        }
+
+        @Override
+        public void validate(ClickHouseVersion version, BigDecimal value)
+        {
+            if (!predicate.test(version)) {
+                return;
+            }
+
+            if (value.compareTo(range.getMin()) >= 0 && value.compareTo(range.getMax()) <= 0) {
+                return;
+            }
+
+            throw new TrinoException(INVALID_ARGUMENTS, format("Value must be between %s and %s in ClickHouse: %s", range.getMin(), range.getMax(), value));
+        }
+    }
+
+    private static class DateWriteValueChecker
+            implements Checker<LocalDate>
+    {
+        private final Predicate<ClickHouseVersion> predicate;
+        private final Range<LocalDate> range;
+
+        public DateWriteValueChecker(Predicate<ClickHouseVersion> predicate, Range<LocalDate> range)
+        {
+            this.predicate = requireNonNull(predicate, "predicate is null");
+            this.range = requireNonNull(range, "range is null");
+        }
+
+        @Override
+        public void validate(ClickHouseVersion version, LocalDate value)
+        {
+            if (!predicate.test(version)) {
+                return;
+            }
+
+            if (value.isBefore(range.getMin()) || value.isAfter(range.getMax())) {
+                throw new TrinoException(INVALID_ARGUMENTS, format("Date must be between %s and %s in ClickHouse: %s", range.getMin(), range.getMax(), value));
+            }
+        }
+    }
+
+    private static class TimestampWriteValueChecker
+            implements Checker<LocalDateTime>
+    {
+        private final Predicate<ClickHouseVersion> predicate;
+        private final Range<LocalDateTime> range;
+
+        public TimestampWriteValueChecker(Predicate<ClickHouseVersion> predicate, Range<LocalDateTime> range)
+        {
+            this.predicate = requireNonNull(predicate, "predicate is null");
+            this.range = requireNonNull(range, "range is null");
+        }
+
+        @Override
+        public void validate(ClickHouseVersion version, LocalDateTime value)
+        {
+            if (!predicate.test(version)) {
+                return;
+            }
+
+            if (value.isBefore(range.getMin()) || value.isAfter(range.getMax())) {
+                DateTimeFormatter formatter = new DateTimeFormatterBuilder()
+                        .appendPattern("uuuu-MM-dd HH:mm:ss")
+                        .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
+                        .toFormatter();
+                throw new TrinoException(
+                        INVALID_ARGUMENTS,
+                        format("Timestamp must be between %s and %s in ClickHouse: %s", formatter.format(range.getMin()), formatter.format(range.getMax()), formatter.format(value)));
+            }
+        }
+    }
+
+    private static class Range<T>
+    {
+        private final T min;
+        private final T max;
+
+        public Range(T min, T max)
+        {
+            this.min = requireNonNull(min, "min is null");
+            this.max = requireNonNull(max, "max is null");
+        }
+
+        public T getMin()
+        {
+            return min;
+        }
+
+        public T getMax()
+        {
+            return max;
+        }
+    }
+}

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseConnectorTest.java
@@ -608,7 +608,12 @@ public abstract class BaseClickHouseConnectorTest
         assertQuery("SELECT orderdate FROM orders WHERE orderdate = DATE '1997-09-14'", "VALUES DATE '1997-09-14'");
         assertQueryFails(
                 "SELECT * FROM orders WHERE orderdate = DATE '-1996-09-14'",
-                "Date must be between 1970-01-01 and 2106-02-07 in ClickHouse: -1996-09-14");
+                errorMessageForDateYearOfEraPredicate("-1996-09-14"));
+    }
+
+    protected String errorMessageForDateYearOfEraPredicate(String date)
+    {
+        return "Date must be between 1970-01-01 and 2106-02-07 in ClickHouse: " + date;
     }
 
     @Override

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseTypeMapping.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseTypeMapping.java
@@ -747,7 +747,7 @@ public abstract class BaseClickHouseTypeMapping
     {
         return new Object[][] {
                 {"1970-01-01 00:00:00"}, // min value in ClickHouse
-                {"2105-12-31 23:59:59"}, // max value in ClickHouse
+                {"2106-02-06 06:28:15"}, // max value in ClickHouse
         };
     }
 
@@ -762,16 +762,19 @@ public abstract class BaseClickHouseTypeMapping
                     format("INSERT INTO %s VALUES (TIMESTAMP '%s')", table.getName(), unsupportedTimestamp),
                     format("Timestamp must be between %s and %s in ClickHouse: %s", minSupportedTimestamp, maxSupportedTimestamp, unsupportedTimestamp));
         }
+
+        try (TestTable table = new TestTable(onRemoteDatabase(), "tpch.test_unsupported_timestamp", "(dt datetime) ENGINE=Log")) {
+            onRemoteDatabase().execute(format("INSERT INTO %s VALUES ('%s')", table.getName(), unsupportedTimestamp));
+            assertQuery(format("SELECT dt <> TIMESTAMP '%s' FROM %s", unsupportedTimestamp, table.getName()), "SELECT true"); // Inserting an unsupported datetime in ClickHouse will turn it into another datetime
+        }
     }
 
     @DataProvider
     public Object[][] unsupportedTimestampDataProvider()
     {
         return new Object[][] {
-                {"-9999-12-31 23:59:59"},
                 {"1969-12-31 23:59:59"}, // min - 1 second
-                {"2106-01-01 00:00:00"}, // max + 1 second
-                {"9999-12-31 23:59:59"},
+                {"2106-02-06 06:28:16"}, // max + 1 second
         };
     }
 

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseTypeMapping.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseTypeMapping.java
@@ -658,13 +658,13 @@ public abstract class BaseClickHouseTypeMapping
                 .execute(getQueryRunner(), session, trinoCreateAndInsert(session, "test_timestamp"))
                 .execute(getQueryRunner(), session, trinoCreateAndInsert("test_timestamp"));
 
-        addTimestampRoundTrips("timestamp")
+        timestampTest("timestamp")
                 .execute(getQueryRunner(), session, clickhouseCreateAndInsert("tpch.test_timestamp"));
-        addTimestampRoundTrips("datetime")
+        timestampTest("datetime")
                 .execute(getQueryRunner(), session, clickhouseCreateAndInsert("tpch.test_datetime"));
     }
 
-    private SqlDataTypeTest addTimestampRoundTrips(String inputType)
+    private SqlDataTypeTest timestampTest(String inputType)
     {
         return SqlDataTypeTest.create()
                 .addRoundTrip(inputType, "'1969-12-31 23:59:59'", createTimestampType(0), "TIMESTAMP '1970-01-01 23:59:59'") // unsupported timestamp become 1970-01-01 23:59:59

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseTypeMapping.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseTypeMapping.java
@@ -706,8 +706,7 @@ public abstract class BaseClickHouseTypeMapping
 
     private SqlDataTypeTest timestampTest(String inputType)
     {
-        return SqlDataTypeTest.create()
-                .addRoundTrip(inputType, "'1969-12-31 23:59:59'", createTimestampType(0), "TIMESTAMP '1970-01-01 23:59:59'") // unsupported timestamp become 1970-01-01 23:59:59
+        return unsupportedTimestampBecomeUnexpectedValueTest(inputType)
                 .addRoundTrip(inputType, "'1970-01-01 00:00:00'", createTimestampType(0), "TIMESTAMP '1970-01-01 00:00:00'") // min value in ClickHouse
                 .addRoundTrip(inputType, "'1986-01-01 00:13:07'", createTimestampType(0), "TIMESTAMP '1986-01-01 00:13:07'") // time gap in Kathmandu
                 .addRoundTrip(inputType, "'2018-03-25 03:17:17'", createTimestampType(0), "TIMESTAMP '2018-03-25 03:17:17'") // time gap in Vilnius
@@ -715,6 +714,12 @@ public abstract class BaseClickHouseTypeMapping
                 .addRoundTrip(inputType, "'2018-10-28 03:33:33'", createTimestampType(0), "TIMESTAMP '2018-10-28 03:33:33'") // time double in Vilnius
                 .addRoundTrip(inputType, "'2105-12-31 23:59:59'", createTimestampType(0), "TIMESTAMP '2105-12-31 23:59:59'") // max value in ClickHouse
                 .addRoundTrip(format("Nullable(%s)", inputType), "NULL", createTimestampType(0), "CAST(NULL AS TIMESTAMP(0))");
+    }
+
+    protected SqlDataTypeTest unsupportedTimestampBecomeUnexpectedValueTest(String inputType)
+    {
+        return SqlDataTypeTest.create()
+                .addRoundTrip(inputType, "'1969-12-31 23:59:59'", createTimestampType(0), "TIMESTAMP '1970-01-01 23:59:59'"); // unsupported timestamp become 1970-01-01 23:59:59
     }
 
     @Test

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseLatestConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseLatestConnectorTest.java
@@ -44,4 +44,25 @@ public class TestClickHouseLatestConnectorTest
         // The numeric value depends on file system
         return OptionalInt.of(255 - ".sql.detached".length());
     }
+
+    @Override
+    protected String errorMessageForCreateTableAsSelectNegativeDate(String date)
+    {
+        // Override because the DateTime range was expanded in version 21.4 and later
+        return "Date must be between 1970-01-01 and 2149-06-06 in ClickHouse: " + date;
+    }
+
+    @Override
+    protected String errorMessageForInsertNegativeDate(String date)
+    {
+        // Override because the DateTime range was expanded in version 21.4 and later
+        return "Date must be between 1970-01-01 and 2149-06-06 in ClickHouse: " + date;
+    }
+
+    @Override
+    protected String errorMessageForDateYearOfEraPredicate(String date)
+    {
+        // Override because the DateTime range was expanded in version 21.4 and later
+        return "Date must be between 1970-01-01 and 2149-06-06 in ClickHouse: " + date;
+    }
 }

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseLatestTypeMapping.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseLatestTypeMapping.java
@@ -70,4 +70,26 @@ public class TestClickHouseLatestTypeMapping
         return SqlDataTypeTest.create()
                 .addRoundTrip(inputType, "'1969-12-31 23:59:59'", createTimestampType(0), "TIMESTAMP '1970-01-01 00:00:00'");
     }
+
+    @DataProvider
+    @Override
+    public Object[][] clickHouseDateTimeMinMaxValuesDataProvider()
+    {
+        // Override because the DateTime range was expanded in version 21.4 and later
+        return new Object[][] {
+                {"1970-01-01 00:00:00"}, // min value in ClickHouse
+                {"2106-02-07 06:28:15"}, // max value in ClickHouse
+        };
+    }
+
+    @DataProvider
+    @Override
+    public Object[][] unsupportedTimestampDataProvider()
+    {
+        // Override because the DateTime range was expanded in version 21.4 and later
+        return new Object[][] {
+                {"1969-12-31 23:59:59"}, // min - 1 second
+                {"2106-02-07 06:28:16"}, // max + 1 second
+        };
+    }
 }

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseLatestTypeMapping.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseLatestTypeMapping.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.clickhouse;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.datatype.SqlDataTypeTest;
+import org.testng.annotations.DataProvider;
+
+import static io.trino.plugin.clickhouse.ClickHouseQueryRunner.createClickHouseQueryRunner;
+import static io.trino.plugin.clickhouse.TestingClickHouseServer.CLICKHOUSE_LATEST_IMAGE;
+import static io.trino.spi.type.TimestampType.createTimestampType;
+
+public class TestClickHouseLatestTypeMapping
+        extends BaseClickHouseTypeMapping
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        clickhouseServer = closeAfterClass(new TestingClickHouseServer(CLICKHOUSE_LATEST_IMAGE));
+        return createClickHouseQueryRunner(clickhouseServer, ImmutableMap.of(),
+                ImmutableMap.<String, String>builder()
+                        .put("metadata.cache-ttl", "10m")
+                        .put("metadata.cache-missing", "true")
+                        .buildOrThrow(),
+                ImmutableList.of());
+    }
+
+    @DataProvider
+    @Override
+    public Object[][] clickHouseDateMinMaxValuesDataProvider()
+    {
+        // Override because the Date range was expanded in version 21.4 and later
+        return new Object[][] {
+                {"1970-01-01"}, // min value in ClickHouse
+                {"2149-06-06"}, // max value in ClickHouse
+        };
+    }
+
+    @DataProvider
+    @Override
+    public Object[][] unsupportedClickHouseDateValuesDataProvider()
+    {
+        // Override because the Date range was expanded in version 21.4 and later
+        return new Object[][] {
+                {"1969-12-31"}, // min - 1 day
+                {"2149-06-07"}, // max + 1 day
+        };
+    }
+
+    @Override
+    protected SqlDataTypeTest unsupportedTimestampBecomeUnexpectedValueTest(String inputType)
+    {
+        // Override because insert DateTime '1969-12-31 23:59:59' directly in ClickHouse will
+        // become '1970-01-01 00:00:00' in version 21.4 and later, however in versions prior
+        // to 21.4 the value will become '1970-01-01 23:59:59'.
+        return SqlDataTypeTest.create()
+                .addRoundTrip(inputType, "'1969-12-31 23:59:59'", createTimestampType(0), "TIMESTAMP '1970-01-01 00:00:00'");
+    }
+}

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseTypeMapping.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseTypeMapping.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.clickhouse;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.QueryRunner;
+
+import static io.trino.plugin.clickhouse.ClickHouseQueryRunner.createClickHouseQueryRunner;
+
+public class TestClickHouseTypeMapping
+        extends BaseClickHouseTypeMapping
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        clickhouseServer = closeAfterClass(new TestingClickHouseServer());
+        return createClickHouseQueryRunner(clickhouseServer, ImmutableMap.of(),
+                ImmutableMap.<String, String>builder()
+                        .put("metadata.cache-ttl", "10m")
+                        .put("metadata.cache-missing", "true")
+                        .buildOrThrow(),
+                ImmutableList.of());
+    }
+}


### PR DESCRIPTION
## Description

Different versions of ClickHouse may support different min/max values
for the same data type, you can refer to the table below:

| version | column type | min value           | max value            |
|---------|-------------|---------------------|----------------------|
| any     | UInt8       | 0                   | 255                  |
| any     | UInt16      | 0                   | 65535                |
| any     | UInt32      | 0                   | 4294967295           |
| any     | UInt64      | 0                   | 18446744073709551615 |
| < 21.4  | Date        | 1970-01-01          | 2106-02-07           |
| < 21.4  | DateTime    | 1970-01-01 00:00:00 | 2106-02-06 06:28:15  |
| >= 21.4 | Date        | 1970-01-01          | 2149-06-06           |
| >= 21.4 | DateTime    | 1970-01-01 00:00:00 | 2106-02-07 06:28:15  |

And when the value written to ClickHouse is out of range, ClickHouse
will store the incorrect result, so we introduced
`TrinoToClickHouseWriteChecker` to check the range of the written value
to prevent ClickHouse from storing the incorrect value.

Introducing `TrinoToClickHouseWriteChecker` is also a preparation for
supporting `DateTime[timezone]` and `DateTime64(precision, [timezone])`.

Fixes #11116 
Related #10537 

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# ClickHouse
* Extend the range of ClickHouse `Date` and `DateTime` values. ({issue}`11116`)
```