### PR TITLE
Various Kudu cleanups and fixes related to schema emulation races

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,8 +397,7 @@ jobs:
             - { modules: plugin/trino-sqlserver }
             - { modules: plugin/trino-memsql }
             - { modules: plugin/trino-oracle }
-            # TODO: re-enable kudu tests after this issue is resolved: https://github.com/trinodb/trino/issues/11203
-            # - { modules: plugin/trino-kudu }
+            - { modules: plugin/trino-kudu }
             - { modules: plugin/trino-druid }
             - { modules: plugin/trino-iceberg }
             - { modules: plugin/trino-iceberg, profile: test-failure-recovery }

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduClientSession.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduClientSession.java
@@ -234,9 +234,9 @@ public class KuduClientSession
         catch (KuduException e) {
             log.debug(e, "Error on doOpenTable");
             if (!listSchemaNames().contains(schemaTableName.getSchemaName())) {
-                throw new SchemaNotFoundException(schemaTableName.getSchemaName());
+                throw new SchemaNotFoundException(schemaTableName.getSchemaName(), e);
             }
-            throw new TableNotFoundException(schemaTableName);
+            throw new TableNotFoundException(schemaTableName, e);
         }
     }
 

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduPageSink.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduPageSink.java
@@ -27,7 +27,7 @@ import io.trino.spi.type.SqlDecimal;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 import org.apache.kudu.client.KuduException;
-import org.apache.kudu.client.KuduSession;
+import org.apache.kudu.client.KuduOperationApplier;
 import org.apache.kudu.client.KuduTable;
 import org.apache.kudu.client.PartialRow;
 import org.apache.kudu.client.Upsert;
@@ -58,13 +58,12 @@ import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.apache.kudu.client.KuduOperationApplier.applyOperationAndVerifySucceeded;
 
 public class KuduPageSink
         implements ConnectorPageSink
 {
     private final ConnectorSession connectorSession;
-    private final KuduSession session;
+    private final KuduClientSession session;
     private final KuduTable table;
     private final List<Type> columnTypes;
     private final List<Type> originalColumnTypes;
@@ -102,35 +101,35 @@ public class KuduPageSink
         this.generateUUID = mapping.isGenerateUUID();
 
         this.table = table;
-        this.session = clientSession.newSession();
+        this.session = clientSession;
         uuid = UUID.randomUUID().toString();
     }
 
     @Override
     public CompletableFuture<?> appendPage(Page page)
     {
-        for (int position = 0; position < page.getPositionCount(); position++) {
-            Upsert upsert = table.newUpsert();
-            PartialRow row = upsert.getRow();
-            int start = 0;
-            if (generateUUID) {
-                String id = format("%s-%08x", uuid, nextSubId++);
-                row.addString(0, id);
-                start = 1;
-            }
+        try (KuduOperationApplier operationApplier = KuduOperationApplier.fromKuduClientSession(session)) {
+            for (int position = 0; position < page.getPositionCount(); position++) {
+                Upsert upsert = table.newUpsert();
+                PartialRow row = upsert.getRow();
+                int start = 0;
+                if (generateUUID) {
+                    String id = format("%s-%08x", uuid, nextSubId++);
+                    row.addString(0, id);
+                    start = 1;
+                }
 
-            for (int channel = 0; channel < page.getChannelCount(); channel++) {
-                appendColumn(row, page, position, channel, channel + start);
-            }
+                for (int channel = 0; channel < page.getChannelCount(); channel++) {
+                    appendColumn(row, page, position, channel, channel + start);
+                }
 
-            try {
-                applyOperationAndVerifySucceeded(session, upsert);
+                operationApplier.applyOperationAsync(upsert);
             }
-            catch (KuduException e) {
-                throw new RuntimeException(e);
-            }
+            return NOT_BLOCKED;
         }
-        return NOT_BLOCKED;
+        catch (KuduException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private void appendColumn(PartialRow row, Page page, int position, int channel, int destChannel)
@@ -191,23 +190,11 @@ public class KuduPageSink
     @Override
     public CompletableFuture<Collection<Slice>> finish()
     {
-        closeSession();
         return completedFuture(ImmutableList.of());
     }
 
     @Override
     public void abort()
     {
-        closeSession();
-    }
-
-    private void closeSession()
-    {
-        try {
-            session.close();
-        }
-        catch (KuduException e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/AbstractKuduWithStandardInferSchemaConnectorTest.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/AbstractKuduWithStandardInferSchemaConnectorTest.java
@@ -32,7 +32,9 @@ public abstract class AbstractKuduWithStandardInferSchemaConnectorTest
     @Test
     public void testListingOfTableForDefaultSchema()
     {
-        assertEquals(computeActual("SHOW TABLES FROM default").getRowCount(), 0);
+        // The special $schemas table is created when listing schema names with schema emulation enabled
+        // Depending on test ordering, this table may or may not be created when this test runs, so filter it out
+        assertEquals(computeActual("SHOW TABLES FROM default LIKE '%$schemas'").getRowCount(), 0);
     }
 
     @Test

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestingKuduServer.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestingKuduServer.java
@@ -102,7 +102,10 @@ public class TestingKuduServer
 
     public HostAndPort getMasterAddress()
     {
-        return HostAndPort.fromParts(master.getContainerIpAddress(), master.getMappedPort(KUDU_MASTER_PORT));
+        // Do not use master.getContainerIpAddress(), it returns "localhost" which the kudu client resolves to:
+        // localhost/127.0.0.1, localhost/0:0:0:0:0:0:0:1
+        // Instead explicitly list only the ipv4 loopback address 127.0.0.1
+        return HostAndPort.fromParts("127.0.0.1", master.getMappedPort(KUDU_MASTER_PORT));
     }
 
     @Override


### PR DESCRIPTION
## Description
Fixes lots of different problems with flaky kudu tests. Let me know if I should split some of these commits into separate PRs 
- Fixes a problem with the connector code itself racing to create the `$schemas` table
- Fixes problems with tests asserting on the number of tables that exist, which races with the `$schemas` table
- Workaround a change in the kudu client introduced in this commit that caused opening a table immediately after creating it to sometimes fail: https://github.com/apache/kudu/commit/4bf7e457b054d9bfb002e3971113e2152b92951a
- Flush kudu operations in batches instead of one at a time, this helps reduce CI runtime. This PR https://github.com/trinodb/trino/pull/10940/files changed the behavior from `AUTO_FLUSH_BACKGROUND` to `AUTO_FLUSH_SYNC` to improve correctness, but unfortunately it caused a performance degradation due to flushing each operation one at a time. This commit keeps correctness while getting better write performance.

## Related issues, pull requests, and links
https://github.com/trinodb/trino/issues/11203

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Kudu
* Fixes race in creating schemas table if schema emulation is enabled. ({issue}`11264`)
* Improve write performance by flushing operations in batches. ({issue}`11264`)
```