### PR TITLE
Support table comment in MongoDB

### DIFF
--- a/docs/src/main/sphinx/connector/mongodb.rst
+++ b/docs/src/main/sphinx/connector/mongodb.rst
@@ -369,6 +369,7 @@ statements, the connector supports the following features:
 * :doc:`/sql/alter-table`
 * :doc:`/sql/create-schema`
 * :doc:`/sql/drop-schema`
+* :doc:`/sql/comment` only supports ``COMMENT ON TABLE``
 
 ALTER TABLE
 ^^^^^^^^^^^

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoTable.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoTable.java
@@ -16,20 +16,24 @@ package io.trino.plugin.mongodb;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
 
 public class MongoTable
 {
     private final MongoTableHandle tableHandle;
     private final List<MongoColumnHandle> columns;
     private final List<MongoIndex> indexes;
+    private final Optional<String> comment;
 
-    public MongoTable(MongoTableHandle tableHandle, List<MongoColumnHandle> columns, List<MongoIndex> indexes)
+    public MongoTable(MongoTableHandle tableHandle, List<MongoColumnHandle> columns, List<MongoIndex> indexes, Optional<String> comment)
     {
         this.tableHandle = tableHandle;
         this.columns = ImmutableList.copyOf(columns);
         this.indexes = ImmutableList.copyOf(indexes);
+        this.comment = requireNonNull(comment, "comment is null");
     }
 
     public MongoTableHandle getTableHandle()
@@ -45,6 +49,11 @@ public class MongoTable
     public List<MongoIndex> getIndexes()
     {
         return indexes;
+    }
+
+    public Optional<String> getComment()
+    {
+        return comment;
     }
 
     @Override

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorTest.java
@@ -65,7 +65,6 @@ public abstract class BaseMongoConnectorTest
             case SUPPORTS_NOT_NULL_CONSTRAINT:
             case SUPPORTS_RENAME_TABLE:
             case SUPPORTS_RENAME_COLUMN:
-            case SUPPORTS_COMMENT_ON_TABLE:
             case SUPPORTS_COMMENT_ON_COLUMN:
                 return false;
             default:


### PR DESCRIPTION
## Description

Support table comment in MongoDB

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Section
* Add support for [`COMMENT ON TABLE`](/sql/comment). ({issue}`11424`)
```
