### PR TITLE
Optimize array_distinct(array_agg(…))

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/arrayagg/ArrayAggregationFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/arrayagg/ArrayAggregationFunction.java
@@ -32,6 +32,8 @@ import io.trino.spi.type.Type;
 @Description("return an array of values")
 public final class ArrayAggregationFunction
 {
+    public static final String NAME = "array_agg";
+
     private ArrayAggregationFunction() {}
 
     @InputFunction

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -36,6 +36,7 @@ import io.trino.sql.planner.iterative.rule.AddIntermediateAggregations;
 import io.trino.sql.planner.iterative.rule.ApplyPreferredTableExecutePartitioning;
 import io.trino.sql.planner.iterative.rule.ApplyPreferredTableWriterPartitioning;
 import io.trino.sql.planner.iterative.rule.ApplyTableScanRedirection;
+import io.trino.sql.planner.iterative.rule.ArrayAggregationAfterDistinct;
 import io.trino.sql.planner.iterative.rule.ArraySortAfterArrayDistinct;
 import io.trino.sql.planner.iterative.rule.CanonicalizeExpressions;
 import io.trino.sql.planner.iterative.rule.CreatePartialTopN;
@@ -455,7 +456,8 @@ public class PlanOptimizers
                                         new PruneOrderByInAggregation(metadata),
                                         new RewriteSpatialPartitioningAggregation(plannerContext),
                                         new SimplifyCountOverConstant(plannerContext),
-                                        new PreAggregateCaseAggregations(plannerContext, typeAnalyzer)))
+                                        new PreAggregateCaseAggregations(plannerContext, typeAnalyzer),
+                                        new ArrayAggregationAfterDistinct(metadata)))
                                 .build()),
                 new IterativeOptimizer(
                         plannerContext,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ArrayAggregationAfterDistinct.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ArrayAggregationAfterDistinct.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.metadata.Metadata;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.operator.aggregation.arrayagg.ArrayAggregationFunction;
+import io.trino.operator.scalar.ArrayDistinctFunction;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.SymbolsExtractor;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.plan.AggregationNode;
+import io.trino.sql.planner.plan.AggregationNode.Aggregation;
+import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.ProjectNode;
+import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.FunctionCall;
+import io.trino.sql.tree.SymbolReference;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.sql.planner.plan.Patterns.aggregation;
+import static io.trino.sql.planner.plan.Patterns.project;
+import static io.trino.sql.planner.plan.Patterns.source;
+import static java.util.Objects.requireNonNull;
+
+public class ArrayAggregationAfterDistinct
+        implements Rule<ProjectNode>
+{
+    private static final Capture<AggregationNode> CHILD = newCapture();
+    private final Metadata metadata;
+
+    public ArrayAggregationAfterDistinct(Metadata metadata)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
+    @Override
+    public Pattern<ProjectNode> getPattern()
+    {
+        return project()
+                .matching(entry -> hasArrayDistinct(metadata, entry))
+                .with(source().matching(aggregation()
+                        .matching(ArrayAggregationAfterDistinct::hasArrayAggregation)
+                        .capturedAs(CHILD)));
+    }
+
+    private static boolean hasArrayAggregation(AggregationNode aggregationNode)
+    {
+        return aggregationNode.getAggregations().values().stream()
+                .anyMatch(aggregation -> aggregation.getResolvedFunction().getSignature().getName().equals(ArrayAggregationFunction.NAME));
+    }
+
+    private static boolean hasArrayDistinct(Metadata metadata, ProjectNode projectNode)
+    {
+        return projectNode.getAssignments().getExpressions().stream()
+                .anyMatch(assignment -> assignment instanceof FunctionCall &&
+                        metadata.decodeFunction(((FunctionCall) assignment).getName()).getSignature().getName().equals(ArrayDistinctFunction.NAME));
+    }
+
+    @Override
+    public Result apply(ProjectNode projectNode, Captures captures, Context context)
+    {
+        AggregationNode aggregationNode = captures.get(CHILD);
+
+        Assignments.Builder assignmentsBuilder = Assignments.builder();
+        ImmutableMap.Builder<Symbol, Aggregation> aggregationsBuilder = ImmutableMap.builder();
+
+        List<Symbol> matchedAggregations = new ArrayList<>();
+        List<Symbol> matchedAssignments = new ArrayList<>();
+
+        // Find all array_agg() aggregations
+        Set<Symbol> arrayAggSymbols = aggregationNode.getAggregations().entrySet().stream()
+                .filter(entry -> entry.getValue().getResolvedFunction().getSignature().getName().equals(ArrayAggregationFunction.NAME))
+                .map(Map.Entry::getKey)
+                .collect(toImmutableSet());
+
+        // Extract project assignments which are array_distinct(array_agg())
+        Map<Symbol, Expression> arrayDistinctCalls = projectNode.getAssignments().entrySet().stream()
+                .filter(entry -> entry.getValue() instanceof FunctionCall)
+                .filter(entry -> {
+                    FunctionCall functionCall = (FunctionCall) entry.getValue();
+                    return functionCall.getArguments().size() == 1 &&
+                            getOnlyElement(functionCall.getArguments()) instanceof SymbolReference &&
+                            arrayAggSymbols.contains(Symbol.from(getOnlyElement(functionCall.getArguments())));
+                })
+                // We only decode function calls that have an array aggregation as only parameter (because decoding is expensive)
+                .filter(entry -> {
+                    FunctionCall functionCall = (FunctionCall) entry.getValue();
+                    ResolvedFunction resolvedFunction = metadata.decodeFunction(functionCall.getName());
+                    return resolvedFunction.getSignature().getName().equals(ArrayDistinctFunction.NAME);
+                })
+                .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        // Identify array_agg() symbols used outside of array_distinct() calls. Those aggregations won't be rewritten
+        Set<Symbol> referencedOutsideArrayDistinctAggregateSymbols = projectNode.getAssignments().entrySet().stream()
+                .filter(entry -> !arrayDistinctCalls.containsKey(entry.getKey()))
+                .flatMap(entry -> SymbolsExtractor.extractUnique(entry.getValue()).stream())
+                .filter(arrayAggSymbols::contains)
+                .collect(toImmutableSet());
+
+        // All array_agg aggregations that are only referenced by array_distinct() shall be rewritten
+        Map<Symbol, Aggregation> arrayAggregationsToMakeDistinct = arrayDistinctCalls.values().stream()
+                .map(expression -> Symbol.from(getOnlyElement(((FunctionCall) expression).getArguments())))
+                .filter(symbol -> !referencedOutsideArrayDistinctAggregateSymbols.contains(symbol))
+                .distinct()
+                .collect(toImmutableMap(symbol -> symbol, symbol -> aggregationNode.getAggregations().get(symbol)));
+
+        // Make the aggregations distinct
+        arrayAggregationsToMakeDistinct.forEach((symbol, aggregation) -> {
+            if (!aggregation.isDistinct()) {
+                matchedAggregations.add(symbol);
+                Aggregation newAggregation = new Aggregation(
+                        aggregation.getResolvedFunction(),
+                        aggregation.getArguments(),
+                        true,
+                        aggregation.getFilter(),
+                        aggregation.getOrderingScheme(),
+                        aggregation.getMask());
+                aggregationsBuilder.put(symbol, newAggregation);
+            }
+        });
+
+        // Swap the relevant array_distinct() symbols with the now distinct array_agg() symbols
+        arrayDistinctCalls.forEach((assignmentSymbol, arrayDistinctCall) -> {
+            FunctionCall functionCall = (FunctionCall) arrayDistinctCall;
+            Expression functionArgument = getOnlyElement(functionCall.getArguments());
+            Symbol arrayAggSymbol = Symbol.from(functionArgument);
+            if (arrayAggregationsToMakeDistinct.containsKey(arrayAggSymbol)) {
+                matchedAssignments.add(assignmentSymbol);
+                assignmentsBuilder.put(assignmentSymbol, arrayAggSymbol.toSymbolReference());
+            }
+        });
+
+        if (!matchedAssignments.isEmpty()) {
+            // re-add not matched assignments
+            projectNode.getAssignments()
+                    .filter(entry -> !matchedAssignments.contains(entry))
+                    .forEach(assignmentsBuilder::put);
+
+            // re-add not matched aggregations
+            aggregationNode.getAggregations().entrySet().stream()
+                    .filter(entry -> !matchedAggregations.contains(entry.getKey()))
+                    .forEach(entry -> aggregationsBuilder.put(entry.getKey(), entry.getValue()));
+
+            AggregationNode newAggregationNode = new AggregationNode(
+                    aggregationNode.getId(),
+                    aggregationNode.getSource(),
+                    aggregationsBuilder.buildOrThrow(),
+                    aggregationNode.getGroupingSets(),
+                    aggregationNode.getPreGroupedSymbols(),
+                    aggregationNode.getStep(),
+                    aggregationNode.getHashSymbol(),
+                    aggregationNode.getGroupIdSymbol());
+            return Result.ofPlanNode(new ProjectNode(projectNode.getId(), newAggregationNode, assignmentsBuilder.build()));
+        }
+
+        return Result.empty();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestArrayAggregationAfterDistinct.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestArrayAggregationAfterDistinct.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.operator.aggregation.arrayagg.ArrayAggregationFunction;
+import io.trino.operator.scalar.ArrayDistinctFunction;
+import io.trino.spi.type.ArrayType;
+import io.trino.sql.planner.assertions.ExpectedValueProvider;
+import io.trino.sql.planner.assertions.PlanMatchPattern;
+import io.trino.sql.planner.iterative.GroupReference;
+import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
+import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.tree.ArithmeticBinaryExpression;
+import io.trino.sql.tree.FunctionCall;
+import io.trino.sql.tree.QualifiedName;
+import io.trino.sql.tree.SymbolReference;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.trino.SessionTestUtils.TEST_SESSION;
+import static io.trino.metadata.MetadataManager.createTestMetadataManager;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.anySymbol;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.globalAggregation;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
+import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expression;
+import static io.trino.sql.planner.plan.AggregationNode.Step.PARTIAL;
+import static io.trino.sql.tree.ArithmeticBinaryExpression.Operator.ADD;
+
+public class TestArrayAggregationAfterDistinct
+        extends BaseRuleTest
+{
+    private static final QualifiedName ARRAY_AGG = createTestMetadataManager().resolveFunction(TEST_SESSION, QualifiedName.of(ArrayAggregationFunction.NAME), fromTypes(BIGINT)).toQualifiedName();
+    private static final QualifiedName ARRAY_MIN = createTestMetadataManager().resolveFunction(TEST_SESSION, QualifiedName.of("array_min"), fromTypes(new ArrayType(BIGINT))).toQualifiedName();
+    private static final QualifiedName ARRAY_MAX = createTestMetadataManager().resolveFunction(TEST_SESSION, QualifiedName.of("array_max"), fromTypes(new ArrayType(BIGINT))).toQualifiedName();
+    private static final QualifiedName ARRAY_DISTINCT = createTestMetadataManager().resolveFunction(TEST_SESSION, QualifiedName.of(ArrayDistinctFunction.NAME), fromTypes(new ArrayType(BIGINT))).toQualifiedName();
+
+    @Test
+    public void singleArrayDistinctArrayAggRuleFires()
+    {
+        ExpectedValueProvider<FunctionCall> aggregationPattern = PlanMatchPattern.functionCall("array_agg", true, ImmutableList.of(anySymbol()));
+        // SELECT ARRAY_DISTINCT(ARRAY_AGG(a)) FROM (VALUES (1), (1)) t(a)
+        tester().assertThat(new ArrayAggregationAfterDistinct(tester().getMetadata()))
+                .on(p -> {
+                    SymbolReference arrayAgg = new SymbolReference("array_agg");
+                    FunctionCall arrayDistinctAfterArrayAgg = new FunctionCall(
+                            ARRAY_DISTINCT,
+                            ImmutableList.of(arrayAgg));
+
+                    return p.project(Assignments.builder()
+                                    .put(p.symbol("output1"), arrayDistinctAfterArrayAgg)
+                                    .build(),
+                            p.aggregation(ap -> ap.globalGrouping()
+                                    .step(PARTIAL)
+                                    .addAggregation(p.symbol("array_agg"), expression("array_agg(a)"), ImmutableList.of(BIGINT))
+                                    .source(p.values(p.symbol("a")))));
+                })
+                .matches(
+                        project(ImmutableMap.of("output1", PlanMatchPattern.expression("array_agg")),
+                                aggregation(
+                                        globalAggregation(),
+                                        ImmutableMap.of(Optional.of("array_agg"), aggregationPattern),
+                                        Optional.empty(),
+                                        PARTIAL,
+                                        node(GroupReference.class))));
+    }
+
+    @Test
+    public void singleArrayDistinctArrayAggAlreadyDistinctRuleFires()
+    {
+        ExpectedValueProvider<FunctionCall> aggregationPattern = PlanMatchPattern.functionCall("array_agg", true, ImmutableList.of(anySymbol()));
+        // SELECT ARRAY_DISTINCT(ARRAY_AGG(DISTINCT a)) FROM (VALUES (1), (1)) t(a)
+        tester().assertThat(new ArrayAggregationAfterDistinct(tester().getMetadata()))
+                .on(p -> {
+                    SymbolReference arrayAgg = new SymbolReference("array_agg");
+                    FunctionCall arrayDistinctAfterArrayAgg = new FunctionCall(
+                            ARRAY_DISTINCT,
+                            ImmutableList.of(arrayAgg));
+
+                    return p.project(Assignments.builder()
+                                    .put(p.symbol("output1"), arrayDistinctAfterArrayAgg)
+                                    .build(),
+                            p.aggregation(ap -> ap.globalGrouping()
+                                    .step(PARTIAL)
+                                    .addAggregation(p.symbol("array_agg"), expression("array_agg(distinct a)"), ImmutableList.of(BIGINT))
+                                    .source(p.values(p.symbol("a")))));
+                })
+                .matches(
+                        project(ImmutableMap.of("output1", PlanMatchPattern.expression("array_agg")),
+                                aggregation(
+                                        globalAggregation(),
+                                        ImmutableMap.of(Optional.of("array_agg"), aggregationPattern),
+                                        Optional.empty(),
+                                        PARTIAL,
+                                        node(GroupReference.class))));
+    }
+//    Fails on java.lang.IllegalStateException: Ambiguous expression "array_agg" matches multiple assignments ["array_agg", "array_agg"]
+//    @Test
+//    public void multipleArrayDistinctSingleArrayAgg()
+//    {
+//        ExpectedValueProvider<FunctionCall> aggregationPattern = PlanMatchPattern.functionCall("array_agg", true, ImmutableList.of(anySymbol()));
+//        // SELECT ARRAY_DISTINCT(ARRAY_AGG(a)), ARRAY_DISTINCT(ARRAY_AGG(a)) FROM (VALUES (1), (1)) t(a)
+//        tester().assertThat(new ArrayAggregationAfterDistinct(tester().getMetadata()))
+//                .on(p -> {
+//                    SymbolReference array_agg = new SymbolReference("array_agg");
+//                    FunctionCall arrayDistinctAfterArrayAgg = new FunctionCall(
+//                            ARRAY_DISTINCT,
+//                            ImmutableList.of(array_agg));
+//
+//                    return p.project(Assignments.builder()
+//                                    .put(p.symbol("output1"), arrayDistinctAfterArrayAgg)
+//                                    .put(p.symbol("output2"), arrayDistinctAfterArrayAgg)
+//                                    .build(),
+//                            p.aggregation(ap -> ap.globalGrouping()
+//                                    .step(PARTIAL)
+//                                    .addAggregation(p.symbol("array_agg"), expression("array_agg(a)"), ImmutableList.of(BIGINT))
+//                                    .source(p.values(p.symbol("a")))));
+//                })
+//                .matches(
+//                        project(ImmutableMap.of(
+//                                "output1", PlanMatchPattern.expression("array_agg"),
+//                                "output2", PlanMatchPattern.expression("array_agg")),
+//                                aggregation(
+//                                        globalAggregation(),
+//                                        ImmutableMap.of(Optional.of("array_agg"), aggregationPattern),
+//                                        Optional.empty(),
+//                                        PARTIAL,
+//                                        node(GroupReference.class))));
+//    }
+
+    @Test
+    public void singleArrayDistinctArrayAggMultipleAssignmentsRuleDoesNotFire()
+    {
+        // SELECT ARRAY_DISTINCT(ARRAY_AGG(a)), ARRAY_AGG(a) FROM (VALUES (1), (1)) t(a)
+        tester().assertThat(new ArrayAggregationAfterDistinct(tester().getMetadata()))
+                .on(p -> {
+                    FunctionCall arrayAgg = new FunctionCall(
+                            ARRAY_AGG,
+                            ImmutableList.of(PlanBuilder.expression("a")));
+                    FunctionCall arrayDistinctAfterArrayAgg = new FunctionCall(
+                            ARRAY_DISTINCT,
+                            ImmutableList.of(arrayAgg));
+                    return p.project(Assignments.builder()
+                                    .put(p.symbol("output1"), arrayDistinctAfterArrayAgg)
+                                    .put(p.symbol("output2"), arrayAgg)
+                                    .build(),
+                            p.aggregation(ap -> ap.globalGrouping()
+                                    .step(PARTIAL)
+                                    .addAggregation(
+                                            p.symbol("array_agg"),
+                                            expression("array_agg(a)"),
+                                            ImmutableList.of(BIGINT))
+                                    .source(p.values(p.symbol("a")))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void deeplyNestedReferenceToArrayAggWithOtherSymbolsRuleDoesNotFire()
+    {
+        // SELECT ARRAY_DISTINCT(ARRAY_AGG(a)), ARRAY_MIN(ARRAY_AGG(a)) + ARRAY_MAX(ARRAY_AGG(b)) FROM (VALUES (1, 2), (1, 2)) t(a, b)
+        tester().assertThat(new ArrayAggregationAfterDistinct(tester().getMetadata()))
+                .on(p -> {
+                    FunctionCall arrayDistinctAfterArrayAgg = new FunctionCall(
+                            ARRAY_DISTINCT,
+                            ImmutableList.of(new SymbolReference("array_agg")));
+                    FunctionCall arrayMinAfterArrayAgg = new FunctionCall(
+                            ARRAY_MIN,
+                            ImmutableList.of(new SymbolReference("array_agg")));
+                    FunctionCall arrayMaxAfterArrayAgg = new FunctionCall(
+                            ARRAY_MAX,
+                            ImmutableList.of(new SymbolReference("array_agg")));
+                    ArithmeticBinaryExpression nestedArrayAggReferences = new ArithmeticBinaryExpression(
+                            ADD,
+                            arrayMinAfterArrayAgg,
+                            arrayMaxAfterArrayAgg);
+
+                    return p.project(Assignments.builder()
+                                    .put(p.symbol("output1"), arrayDistinctAfterArrayAgg)
+                                    .put(p.symbol("output2"), nestedArrayAggReferences)
+                                    .build(),
+                            p.aggregation(ap -> ap.globalGrouping()
+                                    .step(PARTIAL)
+                                    .addAggregation(
+                                            p.symbol("array_agg"),
+                                            expression("array_agg(a)"),
+                                            ImmutableList.of(BIGINT))
+                                    .source(p.values(p.symbol("a")))));
+                }).doesNotFire();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestArrayAggregationAfterDistinct.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestArrayAggregationAfterDistinct.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+public class TestArrayAggregationAfterDistinct
+{
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void singleArrayDistinctArrayAgg()
+    {
+        assertThat(assertions.query(
+                "SELECT ARRAY_DISTINCT(ARRAY_AGG(a)) FROM (VALUES (1), (1)) t(a)"))
+                .matches("VALUES (ARRAY  [1])");
+    }
+
+    @Test
+    public void singleArrayDistinctArrayAggAlreadyDistinct()
+    {
+        assertThat(assertions.query(
+                "SELECT ARRAY_DISTINCT(ARRAY_AGG(DISTINCT a)) FROM (VALUES (1), (1)) t(a)"))
+                .matches("VALUES (ARRAY  [1])");
+    }
+
+    @Test
+    public void multipleArrayDistinctMultipleArrayAgg()
+    {
+        assertThat(assertions.query(
+                "SELECT ARRAY_DISTINCT(ARRAY_AGG(a)), ARRAY_DISTINCT(ARRAY_AGG(DISTINCT b)) FROM (VALUES (1, 2), (1, 2)) t(a, b)"))
+                .matches("VALUES (ARRAY [1], ARRAY [2])");
+    }
+
+    @Test
+    public void multipleArrayDistinctSingleArrayAgg()
+    {
+        assertThat(assertions.query(
+                "SELECT ARRAY_DISTINCT(ARRAY_AGG(a)), ARRAY_DISTINCT(ARRAY_AGG(a)) FROM (VALUES (1, 2), (1, 2)) t(a, b)"))
+                .matches("VALUES (ARRAY [1], ARRAY [1])");
+    }
+
+    @Test
+    public void multipleArrayDistinctArrayAggDifferentOrder()
+    {
+        assertThat(assertions.query(
+                "SELECT ARRAY_DISTINCT(ARRAY_AGG(b)), ARRAY_DISTINCT(ARRAY_AGG(a)) FROM (VALUES (1, 2), (1, 2)) t(a, b)"))
+                .matches("VALUES (ARRAY [2], ARRAY [1])");
+    }
+
+    @Test
+    public void singleArrayDistinctArrayAggMultipleAssignments()
+    {
+        assertThat(assertions.query(
+                "SELECT ARRAY_DISTINCT(ARRAY_AGG(a)), ARRAY_AGG(a) FROM (VALUES (1), (1)) t(a)"))
+                .matches("VALUES (ARRAY [1], ARRAY [1, 1])");
+    }
+
+    @Test
+    public void deeplyNestedReferenceToArrayAggWithOtherSymbols()
+    {
+        assertThat(assertions.query(
+                "SELECT ARRAY_DISTINCT(ARRAY_AGG(a)), ARRAY_MIN(ARRAY_AGG(a)) + ARRAY_MAX(ARRAY_AGG(b)) FROM (VALUES (1, 2), (1, 2)) t(a, b)"))
+                .matches("VALUES (ARRAY [1], 3)");
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

When array_agg is preceded by array_distinct, it is faster to first perform the distinct operation before aggregating the values into an array.

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core engine

> How would you describe this change to a non-technical end user or system administrator?

Performance improvement

## Related issues, pull requests, and links

* Fixes #8776

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
