### PR TITLE
Remove unnecessary purgeData parameter of TrinoCatalog.dropTable

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -829,7 +829,7 @@ public class IcebergMetadata
     @Override
     public void dropTable(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        catalog.dropTable(session, ((IcebergTableHandle) tableHandle).getSchemaTableName(), true);
+        catalog.dropTable(session, ((IcebergTableHandle) tableHandle).getSchemaTableName());
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TrinoCatalog.java
@@ -68,7 +68,7 @@ public interface TrinoCatalog
             String location,
             Map<String, String> properties);
 
-    void dropTable(ConnectorSession session, SchemaTableName schemaTableName, boolean purgeData);
+    void dropTable(ConnectorSession session, SchemaTableName schemaTableName);
 
     void renameTable(ConnectorSession session, SchemaTableName from, SchemaTableName to);
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TrinoHiveCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TrinoHiveCatalog.java
@@ -295,7 +295,7 @@ class TrinoHiveCatalog
     }
 
     @Override
-    public void dropTable(ConnectorSession session, SchemaTableName schemaTableName, boolean purgeData)
+    public void dropTable(ConnectorSession session, SchemaTableName schemaTableName)
     {
         // TODO: support path override in Iceberg table creation: https://github.com/trinodb/trino/issues/8861
         Table table = loadTable(session, schemaTableName);
@@ -304,7 +304,7 @@ class TrinoHiveCatalog
                 table.properties().containsKey(WRITE_METADATA_LOCATION)) {
             throw new TrinoException(NOT_SUPPORTED, "Table " + schemaTableName + " contains Iceberg path override properties and cannot be dropped from Trino");
         }
-        metastore.dropTable(schemaTableName.getSchemaName(), schemaTableName.getTableName(), purgeData);
+        metastore.dropTable(schemaTableName.getSchemaName(), schemaTableName.getTableName(), true);
     }
 
     @Override


### PR DESCRIPTION
It's always same (`true`), because Trino doesn't have two flavors of
`DROP TABLE`.
