### PR TITLE
Add support for ANSI SQL syntax in trim function

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/AggregationAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/AggregationAnalyzer.java
@@ -59,6 +59,7 @@ import io.trino.sql.tree.SimpleCaseExpression;
 import io.trino.sql.tree.SortItem;
 import io.trino.sql.tree.SubqueryExpression;
 import io.trino.sql.tree.SubscriptExpression;
+import io.trino.sql.tree.Trim;
 import io.trino.sql.tree.TryExpression;
 import io.trino.sql.tree.VariableDefinition;
 import io.trino.sql.tree.WhenClause;
@@ -326,6 +327,12 @@ class AggregationAnalyzer
         protected Boolean visitQuantifiedComparisonExpression(QuantifiedComparisonExpression node, Void context)
         {
             return process(node.getValue(), context) && process(node.getSubquery(), context);
+        }
+
+        @Override
+        protected Boolean visitTrim(Trim node, Void context)
+        {
+            return process(node.getTrimSource(), context) && (node.getTrimCharacter().isEmpty() || process(node.getTrimCharacter().get(), context));
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -185,7 +185,7 @@ public class Analysis
     private final Map<NodeRef<Expression>, Type> sortKeyCoercionsForFrameBoundComparison = new LinkedHashMap<>();
     private final Map<NodeRef<Expression>, ResolvedFunction> frameBoundCalculations = new LinkedHashMap<>();
     private final Map<NodeRef<Relation>, List<Type>> relationCoercions = new LinkedHashMap<>();
-    private final Map<NodeRef<FunctionCall>, RoutineEntry> resolvedFunctions = new LinkedHashMap<>();
+    private final Map<NodeRef<Expression>, RoutineEntry> resolvedFunctions = new LinkedHashMap<>();
     private final Map<NodeRef<Identifier>, LambdaArgumentDeclaration> lambdaArgumentReferences = new LinkedHashMap<>();
 
     private final Map<Field, ColumnHandle> columns = new LinkedHashMap<>();
@@ -612,12 +612,12 @@ public class Analysis
                                 columnMaskScopes.isEmpty()));
     }
 
-    public ResolvedFunction getResolvedFunction(FunctionCall function)
+    public ResolvedFunction getResolvedFunction(Expression node)
     {
-        return resolvedFunctions.get(NodeRef.of(function)).getFunction();
+        return resolvedFunctions.get(NodeRef.of(node)).getFunction();
     }
 
-    public void addResolvedFunction(FunctionCall node, ResolvedFunction function, String authorization)
+    public void addResolvedFunction(Expression node, ResolvedFunction function, String authorization)
     {
         resolvedFunctions.put(NodeRef.of(node), new RoutineEntry(function, authorization));
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/ResolvedFunctionCallRewriter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ResolvedFunctionCallRewriter.java
@@ -29,7 +29,7 @@ public final class ResolvedFunctionCallRewriter
 {
     private ResolvedFunctionCallRewriter() {}
 
-    public static Expression rewriteResolvedFunctions(Expression expression, Map<NodeRef<FunctionCall>, ResolvedFunction> resolvedFunctions)
+    public static Expression rewriteResolvedFunctions(Expression expression, Map<NodeRef<Expression>, ResolvedFunction> resolvedFunctions)
     {
         return ExpressionTreeRewriter.rewriteWith(new Visitor(resolvedFunctions), expression);
     }
@@ -37,9 +37,9 @@ public final class ResolvedFunctionCallRewriter
     private static class Visitor
             extends ExpressionRewriter<Void>
     {
-        private final Map<NodeRef<FunctionCall>, ResolvedFunction> resolvedFunctions;
+        private final Map<NodeRef<Expression>, ResolvedFunction> resolvedFunctions;
 
-        public Visitor(Map<NodeRef<FunctionCall>, ResolvedFunction> resolvedFunctions)
+        public Visitor(Map<NodeRef<Expression>, ResolvedFunction> resolvedFunctions)
         {
             this.resolvedFunctions = requireNonNull(resolvedFunctions, "resolvedFunctions is null");
         }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestStringFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestStringFunctions.java
@@ -667,39 +667,6 @@ public class TestStringFunctions
     }
 
     @Test
-    public void testTrim()
-    {
-        assertFunction("TRIM('')", createVarcharType(0), "");
-        assertFunction("TRIM('   ')", createVarcharType(3), "");
-        assertFunction("TRIM('  hello  ')", createVarcharType(9), "hello");
-        assertFunction("TRIM('  hello')", createVarcharType(7), "hello");
-        assertFunction("TRIM('hello  ')", createVarcharType(7), "hello");
-        assertFunction("TRIM(' hello world ')", createVarcharType(13), "hello world");
-
-        assertFunction("TRIM('\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 ')", createVarcharType(10), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
-        assertFunction("TRIM('\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ')", createVarcharType(9), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
-        assertFunction("TRIM(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ')", createVarcharType(9), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
-        assertFunction("TRIM('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B')", createVarcharType(9), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
-        assertFunction("TRIM(' \u2028 \u4FE1\u5FF5 \u7231 \u5E0C\u671B')", createVarcharType(10), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
-    }
-
-    @Test
-    public void testCharTrim()
-    {
-        assertFunction("TRIM(CAST('' AS CHAR(20)))", createVarcharType(20), "");
-        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)))", createVarcharType(9), "hello");
-        assertFunction("TRIM(CAST('  hello' AS CHAR(7)))", createVarcharType(7), "hello");
-        assertFunction("TRIM(CAST('hello  ' AS CHAR(7)))", createVarcharType(7), "hello");
-        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)))", createVarcharType(13), "hello world");
-
-        assertFunction("TRIM(CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 ' AS CHAR(10)))", createVarcharType(10), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
-        assertFunction("TRIM(CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ' AS CHAR(9)))", createVarcharType(9), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
-        assertFunction("TRIM(CAST(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ' AS CHAR(9)))", createVarcharType(9), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
-        assertFunction("TRIM(CAST('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(9)))", createVarcharType(9), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
-        assertFunction("TRIM(CAST(' \u2028 \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(10)))", createVarcharType(10), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
-    }
-
-    @Test
     public void testLeftTrimParametrized()
     {
         assertFunction("LTRIM('', '')", createVarcharType(0), "");
@@ -804,58 +771,6 @@ public class TestStringFunctions
 
         // non latin characters
         assertFunction("RTRIM(CAST('\u017a\u00f3\u0142\u0107' AS CHAR(4)), '\u0107\u0142')", createVarcharType(4), "\u017a\u00f3");
-    }
-
-    @Test
-    public void testTrimParametrized()
-    {
-        assertFunction("TRIM('', '')", createVarcharType(0), "");
-        assertFunction("TRIM('   ', '')", createVarcharType(3), "   ");
-        assertFunction("TRIM('  hello  ', '')", createVarcharType(9), "  hello  ");
-        assertFunction("TRIM('  hello  ', ' ')", createVarcharType(9), "hello");
-        assertFunction("TRIM('  hello  ', 'he ')", createVarcharType(9), "llo");
-        assertFunction("TRIM('  hello  ', 'lo ')", createVarcharType(9), "he");
-        assertFunction("TRIM('  hello', ' ')", createVarcharType(7), "hello");
-        assertFunction("TRIM('hello  ', ' ')", createVarcharType(7), "hello");
-        assertFunction("TRIM('hello  ', 'l o')", createVarcharType(7), "he");
-        assertFunction("TRIM('hello  ', 'l')", createVarcharType(7), "hello  ");
-        assertFunction("TRIM(' hello world ', ' ')", createVarcharType(13), "hello world");
-        assertFunction("TRIM(' hello world ', ' ld')", createVarcharType(13), "hello wor");
-        assertFunction("TRIM(' hello world ', ' eh')", createVarcharType(13), "llo world");
-        assertFunction("TRIM(' hello world ', ' ehlowrd')", createVarcharType(13), "");
-        assertFunction("TRIM(' hello world ', ' x')", createVarcharType(13), "hello world");
-
-        // non latin characters
-        assertFunction("TRIM('\u017a\u00f3\u0142\u0107', '\u0107\u017a')", createVarcharType(4), "\u00f3\u0142");
-
-        // invalid utf-8 characters
-        assertFunction("CAST(TRIM(utf8(from_hex('81')), ' ') AS VARBINARY)", VARBINARY, varbinary(0x81));
-        assertFunction("CAST(TRIM(CONCAT(utf8(from_hex('81')), ' '), ' ') AS VARBINARY)", VARBINARY, varbinary(0x81));
-        assertFunction("CAST(TRIM(CONCAT(' ', utf8(from_hex('81'))), ' ') AS VARBINARY)", VARBINARY, varbinary(0x81));
-        assertFunction("CAST(TRIM(CONCAT(' ', utf8(from_hex('81')), ' '), ' ') AS VARBINARY)", VARBINARY, varbinary(0x81));
-        assertInvalidFunction("TRIM('hello world', utf8(from_hex('81')))", "Invalid UTF-8 encoding in characters: �");
-        assertInvalidFunction("TRIM('hello world', utf8(from_hex('3281')))", "Invalid UTF-8 encoding in characters: 2�");
-    }
-
-    @Test
-    public void testCharTrimParametrized()
-    {
-        assertFunction("TRIM(CAST('' AS CHAR(1)), '')", createVarcharType(1), "");
-        assertFunction("TRIM(CAST('   ' AS CHAR(3)), '')", createVarcharType(3), "");
-        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)), '')", createVarcharType(9), "  hello");
-        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)), ' ')", createVarcharType(9), "hello");
-        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)), 'he ')", createVarcharType(9), "llo");
-        assertFunction("TRIM(CAST('  hello' AS CHAR(7)), ' ')", createVarcharType(7), "hello");
-        assertFunction("TRIM(CAST('  hello' AS CHAR(7)), 'e h')", createVarcharType(7), "llo");
-        assertFunction("TRIM(CAST('hello  ' AS CHAR(7)), 'l')", createVarcharType(7), "hello");
-        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' ')", createVarcharType(13), "hello world");
-        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' eh')", createVarcharType(13), "llo world");
-        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' ehlowrd')", createVarcharType(13), "");
-        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' x')", createVarcharType(13), "hello world");
-        assertFunction("TRIM(CAST('abc def' AS CHAR(7)), 'def')", createVarcharType(7), "abc");
-
-        // non latin characters
-        assertFunction("TRIM(CAST('\u017a\u00f3\u0142\u0107' AS CHAR(4)), '\u017a\u0107\u0142')", createVarcharType(4), "\u00f3");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
@@ -16,6 +16,7 @@ package io.trino.sql.query;
 import com.google.common.collect.ImmutableList;
 import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
+import io.trino.metadata.FunctionBundle;
 import io.trino.spi.type.SqlTime;
 import io.trino.spi.type.SqlTimeWithTimeZone;
 import io.trino.spi.type.SqlTimestamp;
@@ -93,6 +94,11 @@ public class QueryAssertions
     public Session getDefaultSession()
     {
         return runner.getDefaultSession();
+    }
+
+    public void addFunctions(FunctionBundle functionBundle)
+    {
+        runner.addFunctions(functionBundle);
     }
 
     public AssertProvider<QueryAssert> query(@Language("SQL") String query)

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestTrim.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestTrim.java
@@ -1,0 +1,339 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import io.trino.metadata.InternalFunctionBundle;
+import io.trino.operator.scalar.TestStringFunctions;
+import io.trino.spi.TrinoException;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+public class TestTrim
+{
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    public void init()
+    {
+        assertions = new QueryAssertions();
+        assertions.addFunctions(InternalFunctionBundle.builder()
+                .scalars(TestStringFunctions.class) // To use utf8 function
+                .build());
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testLeftTrim()
+    {
+        assertFunction("TRIM(LEADING FROM '')", "CAST('' AS VARCHAR(0))");
+        assertFunction("TRIM(LEADING FROM '   ')", "CAST('' AS VARCHAR(3))");
+        assertFunction("TRIM(LEADING FROM '  hello  ')", "CAST('hello  ' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING FROM '  hello')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(LEADING FROM 'hello  ')", "CAST('hello  ' AS VARCHAR(7))");
+        assertFunction("TRIM(LEADING FROM ' hello world ')", "CAST('hello world ' AS VARCHAR(13))");
+
+        assertFunction("TRIM(LEADING FROM '\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING FROM ' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B ' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING FROM '  \u4FE1\u5FF5 \u7231 \u5E0C\u671B')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING FROM ' \u2028 \u4FE1\u5FF5 \u7231 \u5E0C\u671B')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(10))");
+    }
+
+    @Test
+    public void testCharLeftTrim()
+    {
+        assertFunction("TRIM(LEADING FROM CAST('' AS CHAR(20)))", "CAST('' AS VARCHAR(20))");
+        assertFunction("TRIM(LEADING FROM CAST('' AS CHAR(20)))", "CAST('' AS VARCHAR(20))");
+        assertFunction("TRIM(LEADING FROM CAST('  hello  ' AS CHAR(9)))", "CAST('hello' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING FROM CAST('  hello' AS CHAR(7)))", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(LEADING FROM CAST('hello  ' AS CHAR(7)))", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(LEADING FROM CAST(' hello world ' AS CHAR(13)))", "CAST('hello world' AS VARCHAR(13))");
+
+        assertFunction("TRIM(LEADING FROM CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ' AS CHAR(9)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING FROM CAST(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ' AS CHAR(9)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING FROM CAST('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(9)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING FROM CAST(' \u2028 \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(10)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(10))");
+    }
+
+    @Test
+    public void testRightTrim()
+    {
+        assertFunction("TRIM(TRAILING FROM '')", "CAST('' AS VARCHAR(0))");
+        assertFunction("TRIM(TRAILING FROM '   ')", "CAST('' AS VARCHAR(3))");
+        assertFunction("TRIM(TRAILING FROM '  hello  ')", "CAST('  hello' AS VARCHAR(9))");
+        assertFunction("TRIM(TRAILING FROM '  hello')", "CAST('  hello' AS VARCHAR(7))");
+        assertFunction("TRIM(TRAILING FROM 'hello  ')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(TRAILING FROM ' hello world ')", "CAST(' hello world' AS VARCHAR(13))");
+
+        assertFunction("TRIM(TRAILING FROM '\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 ')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(10))");
+        assertFunction("TRIM(TRAILING FROM '\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(TRAILING FROM ' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ')", "CAST(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(TRAILING FROM '  \u4FE1\u5FF5 \u7231 \u5E0C\u671B')", "CAST('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+    }
+
+    @Test
+    public void testCharRightTrim()
+    {
+        assertFunction("TRIM(TRAILING FROM CAST('' AS CHAR(20)))", "CAST('' AS VARCHAR(20))");
+        assertFunction("TRIM(TRAILING FROM CAST('  hello  ' AS CHAR(9)))", "CAST('  hello' AS VARCHAR(9))");
+        assertFunction("TRIM(TRAILING FROM CAST('  hello' AS CHAR(7)))", "CAST('  hello' AS VARCHAR(7))");
+        assertFunction("TRIM(TRAILING FROM CAST('hello  ' AS CHAR(7)))", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(TRAILING FROM CAST(' hello world ' AS CHAR(13)))", "CAST(' hello world' AS VARCHAR(13))");
+
+        assertFunction("TRIM(TRAILING FROM CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 ' AS CHAR(10)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(10))");
+        assertFunction("TRIM(TRAILING FROM CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ' AS CHAR(9)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(TRAILING FROM CAST(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ' AS CHAR(9)))", "CAST(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(TRAILING FROM CAST('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(9)))", "CAST('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+    }
+
+    @Test
+    public void testLeftTrimParametrized()
+    {
+        assertFunction("TRIM(LEADING '' FROM '')", "CAST('' AS VARCHAR(0))");
+        assertFunction("TRIM(LEADING '' FROM '   ')", "CAST('   ' AS VARCHAR(3))");
+        assertFunction("TRIM(LEADING '' FROM '  hello  ')", "CAST('  hello  ' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING ' ' FROM '  hello  ')", "CAST('hello  ' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING CHAR ' ' FROM '  hello  ')", "CAST('hello  ' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING 'he ' FROM '  hello  ')", "CAST('llo  ' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING ' ' FROM '  hello')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(LEADING 'e h' FROM '  hello')", "CAST('llo' AS VARCHAR(7))");
+        assertFunction("TRIM(LEADING 'l' FROM 'hello  ')", "CAST('hello  ' AS VARCHAR(7))");
+        assertFunction("TRIM(LEADING ' ' FROM ' hello world ')", "CAST('hello world ' AS VARCHAR(13))");
+        assertFunction("TRIM(LEADING ' eh' FROM ' hello world ')", "CAST('llo world ' AS VARCHAR(13))");
+        assertFunction("TRIM(LEADING ' ehlowrd' FROM ' hello world ')", "CAST('' AS VARCHAR(13))");
+        assertFunction("TRIM(LEADING ' x' FROM ' hello world ')", "CAST('hello world ' AS VARCHAR(13))");
+
+        // non latin characters
+        assertFunction("TRIM(LEADING '\u00f3\u017a' FROM '\u017a\u00f3\u0142\u0107')", "CAST('\u0142\u0107' AS VARCHAR(4))");
+
+        // invalid utf-8 characters
+        assertInvalidFunction("TRIM(LEADING utf8(from_hex('3281')) FROM 'hello wolrd')", "Invalid UTF-8 encoding in characters: 2�");
+    }
+
+    @Test
+    public void testCharLeftTrimParametrized()
+    {
+        assertFunction("TRIM(LEADING '' FROM CAST('' AS CHAR(1)))", "CAST('' AS VARCHAR(1))");
+        assertFunction("TRIM(LEADING '' FROM CAST('   ' AS CHAR(3)))", "CAST('' AS VARCHAR(3))");
+        assertFunction("TRIM(LEADING '' FROM CAST('  hello  ' AS CHAR(9)))", "CAST('  hello' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING ' ' FROM CAST('  hello  ' AS CHAR(9)))", "CAST('hello' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING 'he ' FROM CAST('  hello  ' AS CHAR(9)))", "CAST('llo' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING ' ' FROM CAST('  hello' AS CHAR(7)))", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(LEADING 'e h' FROM CAST('  hello' AS CHAR(7)))", "CAST('llo' AS VARCHAR(7))");
+        assertFunction("TRIM(LEADING 'l' FROM CAST('hello  ' AS CHAR(7)))", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(LEADING ' ' FROM CAST(' hello world ' AS CHAR(13)))", "CAST('hello world' AS VARCHAR(13))");
+        assertFunction("TRIM(LEADING ' eh' FROM CAST(' hello world ' AS CHAR(13)))", "CAST('llo world' AS VARCHAR(13))");
+        assertFunction("TRIM(LEADING ' ehlowrd' FROM CAST(' hello world ' AS CHAR(13)))", "CAST('' AS VARCHAR(13))");
+        assertFunction("TRIM(LEADING ' x' FROM CAST(' hello world ' AS CHAR(13)))", "CAST('hello world' AS VARCHAR(13))");
+
+        // non latin characters
+        assertFunction("TRIM(LEADING '\u00f3\u017a' FROM CAST('\u017a\u00f3\u0142\u0107' AS CHAR(4)))", "CAST('\u0142\u0107' AS VARCHAR(4))");
+    }
+
+    @Test
+    public void testRightTrimParametrized()
+    {
+        assertFunction("TRIM(TRAILING '' FROM '')", "CAST('' AS VARCHAR(0))");
+        assertFunction("TRIM(TRAILING '' FROM '   ')", "CAST('   ' AS VARCHAR(3))");
+        assertFunction("TRIM(TRAILING '' FROM '  hello  ')", "CAST('  hello  ' AS VARCHAR(9))");
+        assertFunction("TRIM(TRAILING ' ' FROM '  hello  ')", "CAST('  hello' AS VARCHAR(9))");
+        assertFunction("TRIM(TRAILING 'lo ' FROM '  hello  ')", "CAST('  he' AS VARCHAR(9))");
+        assertFunction("TRIM(TRAILING ' ' FROM 'hello  ')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(TRAILING 'l o' FROM 'hello  ')", "CAST('he' AS VARCHAR(7))");
+        assertFunction("TRIM(TRAILING 'l' FROM 'hello  ')", "CAST('hello  ' AS VARCHAR(7))");
+        assertFunction("TRIM(TRAILING ' ' FROM ' hello world ')", "CAST(' hello world' AS VARCHAR(13))");
+        assertFunction("TRIM(TRAILING ' ld' FROM ' hello world ')", "CAST(' hello wor' AS VARCHAR(13))");
+        assertFunction("TRIM(TRAILING ' ehlowrd' FROM ' hello world ')", "CAST('' AS VARCHAR(13))");
+        assertFunction("TRIM(TRAILING ' x' FROM ' hello world ')", "CAST(' hello world' AS VARCHAR(13))");
+        assertFunction("TRIM(TRAILING 'def' FROM CAST('abc def' AS CHAR(7)))", "CAST('abc' AS VARCHAR(7))");
+
+        // non latin characters
+        assertFunction("TRIM(TRAILING '\u0107\u0142' FROM '\u017a\u00f3\u0142\u0107')", "CAST('\u017a\u00f3' AS VARCHAR(4))");
+
+        // invalid utf-8 characters
+        assertInvalidFunction("TRIM(TRAILING utf8(from_hex('81')) FROM 'hello world')", "Invalid UTF-8 encoding in characters: �");
+        assertInvalidFunction("TRIM(TRAILING utf8(from_hex('3281')) FROM 'hello world')", "Invalid UTF-8 encoding in characters: 2�");
+    }
+
+    @Test
+    public void testTrim()
+    {
+        assertFunction("TRIM('')", "CAST('' AS VARCHAR(0))");
+        assertFunction("TRIM('   ')", "CAST('' AS VARCHAR(3))");
+        assertFunction("TRIM('  hello  ')", "CAST('hello' AS VARCHAR(9))");
+        assertFunction("TRIM('  hello')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM('hello  ')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(' hello world ')", "CAST('hello world' AS VARCHAR(13))");
+        assertFunction("TRIM(BOTH FROM '')", "CAST('' AS VARCHAR(0))");
+        assertFunction("TRIM(BOTH FROM '   ')", "CAST('' AS VARCHAR(3))");
+        assertFunction("TRIM(BOTH FROM '  hello  ')", "CAST('hello' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH FROM '  hello')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(BOTH FROM 'hello  ')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(BOTH FROM ' hello world ')", "CAST('hello world' AS VARCHAR(13))");
+        assertFunction("TRIM(' ' FROM '')", "CAST('' AS VARCHAR(0))");
+        assertFunction("TRIM(' ' FROM '   ')", "CAST('' AS VARCHAR(3))");
+        assertFunction("TRIM(' ' FROM '  hello  ')", "CAST('hello' AS VARCHAR(9))");
+        assertFunction("TRIM(' ' FROM '  hello')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(' ' FROM 'hello  ')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(' ' FROM ' hello world ')", "CAST('hello world' AS VARCHAR(13))");
+
+        assertFunction("TRIM('\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 ')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(10))");
+        assertFunction("TRIM('\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(' \u2028 \u4FE1\u5FF5 \u7231 \u5E0C\u671B')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(10))");
+        assertFunction("TRIM(BOTH FROM '\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 ')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(10))");
+        assertFunction("TRIM(BOTH FROM '\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH FROM ' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH FROM '  \u4FE1\u5FF5 \u7231 \u5E0C\u671B')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH FROM ' \u2028 \u4FE1\u5FF5 \u7231 \u5E0C\u671B')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(10))");
+    }
+
+    @Test
+    public void testCharTrim()
+    {
+        assertFunction("TRIM(CAST('' AS CHAR(20)))", "CAST('' AS VARCHAR(20))");
+        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)))", "CAST('hello' AS VARCHAR(9))");
+        assertFunction("TRIM(CAST('  hello' AS CHAR(7)))", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(CAST('hello  ' AS CHAR(7)))", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)))", "CAST('hello world' AS VARCHAR(13))");
+        assertFunction("TRIM(BOTH FROM CAST('' AS CHAR(20)))", "CAST('' AS VARCHAR(20))");
+        assertFunction("TRIM(BOTH FROM CAST('  hello  ' AS CHAR(9)))", "CAST('hello' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH FROM CAST('  hello' AS CHAR(7)))", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(BOTH FROM CAST('hello  ' AS CHAR(7)))", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(BOTH FROM CAST(' hello world ' AS CHAR(13)))", "CAST('hello world' AS VARCHAR(13))");
+
+        assertFunction("TRIM(CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 ' AS CHAR(10)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(10))");
+        assertFunction("TRIM(CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ' AS CHAR(9)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(CAST(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ' AS CHAR(9)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(CAST('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(9)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(CAST(' \u2028 \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(10)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(10))");
+        assertFunction("TRIM(BOTH FROM CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 ' AS CHAR(10)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(10))");
+        assertFunction("TRIM(BOTH FROM CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ' AS CHAR(9)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH FROM CAST(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ' AS CHAR(9)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH FROM CAST('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(9)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH FROM CAST(' \u2028 \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(10)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(10))");
+    }
+
+    @Test
+    public void testCharTrimParametrized()
+    {
+        assertFunction("TRIM(CAST('' AS CHAR(1)), '')", "CAST('' AS VARCHAR(1))");
+        assertFunction("TRIM(CAST('   ' AS CHAR(3)), '')", "CAST('' AS VARCHAR(3))");
+        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)), '')", "CAST('  hello' AS VARCHAR(9))");
+        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)), ' ')", "CAST('hello' AS VARCHAR(9))");
+        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)), 'he ')", "CAST('llo' AS VARCHAR(9))");
+        assertFunction("TRIM(CAST('  hello' AS CHAR(7)), ' ')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(CAST('  hello' AS CHAR(7)), 'e h')", "CAST('llo' AS VARCHAR(7))");
+        assertFunction("TRIM(CAST('hello  ' AS CHAR(7)), 'l')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' ')", "CAST('hello world' AS VARCHAR(13))");
+        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' eh')", "CAST('llo world' AS VARCHAR(13))");
+        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' ehlowrd')", "CAST('' AS VARCHAR(13))");
+        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' x')", "CAST('hello world' AS VARCHAR(13))");
+        assertFunction("TRIM(CAST('abc def' AS CHAR(7)), 'def')", "CAST('abc' AS VARCHAR(7))");
+        assertFunction("TRIM(BOTH '' FROM CAST('' AS CHAR(1)))", "CAST('' AS VARCHAR(1))");
+        assertFunction("TRIM(BOTH '' FROM CAST('   ' AS CHAR(3)))", "CAST('' AS VARCHAR(3))");
+        assertFunction("TRIM(BOTH '' FROM CAST('  hello  ' AS CHAR(9)))", "CAST('  hello' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH ' ' FROM CAST('  hello  ' AS CHAR(9)))", "CAST('hello' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH 'he ' FROM CAST('  hello  ' AS CHAR(9)))", "CAST('llo' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH ' ' FROM CAST('  hello' AS CHAR(7)))", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(BOTH 'e h' FROM CAST('  hello' AS CHAR(7)))", "CAST('llo' AS VARCHAR(7))");
+        assertFunction("TRIM(BOTH 'l' FROM CAST('hello  ' AS CHAR(7)))", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(BOTH ' ' FROM CAST(' hello world ' AS CHAR(13)))", "CAST('hello world' AS VARCHAR(13))");
+        assertFunction("TRIM(BOTH ' eh' FROM CAST(' hello world ' AS CHAR(13)))", "CAST('llo world' AS VARCHAR(13))");
+        assertFunction("TRIM(BOTH ' ehlowrd' FROM CAST(' hello world ' AS CHAR(13)))", "CAST('' AS VARCHAR(13))");
+        assertFunction("TRIM(BOTH ' x' FROM CAST(' hello world ' AS CHAR(13)))", "CAST('hello world' AS VARCHAR(13))");
+        assertFunction("TRIM(BOTH 'def' FROM CAST('abc def' AS CHAR(7)))", "CAST('abc' AS VARCHAR(7))");
+
+        // non latin characters
+        assertFunction("TRIM(CAST('\u017a\u00f3\u0142\u0107' AS CHAR(4)), '\u017a\u0107\u0142')", "CAST('\u00f3' AS VARCHAR(4))");
+        assertFunction("TRIM(BOTH '\u017a\u0107\u0142' FROM CAST('\u017a\u00f3\u0142\u0107' AS CHAR(4)))", "CAST('\u00f3' AS VARCHAR(4))");
+    }
+
+    @Test
+    public void testTrimParametrized()
+    {
+        assertFunction("TRIM('', '')", "CAST('' AS VARCHAR(0))");
+        assertFunction("TRIM('   ', '')", "CAST('   ' AS VARCHAR(3))");
+        assertFunction("TRIM('  hello  ', '')", "CAST('  hello  ' AS VARCHAR(9))");
+        assertFunction("TRIM('  hello  ', ' ')", "CAST('hello' AS VARCHAR(9))");
+        assertFunction("TRIM('  hello  ', 'he ')", "CAST('llo' AS VARCHAR(9))");
+        assertFunction("TRIM('  hello  ', 'lo ')", "CAST('he' AS VARCHAR(9))");
+        assertFunction("TRIM('  hello', ' ')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM('hello  ', ' ')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM('hello  ', 'l o')", "CAST('he' AS VARCHAR(7))");
+        assertFunction("TRIM('hello  ', 'l')", "CAST('hello  ' AS VARCHAR(7))");
+        assertFunction("TRIM(' hello world ', ' ')", "CAST('hello world' AS VARCHAR(13))");
+        assertFunction("TRIM(' hello world ', ' ld')", "CAST('hello wor' AS VARCHAR(13))");
+        assertFunction("TRIM(' hello world ', ' eh')", "CAST('llo world' AS VARCHAR(13))");
+        assertFunction("TRIM(' hello world ', ' ehlowrd')", "CAST('' AS VARCHAR(13))");
+        assertFunction("TRIM(' hello world ', ' x')", "CAST('hello world' AS VARCHAR(13))");
+        assertFunction("TRIM(BOTH '' FROM '')", "CAST('' AS VARCHAR(0))");
+        assertFunction("TRIM(BOTH '' FROM '   ')", "CAST('   ' AS VARCHAR(3))");
+        assertFunction("TRIM(BOTH '' FROM '  hello  ')", "CAST('  hello  ' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH ' ' FROM '  hello  ')", "CAST('hello' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH 'he ' FROM '  hello  ')", "CAST('llo' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH 'lo ' FROM '  hello  ')", "CAST('he' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH ' ' FROM '  hello')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(BOTH ' ' FROM 'hello  ')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(BOTH 'l o' FROM 'hello  ')", "CAST('he' AS VARCHAR(7))");
+        assertFunction("TRIM(BOTH 'l' FROM 'hello  ')", "CAST('hello  ' AS VARCHAR(7))");
+        assertFunction("TRIM(BOTH ' ' FROM ' hello world ')", "CAST('hello world' AS VARCHAR(13))");
+        assertFunction("TRIM(BOTH ' ld' FROM ' hello world ')", "CAST('hello wor' AS VARCHAR(13))");
+        assertFunction("TRIM(BOTH ' eh' FROM ' hello world ')", "CAST('llo world' AS VARCHAR(13))");
+        assertFunction("TRIM(BOTH ' ehlowrd' FROM ' hello world ')", "CAST('' AS VARCHAR(13))");
+        assertFunction("TRIM(BOTH ' x' FROM ' hello world ')", "CAST('hello world' AS VARCHAR(13))");
+
+        // non latin characters
+        assertFunction("TRIM('\u017a\u00f3\u0142\u0107', '\u0107\u017a')", "CAST('\u00f3\u0142' AS VARCHAR(4))");
+        assertFunction("TRIM(BOTH '\u0107\u017a' FROM '\u017a\u00f3\u0142\u0107')", "CAST('\u00f3\u0142' AS VARCHAR(4))");
+
+        // invalid utf-8 characters
+        assertFunction("CAST(TRIM(utf8(from_hex('81')), ' ') AS VARBINARY)", "x'81'");
+        assertFunction("CAST(TRIM(CONCAT(utf8(from_hex('81')), ' '), ' ') AS VARBINARY)", "x'81'");
+        assertFunction("CAST(TRIM(CONCAT(' ', utf8(from_hex('81'))), ' ') AS VARBINARY)", "x'81'");
+        assertFunction("CAST(TRIM(CONCAT(' ', utf8(from_hex('81')), ' '), ' ') AS VARBINARY)", "x'81'");
+        assertInvalidFunction("TRIM('hello world', utf8(from_hex('81')))", "Invalid UTF-8 encoding in characters: �");
+        assertInvalidFunction("TRIM('hello world', utf8(from_hex('3281')))", "Invalid UTF-8 encoding in characters: 2�");
+        assertInvalidFunction("TRIM(BOTH utf8(from_hex('3281')) FROM 'hello world')", "Invalid UTF-8 encoding in characters: 2�");
+    }
+
+    private void assertFunction(@Language("SQL") String actual, @Language("SQL") String expected)
+    {
+        assertThat(assertions.query("SELECT " + actual)).matches("SELECT " + expected);
+    }
+
+    private void assertInvalidFunction(@Language("SQL") String actual, String message)
+    {
+        assertThatThrownBy(() -> assertions.query("SELECT " + actual))
+                .isInstanceOf(TrinoException.class)
+                .hasMessage(message)
+                .extracting(e -> ((TrinoException) e).getErrorCode().getCode())
+                .isEqualTo(INVALID_FUNCTION_ARGUMENT.toErrorCode().getCode());
+    }
+}

--- a/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4
+++ b/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4
@@ -328,6 +328,12 @@ sampleType
     | SYSTEM
     ;
 
+trimsSpecification
+    : LEADING
+    | TRAILING
+    | BOTH
+    ;
+
 listAggOverflowBehavior
     : ERROR
     | TRUNCATE string? listaggCountIndication
@@ -477,6 +483,9 @@ primaryExpression
     | name=CURRENT_CATALOG                                                                #currentCatalog
     | name=CURRENT_SCHEMA                                                                 #currentSchema
     | name=CURRENT_PATH                                                                   #currentPath
+    | TRIM '(' (trimsSpecification? trimChar=valueExpression? FROM)?
+        trimSource=valueExpression ')'                                                    #trim
+    | TRIM '(' trimSource=valueExpression ',' trimChar=valueExpression ')'                #trim
     | SUBSTRING '(' valueExpression FROM valueExpression (FOR valueExpression)? ')'       #substring
     | NORMALIZE '(' valueExpression (',' normalForm)? ')'                                 #normalize
     | EXTRACT '(' identifier FROM valueExpression ')'                                     #extract
@@ -707,7 +716,7 @@ number
 nonReserved
     // IMPORTANT: this rule must only contain tokens. Nested rules are not supported. See SqlParser.exitNonReserved
     : ADD | ADMIN | AFTER | ALL | ANALYZE | ANY | ARRAY | ASC | AT | AUTHORIZATION
-    | BERNOULLI
+    | BERNOULLI | BOTH
     | CALL | CASCADE | CATALOGS | COLUMN | COLUMNS | COMMENT | COMMIT | COMMITTED | COUNT | CURRENT
     | DATA | DATE | DAY | DEFAULT | DEFINE | DEFINER | DESC | DISTRIBUTED | DOUBLE
     | EMPTY | ERROR | EXCLUDING | EXPLAIN
@@ -716,7 +725,7 @@ nonReserved
     | HOUR
     | IF | IGNORE | INCLUDING | INITIAL | INPUT | INTERVAL | INVOKER | IO | ISOLATION
     | JSON
-    | LAST | LATERAL | LEVEL | LIMIT | LOCAL | LOGICAL
+    | LAST | LATERAL | LEADING | LEVEL | LIMIT | LOCAL | LOGICAL
     | MAP | MATCH | MATCHED | MATCHES | MATCH_RECOGNIZE | MATERIALIZED | MEASURES | MERGE | MINUTE | MONTH
     | NEXT | NFC | NFD | NFKC | NFKD | NO | NONE | NULLIF | NULLS
     | OF | OFFSET | OMIT | ONE | ONLY | OPTION | ORDINALITY | OUTPUT | OVER | OVERFLOW
@@ -724,7 +733,7 @@ nonReserved
     | RANGE | READ | REFRESH | RENAME | REPEATABLE | REPLACE | RESET | RESPECT | RESTRICT | REVOKE | ROLE | ROLES | ROLLBACK | ROW | ROWS | RUNNING
     | SCHEMA | SCHEMAS | SECOND | SECURITY | SEEK | SERIALIZABLE | SESSION | SET | SETS
     | SHOW | SOME | START | STATS | SUBSET | SUBSTRING | SYSTEM
-    | TABLES | TABLESAMPLE | TEXT | TIES | TIME | TIMESTAMP | TO | TRANSACTION | TRUNCATE | TRY_CAST | TYPE
+    | TABLES | TABLESAMPLE | TEXT | TIES | TIME | TIMESTAMP | TO | TRAILING | TRANSACTION | TRUNCATE | TRY_CAST | TYPE
     | UNBOUNDED | UNCOMMITTED | UNMATCHED | UPDATE | USE | USER
     | VALIDATE | VERBOSE | VERSION | VIEW
     | WINDOW | WITHIN | WITHOUT | WORK | WRITE
@@ -747,6 +756,7 @@ AT: 'AT';
 AUTHORIZATION: 'AUTHORIZATION';
 BERNOULLI: 'BERNOULLI';
 BETWEEN: 'BETWEEN';
+BOTH: 'BOTH';
 BY: 'BY';
 CALL: 'CALL';
 CASCADE: 'CASCADE';
@@ -837,6 +847,7 @@ JOIN: 'JOIN';
 JSON: 'JSON';
 LAST: 'LAST';
 LATERAL: 'LATERAL';
+LEADING: 'LEADING';
 LEFT: 'LEFT';
 LEVEL: 'LEVEL';
 LIKE: 'LIKE';
@@ -941,7 +952,9 @@ TIES: 'TIES';
 TIME: 'TIME';
 TIMESTAMP: 'TIMESTAMP';
 TO: 'TO';
+TRAILING: 'TRAILING';
 TRANSACTION: 'TRANSACTION';
+TRIM: 'TRIM';
 TRUE: 'TRUE';
 TRUNCATE: 'TRUNCATE';
 TRY_CAST: 'TRY_CAST';

--- a/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
@@ -90,6 +90,7 @@ import io.trino.sql.tree.SubscriptExpression;
 import io.trino.sql.tree.SymbolReference;
 import io.trino.sql.tree.TimeLiteral;
 import io.trino.sql.tree.TimestampLiteral;
+import io.trino.sql.tree.Trim;
 import io.trino.sql.tree.TryExpression;
 import io.trino.sql.tree.TypeParameter;
 import io.trino.sql.tree.WhenClause;
@@ -189,6 +190,16 @@ public final class ExpressionFormatter
         protected String visitCurrentPath(CurrentPath node, Void context)
         {
             return "CURRENT_PATH";
+        }
+
+        @Override
+        protected String visitTrim(Trim node, Void context)
+        {
+            if (!node.getTrimCharacter().isPresent()) {
+                return format("trim(%s FROM %s)", node.getSpecification(), process(node.getTrimSource(), context));
+            }
+
+            return format("trim(%s %s FROM %s)", node.getSpecification(), process(node.getTrimCharacter().get(), context), process(node.getTrimSource(), context));
         }
 
         @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
@@ -352,6 +352,11 @@ public abstract class AstVisitor<R, C>
         return visitExpression(node, context);
     }
 
+    protected R visitTrim(Trim node, C context)
+    {
+        return visitExpression(node, context);
+    }
+
     protected R visitNullIfExpression(NullIfExpression node, C context)
     {
         return visitExpression(node, context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
@@ -97,6 +97,15 @@ public abstract class DefaultTraversalVisitor<C>
     }
 
     @Override
+    protected Void visitTrim(Trim node, C context)
+    {
+        process(node.getTrimSource(), context);
+        node.getTrimCharacter().ifPresent(trimChar -> process(trimChar, context));
+
+        return null;
+    }
+
+    @Override
     protected Void visitFormat(Format node, C context)
     {
         for (Expression argument : node.getArguments()) {

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionRewriter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionRewriter.java
@@ -210,6 +210,11 @@ public class ExpressionRewriter<C>
         return rewriteExpression(node, context, treeRewriter);
     }
 
+    public Expression rewriteTrim(Trim node, C context, ExpressionTreeRewriter<C> treeRewriter)
+    {
+        return rewriteExpression(node, context, treeRewriter);
+    }
+
     public Expression rewriteFormat(Format node, C context, ExpressionTreeRewriter<C> treeRewriter)
     {
         return rewriteExpression(node, context, treeRewriter);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Trim.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Trim.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class Trim
+        extends Expression
+{
+    private final Specification specification;
+    private final Expression trimSource;
+    private final Optional<Expression> trimCharacter;
+
+    public Trim(Specification specification, Expression trimSource, Optional<Expression> trimCharacter)
+    {
+        this(Optional.empty(), specification, trimSource, trimCharacter);
+    }
+
+    public Trim(NodeLocation location, Specification specification, Expression trimSource, Optional<Expression> trimCharacter)
+    {
+        this(Optional.of(location), specification, trimSource, trimCharacter);
+    }
+
+    private Trim(Optional<NodeLocation> location, Specification specification, Expression trimSource, Optional<Expression> trimCharacter)
+    {
+        super(location);
+        this.specification = requireNonNull(specification, "specification is null");
+        this.trimSource = requireNonNull(trimSource, "trimSource is null");
+        this.trimCharacter = requireNonNull(trimCharacter, "trimCharacter is null");
+    }
+
+    public Specification getSpecification()
+    {
+        return specification;
+    }
+
+    public Expression getTrimSource()
+    {
+        return trimSource;
+    }
+
+    public Optional<Expression> getTrimCharacter()
+    {
+        return trimCharacter;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitTrim(this, context);
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        ImmutableList.Builder<Node> nodes = ImmutableList.builder();
+        nodes.add(trimSource);
+        trimCharacter.ifPresent(nodes::add);
+        return nodes.build();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Trim that = (Trim) o;
+        return specification == that.specification &&
+                Objects.equals(trimSource, that.trimSource) &&
+                Objects.equals(trimCharacter, that.trimCharacter);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(specification, trimSource, trimCharacter);
+    }
+
+    @Override
+    public boolean shallowEquals(Node other)
+    {
+        if (!sameClass(this, other)) {
+            return false;
+        }
+
+        Trim otherTrim = (Trim) other;
+        return specification == otherTrim.specification;
+    }
+
+    public enum Specification
+    {
+        BOTH("trim"),
+        LEADING("ltrim"),
+        TRAILING("rtrim");
+
+        private final String functionName;
+
+        Specification(String functionName)
+        {
+            this.functionName = requireNonNull(functionName, "functionName is null");
+        }
+
+        public String getFunctionName()
+        {
+            return functionName;
+        }
+    }
+}

--- a/docs/src/main/sphinx/language/reserved.rst
+++ b/docs/src/main/sphinx/language/reserved.rst
@@ -75,6 +75,7 @@ Keyword                        SQL:2016      SQL-92
 ``SKIP``                       reserved
 ``TABLE``                      reserved      reserved
 ``THEN``                       reserved      reserved
+``TRIM``                       reserved      reserved
 ``TRUE``                       reserved      reserved
 ``UESCAPE``                    reserved
 ``UNION``                      reserved      reserved


### PR DESCRIPTION
## Description
Add support for ANSI SQL syntax in `trim` function
```
<trim function> ::=
  TRIM <left paren>  <trim operands>  <right paren> 

<trim operands> ::=
  [ [ <trim specification>  ] [ <trim character>  ] FROM ] <trim source> 

<trim source> ::=
  <character value expression> 

<trim specification> ::=
    LEADING
  | TRAILING
  | BOTH

<trim character> ::=
  <character value expression> 
```

## Documentation

(x) Documentation issue #11347 is filed, and can be handled later.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# General
* Add support for ANSI compliant `trim` function. ({issue}`11236 `)
```
