### PR TITLE
Drop table after verifying the behavior in testRenameTable

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -1785,6 +1785,7 @@ public abstract class BaseConnectorTest
         String renamedTable = "test_rename_new_" + randomTableSuffix();
         if (!hasBehavior(SUPPORTS_RENAME_TABLE)) {
             assertQueryFails("ALTER TABLE " + tableName + " RENAME TO " + renamedTable, "This connector does not support renaming tables");
+            assertUpdate("DROP TABLE " + tableName);
             return;
         }
 


### PR DESCRIPTION
## Description

Drop table after verifying the behavior in testRenameTable. The table should be dropped especially for SaaS connector (Redshift, BigQuery and so on). 

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
