### PR TITLE
Support 8-bit field type like tinyint or boolean, which is recognized as numeric type in trino

### DIFF
--- a/lib/trino-orc/src/main/java/io/trino/orc/reader/LongColumnReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/reader/LongColumnReader.java
@@ -23,15 +23,18 @@ import io.trino.orc.stream.InputStreamSource;
 import io.trino.orc.stream.InputStreamSources;
 import io.trino.orc.stream.LongInputStream;
 import io.trino.spi.block.Block;
+import io.trino.spi.block.ByteArrayBlock;
 import io.trino.spi.block.IntArrayBlock;
 import io.trino.spi.block.LongArrayBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.block.ShortArrayBlock;
 import io.trino.spi.type.BigintType;
+import io.trino.spi.type.BooleanType;
 import io.trino.spi.type.DateType;
 import io.trino.spi.type.IntegerType;
 import io.trino.spi.type.SmallintType;
 import io.trino.spi.type.TimeType;
+import io.trino.spi.type.TinyintType;
 import io.trino.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -47,6 +50,7 @@ import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.orc.metadata.Stream.StreamKind.DATA;
 import static io.trino.orc.metadata.Stream.StreamKind.PRESENT;
 import static io.trino.orc.reader.ReaderUtils.minNonNullValueSize;
+import static io.trino.orc.reader.ReaderUtils.unpackByteNulls;
 import static io.trino.orc.reader.ReaderUtils.unpackIntNulls;
 import static io.trino.orc.reader.ReaderUtils.unpackLongNulls;
 import static io.trino.orc.reader.ReaderUtils.unpackShortNulls;
@@ -76,6 +80,7 @@ public class LongColumnReader
     private boolean rowGroupOpen;
 
     // only one of the three arrays will be used
+    private byte[] byteNonNullValueTemp = new byte[0];
     private short[] shortNonNullValueTemp = new short[0];
     private int[] intNonNullValueTemp = new int[0];
     private long[] longNonNullValueTemp = new long[0];
@@ -86,7 +91,13 @@ public class LongColumnReader
             throws OrcCorruptionException
     {
         requireNonNull(type, "type is null");
-        verifyStreamType(column, type, t -> t instanceof BigintType || t instanceof IntegerType || t instanceof SmallintType || t instanceof DateType || t instanceof TimeType);
+        verifyStreamType(column, type, t -> t instanceof BigintType
+                || t instanceof IntegerType
+                || t instanceof SmallintType
+                || t instanceof DateType
+                || t instanceof TimeType
+                || t instanceof BooleanType
+                || t instanceof TinyintType);
         this.type = type;
 
         this.column = requireNonNull(column, "column is null");
@@ -178,6 +189,11 @@ public class LongColumnReader
             dataStream.next(values, nextBatchSize);
             return new ShortArrayBlock(nextBatchSize, Optional.empty(), values);
         }
+        if (type instanceof BooleanType || type instanceof TinyintType) {
+            byte[] values = new byte[nextBatchSize];
+            dataStream.next(values, nextBatchSize);
+            return new ByteArrayBlock(nextBatchSize, Optional.empty(), values);
+        }
         throw new VerifyError("Unsupported type " + type);
     }
 
@@ -194,6 +210,9 @@ public class LongColumnReader
         }
         if (type instanceof SmallintType) {
             return shortReadNullBlock(isNull, nonNullCount);
+        }
+        if (type instanceof BooleanType || type instanceof TinyintType) {
+            return byteReadNullBlock(isNull, nonNullCount);
         }
         throw new VerifyError("Unsupported type " + type);
     }
@@ -247,6 +266,23 @@ public class LongColumnReader
         short[] result = unpackShortNulls(shortNonNullValueTemp, isNull);
 
         return new ShortArrayBlock(nextBatchSize, Optional.of(isNull), result);
+    }
+
+    private Block byteReadNullBlock(boolean[] isNull, int nonNullCount)
+            throws IOException
+    {
+        verifyNotNull(dataStream);
+        int minNonNullValueSize = minNonNullValueSize(nonNullCount);
+        if (byteNonNullValueTemp.length < minNonNullValueSize) {
+            byteNonNullValueTemp = new byte[minNonNullValueSize];
+            memoryContext.setBytes(sizeOf(byteNonNullValueTemp));
+        }
+
+        dataStream.next(byteNonNullValueTemp, nonNullCount);
+
+        byte[] result = unpackByteNulls(byteNonNullValueTemp, isNull);
+
+        return new ByteArrayBlock(nextBatchSize, Optional.of(isNull), result);
     }
 
     private void openRowGroup()

--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/LongInputStream.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/LongInputStream.java
@@ -32,6 +32,9 @@ public interface LongInputStream
     void next(short[] values, int items)
             throws IOException;
 
+    void next(byte[] values, int items)
+            throws IOException;
+
     default long sum(int items)
             throws IOException
     {

--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/LongInputStreamV1.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/LongInputStreamV1.java
@@ -13,6 +13,7 @@
  */
 package io.trino.orc.stream;
 
+import com.google.common.primitives.SignedBytes;
 import io.trino.orc.OrcCorruptionException;
 import io.trino.orc.checkpoint.LongStreamCheckpoint;
 import io.trino.orc.checkpoint.LongStreamV1Checkpoint;
@@ -198,6 +199,39 @@ public class LongInputStreamV1
             offset += chunkSize;
             items -= chunkSize;
         }
+    }
+
+    @Override
+    public void next(byte[] values, int items) throws IOException
+    {
+        int offset = 0;
+        while (items > 0) {
+            if (used == numLiterals) {
+                numLiterals = 0;
+                used = 0;
+                readValues();
+            }
+
+            int chunkSize = min(numLiterals - used, items);
+            if (repeat) {
+                for (int i = 0; i < chunkSize; i++) {
+                    long literal = literals[0] + ((used + i) * delta);
+                    byte value = SignedBytes.saturatedCast(literal);
+                    values[offset + i] = value;
+                }
+            }
+            else {
+                for (int i = 0; i < chunkSize; i++) {
+                    long literal = literals[used + i];
+                    byte value = SignedBytes.saturatedCast(literal);
+                    values[offset + i] = value;
+                }
+            }
+            used += chunkSize;
+            offset += chunkSize;
+            items -= chunkSize;
+        }
+
     }
 
     @Override

--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/LongInputStreamV2.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/LongInputStreamV2.java
@@ -13,6 +13,7 @@
  */
 package io.trino.orc.stream;
 
+import com.google.common.primitives.SignedBytes;
 import io.trino.orc.OrcCorruptionException;
 import io.trino.orc.checkpoint.LongStreamCheckpoint;
 import io.trino.orc.checkpoint.LongStreamV2Checkpoint;
@@ -400,6 +401,28 @@ public class LongInputStreamV2
                 if (literal != value) {
                     throw new OrcCorruptionException(input.getOrcDataSourceId(), "Decoded value out of range for a 16bit number");
                 }
+                values[offset + i] = value;
+            }
+            used += chunkSize;
+            offset += chunkSize;
+            items -= chunkSize;
+        }
+    }
+
+    @Override
+    public void next(byte[] values, int items) throws IOException {
+        int offset = 0;
+        while (items > 0) {
+            if (used == numLiterals) {
+                numLiterals = 0;
+                used = 0;
+                readValues();
+            }
+
+            int chunkSize = min(numLiterals - used, items);
+            for (int i = 0; i < chunkSize; i++) {
+                long literal = literals[used + i];
+                byte value = SignedBytes.saturatedCast(literal);
                 values[offset + i] = value;
             }
             used += chunkSize;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
It is a improvement.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
The modification of the code is in client library module `trino-orc`.

> How would you describe this change to a non-technical end user or system administrator?
When trino reads the hive orc table of the lower protobuf version, an error is reported when parsing the tinyint/boolean field. 
The field length is 8-bits and considered to be numeric type instead of the original types, but trino do not support parsing 8-bits numeric field.
So I Try to add support for 8-bits numeric field.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->
Fixes #11428 

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

- [x]  No documentation is needed.
- [ ] Sufficient documentation is included in this PR.
- [ ] Documentation PR is available with #prnumber.
- [ ] Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

- [x] No release notes entries required.
- [ ] Release notes entries required with the following suggested text: