### PR TITLE
Deny comment on unsupported table

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/CreateTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateTableTask.java
@@ -71,6 +71,7 @@ import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.TABLE_ALREADY_EXISTS;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.TYPE_NOT_FOUND;
+import static io.trino.spi.connector.ConnectorCapabilities.COMMENT_ON_TABLE;
 import static io.trino.spi.connector.ConnectorCapabilities.NOT_NULL_COLUMN_CONSTRAINT;
 import static io.trino.sql.ParameterUtils.parameterExtractor;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
@@ -134,6 +135,10 @@ public class CreateTableTask
         }
 
         CatalogName catalogName = getRequiredCatalogHandle(plannerContext.getMetadata(), session, statement, tableName.getCatalogName());
+
+        if (statement.getComment().isPresent() && !plannerContext.getMetadata().getConnectorCapabilities(session, catalogName).contains(COMMENT_ON_TABLE)) {
+            throw new TrinoException(NOT_SUPPORTED, "This connector does not support setting table comments");
+        }
 
         LinkedHashMap<String, ColumnMetadata> columns = new LinkedHashMap<>();
         Map<String, Object> inheritedProperties = ImmutableMap.of();

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorCapabilities.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorCapabilities.java
@@ -16,4 +16,5 @@ package io.trino.spi.connector;
 public enum ConnectorCapabilities
 {
     NOT_NULL_COLUMN_CONSTRAINT,
+    COMMENT_ON_TABLE,
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConnector.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConnector.java
@@ -20,6 +20,7 @@ import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorAccessControl;
+import io.trino.spi.connector.ConnectorCapabilities;
 import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.ConnectorNodePartitioningProvider;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
@@ -39,6 +40,8 @@ import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Sets.immutableEnumSet;
+import static io.trino.spi.connector.ConnectorCapabilities.COMMENT_ON_TABLE;
 import static io.trino.spi.transaction.IsolationLevel.READ_UNCOMMITTED;
 import static io.trino.spi.transaction.IsolationLevel.checkConnectorSupports;
 import static java.util.Objects.requireNonNull;
@@ -217,6 +220,12 @@ public class HiveConnector
     public final void shutdown()
     {
         lifeCycleManager.stop();
+    }
+
+    @Override
+    public Set<ConnectorCapabilities> getCapabilities()
+    {
+        return immutableEnumSet(COMMENT_ON_TABLE);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConnector.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConnector.java
@@ -40,6 +40,7 @@ import java.util.Set;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Sets.immutableEnumSet;
+import static io.trino.spi.connector.ConnectorCapabilities.COMMENT_ON_TABLE;
 import static io.trino.spi.connector.ConnectorCapabilities.NOT_NULL_COLUMN_CONSTRAINT;
 import static io.trino.spi.transaction.IsolationLevel.SERIALIZABLE;
 import static io.trino.spi.transaction.IsolationLevel.checkConnectorSupports;
@@ -94,7 +95,7 @@ public class IcebergConnector
     @Override
     public Set<ConnectorCapabilities> getCapabilities()
     {
-        return immutableEnumSet(NOT_NULL_COLUMN_CONSTRAINT);
+        return immutableEnumSet(NOT_NULL_COLUMN_CONSTRAINT, COMMENT_ON_TABLE);
     }
 
     @Override

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -2002,6 +2002,23 @@ public abstract class BaseConnectorTest
     }
 
     @Test
+    public void testCreateTableWithComment()
+    {
+        String tableName = "test_create_" + randomTableSuffix();
+        String createTable = "CREATE TABLE " + tableName + " (a bigint) COMMENT 'foo'";
+
+        if (!hasBehavior(SUPPORTS_COMMENT_ON_TABLE)) {
+            assertThatThrownBy(() ->
+                    assertUpdate(createTable))
+                    .hasMessage("This connector does not support setting table comments");
+        }
+        else {
+            assertUpdate(createTable);
+            assertThat(getTableComment(tableName)).isEqualTo("foo");
+        }
+    }
+
+    @Test
     public void testCommentTable()
     {
         if (!hasBehavior(SUPPORTS_COMMENT_ON_TABLE)) {


### PR DESCRIPTION
## Description

Deny comment on unsupported table

> Is this change a fix, improvement, new feature, refactoring, or other?
It is a fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
CreateTableTask and CommentTask

> How would you describe this change to a non-technical end user or system administrator?
It will deny the operate of comment on unsupported table when you create table with comment or comment on table.

## Related issues, pull requests, and links

* Fixes [#11348](https://github.com/trinodb/trino/issues/11348)

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix deny the operate of comment on unsupported table. ({issue}`11348`)
```
