### PR TITLE
Remove useless import in TableExecute

### DIFF
--- a/core/trino-parser/src/main/java/io/trino/sql/tree/TableExecute.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/TableExecute.java
@@ -14,7 +14,6 @@
 package io.trino.sql.tree;
 
 import com.google.common.collect.ImmutableList;
-import org.checkerframework.checker.units.qual.C;
 
 import java.util.List;
 import java.util.Objects;


### PR DESCRIPTION
## Description

Remove useless import in ``io.trino.sql.tree.TableExecute``

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Remove useless import in ``io.trino.sql.tree.TableExecute``.
```
