### PR TITLE
Allow Metastore to be injected via Modules in TestingHivePlugin

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestingHiveConnectorFactory.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestingHiveConnectorFactory.java
@@ -29,16 +29,16 @@ import static java.util.Objects.requireNonNull;
 public class TestingHiveConnectorFactory
         implements ConnectorFactory
 {
-    private final HiveMetastore metastore;
+    private final Optional<HiveMetastore> metastore;
     private final Module module;
     private final Optional<CachingDirectoryLister> cachingDirectoryLister;
 
     public TestingHiveConnectorFactory(HiveMetastore metastore)
     {
-        this(metastore, EMPTY_MODULE, Optional.empty());
+        this(Optional.of(metastore), EMPTY_MODULE, Optional.empty());
     }
 
-    public TestingHiveConnectorFactory(HiveMetastore metastore, Module module, Optional<CachingDirectoryLister> cachingDirectoryLister)
+    public TestingHiveConnectorFactory(Optional<HiveMetastore> metastore, Module module, Optional<CachingDirectoryLister> cachingDirectoryLister)
     {
         this.metastore = requireNonNull(metastore, "metastore is null");
         this.module = requireNonNull(module, "module is null");
@@ -54,6 +54,6 @@ public class TestingHiveConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
-        return createConnector(catalogName, config, context, module, Optional.of(metastore), cachingDirectoryLister);
+        return createConnector(catalogName, config, context, module, metastore, cachingDirectoryLister);
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestingHivePlugin.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestingHivePlugin.java
@@ -27,16 +27,16 @@ import static java.util.Objects.requireNonNull;
 public class TestingHivePlugin
         implements Plugin
 {
-    private final HiveMetastore metastore;
+    private final Optional<HiveMetastore> metastore;
     private final Module module;
     private final Optional<CachingDirectoryLister> cachingDirectoryLister;
 
     public TestingHivePlugin(HiveMetastore metastore)
     {
-        this(metastore, EMPTY_MODULE, Optional.empty());
+        this(Optional.of(metastore), EMPTY_MODULE, Optional.empty());
     }
 
-    public TestingHivePlugin(HiveMetastore metastore, Module module, Optional<CachingDirectoryLister> cachingDirectoryLister)
+    public TestingHivePlugin(Optional<HiveMetastore> metastore, Module module, Optional<CachingDirectoryLister> cachingDirectoryLister)
     {
         this.metastore = requireNonNull(metastore, "metastore is null");
         this.module = requireNonNull(module, "module is null");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

`TestingHivePlugin` requires to `HiveMetastore` instance to be specified at the time of creation, this patch allows us to obtain the same from the underlying modules if not specified during creation.  

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Refactoring
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Hive connector (in test)

> How would you describe this change to a non-technical end user or system administrator?

no user facing change

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
