### PR TITLE
Bumped h2 from 1.4.2 to 2.1.210

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1096,7 +1096,7 @@
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
-                <version>1.4.200</version>
+                <version>2.1.210</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Even though its used only in testing, H2 has a known RCE, seen [here](https://github.com/advisories/GHSA-h376-j262-vhq6). Given its severity, it would be wise to upgrade. 

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other? Dependency upgrade.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? Changes made to the testing suite via h2. 

> How would you describe this change to a non-technical end-user or system administrator?
A known CVE has been found in one of the dependencies that allow remote code to be executed against a machine, potentially exposing sensitive data. 

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Removes RCE vulnerability in H2 [issue](https://github.com/trinodb/trino/issues/11227)
```
