### PR TITLE
TRY should handle invalid value error in cast VACHAR as TIMESTAMP

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/VarcharToTimestampCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/VarcharToTimestampCast.java
@@ -23,6 +23,7 @@ import io.trino.spi.function.SqlType;
 import io.trino.spi.type.LongTimestamp;
 import io.trino.type.DateTimes;
 
+import java.time.DateTimeException;
 import java.time.ZonedDateTime;
 import java.util.regex.Matcher;
 
@@ -74,7 +75,7 @@ public final class VarcharToTimestampCast
 
         Matcher matcher = DateTimes.DATETIME_PATTERN.matcher(value);
         if (!matcher.matches()) {
-            throw new IllegalArgumentException("Invalid timestamp: " + value);
+            throw new TrinoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to timestamp: " + value);
         }
 
         String year = matcher.group("year");
@@ -85,16 +86,22 @@ public final class VarcharToTimestampCast
         String second = matcher.group("second");
         String fraction = matcher.group("fraction");
 
-        long epochSecond = ZonedDateTime.of(
-                Integer.parseInt(year),
-                Integer.parseInt(month),
-                Integer.parseInt(day),
-                hour == null ? 0 : Integer.parseInt(hour),
-                minute == null ? 0 : Integer.parseInt(minute),
-                second == null ? 0 : Integer.parseInt(second),
-                0,
-                UTC)
-                .toEpochSecond();
+        long epochSecond;
+        try {
+            epochSecond = ZonedDateTime.of(
+                            Integer.parseInt(year),
+                            Integer.parseInt(month),
+                            Integer.parseInt(day),
+                            hour == null ? 0 : Integer.parseInt(hour),
+                            minute == null ? 0 : Integer.parseInt(minute),
+                            second == null ? 0 : Integer.parseInt(second),
+                            0,
+                            UTC)
+                    .toEpochSecond();
+        }
+        catch (DateTimeException e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to timestamp: " + value, e);
+        }
 
         int actualPrecision = 0;
         long fractionValue = 0;
@@ -118,7 +125,7 @@ public final class VarcharToTimestampCast
 
         Matcher matcher = DateTimes.DATETIME_PATTERN.matcher(value);
         if (!matcher.matches()) {
-            throw new IllegalArgumentException("Invalid timestamp: " + value);
+            throw new TrinoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to timestamp: " + value);
         }
 
         String year = matcher.group("year");
@@ -129,16 +136,22 @@ public final class VarcharToTimestampCast
         String second = matcher.group("second");
         String fraction = matcher.group("fraction");
 
-        long epochSecond = ZonedDateTime.of(
-                Integer.parseInt(year),
-                Integer.parseInt(month),
-                Integer.parseInt(day),
-                hour == null ? 0 : Integer.parseInt(hour),
-                minute == null ? 0 : Integer.parseInt(minute),
-                second == null ? 0 : Integer.parseInt(second),
-                0,
-                UTC)
-                .toEpochSecond();
+        long epochSecond;
+        try {
+            epochSecond = ZonedDateTime.of(
+                            Integer.parseInt(year),
+                            Integer.parseInt(month),
+                            Integer.parseInt(day),
+                            hour == null ? 0 : Integer.parseInt(hour),
+                            minute == null ? 0 : Integer.parseInt(minute),
+                            second == null ? 0 : Integer.parseInt(second),
+                            0,
+                            UTC)
+                    .toEpochSecond();
+        }
+        catch (DateTimeException e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to timestamp: " + value, e);
+        }
 
         int actualPrecision = 0;
         long fractionValue = 0;

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamptz/VarcharToTimestampWithTimeZoneCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamptz/VarcharToTimestampWithTimeZoneCast.java
@@ -23,8 +23,10 @@ import io.trino.spi.function.SqlType;
 import io.trino.spi.type.LongTimestampWithTimeZone;
 import io.trino.type.DateTimes;
 
+import java.time.DateTimeException;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.zone.ZoneRulesException;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 
@@ -86,7 +88,7 @@ public final class VarcharToTimestampWithTimeZoneCast
 
         Matcher matcher = DateTimes.DATETIME_PATTERN.matcher(value);
         if (!matcher.matches()) {
-            throw new IllegalArgumentException("Invalid timestamp: " + value);
+            throw new TrinoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to timestamp: " + value);
         }
 
         String year = matcher.group("year");
@@ -98,17 +100,25 @@ public final class VarcharToTimestampWithTimeZoneCast
         String fraction = matcher.group("fraction");
         String timezone = matcher.group("timezone");
 
-        ZoneId zone = zoneId.apply(timezone);
-        long epochSecond = ZonedDateTime.of(
-                Integer.parseInt(year),
-                Integer.parseInt(month),
-                Integer.parseInt(day),
-                hour == null ? 0 : Integer.parseInt(hour),
-                minute == null ? 0 : Integer.parseInt(minute),
-                second == null ? 0 : Integer.parseInt(second),
-                0,
-                zone)
-                .toEpochSecond();
+        ZoneId zone;
+        long epochSecond;
+
+        try {
+            zone = zoneId.apply(timezone);
+            epochSecond = ZonedDateTime.of(
+                            Integer.parseInt(year),
+                            Integer.parseInt(month),
+                            Integer.parseInt(day),
+                            hour == null ? 0 : Integer.parseInt(hour),
+                            minute == null ? 0 : Integer.parseInt(minute),
+                            second == null ? 0 : Integer.parseInt(second),
+                            0,
+                            zone)
+                    .toEpochSecond();
+        }
+        catch (DateTimeException e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to timestamp: " + value, e);
+        }
 
         int actualPrecision = 0;
         long fractionValue = 0;
@@ -131,7 +141,7 @@ public final class VarcharToTimestampWithTimeZoneCast
 
         Matcher matcher = DateTimes.DATETIME_PATTERN.matcher(value);
         if (!matcher.matches()) {
-            throw new IllegalArgumentException("Invalid timestamp: " + value);
+            throw new TrinoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to timestamp: " + value);
         }
 
         String year = matcher.group("year");
@@ -143,17 +153,25 @@ public final class VarcharToTimestampWithTimeZoneCast
         String fraction = matcher.group("fraction");
         String timezone = matcher.group("timezone");
 
-        ZoneId zone = zoneId.apply(timezone);
-        long epochSecond = ZonedDateTime.of(
-                Integer.parseInt(year),
-                Integer.parseInt(month),
-                Integer.parseInt(day),
-                hour == null ? 0 : Integer.parseInt(hour),
-                minute == null ? 0 : Integer.parseInt(minute),
-                second == null ? 0 : Integer.parseInt(second),
-                0,
-                zone)
-                .toEpochSecond();
+        ZoneId zone;
+        long epochSecond;
+
+        try {
+            zone = zoneId.apply(timezone);
+            epochSecond = ZonedDateTime.of(
+                            Integer.parseInt(year),
+                            Integer.parseInt(month),
+                            Integer.parseInt(day),
+                            hour == null ? 0 : Integer.parseInt(hour),
+                            minute == null ? 0 : Integer.parseInt(minute),
+                            second == null ? 0 : Integer.parseInt(second),
+                            0,
+                            zone)
+                    .toEpochSecond();
+        }
+        catch (DateTimeException e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to timestamp: " + value, e);
+        }
 
         int actualPrecision = 0;
         long fractionValue = 0;

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestTryFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestTryFunction.java
@@ -27,7 +27,9 @@ import static io.trino.spi.type.DecimalType.createDecimalType;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.SqlDecimal.decimal;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.trino.spi.type.TimestampType.createTimestampType;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.type.JsonType.JSON;
 import static io.trino.type.UnknownType.UNKNOWN;
@@ -70,6 +72,9 @@ public class TestTryFunction
         assertFunction(createTryExpression("1/0"), INTEGER, null);
         assertFunction(createTryExpression("JSON_PARSE('INVALID')"), JSON, null);
         assertFunction(createTryExpression("CAST(NULL AS INTEGER)"), INTEGER, null);
+        assertFunction(createTryExpression("CAST('0000-00-01' AS TIMESTAMP)"), TIMESTAMP_MILLIS, null);
+        assertFunction(createTryExpression("CAST('0000-01-00' AS TIMESTAMP)"), TIMESTAMP_MILLIS, null);
+        assertFunction(createTryExpression("CAST('0000-01-01 ABC' AS TIMESTAMP WITH TIME ZONE)"), TIMESTAMP_TZ_MILLIS, null);
         assertFunction(createTryExpression("ABS(-9223372036854775807 - 1)"), BIGINT, null);
 
         // Exceptions that should not be suppressed

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestTimestamp.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestTimestamp.java
@@ -2671,6 +2671,36 @@ public class TestTimestamp
         assertThat(assertions.expression("TIMESTAMP '2020-05-01 12:34:56.123456789123' AT TIME ZONE INTERVAL '10' HOUR", session)).matches("TIMESTAMP '2020-05-01 09:34:56.123456789123 +10:00'");
     }
 
+    @Test
+    public void testCastInvalidTimestamp()
+    {
+        assertThatThrownBy(() -> assertions.expression("CAST('ABC' AS TIMESTAMP)"))
+                .hasMessage("Value cannot be cast to timestamp: ABC");
+        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-00 00:00:00' AS TIMESTAMP)"))
+                .hasMessage("Value cannot be cast to timestamp: 2022-01-00 00:00:00");
+        assertThatThrownBy(() -> assertions.expression("CAST('2022-00-01 00:00:00' AS TIMESTAMP)"))
+                .hasMessage("Value cannot be cast to timestamp: 2022-00-01 00:00:00");
+        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-01 25:00:00' AS TIMESTAMP)"))
+                .hasMessage("Value cannot be cast to timestamp: 2022-01-01 25:00:00");
+        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-01 00:61:00' AS TIMESTAMP)"))
+                .hasMessage("Value cannot be cast to timestamp: 2022-01-01 00:61:00");
+        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-01 00:00:61' AS TIMESTAMP)"))
+                .hasMessage("Value cannot be cast to timestamp: 2022-01-01 00:00:61");
+
+        assertThatThrownBy(() -> assertions.expression("CAST('ABC' AS TIMESTAMP(12))"))
+                .hasMessage("Value cannot be cast to timestamp: ABC");
+        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-00 00:00:00' AS TIMESTAMP(12))"))
+                .hasMessage("Value cannot be cast to timestamp: 2022-01-00 00:00:00");
+        assertThatThrownBy(() -> assertions.expression("CAST('2022-00-01 00:00:00' AS TIMESTAMP(12))"))
+                .hasMessage("Value cannot be cast to timestamp: 2022-00-01 00:00:00");
+        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-01 25:00:00' AS TIMESTAMP(12))"))
+                .hasMessage("Value cannot be cast to timestamp: 2022-01-01 25:00:00");
+        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-01 00:61:00' AS TIMESTAMP(12))"))
+                .hasMessage("Value cannot be cast to timestamp: 2022-01-01 00:61:00");
+        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-01 00:00:61' AS TIMESTAMP(12))"))
+                .hasMessage("Value cannot be cast to timestamp: 2022-01-01 00:00:61");
+    }
+
     private static BiFunction<Session, QueryRunner, Object> timestamp(int precision, int year, int month, int day, int hour, int minute, int second, long picoOfSecond)
     {
         return (session, queryRunner) -> {

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamptz/TestTimestampWithTimeZone.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamptz/TestTimestampWithTimeZone.java
@@ -2424,6 +2424,40 @@ public class TestTimestampWithTimeZone
                 .matches("VALUES BIGINT '1'");
     }
 
+    @Test
+    public void testCastInvalidTimestamp()
+    {
+        assertThatThrownBy(() -> assertions.expression("CAST('ABC' AS TIMESTAMP WITH TIME ZONE)"))
+                .hasMessage("Value cannot be cast to timestamp: ABC");
+        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-00 00:00:00 UTC' AS TIMESTAMP WITH TIME ZONE)"))
+                .hasMessage("Value cannot be cast to timestamp: 2022-01-00 00:00:00 UTC");
+        assertThatThrownBy(() -> assertions.expression("CAST('2022-00-01 00:00:00 UTC' AS TIMESTAMP WITH TIME ZONE)"))
+                .hasMessage("Value cannot be cast to timestamp: 2022-00-01 00:00:00 UTC");
+        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-01 25:00:00 UTC' AS TIMESTAMP WITH TIME ZONE)"))
+                .hasMessage("Value cannot be cast to timestamp: 2022-01-01 25:00:00 UTC");
+        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-01 00:61:00 UTC' AS TIMESTAMP WITH TIME ZONE)"))
+                .hasMessage("Value cannot be cast to timestamp: 2022-01-01 00:61:00 UTC");
+        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-01 00:00:61 UTC' AS TIMESTAMP WITH TIME ZONE)"))
+                .hasMessage("Value cannot be cast to timestamp: 2022-01-01 00:00:61 UTC");
+        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-01 00:00:00 ABC' AS TIMESTAMP WITH TIME ZONE)"))
+                .hasMessage("Value cannot be cast to timestamp: 2022-01-01 00:00:00 ABC");
+
+        assertThatThrownBy(() -> assertions.expression("CAST('ABC' AS TIMESTAMP(12))"))
+                .hasMessage("Value cannot be cast to timestamp: ABC");
+        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-00 00:00:00 UTC' AS TIMESTAMP(12) WITH TIME ZONE)"))
+                .hasMessage("Value cannot be cast to timestamp: 2022-01-00 00:00:00 UTC");
+        assertThatThrownBy(() -> assertions.expression("CAST('2022-00-01 00:00:00 UTC' AS TIMESTAMP(12) WITH TIME ZONE)"))
+                .hasMessage("Value cannot be cast to timestamp: 2022-00-01 00:00:00 UTC");
+        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-01 25:00:00 UTC' AS TIMESTAMP(12) WITH TIME ZONE)"))
+                .hasMessage("Value cannot be cast to timestamp: 2022-01-01 25:00:00 UTC");
+        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-01 00:61:00 UTC' AS TIMESTAMP(12) WITH TIME ZONE)"))
+                .hasMessage("Value cannot be cast to timestamp: 2022-01-01 00:61:00 UTC");
+        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-01 00:00:61 UTC' AS TIMESTAMP(12) WITH TIME ZONE)"))
+                .hasMessage("Value cannot be cast to timestamp: 2022-01-01 00:00:61 UTC");
+        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-01 00:00:00 ABC' AS TIMESTAMP(12) WITH TIME ZONE)"))
+                .hasMessage("Value cannot be cast to timestamp: 2022-01-01 00:00:00 ABC");
+    }
+
     private BiFunction<Session, QueryRunner, Object> timestampWithTimeZone(int precision, int year, int month, int day, int hour, int minute, int second, long picoOfSecond, TimeZoneKey timeZoneKey)
     {
         return (session, queryRunner) -> {


### PR DESCRIPTION
## Description

Previously (at least in 317), `TRY(CAST(xxxx AS TIMESTAMP)` returned `NULL` for a timestamp that contains an invalid value like `0000-00-00` but in the latest Trino, it fails with the following error:
```
Invalid value for MonthOfYear (valid values 1 - 12): 0
```
[Trino's document](https://trino.io/docs/current/functions/conditional.html#try) says:

> The following errors are handled by TRY:
> * Division by zero
> * Invalid cast or function argument
> * Numeric value out of range

Therefore,  I think TRY should cover this case. This pull request will resurrect the previous behavior which returns `NULL` for invalid values in timestamp.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
