### PR TITLE
Forbid usage of static inner test classes in TestNG

### DIFF
--- a/plugin/trino-kudu/pom.xml
+++ b/plugin/trino-kudu/pom.xml
@@ -155,6 +155,12 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-testing-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-tpch</artifactId>
             <scope>test</scope>
         </dependency>

--- a/testing/trino-testing-services/src/main/java/io/trino/testng/services/ReportInnerTestClasses.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testng/services/ReportInnerTestClasses.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testng.services;
+
+import org.testng.IClassListener;
+import org.testng.ITestClass;
+
+import java.util.Optional;
+
+import static com.google.common.base.Throwables.getStackTraceAsString;
+import static io.trino.testng.services.Listeners.reportListenerFailure;
+
+/**
+ * Detects test classes which are defined as inner classes
+ * TestNG support is poor for these inner test classes: https://github.com/trinodb/trino/pull/11185
+ */
+public class ReportInnerTestClasses
+        implements IClassListener
+{
+    @Override
+    public void onBeforeClass(ITestClass iTestClass)
+    {
+        try {
+            reportInnerTestClasses(iTestClass);
+        }
+        catch (RuntimeException | Error e) {
+            reportListenerFailure(
+                    ReportInnerTestClasses.class,
+                    "Failed to process %s: \n%s",
+                    iTestClass,
+                    getStackTraceAsString(e));
+        }
+    }
+
+    private void reportInnerTestClasses(ITestClass testClass)
+    {
+        Class<?> realClass = testClass.getRealClass();
+
+        if (realClass.getName().startsWith("io.trino.testng.services")) {
+            // ignore internal testcases
+            return;
+        }
+
+        Optional<Class<?>> maybeEnclosingClass = Optional.ofNullable(realClass.getEnclosingClass());
+        maybeEnclosingClass.ifPresent(enclosingClass ->
+                reportListenerFailure(ReportInnerTestClasses.class,
+                        "Test class %s is defined as an inner class, has an enclosing class %s",
+                        realClass.getName(),
+                        enclosingClass.getName()));
+    }
+
+    @Override
+    public void onAfterClass(ITestClass iTestClass)
+    {
+    }
+}

--- a/testing/trino-testing-services/src/main/resources/META-INF/services/org.testng.ITestNGListener
+++ b/testing/trino-testing-services/src/main/resources/META-INF/services/org.testng.ITestNGListener
@@ -7,3 +7,4 @@ io.trino.testng.services.LogTestDurationListener
 io.trino.testng.services.RetryAnnotationTransformer
 io.trino.testng.services.FlakyAnnotationVerifier
 io.trino.testng.services.ProgressLoggingListener
+io.trino.testng.services.ReportInnerTestClasses


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

TestNG support for static inner test classes is poor

Adds a TestNG listener to fail if a test class is defined as a static inner class

## Related issues, pull requests, and links
This PR introduced usage of static inner test classes in kudu:
https://github.com/trinodb/trino/pull/10940

This PR subsequently removed the static inner test classes after some tests were not being run:
https://github.com/trinodb/trino/pull/11185


## Documentation

(X) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(X) No release notes entries required.
( ) Release notes entries required with the following suggested text:
