### PR TITLE
Bump postgresql driver to 42.3.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1595,7 +1595,7 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>42.3.1</version>
+                <version>42.3.3</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

It addresses CVE-2022-21724.

It also includes some fixes around calendars being used in thread-safe
way, result of PgObject#isNull, possible connection leak and loss of
microseconds when reading TIME(6) via getTimestamp.

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.