### PR TITLE
Add catalog.skip-load-error config param for silent catalog file loading

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/StaticCatalogStore.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/StaticCatalogStore.java
@@ -94,7 +94,7 @@ public class StaticCatalogStore
         }
         catch (Exception e) {
             if (skipLoadError) {
-                log.warn("-- Skipping catalog %s, loading error: %s --", file, e.getMessage());
+                log.warn(e, "-- Skipping catalog %s, failed to load --", file);
             }
             else {
                 throw e;

--- a/core/trino-main/src/main/java/io/trino/metadata/StaticCatalogStoreConfig.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/StaticCatalogStoreConfig.java
@@ -29,6 +29,7 @@ public class StaticCatalogStoreConfig
 
     private File catalogConfigurationDir = new File("etc/catalog/");
     private List<String> disabledCatalogs;
+    private boolean skipLoadError;
 
     @NotNull
     public File getCatalogConfigurationDir()
@@ -59,6 +60,18 @@ public class StaticCatalogStoreConfig
     public StaticCatalogStoreConfig setDisabledCatalogs(List<String> catalogs)
     {
         this.disabledCatalogs = (catalogs == null) ? null : ImmutableList.copyOf(catalogs);
+        return this;
+    }
+
+    public boolean getSkipLoadError()
+    {
+        return skipLoadError;
+    }
+
+    @Config("catalog.skip-load-error")
+    public StaticCatalogStoreConfig setSkipLoadError(boolean skipLoadError)
+    {
+        this.skipLoadError = skipLoadError;
         return this;
     }
 }

--- a/core/trino-main/src/test/java/io/trino/metadata/TestStaticCatalogStoreConfig.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestStaticCatalogStoreConfig.java
@@ -31,7 +31,8 @@ public class TestStaticCatalogStoreConfig
     {
         assertRecordedDefaults(recordDefaults(StaticCatalogStoreConfig.class)
                 .setCatalogConfigurationDir(new File("etc/catalog"))
-                .setDisabledCatalogs((String) null));
+                .setDisabledCatalogs((String) null)
+                .setSkipLoadError(false));
     }
 
     @Test
@@ -40,11 +41,13 @@ public class TestStaticCatalogStoreConfig
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("catalog.config-dir", "/foo")
                 .put("catalog.disabled-catalogs", "abc,xyz")
+                .put("catalog.skip-load-error", "true")
                 .buildOrThrow();
 
         StaticCatalogStoreConfig expected = new StaticCatalogStoreConfig()
                 .setCatalogConfigurationDir(new File("/foo"))
-                .setDisabledCatalogs(ImmutableList.of("abc", "xyz"));
+                .setDisabledCatalogs(ImmutableList.of("abc", "xyz"))
+                .setSkipLoadError(true);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description
Add catalog.skip-load-error config param for silent catalog file loading with default file-based StaticCatalogStore.

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
(x) Documentation issue #11330 is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# General
* Add boolean catalog.skip-load-error configuration parameter for silent catalog file loading.
```
