### PR TITLE
Allow passing extra credentials details to AWS Glue in customAWSCredntialProvider 

### DIFF
--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -567,6 +567,10 @@ Property Name                                        Description
                                                      AWS credentials. Can be used to supply a custom credentials
                                                      provider.
 
+``hive.metastore.glue.aws-credentials-providerconf`` Location of the file contains configuration details
+                                                     required by ``hive.metastore.glue.aws-credentials-provider``
+
+
 ``hive.metastore.glue.aws-access-key``               AWS access key to use to connect to the Glue Catalog. If
                                                      specified along with ``hive.metastore.glue.aws-secret-key``,
                                                      this parameter takes precedence over

--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHivePlugin.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHivePlugin.java
@@ -127,6 +127,33 @@ public class TestHivePlugin
     }
 
     @Test
+    public void testGlueMetastoreCustomAwsCredentialsProvider()
+            throws IOException
+    {
+        ConnectorFactory factory = getHiveConnectorFactory();
+        Path customCredConf = Files.createTempFile(null, null);
+
+        assertThatThrownBy(() -> factory.create(
+                "test",
+                ImmutableMap.of(
+                        "hive.metastore", "glue",
+                        "hive.metastore.glue.region", "us-east-2",
+                        "hive.metastore.glue.aws-credentials-providerconf", customCredConf.toString()),
+                new TestingConnectorContext()))
+                .hasMessageContaining("AwsCredentialsProvider class must be set when AwsCredentialsProviderConf is set");
+
+        factory.create(
+                        "test",
+                        ImmutableMap.of(
+                                "hive.metastore", "glue",
+                                "hive.metastore.glue.region", "us-east-2",
+                                "hive.metastore.glue.aws-credentials-provider", "io.trino.plugin.hive.metastore.glue.TestCustomAwsProvider",
+                                "hive.metastore.glue.aws-credentials-providerconf", customCredConf.toString()),
+                        new TestingConnectorContext())
+                .shutdown();
+    }
+
+    @Test
     public void testRecordingMetastore()
     {
         ConnectorFactory factory = getHiveConnectorFactory();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastoreConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastoreConfig.java
@@ -17,10 +17,12 @@ import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.configuration.DefunctConfig;
+import io.airlift.configuration.validation.FileExists;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 
+import java.io.File;
 import java.util.Optional;
 
 @DefunctConfig("hive.metastore.glue.use-instance-credentials")
@@ -37,6 +39,7 @@ public class GlueHiveMetastoreConfig
     private Optional<String> awsAccessKey = Optional.empty();
     private Optional<String> awsSecretKey = Optional.empty();
     private Optional<String> awsCredentialsProvider = Optional.empty();
+    private Optional<File> awsCredentialsProviderConf = Optional.empty();
     private Optional<String> catalogId = Optional.empty();
     private int partitionSegments = 5;
     private int getPartitionThreads = 20;
@@ -200,6 +203,19 @@ public class GlueHiveMetastoreConfig
     public GlueHiveMetastoreConfig setAwsCredentialsProvider(String awsCredentialsProvider)
     {
         this.awsCredentialsProvider = Optional.ofNullable(awsCredentialsProvider);
+        return this;
+    }
+
+    public Optional<@FileExists File> getAwsCredentialsProviderConf()
+    {
+        return awsCredentialsProviderConf;
+    }
+
+    @Config("hive.metastore.glue.aws-credentials-providerconf")
+    @ConfigDescription("Location of the file contains configuration details required by AwsCredentialsProvider class")
+    public GlueHiveMetastoreConfig setAwsCredentialsProviderConf(File awsCredentialsProviderConf)
+    {
+        this.awsCredentialsProviderConf = Optional.ofNullable(awsCredentialsProviderConf);
         return this;
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestCustomAwsProvider.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestCustomAwsProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.metastore.glue;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+
+import java.io.File;
+
+public class TestCustomAwsProvider
+        implements AWSCredentialsProvider
+{
+    public TestCustomAwsProvider(File configFile)
+    {
+    }
+
+    @Override
+    public AWSCredentials getCredentials()
+    {
+        return null;
+    }
+
+    @Override
+    public void refresh()
+    {
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
@@ -16,6 +16,9 @@ package io.trino.plugin.hive.metastore.glue;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
@@ -39,6 +42,7 @@ public class TestGlueHiveMetastoreConfig
                 .setAwsAccessKey(null)
                 .setAwsSecretKey(null)
                 .setAwsCredentialsProvider(null)
+                .setAwsCredentialsProviderConf(null)
                 .setCatalogId(null)
                 .setPartitionSegments(5)
                 .setGetPartitionThreads(20)
@@ -49,7 +53,9 @@ public class TestGlueHiveMetastoreConfig
 
     @Test
     public void testExplicitPropertyMapping()
+            throws IOException
     {
+        Path awsCustomCredentialConf = Files.createTempFile(null, null);
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("hive.metastore.glue.region", "us-east-1")
                 .put("hive.metastore.glue.endpoint-url", "http://foo.bar")
@@ -62,6 +68,7 @@ public class TestGlueHiveMetastoreConfig
                 .put("hive.metastore.glue.aws-access-key", "ABC")
                 .put("hive.metastore.glue.aws-secret-key", "DEF")
                 .put("hive.metastore.glue.aws-credentials-provider", "custom")
+                .put("hive.metastore.glue.aws-credentials-providerconf", awsCustomCredentialConf.toString())
                 .put("hive.metastore.glue.catalogid", "0123456789")
                 .put("hive.metastore.glue.partitions-segments", "10")
                 .put("hive.metastore.glue.get-partition-threads", "42")
@@ -82,6 +89,7 @@ public class TestGlueHiveMetastoreConfig
                 .setAwsAccessKey("ABC")
                 .setAwsSecretKey("DEF")
                 .setAwsCredentialsProvider("custom")
+                .setAwsCredentialsProviderConf(awsCustomCredentialConf.toFile())
                 .setCatalogId("0123456789")
                 .setPartitionSegments(10)
                 .setGetPartitionThreads(42)


### PR DESCRIPTION
add custom credentials conf support for glue metastore (#11271)

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
As of now AWS credential class to connect to AWS glue can be overridden with `hive.metastore.glue.aws-credentials-provider` but there is no easy way to pass the required configuration for the class. This PR adds new configuration property `hive.metastore.glue.aws-credentials-providerconf` this enables passing a location of file to supply required details for above overridden class.

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
New feature, Support passing required credential conf to glue metastore. 

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
Change in trino-hive connector, to aws glue metastore when custom credential is used.

> How would you describe this change to a non-technical end user or system administrator?
With this change custom credential can pass it's own specifc conf
## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ✔) Updated the required documentation.
( ✔) Sufficient documentation is included in this PR.
( ✔) Documentation PR is available with #prnumber.
( ✔) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fixes #11271 (add custom credentials conf support for glue metastore `#11271`)
```
