### PR TITLE
Update memsql plugin JDBC driver dependency

### DIFF
--- a/docs/src/main/sphinx/connector/memsql.rst
+++ b/docs/src/main/sphinx/connector/memsql.rst
@@ -28,7 +28,7 @@ connection properties as appropriate for your setup:
 .. code-block:: text
 
     connector.name=memsql
-    connection-url=jdbc:mariadb://example.net:3306
+    connection-url=jdbc:singlestore://example.net:3306
     connection-user=root
     connection-password=secret
 
@@ -47,10 +47,10 @@ parameter to the ``connection-url`` configuration property:
 
 .. code-block:: properties
 
-  connection-url=jdbc:mariadb://example.net:3306/?useSsl=true
+  connection-url=jdbc:singlestore://example.net:3306/?useSsl=true
 
 For more information on TLS configuration options, see the `JDBC driver
-documentation <https://mariadb.com/kb/en/about-mariadb-connector-j/#tls-parameters>`_.
+documentation <https://docs.singlestore.com/db/v7.6/en/developer-resources/connect-with-application-development-tools/connect-with-java-jdbc/the-singlestore-jdbc-driver.html#tls-parameters>`_.
 
 Multiple SingleStore servers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/plugin/trino-memsql/pom.xml
+++ b/plugin/trino-memsql/pom.xml
@@ -59,6 +59,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.singlestore</groupId>
+            <artifactId>singlestore-jdbc-client</artifactId>
+            <version>1.0.1</version>
+        </dependency>
+
+        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>
@@ -66,12 +72,6 @@
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.mariadb.jdbc</groupId>
-            <artifactId>mariadb-java-client</artifactId>
-            <version>2.7.2</version>
         </dependency>
 
         <!-- Trino SPI -->

--- a/plugin/trino-memsql/src/main/java/io/trino/plugin/memsql/MemSqlClient.java
+++ b/plugin/trino-memsql/src/main/java/io/trino/plugin/memsql/MemSqlClient.java
@@ -53,6 +53,7 @@ import io.trino.spi.type.TypeSignature;
 import io.trino.spi.type.VarcharType;
 
 import javax.inject.Inject;
+
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
@@ -204,7 +205,7 @@ public class MemSqlClient
         RemoteTableName remoteTableName = tableHandle.getRequiredNamedRelation().getRemoteTableName();
 
         try (Connection connection = connectionFactory.openConnection(session);
-            ResultSet resultSet = getColumns(tableHandle, connection.getMetaData())) {
+                ResultSet resultSet = getColumns(tableHandle, connection.getMetaData())) {
             Map<String, Integer> timestampPrecisions = getTimestampPrecisions(connection, tableHandle);
             int allColumns = 0;
             List<JdbcColumnHandle> columns = new ArrayList<>();

--- a/plugin/trino-memsql/src/main/java/io/trino/plugin/memsql/MemSqlClient.java
+++ b/plugin/trino-memsql/src/main/java/io/trino/plugin/memsql/MemSqlClient.java
@@ -25,6 +25,7 @@ import io.trino.plugin.jdbc.JdbcJoinCondition;
 import io.trino.plugin.jdbc.JdbcSortItem;
 import io.trino.plugin.jdbc.JdbcTableHandle;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
+import io.trino.plugin.jdbc.LongReadFunction;
 import io.trino.plugin.jdbc.LongWriteFunction;
 import io.trino.plugin.jdbc.PreparedQuery;
 import io.trino.plugin.jdbc.QueryBuilder;
@@ -53,7 +54,6 @@ import io.trino.spi.type.TypeSignature;
 import io.trino.spi.type.VarcharType;
 
 import javax.inject.Inject;
-
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
@@ -61,6 +61,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -101,7 +102,6 @@ import static io.trino.plugin.jdbc.StandardColumnMappings.realWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.shortDecimalWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.smallintColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.smallintWriteFunction;
-import static io.trino.plugin.jdbc.StandardColumnMappings.timeColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.timeWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.timestampColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.timestampWriteFunction;
@@ -125,6 +125,10 @@ import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimeType.createTimeType;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
 import static io.trino.spi.type.TimestampType.createTimestampType;
+import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_DAY;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_DAY;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
+import static io.trino.spi.type.Timestamps.round;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static java.lang.Float.floatToRawIntBits;
@@ -203,7 +207,7 @@ public class MemSqlClient
         RemoteTableName remoteTableName = tableHandle.getRequiredNamedRelation().getRemoteTableName();
 
         try (Connection connection = connectionFactory.openConnection(session);
-                ResultSet resultSet = getColumns(tableHandle, connection.getMetaData())) {
+            ResultSet resultSet = getColumns(tableHandle, connection.getMetaData())) {
             Map<String, Integer> timestampPrecisions = getTimestampPrecisions(connection, tableHandle);
             int allColumns = 0;
             List<JdbcColumnHandle> columns = new ArrayList<>();
@@ -365,7 +369,7 @@ public class MemSqlClient
                         dateWriteFunction()));
             case Types.TIME:
                 TimeType timeType = createTimeType(typeHandle.getRequiredDecimalDigits());
-                return Optional.of(timeColumnMapping(timeType));
+                return Optional.of(memsqlTimeColumnMapping(timeType));
             case Types.TIMESTAMP:
                 // TODO (https://github.com/trinodb/trino/issues/5450) Fix DST handling
                 TimestampType timestampType = createTimestampType(typeHandle.getRequiredDecimalDigits());
@@ -376,6 +380,46 @@ public class MemSqlClient
             return mapToUnboundedVarchar(typeHandle);
         }
         return Optional.empty();
+    }
+
+    public static ColumnMapping memsqlTimeColumnMapping(TimeType timeType) {
+        return ColumnMapping.longMapping(
+                timeType,
+                timeReadFunction(timeType),
+                timeWriteFunction(timeType.getPrecision()));
+    }
+
+    public static LongReadFunction timeReadFunction(TimeType timeType) {
+        requireNonNull(timeType, "timeType is null");
+        checkArgument(timeType.getPrecision() <= 9, "Unsupported type precision: %s", timeType);
+        return (resultSet, columnIndex) -> {
+            LocalTime time = resultSet.getObject(columnIndex, LocalTime.class);
+            String timeString = resultSet.getString(columnIndex);
+            // TODO: proper verification on read and write
+            if (timeString != null) {
+                String[] parts = timeString.split(":");
+                if (parts != null) {
+                    String hh = parts[0];
+                    if (hh.startsWith("-")) {
+                        throw new IllegalArgumentException(timeString + " is negative");
+                    } else {
+                        int hours = Integer.parseInt(hh);
+                        if (hours >= 24) {
+                            throw new IllegalArgumentException(timeString + " is greater than 1 day");
+                        }
+                    }
+                }
+            }
+
+            long nanosOfDay = time.toNanoOfDay();
+            verify(nanosOfDay < NANOSECONDS_PER_DAY, "Invalid value of nanosOfDay: %s", nanosOfDay);
+            long picosOfDay = nanosOfDay * PICOSECONDS_PER_NANOSECOND;
+            long rounded = round(picosOfDay, 12 - timeType.getPrecision());
+            if (rounded == PICOSECONDS_PER_DAY) {
+                rounded = 0;
+            }
+            return rounded;
+        };
     }
 
     @Override
@@ -624,16 +668,16 @@ public class MemSqlClient
         }
 
         String typeName = typeHandle.getJdbcTypeName().get();
-        if (typeName.equalsIgnoreCase("tinyint unsigned")) {
+        if (typeName.equalsIgnoreCase("tinyint(3) unsigned")) {
             return Optional.of(smallintColumnMapping());
         }
-        if (typeName.equalsIgnoreCase("smallint unsigned")) {
+        if (typeName.equalsIgnoreCase("smallint(5) unsigned")) {
             return Optional.of(integerColumnMapping());
         }
-        if (typeName.equalsIgnoreCase("int unsigned")) {
+        if (typeName.equalsIgnoreCase("int(10) unsigned")) {
             return Optional.of(bigintColumnMapping());
         }
-        if (typeName.equalsIgnoreCase("bigint unsigned")) {
+        if (typeName.equalsIgnoreCase("bigint(20) unsigned")) {
             return Optional.of(decimalColumnMapping(createDecimalType(20)));
         }
 

--- a/plugin/trino-memsql/src/main/java/io/trino/plugin/memsql/MemSqlClientModule.java
+++ b/plugin/trino-memsql/src/main/java/io/trino/plugin/memsql/MemSqlClientModule.java
@@ -18,6 +18,7 @@ import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
+import com.singlestore.jdbc.Driver;
 import io.trino.plugin.jdbc.BaseJdbcConfig;
 import io.trino.plugin.jdbc.ConnectionFactory;
 import io.trino.plugin.jdbc.DecimalModule;
@@ -25,7 +26,6 @@ import io.trino.plugin.jdbc.DriverConnectionFactory;
 import io.trino.plugin.jdbc.ForBaseJdbc;
 import io.trino.plugin.jdbc.JdbcClient;
 import io.trino.plugin.jdbc.credential.CredentialProvider;
-import org.mariadb.jdbc.Driver;
 
 import java.util.Properties;
 

--- a/plugin/trino-memsql/src/main/java/io/trino/plugin/memsql/MemSqlClientModule.java
+++ b/plugin/trino-memsql/src/main/java/io/trino/plugin/memsql/MemSqlClientModule.java
@@ -63,7 +63,8 @@ public class MemSqlClientModule
     }
 
     @VisibleForTesting
-    static String ensureUrlBackwardCompatibility(String connectionUrl) {
+    static String ensureUrlBackwardCompatibility(String connectionUrl)
+    {
         // including "jdbc:" portion in case-insensitive match in case other url parts also contain "mariadb" literal
         return connectionUrl.replaceAll("(?i)" + Pattern.quote("jdbc:mariadb"), "jdbc:singlestore");
     }

--- a/plugin/trino-memsql/src/main/java/io/trino/plugin/memsql/MemSqlClientModule.java
+++ b/plugin/trino-memsql/src/main/java/io/trino/plugin/memsql/MemSqlClientModule.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.memsql;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Provides;
@@ -28,6 +29,7 @@ import io.trino.plugin.jdbc.JdbcClient;
 import io.trino.plugin.jdbc.credential.CredentialProvider;
 
 import java.util.Properties;
+import java.util.regex.Pattern;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
 
@@ -55,8 +57,14 @@ public class MemSqlClientModule
 
         return new DriverConnectionFactory(
                 new Driver(),
-                config.getConnectionUrl(),
+                ensureUrlBackwardCompatibility(config.getConnectionUrl()),
                 connectionProperties,
                 credentialProvider);
+    }
+
+    @VisibleForTesting
+    static String ensureUrlBackwardCompatibility(String connectionUrl) {
+        // including "jdbc:" portion in case-insensitive match in case other url parts also contain "mariadb" literal
+        return connectionUrl.replaceAll("(?i)" + Pattern.quote("jdbc:mariadb"), "jdbc:singlestore");
     }
 }

--- a/plugin/trino-memsql/src/main/java/io/trino/plugin/memsql/MemSqlTimeColumnMapping.java
+++ b/plugin/trino-memsql/src/main/java/io/trino/plugin/memsql/MemSqlTimeColumnMapping.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.memsql;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.trino.plugin.jdbc.ColumnMapping;
+import io.trino.plugin.jdbc.LongReadFunction;
+import io.trino.plugin.jdbc.LongWriteFunction;
+import io.trino.spi.type.TimeType;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeParseException;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
+import static io.trino.plugin.jdbc.StandardColumnMappings.fromTrinoTime;
+import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_DAY;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_DAY;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
+import static io.trino.spi.type.Timestamps.round;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * {@link MemSqlTimeColumnMapping} is a utility class for parsing times returned by {@code SingleStore} driver.
+ *
+ * {@see com.singlestore.jdbc.codec.list.LocalTimeCodec}
+ */
+class MemSqlTimeColumnMapping
+{
+
+    static ColumnMapping memSqlTimeColumnMapping(TimeType timeType)
+    {
+        return ColumnMapping.longMapping(
+                timeType,
+                memsqlTimeReadFunction(timeType),
+                memsqlTimeWriteFunction(timeType.getPrecision()));
+    }
+
+    static LongReadFunction memsqlTimeReadFunction(TimeType timeType)
+    {
+        requireNonNull(timeType, "timeType is null");
+        checkArgument(timeType.getPrecision() <= 9, "Unsupported type precision: %s", timeType);
+        int precision = timeType.getPrecision();
+        return (resultSet, columnIndex) -> {
+            // SingleStore driver wraps values <00:00:00 and >24:00:00, but we must disallow them
+            // LocalTime time = resultSet.getObject(columnIndex, LocalTime.class);
+            String timeString = resultSet.getString(columnIndex);
+            return parseMemSqlLocalTime(timeString, precision);
+        };
+    }
+
+    @VisibleForTesting
+    static long parseMemSqlLocalTime(String timeString, int precision)
+    {
+        try {
+            LocalTime time = LocalTime.from(ISO_LOCAL_TIME.parse(timeString));
+            long nanosOfDay = time.toNanoOfDay();
+            verify(nanosOfDay < NANOSECONDS_PER_DAY, "Invalid value of nanosOfDay: %s", nanosOfDay);
+            long picosOfDay = nanosOfDay * PICOSECONDS_PER_NANOSECOND;
+            long rounded = round(picosOfDay, 12 - precision);
+            if (rounded == PICOSECONDS_PER_DAY) {
+                rounded = 0;
+            }
+            return rounded;
+        }
+        catch (DateTimeParseException e) {
+            throw new IllegalStateException(e.getMessage(), e);
+        }
+    }
+
+    public static LongWriteFunction memsqlTimeWriteFunction(int precision)
+    {
+        checkArgument(precision <= 9, "Unsupported precision: %s", precision);
+        return (statement, index, picosOfDay) -> {
+            picosOfDay = round(picosOfDay, 12 - precision);
+            if (picosOfDay == PICOSECONDS_PER_DAY) {
+                picosOfDay = 0;
+            }
+            statement.setObject(index, fromTrinoTime(picosOfDay));
+        };
+    }
+
+    private MemSqlTimeColumnMapping() {
+        // prevent instantiation of utility class
+    }
+}

--- a/plugin/trino-memsql/src/main/java/io/trino/plugin/memsql/MemSqlTimeColumnMapping.java
+++ b/plugin/trino-memsql/src/main/java/io/trino/plugin/memsql/MemSqlTimeColumnMapping.java
@@ -39,7 +39,6 @@ import static java.util.Objects.requireNonNull;
  */
 class MemSqlTimeColumnMapping
 {
-
     static ColumnMapping memSqlTimeColumnMapping(TimeType timeType)
     {
         return ColumnMapping.longMapping(
@@ -92,7 +91,8 @@ class MemSqlTimeColumnMapping
         };
     }
 
-    private MemSqlTimeColumnMapping() {
+    private MemSqlTimeColumnMapping()
+    {
         // prevent instantiation of utility class
     }
 }

--- a/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlClientModule.java
+++ b/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlClientModule.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.memsql;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static io.trino.testing.assertions.Assert.assertEquals;
+
+public class TestMemSqlClientModule {
+
+    @Test(dataProvider = "connectionUrls")
+    public void testMariaDbUrlCompatability(String[] mariaDbUrls)
+    {
+        assertEquals(MemSqlClientModule.ensureUrlBackwardCompatibility(mariaDbUrls[0]), mariaDbUrls[1]);
+    }
+
+    @DataProvider
+    public Object[][] connectionUrls()
+    {
+        return new Object[][]{
+                // input / expected result
+                {"jdbc:mariadb://test_mariadb", "jdbc:singlestore://test_mariadb"},
+                {"JDBC:MARIADB://test_mariadb", "jdbc:singlestore://test_mariadb"},
+                {"jdbc:mariadb://TEST_MARIADB", "jdbc:singlestore://TEST_MARIADB"},
+                {"jdbc:mariadb:loadbalance://test_mariadb", "jdbc:singlestore:loadbalance://test_mariadb"},
+                {"jdbc:MARIADB:sequential://test_mariadb", "jdbc:singlestore:sequential://test_mariadb"},
+        };
+    }
+}

--- a/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlClientModule.java
+++ b/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlClientModule.java
@@ -19,8 +19,8 @@ import org.testng.annotations.Test;
 
 import static io.trino.testing.assertions.Assert.assertEquals;
 
-public class TestMemSqlClientModule {
-
+public class TestMemSqlClientModule
+{
     @Test(dataProvider = "connectionUrls")
     public void testMariaDbUrlCompatability(String[] mariaDbUrls)
     {
@@ -30,7 +30,7 @@ public class TestMemSqlClientModule {
     @DataProvider
     public Object[][] connectionUrls()
     {
-        return new Object[][]{
+        return new Object[][] {
                 // input / expected result
                 {"jdbc:mariadb://test_mariadb", "jdbc:singlestore://test_mariadb"},
                 {"JDBC:MARIADB://test_mariadb", "jdbc:singlestore://test_mariadb"},

--- a/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlPlugin.java
+++ b/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlPlugin.java
@@ -28,6 +28,6 @@ public class TestMemSqlPlugin
     {
         Plugin plugin = new MemSqlPlugin();
         ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
-        factory.create("test", ImmutableMap.of("connection-url", "jdbc:mariadb://test"), new TestingConnectorContext()).shutdown();
+        factory.create("test", ImmutableMap.of("connection-url", "jdbc:singlestore://test"), new TestingConnectorContext()).shutdown();
     }
 }

--- a/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlTimeColumnMapping.java
+++ b/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlTimeColumnMapping.java
@@ -19,9 +19,9 @@ import org.testng.annotations.Test;
 
 import static io.trino.plugin.memsql.MemSqlTimeColumnMapping.parseMemSqlLocalTime;
 
-public class TestMemSqlTimeColumnMapping {
-
-    @Test(dataProvider = "unsupportedTimeDataProvider", expectedExceptions = {IllegalStateException.class})
+public class TestMemSqlTimeColumnMapping
+{
+    @Test(dataProvider = "unsupportedTimeDataProvider", expectedExceptions = IllegalStateException.class)
     public void testUnsupportedTimeMapping(String localTime)
     {
         parseMemSqlLocalTime(localTime, 9);

--- a/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlTimeColumnMapping.java
+++ b/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlTimeColumnMapping.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.memsql;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static io.trino.plugin.memsql.MemSqlTimeColumnMapping.parseMemSqlLocalTime;
+
+public class TestMemSqlTimeColumnMapping {
+
+    @Test(dataProvider = "unsupportedTimeDataProvider", expectedExceptions = {IllegalStateException.class})
+    public void testUnsupportedTimeMapping(String localTime)
+    {
+        parseMemSqlLocalTime(localTime, 9);
+    }
+
+    @DataProvider
+    public Object[][] unsupportedTimeDataProvider()
+    {
+        return new Object[][] {
+                {"-838:59:59"}, // min value in MemSQL
+                {"-00:00:01"},
+                {"24:00:00"},
+                {"838:59:59"}, // max value in MemSQL
+        };
+    }
+}

--- a/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlTypeMapping.java
+++ b/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlTypeMapping.java
@@ -642,6 +642,7 @@ public class TestMemSqlTypeMapping
         };
     }
 
+
     @Test(dataProvider = "unsupportedDateTimePrecisions")
     public void testUnsupportedTimePrecision(int precision)
     {

--- a/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlTypeMapping.java
+++ b/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlTypeMapping.java
@@ -642,7 +642,6 @@ public class TestMemSqlTypeMapping
         };
     }
 
-
     @Test(dataProvider = "unsupportedDateTimePrecisions")
     public void testUnsupportedTimePrecision(int precision)
     {

--- a/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlTypeMapping.java
+++ b/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlTypeMapping.java
@@ -621,13 +621,13 @@ public class TestMemSqlTypeMapping
         try (TestTable table = new TestTable(memSqlServer::execute, "tpch.test_unsupported_time", "(col time)", ImmutableList.of(format("'%s'", unsupportedTime)))) {
             assertQueryFails(
                     "SELECT * FROM " + table.getName(),
-                    format("\\Q%s cannot be parse as LocalTime (format is \"HH:mm:ss[.S]\" for data type \"TIME\")", unsupportedTime));
+                    format("Text '%s' could not be parsed.*", unsupportedTime));
         }
 
         try (TestTable table = new TestTable(memSqlServer::execute, "tpch.test_unsupported_time", "(col time(6))", ImmutableList.of(format("'%s'", unsupportedTime)))) {
             assertQueryFails(
                     "SELECT * FROM " + table.getName(),
-                    format("\\Q%s.000000 cannot be parse as LocalTime (format is \"HH:mm:ss[.S]\" for data type \"TIME\")", unsupportedTime));
+                    format("Text '%s.000000' could not be parsed.*", unsupportedTime));
         }
     }
 

--- a/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestingMemSqlServer.java
+++ b/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestingMemSqlServer.java
@@ -71,7 +71,7 @@ public class TestingMemSqlServer
     @Override
     public String getDriverClassName()
     {
-        return "org.mariadb.jdbc.Driver";
+        return "com.singlestore.jdbc.Driver";
     }
 
     @Override
@@ -89,7 +89,7 @@ public class TestingMemSqlServer
     @Override
     public String getJdbcUrl()
     {
-        return "jdbc:mariadb://" + getContainerIpAddress() + ":" + getMappedPort(MEMSQL_PORT);
+        return "jdbc:singlestore://" + getContainerIpAddress() + ":" + getMappedPort(MEMSQL_PORT);
     }
 
     @Override

--- a/testing/trino-server-dev/etc/catalog/memsql.properties
+++ b/testing/trino-server-dev/etc/catalog/memsql.properties
@@ -1,4 +1,4 @@
 connector.name=memsql
-connection-url=jdbc:mariadb://localhost:13306
+connection-url=jdbc:singlestore://localhost:13306
 connection-user=test
 connection-password=test


### PR DESCRIPTION

Fixes https://github.com/trinodb/trino/issues/10669

## Description

Update plugin dependency from MariaDB driver to official SingleStore (memsql) driver.

## Related issues, pull requests, and links

* Fixes #10669

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

