### PR TITLE
Add Hive dynamic row filtering fragment to Trino connector files

### DIFF
--- a/docs/src/main/sphinx/connector/hive-dynamic-row-filtering.fragment
+++ b/docs/src/main/sphinx/connector/hive-dynamic-row-filtering.fragment
@@ -1,0 +1,36 @@
+Dynamic row filtering
+^^^^^^^^^^^^^^^^^^^^^
+
+:doc:`Dynamic filtering </admin/dynamic-filtering>`, and specifically also
+dynamic row filtering, is enabled by default. Row filtering improves the
+effectiveness of dynamic filtering for a connector by using dynamic filters to
+remove unnecessary rows during a table scan. It is especially powerful for
+selective filters on columns that are not used for partitioning, bucketing, or
+when the values do not appear in any clustered order naturally.
+
+As a result the amount of data read from storage and transferred across the
+network is further reduced. You get access to higher query performance and a
+reduced cost.
+
+You can use the following properties to configure dynamic row filtering:
+
+.. list-table:: Dynamic row filtering properties
+    :widths: 45, 55
+    :header-rows: 1
+
+    * - Property name
+      - Description
+    * - ``dynamic-row-filtering.enabled``
+      - Toggle dynamic row filtering. Defaults to ``true``. Catalog session
+        property name is ``dynamic_row_filtering_enabled``.
+    * - ``dynamic-row-filtering.selectivity-threshold``
+      - Control the threshold for the fraction of the selected rows from the
+        overall table above which dynamic row filters are not used. Defaults to
+        0.7. Catalog session property name is
+        ``dynamic_row_filtering_selectivity_threshold``.
+    * - ``dynamic-row-filtering.wait-timeout``
+      - Duration to wait for completion of dynamic row filtering. Defaults to 0.
+        The default causes query processing to proceed without waiting for the
+        dynamic row filter, it is collected asynchronously and used as soon as
+        it becomes available. Catalog session property name is
+        ``dynamic_row_filtering_wait_timeout``.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Documentation change

> How would you describe this change to a non-technical end user or system administrator?

Add Hive dynamic row filtering fragment to Trino connector files so the fragment appears in the documentation.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:
