### PR TITLE
Allocate new Slice for VariableWidthBlockEncoding readBlock

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/buffer/PagesSerdeUtil.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/PagesSerdeUtil.java
@@ -14,19 +14,26 @@
 package io.trino.execution.buffer;
 
 import com.google.common.collect.AbstractIterator;
+import com.google.common.io.ByteStreams;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slices;
 import io.airlift.slice.XxHash64;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockEncodingSerde;
 
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.util.Iterator;
 import java.util.List;
 
 import static io.trino.block.BlockSerdeUtil.readBlock;
 import static io.trino.block.BlockSerdeUtil.writeBlock;
+import static io.trino.execution.buffer.PagesSerde.SERIALIZED_PAGE_HEADER_SIZE;
 import static io.trino.execution.buffer.PagesSerde.readSerializedPage;
 import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
@@ -93,9 +100,9 @@ public final class PagesSerdeUtil
         return size;
     }
 
-    public static Iterator<Page> readPages(PagesSerde serde, SliceInput sliceInput)
+    public static Iterator<Page> readPages(PagesSerde serde, InputStream inputStream)
     {
-        return new PageReader(serde, sliceInput);
+        return new PageReader(serde, inputStream);
     }
 
     private static class PageReader
@@ -103,50 +110,72 @@ public final class PagesSerdeUtil
     {
         private final PagesSerde serde;
         private final PagesSerde.PagesSerdeContext context;
-        private final SliceInput input;
+        private final InputStream inputStream;
+        private final byte[] headerBuffer = new byte[SERIALIZED_PAGE_HEADER_SIZE];
+        private final Slice headerSlice = Slices.wrappedBuffer(headerBuffer);
 
-        PageReader(PagesSerde serde, SliceInput input)
+        PageReader(PagesSerde serde, InputStream inputStream)
         {
             this.serde = requireNonNull(serde, "serde is null");
-            this.input = requireNonNull(input, "input is null");
+            this.inputStream = requireNonNull(inputStream, "inputStream is null");
             this.context = serde.newContext();
         }
 
         @Override
         protected Page computeNext()
         {
-            if (!input.isReadable()) {
-                context.close(); // Release context buffers
-                return endOfData();
-            }
+            try {
+                int read = ByteStreams.read(inputStream, headerBuffer, 0, headerBuffer.length);
+                if (read <= 0) {
+                    context.close(); // Release context buffers
+                    return endOfData();
+                }
+                else if (read != headerBuffer.length) {
+                    throw new EOFException();
+                }
 
-            return serde.deserialize(context, readSerializedPage(input));
+                return serde.deserialize(context, readSerializedPage(headerSlice, inputStream));
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
         }
     }
 
-    public static Iterator<Slice> readSerializedPages(SliceInput sliceInput)
+    public static Iterator<Slice> readSerializedPages(InputStream inputStream)
     {
-        return new SerializedPageReader(sliceInput);
+        return new SerializedPageReader(inputStream);
     }
 
     private static class SerializedPageReader
             extends AbstractIterator<Slice>
     {
-        private final SliceInput input;
+        private final InputStream inputStream;
+        private final byte[] headerBuffer = new byte[SERIALIZED_PAGE_HEADER_SIZE];
+        private final Slice headerSlice = Slices.wrappedBuffer(headerBuffer);
 
-        SerializedPageReader(SliceInput input)
+        SerializedPageReader(InputStream input)
         {
-            this.input = requireNonNull(input, "input is null");
+            this.inputStream = requireNonNull(input, "inputStream is null");
         }
 
         @Override
         protected Slice computeNext()
         {
-            if (!input.isReadable()) {
-                return endOfData();
-            }
+            try {
+                int read = ByteStreams.read(inputStream, headerBuffer, 0, headerBuffer.length);
+                if (read <= 0) {
+                    return endOfData();
+                }
+                else if (read != headerBuffer.length) {
+                    throw new EOFException();
+                }
 
-            return readSerializedPage(input);
+                return readSerializedPage(headerSlice, inputStream);
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/HttpPageBufferClient.java
+++ b/core/trino-main/src/main/java/io/trino/operator/HttpPageBufferClient.java
@@ -15,6 +15,7 @@ package io.trino.operator;
 
 import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
+import com.google.common.io.LittleEndianDataInputStream;
 import com.google.common.net.MediaType;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
@@ -27,9 +28,7 @@ import io.airlift.http.client.Response;
 import io.airlift.http.client.ResponseHandler;
 import io.airlift.http.client.ResponseTooLargeException;
 import io.airlift.log.Logger;
-import io.airlift.slice.InputStreamSliceInput;
 import io.airlift.slice.Slice;
-import io.airlift.slice.SliceInput;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.FeaturesConfig.DataIntegrityVerification;
@@ -684,7 +683,7 @@ public final class HttpPageBufferClient
                 boolean complete = getComplete(response, uri);
                 boolean remoteTaskFailed = getTaskFailed(response, uri);
 
-                try (SliceInput input = new InputStreamSliceInput(response.getInputStream())) {
+                try (LittleEndianDataInputStream input = new LittleEndianDataInputStream(response.getInputStream())) {
                     int magic = input.readInt();
                     if (magic != SERIALIZED_PAGES_MAGIC) {
                         throw new IllegalStateException(format("Invalid stream header, expected 0x%08x, but was 0x%08x", SERIALIZED_PAGES_MAGIC, magic));

--- a/core/trino-main/src/main/java/io/trino/spiller/FileSingleStreamSpiller.java
+++ b/core/trino-main/src/main/java/io/trino/spiller/FileSingleStreamSpiller.java
@@ -20,7 +20,6 @@ import com.google.common.io.Closer;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
-import io.airlift.slice.InputStreamSliceInput;
 import io.airlift.slice.OutputStreamSliceOutput;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
@@ -168,7 +167,7 @@ public class FileSingleStreamSpiller
 
         try {
             InputStream input = closer.register(targetFile.newInputStream());
-            Iterator<Page> pages = PagesSerdeUtil.readPages(serde, new InputStreamSliceInput(input, BUFFER_SIZE));
+            Iterator<Page> pages = PagesSerdeUtil.readPages(serde, input);
             return closeWhenExhausted(pages, input);
         }
         catch (IOException e) {

--- a/core/trino-main/src/test/java/io/trino/spiller/TestFileSingleStreamSpiller.java
+++ b/core/trino-main/src/test/java/io/trino/spiller/TestFileSingleStreamSpiller.java
@@ -16,7 +16,6 @@ package io.trino.spiller;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import com.google.common.util.concurrent.ListeningExecutorService;
-import io.airlift.slice.InputStreamSliceInput;
 import io.airlift.slice.Slice;
 import io.trino.execution.buffer.PagesSerdeUtil;
 import io.trino.memory.context.LocalMemoryContext;
@@ -129,7 +128,7 @@ public class TestFileSingleStreamSpiller
 
         // Assert the spill codec flags match the expected configuration
         try (InputStream is = newInputStream(listFiles(spillPath.toPath()).get(0))) {
-            Iterator<Slice> serializedPages = PagesSerdeUtil.readSerializedPages(new InputStreamSliceInput(is));
+            Iterator<Slice> serializedPages = PagesSerdeUtil.readSerializedPages(is);
             assertTrue(serializedPages.hasNext(), "at least one page should be successfully read back");
             Slice serializedPage = serializedPages.next();
             assertEquals(isSerializedPageCompressed(serializedPage), compression);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlockEncoding.java
@@ -68,7 +68,8 @@ public class VariableWidthBlockEncoding
         boolean[] valueIsNull = decodeNullBits(sliceInput, positionCount).orElse(null);
 
         int blockSize = sliceInput.readInt();
-        Slice slice = sliceInput.readSlice(blockSize);
+        Slice slice = Slices.allocate(blockSize);
+        sliceInput.readBytes(slice);
 
         return new VariableWidthBlock(0, positionCount, slice, offsets, valueIsNull);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

This PR changes VariableWidthBlock to be backed by newly allocated Slices instead of returning a view into a page:
1. This will fix the calculation of page retained size.
2. `VariableWidthBlockEncoding` is the only block encoding that creates direct references to the input slice instead of copying data into newly allocated memory. It's better to make things consistent.
3. This is also blocking https://github.com/trinodb/trino/pull/11174, where ExchangeStorageReader returns a view of a byte range of byte array, but due to `VariableWidthBlockEncoding` retaining references, it caused memory leaks.

This however, will have a small performance cost. I did another optimization to offset the cost --- replacing `InputStreamSliceInput` with `LittleEndianDataInputStream` in `HttpPageBufferClient`, such that we avoid memory copy costs in `InputStreamSliceInput`'s internal buffer.

It turns out that these two changes combines resulted in a net win for efficiency, both in terms of CPU and latency (benchmark on `hive_sf1000_parquet_part`):
![image](https://user-images.githubusercontent.com/9404831/157388361-f4adb08f-588a-4a6e-ae6c-a6a2e34d19fe.png)
(benchmark on `hive_sf1000_parquet_unpart`):
![image](https://user-images.githubusercontent.com/9404831/157560592-c489fa6e-2520-485e-afad-e1d51acd299c.png)

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core query engine.

> How would you describe this change to a non-technical end user or system administrator?

N/A

## Related issues, pull requests, and links

Blocks https://github.com/trinodb/trino/pull/11174

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

() No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Core Engine
* Allocate a new Slice instead of returning a view when decoding `VariableWidthBlock`s, fixing memory accounting of pages involving such blocks. Also eliminated extra memory copy when consuming data in  `HttpPageBufferClient`.Benchmark shows that these two combined demonstrated a 0.7%-2.7% CPU efficiency improvement on TPC-H and TPC-DS datasets. ({issue}`11315`)
```