### PR TITLE
Implement parallel read from S3 for exchange storage

### DIFF
--- a/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/ExchangeSourceFile.java
+++ b/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/ExchangeSourceFile.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.exchange;
+
+import javax.annotation.concurrent.Immutable;
+import javax.crypto.SecretKey;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class ExchangeSourceFile
+{
+    private final URI fileUri;
+    private final Optional<SecretKey> secretKey;
+    private final long fileSize;
+
+    public ExchangeSourceFile(URI fileUri, Optional<SecretKey> secretKey, long fileSize)
+    {
+        this.fileUri = requireNonNull(fileUri, "fileUri is null");
+        this.secretKey = requireNonNull(secretKey, "secretKey is null");
+        this.fileSize = fileSize;
+    }
+
+    public URI getFileUri()
+    {
+        return fileUri;
+    }
+
+    public Optional<SecretKey> getSecretKey()
+    {
+        return secretKey;
+    }
+
+    public long getFileSize()
+    {
+        return fileSize;
+    }
+}

--- a/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/ExchangeStorageReader.java
+++ b/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/ExchangeStorageReader.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.exchange;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.slice.Slice;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+@ThreadSafe
+public interface ExchangeStorageReader
+        extends Closeable
+{
+    Slice read() throws IOException;
+
+    ListenableFuture<Void> isBlocked();
+
+    long getRetainedSize();
+
+    boolean isFinished();
+
+    @Override
+    void close();
+}

--- a/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/ExchangeStorageWriter.java
+++ b/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/ExchangeStorageWriter.java
@@ -1,4 +1,3 @@
-package io.trino.plugin.exchange;
 /*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +11,7 @@ package io.trino.plugin.exchange;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.trino.plugin.exchange;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.slice.Slice;

--- a/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/FileSystemExchangeConfig.java
+++ b/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/FileSystemExchangeConfig.java
@@ -14,14 +14,20 @@
 package io.trino.plugin.exchange;
 
 import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.units.DataSize;
+import io.airlift.units.MinDataSize;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
+
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
 public class FileSystemExchangeConfig
 {
     private String baseDirectory;
     private boolean exchangeEncryptionEnabled;
+    private DataSize maxPageStorageSize = DataSize.of(16, MEGABYTE);
     private int exchangeSinkBufferPoolMinSize;
 
     @NotNull
@@ -46,6 +52,20 @@ public class FileSystemExchangeConfig
     public FileSystemExchangeConfig setExchangeEncryptionEnabled(boolean exchangeEncryptionEnabled)
     {
         this.exchangeEncryptionEnabled = exchangeEncryptionEnabled;
+        return this;
+    }
+
+    @NotNull
+    public DataSize getMaxPageStorageSize()
+    {
+        return maxPageStorageSize;
+    }
+
+    @Config("exchange.max-page-storage-size")
+    @ConfigDescription("Max storage size of a page written to a sink, including the page itself and its size represented as an int")
+    public FileSystemExchangeConfig setMaxPageStorageSize(DataSize maxPageStorageSize)
+    {
+        this.maxPageStorageSize = maxPageStorageSize;
         return this;
     }
 

--- a/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/FileSystemExchangeConfig.java
+++ b/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/FileSystemExchangeConfig.java
@@ -25,7 +25,7 @@ import static io.airlift.units.DataSize.Unit.MEGABYTE;
 public class FileSystemExchangeConfig
 {
     private String baseDirectory;
-    private boolean exchangeEncryptionEnabled;
+    private boolean exchangeEncryptionEnabled = true;
     // For S3, we make read requests aligned with part boundaries. Incomplete slice at the end of the buffer is
     // possible and will be copied to the beginning of the new buffer, and we need to make room for that.
     // Therefore, it's recommended to set `maxPageStorageSize` to be slightly larger than a multiple of part size.

--- a/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/FileSystemExchangeManager.java
+++ b/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/FileSystemExchangeManager.java
@@ -37,6 +37,7 @@ import java.util.concurrent.ExecutorService;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static java.lang.Math.toIntExact;
 import static java.util.Collections.nCopies;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newCachedThreadPool;
@@ -51,6 +52,7 @@ public class FileSystemExchangeManager
     private final FileSystemExchangeStorage exchangeStorage;
     private final URI baseDirectory;
     private final boolean exchangeEncryptionEnabled;
+    private final int maxPageStorageSize;
     private final int exchangeSinkBufferPoolMinSize;
     private final ExecutorService executor;
 
@@ -67,6 +69,7 @@ public class FileSystemExchangeManager
         }
         this.baseDirectory = URI.create(baseDirectory);
         this.exchangeEncryptionEnabled = fileSystemExchangeConfig.isExchangeEncryptionEnabled();
+        this.maxPageStorageSize = toIntExact(fileSystemExchangeConfig.getMaxPageStorageSize().toBytes());
         this.exchangeSinkBufferPoolMinSize = fileSystemExchangeConfig.getExchangeSinkBufferPoolMinSize();
         this.executor = newCachedThreadPool(daemonThreadsNamed("exchange-source-handles-creation-%s"));
     }
@@ -99,6 +102,7 @@ public class FileSystemExchangeManager
                 instanceHandle.getOutputDirectory(),
                 instanceHandle.getOutputPartitionCount(),
                 instanceHandle.getSinkHandle().getSecretKey().map(key -> new SecretKeySpec(key, 0, key.length, "AES")),
+                maxPageStorageSize,
                 exchangeSinkBufferPoolMinSize);
     }
 

--- a/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/FileSystemExchangeStorage.java
+++ b/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/FileSystemExchangeStorage.java
@@ -1,4 +1,3 @@
-package io.trino.plugin.exchange;
 /*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +11,7 @@ package io.trino.plugin.exchange;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.trino.plugin.exchange;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.slice.SliceInput;

--- a/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/FileSystemExchangeStorage.java
+++ b/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/FileSystemExchangeStorage.java
@@ -28,7 +28,7 @@ public interface FileSystemExchangeStorage
 {
     void createDirectories(URI dir) throws IOException;
 
-    SliceInput getSliceInput(URI file, Optional<SecretKey> secretKey) throws IOException;
+    SliceInput getSliceInput(ExchangeSourceFile exchangeSourceFile) throws IOException;
 
     ExchangeStorageWriter createExchangeStorageWriter(URI file, Optional<SecretKey> secretKey) throws IOException;
 

--- a/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/FileSystemExchangeStorage.java
+++ b/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/FileSystemExchangeStorage.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.exchange;
 
 import com.google.common.util.concurrent.ListenableFuture;
-import io.airlift.slice.SliceInput;
 
 import javax.crypto.SecretKey;
 
@@ -22,13 +21,14 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
+import java.util.Queue;
 
 public interface FileSystemExchangeStorage
         extends AutoCloseable
 {
     void createDirectories(URI dir) throws IOException;
 
-    SliceInput getSliceInput(ExchangeSourceFile exchangeSourceFile) throws IOException;
+    ExchangeStorageReader createExchangeStorageReader(Queue<ExchangeSourceFile> sourceFiles, int maxPageStorageSize);
 
     ExchangeStorageWriter createExchangeStorageWriter(URI file, Optional<SecretKey> secretKey) throws IOException;
 

--- a/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/s3/BufferWriteAsyncResponseTransformer.java
+++ b/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/s3/BufferWriteAsyncResponseTransformer.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.exchange.s3;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.core.internal.async.ByteArrayAsyncResponseTransformer;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.System.arraycopy;
+import static java.util.Objects.requireNonNull;
+import static software.amazon.awssdk.utils.FunctionalUtils.invokeSafely;
+
+/**
+ *  An implementation of {@link AsyncResponseTransformer} that writes data to the specified range of the given buffer.
+ *  This class mimics the implementation of {@link ByteArrayAsyncResponseTransformer} but avoids memory copying.
+ *
+ * {@link AsyncResponseTransformer} that writes the data to the specified range of the given buffer
+ *
+ * @param <ResponseT> Response POJO type.
+ */
+public final class BufferWriteAsyncResponseTransformer<ResponseT>
+        implements AsyncResponseTransformer<ResponseT, ResponseT>
+{
+    private final byte[] buffer;
+    private final int offset;
+
+    private volatile CompletableFuture<Void> cf;
+    private volatile ResponseT response;
+
+    public BufferWriteAsyncResponseTransformer(byte[] buffer, int offset)
+    {
+        checkArgument(offset < buffer.length, "Buffer offset should be smaller than buffer length");
+        this.buffer = requireNonNull(buffer, "buffer is null");
+        this.offset = offset;
+    }
+
+    @Override
+    public CompletableFuture<ResponseT> prepare()
+    {
+        cf = new CompletableFuture<>();
+        return cf.thenApply(ignored -> response);
+    }
+
+    @Override
+    public void onResponse(ResponseT response)
+    {
+        this.response = response;
+    }
+
+    @Override
+    public void onStream(SdkPublisher<ByteBuffer> publisher)
+    {
+        publisher.subscribe(new BufferSubscriber(buffer, offset, cf));
+    }
+
+    @Override
+    public void exceptionOccurred(Throwable throwable)
+    {
+        cf.completeExceptionally(throwable);
+    }
+
+    /**
+     * {@link Subscriber} implementation that writes chunks to given range of a buffer.
+     */
+    static class BufferSubscriber
+            implements Subscriber<ByteBuffer>
+    {
+        private int offset;
+
+        private final byte[] buffer;
+        private final CompletableFuture<Void> future;
+
+        private Subscription subscription;
+
+        BufferSubscriber(byte[] buffer, int offset, CompletableFuture<Void> future)
+        {
+            // this assignment is expected to be followed by an assignment of a final field to ensure safe publication
+            this.offset = offset;
+
+            this.buffer = requireNonNull(buffer, "buffer is null");
+            this.future = requireNonNull(future, "future is null");
+        }
+
+        @Override
+        public void onSubscribe(Subscription s)
+        {
+            if (this.subscription != null) {
+                s.cancel();
+                return;
+            }
+            this.subscription = s;
+            subscription.request(Long.MAX_VALUE);
+        }
+
+        @Override
+        public void onNext(ByteBuffer byteBuffer)
+        {
+            invokeSafely(() -> {
+                int readableBytes = byteBuffer.remaining();
+                if (byteBuffer.hasArray()) {
+                    arraycopy(byteBuffer.array(), byteBuffer.arrayOffset() + byteBuffer.position(), buffer, offset, readableBytes);
+                }
+                else {
+                    byteBuffer.asReadOnlyBuffer().get(buffer, offset, readableBytes);
+                }
+                offset += readableBytes;
+            });
+            subscription.request(1);
+        }
+
+        @Override
+        public void onError(Throwable throwable)
+        {
+            future.completeExceptionally(throwable);
+        }
+
+        @Override
+        public void onComplete()
+        {
+            future.complete(null);
+        }
+    }
+
+    static <ResponseT> AsyncResponseTransformer<ResponseT, ResponseT> toBufferWrite(byte[] buffer, int offset)
+    {
+        return new BufferWriteAsyncResponseTransformer<>(buffer, offset);
+    }
+}

--- a/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/s3/S3FileSystemExchangeStorage.java
+++ b/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/s3/S3FileSystemExchangeStorage.java
@@ -22,6 +22,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.slice.InputStreamSliceInput;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceInput;
+import io.trino.plugin.exchange.ExchangeSourceFile;
 import io.trino.plugin.exchange.ExchangeStorageWriter;
 import io.trino.plugin.exchange.FileStatus;
 import io.trino.plugin.exchange.FileSystemExchangeStorage;
@@ -135,9 +136,12 @@ public class S3FileSystemExchangeStorage
     }
 
     @Override
-    public SliceInput getSliceInput(URI file, Optional<SecretKey> secretKey)
+    public SliceInput getSliceInput(ExchangeSourceFile exchangeSourceFile)
             throws IOException
     {
+        URI file = exchangeSourceFile.getFileUri();
+        Optional<SecretKey> secretKey = exchangeSourceFile.getSecretKey();
+
         GetObjectRequest.Builder getObjectRequestBuilder = GetObjectRequest.builder()
                 .bucket(getBucketName(file))
                 .key(keyFromUri(file));

--- a/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/TestFileSystemExchangeConfig.java
+++ b/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/TestFileSystemExchangeConfig.java
@@ -31,7 +31,7 @@ public class TestFileSystemExchangeConfig
     {
         assertRecordedDefaults(recordDefaults(FileSystemExchangeConfig.class)
                 .setBaseDirectory(null)
-                .setExchangeEncryptionEnabled(false)
+                .setExchangeEncryptionEnabled(true)
                 .setMaxPageStorageSize(DataSize.of(16, MEGABYTE))
                 .setExchangeSinkBufferPoolMinSize(10)
                 .setExchangeSourceConcurrentReaders(4));
@@ -42,7 +42,7 @@ public class TestFileSystemExchangeConfig
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("exchange.base-directory", "s3n://exchange-spooling-test/")
-                .put("exchange.encryption-enabled", "true")
+                .put("exchange.encryption-enabled", "false")
                 .put("exchange.max-page-storage-size", "32MB")
                 .put("exchange.sink-buffer-pool-min-size", "20")
                 .put("exchange.source-concurrent-readers", "10")
@@ -50,7 +50,7 @@ public class TestFileSystemExchangeConfig
 
         FileSystemExchangeConfig expected = new FileSystemExchangeConfig()
                 .setBaseDirectory("s3n://exchange-spooling-test/")
-                .setExchangeEncryptionEnabled(true)
+                .setExchangeEncryptionEnabled(false)
                 .setMaxPageStorageSize(DataSize.of(32, MEGABYTE))
                 .setExchangeSinkBufferPoolMinSize(20)
                 .setExchangeSourceConcurrentReaders(10);

--- a/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/TestFileSystemExchangeConfig.java
+++ b/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/TestFileSystemExchangeConfig.java
@@ -33,7 +33,8 @@ public class TestFileSystemExchangeConfig
                 .setBaseDirectory(null)
                 .setExchangeEncryptionEnabled(false)
                 .setMaxPageStorageSize(DataSize.of(16, MEGABYTE))
-                .setExchangeSinkBufferPoolMinSize(0));
+                .setExchangeSinkBufferPoolMinSize(10)
+                .setExchangeSourceConcurrentReaders(4));
     }
 
     @Test
@@ -43,14 +44,16 @@ public class TestFileSystemExchangeConfig
                 .put("exchange.base-directory", "s3n://exchange-spooling-test/")
                 .put("exchange.encryption-enabled", "true")
                 .put("exchange.max-page-storage-size", "32MB")
-                .put("exchange.sink-buffer-pool-min-size", "10")
+                .put("exchange.sink-buffer-pool-min-size", "20")
+                .put("exchange.source-concurrent-readers", "10")
                 .buildOrThrow();
 
         FileSystemExchangeConfig expected = new FileSystemExchangeConfig()
                 .setBaseDirectory("s3n://exchange-spooling-test/")
                 .setExchangeEncryptionEnabled(true)
                 .setMaxPageStorageSize(DataSize.of(32, MEGABYTE))
-                .setExchangeSinkBufferPoolMinSize(10);
+                .setExchangeSinkBufferPoolMinSize(20)
+                .setExchangeSourceConcurrentReaders(10);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/TestFileSystemExchangeConfig.java
+++ b/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/TestFileSystemExchangeConfig.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.exchange;
 
 import com.google.common.collect.ImmutableMap;
+import io.airlift.units.DataSize;
 import org.testng.annotations.Test;
 
 import java.util.Map;
@@ -21,6 +22,7 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
 public class TestFileSystemExchangeConfig
 {
@@ -30,6 +32,7 @@ public class TestFileSystemExchangeConfig
         assertRecordedDefaults(recordDefaults(FileSystemExchangeConfig.class)
                 .setBaseDirectory(null)
                 .setExchangeEncryptionEnabled(false)
+                .setMaxPageStorageSize(DataSize.of(16, MEGABYTE))
                 .setExchangeSinkBufferPoolMinSize(0));
     }
 
@@ -39,12 +42,14 @@ public class TestFileSystemExchangeConfig
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("exchange.base-directory", "s3n://exchange-spooling-test/")
                 .put("exchange.encryption-enabled", "true")
+                .put("exchange.max-page-storage-size", "32MB")
                 .put("exchange.sink-buffer-pool-min-size", "10")
                 .buildOrThrow();
 
         FileSystemExchangeConfig expected = new FileSystemExchangeConfig()
                 .setBaseDirectory("s3n://exchange-spooling-test/")
                 .setExchangeEncryptionEnabled(true)
+                .setMaxPageStorageSize(DataSize.of(32, MEGABYTE))
                 .setExchangeSinkBufferPoolMinSize(10);
 
         assertFullMapping(properties, expected);

--- a/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/containers/MinioStorage.java
+++ b/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/containers/MinioStorage.java
@@ -87,10 +87,11 @@ public class MinioStorage
     {
         return ImmutableMap.<String, String>builder()
                 .put("exchange.base-directory", "s3n://" + minioStorage.getBucketName())
+                // TODO: enable exchange encryption after https is supported for Trino MinIO
+                .put("exchange.encryption-enabled", "false")
                 .put("exchange.s3.aws-access-key", MinioStorage.ACCESS_KEY)
                 .put("exchange.s3.aws-secret-key", MinioStorage.SECRET_KEY)
                 .put("exchange.s3.region", "us-east-1")
-                // TODO: enable exchange encryption after https is supported for Trino MinIO
                 .put("exchange.s3.endpoint", "http://" + minioStorage.getMinio().getMinioApiEndpoint())
                 .buildOrThrow();
     }

--- a/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/local/TestLocalFileSystemExchangeManager.java
+++ b/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/local/TestLocalFileSystemExchangeManager.java
@@ -25,7 +25,6 @@ public class TestLocalFileSystemExchangeManager
     protected ExchangeManager createExchangeManager()
     {
         return new FileSystemExchangeManagerFactory().create(ImmutableMap.of(
-                "exchange.base-directory", System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager",
-                "exchange.encryption-enabled", "true"));
+                "exchange.base-directory", System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager"));
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement of the read path for exchange sources.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

To the trino-exchange plugin.

> How would you describe this change to a non-technical end user or system administrator?

This PR implements parallel read for s3-based exchange storage, including inter-file and intra-file level parallelism, and improves the overall throughput of fault tolerant execution.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->
https://github.com/trinodb/trino/issues/11050

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

After implementation/configs stabilize and get well tested, we will add documentations related to fault tolerant execution.

## Release notes

() No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Exchange plugin
* Implement parallel read for ExchangeSource. In particular, for S3-based spooling, implemented inter and intra file parallel read. ({issue}`11050`)
```