### PR TITLE
Update memsql plugin JDBC driver dependency

### DIFF
--- a/docs/src/main/sphinx/connector/memsql.rst
+++ b/docs/src/main/sphinx/connector/memsql.rst
@@ -3,9 +3,7 @@ SingleStore (MemSQL) connector
 ==============================
 
 The SingleStore (formerly known as MemSQL) connector allows querying and
-creating tables in an external SingleStore database. The SingleStore connector
-is very similar to the MySQL connector with the only difference being the
-underlying driver.
+creating tables in an external SingleStore database.
 
 Requirements
 ------------
@@ -28,7 +26,7 @@ connection properties as appropriate for your setup:
 .. code-block:: text
 
     connector.name=memsql
-    connection-url=jdbc:mariadb://example.net:3306
+    connection-url=jdbc:singlestore://example.net:3306
     connection-user=root
     connection-password=secret
 
@@ -47,10 +45,10 @@ parameter to the ``connection-url`` configuration property:
 
 .. code-block:: properties
 
-  connection-url=jdbc:mariadb://example.net:3306/?useSsl=true
+  connection-url=jdbc:singlestore://example.net:3306/?useSsl=true
 
 For more information on TLS configuration options, see the `JDBC driver
-documentation <https://mariadb.com/kb/en/about-mariadb-connector-j/#tls-parameters>`_.
+documentation <https://docs.singlestore.com/db/v7.6/en/developer-resources/connect-with-application-development-tools/connect-with-java-jdbc/the-singlestore-jdbc-driver.html#tls-parameters>`_.
 
 Multiple SingleStore servers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/plugin/trino-memsql/pom.xml
+++ b/plugin/trino-memsql/pom.xml
@@ -59,6 +59,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.singlestore</groupId>
+            <artifactId>singlestore-jdbc-client</artifactId>
+            <version>1.0.1</version>
+        </dependency>
+
+        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>
@@ -66,12 +72,6 @@
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.mariadb.jdbc</groupId>
-            <artifactId>mariadb-java-client</artifactId>
-            <version>2.7.2</version>
         </dependency>
 
         <!-- Trino SPI -->

--- a/plugin/trino-memsql/src/main/java/io/trino/plugin/memsql/MemSqlClientModule.java
+++ b/plugin/trino-memsql/src/main/java/io/trino/plugin/memsql/MemSqlClientModule.java
@@ -18,6 +18,7 @@ import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
+import com.singlestore.jdbc.Driver;
 import io.trino.plugin.jdbc.BaseJdbcConfig;
 import io.trino.plugin.jdbc.ConnectionFactory;
 import io.trino.plugin.jdbc.DecimalModule;
@@ -25,7 +26,6 @@ import io.trino.plugin.jdbc.DriverConnectionFactory;
 import io.trino.plugin.jdbc.ForBaseJdbc;
 import io.trino.plugin.jdbc.JdbcClient;
 import io.trino.plugin.jdbc.credential.CredentialProvider;
-import org.mariadb.jdbc.Driver;
 
 import java.util.Properties;
 

--- a/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlPlugin.java
+++ b/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlPlugin.java
@@ -28,6 +28,6 @@ public class TestMemSqlPlugin
     {
         Plugin plugin = new MemSqlPlugin();
         ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
-        factory.create("test", ImmutableMap.of("connection-url", "jdbc:mariadb://test"), new TestingConnectorContext()).shutdown();
+        factory.create("test", ImmutableMap.of("connection-url", "jdbc:singlestore://test"), new TestingConnectorContext()).shutdown();
     }
 }

--- a/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlTypeMapping.java
+++ b/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlTypeMapping.java
@@ -704,16 +704,17 @@ public class TestMemSqlTypeMapping
     @Test(dataProvider = "unsupportedTimeDataProvider")
     public void testUnsupportedTime(String unsupportedTime)
     {
+        // SingleStore stores incorrect results when the values are out of supported range. This test should be fixed when SingleStore changes the behavior
         try (TestTable table = new TestTable(memSqlServer::execute, "tpch.test_unsupported_time", "(col time)", ImmutableList.of(format("'%s'", unsupportedTime)))) {
             assertQueryFails(
                     "SELECT * FROM " + table.getName(),
-                    format("\\Q%s cannot be parse as LocalTime (format is \"HH:mm:ss[.S]\" for data type \"TIME\")", unsupportedTime));
+                    format("Supported Trino TIME type range is between 00:00:00 and 23:59:59.999999 but got %s", unsupportedTime));
         }
 
         try (TestTable table = new TestTable(memSqlServer::execute, "tpch.test_unsupported_time", "(col time(6))", ImmutableList.of(format("'%s'", unsupportedTime)))) {
             assertQueryFails(
                     "SELECT * FROM " + table.getName(),
-                    format("\\Q%s.000000 cannot be parse as LocalTime (format is \"HH:mm:ss[.S]\" for data type \"TIME\")", unsupportedTime));
+                    format("Supported Trino TIME type range is between 00:00:00 and 23:59:59.999999 but got %s.000000", unsupportedTime));
         }
     }
 

--- a/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestingMemSqlServer.java
+++ b/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestingMemSqlServer.java
@@ -71,7 +71,7 @@ public class TestingMemSqlServer
     @Override
     public String getDriverClassName()
     {
-        return "org.mariadb.jdbc.Driver";
+        return "com.singlestore.jdbc.Driver";
     }
 
     @Override
@@ -89,7 +89,7 @@ public class TestingMemSqlServer
     @Override
     public String getJdbcUrl()
     {
-        return "jdbc:mariadb://" + getContainerIpAddress() + ":" + getMappedPort(MEMSQL_PORT);
+        return "jdbc:singlestore://" + getContainerIpAddress() + ":" + getMappedPort(MEMSQL_PORT);
     }
 
     @Override

--- a/testing/trino-server-dev/etc/catalog/memsql.properties
+++ b/testing/trino-server-dev/etc/catalog/memsql.properties
@@ -1,4 +1,4 @@
 connector.name=memsql
-connection-url=jdbc:mariadb://localhost:13306
+connection-url=jdbc:singlestore://localhost:13306
 connection-user=test
 connection-password=test


### PR DESCRIPTION
Fixes https://github.com/trinodb/trino/issues/10669

## Description
Upgrade MemSQL Plugin dependency from MariaDB driver to SingleStore driver.

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Connector / MemSQL Plugin

> How would you describe this change to a non-technical end user or system administrator?

Updating Plugin driver dependency to use official SingleStore driver which is under active development and supersedes previous MariaDB driver

## Related issues, pull requests, and links
* Fixes #10669
<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
## SingleStore (MemSQL) connector
* Updated the connector to use official [Single Store JDBC Driver](https://docs.singlestore.com/managed-service/en/developer-resources/connect-with-application-development-tools/connect-with-java-jdbc/the-singlestore-jdbc-driver.html). As a result, `connection-url` in catalog 
  configuration files needs to be updated from `jdbc:mariadb:...` to `jdbc:singlestore:...`. ({issue}`10669`)
```
