### PR TITLE
Add support for LIKE escape parameter in Elasticsearch connector expression pushdown

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestConnectorExpressionTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestConnectorExpressionTranslator.java
@@ -100,6 +100,20 @@ public class TestConnectorExpressionTranslator
                         List.of(new Variable("varchar_symbol_1", VARCHAR_TYPE),
                                 new Constant(Slices.wrappedBuffer(pattern.getBytes(UTF_8)), createVarcharType(pattern.length()))))));
 
+        String escape = "\\";
+        assertTranslationToConnectorExpression(
+                TEST_SESSION,
+                new LikePredicate(
+                        new SymbolReference("varchar_symbol_1"),
+                        new StringLiteral(pattern),
+                        Optional.of(new StringLiteral(escape))),
+                Optional.of(new Call(BOOLEAN,
+                        LIKE_PATTERN_FUNCTION_NAME,
+                        List.of(
+                                new Variable("varchar_symbol_1", VARCHAR_TYPE),
+                                new Constant(Slices.wrappedBuffer(pattern.getBytes(UTF_8)), createVarcharType(pattern.length())),
+                                new Constant(Slices.wrappedBuffer(escape.getBytes(UTF_8)), createVarcharType(escape.length()))))));
+
         transaction(new TestingTransactionManager(), new AllowAllAccessControl())
                 .readOnly()
                 .execute(TEST_SESSION, transactionSession -> {

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/RewriteLikeWithEscape.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/RewriteLikeWithEscape.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc.expression;
+
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.type.VarcharType;
+
+import java.util.Optional;
+
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argument;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argumentCount;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.expression;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.spi.expression.StandardFunctions.LIKE_PATTERN_FUNCTION_NAME;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static java.lang.String.format;
+
+public class RewriteLikeWithEscape
+        implements ConnectorExpressionRule<Call, String>
+{
+    private static final Capture<ConnectorExpression> LIKE_VALUE = newCapture();
+    private static final Capture<ConnectorExpression> LIKE_PATTERN = newCapture();
+    private static final Capture<ConnectorExpression> ESCAPE_VALUE = newCapture();
+
+    private static final Pattern<Call> PATTERN = call()
+            .with(functionName().equalTo(LIKE_PATTERN_FUNCTION_NAME))
+            .with(type().equalTo(BOOLEAN))
+            .with(argumentCount().equalTo(3))
+            // TODO support LIKE on char(n)
+            .with(argument(0).matching(expression().capturedAs(LIKE_VALUE).with(type().matching(VarcharType.class::isInstance))))
+            // Currently, LIKE's pattern must be a varchar.
+            .with(argument(1).matching(expression().capturedAs(LIKE_PATTERN).with(type().matching(VarcharType.class::isInstance))))
+            .with(argument(2).matching(expression().capturedAs(ESCAPE_VALUE).with(type().matching(VarcharType.class::isInstance))));
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<String> rewrite(Call call, Captures captures, RewriteContext<String> context)
+    {
+        Optional<String> value = context.defaultRewrite(captures.get(LIKE_VALUE));
+        if (value.isEmpty()) {
+            return Optional.empty();
+        }
+        Optional<String> pattern = context.defaultRewrite(captures.get(LIKE_PATTERN));
+        if (pattern.isEmpty()) {
+            return Optional.empty();
+        }
+        Optional<String> escape = context.defaultRewrite(captures.get(ESCAPE_VALUE));
+        if (escape.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(format("%s LIKE %s ESCAPE %s", value.get(), pattern.get(), escape.get()));
+    }
+}

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -63,6 +63,7 @@ import io.trino.plugin.jdbc.aggregation.ImplementSum;
 import io.trino.plugin.jdbc.aggregation.ImplementVariancePop;
 import io.trino.plugin.jdbc.aggregation.ImplementVarianceSamp;
 import io.trino.plugin.jdbc.expression.RewriteLike;
+import io.trino.plugin.jdbc.expression.RewriteLikeWithEscape;
 import io.trino.plugin.jdbc.expression.RewriteVarcharConstant;
 import io.trino.plugin.jdbc.expression.RewriteVariable;
 import io.trino.plugin.jdbc.mapping.IdentifierMapping;
@@ -307,7 +308,8 @@ public class PostgreSqlClient
         connectorExpressionRewriter = new ConnectorExpressionRewriter<>(this::quoted, ImmutableSet.of(
                 new RewriteVariable(),
                 new RewriteVarcharConstant(),
-                new RewriteLike()));
+                new RewriteLike(),
+                new RewriteLikeWithEscape()));
     }
 
     @Override

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlClient.java
@@ -202,7 +202,7 @@ public class TestPostgreSqlClient
                 createTestingTypeAnalyzer(PLANNER_CONTEXT),
                 TypeProvider.viewOf(Map.of(new Symbol("c_varchar"), VARCHAR_COLUMN.getColumnType())),
                 PLANNER_CONTEXT))
-                // Currently, LIKE with ESCAPE isn't converted to ConnectorExpression. Update the test when it gets converted.
-                .isEmpty();
+                // TODO: Implement translation in the client
+                .isPresent();
     }
 }

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlClient.java
@@ -193,16 +193,18 @@ public class TestPostgreSqlClient
                 .hasValue("\"c_varchar\" LIKE '%pattern%'");
 
         // c_varchar LIKE '%pattern\%' ESCAPE '\'
-        assertThat(ConnectorExpressionTranslator.translate(
-                TEST_SESSION,
-                new LikePredicate(
-                        new SymbolReference("c_varchar"),
-                        new StringLiteral("%pattern\\%"),
-                        new StringLiteral("\\")),
-                createTestingTypeAnalyzer(PLANNER_CONTEXT),
-                TypeProvider.viewOf(Map.of(new Symbol("c_varchar"), VARCHAR_COLUMN.getColumnType())),
-                PLANNER_CONTEXT))
-                // TODO: Implement translation in the client
-                .isPresent();
+        assertThat(JDBC_CLIENT.convertPredicate(SESSION,
+                ConnectorExpressionTranslator.translate(
+                        TEST_SESSION,
+                        new LikePredicate(
+                                new SymbolReference("c_varchar"),
+                                new StringLiteral("%pattern\\%"),
+                                new StringLiteral("\\")),
+                        createTestingTypeAnalyzer(PLANNER_CONTEXT),
+                        TypeProvider.viewOf(Map.of(new Symbol("c_varchar"), VARCHAR_COLUMN.getColumnType())),
+                        PLANNER_CONTEXT)
+                        .orElseThrow(),
+                Map.of(VARCHAR_COLUMN.getColumnName(), VARCHAR_COLUMN)))
+                .hasValue("\"c_varchar\" LIKE '%pattern\\%' ESCAPE '\\'");
     }
 }

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -715,6 +715,28 @@ public class TestPostgreSqlConnectorTest
         }
     }
 
+    @Test
+    public void testLikeWithEscapePredicatePushdown()
+    {
+        assertThat(query("SELECT nationkey FROM nation WHERE name LIKE '%A%' ESCAPE '\\'"))
+                .isFullyPushedDown();
+
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "test_like_with_escape_predicate_pushdown",
+                "(id integer, a_varchar varchar(4))",
+                List.of(
+                        "1, 'A%b'",
+                        "2, 'Asth'",
+                        "3, 'ą%b'",
+                        "4, 'ąsth'"))) {
+            assertThat(query("SELECT id FROM " + table.getName() + " WHERE a_varchar LIKE '%A\\%%' ESCAPE '\\'"))
+                    .isFullyPushedDown();
+            assertThat(query("SELECT id FROM " + table.getName() + " WHERE a_varchar LIKE '%ą\\%%' ESCAPE '\\'"))
+                    .isFullyPushedDown();
+        }
+    }
+
     @Override
     protected String errorMessageForInsertIntoNotNullColumn(String columnName)
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

This PR adds support for like with escape expression pushdown in ES connector.

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core engine and connector.

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
