### PR TITLE
Skip test-docs job when PR contains release-notes label

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,7 +60,7 @@ jobs:
 
   test-docs:
     needs: path-filters
-    if: ${{ needs.path-filters.outputs.docs == 'true' && needs.path-filters.outputs.other == 'false' }}
+    if: ${{ needs.path-filters.outputs.docs == 'true' && needs.path-filters.outputs.other == 'false' && !contains(github.event.pull_request.labels.*.name, 'release-notes') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description

Let test-docs run when PR doesn't contain `release-notes` label. 

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
