### PR TITLE
Fix broken url in rn372

### DIFF
--- a/docs/src/main/sphinx/release/release-372.md
+++ b/docs/src/main/sphinx/release/release-372.md
@@ -9,7 +9,7 @@
   property. ({issue}`11098`)
 * Improve performance of specific queries which compare table columns of type
   `timestamp` with `date` literals. ({issue}`11170`)
-* Add redirection awareness for `ADD COLUMN`, `DROP TABLE`, `COMMENT` tasks. ({issue} `11072`)
+* Add redirection awareness for `ADD COLUMN`, `DROP TABLE`, `COMMENT` tasks. ({issue}`11072`)
 * Remove support for reserved memory pool. Configuration property
   `experimental.reserved-pool-disabled` can no longer be used. ({issue}`6677`)
 * Ensure memory is released completely after query completion. ({issue}`11030`)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Edit to make url display properly on the release note page.

> Is this change a fix, improvement, new feature, refactoring, or other? Fix/improve

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? Docs

> How would you describe this change to a non-technical end user or system administrator? Fixed broken url to release note issue.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:
