### PR TITLE
Expire PageFunction and CursorProcessor caches by time

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/gen/ExpressionCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/ExpressionCompiler.java
@@ -53,6 +53,7 @@ import static io.trino.sql.relational.Expressions.constant;
 import static io.trino.util.CompilerUtils.defineClass;
 import static io.trino.util.CompilerUtils.makeClassName;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.HOURS;
 
 public class ExpressionCompiler
 {
@@ -67,7 +68,8 @@ public class ExpressionCompiler
         this.pageFunctionCompiler = requireNonNull(pageFunctionCompiler, "pageFunctionCompiler is null");
         this.cursorProcessors = buildNonEvictableCache(CacheBuilder.newBuilder()
                         .recordStats()
-                        .maximumSize(1000),
+                        .maximumSize(1000)
+                        .expireAfterWrite(1, HOURS),
                 CacheLoader.from(key -> compile(key.getFilter(), key.getProjections(), new CursorProcessorCompiler(metadata), CursorProcessor.class)));
         this.cacheStatsMBean = new CacheStatsMBean(cursorProcessors);
     }

--- a/core/trino-main/src/main/java/io/trino/sql/gen/PageFunctionCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/PageFunctionCompiler.java
@@ -98,6 +98,7 @@ import static io.trino.util.CompilerUtils.defineClass;
 import static io.trino.util.CompilerUtils.makeClassName;
 import static io.trino.util.Reflection.constructorMethodHandle;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.HOURS;
 
 public class PageFunctionCompiler
 {
@@ -123,7 +124,8 @@ public class PageFunctionCompiler
             projectionCache = buildNonEvictableCache(
                     CacheBuilder.newBuilder()
                             .recordStats()
-                            .maximumSize(expressionCacheSize),
+                            .maximumSize(expressionCacheSize)
+                            .expireAfterWrite(1, HOURS),
                     CacheLoader.from(projection -> compileProjectionInternal(projection, Optional.empty())));
             projectionCacheStats = new CacheStatsMBean(projectionCache);
         }
@@ -136,7 +138,8 @@ public class PageFunctionCompiler
             filterCache = buildNonEvictableCache(
                     CacheBuilder.newBuilder()
                             .recordStats()
-                            .maximumSize(expressionCacheSize),
+                            .maximumSize(expressionCacheSize)
+                            .expireAfterWrite(1, HOURS),
                     CacheLoader.from(filter -> compileFilterInternal(filter, Optional.empty())));
             filterCacheStats = new CacheStatsMBean(filterCache);
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

Set cache expiration time for generated PageFunction classes and CursorProcessor classes.

## Related issues, pull requests, and links
Relates to https://github.com/trinodb/trino/issues/11234 and https://github.com/trinodb/trino/pull/11358

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

() No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Section
* Set cache expiration time for generated PageFunction classes and CursorProcessor classes. ([{issue}`11234`]
```
