### PR TITLE
Enable aggregation spill only when all aggregations are spillable

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/HashAggregationOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/HashAggregationOperator.java
@@ -422,7 +422,7 @@ public class HashAggregationOperator
 
     private boolean isSpillable()
     {
-        return aggregatorFactories.stream().anyMatch(AggregatorFactory::isSpillable);
+        return aggregatorFactories.stream().allMatch(AggregatorFactory::isSpillable);
     }
 
     @Override

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestAggregations.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestAggregations.java
@@ -16,10 +16,12 @@ package io.trino.testing;
 import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.spi.type.TimeZoneKey;
+import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 
 import java.util.List;
 
+import static io.trino.SystemSessionProperties.USE_MARK_DISTINCT;
 import static io.trino.testing.MaterializedResult.resultBuilder;
 import static io.trino.testing.QueryAssertions.assertEqualsIgnoreOrder;
 import static org.testng.Assert.assertEquals;
@@ -233,7 +235,17 @@ public abstract class AbstractTestAggregations
     @Test
     public void testDistinctGroupBy()
     {
-        assertQuery("SELECT COUNT(DISTINCT clerk) AS count, orderdate FROM orders GROUP BY orderdate ORDER BY count, orderdate");
+        @Language("SQL") String query = "" +
+                "SELECT COUNT(DISTINCT clerk) AS count_distinct, COUNT(clerk) AS count, orderdate " +
+                "FROM orders " +
+                "GROUP BY orderdate " +
+                "ORDER BY count_distinct, orderdate";
+        assertQuery(query);
+        assertQuery(
+                Session.builder(getSession())
+                        .setSystemProperty(USE_MARK_DISTINCT, "false")
+                        .build(),
+                query);
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

bugfix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core query engine

> How would you describe this change to a non-technical end user or system administrator?

queries might return wrong results when spill was enabled and aggregation was used

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# General
* Fix aggregation results when distinct or ordered aggregation is used with spilling. ({issue}`issuenumber`)
```
