### PR TITLE
Add support to redirect table operations from Iceberg to Hive

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -21,6 +21,8 @@ import io.trino.plugin.hive.HiveCompressionCodec;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
+import java.util.Optional;
+
 import static io.trino.plugin.hive.HiveCompressionCodec.ZSTD;
 import static io.trino.plugin.iceberg.CatalogType.HIVE_METASTORE;
 import static io.trino.plugin.iceberg.IcebergFileFormat.ORC;
@@ -37,6 +39,7 @@ public class IcebergConfig
     private Duration dynamicFilteringWaitTimeout = new Duration(0, SECONDS);
     private boolean tableStatisticsEnabled = true;
     private boolean projectionPushdownEnabled = true;
+    private Optional<String> hiveCatalogName = Optional.empty();
 
     public CatalogType getCatalogType()
     {
@@ -164,6 +167,19 @@ public class IcebergConfig
     public IcebergConfig setProjectionPushdownEnabled(boolean projectionPushdownEnabled)
     {
         this.projectionPushdownEnabled = projectionPushdownEnabled;
+        return this;
+    }
+
+    public Optional<String> getHiveCatalogName()
+    {
+        return hiveCatalogName;
+    }
+
+    @Config("iceberg.hive-catalog-name")
+    @ConfigDescription("Catalog to redirect to when a Hive table is referenced")
+    public IcebergConfig setHiveCatalogName(String hiveCatalogName)
+    {
+        this.hiveCatalogName = Optional.ofNullable(hiveCatalogName);
         return this;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -63,6 +63,7 @@ import io.trino.spi.connector.RetryMode;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
 import io.trino.spi.connector.SystemTable;
+import io.trino.spi.connector.TableColumnsMetadata;
 import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.expression.Variable;
@@ -115,6 +116,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -151,7 +153,6 @@ import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.connector.RetryMode.NO_RETRIES;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static java.lang.String.format;
-import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.joining;
@@ -206,7 +207,10 @@ public class IcebergMetadata
     public IcebergTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)
     {
         IcebergTableName name = IcebergTableName.from(tableName.getTableName());
-        verify(name.getTableType() == DATA, "Wrong table type: " + name.getTableNameWithType());
+        if (name.getTableType() != DATA) {
+            // Pretend the table does not exist to produce better error message in case of table redirects to Hive
+            return null;
+        }
 
         Table table;
         try {
@@ -236,6 +240,7 @@ public class IcebergMetadata
                 .map(systemTable -> new ClassLoaderSafeSystemTable(systemTable, getClass().getClassLoader()));
     }
 
+    @SuppressWarnings("TryWithIdenticalCatches")
     private Optional<SystemTable> getRawSystemTable(ConnectorSession session, SchemaTableName tableName)
     {
         IcebergTableName name = IcebergTableName.from(tableName.getTableName());
@@ -249,6 +254,10 @@ public class IcebergMetadata
             table = catalog.loadTable(session, new SchemaTableName(tableName.getSchemaName(), name.getTableName()));
         }
         catch (TableNotFoundException e) {
+            return Optional.empty();
+        }
+        catch (UnknownTableTypeException e) {
+            // avoid dealing with non Iceberg tables
             return Optional.empty();
         }
 
@@ -395,27 +404,43 @@ public class IcebergMetadata
     @Override
     public Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
     {
-        List<SchemaTableName> tables = prefix.getTable()
-                .map(ignored -> singletonList(prefix.toSchemaTableName()))
-                .orElseGet(() -> listTables(session, prefix.getSchema()));
+        throw new UnsupportedOperationException("The deprecated listTableColumns is not supported because streamTableColumns is implemented instead");
+    }
 
-        ImmutableMap.Builder<SchemaTableName, List<ColumnMetadata>> columns = ImmutableMap.builder();
-        for (SchemaTableName table : tables) {
-            try {
-                columns.put(table, getTableMetadata(session, table).getColumns());
-            }
-            catch (TableNotFoundException e) {
-                // table disappeared during listing operation
-            }
-            catch (UnknownTableTypeException e) {
-                // ignore table of unknown type
-            }
-            catch (RuntimeException e) {
-                // Table can be being removed and this may cause all sorts of exceptions. Log, because we're catching broadly.
-                log.warn(e, "Failed to access metadata of table %s during column listing for %s", table, prefix);
-            }
+    @Override
+    @SuppressWarnings("TryWithIdenticalCatches")
+    public Stream<TableColumnsMetadata> streamTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        requireNonNull(prefix, "prefix is null");
+        List<SchemaTableName> schemaTableNames;
+        if (prefix.getTable().isEmpty()) {
+            schemaTableNames = catalog.listTables(session, prefix.getSchema());
         }
-        return columns.buildOrThrow();
+        else {
+            schemaTableNames = ImmutableList.of(prefix.toSchemaTableName());
+        }
+        return schemaTableNames.stream()
+                .flatMap(tableName -> {
+                    try {
+                        if (redirectTable(session, tableName).isPresent()) {
+                            return Stream.of(TableColumnsMetadata.forRedirectedTable(tableName));
+                        }
+                        return Stream.of(TableColumnsMetadata.forTable(tableName, getTableMetadata(session, tableName).getColumns()));
+                    }
+                    catch (TableNotFoundException e) {
+                        // Table disappeared during listing operation
+                        return Stream.empty();
+                    }
+                    catch (UnknownTableTypeException e) {
+                        // Skip unsupported table type in case that the table redirects are not enabled
+                        return Stream.empty();
+                    }
+                    catch (RuntimeException e) {
+                        // Table can be being removed and this may cause all sorts of exceptions. Log, because we're catching broadly.
+                        log.warn(e, "Failed to access metadata of table %s during streaming table columns for %s", tableName, prefix);
+                        return Stream.empty();
+                    }
+                });
     }
 
     @Override
@@ -1392,6 +1417,12 @@ public class IcebergMetadata
             }
         }
         return viewToken;
+    }
+
+    @Override
+    public Optional<CatalogSchemaTableName> redirectTable(ConnectorSession session, SchemaTableName tableName)
+    {
+        return catalog.redirectTable(session, tableName);
     }
 
     private static class TableToken

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/TrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/TrinoCatalog.java
@@ -15,6 +15,7 @@ package io.trino.plugin.iceberg.catalog;
 
 import io.trino.plugin.iceberg.ColumnIdentity;
 import io.trino.plugin.iceberg.UnknownTableTypeException;
+import io.trino.spi.connector.CatalogSchemaTableName;
 import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorViewDefinition;
@@ -119,4 +120,6 @@ public interface TrinoCatalog
     void renameMaterializedView(ConnectorSession session, SchemaTableName source, SchemaTableName target);
 
     void updateColumnComment(ConnectorSession session, SchemaTableName schemaTableName, ColumnIdentity columnIdentity, Optional<String> comment);
+
+    Optional<CatalogSchemaTableName> redirectTable(ConnectorSession session, SchemaTableName tableName);
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseSharedMetastoreTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseSharedMetastoreTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import io.trino.testing.AbstractTestQueryFramework;
+import org.testng.annotations.Test;
+
+import java.nio.file.Path;
+
+import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testng.Assert.assertEquals;
+
+public abstract class BaseSharedMetastoreTest
+        extends AbstractTestQueryFramework
+{
+    protected final String schema = "test_shared_schema_" + randomTableSuffix();
+    protected Path dataDirectory;
+
+    protected abstract String getExpectedHiveCreateSchema(String catalogName);
+
+    protected abstract String getExpectedIcebergCreateSchema(String catalogName);
+
+    @Test
+    public void testSelect()
+    {
+        assertQuery("SELECT * FROM iceberg." + schema + ".nation", "SELECT * FROM nation");
+        assertQuery("SELECT * FROM hive." + schema + ".region", "SELECT * FROM region");
+        assertQuery("SELECT * FROM hive_with_redirections." + schema + ".nation", "SELECT * FROM nation");
+        assertQuery("SELECT * FROM hive_with_redirections." + schema + ".region", "SELECT * FROM region");
+        assertQuery("SELECT * FROM iceberg_with_redirections." + schema + ".nation", "SELECT * FROM nation");
+        assertQuery("SELECT * FROM iceberg_with_redirections." + schema + ".region", "SELECT * FROM region");
+
+        assertThatThrownBy(() -> query("SELECT * FROM iceberg." + schema + ".region"))
+                .hasMessageContaining("Not an Iceberg table");
+        assertThatThrownBy(() -> query("SELECT * FROM hive." + schema + ".nation"))
+                .hasMessageContaining("Cannot query Iceberg table");
+    }
+
+    @Test
+    public void testReadInformationSchema()
+    {
+        assertThat(query("SELECT table_schema FROM hive.information_schema.tables WHERE table_name = 'region'"))
+                .skippingTypesCheck()
+                .containsAll("VALUES '" + schema + "'");
+        assertThat(query("SELECT table_schema FROM iceberg.information_schema.tables WHERE table_name = 'nation'"))
+                .skippingTypesCheck()
+                .containsAll("VALUES '" + schema + "'");
+        assertThat(query("SELECT table_schema FROM hive_with_redirections.information_schema.tables WHERE table_name = 'region'"))
+                .skippingTypesCheck()
+                .containsAll("VALUES '" + schema + "'");
+        assertThat(query("SELECT table_schema FROM hive_with_redirections.information_schema.tables WHERE table_name = 'nation'"))
+                .skippingTypesCheck()
+                .containsAll("VALUES '" + schema + "'");
+        assertThat(query("SELECT table_schema FROM iceberg_with_redirections.information_schema.tables WHERE table_name = 'region'"))
+                .skippingTypesCheck()
+                .containsAll("VALUES '" + schema + "'");
+
+        assertQuery("SELECT table_name, column_name from hive.information_schema.columns WHERE table_schema = '" + schema + "'",
+                "VALUES ('region', 'regionkey'), ('region', 'name'), ('region', 'comment')");
+        assertQuery("SELECT table_name, column_name from iceberg.information_schema.columns WHERE table_schema = '" + schema + "'",
+                "VALUES ('nation', 'nationkey'), ('nation', 'name'), ('nation', 'regionkey'), ('nation', 'comment')");
+        assertQuery("SELECT table_name, column_name from hive_with_redirections.information_schema.columns WHERE table_schema = '" + schema + "'",
+                "VALUES" +
+                        "('region', 'regionkey'), ('region', 'name'), ('region', 'comment'), " +
+                        "('nation', 'nationkey'), ('nation', 'name'), ('nation', 'regionkey'), ('nation', 'comment')");
+        assertQuery("SELECT table_name, column_name from iceberg_with_redirections.information_schema.columns WHERE table_schema = '" + schema + "'",
+                "VALUES" +
+                        "('region', 'regionkey'), ('region', 'name'), ('region', 'comment'), " +
+                        "('nation', 'nationkey'), ('nation', 'name'), ('nation', 'regionkey'), ('nation', 'comment')");
+    }
+
+    @Test
+    public void testShowTables()
+    {
+        assertQuery("SHOW TABLES FROM iceberg." + schema, "VALUES 'region', 'nation'");
+        assertQuery("SHOW TABLES FROM hive." + schema, "VALUES 'region', 'nation'");
+        assertQuery("SHOW TABLES FROM hive_with_redirections." + schema, "VALUES 'region', 'nation'");
+        assertQuery("SHOW TABLES FROM iceberg_with_redirections." + schema, "VALUES 'region', 'nation'");
+
+        assertThatThrownBy(() -> query("SHOW CREATE TABLE iceberg." + schema + ".region"))
+                .hasMessageContaining("Not an Iceberg table");
+        assertThatThrownBy(() -> query("SHOW CREATE TABLE hive." + schema + ".nation"))
+                .hasMessageContaining("Cannot query Iceberg table");
+
+        assertThatThrownBy(() -> query("DESCRIBE iceberg." + schema + ".region"))
+                .hasMessageContaining("Not an Iceberg table");
+        assertThatThrownBy(() -> query("DESCRIBE hive." + schema + ".nation"))
+                .hasMessageContaining("Cannot query Iceberg table");
+    }
+
+    @Test
+    public void testShowSchemas()
+    {
+        assertThat(query("SHOW SCHEMAS FROM hive"))
+                .skippingTypesCheck()
+                .containsAll("VALUES '" + schema + "'");
+        assertThat(query("SHOW SCHEMAS FROM iceberg"))
+                .skippingTypesCheck()
+                .containsAll("VALUES '" + schema + "'");
+        assertThat(query("SHOW SCHEMAS FROM hive_with_redirections"))
+                .skippingTypesCheck()
+                .containsAll("VALUES '" + schema + "'");
+
+        String showCreateHiveSchema = (String) computeActual("SHOW CREATE SCHEMA hive." + schema).getOnlyValue();
+        assertEquals(
+                showCreateHiveSchema,
+                getExpectedHiveCreateSchema("hive"));
+        String showCreateIcebergSchema = (String) computeActual("SHOW CREATE SCHEMA iceberg." + schema).getOnlyValue();
+        assertEquals(
+                showCreateIcebergSchema,
+                getExpectedIcebergCreateSchema("iceberg"));
+        String showCreateHiveWithRedirectionsSchema = (String) computeActual("SHOW CREATE SCHEMA hive_with_redirections." + schema).getOnlyValue();
+        assertEquals(
+                showCreateHiveWithRedirectionsSchema,
+                getExpectedHiveCreateSchema("hive_with_redirections"));
+        String showCreateIcebergWithRedirectionsSchema = (String) computeActual("SHOW CREATE SCHEMA iceberg_with_redirections." + schema).getOnlyValue();
+        assertEquals(
+                showCreateIcebergWithRedirectionsSchema,
+                getExpectedIcebergCreateSchema("iceberg_with_redirections"));
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
@@ -44,7 +44,8 @@ public class TestIcebergConfig
                 .setCatalogType(HIVE_METASTORE)
                 .setDynamicFilteringWaitTimeout(new Duration(0, MINUTES))
                 .setTableStatisticsEnabled(true)
-                .setProjectionPushdownEnabled(true));
+                .setProjectionPushdownEnabled(true)
+                .setHiveCatalogName(null));
     }
 
     @Test
@@ -60,6 +61,7 @@ public class TestIcebergConfig
                 .put("iceberg.dynamic-filtering.wait-timeout", "1h")
                 .put("iceberg.table-statistics-enabled", "false")
                 .put("iceberg.projection-pushdown-enabled", "false")
+                .put("iceberg.hive-catalog-name", "hive")
                 .buildOrThrow();
 
         IcebergConfig expected = new IcebergConfig()
@@ -71,7 +73,8 @@ public class TestIcebergConfig
                 .setCatalogType(GLUE)
                 .setDynamicFilteringWaitTimeout(Duration.valueOf("1h"))
                 .setTableStatisticsEnabled(false)
-                .setProjectionPushdownEnabled(false);
+                .setProjectionPushdownEnabled(false)
+                .setHiveCatalogName("hive");
 
         assertFullMapping(properties, expected);
     }

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hive-iceberg-redirections/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hive-iceberg-redirections/iceberg.properties
@@ -1,3 +1,4 @@
 connector.name=iceberg
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
+iceberg.hive-catalog-name=hive

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergHiveTablesCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergHiveTablesCompatibility.java
@@ -44,8 +44,11 @@ public class TestIcebergHiveTablesCompatibility
         assertQueryFailure(() -> onTrino().executeQuery("SELECT * FROM iceberg.default." + tableName))
                 .hasMessageMatching("Query failed \\(#\\w+\\):\\Q Not an Iceberg table: default." + tableName);
 
-        assertQueryFailure(() -> onTrino().executeQuery("SELECT * FROM iceberg.default.\"" + tableName + "$files\""))
+        assertQueryFailure(() -> onTrino().executeQuery("SELECT * FROM iceberg.default.\"" + tableName + "$data\""))
                 .hasMessageMatching("Query failed \\(#\\w+\\):\\Q Not an Iceberg table: default." + tableName);
+
+        assertQueryFailure(() -> onTrino().executeQuery("SELECT * FROM iceberg.default.\"" + tableName + "$files\""))
+                .hasMessageMatching("Query failed \\(#\\w+\\):\\Q line 1:15: Table 'iceberg.default." + tableName + "$files' does not exist");
 
         onTrino().executeQuery("DROP TABLE hive.default." + tableName);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

New property introduced for the Iceberg connector: `iceberg.hive-catalog-name`

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

New feature

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

The changes in this PR affect mainly the Iceberg connector. 

> How would you describe this change to a non-technical end user or system administrator?

In an environment which makes use of a shared metastore it may come in handy to have table redirects to automatically allow Trino to translate a table name like `iceberg.default.hive_table_name` towards the name `hive.default.hive_table_name`.

Note that the translation can happen quite transparently when the user connects to a predefined catalog and schema (e.g. : `iceberg.default`) and the table operation looks like: `SELECT * FROM hive_table_name`. 

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Iceberg
* Add support to redirect table operations from Iceberg to Hive
```
