### PR TITLE
Set useNativeGit in git-commit-id-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1761,6 +1761,8 @@
                         <runOnlyOnce>true</runOnlyOnce>
                         <injectAllReactorProjects>true</injectAllReactorProjects>
                         <offline>true</offline>
+                        <!-- A workaround to make build work in a Git worktree, see https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/215 -->
+                        <useNativeGit>true</useNativeGit>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
## Description

This is a workaround for inability to build Trino in a git worktree. This is a long-standing issue in the plugin, see git-commit-id/git-commit-id-maven-plugin#215.

## Related issues, pull requests, and links

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) I'm uncertain if this qualifies to release notes. This fixes an annoyance for me, but I'm not sure if it's notable enough for others.
( ) Release notes entries required with the following suggested text: