### PR TITLE
Support column comments in MongoDB

### DIFF
--- a/docs/src/main/sphinx/connector/mongodb.rst
+++ b/docs/src/main/sphinx/connector/mongodb.rst
@@ -369,7 +369,7 @@ statements, the connector supports the following features:
 * :doc:`/sql/alter-table`
 * :doc:`/sql/create-schema`
 * :doc:`/sql/drop-schema`
-* :doc:`/sql/comment` only supports ``COMMENT ON TABLE``
+* :doc:`/sql/comment`
 
 ALTER TABLE
 ^^^^^^^^^^^

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoColumnHandle.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoColumnHandle.java
@@ -21,6 +21,7 @@ import io.trino.spi.type.Type;
 import org.bson.Document;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
@@ -31,16 +32,19 @@ public class MongoColumnHandle
     private final String name;
     private final Type type;
     private final boolean hidden;
+    private final Optional<String> comment;
 
     @JsonCreator
     public MongoColumnHandle(
             @JsonProperty("name") String name,
             @JsonProperty("columnType") Type type,
-            @JsonProperty("hidden") boolean hidden)
+            @JsonProperty("hidden") boolean hidden,
+            @JsonProperty("comment") Optional<String> comment)
     {
         this.name = requireNonNull(name, "name is null");
         this.type = requireNonNull(type, "type is null");
         this.hidden = hidden;
+        this.comment = requireNonNull(comment, "comment is null");
     }
 
     @JsonProperty
@@ -61,12 +65,19 @@ public class MongoColumnHandle
         return hidden;
     }
 
+    @JsonProperty
+    public Optional<String> getComment()
+    {
+        return comment;
+    }
+
     public ColumnMetadata toColumnMetadata()
     {
         return ColumnMetadata.builder()
                 .setName(name)
                 .setType(type)
                 .setHidden(hidden)
+                .setComment(comment)
                 .build();
     }
 
@@ -74,13 +85,14 @@ public class MongoColumnHandle
     {
         return new Document().append("name", name)
                 .append("type", type.getTypeSignature().toString())
-                .append("hidden", hidden);
+                .append("hidden", hidden)
+                .append("comment", comment.orElse(null));
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, type, hidden);
+        return Objects.hash(name, type, hidden, comment);
     }
 
     @Override
@@ -95,7 +107,8 @@ public class MongoColumnHandle
         MongoColumnHandle other = (MongoColumnHandle) obj;
         return Objects.equals(name, other.name) &&
                 Objects.equals(type, other.type) &&
-                Objects.equals(hidden, other.hidden);
+                Objects.equals(hidden, other.hidden) &&
+                Objects.equals(comment, other.comment);
     }
 
     @Override
@@ -105,6 +118,7 @@ public class MongoColumnHandle
                 .add("name", name)
                 .add("type", type)
                 .add("hidden", hidden)
+                .add("comment", comment)
                 .toString();
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
@@ -191,6 +191,14 @@ public class MongoMetadata
     }
 
     @Override
+    public void setColumnComment(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle, Optional<String> comment)
+    {
+        MongoTableHandle table = (MongoTableHandle) tableHandle;
+        MongoColumnHandle column = (MongoColumnHandle) columnHandle;
+        mongoSession.setColumnComment(table.getSchemaTableName(), column.getName(), comment);
+    }
+
+    @Override
     public void addColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnMetadata column)
     {
         mongoSession.addColumn(((MongoTableHandle) tableHandle).getSchemaTableName(), column);
@@ -354,7 +362,7 @@ public class MongoMetadata
     private static List<MongoColumnHandle> buildColumnHandles(ConnectorTableMetadata tableMetadata)
     {
         return tableMetadata.getColumns().stream()
-                .map(m -> new MongoColumnHandle(m.getName(), m.getType(), m.isHidden()))
+                .map(m -> new MongoColumnHandle(m.getName(), m.getType(), m.isHidden(), Optional.ofNullable(m.getComment())))
                 .collect(toList());
     }
 

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorTest.java
@@ -65,7 +65,6 @@ public abstract class BaseMongoConnectorTest
             case SUPPORTS_NOT_NULL_CONSTRAINT:
             case SUPPORTS_RENAME_TABLE:
             case SUPPORTS_RENAME_COLUMN:
-            case SUPPORTS_COMMENT_ON_COLUMN:
                 return false;
             default:
                 return super.hasBehavior(connectorBehavior);
@@ -134,6 +133,18 @@ public abstract class BaseMongoConnectorTest
                 {"[9, \"test\"]", "CAST(row(9, 'test') AS row(_pos1 bigint, _pos2 varchar))"}, // array with multiple types -> row
                 {"{\"$ref\":\"test_ref\",\"$id\":ObjectId(\"4e3f33de6266b5845052c02c\"),\"$db\":\"test_db\"}", "CAST(row('test_db', 'test_ref', ObjectId('4e3f33de6266b5845052c02c')) AS row(databasename varchar, collectionname varchar, id ObjectId))"}, // dbref -> row
         };
+    }
+
+    @Test
+    public void testCreateTableWithColumnComment()
+    {
+        // TODO (https://github.com/trinodb/trino/issues/11162) Merge into io.trino.testing.BaseConnectorTest#testCommentColumn
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_column_comment", "(col integer COMMENT 'test')")) {
+            assertThat((String) computeScalar("SHOW CREATE TABLE " + table.getName()))
+                    .isEqualTo(format("CREATE TABLE %s.%s.%s (\n" +
+                            "   col integer COMMENT 'test'\n" +
+                            ")", getSession().getCatalog().orElseThrow(), getSession().getSchema().orElseThrow(), table.getName()));
+        }
     }
 
     @Test

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoSession.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoSession.java
@@ -22,6 +22,8 @@ import io.trino.spi.predicate.ValueSet;
 import org.bson.Document;
 import org.testng.annotations.Test;
 
+import java.util.Optional;
+
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.predicate.Range.equal;
 import static io.trino.spi.predicate.Range.greaterThan;
@@ -35,9 +37,9 @@ import static org.testng.Assert.assertEquals;
 
 public class TestMongoSession
 {
-    private static final MongoColumnHandle COL1 = new MongoColumnHandle("col1", BIGINT, false);
-    private static final MongoColumnHandle COL2 = new MongoColumnHandle("col2", createUnboundedVarcharType(), false);
-    private static final MongoColumnHandle COL3 = new MongoColumnHandle("col3", createUnboundedVarcharType(), false);
+    private static final MongoColumnHandle COL1 = new MongoColumnHandle("col1", BIGINT, false, Optional.empty());
+    private static final MongoColumnHandle COL2 = new MongoColumnHandle("col2", createUnboundedVarcharType(), false, Optional.empty());
+    private static final MongoColumnHandle COL3 = new MongoColumnHandle("col3", createUnboundedVarcharType(), false, Optional.empty());
 
     @Test
     public void testBuildQuery()


### PR DESCRIPTION
## Description

Support column comments in MongoDB

## Documentation

(x) Sufficient documentation is included in this PR.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# MongoDB
* Add support for [`COMMENT ON COLUMN`](/sql/comment). ({issue}`11457`)
```
