### PR TITLE
Bump bytecode dependency version to 1.4

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MapTransformValuesFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MapTransformValuesFunction.java
@@ -233,14 +233,16 @@ public final class MapTransformValuesFunction
                                         "Close builder before throwing to avoid subsequent calls finding it in an inconsistent state if we are in a TRY() call.",
                                         transformedValueElement.set(function.invoke("apply", Object.class, keyElement.cast(Object.class), valueElement.cast(Object.class))
                                                 .cast(transformedValueJavaType)),
-                                        new BytecodeBlock()
-                                                .append(mapBlockBuilder.invoke("closeEntry", BlockBuilder.class).pop())
-                                                .append(pageBuilder.invoke("declarePosition", void.class))
-                                                .putVariable(transformationException)
-                                                .append(invokeStatic(Throwables.class, "throwIfUnchecked", void.class, transformationException))
-                                                .append(newInstance(RuntimeException.class, transformationException))
-                                                .throwObject(),
-                                        type(Throwable.class)))
+                                        ImmutableList.of(
+                                                new TryCatch.CatchBlock(
+                                                        new BytecodeBlock()
+                                                                .append(mapBlockBuilder.invoke("closeEntry", BlockBuilder.class).pop())
+                                                                .append(pageBuilder.invoke("declarePosition", void.class))
+                                                                .putVariable(transformationException)
+                                                                .append(invokeStatic(Throwables.class, "throwIfUnchecked", void.class, transformationException))
+                                                                .append(newInstance(RuntimeException.class, transformationException))
+                                                                .throwObject(),
+                                                        ImmutableList.of(type(Throwable.class))))))
                         .append(keySqlType.invoke("appendTo", void.class, block, position, blockBuilder))
                         .append(writeTransformedValueElement)));
 

--- a/pom.xml
+++ b/pom.xml
@@ -684,7 +684,7 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>bytecode</artifactId>
-                <version>1.2</version>
+                <version>1.4</version>
             </dependency>
 
             <dependency>
@@ -1558,7 +1558,7 @@
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm</artifactId>
-                <version>9.1</version>
+                <version>9.2</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

Make use of the latest  `bytecode` library dependency.

This new version of the `bytecode` library comes also with the up-to-date `asm` dependencies (`9.2`) from the current version(`6.x`)

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Upgrading the version of a dependent library fits in "other" category.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

This change is of internal nature to Trino and shouldn't have any visible outcome on the exposed functionality.

> How would you describe this change to a non-technical end user or system administrator?

Dependency update.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

Through the upgrade of `bytecode` and subsequently the `asm` libraries, the PR https://github.com/trinodb/trino/pull/7828 will be unblocked because it doesn't need to exclude anymore Datastax Cassandra driver dependencies.

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
