### PR TITLE
Make user property optional in JDBC

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
@@ -215,7 +215,7 @@ public class ClientOptions
     {
         return new ClientSession(
                 parseServer(server),
-                user.orElse(null),
+                user,
                 sessionUser,
                 source,
                 Optional.ofNullable(traceToken),

--- a/client/trino-cli/src/test/java/io/trino/cli/TestQueryRunner.java
+++ b/client/trino-cli/src/test/java/io/trino/cli/TestQueryRunner.java
@@ -104,7 +104,7 @@ public class TestQueryRunner
     {
         return new ClientSession(
                 server.url("/").uri(),
-                "user",
+                Optional.of("user"),
                 Optional.empty(),
                 "source",
                 Optional.empty(),

--- a/client/trino-client/src/main/java/io/trino/client/ClientSession.java
+++ b/client/trino-client/src/main/java/io/trino/client/ClientSession.java
@@ -34,7 +34,7 @@ import static java.util.Objects.requireNonNull;
 public class ClientSession
 {
     private final URI server;
-    private final String principal;
+    private final Optional<String> principal;
     private final Optional<String> user;
     private final String source;
     private final Optional<String> traceToken;
@@ -68,7 +68,7 @@ public class ClientSession
 
     public ClientSession(
             URI server,
-            String principal,
+            Optional<String> principal,
             Optional<String> user,
             String source,
             Optional<String> traceToken,
@@ -143,7 +143,7 @@ public class ClientSession
         return server;
     }
 
-    public String getPrincipal()
+    public Optional<String> getPrincipal()
     {
         return principal;
     }
@@ -270,7 +270,7 @@ public class ClientSession
     public static final class Builder
     {
         private URI server;
-        private String principal;
+        private Optional<String> principal;
         private Optional<String> user;
         private String source;
         private Optional<String> traceToken;

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
@@ -161,7 +161,7 @@ final class ConnectionProperties
     {
         public User()
         {
-            super("user", REQUIRED, ALLOWED, NON_EMPTY_STRING_CONVERTER);
+            super("user", NOT_REQUIRED, ALLOWED, NON_EMPTY_STRING_CONVERTER);
         }
     }
 

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
@@ -93,7 +93,7 @@ public class TrinoConnection
 
     private final URI jdbcUri;
     private final URI httpUri;
-    private final String user;
+    private final Optional<String> user;
     private final Optional<String> sessionUser;
     private final boolean compressionDisabled;
     private final boolean assumeLiteralNamesInMetadataCallsForNonConformingClients;
@@ -678,11 +678,6 @@ public class TrinoConnection
     URI getURI()
     {
         return jdbcUri;
-    }
-
-    String getUser()
-    {
-        return user;
     }
 
     @VisibleForTesting

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDatabaseMetaData.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDatabaseMetaData.java
@@ -83,7 +83,10 @@ public class TrinoDatabaseMetaData
     public String getUserName()
             throws SQLException
     {
-        return connection.getUser();
+        try (ResultSet rs = select("SELECT current_user")) {
+            rs.next();
+            return rs.getString(1);
+        }
     }
 
     @Override

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
@@ -167,10 +167,16 @@ public final class TrinoDriverUri
         return buildHttpUri();
     }
 
-    public String getUser()
+    public String getRequiredUser()
             throws SQLException
     {
         return USER.getRequiredValue(properties);
+    }
+
+    public Optional<String> getUser()
+            throws SQLException
+    {
+        return USER.getValue(properties);
     }
 
     public Optional<String> getSessionUser()
@@ -258,7 +264,7 @@ public final class TrinoDriverUri
                 if (!useSecureConnection) {
                     throw new SQLException("Authentication using username/password requires SSL to be enabled");
                 }
-                builder.addInterceptor(basicAuth(getUser(), password));
+                builder.addInterceptor(basicAuth(getRequiredUser(), password));
             }
 
             if (useSecureConnection) {

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcExternalAuthentication.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcExternalAuthentication.java
@@ -242,7 +242,6 @@ public class TestJdbcExternalAuthentication
     {
         String url = format("jdbc:trino://localhost:%s", server.getHttpsAddress().getPort());
         Properties properties = new Properties();
-        properties.setProperty("user", "test");
         properties.setProperty("SSL", "true");
         properties.setProperty("SSLTrustStorePath", new File(getResource("localhost.truststore").toURI()).getPath());
         properties.setProperty("SSLTrustStorePassword", "changeit");

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
@@ -263,6 +263,16 @@ public class TestTrinoDatabaseMetaData
     }
 
     @Test
+    public void testGetUserName()
+            throws Exception
+    {
+        try (Connection connection = createConnection()) {
+            DatabaseMetaData metaData = connection.getMetaData();
+            assertEquals(metaData.getUserName(), "admin");
+        }
+    }
+
+    @Test
     public void testGetCatalogs()
             throws Exception
     {

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriver.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriver.java
@@ -391,7 +391,7 @@ public class TestTrinoDriver
 
         assertThat(infos)
                 .extracting(TestTrinoDriver::driverPropertyInfoToString)
-                .contains("{name=user, required=true}")
+                .contains("{name=user, required=false}")
                 .contains("{name=password, required=false}")
                 .contains("{name=accessToken, required=false}")
                 .contains("{name=SSL, required=false, choices=[true, false]}");
@@ -413,7 +413,7 @@ public class TestTrinoDriver
 
         assertThat(infos)
                 .extracting(TestTrinoDriver::driverPropertyInfoToString)
-                .contains("{name=user, value=test, required=true}")
+                .contains("{name=user, value=test, required=false}")
                 .contains("{name=SSL, value=true, required=false, choices=[true, false]}")
                 .contains("{name=SSLVerification, required=false, choices=[FULL, CA, NONE]}")
                 .contains("{name=SSLTrustStorePath, required=false}");
@@ -774,22 +774,10 @@ public class TestTrinoDriver
     }
 
     @Test
-    public void testUserIsRequired()
-    {
-        assertThatThrownBy(() -> DriverManager.getConnection(jdbcUrl()))
-                .isInstanceOf(SQLException.class)
-                .hasMessage("Connection property 'user' is required");
-    }
-
-    @Test
     public void testNullConnectProperties()
             throws Exception
     {
-        Driver driver = DriverManager.getDriver("jdbc:trino:");
-
-        assertThatThrownBy(() -> driver.connect(jdbcUrl(), null))
-                .isInstanceOf(SQLException.class)
-                .hasMessage("Connection property 'user' is required");
+        DriverManager.getDriver("jdbc:trino:").connect(jdbcUrl(), null);
     }
 
     @Test

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriverAuth.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriverAuth.java
@@ -328,7 +328,6 @@ public class TestTrinoDriverAuth
     {
         String url = format("jdbc:trino://localhost:%s", server.getHttpsAddress().getPort());
         Properties properties = new Properties();
-        properties.setProperty("user", "test");
         properties.setProperty("SSL", "true");
         properties.setProperty("SSLTrustStorePath", new File(getResource("localhost.truststore").toURI()).getPath());
         properties.setProperty("SSLTrustStorePassword", "changeit");
@@ -341,7 +340,6 @@ public class TestTrinoDriverAuth
     {
         String url = format("jdbc:trino://localhost:%s", server.getHttpsAddress().getPort());
         Properties properties = new Properties();
-        properties.setProperty("user", "test");
         additionalProperties.forEach(properties::setProperty);
         return DriverManager.getConnection(url, properties);
     }

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriverUri.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriverUri.java
@@ -175,13 +175,6 @@ public class TestTrinoDriverUri
         assertInvalid("jdbc:presto://localhost:8080", "Invalid JDBC URL: jdbc:presto://localhost:8080");
     }
 
-    @Test(expectedExceptions = SQLException.class, expectedExceptionsMessageRegExp = "Connection property 'user' is required")
-    public void testRequireUser()
-            throws Exception
-    {
-        TrinoDriverUri.create("jdbc:trino://localhost:8080", new Properties());
-    }
-
     @Test(expectedExceptions = SQLException.class, expectedExceptionsMessageRegExp = "Connection property 'user' value is empty")
     public void testEmptyUser()
             throws Exception

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-tls-kerberos-delegation/tempto-configuration.yaml
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-tls-kerberos-delegation/tempto-configuration.yaml
@@ -1,7 +1,6 @@
 databases:
   presto:
     jdbc_url: "jdbc:trino://${databases.presto.host}:${databases.presto.port}/hive/${databases.hive.schema}?\
-      user=${databases.presto.cli_kerberos_principal}&\
       SSL=true&\
       SSLTrustStorePath=${databases.presto.https_keystore_path}&\
       SSLTrustStorePassword=${databases.presto.https_keystore_password}&\

--- a/testing/trino-product-tests-launcher/src/test/java/io/trino/tests/product/launcher/local/TestManuallyJdbcOauth2.java
+++ b/testing/trino-product-tests-launcher/src/test/java/io/trino/tests/product/launcher/local/TestManuallyJdbcOauth2.java
@@ -58,7 +58,6 @@ public class TestManuallyJdbcOauth2
             throws SQLException
     {
         Properties properties = new Properties();
-        properties.setProperty("user", "test");
         String jdbcUrl = format("jdbc:trino://presto-master:7778?"
                 + "SSL=true&"
                 + "SSLTrustStorePath=%s&"

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/jdbc/TestExternalAuthorizerOAuth2.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/jdbc/TestExternalAuthorizerOAuth2.java
@@ -40,7 +40,6 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Properties;
 
 import static com.google.common.base.Preconditions.checkState;
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
@@ -98,9 +97,7 @@ public class TestExternalAuthorizerOAuth2
             throws Exception
     {
         prepareHandler();
-        Properties properties = new Properties();
-        properties.setProperty("user", "test");
-        try (Connection connection = DriverManager.getConnection(jdbcUrl, properties);
+        try (Connection connection = DriverManager.getConnection(jdbcUrl);
                 PreparedStatement statement = connection.prepareStatement("SELECT * FROM tpch.tiny.nation");
                 ResultSet results = statement.executeQuery()) {
             assertThat(forResultSet(results)).matches(TpchTableResults.PRESTO_NATION_RESULT);
@@ -112,9 +109,7 @@ public class TestExternalAuthorizerOAuth2
             throws Exception
     {
         prepareHandler();
-        Properties properties = new Properties();
-        properties.setProperty("user", "test");
-        try (Connection connection = DriverManager.getConnection(jdbcUrl, properties);
+        try (Connection connection = DriverManager.getConnection(jdbcUrl);
                 PreparedStatement statement = connection.prepareStatement("SELECT * FROM tpch.tiny.nation");
                 ResultSet results = statement.executeQuery()) {
             assertThat(forResultSet(results)).matches(TpchTableResults.PRESTO_NATION_RESULT);
@@ -133,9 +128,7 @@ public class TestExternalAuthorizerOAuth2
             throws SQLException
     {
         prepareHandler();
-        Properties properties = new Properties();
-        properties.setProperty("user", "test");
-        try (Connection connection = DriverManager.getConnection(jdbcUrl, properties);
+        try (Connection connection = DriverManager.getConnection(jdbcUrl);
                 PreparedStatement statement = connection.prepareStatement("SELECT array_sort(current_groups())");
                 ResultSet rs = statement.executeQuery()) {
             assertThat(forResultSet(rs)).containsOnly(row(ImmutableList.of("admin", "public")));

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestingTrinoClient.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestingTrinoClient.java
@@ -148,7 +148,7 @@ public abstract class AbstractTestingTrinoClient<T>
 
         return new ClientSession(
                 server,
-                session.getIdentity().getUser(),
+                Optional.of(session.getIdentity().getUser()),
                 Optional.empty(),
                 session.getSource().orElse(null),
                 session.getTraceToken(),

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestFinalQueryInfo.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestFinalQueryInfo.java
@@ -65,7 +65,7 @@ public class TestFinalQueryInfo
         try {
             ClientSession clientSession = new ClientSession(
                     queryRunner.getCoordinator().getBaseUrl(),
-                    "user",
+                    Optional.of("user"),
                     Optional.empty(),
                     "source",
                     Optional.empty(),

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestUserImpersonationAccessControl.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestUserImpersonationAccessControl.java
@@ -86,7 +86,7 @@ public class TestUserImpersonationAccessControl
         try {
             ClientSession clientSession = new ClientSession(
                     getDistributedQueryRunner().getCoordinator().getBaseUrl(),
-                    "user",
+                    Optional.of("user"),
                     Optional.of(assumedUser),
                     "source",
                     Optional.empty(),


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
`user` property is only required in two scenarios:
* no authentication - in this case the server will return a well-formed
  error,
* basic authentication - the driver will validate the configuration and
  return an error if only password was provided.

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# JDBC Driver
* Remove `user` property requirement
```

Fixes: https://github.com/trinodb/trino/issues/9669
