### PR TITLE
Migrate raptor connector to MySQL Connector/J 8.x

### DIFF
--- a/plugin/trino-raptor-legacy/pom.xml
+++ b/plugin/trino-raptor-legacy/pom.xml
@@ -147,8 +147,6 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <!-- TODO (https://github.com/trinodb/trino/issues/8302) update MySQL driver to version used everywhere else -->
-            <version>5.1.48</version>
         </dependency>
 
         <dependency>

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/util/DatabaseUtil.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/util/DatabaseUtil.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.raptor.legacy.util;
 
 import com.google.common.base.Throwables;
+import com.mysql.cj.jdbc.JdbcStatement;
 import io.trino.spi.TrinoException;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.HandleCallback;
@@ -33,7 +34,7 @@ import java.util.function.Predicate;
 
 import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.reflect.Reflection.newProxy;
-import static com.mysql.jdbc.MysqlErrorNumbers.ER_TRANS_CACHE_FULL;
+import static com.mysql.cj.exceptions.MysqlErrorNumbers.ER_TRANS_CACHE_FULL;
 import static io.trino.plugin.raptor.legacy.RaptorErrorCode.RAPTOR_METADATA_ERROR;
 import static java.sql.Types.INTEGER;
 import static java.util.Objects.requireNonNull;
@@ -109,8 +110,8 @@ public final class DatabaseUtil
     public static void enableStreamingResults(Statement statement)
             throws SQLException
     {
-        if (statement.isWrapperFor(com.mysql.jdbc.Statement.class)) {
-            statement.unwrap(com.mysql.jdbc.Statement.class).enableStreamingResults();
+        if (statement.isWrapperFor(JdbcStatement.class)) {
+            statement.unwrap(JdbcStatement.class).enableStreamingResults();
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dep.accumulo.version>1.7.4</dep.accumulo.version>
         <dep.accumulo-hadoop.version>2.7.7-1</dep.accumulo-hadoop.version>
         <dep.antlr.version>4.9.3</dep.antlr.version>
-        <dep.airlift.version>214</dep.airlift.version>
+        <dep.airlift.version>215</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.aws-sdk.version>1.12.172</dep.aws-sdk.version>
         <dep.okhttp.version>3.14.9</dep.okhttp.version>


### PR DESCRIPTION
**NOTE: Depends on https://github.com/airlift/airlift/pull/986 and will require a new airlift release**

## Description

Upgrading to Connector/J 8.x allows using both MySQL 5.x and 8.x with
raptor plugin.

## Related issues, pull requests, and links

Fixes https://github.com/trinodb/trino/issues/8302

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text: