### PR TITLE
Change return type of trim functions with char argument to varchar

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/StringFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/StringFunctions.java
@@ -483,7 +483,7 @@ public final class StringFunctions
     @Description("Removes whitespace from the beginning of a string")
     @ScalarFunction("ltrim")
     @LiteralParameters("x")
-    @SqlType("char(x)")
+    @SqlType("varchar(x)")
     public static Slice charLeftTrim(@SqlType("char(x)") Slice slice)
     {
         return SliceUtf8.leftTrim(slice);
@@ -501,7 +501,7 @@ public final class StringFunctions
     @Description("Removes whitespace from the end of a string")
     @ScalarFunction("rtrim")
     @LiteralParameters("x")
-    @SqlType("char(x)")
+    @SqlType("varchar(x)")
     public static Slice charRightTrim(@SqlType("char(x)") Slice slice)
     {
         return rightTrim(slice);
@@ -519,7 +519,7 @@ public final class StringFunctions
     @Description("Removes whitespace from the beginning and end of a string")
     @ScalarFunction("trim")
     @LiteralParameters("x")
-    @SqlType("char(x)")
+    @SqlType("varchar(x)")
     public static Slice charTrim(@SqlType("char(x)") Slice slice)
     {
         return trim(slice);
@@ -537,7 +537,7 @@ public final class StringFunctions
     @Description("Remove the longest string containing only given characters from the beginning of a string")
     @ScalarFunction("ltrim")
     @LiteralParameters("x")
-    @SqlType("char(x)")
+    @SqlType("varchar(x)")
     public static Slice charLeftTrim(@SqlType("char(x)") Slice slice, @SqlType(CodePointsType.NAME) int[] codePointsToTrim)
     {
         return leftTrim(slice, codePointsToTrim);
@@ -555,7 +555,7 @@ public final class StringFunctions
     @Description("Remove the longest string containing only given characters from the end of a string")
     @ScalarFunction("rtrim")
     @LiteralParameters("x")
-    @SqlType("char(x)")
+    @SqlType("varchar(x)")
     public static Slice charRightTrim(@SqlType("char(x)") Slice slice, @SqlType(CodePointsType.NAME) int[] codePointsToTrim)
     {
         return trimTrailingSpaces(rightTrim(slice, codePointsToTrim));
@@ -573,7 +573,7 @@ public final class StringFunctions
     @Description("Remove the longest string containing only given characters from the beginning and end of a string")
     @ScalarFunction("trim")
     @LiteralParameters("x")
-    @SqlType("char(x)")
+    @SqlType("varchar(x)")
     public static Slice charTrim(@SqlType("char(x)") Slice slice, @SqlType(CodePointsType.NAME) int[] codePointsToTrim)
     {
         return trimTrailingSpaces(trim(slice, codePointsToTrim));

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestStringFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestStringFunctions.java
@@ -623,16 +623,16 @@ public class TestStringFunctions
     @Test
     public void testCharLeftTrim()
     {
-        assertFunction("LTRIM(CAST('' AS CHAR(20)))", createCharType(20), padRight("", 20));
-        assertFunction("LTRIM(CAST('  hello  ' AS CHAR(9)))", createCharType(9), padRight("hello", 9));
-        assertFunction("LTRIM(CAST('  hello' AS CHAR(7)))", createCharType(7), padRight("hello", 7));
-        assertFunction("LTRIM(CAST('hello  ' AS CHAR(7)))", createCharType(7), padRight("hello", 7));
-        assertFunction("LTRIM(CAST(' hello world ' AS CHAR(13)))", createCharType(13), padRight("hello world", 13));
+        assertFunction("LTRIM(CAST('' AS CHAR(20)))", createVarcharType(20), "");
+        assertFunction("LTRIM(CAST('  hello  ' AS CHAR(9)))", createVarcharType(9), "hello");
+        assertFunction("LTRIM(CAST('  hello' AS CHAR(7)))", createVarcharType(7), "hello");
+        assertFunction("LTRIM(CAST('hello  ' AS CHAR(7)))", createVarcharType(7), "hello");
+        assertFunction("LTRIM(CAST(' hello world ' AS CHAR(13)))", createVarcharType(13), "hello world");
 
-        assertFunction("LTRIM(CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ' AS CHAR(9)))", createCharType(9), padRight("\u4FE1\u5FF5 \u7231 \u5E0C\u671B", 9));
-        assertFunction("LTRIM(CAST(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ' AS CHAR(9)))", createCharType(9), padRight("\u4FE1\u5FF5 \u7231 \u5E0C\u671B", 9));
-        assertFunction("LTRIM(CAST('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(9)))", createCharType(9), padRight("\u4FE1\u5FF5 \u7231 \u5E0C\u671B", 9));
-        assertFunction("LTRIM(CAST(' \u2028 \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(10)))", createCharType(10), padRight("\u4FE1\u5FF5 \u7231 \u5E0C\u671B", 10));
+        assertFunction("LTRIM(CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ' AS CHAR(9)))", createVarcharType(9), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
+        assertFunction("LTRIM(CAST(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ' AS CHAR(9)))", createVarcharType(9), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
+        assertFunction("LTRIM(CAST('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(9)))", createVarcharType(9), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
+        assertFunction("LTRIM(CAST(' \u2028 \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(10)))", createVarcharType(10), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
     }
 
     @Test
@@ -654,16 +654,16 @@ public class TestStringFunctions
     @Test
     public void testCharRightTrim()
     {
-        assertFunction("RTRIM(CAST('' AS CHAR(20)))", createCharType(20), padRight("", 20));
-        assertFunction("RTRIM(CAST('  hello  ' AS CHAR(9)))", createCharType(9), padRight("  hello", 9));
-        assertFunction("RTRIM(CAST('  hello' AS CHAR(7)))", createCharType(7), padRight("  hello", 7));
-        assertFunction("RTRIM(CAST('hello  ' AS CHAR(7)))", createCharType(7), padRight("hello", 7));
-        assertFunction("RTRIM(CAST(' hello world ' AS CHAR(13)))", createCharType(13), padRight(" hello world", 13));
+        assertFunction("RTRIM(CAST('' AS CHAR(20)))", createVarcharType(20), "");
+        assertFunction("RTRIM(CAST('  hello  ' AS CHAR(9)))", createVarcharType(9), "  hello");
+        assertFunction("RTRIM(CAST('  hello' AS CHAR(7)))", createVarcharType(7), "  hello");
+        assertFunction("RTRIM(CAST('hello  ' AS CHAR(7)))", createVarcharType(7), "hello");
+        assertFunction("RTRIM(CAST(' hello world ' AS CHAR(13)))", createVarcharType(13), " hello world");
 
-        assertFunction("RTRIM(CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 ' AS CHAR(10)))", createCharType(10), padRight("\u4FE1\u5FF5 \u7231 \u5E0C\u671B", 10));
-        assertFunction("RTRIM(CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ' AS CHAR(9)))", createCharType(9), padRight("\u4FE1\u5FF5 \u7231 \u5E0C\u671B", 9));
-        assertFunction("RTRIM(CAST(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ' AS CHAR(9)))", createCharType(9), padRight(" \u4FE1\u5FF5 \u7231 \u5E0C\u671B", 9));
-        assertFunction("RTRIM(CAST('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(9)))", createCharType(9), padRight("  \u4FE1\u5FF5 \u7231 \u5E0C\u671B", 9));
+        assertFunction("RTRIM(CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 ' AS CHAR(10)))", createVarcharType(10), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
+        assertFunction("RTRIM(CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ' AS CHAR(9)))", createVarcharType(9), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
+        assertFunction("RTRIM(CAST(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ' AS CHAR(9)))", createVarcharType(9), " \u4FE1\u5FF5 \u7231 \u5E0C\u671B");
+        assertFunction("RTRIM(CAST('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(9)))", createVarcharType(9), "  \u4FE1\u5FF5 \u7231 \u5E0C\u671B");
     }
 
     @Test
@@ -686,17 +686,17 @@ public class TestStringFunctions
     @Test
     public void testCharTrim()
     {
-        assertFunction("TRIM(CAST('' AS CHAR(20)))", createCharType(20), padRight("", 20));
-        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)))", createCharType(9), padRight("hello", 9));
-        assertFunction("TRIM(CAST('  hello' AS CHAR(7)))", createCharType(7), padRight("hello", 7));
-        assertFunction("TRIM(CAST('hello  ' AS CHAR(7)))", createCharType(7), padRight("hello", 7));
-        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)))", createCharType(13), padRight("hello world", 13));
+        assertFunction("TRIM(CAST('' AS CHAR(20)))", createVarcharType(20), "");
+        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)))", createVarcharType(9), "hello");
+        assertFunction("TRIM(CAST('  hello' AS CHAR(7)))", createVarcharType(7), "hello");
+        assertFunction("TRIM(CAST('hello  ' AS CHAR(7)))", createVarcharType(7), "hello");
+        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)))", createVarcharType(13), "hello world");
 
-        assertFunction("TRIM(CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 ' AS CHAR(10)))", createCharType(10), padRight("\u4FE1\u5FF5 \u7231 \u5E0C\u671B", 10));
-        assertFunction("TRIM(CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ' AS CHAR(9)))", createCharType(9), padRight("\u4FE1\u5FF5 \u7231 \u5E0C\u671B", 9));
-        assertFunction("TRIM(CAST(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ' AS CHAR(9)))", createCharType(9), padRight("\u4FE1\u5FF5 \u7231 \u5E0C\u671B", 9));
-        assertFunction("TRIM(CAST('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(9)))", createCharType(9), padRight("\u4FE1\u5FF5 \u7231 \u5E0C\u671B", 9));
-        assertFunction("TRIM(CAST(' \u2028 \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(10)))", createCharType(10), padRight("\u4FE1\u5FF5 \u7231 \u5E0C\u671B", 10));
+        assertFunction("TRIM(CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 ' AS CHAR(10)))", createVarcharType(10), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
+        assertFunction("TRIM(CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ' AS CHAR(9)))", createVarcharType(9), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
+        assertFunction("TRIM(CAST(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ' AS CHAR(9)))", createVarcharType(9), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
+        assertFunction("TRIM(CAST('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(9)))", createVarcharType(9), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
+        assertFunction("TRIM(CAST(' \u2028 \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(10)))", createVarcharType(10), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
     }
 
     @Test
@@ -731,21 +731,21 @@ public class TestStringFunctions
     @Test
     public void testCharLeftTrimParametrized()
     {
-        assertFunction("LTRIM(CAST('' AS CHAR(1)), '')", createCharType(1), padRight("", 1));
-        assertFunction("LTRIM(CAST('   ' AS CHAR(3)), '')", createCharType(3), padRight("", 3));
-        assertFunction("LTRIM(CAST('  hello  ' AS CHAR(9)), '')", createCharType(9), padRight("  hello", 9));
-        assertFunction("LTRIM(CAST('  hello  ' AS CHAR(9)), ' ')", createCharType(9), padRight("hello", 9));
-        assertFunction("LTRIM(CAST('  hello  ' AS CHAR(9)), 'he ')", createCharType(9), padRight("llo", 9));
-        assertFunction("LTRIM(CAST('  hello' AS CHAR(7)), ' ')", createCharType(7), padRight("hello", 7));
-        assertFunction("LTRIM(CAST('  hello' AS CHAR(7)), 'e h')", createCharType(7), padRight("llo", 7));
-        assertFunction("LTRIM(CAST('hello  ' AS CHAR(7)), 'l')", createCharType(7), padRight("hello", 7));
-        assertFunction("LTRIM(CAST(' hello world ' AS CHAR(13)), ' ')", createCharType(13), padRight("hello world", 13));
-        assertFunction("LTRIM(CAST(' hello world ' AS CHAR(13)), ' eh')", createCharType(13), padRight("llo world", 13));
-        assertFunction("LTRIM(CAST(' hello world ' AS CHAR(13)), ' ehlowrd')", createCharType(13), padRight("", 13));
-        assertFunction("LTRIM(CAST(' hello world ' AS CHAR(13)), ' x')", createCharType(13), padRight("hello world", 13));
+        assertFunction("LTRIM(CAST('' AS CHAR(1)), '')", createVarcharType(1), "");
+        assertFunction("LTRIM(CAST('   ' AS CHAR(3)), '')", createVarcharType(3), "");
+        assertFunction("LTRIM(CAST('  hello  ' AS CHAR(9)), '')", createVarcharType(9), "  hello");
+        assertFunction("LTRIM(CAST('  hello  ' AS CHAR(9)), ' ')", createVarcharType(9), "hello");
+        assertFunction("LTRIM(CAST('  hello  ' AS CHAR(9)), 'he ')", createVarcharType(9), "llo");
+        assertFunction("LTRIM(CAST('  hello' AS CHAR(7)), ' ')", createVarcharType(7), "hello");
+        assertFunction("LTRIM(CAST('  hello' AS CHAR(7)), 'e h')", createVarcharType(7), "llo");
+        assertFunction("LTRIM(CAST('hello  ' AS CHAR(7)), 'l')", createVarcharType(7), "hello");
+        assertFunction("LTRIM(CAST(' hello world ' AS CHAR(13)), ' ')", createVarcharType(13), "hello world");
+        assertFunction("LTRIM(CAST(' hello world ' AS CHAR(13)), ' eh')", createVarcharType(13), "llo world");
+        assertFunction("LTRIM(CAST(' hello world ' AS CHAR(13)), ' ehlowrd')", createVarcharType(13), "");
+        assertFunction("LTRIM(CAST(' hello world ' AS CHAR(13)), ' x')", createVarcharType(13), "hello world");
 
         // non latin characters
-        assertFunction("LTRIM(CAST('\u017a\u00f3\u0142\u0107' AS CHAR(4)), '\u00f3\u017a')", createCharType(4), padRight("\u0142\u0107", 4));
+        assertFunction("LTRIM(CAST('\u017a\u00f3\u0142\u0107' AS CHAR(4)), '\u00f3\u017a')", createVarcharType(4), "\u0142\u0107");
     }
 
     private static SqlVarbinary varbinary(int... bytesAsInts)
@@ -772,7 +772,7 @@ public class TestStringFunctions
         assertFunction("RTRIM(' hello world ', ' ld')", createVarcharType(13), " hello wor");
         assertFunction("RTRIM(' hello world ', ' ehlowrd')", createVarcharType(13), "");
         assertFunction("RTRIM(' hello world ', ' x')", createVarcharType(13), " hello world");
-        assertFunction("RTRIM(CAST('abc def' AS CHAR(7)), 'def')", createCharType(7), padRight("abc", 7));
+        assertFunction("RTRIM(CAST('abc def' AS CHAR(7)), 'def')", createVarcharType(7), "abc");
 
         // non latin characters
         assertFunction("RTRIM('\u017a\u00f3\u0142\u0107', '\u0107\u0142')", createVarcharType(4), "\u017a\u00f3");
@@ -789,21 +789,21 @@ public class TestStringFunctions
     @Test
     public void testCharRightTrimParametrized()
     {
-        assertFunction("RTRIM(CAST('' AS CHAR(1)), '')", createCharType(1), padRight("", 1));
-        assertFunction("RTRIM(CAST('   ' AS CHAR(3)), '')", createCharType(3), padRight("", 3));
-        assertFunction("RTRIM(CAST('  hello  ' AS CHAR(9)), '')", createCharType(9), padRight("  hello", 9));
-        assertFunction("RTRIM(CAST('  hello  ' AS CHAR(9)), ' ')", createCharType(9), padRight("  hello", 9));
-        assertFunction("RTRIM(CAST('  hello  ' AS CHAR(9)), 'he ')", createCharType(9), padRight("  hello", 9));
-        assertFunction("RTRIM(CAST('  hello' AS CHAR(7)), ' ')", createCharType(7), padRight("  hello", 7));
-        assertFunction("RTRIM(CAST('  hello' AS CHAR(7)), 'e h')", createCharType(7), padRight("  hello", 7));
-        assertFunction("RTRIM(CAST('hello  ' AS CHAR(7)), 'l')", createCharType(7), padRight("hello", 7));
-        assertFunction("RTRIM(CAST(' hello world ' AS CHAR(13)), ' ')", createCharType(13), padRight(" hello world", 13));
-        assertFunction("RTRIM(CAST(' hello world ' AS CHAR(13)), ' eh')", createCharType(13), padRight(" hello world", 13));
-        assertFunction("RTRIM(CAST(' hello world ' AS CHAR(13)), ' ehlowrd')", createCharType(13), padRight("", 13));
-        assertFunction("RTRIM(CAST(' hello world ' AS CHAR(13)), ' x')", createCharType(13), padRight(" hello world", 13));
+        assertFunction("RTRIM(CAST('' AS CHAR(1)), '')", createVarcharType(1), "");
+        assertFunction("RTRIM(CAST('   ' AS CHAR(3)), '')", createVarcharType(3), "");
+        assertFunction("RTRIM(CAST('  hello  ' AS CHAR(9)), '')", createVarcharType(9), "  hello");
+        assertFunction("RTRIM(CAST('  hello  ' AS CHAR(9)), ' ')", createVarcharType(9), "  hello");
+        assertFunction("RTRIM(CAST('  hello  ' AS CHAR(9)), 'he ')", createVarcharType(9), "  hello");
+        assertFunction("RTRIM(CAST('  hello' AS CHAR(7)), ' ')", createVarcharType(7), "  hello");
+        assertFunction("RTRIM(CAST('  hello' AS CHAR(7)), 'e h')", createVarcharType(7), "  hello");
+        assertFunction("RTRIM(CAST('hello  ' AS CHAR(7)), 'l')", createVarcharType(7), "hello");
+        assertFunction("RTRIM(CAST(' hello world ' AS CHAR(13)), ' ')", createVarcharType(13), " hello world");
+        assertFunction("RTRIM(CAST(' hello world ' AS CHAR(13)), ' eh')", createVarcharType(13), " hello world");
+        assertFunction("RTRIM(CAST(' hello world ' AS CHAR(13)), ' ehlowrd')", createVarcharType(13), "");
+        assertFunction("RTRIM(CAST(' hello world ' AS CHAR(13)), ' x')", createVarcharType(13), " hello world");
 
         // non latin characters
-        assertFunction("RTRIM(CAST('\u017a\u00f3\u0142\u0107' AS CHAR(4)), '\u0107\u0142')", createCharType(4), padRight("\u017a\u00f3", 4));
+        assertFunction("RTRIM(CAST('\u017a\u00f3\u0142\u0107' AS CHAR(4)), '\u0107\u0142')", createVarcharType(4), "\u017a\u00f3");
     }
 
     @Test
@@ -840,22 +840,22 @@ public class TestStringFunctions
     @Test
     public void testCharTrimParametrized()
     {
-        assertFunction("TRIM(CAST('' AS CHAR(1)), '')", createCharType(1), padRight("", 1));
-        assertFunction("TRIM(CAST('   ' AS CHAR(3)), '')", createCharType(3), padRight("", 3));
-        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)), '')", createCharType(9), padRight("  hello", 9));
-        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)), ' ')", createCharType(9), padRight("hello", 9));
-        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)), 'he ')", createCharType(9), padRight("llo", 9));
-        assertFunction("TRIM(CAST('  hello' AS CHAR(7)), ' ')", createCharType(7), padRight("hello", 7));
-        assertFunction("TRIM(CAST('  hello' AS CHAR(7)), 'e h')", createCharType(7), padRight("llo", 7));
-        assertFunction("TRIM(CAST('hello  ' AS CHAR(7)), 'l')", createCharType(7), padRight("hello", 7));
-        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' ')", createCharType(13), padRight("hello world", 13));
-        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' eh')", createCharType(13), padRight("llo world", 13));
-        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' ehlowrd')", createCharType(13), padRight("", 13));
-        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' x')", createCharType(13), padRight("hello world", 13));
-        assertFunction("TRIM(CAST('abc def' AS CHAR(7)), 'def')", createCharType(7), padRight("abc", 7));
+        assertFunction("TRIM(CAST('' AS CHAR(1)), '')", createVarcharType(1), "");
+        assertFunction("TRIM(CAST('   ' AS CHAR(3)), '')", createVarcharType(3), "");
+        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)), '')", createVarcharType(9), "  hello");
+        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)), ' ')", createVarcharType(9), "hello");
+        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)), 'he ')", createVarcharType(9), "llo");
+        assertFunction("TRIM(CAST('  hello' AS CHAR(7)), ' ')", createVarcharType(7), "hello");
+        assertFunction("TRIM(CAST('  hello' AS CHAR(7)), 'e h')", createVarcharType(7), "llo");
+        assertFunction("TRIM(CAST('hello  ' AS CHAR(7)), 'l')", createVarcharType(7), "hello");
+        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' ')", createVarcharType(13), "hello world");
+        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' eh')", createVarcharType(13), "llo world");
+        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' ehlowrd')", createVarcharType(13), "");
+        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' x')", createVarcharType(13), "hello world");
+        assertFunction("TRIM(CAST('abc def' AS CHAR(7)), 'def')", createVarcharType(7), "abc");
 
         // non latin characters
-        assertFunction("TRIM(CAST('\u017a\u00f3\u0142\u0107' AS CHAR(4)), '\u017a\u0107\u0142')", createCharType(4), padRight("\u00f3", 4));
+        assertFunction("TRIM(CAST('\u017a\u00f3\u0142\u0107' AS CHAR(4)), '\u017a\u0107\u0142')", createVarcharType(4), "\u00f3");
     }
 
     @Test


### PR DESCRIPTION
## Description

Change return type of trim functions with char argument to varchar

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# General
* Fix `trim`, `ltrim` and `rtim` function results when the argument is `char` type. 
  Previously, it returned padded results as `char` type. It returns `varchar` type without padding now. ({issue}`11440`)
```
