### PR TITLE
Ensure cached query results are discarded

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
@@ -444,8 +444,10 @@ class Query
         // only return a next if
         // (1) the query is not done AND the query state is not FAILED
         //   OR
-        // (2)there is more data to send (due to buffering)
-        if (queryInfo.getState() != FAILED && (!queryInfo.isFinalQueryInfo() || !exchangeClient.isFinished() || (lastResult != null && lastResult.getData() != null))) {
+        // (2) there is more data to send (due to buffering)
+        //   OR
+        // (3) cached query result needs client acknowledgement to discard
+        if (queryInfo.getState() != FAILED && (!queryInfo.isFinalQueryInfo() || !exchangeClient.isFinished() || (queryInfo.getOutputStage().isPresent() && !resultRows.isEmpty()))) {
             nextToken = OptionalLong.of(token + 1);
         }
         else {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix.

Previous attempt was https://github.com/trinodb/trino/commit/da2cd0aa568846c4111ee819bdf45fddb7da147d, but it doesn't work out in the following cases:
1. If query only needs to call `getNextResult` once, on the first call `lastResult` is null, we will not have the next token to clear the cached result
2. It's possible for exchange to return empty result yet not finished. In this case we will not have the next token to clear the cached result either.

This PR improves the logic to check `resultRows`, as `lastResult` will be set to a `QueryResults` containing `resultRows` at the end. If it's non-empty, then we need next token to clear the cached result. Note that the `queryInfo.getOutputStage().isPresent()` check is needed as https://github.com/trinodb/trino/blob/736c160dffe97544612b524802631e6b63ecf596/core/trino-main/src/main/java/io/trino/server/protocol/Query.java#L510-L515

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core engine.

> How would you describe this change to a non-technical end user or system administrator?

This ensures cached query results are discarded upon completion, which improves memory usage of coordinator.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
