### PR TITLE
Deprecate 'memsql' connector name in MemSQL connector

### DIFF
--- a/docs/src/main/sphinx/connector/memsql.rst
+++ b/docs/src/main/sphinx/connector/memsql.rst
@@ -25,7 +25,7 @@ connection properties as appropriate for your setup:
 
 .. code-block:: text
 
-    connector.name=memsql
+    connector.name=singlestore
     connection-url=jdbc:singlestore://example.net:3306
     connection-user=root
     connection-password=secret
@@ -73,25 +73,25 @@ Querying SingleStore
 The SingleStore connector provides a schema for every SingleStore *database*.
 You can see the available SingleStore databases by running ``SHOW SCHEMAS``::
 
-    SHOW SCHEMAS FROM memsql;
+    SHOW SCHEMAS FROM singlestore;
 
 If you have a SingleStore database named ``web``, you can view the tables
 in this database by running ``SHOW TABLES``::
 
-    SHOW TABLES FROM memsql.web;
+    SHOW TABLES FROM singlestore.web;
 
 You can see a list of the columns in the ``clicks`` table in the ``web``
 database using either of the following::
 
-    DESCRIBE memsql.web.clicks;
-    SHOW COLUMNS FROM memsql.web.clicks;
+    DESCRIBE singlestore.web.clicks;
+    SHOW COLUMNS FROM singlestore.web.clicks;
 
 Finally, you can access the ``clicks`` table in the ``web`` database::
 
-    SELECT * FROM memsql.web.clicks;
+    SELECT * FROM singlestore.web.clicks;
 
 If you used a different name for your catalog properties file, use
-that catalog name instead of ``memsql`` in the above examples.
+that catalog name instead of ``singlestore`` in the above examples.
 
 .. _singlestore-type-mapping:
 

--- a/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlPlugin.java
+++ b/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlPlugin.java
@@ -19,7 +19,8 @@ import io.trino.spi.connector.ConnectorFactory;
 import io.trino.testing.TestingConnectorContext;
 import org.testng.annotations.Test;
 
-import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.collect.MoreCollectors.toOptional;
+import static com.google.common.collect.Streams.stream;
 
 public class TestMemSqlPlugin
 {
@@ -27,7 +28,21 @@ public class TestMemSqlPlugin
     public void testCreateConnector()
     {
         Plugin plugin = new MemSqlPlugin();
-        ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
+        ConnectorFactory factory = stream(plugin.getConnectorFactories())
+                .filter(connectorFactory -> connectorFactory.getName().equals("singlestore"))
+                .collect(toOptional())
+                .orElseThrow();
+        factory.create("test", ImmutableMap.of("connection-url", "jdbc:singlestore://test"), new TestingConnectorContext()).shutdown();
+    }
+
+    @Test
+    public void testCreateConnectorLegacyName()
+    {
+        Plugin plugin = new MemSqlPlugin();
+        ConnectorFactory factory = stream(plugin.getConnectorFactories())
+                .filter(connectorFactory -> connectorFactory.getName().equals("memsql"))
+                .collect(toOptional())
+                .orElseThrow();
         factory.create("test", ImmutableMap.of("connection-url", "jdbc:singlestore://test"), new TestingConnectorContext()).shutdown();
     }
 }


### PR DESCRIPTION
## Description

Deprecate 'memsql' as the connector name and allow `singlestore` in MemSQL connector. This is the first step of renaming the connector.

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# SingleStore (MmeSQL)
* Deprecate `memsql` as the connector name. We recommend using `singlestore` in the `connector.name` configuration property. ({issue}`11459`)
```
