### PR TITLE
Temporarily disable kudu tests from running in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,7 +395,8 @@ jobs:
             - { modules: plugin/trino-sqlserver }
             - { modules: plugin/trino-memsql }
             - { modules: plugin/trino-oracle }
-            - { modules: plugin/trino-kudu }
+            # TODO: re-enable kudu tests after this issue is resolved: https://github.com/trinodb/trino/issues/11203
+            # - { modules: plugin/trino-kudu }
             - { modules: plugin/trino-druid }
             - { modules: plugin/trino-iceberg }
             - { modules: plugin/trino-iceberg, profile: test-failure-recovery }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Flakiness is happening often and impacting other PRs.

## Related issues, pull requests, and links
https://github.com/trinodb/trino/issues/11203
https://github.com/trinodb/trino/pull/11264

Disabling due to conversation here: https://github.com/trinodb/trino/pull/11286#issuecomment-1058265700
Unfortunately the flakiness occurs during creating a table and then subsequently opening it. Because this flakiness can occur in almost any integration test (eg: loading TPCH test data) disabling the whole suite makes more sense. 


## Documentation

(X ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(X ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

