### PR TITLE
Support renaming table in MongoDB

### DIFF
--- a/docs/src/main/sphinx/connector/mongodb.rst
+++ b/docs/src/main/sphinx/connector/mongodb.rst
@@ -389,5 +389,6 @@ statements, the connector supports the following features:
 ALTER TABLE
 ^^^^^^^^^^^
 
-The connector does not support ``ALTER TABLE RENAME`` operations. Other uses of
-``ALTER TABLE`` are supported.
+The connector supports ``ALTER TABLE RENAME TO``, ``ALTER TABLE ADD COLUMN``
+and ``ALTER TABLE DROP COLUMN`` operations.
+Other uses of ``ALTER TABLE`` are not supported.

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
@@ -199,6 +199,13 @@ public class MongoMetadata
     }
 
     @Override
+    public void renameTable(ConnectorSession session, ConnectorTableHandle tableHandle, SchemaTableName newTableName)
+    {
+        MongoTableHandle table = (MongoTableHandle) tableHandle;
+        mongoSession.renameTable(table.getSchemaTableName(), newTableName);
+    }
+
+    @Override
     public void addColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnMetadata column)
     {
         mongoSession.addColumn(((MongoTableHandle) tableHandle).getSchemaTableName(), column);

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorSmokeTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorSmokeTest.java
@@ -26,9 +26,6 @@ public abstract class BaseMongoConnectorSmokeTest
             case SUPPORTS_RENAME_SCHEMA:
                 return false;
 
-            case SUPPORTS_RENAME_TABLE:
-                return false;
-
             case SUPPORTS_NOT_NULL_CONSTRAINT:
                 return false;
 

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorTest.java
@@ -63,7 +63,6 @@ public abstract class BaseMongoConnectorTest
         switch (connectorBehavior) {
             case SUPPORTS_RENAME_SCHEMA:
             case SUPPORTS_NOT_NULL_CONSTRAINT:
-            case SUPPORTS_RENAME_TABLE:
             case SUPPORTS_RENAME_COLUMN:
                 return false;
             default:
@@ -468,6 +467,21 @@ public abstract class BaseMongoConnectorTest
 
         assertQuery("SELECT value FROM testcase.testinsensitive WHERE name = 'def'", "SELECT 2");
         assertUpdate("DROP TABLE testcase.testinsensitive");
+    }
+
+    @Test
+    public void testCaseInsensitiveRenameTable()
+    {
+        MongoCollection<Document> collection = client.getDatabase("testCase_RenameTable").getCollection("testInsensitive_RenameTable");
+        collection.insertOne(new Document(ImmutableMap.of("value", 1)));
+        assertQuery("SHOW TABLES IN testcase_renametable", "SELECT 'testinsensitive_renametable'");
+        assertQuery("SELECT value FROM testcase_renametable.testinsensitive_renametable", "SELECT 1");
+
+        assertUpdate("ALTER TABLE testcase_renametable.testinsensitive_renametable RENAME TO testcase_renametable.testinsensitive_renamed_table");
+
+        assertQuery("SHOW TABLES IN testcase_renametable", "SELECT 'testinsensitive_renamed_table'");
+        assertQuery("SELECT value FROM testcase_renametable.testinsensitive_renamed_table", "SELECT 1");
+        assertUpdate("DROP TABLE testcase_renametable.testinsensitive_renamed_table");
     }
 
     @Test


### PR DESCRIPTION
## Description

Support renaming table in MongoDB

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# MongoDB
* Add support for [`ALTER TABLE ... RENAME TO ...`](/sql/alter-table). ({issue}`11423`)
```
