### PR TITLE
Support table comments in BigQuery

### DIFF
--- a/docs/src/main/sphinx/connector/bigquery.rst
+++ b/docs/src/main/sphinx/connector/bigquery.rst
@@ -179,6 +179,7 @@ statements, the connector supports the following features:
 * :doc:`/sql/drop-table`
 * :doc:`/sql/create-schema`
 * :doc:`/sql/drop-schema`
+* :doc:`/sql/comment` only supports ``COMMENT ON TABLE``
 
 FAQ
 ---

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
@@ -213,6 +213,13 @@ public class BigQueryClient
         bigQuery.delete(tableId);
     }
 
+    public void setTableComment(TableId tableId, Optional<String> comment)
+    {
+        update(getRequiredTable(tableId).toBuilder()
+                .setDescription(comment.orElse(null))
+                .build());
+    }
+
     Job create(JobInfo jobInfo)
     {
         return bigQuery.create(jobInfo);

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
@@ -269,8 +269,7 @@ public class BigQueryMetadata
         String remoteTableName = client.toRemoteTable(projectId, remoteSchemaName, sourceTableName.getTableName())
                 .map(RemoteDatabaseObject::getOnlyRemoteName)
                 .orElseThrow(() -> new TableNotFoundException(viewDefinitionTableName));
-        TableInfo tableInfo = client.getTable(TableId.of(projectId, remoteSchemaName, remoteTableName))
-                .orElseThrow(() -> new TableNotFoundException(viewDefinitionTableName));
+        TableInfo tableInfo = client.getRequiredTable(TableId.of(projectId, remoteSchemaName, remoteTableName));
         if (!(tableInfo.getDefinition() instanceof ViewDefinition)) {
             throw new TableNotFoundException(viewDefinitionTableName);
         }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitManager.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitManager.java
@@ -31,8 +31,6 @@ import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.connector.FixedSplitSource;
-import io.trino.spi.connector.SchemaTableName;
-import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.predicate.TupleDomain;
 
 import javax.inject.Inject;
@@ -134,8 +132,7 @@ public class BigQuerySplitManager
             }
             else {
                 // no filters, so we can take the value from the table info when the object is TABLE
-                TableInfo tableInfo = client.getTable(remoteTableId)
-                        .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(remoteTableId.getDataset(), remoteTableId.getTable())));
+                TableInfo tableInfo = client.getRequiredTable(remoteTableId);
                 if (tableInfo.getDefinition().getType() == TABLE) {
                     numberOfRows = tableInfo.getNumRows().longValue();
                 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTableHandle.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTableHandle.java
@@ -36,6 +36,7 @@ public class BigQueryTableHandle
     private final String type;
     private final TupleDomain<ColumnHandle> constraint;
     private final Optional<List<ColumnHandle>> projectedColumns;
+    private final Optional<String> comment;
 
     @JsonCreator
     public BigQueryTableHandle(
@@ -43,13 +44,15 @@ public class BigQueryTableHandle
             @JsonProperty("remoteTableName") RemoteTableName remoteTableName,
             @JsonProperty("type") String type,
             @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint,
-            @JsonProperty("projectedColumns") Optional<List<ColumnHandle>> projectedColumns)
+            @JsonProperty("projectedColumns") Optional<List<ColumnHandle>> projectedColumns,
+            @JsonProperty("comment") Optional<String> comment)
     {
         this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
         this.remoteTableName = requireNonNull(remoteTableName, "remoteTableName is null");
         this.type = requireNonNull(type, "type is null");
         this.constraint = requireNonNull(constraint, "constraint is null");
         this.projectedColumns = requireNonNull(projectedColumns, "projectedColumns is null");
+        this.comment = requireNonNull(comment, "comment is null");
     }
 
     public BigQueryTableHandle(SchemaTableName schemaTableName, RemoteTableName remoteTableName, TableInfo tableInfo)
@@ -59,7 +62,8 @@ public class BigQueryTableHandle
                 remoteTableName,
                 tableInfo.getDefinition().getType().toString(),
                 TupleDomain.all(),
-                Optional.empty());
+                Optional.empty(),
+                Optional.ofNullable(tableInfo.getDescription()));
     }
 
     @JsonProperty
@@ -92,6 +96,12 @@ public class BigQueryTableHandle
         return projectedColumns;
     }
 
+    @JsonProperty
+    public Optional<String> getComment()
+    {
+        return comment;
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -107,7 +117,8 @@ public class BigQueryTableHandle
         return Objects.equals(schemaTableName, that.schemaTableName) &&
                 Objects.equals(type, that.type) &&
                 Objects.equals(constraint, that.constraint) &&
-                Objects.equals(projectedColumns, that.projectedColumns);
+                Objects.equals(projectedColumns, that.projectedColumns) &&
+                Objects.equals(comment, that.comment);
     }
 
     @Override
@@ -125,16 +136,17 @@ public class BigQueryTableHandle
                 .add("type", type)
                 .add("constraint", constraint)
                 .add("projectedColumns", projectedColumns)
+                .add("comment", comment)
                 .toString();
     }
 
     BigQueryTableHandle withConstraint(TupleDomain<ColumnHandle> newConstraint)
     {
-        return new BigQueryTableHandle(schemaTableName, remoteTableName, type, newConstraint, projectedColumns);
+        return new BigQueryTableHandle(schemaTableName, remoteTableName, type, newConstraint, projectedColumns, comment);
     }
 
     BigQueryTableHandle withProjectedColumns(List<ColumnHandle> newProjectedColumns)
     {
-        return new BigQueryTableHandle(schemaTableName, remoteTableName, type, constraint, Optional.of(newProjectedColumns));
+        return new BigQueryTableHandle(schemaTableName, remoteTableName, type, constraint, Optional.of(newProjectedColumns), comment);
     }
 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ReadSessionCreator.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ReadSessionCreator.java
@@ -23,8 +23,6 @@ import com.google.cloud.bigquery.storage.v1.ReadSession;
 import io.airlift.units.Duration;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
-import io.trino.spi.connector.SchemaTableName;
-import io.trino.spi.connector.TableNotFoundException;
 
 import java.util.List;
 import java.util.Optional;
@@ -56,8 +54,7 @@ public class ReadSessionCreator
     public ReadSession create(ConnectorSession session, TableId remoteTable, List<String> selectedFields, Optional<String> filter, int parallelism)
     {
         BigQueryClient client = bigQueryClientFactory.create(session);
-        TableInfo tableDetails = client.getTable(remoteTable)
-                .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(remoteTable.getDataset(), remoteTable.getTable())));
+        TableInfo tableDetails = client.getRequiredTable(remoteTable);
 
         TableInfo actualTable = getActualTable(client, tableDetails, selectedFields);
 

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ViewMaterializationCache.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ViewMaterializationCache.java
@@ -26,8 +26,6 @@ import io.airlift.log.Logger;
 import io.airlift.units.Duration;
 import io.trino.collect.cache.NonEvictableCache;
 import io.trino.spi.TrinoException;
-import io.trino.spi.connector.SchemaTableName;
-import io.trino.spi.connector.TableNotFoundException;
 
 import javax.inject.Inject;
 
@@ -120,8 +118,7 @@ public class ViewMaterializationCache
                 throw convertToBigQueryException(job.getStatus().getError());
             }
             // add expiration time to the table
-            TableInfo createdTable = bigQueryClient.getTable(destinationTable)
-                    .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(destinationTable.getDataset(), destinationTable.getTable())));
+            TableInfo createdTable = bigQueryClient.getRequiredTable(destinationTable);
             long expirationTimeMillis = createdTable.getCreationTime() + viewExpiration.toMillis();
             Table updatedTable = bigQueryClient.update(createdTable.toBuilder()
                     .setExpirationTime(expirationTimeMillis)

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConnectorTest.java
@@ -74,7 +74,6 @@ public class TestBigQueryConnectorTest
             case SUPPORTS_ADD_COLUMN:
             case SUPPORTS_DROP_COLUMN:
             case SUPPORTS_RENAME_COLUMN:
-            case SUPPORTS_COMMENT_ON_TABLE:
             case SUPPORTS_COMMENT_ON_COLUMN:
                 return false;
             default:


### PR DESCRIPTION
## Description

Support table comments in BigQuery

## Documentation

(x) Sufficient documentation is included in this PR.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# BigQuery
* Add support for [`COMMENT ON TABLE`](/sql/comment). ({issue}`number`)
```
