### PR TITLE
Don't exclude anything in test matrix if impacted modules list is empty

### DIFF
--- a/.github/bin/build-matrix-from-impacted.py
+++ b/.github/bin/build-matrix-from-impacted.py
@@ -58,7 +58,7 @@ def build(matrix_file, impacted_file, output_file):
         modules = item.get("modules", [])
         if isinstance(modules, str):
             modules = [modules]
-        if not any(module in impacted for module in modules):
+        if impacted and not any(module in impacted for module in modules):
             logging.info("Excluding matrix section: %s", item)
             continue
         include.append(
@@ -68,8 +68,7 @@ def build(matrix_file, impacted_file, output_file):
                 "profile": item.get("profile", ""),
             }
         )
-    if include:
-        matrix["include"] = include
+    matrix["include"] = include
     json.dump(matrix, output_file)
     output_file.write("\n")
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,6 +370,8 @@ jobs:
           $RETRY $MAVEN validate ${MAVEN_FAST_INSTALL} -P disable-check-spi-dependencies -pl '!:trino-docs,!:trino-server,!:trino-server-rpm'
       - id: set-matrix
         run: |
+          # GIB doesn't run on master, so make sure the file always exist
+          touch gib-impacted.log
           cat <<EOF > .github/test-matrix.yaml
           include:
             - { modules: core/trino-main }
@@ -401,7 +403,7 @@ jobs:
             - { modules: [ client/trino-jdbc, plugin/trino-base-jdbc, plugin/trino-thrift, plugin/trino-memory ] }
             - { modules: plugin/trino-bigquery }
           EOF
-          ./.github/bin/build-matrix-from-impacted.py -v -m .github/test-matrix.yaml -o matrix.json
+          ./.github/bin/build-matrix-from-impacted.py -v -i gib-impacted.log -m .github/test-matrix.yaml -o matrix.json
           echo "Matrix: $(jq '.' matrix.json)"
           echo "::set-output name=matrix::$(jq -c '.' matrix.json)"
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

This is a follow up to #10323 that did not properly handled running GIB on the master branch. This PR ensures that:
* the impacted modules log file `gib-impacted.log` always exists
* nothing is excluded from the test matrix if the file is empty

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
other - ci fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
other - ci fix

> How would you describe this change to a non-technical end user or system administrator?
n/a

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
