### PR TITLE
Make sure that quoted identifiers remain quoted in formatter

### DIFF
--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -1511,7 +1511,7 @@ public final class SqlFormatter
         public Void visitSetSession(SetSession node, Integer indent)
         {
             builder.append("SET SESSION ")
-                    .append(node.getName())
+                    .append(formatName(node.getName()))
                     .append(" = ")
                     .append(formatExpression(node.getValue()));
 
@@ -1522,7 +1522,7 @@ public final class SqlFormatter
         public Void visitResetSession(ResetSession node, Integer indent)
         {
             builder.append("RESET SESSION ")
-                    .append(node.getName());
+                    .append(formatName(node.getName()));
 
             return null;
         }

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -1010,6 +1010,20 @@ public class TestSqlParser
     }
 
     @Test
+    public void testSessionIdentifiers()
+    {
+        assertStatement("SET SESSION \"foo-bar\".baz = 'x'",
+                new SetSession(QualifiedName.of("foo-bar", "baz"), new StringLiteral("x")));
+        assertStatementIsInvalid("SET SESSION foo-bar.name = 'value'")
+                .withMessage("line 1:16: mismatched input '-'. Expecting: '.', '='");
+
+        assertStatement("RESET SESSION \"foo-bar\".baz",
+                new ResetSession(QualifiedName.of("foo-bar", "baz")));
+        assertStatementIsInvalid("RESET SESSION foo-bar.name")
+                .withMessage("line 1:18: mismatched input '-'. Expecting: '.', <EOF>");
+    }
+
+    @Test
     public void testShowSession()
     {
         assertStatement("SHOW SESSION", new ShowSession(Optional.empty(), Optional.empty()));


### PR DESCRIPTION
The `SqlFormatter` effectively drops quotes from the quoted identifiers when formatting 'SET SESSION' statement (https://github.com/trinodb/trino/blob/master/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java#L1514).

This causes valid queries to fail: e.g. `SET SESSION "name-suffix".property = 'value'` throws `io.trino.spi.TrinoException: Formatted query does not parse` even when identifier (`name-suffix`) is quoted.