### PR TITLE
Enable test for partitioned table in BigQuery

### DIFF
--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConnectorTest.java
@@ -331,7 +331,7 @@ public class TestBigQueryConnectorTest
         return nullToEmpty(exception.getMessage()).matches(".*(Fields must contain only letters, numbers, and underscores, start with a letter or underscore, and be at most 300 characters long).*");
     }
 
-    @Test(enabled = false)
+    @Test
     public void testSelectFromHourlyPartitionedTable()
     {
         try (TestTable table = new TestTable(
@@ -343,7 +343,7 @@ public class TestBigQueryConnectorTest
         }
     }
 
-    @Test(enabled = false)
+    @Test
     public void testSelectFromYearlyPartitionedTable()
     {
         try (TestTable table = new TestTable(


### PR DESCRIPTION
## Description

Enable test for partitioned table in BigQuery. These tests were disabled because we didn't want to run tests due
to lack of CI environment.

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

