### PR TITLE
Remove deprecated constructor from JdbcColumnHandle

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcColumnHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcColumnHandle.java
@@ -42,15 +42,6 @@ public final class JdbcColumnHandle
     }
 
     /**
-     * @deprecated Use {@link #builder()} instead.
-     */
-    @Deprecated
-    public JdbcColumnHandle(String columnName, JdbcTypeHandle jdbcTypeHandle, Type columnType, boolean nullable)
-    {
-        this(columnName, jdbcTypeHandle, columnType, nullable, Optional.empty());
-    }
-
-    /**
      * @deprecated This constructor is intended to be used by JSON deserialization only. Use {@link #builder()} instead.
      */
     @Deprecated

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcQueryBuilder.java
@@ -575,12 +575,11 @@ public class TestDefaultJdbcQueryBuilder
     {
         List<JdbcColumnHandle> projectedColumns = ImmutableList.of(
                 this.columns.get(2),
-                new JdbcColumnHandle(
-                        "s",
-                        JDBC_BIGINT,
-                        BIGINT,
-                        true,
-                        Optional.empty()));
+                JdbcColumnHandle.builder()
+                        .setColumnName("s")
+                        .setJdbcTypeHandle(JDBC_BIGINT)
+                        .setColumnType(BIGINT)
+                        .build());
 
         Connection connection = database.getConnection();
 
@@ -619,12 +618,11 @@ public class TestDefaultJdbcQueryBuilder
 
         List<JdbcColumnHandle> projectedColumns = ImmutableList.of(
                 this.columns.get(2),
-                new JdbcColumnHandle(
-                        "s",
-                        JDBC_BIGINT,
-                        BIGINT,
-                        true,
-                        Optional.empty()));
+                JdbcColumnHandle.builder()
+                        .setColumnName("s")
+                        .setJdbcTypeHandle(JDBC_BIGINT)
+                        .setColumnType(BIGINT)
+                        .build());
 
         Connection connection = database.getConnection();
 

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcColumnHandle.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcColumnHandle.java
@@ -30,7 +30,14 @@ public class TestJdbcColumnHandle
     @Test
     public void testJsonRoundTrip()
     {
-        assertJsonRoundTrip(COLUMN_CODEC, new JdbcColumnHandle("columnName", JDBC_VARCHAR, VARCHAR, true, Optional.of("some comment")));
+        assertJsonRoundTrip(
+                COLUMN_CODEC,
+                JdbcColumnHandle.builder()
+                        .setColumnName("columnName")
+                        .setJdbcTypeHandle(JDBC_VARCHAR)
+                        .setColumnType(VARCHAR)
+                        .setComment(Optional.of("some comment"))
+                        .build());
     }
 
     @Test


### PR DESCRIPTION
## Description

Remove deprecated constructor from `JdbcColumnHandle`

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
