### PR TITLE
Remove incorrect development rule about alphabetizing code

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -52,9 +52,7 @@ In addition to those you should also adhere to the following:
 ### Alphabetize
 
 Alphabetize sections in the documentation source files (both in the table of
-contents files and other regular documentation files).  In general, alphabetize
-methods/variables/sections if such ordering already exists in the surrounding
-code.
+contents files and other regular documentation files).
 
 ### Use streams
 


### PR DESCRIPTION
Documentation listings, like list of connectors, should probably be
alphabetized, but code sections do not. The logic ordering of
components, and grouping of related things, is more important.
