### PR TITLE
Replace references to "Presto" and "SEP" in Delta Lake connector

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitSource.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitSource.java
@@ -73,7 +73,7 @@ public class DeltaLakeSplitSource
         this.dynamicFilter = requireNonNull(dynamicFilter, "dynamicFilter is null");
         queueSplits(splits, queue, executor)
                 .exceptionally(throwable -> {
-                    // set prestoException before finishing the queue to ensure failure is observed instead of successful completion
+                    // set trinoException before finishing the queue to ensure failure is observed instead of successful completion
                     // (the field is declared as volatile to make sure that the change is visible right away to other threads)
                     trinoException = new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to generate splits for " + this.tableName, throwable);
                     try {
@@ -139,7 +139,7 @@ public class DeltaLakeSplitSource
     public boolean isFinished()
     {
         if (queue.isFinished()) {
-            // Note: queue and prestoException need to be checked in the appropriate order
+            // Note: queue and trinoException need to be checked in the appropriate order
             // When throwable is set, we want getNextBatch to be called, so that we can propagate the exception
             return trinoException == null;
         }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTableProperties.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTableProperties.java
@@ -43,7 +43,7 @@ public class DeltaLakeTableProperties
     //       to pass the column names to ConnectorMetadata#getStatisticsCollectionMetadata; we should consider passing
     //       ConnectorTableHandle instead of ConnectorTableMetadata as an argument since it makes more information
     //       available (including the names of the columns to be analyzed)
-    public static final String ANALYZE_COLUMNS_PROPERTY = "$sep.analyze_columns";
+    public static final String ANALYZE_COLUMNS_PROPERTY = "$trino.analyze_columns";
 
     private final List<PropertyMetadata<?>> tableProperties;
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
@@ -373,7 +373,7 @@ public class HiveMetastoreBackedDeltaLakeMetastore
 
     private boolean isValidInRange(Double d)
     {
-        // Delta considers NaN a valid min/max value but Presto does not
+        // Delta considers NaN a valid min/max value but Trino does not
         return d != null && !d.isNaN();
     }
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeParquetStatisticsUtils.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeParquetStatisticsUtils.java
@@ -165,7 +165,7 @@ public class DeltaLakeParquetStatisticsUtils
             return Optional.empty();
         }
 
-        LOG.warn("Accumulating Parquet statistics with Presto type: %s and Parquet statistics of type: %s is not supported", type, statistics);
+        LOG.warn("Accumulating Parquet statistics with Trino type: %s and Parquet statistics of type: %s is not supported", type, statistics);
         return Optional.empty();
     }
 
@@ -245,7 +245,7 @@ public class DeltaLakeParquetStatisticsUtils
             return Optional.empty();
         }
 
-        LOG.warn("Accumulating Parquet statistics with Presto type: %s and Parquet statistics of type: %s is not supported", type, statistics);
+        LOG.warn("Accumulating Parquet statistics with Trino type: %s and Parquet statistics of type: %s is not supported", type, statistics);
         return Optional.empty();
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeSchemaSupport.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeSchemaSupport.java
@@ -120,7 +120,7 @@ public final class DeltaLakeSchemaSupport
 
         fieldContents.put("metadata", ImmutableMap.of());
         fieldContents.put("name", name);
-        fieldContents.put("nullable", true); // TODO: Is column nullability configurable in Presto?
+        fieldContents.put("nullable", true); // TODO: Is column nullability configurable in Trino?
         fieldContents.put("type", serializeColumnType(type));
 
         return fieldContents.buildOrThrow();

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -669,7 +669,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     public void testSelectOldDate()
     {
         // Due to calendar shifts the read value is different than the written value.
-        // This means that the Presto value falls outside of the Databricks min/max values from the file statistics
+        // This means that the Trino value falls outside of the Databricks min/max values from the file statistics
         assertQuery("SELECT * FROM old_dates", "VALUES (DATE '0099-12-30', 1), (DATE '1582-10-15', 2), (DATE '1960-01-01', 3), (DATE '2020-01-01', 4)");
         assertQuery("SELECT * FROM old_dates WHERE d = DATE '0099-12-30'", "VALUES (DATE '0099-12-30', 1)");
         assertQuery("SELECT * FROM old_dates WHERE d = DATE '1582-10-15'", "VALUES (DATE '1582-10-15', 2)");
@@ -1166,7 +1166,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
         assertThat(listCheckpointFiles(transactionLogDirectory)).hasSize(1);
         testCountQuery(format("SELECT count(*) FROM %s WHERE l = 0", tableName), 3, 3);
 
-        // fill in with extra transaction to force one more checkpoint made by SEP
+        // fill in with extra transaction to force one more checkpoint made by Trino
         // the checkpoint will be based on DB checkpoint which includes only struct stats
         assertUpdate(format("INSERT INTO %s VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)", tableName), 1);
         assertUpdate(format("INSERT INTO %s VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)", tableName), 1);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
@@ -81,7 +81,7 @@ public class TestDeltaLakePageSink
             List<LineItemColumn> columns = ImmutableList.copyOf(LineItemColumn.values());
             List<Type> columnTypes = columns.stream()
                     .map(LineItemColumn::getType)
-                    .map(TestDeltaLakePageSink::getPrestoType)
+                    .map(TestDeltaLakePageSink::getTrinoType)
                     .collect(toList());
 
             PageBuilder pageBuilder = new PageBuilder(columnTypes);
@@ -185,13 +185,13 @@ public class TestDeltaLakePageSink
         for (LineItemColumn column : columns) {
             handles.add(new DeltaLakeColumnHandle(
                     column.getColumnName(),
-                    getPrestoType(column.getType()),
+                    getTrinoType(column.getType()),
                     REGULAR));
         }
         return handles.build();
     }
 
-    private static Type getPrestoType(TpchColumnType type)
+    private static Type getTrinoType(TpchColumnType type)
     {
         switch (type.getBase()) {
             case IDENTIFIER:

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeReadTimestamps.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeReadTimestamps.java
@@ -158,11 +158,11 @@ public class TestDeltaLakeReadTimestamps
         String actual = "SELECT col_0, " + projections + " FROM read_timestamps WHERE col_0 = '" + zone + "'";
         Session session = sessionBuilder.build();
         assertQuery(session, actual, expected);
-        actual = "SELECT col_0, " + projections + " FROM read_timestamps WHERE " + buildPrestoWhereClauses(zone, testCases);
+        actual = "SELECT col_0, " + projections + " FROM read_timestamps WHERE " + buildTrinoWhereClauses(zone, testCases);
         assertQuery(session, actual, expected);
     }
 
-    private String buildPrestoWhereClauses(String zone, List<Instant> testCases)
+    private String buildTrinoWhereClauses(String zone, List<Instant> testCases)
     {
         List<String> predicates = new ArrayList<>();
         // partition values


### PR DESCRIPTION
We missed a few references to "Presto" and "SEP" in the Delta Lake connector; I've fixed these to say "Trino."