### PR TITLE
Fix NPE when flushing exchange sink writers

### DIFF
--- a/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/FileSystemExchangeSink.java
+++ b/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/FileSystemExchangeSink.java
@@ -259,7 +259,7 @@ public class FileSystemExchangeSink
         private void flushIfNeeded(boolean finished)
         {
             SliceOutput buffer = currentBuffer;
-            if (!buffer.isWritable() || finished) {
+            if (buffer != null && (!buffer.isWritable() || finished)) {
                 if (!buffer.isWritable()) {
                     currentBuffer = null;
                 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

trino-exchange plugin
> How would you describe this change to a non-technical end user or system administrator?

This guards against NullPointException in a corner case. When our last write fills in the buffer exactly, we set `currentBuffer` to null. And after that we call `finish` and `flushIfNeeded` will be called. Therefore a null check is necessary.

A unit test covering this corner case will be added in https://github.com/trinodb/trino/pull/11174

## Related issues, pull requests, and links

N/A

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:
