### PR TITLE
Ensure that underlying resources of the parquet reader are closed

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeUpdatablePageSource.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeUpdatablePageSource.java
@@ -239,9 +239,8 @@ public class DeltaLakeUpdatablePageSource
         checkArgument(rowIdColumnIndex.isPresent(), "RowId column was not provided during delete operation");
         this.rowIdColumnIndex = rowIdColumnIndex.getAsInt();
 
-        try {
-            Path fsPath = new Path(path);
-            ParquetFileReader parquetReader = ParquetFileReader.open(HadoopInputFile.fromPath(fsPath, hdfsEnvironment.getConfiguration(hdfsContext, fsPath)));
+        Path fsPath = new Path(path);
+        try (ParquetFileReader parquetReader = ParquetFileReader.open(HadoopInputFile.fromPath(fsPath, hdfsEnvironment.getConfiguration(hdfsContext, fsPath)))) {
             checkArgument(parquetReader.getRecordCount() <= Integer.MAX_VALUE, "Deletes from files with more than Integer.MAX_VALUE rows is not supported");
             this.totalRecordCount = toIntExact(parquetReader.getRecordCount());
             this.rowsToDelete = new BitSet(totalRecordCount);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorSmokeTest.java
@@ -57,6 +57,7 @@ public class TestDeltaLakeConnectorSmokeTest
                 ImmutableMap.<String, String>builder()
                         .putAll(connectorProperties)
                         .put("delta.enable-non-concurrent-writes", "true")
+                        .put("hive.s3.max-connections", "2")
                         .buildOrThrow(),
                 dockerizedMinioDataLake.getMinioAddress(),
                 dockerizedMinioDataLake.getTestingHadoop());

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeOptimizedWriterConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeOptimizedWriterConnectorSmokeTest.java
@@ -34,6 +34,7 @@ public class TestDeltaLakeOptimizedWriterConnectorSmokeTest
                         .putAll(connectorProperties)
                         .put("parquet.experimental-optimized-writer.enabled", "true")
                         .put("delta.enable-non-concurrent-writes", "true")
+                        .put("hive.s3.max-connections", "2")
                         .buildOrThrow(),
                 dockerizedMinioDataLake.getMinioAddress(),
                 dockerizedMinioDataLake.getTestingHadoop());


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

Release the underlying resources after reading the number of records from the Parquet file.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Delta Lake connector.

> How would you describe this change to a non-technical end user or system administrator?

Before this change, the underlying AWS client library which was accumulating “leased” connections after each `UPDATE` statement performed via delta-lake connector. This sounded like a connection leak.
The current change makes sure that the underlying resources after reading the number of records from the Parquet file
via AWS S3 API are being closed. In this manner, the leased connection is being released.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
