### PR TITLE
Add OpenSearch test for Elasticsearch connector test

### DIFF
--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchServer.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchServer.java
@@ -47,6 +47,7 @@ public class ElasticsearchServer
         container = new ElasticsearchContainer(dockerImageName);
         container.withNetwork(network);
         container.withNetworkAliases("elasticsearch-server");
+        container.withEnv("DISABLE_SECURITY_PLUGIN", "true"); // Required for OpenSearch container
 
         configurationPath = createTempDirectory(null);
         for (Map.Entry<String, String> entry : configurationFiles.entrySet()) {

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearchOpenSearchConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearchOpenSearchConnectorTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.elasticsearch;
+
+import static java.lang.String.format;
+
+public class TestElasticsearchOpenSearchConnectorTest
+        extends BaseElasticsearchConnectorTest
+{
+    public TestElasticsearchOpenSearchConnectorTest()
+    {
+        super("opensearchproject/opensearch:1.2.4");
+    }
+
+    @Override
+    protected String indexEndpoint(String index, String docId)
+    {
+        return format("/%s/_doc/%s", index, docId);
+    }
+
+    @Override
+    protected String indexMapping(String properties)
+    {
+        return "{\"mappings\": " + properties + "}";
+    }
+}


### PR DESCRIPTION
## Description

Add OpenSearch test for Elasticsearch connector test

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
