### PR TITLE
Minor refactors to SqlServer type mapping tests

### DIFF
--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerTypeMapping.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerTypeMapping.java
@@ -73,6 +73,8 @@ public abstract class BaseSqlServerTypeMapping
     private final ZoneId kathmandu = ZoneId.of("Asia/Kathmandu");
     private final LocalDateTime timeGapInKathmandu = LocalDateTime.of(1986, 1, 1, 0, 13, 7);
 
+    protected TestingSqlServer sqlServer;
+
     @BeforeClass
     public void setUp()
     {
@@ -756,5 +758,8 @@ public abstract class BaseSqlServerTypeMapping
         verify(isGap(zone, dateTime), "Expected %s to be a gap in %s", dateTime, zone);
     }
 
-    protected abstract SqlExecutor onRemoteDatabase();
+    protected SqlExecutor onRemoteDatabase()
+    {
+        return sqlServer::execute;
+    }
 }

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerTypeMapping.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerTypeMapping.java
@@ -16,15 +16,12 @@ package io.trino.plugin.sqlserver;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.testing.QueryRunner;
-import io.trino.testing.sql.SqlExecutor;
 
 import static io.trino.plugin.sqlserver.SqlServerQueryRunner.createSqlServerQueryRunner;
 
 public class TestSqlServerTypeMapping
         extends BaseSqlServerTypeMapping
 {
-    protected TestingSqlServer sqlServer;
-
     @Override
     protected QueryRunner createQueryRunner()
             throws Exception
@@ -35,11 +32,5 @@ public class TestSqlServerTypeMapping
                 ImmutableMap.of(),
                 ImmutableMap.of(),
                 ImmutableList.of());
-    }
-
-    @Override
-    protected SqlExecutor onRemoteDatabase()
-    {
-        return sqlServer::execute;
     }
 }


### PR DESCRIPTION
- Move `sqlServer` to BaseSqlServerTypeMapping
- Remove onRemoteDatabase in TestSqlServerTypeMapping
- Implement onRemoteDatabase in BaseSqlServerTypeMapping

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Refactoring.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

SqlServer connector type mapping tests.

> How would you describe this change to a non-technical end user or system administrator?

N/A.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

https://github.com/trinodb/trino/pull/11148#discussion_r814545286

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
