### PR TITLE
Set hbase.client.retries.number as 15 in testing Phoenix server

### DIFF
--- a/plugin/trino-phoenix/src/test/java/io/trino/plugin/phoenix/TestingPhoenixServer.java
+++ b/plugin/trino-phoenix/src/test/java/io/trino/plugin/phoenix/TestingPhoenixServer.java
@@ -89,7 +89,7 @@ public final class TestingPhoenixServer
         this.conf.set("hbase.security.logger", "ERROR");
         this.conf.setInt(MASTER_INFO_PORT, -1);
         this.conf.setInt(REGIONSERVER_INFO_PORT, -1);
-        this.conf.setInt(HBASE_CLIENT_RETRIES_NUMBER, 1);
+        this.conf.setInt(HBASE_CLIENT_RETRIES_NUMBER, 15);
         this.conf.setBoolean("phoenix.schema.isNamespaceMappingEnabled", true);
         this.conf.set("hbase.regionserver.wal.codec", "org.apache.hadoop.hbase.regionserver.wal.IndexedWALEditCodec");
         this.hbaseTestingUtility = new HBaseTestingUtility(conf);

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestingPhoenixServer.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestingPhoenixServer.java
@@ -89,7 +89,7 @@ public final class TestingPhoenixServer
         this.conf.set("hbase.security.logger", "ERROR");
         this.conf.setInt(MASTER_INFO_PORT, -1);
         this.conf.setInt(REGIONSERVER_INFO_PORT, -1);
-        this.conf.setInt(HBASE_CLIENT_RETRIES_NUMBER, 1);
+        this.conf.setInt(HBASE_CLIENT_RETRIES_NUMBER, 15);
         this.conf.setBoolean("phoenix.schema.isNamespaceMappingEnabled", true);
         this.conf.set("hbase.regionserver.wal.codec", "org.apache.hadoop.hbase.regionserver.wal.IndexedWALEditCodec");
         this.hbaseTestingUtility = new HBaseTestingUtility(conf);


### PR DESCRIPTION
## Description

Set `hbase.client.retries.number` as 15 in testing Phoenix server to fix flaky tests.

## Related issues, pull requests, and links

* Fixes #11303
* Fixes #7216
* Fixes #9199

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
