### PR TITLE
Cache accumulator factory

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/TopologyAwareNodeSelectorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/TopologyAwareNodeSelectorFactory.java
@@ -38,13 +38,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.SystemSessionProperties.getMaxUnacknowledgedSplitsPerTask;
+import static io.trino.collect.cache.CacheUtils.uncheckedCacheGet;
 import static io.trino.collect.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.metadata.NodeState.ACTIVE;
 import static java.util.Objects.requireNonNull;
@@ -181,12 +181,6 @@ public class TopologyAwareNodeSelectorFactory
     private boolean markInaccessibleNode(InternalNode node)
     {
         Object marker = new Object();
-        try {
-            return inaccessibleNodeLogCache.get(node, () -> marker) == marker;
-        }
-        catch (ExecutionException e) {
-            // impossible
-            throw new RuntimeException(e);
-        }
+        return uncheckedCacheGet(inaccessibleNodeLogCache, node, () -> marker) == marker;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/UniformNodeSelectorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/UniformNodeSelectorFactory.java
@@ -35,13 +35,13 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.SystemSessionProperties.getMaxUnacknowledgedSplitsPerTask;
+import static io.trino.collect.cache.CacheUtils.uncheckedCacheGet;
 import static io.trino.collect.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.metadata.NodeState.ACTIVE;
 import static java.util.Objects.requireNonNull;
@@ -164,12 +164,6 @@ public class UniformNodeSelectorFactory
     private boolean markInaccessibleNode(InternalNode node)
     {
         Object marker = new Object();
-        try {
-            return inaccessibleNodeLogCache.get(node, () -> marker) == marker;
-        }
-        catch (ExecutionException e) {
-            // impossible
-            throw new RuntimeException(e);
-        }
+        return uncheckedCacheGet(inaccessibleNodeLogCache, node, () -> marker) == marker;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionManager.java
@@ -34,13 +34,13 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.primitives.Primitives.wrap;
 import static io.trino.client.NodeVersion.UNKNOWN;
+import static io.trino.collect.cache.CacheUtils.uncheckedCacheGet;
 import static io.trino.collect.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_ERROR;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
@@ -77,9 +77,9 @@ public class FunctionManager
     public FunctionInvoker getScalarFunctionInvoker(ResolvedFunction resolvedFunction, InvocationConvention invocationConvention)
     {
         try {
-            return specializedScalarCache.get(new FunctionKey(resolvedFunction, invocationConvention), () -> getScalarFunctionInvokerInternal(resolvedFunction, invocationConvention));
+            return uncheckedCacheGet(specializedScalarCache, new FunctionKey(resolvedFunction, invocationConvention), () -> getScalarFunctionInvokerInternal(resolvedFunction, invocationConvention));
         }
-        catch (ExecutionException | UncheckedExecutionException e) {
+        catch (UncheckedExecutionException e) {
             throwIfInstanceOf(e.getCause(), TrinoException.class);
             throw new RuntimeException(e.getCause());
         }
@@ -100,9 +100,9 @@ public class FunctionManager
     public AggregationMetadata getAggregateFunctionImplementation(ResolvedFunction resolvedFunction)
     {
         try {
-            return specializedAggregationCache.get(new FunctionKey(resolvedFunction), () -> getAggregateFunctionImplementationInternal(resolvedFunction));
+            return uncheckedCacheGet(specializedAggregationCache, new FunctionKey(resolvedFunction), () -> getAggregateFunctionImplementationInternal(resolvedFunction));
         }
-        catch (ExecutionException | UncheckedExecutionException e) {
+        catch (UncheckedExecutionException e) {
             throwIfInstanceOf(e.getCause(), TrinoException.class);
             throw new RuntimeException(e.getCause());
         }
@@ -120,9 +120,9 @@ public class FunctionManager
     public WindowFunctionSupplier getWindowFunctionImplementation(ResolvedFunction resolvedFunction)
     {
         try {
-            return specializedWindowCache.get(new FunctionKey(resolvedFunction), () -> getWindowFunctionImplementationInternal(resolvedFunction));
+            return uncheckedCacheGet(specializedWindowCache, new FunctionKey(resolvedFunction), () -> getWindowFunctionImplementationInternal(resolvedFunction));
         }
-        catch (ExecutionException | UncheckedExecutionException e) {
+        catch (UncheckedExecutionException e) {
             throwIfInstanceOf(e.getCause(), TrinoException.class);
             throw new RuntimeException(e.getCause());
         }

--- a/core/trino-main/src/main/java/io/trino/metadata/TypeRegistry.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/TypeRegistry.java
@@ -48,11 +48,11 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutionException;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.throwIfUnchecked;
+import static io.trino.collect.cache.CacheUtils.uncheckedCacheGet;
 import static io.trino.collect.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BOXED_NULLABLE;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
@@ -177,9 +177,9 @@ public final class TypeRegistry
         Type type = types.get(signature);
         if (type == null) {
             try {
-                return parametricTypeCache.get(signature, () -> instantiateParametricType(signature));
+                return uncheckedCacheGet(parametricTypeCache, signature, () -> instantiateParametricType(signature));
             }
-            catch (ExecutionException | UncheckedExecutionException e) {
+            catch (UncheckedExecutionException e) {
                 throwIfUnchecked(e.getCause());
                 throw new RuntimeException(e.getCause());
             }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/AccumulatorCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/AccumulatorCompiler.java
@@ -87,8 +87,7 @@ public final class AccumulatorCompiler
     public static AccumulatorFactory generateAccumulatorFactory(
             BoundSignature boundSignature,
             AggregationMetadata metadata,
-            FunctionNullability functionNullability,
-            List<Supplier<Object>> lambdaProviders)
+            FunctionNullability functionNullability)
     {
         // change types used in Aggregation methods to types used in the core Trino engine to simplify code generation
         metadata = normalizeAggregationMethods(metadata);
@@ -115,7 +114,7 @@ public final class AccumulatorCompiler
         return new CompiledAccumulatorFactory(
                 accumulatorConstructor,
                 groupedAccumulatorConstructor,
-                lambdaProviders);
+                metadata.getLambdaInterfaces());
     }
 
     private static <T> Constructor<? extends T> generateAccumulatorClass(

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/AccumulatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/AccumulatorFactory.java
@@ -13,13 +13,18 @@
  */
 package io.trino.operator.aggregation;
 
+import java.util.List;
+import java.util.function.Supplier;
+
 public interface AccumulatorFactory
 {
-    Accumulator createAccumulator();
+    List<Class<?>> getLambdaInterfaces();
 
-    Accumulator createIntermediateAccumulator();
+    Accumulator createAccumulator(List<Supplier<Object>> lambdaProviders);
 
-    GroupedAccumulator createGroupedAccumulator();
+    Accumulator createIntermediateAccumulator(List<Supplier<Object>> lambdaProviders);
 
-    GroupedAccumulator createGroupedIntermediateAccumulator();
+    GroupedAccumulator createGroupedAccumulator(List<Supplier<Object>> lambdaProviders);
+
+    GroupedAccumulator createGroupedIntermediateAccumulator(List<Supplier<Object>> lambdaProviders);
 }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/AggregatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/AggregatorFactory.java
@@ -19,6 +19,7 @@ import io.trino.sql.planner.plan.AggregationNode.Step;
 
 import java.util.List;
 import java.util.OptionalInt;
+import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
@@ -32,6 +33,7 @@ public class AggregatorFactory
     private final List<Integer> inputChannels;
     private final OptionalInt maskChannel;
     private final boolean spillable;
+    private final List<Supplier<Object>> lambdaProviders;
 
     public AggregatorFactory(
             AccumulatorFactory accumulatorFactory,
@@ -40,7 +42,8 @@ public class AggregatorFactory
             Type finalType,
             List<Integer> inputChannels,
             OptionalInt maskChannel,
-            boolean spillable)
+            boolean spillable,
+            List<Supplier<Object>> lambdaProviders)
     {
         this.accumulatorFactory = requireNonNull(accumulatorFactory, "accumulatorFactory is null");
         this.step = requireNonNull(step, "step is null");
@@ -49,6 +52,7 @@ public class AggregatorFactory
         this.inputChannels = ImmutableList.copyOf(requireNonNull(inputChannels, "inputChannels is null"));
         this.maskChannel = requireNonNull(maskChannel, "maskChannel is null");
         this.spillable = spillable;
+        this.lambdaProviders = ImmutableList.copyOf(requireNonNull(lambdaProviders, "lambdaProviders is null"));
 
         checkArgument(step.isInputRaw() || inputChannels.size() == 1, "expected 1 input channel for intermediate aggregation");
     }
@@ -57,10 +61,10 @@ public class AggregatorFactory
     {
         Accumulator accumulator;
         if (step.isInputRaw()) {
-            accumulator = accumulatorFactory.createAccumulator();
+            accumulator = accumulatorFactory.createAccumulator(lambdaProviders);
         }
         else {
-            accumulator = accumulatorFactory.createIntermediateAccumulator();
+            accumulator = accumulatorFactory.createIntermediateAccumulator(lambdaProviders);
         }
         return new Aggregator(accumulator, step, intermediateType, finalType, inputChannels, maskChannel);
     }
@@ -69,10 +73,10 @@ public class AggregatorFactory
     {
         GroupedAccumulator accumulator;
         if (step.isInputRaw()) {
-            accumulator = accumulatorFactory.createGroupedAccumulator();
+            accumulator = accumulatorFactory.createGroupedAccumulator(lambdaProviders);
         }
         else {
-            accumulator = accumulatorFactory.createGroupedIntermediateAccumulator();
+            accumulator = accumulatorFactory.createGroupedIntermediateAccumulator(lambdaProviders);
         }
         return new GroupedAggregator(accumulator, step, intermediateType, finalType, inputChannels, maskChannel);
     }
@@ -81,10 +85,10 @@ public class AggregatorFactory
     {
         GroupedAccumulator accumulator;
         if (step.isInputRaw()) {
-            accumulator = accumulatorFactory.createGroupedAccumulator();
+            accumulator = accumulatorFactory.createGroupedAccumulator(lambdaProviders);
         }
         else {
-            accumulator = accumulatorFactory.createGroupedIntermediateAccumulator();
+            accumulator = accumulatorFactory.createGroupedIntermediateAccumulator(lambdaProviders);
         }
         return new GroupedAggregator(accumulator, step, intermediateType, finalType, ImmutableList.of(inputChannel), maskChannel);
     }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/CompiledAccumulatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/CompiledAccumulatorFactory.java
@@ -26,20 +26,26 @@ public class CompiledAccumulatorFactory
 {
     private final Constructor<? extends Accumulator> accumulatorConstructor;
     private final Constructor<? extends GroupedAccumulator> groupedAccumulatorConstructor;
-    private final List<Supplier<Object>> lambdaProviders;
+    private final List<Class<?>> lambdaInterfaces;
 
     public CompiledAccumulatorFactory(
             Constructor<? extends Accumulator> accumulatorConstructor,
             Constructor<? extends GroupedAccumulator> groupedAccumulatorConstructor,
-            List<Supplier<Object>> lambdaProviders)
+            List<Class<?>> lambdaInterfaces)
     {
         this.accumulatorConstructor = requireNonNull(accumulatorConstructor, "accumulatorConstructor is null");
         this.groupedAccumulatorConstructor = requireNonNull(groupedAccumulatorConstructor, "groupedAccumulatorConstructor is null");
-        this.lambdaProviders = ImmutableList.copyOf(requireNonNull(lambdaProviders, "lambdaProviders is null"));
+        this.lambdaInterfaces = ImmutableList.copyOf(requireNonNull(lambdaInterfaces, "lambdaInterfaces is null"));
     }
 
     @Override
-    public Accumulator createAccumulator()
+    public List<Class<?>> getLambdaInterfaces()
+    {
+        return lambdaInterfaces;
+    }
+
+    @Override
+    public Accumulator createAccumulator(List<Supplier<Object>> lambdaProviders)
     {
         try {
             return accumulatorConstructor.newInstance(lambdaProviders);
@@ -50,7 +56,7 @@ public class CompiledAccumulatorFactory
     }
 
     @Override
-    public Accumulator createIntermediateAccumulator()
+    public Accumulator createIntermediateAccumulator(List<Supplier<Object>> lambdaProviders)
     {
         try {
             return accumulatorConstructor.newInstance(lambdaProviders);
@@ -61,7 +67,7 @@ public class CompiledAccumulatorFactory
     }
 
     @Override
-    public GroupedAccumulator createGroupedAccumulator()
+    public GroupedAccumulator createGroupedAccumulator(List<Supplier<Object>> lambdaProviders)
     {
         try {
             return groupedAccumulatorConstructor.newInstance(lambdaProviders);
@@ -72,7 +78,7 @@ public class CompiledAccumulatorFactory
     }
 
     @Override
-    public GroupedAccumulator createGroupedIntermediateAccumulator()
+    public GroupedAccumulator createGroupedIntermediateAccumulator(List<Supplier<Object>> lambdaProviders)
     {
         try {
             return groupedAccumulatorConstructor.newInstance(lambdaProviders);

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/DistinctAccumulatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/DistinctAccumulatorFactory.java
@@ -29,6 +29,7 @@ import io.trino.type.BlockTypeOperators;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -60,10 +61,16 @@ public class DistinctAccumulatorFactory
     }
 
     @Override
-    public Accumulator createAccumulator()
+    public List<Class<?>> getLambdaInterfaces()
+    {
+        return delegate.getLambdaInterfaces();
+    }
+
+    @Override
+    public Accumulator createAccumulator(List<Supplier<Object>> lambdaProviders)
     {
         return new DistinctAccumulator(
-                delegate.createAccumulator(),
+                delegate.createAccumulator(lambdaProviders),
                 argumentTypes,
                 session,
                 joinCompiler,
@@ -71,16 +78,16 @@ public class DistinctAccumulatorFactory
     }
 
     @Override
-    public Accumulator createIntermediateAccumulator()
+    public Accumulator createIntermediateAccumulator(List<Supplier<Object>> lambdaProviders)
     {
-        return delegate.createIntermediateAccumulator();
+        return delegate.createIntermediateAccumulator(lambdaProviders);
     }
 
     @Override
-    public GroupedAccumulator createGroupedAccumulator()
+    public GroupedAccumulator createGroupedAccumulator(List<Supplier<Object>> lambdaProviders)
     {
         return new DistinctGroupedAccumulator(
-                delegate.createGroupedAccumulator(),
+                delegate.createGroupedAccumulator(lambdaProviders),
                 argumentTypes,
                 session,
                 joinCompiler,
@@ -88,9 +95,9 @@ public class DistinctAccumulatorFactory
     }
 
     @Override
-    public GroupedAccumulator createGroupedIntermediateAccumulator()
+    public GroupedAccumulator createGroupedIntermediateAccumulator(List<Supplier<Object>> lambdaProviders)
     {
-        return delegate.createGroupedIntermediateAccumulator();
+        return delegate.createGroupedIntermediateAccumulator(lambdaProviders);
     }
 
     private static class DistinctAccumulator

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedAccumulatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedAccumulatorFactory.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -64,29 +65,35 @@ public class OrderedAccumulatorFactory
     }
 
     @Override
-    public Accumulator createAccumulator()
+    public List<Class<?>> getLambdaInterfaces()
     {
-        Accumulator accumulator = delegate.createAccumulator();
+        return delegate.getLambdaInterfaces();
+    }
+
+    @Override
+    public Accumulator createAccumulator(List<Supplier<Object>> lambdaProviders)
+    {
+        Accumulator accumulator = delegate.createAccumulator(lambdaProviders);
         return new OrderedAccumulator(accumulator, sourceTypes, argumentChannels, orderByChannels, orderings, pagesIndexFactory);
     }
 
     @Override
-    public Accumulator createIntermediateAccumulator()
+    public Accumulator createIntermediateAccumulator(List<Supplier<Object>> lambdaProviders)
     {
-        return delegate.createIntermediateAccumulator();
+        return delegate.createIntermediateAccumulator(lambdaProviders);
     }
 
     @Override
-    public GroupedAccumulator createGroupedAccumulator()
+    public GroupedAccumulator createGroupedAccumulator(List<Supplier<Object>> lambdaProviders)
     {
-        GroupedAccumulator accumulator = delegate.createGroupedAccumulator();
+        GroupedAccumulator accumulator = delegate.createGroupedAccumulator(lambdaProviders);
         return new OrderingGroupedAccumulator(accumulator, sourceTypes, argumentChannels, orderByChannels, orderings, pagesIndexFactory);
     }
 
     @Override
-    public GroupedAccumulator createGroupedIntermediateAccumulator()
+    public GroupedAccumulator createGroupedIntermediateAccumulator(List<Supplier<Object>> lambdaProviders)
     {
-        return delegate.createGroupedIntermediateAccumulator();
+        return delegate.createGroupedIntermediateAccumulator(lambdaProviders);
     }
 
     private static class OrderedAccumulator

--- a/core/trino-main/src/main/java/io/trino/operator/window/AggregationWindowFunctionSupplier.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/AggregationWindowFunctionSupplier.java
@@ -54,7 +54,7 @@ public class AggregationWindowFunctionSupplier
         return new AggregateWindowFunction(() -> createWindowAccumulator(lambdaProviders), hasRemoveInput);
     }
 
-    private WindowAccumulator createWindowAccumulator(List<Supplier<Object>> lambdaProviders)
+    public WindowAccumulator createWindowAccumulator(List<Supplier<Object>> lambdaProviders)
     {
         try {
             return constructor.newInstance(lambdaProviders);

--- a/core/trino-main/src/main/java/io/trino/operator/window/pattern/MatchAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/pattern/MatchAggregation.java
@@ -16,9 +16,8 @@ package io.trino.operator.window.pattern;
 import io.trino.memory.context.AggregatedMemoryContext;
 import io.trino.memory.context.LocalMemoryContext;
 import io.trino.metadata.BoundSignature;
-import io.trino.metadata.FunctionNullability;
-import io.trino.operator.aggregation.AggregationMetadata;
 import io.trino.operator.aggregation.WindowAccumulator;
+import io.trino.operator.window.AggregationWindowFunctionSupplier;
 import io.trino.operator.window.MappedWindowIndex;
 import io.trino.operator.window.matcher.ArrayView;
 import io.trino.operator.window.pattern.SetEvaluator.SetEvaluatorSupplier;
@@ -26,11 +25,9 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 
-import java.lang.reflect.Constructor;
 import java.util.List;
 import java.util.function.Supplier;
 
-import static io.trino.operator.aggregation.AccumulatorCompiler.generateWindowAccumulatorClass;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -193,8 +190,7 @@ public class MatchAggregation
 
         public MatchAggregationInstantiator(
                 BoundSignature boundSignature,
-                AggregationMetadata aggregationMetadata,
-                FunctionNullability functionNullability,
+                AggregationWindowFunctionSupplier aggregationWindowFunctionSupplier,
                 List<Integer> argumentChannels,
                 List<Supplier<Object>> lambdaProviders,
                 SetEvaluatorSupplier setEvaluatorSupplier)
@@ -203,24 +199,13 @@ public class MatchAggregation
             this.argumentChannels = requireNonNull(argumentChannels, "argumentChannels is null");
             this.setEvaluatorSupplier = requireNonNull(setEvaluatorSupplier, "setEvaluatorSupplier is null");
 
-            Constructor<? extends WindowAccumulator> constructor = generateWindowAccumulatorClass(boundSignature, aggregationMetadata, functionNullability);
-            this.accumulatorFactory = () -> createWindowAccumulator(constructor, lambdaProviders);
+            this.accumulatorFactory = () -> aggregationWindowFunctionSupplier.createWindowAccumulator(lambdaProviders);
         }
 
         public MatchAggregation get(AggregatedMemoryContext memoryContextSupplier)
         {
             requireNonNull(memoryContextSupplier, "memoryContextSupplier is null");
             return new MatchAggregation(boundSignature, accumulatorFactory, argumentChannels, setEvaluatorSupplier.get(), memoryContextSupplier);
-        }
-
-        private static WindowAccumulator createWindowAccumulator(Constructor<? extends WindowAccumulator> constructor, List<Supplier<Object>> lambdaProviders)
-        {
-            try {
-                return constructor.newInstance(lambdaProviders);
-            }
-            catch (ReflectiveOperationException e) {
-                throw new RuntimeException(e);
-            }
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/type/TypeOperatorsCache.java
+++ b/core/trino-main/src/main/java/io/trino/type/TypeOperatorsCache.java
@@ -18,11 +18,11 @@ import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.trino.collect.cache.NonKeyEvictableCache;
 import org.weakref.jmx.Managed;
 
-import java.util.concurrent.ExecutionException;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Throwables.throwIfUnchecked;
+import static io.trino.collect.cache.CacheUtils.uncheckedCacheGet;
 import static io.trino.collect.cache.SafeCaches.buildNonEvictableCacheWithWeakInvalidateAll;
 
 public class TypeOperatorsCache
@@ -36,9 +36,9 @@ public class TypeOperatorsCache
     public Object apply(Object operatorConvention, Supplier<Object> supplier)
     {
         try {
-            return cache.get(operatorConvention, supplier::get);
+            return uncheckedCacheGet(cache, operatorConvention, supplier);
         }
-        catch (ExecutionException | UncheckedExecutionException e) {
+        catch (UncheckedExecutionException e) {
             throwIfUnchecked(e.getCause());
             throw new RuntimeException(e.getCause());
         }

--- a/core/trino-main/src/main/java/io/trino/util/FastutilSetHelper.java
+++ b/core/trino-main/src/main/java/io/trino/util/FastutilSetHelper.java
@@ -31,11 +31,11 @@ import java.lang.invoke.MethodHandle;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.base.Verify.verifyNotNull;
+import static io.trino.collect.cache.CacheUtils.uncheckedCacheGet;
 import static io.trino.collect.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.util.SingleAccessMethodCompiler.compileSingleAccessMethod;
 import static java.lang.Boolean.TRUE;
@@ -248,12 +248,13 @@ public final class FastutilSetHelper
         {
             try {
                 @SuppressWarnings("unchecked")
-                GeneratedMethod<T> generatedMethod = (GeneratedMethod<T>) generatedMethodCache.get(
+                GeneratedMethod<T> generatedMethod = (GeneratedMethod<T>) uncheckedCacheGet(
+                        generatedMethodCache,
                         new MethodKey<>(type, operatorInterface),
                         () -> new GeneratedMethod<>(type, operatorInterface, methodHandle));
                 return generatedMethod.get();
             }
-            catch (ExecutionException | UncheckedExecutionException e) {
+            catch (UncheckedExecutionException e) {
                 throwIfUnchecked(e.getCause());
                 throw new RuntimeException(e.getCause());
             }

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestAccumulatorCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestAccumulatorCompiler.java
@@ -97,7 +97,7 @@ public class TestAccumulatorCompiler
         FunctionNullability functionNullability = new FunctionNullability(false, ImmutableList.of(false));
 
         // test if we can compile aggregation
-        AccumulatorFactory accumulatorFactory = AccumulatorCompiler.generateAccumulatorFactory(signature, metadata, functionNullability, ImmutableList.of());
+        AccumulatorFactory accumulatorFactory = AccumulatorCompiler.generateAccumulatorFactory(signature, metadata, functionNullability);
         assertThat(accumulatorFactory).isNotNull();
         assertThat(AccumulatorCompiler.generateWindowAccumulatorClass(signature, metadata, functionNullability)).isNotNull();
 

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestingAggregationFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestingAggregationFunction.java
@@ -51,7 +51,7 @@ public class TestingAggregationFunction
                 .collect(toImmutableList());
         intermediateType = (intermediateTypes.size() == 1) ? getOnlyElement(intermediateTypes) : RowType.anonymous(intermediateTypes);
         this.finalType = signature.getReturnType();
-        this.factory = generateAccumulatorFactory(signature, aggregationMetadata, functionNullability, ImmutableList.of());
+        this.factory = generateAccumulatorFactory(signature, aggregationMetadata, functionNullability);
         distinctFactory = new DistinctAccumulatorFactory(
                 factory,
                 parameterTypes,
@@ -114,6 +114,7 @@ public class TestingAggregationFunction
                 finalType,
                 inputChannels,
                 maskChannel,
-                true);
+                true,
+                ImmutableList.of());
     }
 }

--- a/lib/trino-collect/src/main/java/io/trino/collect/cache/CacheUtils.java
+++ b/lib/trino-collect/src/main/java/io/trino/collect/cache/CacheUtils.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.collect.cache;
+
+import com.google.common.cache.Cache;
+
+import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
+
+public final class CacheUtils
+{
+    private CacheUtils() {}
+
+    public static <K, V> V uncheckedCacheGet(Cache<K, V> cache, K key, Supplier<V> loader)
+    {
+        try {
+            return cache.get(key, loader::get);
+        }
+        catch (ExecutionException e) {
+            // this can not happen because a supplier can not throw a checked exception
+            throw new RuntimeException("Unexpected checked exception from cache load", e);
+        }
+    }
+}

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClientFactory.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClientFactory.java
@@ -25,8 +25,8 @@ import io.trino.spi.connector.ConnectorSession;
 import javax.inject.Inject;
 
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 
+import static io.trino.collect.cache.CacheUtils.uncheckedCacheGet;
 import static io.trino.collect.cache.SafeCaches.buildNonEvictableCache;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -64,12 +64,7 @@ public class BigQueryClientFactory
     {
         IdentityCacheMapping.IdentityCacheKey cacheKey = identityCacheMapping.getRemoteUserCacheKey(session);
 
-        try {
-            return clientCache.get(cacheKey, () -> createBigQueryClient(session));
-        }
-        catch (ExecutionException e) {
-            return createBigQueryClient(session);
-        }
+        return uncheckedCacheGet(clientCache, cacheKey, () -> createBigQueryClient(session));
     }
 
     protected BigQueryClient createBigQueryClient(ConnectorSession session)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/statistics/CachingDeltaLakeStatisticsAccess.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/statistics/CachingDeltaLakeStatisticsAccess.java
@@ -26,9 +26,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import java.time.Duration;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 
 import static com.google.common.base.Throwables.throwIfInstanceOf;
+import static io.trino.collect.cache.CacheUtils.uncheckedCacheGet;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
@@ -59,9 +59,9 @@ public class CachingDeltaLakeStatisticsAccess
     public Optional<DeltaLakeStatistics> readDeltaLakeStatistics(ConnectorSession session, String tableLocation)
     {
         try {
-            return cache.get(tableLocation, () -> delegate.readDeltaLakeStatistics(session, tableLocation));
+            return uncheckedCacheGet(cache, tableLocation, () -> delegate.readDeltaLakeStatistics(session, tableLocation));
         }
-        catch (ExecutionException | UncheckedExecutionException e) {
+        catch (UncheckedExecutionException e) {
             throwIfInstanceOf(e.getCause(), TrinoException.class);
             throw new TrinoException(GENERIC_INTERNAL_ERROR, "Error reading statistics from cache", e.getCause());
         }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/CachingDirectoryLister.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/CachingDirectoryLister.java
@@ -37,11 +37,11 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.collect.cache.CacheUtils.uncheckedCacheGet;
 import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
@@ -96,13 +96,7 @@ public class CachingDirectoryLister
             return fs.listLocatedStatus(path);
         }
 
-        ValueHolder cachedValueHolder;
-        try {
-            cachedValueHolder = cache.get(path, ValueHolder::new);
-        }
-        catch (ExecutionException e) {
-            throw new RuntimeException(e); // cannot happen
-        }
+        ValueHolder cachedValueHolder = uncheckedCacheGet(cache, path, ValueHolder::new);
         if (cachedValueHolder.getFiles().isPresent()) {
             return simpleRemoteIterator(cachedValueHolder.getFiles().get());
         }

--- a/plugin/trino-ml/src/main/java/io/trino/plugin/ml/MLFunctions.java
+++ b/plugin/trino-ml/src/main/java/io/trino/plugin/ml/MLFunctions.java
@@ -24,9 +24,8 @@ import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.type.StandardTypes;
 
-import java.util.concurrent.ExecutionException;
-
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.collect.cache.CacheUtils.uncheckedCacheGet;
 import static io.trino.collect.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.plugin.ml.type.ClassifierType.BIGINT_CLASSIFIER;
 import static io.trino.plugin.ml.type.ClassifierType.VARCHAR_CLASSIFIER;
@@ -77,11 +76,6 @@ public final class MLFunctions
     private static Model getOrLoadModel(Slice slice)
     {
         HashCode modelHash = ModelUtils.modelHash(slice);
-        try {
-            return MODEL_CACHE.get(modelHash, () -> ModelUtils.deserialize(slice));
-        }
-        catch (ExecutionException e) {
-            throw new RuntimeException(e);
-        }
+        return uncheckedCacheGet(MODEL_CACHE, modelHash, () -> ModelUtils.deserialize(slice));
     }
 }

--- a/testing/trino-benchmark/src/main/java/io/trino/benchmark/BenchmarkAggregationFunction.java
+++ b/testing/trino-benchmark/src/main/java/io/trino/benchmark/BenchmarkAggregationFunction.java
@@ -39,11 +39,7 @@ public class BenchmarkAggregationFunction
         BoundSignature signature = resolvedFunction.getSignature();
         intermediateType = getOnlyElement(aggregationMetadata.getAccumulatorStateDescriptors()).getSerializer().getSerializedType();
         finalType = signature.getReturnType();
-        accumulatorFactory = generateAccumulatorFactory(
-                signature,
-                aggregationMetadata,
-                resolvedFunction.getFunctionNullability(),
-                ImmutableList.of());
+        accumulatorFactory = generateAccumulatorFactory(signature, aggregationMetadata, resolvedFunction.getFunctionNullability());
     }
 
     public AggregatorFactory bind(List<Integer> inputChannels)
@@ -55,6 +51,7 @@ public class BenchmarkAggregationFunction
                 finalType,
                 inputChannels,
                 OptionalInt.empty(),
-                true);
+                true,
+                ImmutableList.of());
     }
 }


### PR DESCRIPTION
## Description

Cache generated aggregation accumulator classes.  When accumulator factory was split from function management we lost the caching of part of the generated code.

## Related issues, pull requests, and links

* Fixes #11234

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# General
* Fix regression in aggregation performance caused by not reusing generated accumulator factories. ({issue}`issuenumber`)
```
