### PR TITLE
Fix reading Iceberg $manifests table when contains_nan is NULL

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ManifestsTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ManifestsTable.java
@@ -137,7 +137,13 @@ public class ManifestsTable
 
             BlockBuilder rowBuilder = singleArrayWriter.beginBlockEntry();
             BOOLEAN.writeBoolean(rowBuilder, summary.containsNull());
-            BOOLEAN.writeBoolean(rowBuilder, summary.containsNaN());
+            Boolean containsNan = summary.containsNaN();
+            if (containsNan == null) {
+                rowBuilder.appendNull();
+            }
+            else {
+                BOOLEAN.writeBoolean(rowBuilder, containsNan);
+            }
             VARCHAR.writeString(rowBuilder, field.transform().toHumanString(
                     Conversions.fromByteBuffer(nestedType, summary.lowerBound())));
             VARCHAR.writeString(rowBuilder, field.transform().toHumanString(


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

This change affects queries on `$manifests` Iceberg metadata tables.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

This PR fixes the handling of `contains_nan` field for partition summaries in Iceberg manifests table.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

This change affects the Iceberg connector.

> How would you describe this change to a non-technical end user or system administrator?

Add handling for reading correctly the manifests of Iceberg files written with older Iceberg version (that didn't contain yet `contains_nan` field handling).

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

Fixes #11237

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
