### PR TITLE
Fix node cleanup for MemSQL tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,7 +428,7 @@ jobs:
         run: echo "::add-matcher::.github/problem-matcher.json"
       - name: Cleanup node
         # This is required as a virtual environment update 20210219.1 left too little space for MemSQL to work
-        if: matrix.modules == ':trino-memsql'
+        if: matrix.modules == 'plugin/trino-memsql'
         run: .github/bin/cleanup-node.sh
       - name: Maven Install
         run: |


### PR DESCRIPTION
This fixes a missed instance of `:trino-memsql` to `plugin/trino-memsql` when checking whether to run the CI cleanup step.