### PR TITLE
Add format_data_size function

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/DataSizeFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/DataSizeFunctions.java
@@ -21,10 +21,14 @@ import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.type.Decimals;
 import io.trino.spi.type.Int128;
+import io.trino.spi.type.StandardTypes;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.math.RoundingMode;
+import java.text.DecimalFormat;
 
+import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static java.lang.Character.isDigit;
@@ -32,7 +36,19 @@ import static java.lang.String.format;
 
 public final class DataSizeFunctions
 {
-    private DataSizeFunctions() {}
+    private final DecimalFormat format3Number;
+    private final DecimalFormat format2Number;
+    private final DecimalFormat format1Number;
+
+    public DataSizeFunctions()
+    {
+        format3Number = new DecimalFormat("#.##");
+        format3Number.setRoundingMode(RoundingMode.HALF_UP);
+        format2Number = new DecimalFormat("#.#");
+        format2Number.setRoundingMode(RoundingMode.HALF_UP);
+        format1Number = new DecimalFormat("#");
+        format1Number.setRoundingMode(RoundingMode.HALF_UP);
+    }
 
     @Description("Converts data size string to bytes")
     @ScalarFunction(value = "parse_data_size", alias = "parse_presto_data_size")
@@ -41,7 +57,39 @@ public final class DataSizeFunctions
     public static Int128 parsePrestoDataSize(@SqlType("varchar(x)") Slice input)
     {
         String dataSize = input.toStringUtf8();
+        int valueLength = getValueLength(dataSize);
+        BigDecimal value = parseValue(dataSize.substring(0, valueLength), dataSize);
+        Unit unit = Unit.parse(dataSize.substring(valueLength), dataSize);
+        BigInteger bytes = value.multiply(unit.getFactor()).toBigInteger();
+        try {
+            return Decimals.valueOf(bytes);
+        }
+        catch (ArithmeticException e) {
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Value out of range: '%s' ('%sB')", dataSize, bytes));
+        }
+    }
 
+    @Description("Converts decimal data size string to bytes")
+    @ScalarFunction("parse_data_size_decimal")
+    @LiteralParameters("x")
+    @SqlType("decimal(38,0)")
+    public static Int128 parseDataSizeDecimal(@SqlType("varchar(x)") Slice input)
+    {
+        String dataSize = input.toStringUtf8();
+        int valueLength = getValueLength(dataSize);
+        BigDecimal value = parseValue(dataSize.substring(0, valueLength), dataSize);
+        Unit unit = Unit.parseDecimal(dataSize.substring(valueLength), dataSize);
+        BigInteger bytes = value.multiply(unit.getFactor()).toBigInteger();
+        try {
+            return Decimals.valueOf(bytes);
+        }
+        catch (ArithmeticException e) {
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Value out of range: '%s' ('%sB')", dataSize, bytes));
+        }
+    }
+
+    private static int getValueLength(String dataSize)
+    {
         int valueLength = 0;
         for (int i = 0; i < dataSize.length(); i++) {
             char c = dataSize.charAt(i);
@@ -56,16 +104,7 @@ public final class DataSizeFunctions
         if (valueLength == 0) {
             throw invalidDataSize(dataSize);
         }
-
-        BigDecimal value = parseValue(dataSize.substring(0, valueLength), dataSize);
-        Unit unit = Unit.parse(dataSize.substring(valueLength), dataSize);
-        BigInteger bytes = value.multiply(unit.getFactor()).toBigInteger();
-        try {
-            return Decimals.valueOf(bytes);
-        }
-        catch (ArithmeticException e) {
-            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Value out of range: '%s' ('%sB')", dataSize, bytes));
-        }
+        return valueLength;
     }
 
     private static BigDecimal parseValue(String value, String dataSize)
@@ -85,21 +124,50 @@ public final class DataSizeFunctions
 
     private enum Unit
     {
-        BYTE(BigDecimal.ONE),
-        KILOBYTE(new BigDecimal(1L << 10)),
-        MEGABYTE(new BigDecimal(1L << 20)),
-        GIGABYTE(new BigDecimal(1L << 30)),
-        TERABYTE(new BigDecimal(1L << 40)),
-        PETABYTE(new BigDecimal(1L << 50)),
-        EXABYTE(new BigDecimal(1L << 60)),
-        ZETTABYTE(new BigDecimal(1L << 60).multiply(new BigDecimal(1L << 10))),
-        YOTTABYTE(new BigDecimal(1L << 60).multiply(new BigDecimal(1L << 20)));
+        BYTE(0, 1024),
+        KILOBYTE(1, 1000),
+        MEGABYTE(2, 1000),
+        GIGABYTE(3, 1000),
+        TERABYTE(4, 1000),
+        PETABYTE(5, 1000),
+        EXABYTE(6, 1000),
+        ZETTABYTE(7, 1000),
+        YOTTABYTE(8, 1000),
+
+        KIBIBYTE(1, 1024),
+        MEBIBYTE(2, 1024),
+        GIBIBYTE(3, 1024),
+        TEBIBYTE(4, 1024),
+        PEBIBYTE(5, 1024),
+        EXBIBYTE(6, 1024),
+        ZEBIBYTE(7, 1024),
+        YOBIBYTE(8, 1024);
 
         private final BigDecimal factor;
 
-        Unit(BigDecimal factor)
+        Unit(int factor, int base)
         {
-            this.factor = factor;
+            if (base == 1024) {
+                if (factor <= 6) {
+                    this.factor = new BigDecimal(1L << factor * 10);
+                }
+                else {
+                    this.factor = new BigDecimal(1L << 60)
+                            .multiply(new BigDecimal(1L << (factor % 6) * 10));
+                }
+                return;
+            }
+            if (base == 1000) {
+                if (factor <= 6) {
+                    this.factor = new BigDecimal("1" + "0".repeat(factor * 3));
+                }
+                else {
+                    this.factor = new BigDecimal("1" + "0".repeat(6 * 3))
+                            .multiply(new BigDecimal("1" + "0".repeat((factor % 6) * 3)));
+                }
+                return;
+            }
+            throw new IllegalArgumentException("Base of Unit must be either 1024 or 1000");
         }
 
         public BigDecimal getFactor()
@@ -108,6 +176,32 @@ public final class DataSizeFunctions
         }
 
         public static Unit parse(String unitString, String dataSize)
+        {
+            switch (unitString) {
+                case "B":
+                    return BYTE;
+                case "kB":
+                    return KIBIBYTE;
+                case "MB":
+                    return MEBIBYTE;
+                case "GB":
+                    return GIBIBYTE;
+                case "TB":
+                    return TEBIBYTE;
+                case "PB":
+                    return PEBIBYTE;
+                case "EB":
+                    return EXBIBYTE;
+                case "ZB":
+                    return ZEBIBYTE;
+                case "YB":
+                    return YOBIBYTE;
+                default:
+                    throw invalidDataSize(dataSize);
+            }
+        }
+
+        public static Unit parseDecimal(String unitString, String dataSize)
         {
             switch (unitString) {
                 case "B":
@@ -132,5 +226,93 @@ public final class DataSizeFunctions
                     throw invalidDataSize(dataSize);
             }
         }
+    }
+
+    @Description("Formats data size as bytes using a unit symbol")
+    @ScalarFunction("format_data_size")
+    @SqlType(StandardTypes.VARCHAR)
+    public Slice formatDataSize(@SqlType(StandardTypes.BIGINT) long value)
+    {
+        return utf8Slice(formatLong(value, 1024));
+    }
+
+    @Description("Formats data size as bytes using a unit symbol")
+    @ScalarFunction("format_data_size")
+    @SqlType(StandardTypes.VARCHAR)
+    public Slice formatDataSize(@SqlType(StandardTypes.DOUBLE) double value)
+    {
+        return utf8Slice(formatLong(value, 1024));
+    }
+
+    @Description("Formats data size as bytes using a unit symbol and a decimal base")
+    @ScalarFunction("format_data_size_decimal")
+    @SqlType(StandardTypes.VARCHAR)
+    public Slice formatDataSizeDecimal(@SqlType(StandardTypes.BIGINT) long value)
+    {
+        return utf8Slice(formatLong(value, 1000));
+    }
+
+    @Description("Formats data size as bytes using a unit symbol and a decimal base")
+    @ScalarFunction("format_data_size_decimal")
+    @SqlType(StandardTypes.VARCHAR)
+    public Slice formatDataSizeDecimal(@SqlType(StandardTypes.DOUBLE) double value)
+    {
+        return utf8Slice(formatLong(value, 1000));
+    }
+
+    private String formatLong(double value, long base)
+    {
+        if (Double.isNaN(value) || Double.isInfinite(value)) {
+            return Double.toString(value);
+        }
+        String unit = "B";
+        if (value >= base || value <= -base) {
+            value /= base;
+            unit = "kB";
+        }
+        if (value >= base || value <= -base) {
+            value /= base;
+            unit = "MB";
+        }
+        if (value >= base || value <= -base) {
+            value /= base;
+            unit = "GB";
+        }
+        if (value >= base || value <= -base) {
+            value /= base;
+            unit = "TB";
+        }
+        if (value >= base || value <= -base) {
+            value /= base;
+            unit = "PB";
+        }
+        if (value >= base || value <= -base) {
+            value /= base;
+            unit = "EB";
+        }
+        if (value >= base || value <= -base) {
+            value /= base;
+            unit = "ZB";
+        }
+        if (value >= base || value <= -base) {
+            value /= base;
+            unit = "YB";
+        }
+
+        return getFormat(value).format(value) + unit;
+    }
+
+    private DecimalFormat getFormat(double value)
+    {
+        if (Math.abs(value) < 10) {
+            // show up to two decimals to get 3 significant digits
+            return format3Number;
+        }
+        if (Math.abs(value) < 100) {
+            // show up to one decimal to get 3 significant digits
+            return format2Number;
+        }
+        // show no decimals -- we have enough digits in the integer part
+        return format1Number;
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestDataSizeFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestDataSizeFunctions.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.TestInstance;
 import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.type.DecimalType.createDecimalType;
 import static io.trino.spi.type.SqlDecimal.decimal;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
@@ -122,5 +123,294 @@ public class TestDataSizeFunctions
         assertTrinoExceptionThrownBy(() -> assertions.function("parse_data_size", "'99999999999999YB'").evaluate())
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
                 .hasMessage("Value out of range: '99999999999999YB' ('120892581961461708544797985370825293824B')");
+    }
+
+    @Test
+    public void testParseDataSizeDecimal()
+    {
+        assertThat(assertions.function("parse_data_size_decimal", "'0B'"))
+                .isEqualTo(decimal("0", DECIMAL));
+        assertThat(assertions.function("parse_data_size_decimal", "'1B'"))
+                .isEqualTo(decimal("1", DECIMAL));
+        assertThat(assertions.function("parse_data_size_decimal", "'1.2B'"))
+                .isEqualTo(decimal("1", DECIMAL));
+        assertThat(assertions.function("parse_data_size_decimal", "'1.9B'"))
+                .isEqualTo(decimal("1", DECIMAL));
+        assertThat(assertions.function("parse_data_size_decimal", "'2.2kB'"))
+                .isEqualTo(decimal("2200", DECIMAL));
+        assertThat(assertions.function("parse_data_size_decimal", "'2.23kB'"))
+                .isEqualTo(decimal("2230", DECIMAL));
+        assertThat(assertions.function("parse_data_size_decimal", "'2.234kB'"))
+                .isEqualTo(decimal("2234", DECIMAL));
+        assertThat(assertions.function("parse_data_size_decimal", "'3MB'"))
+                .isEqualTo(decimal("3000000", DECIMAL));
+        assertThat(assertions.function("parse_data_size_decimal", "'4GB'"))
+                .isEqualTo(decimal("4000000000", DECIMAL));
+        assertThat(assertions.function("parse_data_size_decimal", "'4TB'"))
+                .isEqualTo(decimal("4000000000000", DECIMAL));
+        assertThat(assertions.function("parse_data_size_decimal", "'5PB'"))
+                .isEqualTo(decimal("5000000000000000", DECIMAL));
+        assertThat(assertions.function("parse_data_size_decimal", "'6EB'"))
+                .isEqualTo(decimal("6000000000000000000", DECIMAL));
+        assertThat(assertions.function("parse_data_size_decimal", "'7ZB'"))
+                .isEqualTo(decimal("7000000000000000000000", DECIMAL));
+        assertThat(assertions.function("parse_data_size_decimal", "'8YB'"))
+                .isEqualTo(decimal("8000000000000000000000000", DECIMAL));
+        assertThat(assertions.function("parse_data_size_decimal", "'6917529027641081856EB'"))
+                .isEqualTo(decimal("6917529027641081856000000000000000000", DECIMAL));
+        assertThat(assertions.function("parse_data_size_decimal", "'69175290276410818560EB'"))
+                .isEqualTo(decimal("69175290276410818560000000000000000000", DECIMAL));
+        assertThat(assertions.function("parse_data_size_decimal", "'99999999999999YB'"))
+                .isEqualTo(decimal("99999999999999000000000000000000000000", DECIMAL));
+
+        assertTrinoExceptionThrownBy(() -> assertions.function("parse_data_size_decimal", "''").evaluate())
+                .hasMessage("Invalid data size: ''");
+        assertTrinoExceptionThrownBy(() -> assertions.function("parse_data_size_decimal", "'0'").evaluate())
+                .hasMessage("Invalid data size: '0'");
+        assertTrinoExceptionThrownBy(() -> assertions.function("parse_data_size_decimal", "'10KB'").evaluate())
+                .hasMessage("Invalid data size: '10KB'");
+        assertTrinoExceptionThrownBy(() -> assertions.function("parse_data_size_decimal", "'KB'").evaluate())
+                .hasMessage("Invalid data size: 'KB'");
+        assertTrinoExceptionThrownBy(() -> assertions.function("parse_data_size_decimal", "'-1B'").evaluate())
+                .hasMessage("Invalid data size: '-1B'");
+        assertTrinoExceptionThrownBy(() -> assertions.function("parse_data_size_decimal", "'12345K'").evaluate())
+                .hasMessage("Invalid data size: '12345K'");
+        assertTrinoExceptionThrownBy(() -> assertions.function("parse_data_size_decimal", "'A12345B'").evaluate())
+                .hasMessage("Invalid data size: 'A12345B'");
+        assertTrinoExceptionThrownBy(() -> assertions.function("parse_data_size_decimal", "'999999999999999YB'").evaluate())
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Value out of range: '999999999999999YB' ('999999999999999000000000000000000000000B')");
+    }
+
+    @Test
+    public void testFormatDataSize()
+    {
+        assertThat(assertions.function("format_data_size", "TINYINT '123'"))
+                .isEqualTo("123B");
+        assertThat(assertions.function("format_data_size", "SMALLINT '12345'"))
+                .isEqualTo("12.1kB");
+        assertThat(assertions.function("format_data_size", "SMALLINT '12399'"))
+                .isEqualTo("12.1kB");
+        assertThat(assertions.function("format_data_size", "INTEGER '123456'"))
+                .isEqualTo("121kB");
+        assertThat(assertions.function("format_data_size", "INTEGER '1048576'"))
+                .isEqualTo("1MB");
+        assertThat(assertions.function("format_data_size", "INTEGER '12345678'"))
+                .isEqualTo("11.8MB");
+        assertThat(assertions.function("format_data_size", "INTEGER '12399999'"))
+                .isEqualTo("11.8MB");
+        assertThat(assertions.function("format_data_size", "BIGINT '12345678901'"))
+                .isEqualTo("11.5GB");
+        assertThat(assertions.function("format_data_size", "BIGINT '12399999999'"))
+                .isEqualTo("11.5GB");
+
+        assertThat(assertions.function("format_data_size", "DOUBLE '1234.5'"))
+                .isEqualTo("1.21kB");
+        assertThat(assertions.function("format_data_size", "DOUBLE '1239.9'"))
+                .isEqualTo("1.21kB");
+        assertThat(assertions.function("format_data_size", "REAL '1234567.8'"))
+                .isEqualTo("1.18MB");
+        assertThat(assertions.function("format_data_size", "REAL '1239999.9'"))
+                .isEqualTo("1.18MB");
+        assertThat(assertions.function("format_data_size", "DECIMAL '1234567890.1'"))
+                .isEqualTo("1.15GB");
+        assertThat(assertions.function("format_data_size", "DECIMAL '1239999999.9'"))
+                .isEqualTo("1.15GB");
+        assertThat(assertions.function("format_data_size", "DECIMAL '1239999999999.9'"))
+                .isEqualTo("1.13TB");
+        assertThat(assertions.function("format_data_size", "DECIMAL '1239999999999999.9'"))
+                .isEqualTo("1.1PB");
+        assertThat(assertions.function("format_data_size", "DECIMAL '1239999999999999999.9'"))
+                .isEqualTo("1.08EB");
+        assertThat(assertions.function("format_data_size", "DECIMAL '1239999999999999999999.9'"))
+                .isEqualTo("1.05ZB");
+        assertThat(assertions.function("format_data_size", "DECIMAL '1239999999999999999999999.9'"))
+                .isEqualTo("1.03YB");
+        assertThat(assertions.function("format_data_size", "DECIMAL '1239999999999999999999999999.9'"))
+                .isEqualTo("1026YB");
+
+        assertThat(assertions.function("format_data_size", "-999"))
+                .isEqualTo("-999B");
+        assertThat(assertions.function("format_data_size", "-1000"))
+                .isEqualTo("-1000B");
+        assertThat(assertions.function("format_data_size", "-999999"))
+                .isEqualTo("-977kB");
+        assertThat(assertions.function("format_data_size", "-1000000"))
+                .isEqualTo("-977kB");
+        assertThat(assertions.function("format_data_size", "-999999999"))
+                .isEqualTo("-954MB");
+        assertThat(assertions.function("format_data_size", "-1000000000"))
+                .isEqualTo("-954MB");
+        assertThat(assertions.function("format_data_size", "-999999999999"))
+                .isEqualTo("-931GB");
+        assertThat(assertions.function("format_data_size", "-1000000000000"))
+                .isEqualTo("-931GB");
+        assertThat(assertions.function("format_data_size", "-999999999999999"))
+                .isEqualTo("-909TB");
+        assertThat(assertions.function("format_data_size", "-1000000000000000"))
+                .isEqualTo("-909TB");
+        assertThat(assertions.function("format_data_size", "-9223372036854775808"))
+                .isEqualTo("-8EB");
+
+        assertThat(assertions.function("format_data_size", "0"))
+                .isEqualTo("0B");
+        assertThat(assertions.function("format_data_size", "999"))
+                .isEqualTo("999B");
+        assertThat(assertions.function("format_data_size", "1000"))
+                .isEqualTo("1000B");
+        assertThat(assertions.function("format_data_size", "999999"))
+                .isEqualTo("977kB");
+        assertThat(assertions.function("format_data_size", "1000000"))
+                .isEqualTo("977kB");
+        assertThat(assertions.function("format_data_size", "999999999"))
+                .isEqualTo("954MB");
+        assertThat(assertions.function("format_data_size", "1000000000"))
+                .isEqualTo("954MB");
+        assertThat(assertions.function("format_data_size", "999999999999"))
+                .isEqualTo("931GB");
+        assertThat(assertions.function("format_data_size", "1000000000000"))
+                .isEqualTo("931GB");
+        assertThat(assertions.function("format_data_size", "999999999999999"))
+                .isEqualTo("909TB");
+        assertThat(assertions.function("format_data_size", "1000000000000000"))
+                .isEqualTo("909TB");
+        assertThat(assertions.function("format_data_size", "9223372036854775807"))
+                .isEqualTo("8EB");
+
+        assertThat(assertions.function("format_data_size", "DOUBLE 'NaN'"))
+                .isEqualTo("NaN");
+        assertThat(assertions.function("format_data_size", "DOUBLE '+Infinity'"))
+                .isEqualTo("Infinity");
+        assertThat(assertions.function("format_data_size", "DOUBLE '-Infinity'"))
+                .isEqualTo("-Infinity");
+
+        assertThat(assertions.function("format_data_size", "CAST(NULL AS TINYINT)"))
+                .isNull(VARCHAR);
+        assertThat(assertions.function("format_data_size", "CAST(NULL AS SMALLINT)"))
+                .isNull(VARCHAR);
+        assertThat(assertions.function("format_data_size", "CAST(NULL AS INTEGER)"))
+                .isNull(VARCHAR);
+        assertThat(assertions.function("format_data_size", "CAST(NULL AS DOUBLE)"))
+                .isNull(VARCHAR);
+        assertThat(assertions.function("format_data_size", "CAST(NULL AS REAL)"))
+                .isNull(VARCHAR);
+        assertThat(assertions.function("format_data_size", "CAST(NULL AS DECIMAL)"))
+                .isNull(VARCHAR);
+    }
+
+    @Test
+    public void testFormatDataSizeDecimal()
+    {
+        assertThat(assertions.function("format_data_size_decimal", "TINYINT '123'"))
+                .isEqualTo("123B");
+        assertThat(assertions.function("format_data_size_decimal", "SMALLINT '12345'"))
+                .isEqualTo("12.3kB");
+        assertThat(assertions.function("format_data_size_decimal", "SMALLINT '12399'"))
+                .isEqualTo("12.4kB");
+        assertThat(assertions.function("format_data_size_decimal", "INTEGER '123456'"))
+                .isEqualTo("123kB");
+        assertThat(assertions.function("format_data_size_decimal", "INTEGER '1048576'"))
+                .isEqualTo("1.05MB");
+        assertThat(assertions.function("format_data_size_decimal", "INTEGER '12345678'"))
+                .isEqualTo("12.3MB");
+        assertThat(assertions.function("format_data_size_decimal", "INTEGER '12399999'"))
+                .isEqualTo("12.4MB");
+        assertThat(assertions.function("format_data_size_decimal", "BIGINT '12345678901'"))
+                .isEqualTo("12.3GB");
+        assertThat(assertions.function("format_data_size_decimal", "BIGINT '12399999999'"))
+                .isEqualTo("12.4GB");
+
+        assertThat(assertions.function("format_data_size_decimal", "DOUBLE '1234.5'"))
+                .isEqualTo("1.23kB");
+        assertThat(assertions.function("format_data_size_decimal", "DOUBLE '1239.9'"))
+                .isEqualTo("1.24kB");
+        assertThat(assertions.function("format_data_size_decimal", "REAL '1234567.8'"))
+                .isEqualTo("1.23MB");
+        assertThat(assertions.function("format_data_size_decimal", "REAL '1239999.9'"))
+                .isEqualTo("1.24MB");
+        assertThat(assertions.function("format_data_size_decimal", "DECIMAL '1234567890.1'"))
+                .isEqualTo("1.23GB");
+        assertThat(assertions.function("format_data_size_decimal", "DECIMAL '1239999999.9'"))
+                .isEqualTo("1.24GB");
+        assertThat(assertions.function("format_data_size_decimal", "DECIMAL '1239999999999.9'"))
+                .isEqualTo("1.24TB");
+        assertThat(assertions.function("format_data_size_decimal", "DECIMAL '1239999999999999.9'"))
+                .isEqualTo("1.24PB");
+        assertThat(assertions.function("format_data_size_decimal", "DECIMAL '1239999999999999999.9'"))
+                .isEqualTo("1.24EB");
+        assertThat(assertions.function("format_data_size_decimal", "DECIMAL '1239999999999999999999.9'"))
+                .isEqualTo("1.24ZB");
+        assertThat(assertions.function("format_data_size_decimal", "DECIMAL '1239999999999999999999999.9'"))
+                .isEqualTo("1.24YB");
+        assertThat(assertions.function("format_data_size_decimal", "DECIMAL '1239999999999999999999999999.9'"))
+                .isEqualTo("1240YB");
+
+        assertThat(assertions.function("format_data_size_decimal", "-999"))
+                .isEqualTo("-999B");
+        assertThat(assertions.function("format_data_size_decimal", "-1000"))
+                .isEqualTo("-1kB");
+        assertThat(assertions.function("format_data_size_decimal", "-999999"))
+                .isEqualTo("-1000kB");
+        assertThat(assertions.function("format_data_size_decimal", "-1000000"))
+                .isEqualTo("-1MB");
+        assertThat(assertions.function("format_data_size_decimal", "-999999999"))
+                .isEqualTo("-1000MB");
+        assertThat(assertions.function("format_data_size_decimal", "-1000000000"))
+                .isEqualTo("-1GB");
+        assertThat(assertions.function("format_data_size_decimal", "-999999999999"))
+                .isEqualTo("-1000GB");
+        assertThat(assertions.function("format_data_size_decimal", "-1000000000000"))
+                .isEqualTo("-1TB");
+        assertThat(assertions.function("format_data_size_decimal", "-999999999999999"))
+                .isEqualTo("-1000TB");
+        assertThat(assertions.function("format_data_size_decimal", "-1000000000000000"))
+                .isEqualTo("-1PB");
+        assertThat(assertions.function("format_data_size_decimal", "-9223372036854775808"))
+                .isEqualTo("-9.22EB");
+
+        assertThat(assertions.function("format_data_size_decimal", "0"))
+                .isEqualTo("0B");
+        assertThat(assertions.function("format_data_size_decimal", "999"))
+                .isEqualTo("999B");
+        assertThat(assertions.function("format_data_size_decimal", "1000"))
+                .isEqualTo("1kB");
+        assertThat(assertions.function("format_data_size_decimal", "999999"))
+                .isEqualTo("1000kB");
+        assertThat(assertions.function("format_data_size_decimal", "1000000"))
+                .isEqualTo("1MB");
+        assertThat(assertions.function("format_data_size_decimal", "999999999"))
+                .isEqualTo("1000MB");
+        assertThat(assertions.function("format_data_size_decimal", "1000000000"))
+                .isEqualTo("1GB");
+        assertThat(assertions.function("format_data_size_decimal", "999999999999"))
+                .isEqualTo("1000GB");
+        assertThat(assertions.function("format_data_size_decimal", "1000000000000"))
+                .isEqualTo("1TB");
+        assertThat(assertions.function("format_data_size_decimal", "999999999999999"))
+                .isEqualTo("1000TB");
+        assertThat(assertions.function("format_data_size_decimal", "1000000000000000"))
+                .isEqualTo("1PB");
+        assertThat(assertions.function("format_data_size_decimal", "9223372036854775807"))
+                .isEqualTo("9.22EB");
+
+        assertThat(assertions.function("format_data_size_decimal", "DOUBLE 'NaN'"))
+                .isEqualTo("NaN");
+        assertThat(assertions.function("format_data_size_decimal", "DOUBLE '+Infinity'"))
+                .isEqualTo("Infinity");
+        assertThat(assertions.function("format_data_size_decimal", "DOUBLE '-Infinity'"))
+                .isEqualTo("-Infinity");
+
+        assertThat(assertions.function("format_data_size_decimal", "CAST(NULL AS TINYINT)"))
+                .isNull(VARCHAR);
+        assertThat(assertions.function("format_data_size_decimal", "CAST(NULL AS SMALLINT)"))
+                .isNull(VARCHAR);
+        assertThat(assertions.function("format_data_size_decimal", "CAST(NULL AS INTEGER)"))
+                .isNull(VARCHAR);
+        assertThat(assertions.function("format_data_size_decimal", "CAST(NULL AS DOUBLE)"))
+                .isNull(VARCHAR);
+        assertThat(assertions.function("format_data_size_decimal", "CAST(NULL AS REAL)"))
+                .isNull(VARCHAR);
+        assertThat(assertions.function("format_data_size_decimal", "CAST(NULL AS DECIMAL)"))
+                .isNull(VARCHAR);
     }
 }

--- a/docs/src/main/sphinx/functions/conversion.rst
+++ b/docs/src/main/sphinx/functions/conversion.rst
@@ -62,7 +62,7 @@ Formatting
 Data size
 ---------
 
-The ``parse_data_size`` function supports the following units:
+The ``format_data_size`` and ``parse_data_size`` functions supports the following units:
 
 ======= ============= ==============
 Unit    Description   Value
@@ -78,6 +78,36 @@ Unit    Description   Value
 ``YB``  Yottabytes    1024\ :sup:`8`
 ======= ============= ==============
 
+The ``format_data_size_decimal`` and ``parse_data_size_decimal`` functions supports the following units:
+
+======= ============= ==============
+Unit    Description   Value
+======= ============= ==============
+``B``   Bytes         1
+``kB``  Kilobytes     1000
+``MB``  Megabytes     1000\ :sup:`2`
+``GB``  Gigabytes     1000\ :sup:`3`
+``TB``  Terabytes     1000\ :sup:`4`
+``PB``  Petabytes     1000\ :sup:`5`
+``EB``  Exabytes      1000\ :sup:`6`
+``ZB``  Zettabytes    1000\ :sup:`7`
+``YB``  Yottabytes    1000\ :sup:`8`
+======= ============= ==============
+
+.. function:: format_data_size(number) -> varchar
+
+    Returns a formatted string using a unit symbol::
+
+        SELECT format_data_size(123456); -- '121kB'
+        SELECT format_data_size(1048576); -- '1MB'
+
+.. function:: format_data_size_decimal(number) -> varchar
+
+    Returns a formatted string using a unit symbol::
+
+        SELECT format_data_size_decimal(123456); -- '123kB'
+        SELECT format_data_size_decimal(1048576); -- '1.05MB'
+
 .. function:: parse_data_size(string) -> decimal(38)
 
     Parses ``string`` of format ``value unit`` into a number, where
@@ -87,6 +117,16 @@ Unit    Description   Value
         SELECT parse_data_size('1kB'); -- 1024
         SELECT parse_data_size('1MB'); -- 1048576
         SELECT parse_data_size('2.3MB'); -- 2411724
+
+.. function:: parse_data_size_decimal(string) -> decimal(38)
+
+    Parses ``string`` of format ``value unit`` into a number, where
+    ``value`` is the fractional number of ``unit`` values::
+
+        SELECT parse_data_size_decimal('1B'); -- 1
+        SELECT parse_data_size_decimal('1kB'); -- 1000
+        SELECT parse_data_size_decimal('1MB'); -- 1000000
+        SELECT parse_data_size_decimal('2.3MB'); -- 2300000
 
 Miscellaneous
 -------------

--- a/docs/src/main/sphinx/functions/list-by-topic.rst
+++ b/docs/src/main/sphinx/functions/list-by-topic.rst
@@ -177,7 +177,12 @@ Conversion
 For more details, see :doc:`conversion`
 
 * :func:`cast`
+* :func:`format_data_size`
+* :func:`format_data_size_decimal`
+* :func:`format_number`
 * :func:`format`
+* :func:`parse_data_size`
+* :func:`parse_data_size_decimal`
 * :func:`try_cast`
 * :func:`typeof`
 

--- a/docs/src/main/sphinx/functions/list.rst
+++ b/docs/src/main/sphinx/functions/list.rst
@@ -159,6 +159,8 @@ F
 - :func:`flatten`
 - :func:`floor`
 - :func:`format`
+- :func:`format_data_size`
+- :func:`format_data_size_decimal`
 - :func:`format_datetime`
 - :func:`format_number`
 - :func:`from_base`
@@ -333,6 +335,7 @@ P
 - :func:`parse_datetime`
 - :func:`parse_duration`
 - :func:`parse_data_size`
+- :func:`parse_data_size_decimal`
 - :func:`percent_rank`
 - :func:`pi`
 - :func:`position`


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

Add a `format_data_size` function, similar to `format_number` but using SI unit prefixes and bytes (`kB`, `MB` etc).

This is based on #1905

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
new feature

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
core functions

> How would you describe this change to a non-technical end user or system administrator?
`format_data_size` and `format_data_size_decimal` allows formatting huge number of bytes to a human-readable format

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# General
* Add `format_data_size`, `parse_data_size_decimal`, and `format_data_size_decimal` functions. ({issue}`issuenumber`)
```
