### PR TITLE
Use Sphinx default width in documentation

### DIFF
--- a/docs/src/main/sphinx/static/trino.css
+++ b/docs/src/main/sphinx/static/trino.css
@@ -60,16 +60,6 @@ pre.literal-block {
     font-size: 0.8rem
 }
 
-@media only screen and (min-width: 88.25em) {
-    .md-grid {
-        max-width: 61rem;
-    }
-
-    .md-sidebar--secondary {
-        margin-left: 61rem;
-    }
-}
-
 .o-tooltip--left:after {
     font-size: 0.6rem;
 }


### PR DESCRIPTION
## Description

Use Sphinx default width in documentation

Default CSS exists at https://github.com/bashtage/sphinx-material/blob/main/sphinx_material/sphinx_material/static/stylesheets/application.css

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

### Before 
<img width="1775" alt="Screen Shot 2022-03-10 at 17 07 51" src="https://user-images.githubusercontent.com/6237050/157616817-cf06b34e-d585-499d-9b9a-3be91e8a2de6.png">

### After
<img width="1776" alt="Screen Shot 2022-03-10 at 17 07 58" src="https://user-images.githubusercontent.com/6237050/157616859-021a22f4-dd25-4465-a672-5d725a43b680.png">
