### PR TITLE
Avoid using duplicated link names

### DIFF
--- a/docs/src/main/sphinx/connector/jdbc-type-mapping.fragment
+++ b/docs/src/main/sphinx/connector/jdbc-type-mapping.fragment
@@ -1,5 +1,5 @@
-General configuration properties
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Type mapping configuration properties
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The following properties can be used to configure how data types from the
 connected data source are mapped to Trino data types and how the metadata is


### PR DESCRIPTION
After generating /sphinx/connector/redshift.rst by Sphinx, there are two conflicts ids. Change the name of the configuration in 'Type mapping' from 'General configuration properties' to 'Type mapping configuration properties'

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

change a  fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

documetation

> How would you describe this change to a non-technical end user or system administrator?

This change makes it easier to find and understand the Trino properties reference docs.

## Related issues, pull requests, and links

* Fixes #11381

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:
