### PR TITLE
Add missing query transition to RUNNING state with task-level retries

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/SqlQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/SqlQueryScheduler.java
@@ -1924,6 +1924,8 @@ public class SqlQueryScheduler
                 return;
             }
 
+            stateMachine.transitionToRunning();
+
             try (SetThreadName ignored = new SetThreadName("Query-%s", queryStateMachine.getQueryId())) {
                 List<ListenableFuture<Void>> blockedStages = new ArrayList<>();
                 while (!isFinishingOrDone(queryStateMachine) && !stateMachine.getState().isDone()) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Add missing query transition to RUNNING state with task-level retries

> Is this change a fix, improvement, new feature, refactoring, or other?

fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core query engine

> How would you describe this change to a non-technical end user or system administrator?

Without the fix queries were stuck in STARTING state for whole execution if task-level retries were enabled.

## Related issues, pull requests, and links

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix bug where queries were not transitioned to RUNNING state when task-level retries were enabled. ({issue}`11198`)
```
