### PR TITLE
Allow starting Elasticsearch container with VM options in query runner

### DIFF
--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchExternalQueryRunner.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchExternalQueryRunner.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.elasticsearch;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.net.HostAndPort;
+import io.airlift.log.Logger;
+import io.airlift.log.Logging;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.tpch.TpchTable;
+
+import static io.trino.plugin.elasticsearch.ElasticsearchQueryRunner.createElasticsearchQueryRunner;
+import static java.lang.Integer.parseInt;
+
+public class ElasticsearchExternalQueryRunner
+{
+    private static final String HOSTNAME = System.getProperty("elasticsearch.host", "localhost");
+    private static final int PORT = parseInt(System.getProperty("elasticsearch.port", "9200"));
+
+    private ElasticsearchExternalQueryRunner() {}
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        // Please set hostname and port via VM options. e.g. "-Delasticsearch.host=localhost -Delasticsearch.port=9200"
+        // To start Elasticsearch:
+        // docker run -p 9200:9200 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.6.2
+        Logging.initialize();
+
+        DistributedQueryRunner queryRunner = createElasticsearchQueryRunner(
+                HostAndPort.fromParts(HOSTNAME, PORT),
+                TpchTable.getTables(),
+                ImmutableMap.of("http-server.http.port", "8080"),
+                ImmutableMap.of(),
+                3);
+
+        Logger log = Logger.get(ElasticsearchExternalQueryRunner.class);
+        log.info("======== SERVER STARTED ========");
+        log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());
+    }
+}

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchQueryRunner.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchQueryRunner.java
@@ -33,6 +33,7 @@ import java.util.Map;
 
 import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.airlift.units.Duration.nanosSince;
+import static io.trino.plugin.elasticsearch.ElasticsearchServer.ELASTICSEARCH_7_IMAGE;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.lang.String.format;
@@ -127,13 +128,10 @@ public final class ElasticsearchQueryRunner
     public static void main(String[] args)
             throws Exception
     {
-        // To start Elasticsearch:
-        // docker run -p 9200:9200 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.6.2
-
         Logging.initialize();
 
         DistributedQueryRunner queryRunner = createElasticsearchQueryRunner(
-                HostAndPort.fromParts("localhost", 9200),
+                new ElasticsearchServer(ELASTICSEARCH_7_IMAGE, ImmutableMap.of()).getAddress(),
                 TpchTable.getTables(),
                 ImmutableMap.of("http-server.http.port", "8080"),
                 ImmutableMap.of(),

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchServer.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchServer.java
@@ -31,6 +31,8 @@ import static org.testcontainers.utility.MountableFile.forHostPath;
 
 public class ElasticsearchServer
 {
+    public static final String ELASTICSEARCH_7_IMAGE = "elasticsearch:7.0.0";
+
     private final Path configurationPath;
     private final ElasticsearchContainer container;
 

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearch7ConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearch7ConnectorTest.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.elasticsearch;
 
+import static io.trino.plugin.elasticsearch.ElasticsearchServer.ELASTICSEARCH_7_IMAGE;
 import static java.lang.String.format;
 
 public class TestElasticsearch7ConnectorTest
@@ -20,7 +21,7 @@ public class TestElasticsearch7ConnectorTest
 {
     public TestElasticsearch7ConnectorTest()
     {
-        super("elasticsearch:7.0.0");
+        super(ELASTICSEARCH_7_IMAGE);
     }
 
     @Override


### PR DESCRIPTION
## Description

Allow starting Elasticsearch container with VM options in query runner

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

