### PR TITLE
Test Iceberg Glue API invocation counts

### DIFF
--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -81,6 +81,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>stats</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
         </dependency>
 
@@ -338,6 +343,7 @@
                                 <exclude>**/TestIcebergGlueCatalogConnectorSmokeTest.java</exclude>
                                 <exclude>**/TestTrinoGlueCatalogTest.java</exclude>
                                 <exclude>**/TestSharedGlueMetastore.java</exclude>
+                                <exclude>**/TestIcebergGlueCatalogAccessOperations.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>
@@ -402,7 +408,19 @@
                                 <include>**/TestIcebergGlueCatalogConnectorSmokeTest.java</include>
                                 <include>**/TestTrinoGlueCatalogTest.java</include>
                                 <include>**/TestSharedGlueMetastore.java</include>
+                                <include>**/TestIcebergGlueCatalogAccessOperations.java</include>
                             </includes>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.basepom.maven</groupId>
+                        <artifactId>duplicate-finder-maven-plugin</artifactId>
+                        <configuration>
+                            <ignoredResourcePatterns>
+                                <!-- com.amazonaws:aws-java-sdk-core and software.amazon.awssdk:sdk-core MIME type file duplicate-->
+                                <ignoredResourcePattern>mime.types</ignoredResourcePattern>
+                                <ignoredResourcePattern>about.html</ignoredResourcePattern>
+                            </ignoredResourcePatterns>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/GlueMetastoreMethod.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/GlueMetastoreMethod.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.math.DoubleMath;
+import io.trino.plugin.hive.metastore.glue.GlueMetastoreApiStats;
+import io.trino.plugin.hive.metastore.glue.GlueMetastoreStats;
+
+import java.math.RoundingMode;
+import java.util.function.Function;
+
+import static java.util.Objects.requireNonNull;
+
+public enum GlueMetastoreMethod
+{
+    BATCH_CREATE_PARTITION(GlueMetastoreStats::getBatchCreatePartition),
+    BATCH_UPDATE_PARTITION(GlueMetastoreStats::getBatchUpdatePartition),
+    CREATE_DATABASE(GlueMetastoreStats::getCreateDatabase),
+    CREATE_PARTITIONS(GlueMetastoreStats::getCreatePartitions),
+    CREATE_TABLE(GlueMetastoreStats::getCreateTable),
+    DELETE_COLUMN_STATISTICS_FOR_PARTITION(GlueMetastoreStats::getDeleteColumnStatisticsForPartition),
+    DELETE_COLUMN_STATISTICS_FOR_TABLE(GlueMetastoreStats::getDeleteColumnStatisticsForTable),
+    DELETE_DATA_BASE(GlueMetastoreStats::getDeleteDatabase),
+    DELETE_PARTITION(GlueMetastoreStats::getDeletePartition),
+    DELETE_TABLE(GlueMetastoreStats::getDeleteTable),
+    GET_COLUMN_STATISTICS_FOR_PARTITION(GlueMetastoreStats::getGetColumnStatisticsForPartition),
+    GET_COLUMN_STATISTICS_FOR_TABLE(GlueMetastoreStats::getDeleteColumnStatisticsForTable),
+    GET_DATABASE(GlueMetastoreStats::getGetDatabase),
+    GET_DATABASES(GlueMetastoreStats::getGetDatabases),
+    GET_PARTITION(GlueMetastoreStats::getGetPartition),
+    GET_PARTITION_BY_NAME(GlueMetastoreStats::getGetPartitionByName),
+    GET_PARTITION_NAMES(GlueMetastoreStats::getGetPartitionNames),
+    GET_PARTITIONS(GlueMetastoreStats::getGetPartitions),
+    GET_TABLE(GlueMetastoreStats::getGetTable),
+    GET_TABLES(GlueMetastoreStats::getGetTables),
+    UPDATE_COLUMN_STATISTICS_FOR_PARTITION(GlueMetastoreStats::getUpdateColumnStatisticsForPartition),
+    UPDATE_COLUMN_STATISTICS_FOR_TABLE(GlueMetastoreStats::getUpdateColumnStatisticsForTable),
+    UPDATE_DATABASE(GlueMetastoreStats::getUpdateDatabase),
+    UPDATE_PARTITION(GlueMetastoreStats::getUpdatePartition),
+    UPDATE_TABLE(GlueMetastoreStats::getUpdateTable),
+    /**/;
+
+    private final Function<GlueMetastoreStats, GlueMetastoreApiStats> extractor;
+
+    GlueMetastoreMethod(Function<GlueMetastoreStats, GlueMetastoreApiStats> extractor)
+    {
+        this.extractor = requireNonNull(extractor, "extractor is null");
+    }
+
+    public GlueMetastoreApiStats getStatFrom(GlueMetastoreStats stats)
+    {
+        return this.extractor.apply(stats);
+    }
+
+    public int getInvocationCount(GlueMetastoreStats stats)
+    {
+        double count = this.getStatFrom(stats).getTime().getAllTime().getCount();
+        return DoubleMath.roundToInt(count, RoundingMode.UNNECESSARY);
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGlueCatalogAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGlueCatalogAccessOperations.java
@@ -1,0 +1,514 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.Multiset;
+import com.google.common.collect.Sets;
+import com.google.inject.Binder;
+import com.google.inject.Inject;
+import com.google.inject.Module;
+import com.google.inject.TypeLiteral;
+import io.trino.Session;
+import io.trino.plugin.hive.metastore.glue.GlueMetastoreStats;
+import io.trino.plugin.iceberg.catalog.IcebergTableOperationsProvider;
+import io.trino.plugin.iceberg.catalog.TrinoCatalogFactory;
+import io.trino.plugin.iceberg.catalog.glue.GlueIcebergTableOperationsProvider;
+import io.trino.plugin.iceberg.catalog.glue.TrinoGlueCatalogFactory;
+import io.trino.spi.NodeManager;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import javax.inject.Qualifier;
+
+import java.io.File;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.google.common.base.Verify.verifyNotNull;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.trino.plugin.iceberg.GlueMetastoreMethod.CREATE_TABLE;
+import static io.trino.plugin.iceberg.GlueMetastoreMethod.GET_DATABASE;
+import static io.trino.plugin.iceberg.GlueMetastoreMethod.GET_TABLE;
+import static io.trino.plugin.iceberg.TableType.DATA;
+import static io.trino.plugin.iceberg.TableType.FILES;
+import static io.trino.plugin.iceberg.TableType.HISTORY;
+import static io.trino.plugin.iceberg.TableType.MANIFESTS;
+import static io.trino.plugin.iceberg.TableType.PARTITIONS;
+import static io.trino.plugin.iceberg.TableType.PROPERTIES;
+import static io.trino.plugin.iceberg.TableType.SNAPSHOTS;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static java.lang.String.format;
+import static java.lang.String.join;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.fail;
+
+/*
+ * The test currently uses AWS Default Credential Provider Chain,
+ * See https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
+ * on ways to set your AWS credentials which will be needed to run this test.
+ */
+@Test(singleThreaded = true) // metastore invocation counters shares mutable state so can't be run from many threads simultaneously
+public class TestIcebergGlueCatalogAccessOperations
+        extends AbstractTestQueryFramework
+{
+    private final String testSchema = "test_schema_" + randomTableSuffix();
+    private final Session testSession = testSessionBuilder()
+            .setCatalog("iceberg")
+            .setSchema(testSchema)
+            .build();
+
+    private GlueMetastoreStats catalogStats;
+    private GlueMetastoreStats tableOperationStats;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        File tmp = Files.createTempDirectory("test_iceberg").toFile();
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(testSession).build();
+
+        AtomicReference<GlueMetastoreStats> catalogStatsReference = new AtomicReference<>();
+        AtomicReference<GlueMetastoreStats> tableOperationStatsReference = new AtomicReference<>();
+
+        queryRunner.installPlugin(new TestingIcebergPlugin(
+                Optional.empty(),
+                Optional.empty(),
+                new StealStatsModule(catalogStatsReference, tableOperationStatsReference)));
+        queryRunner.createCatalog("iceberg", "iceberg",
+                ImmutableMap.of(
+                        "iceberg.catalog.type", "glue",
+                        "hive.metastore.glue.default-warehouse-dir", tmp.getAbsolutePath()));
+
+        queryRunner.execute("CREATE SCHEMA " + testSchema);
+
+        catalogStats = verifyNotNull(catalogStatsReference.get(), "catalogStatsReference not set");
+        tableOperationStats = verifyNotNull(tableOperationStatsReference.get(), "tableOperationStatsReference not set");
+        return queryRunner;
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void cleanUpSchema()
+    {
+        getQueryRunner().execute("DROP SCHEMA " + testSchema);
+    }
+
+    @Test
+    public void testCreateTable()
+    {
+        try {
+            assertGlueMetastoreApiInvocations("CREATE TABLE test_create (id VARCHAR, age INT)",
+                    ImmutableMultiset.builder()
+                            .add(CREATE_TABLE)
+                            .add(GET_DATABASE)
+                            .add(GET_TABLE)
+                            .build());
+        }
+        finally {
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_create");
+        }
+    }
+
+    @Test
+    public void testCreateTableAsSelect()
+    {
+        try {
+            assertGlueMetastoreApiInvocations("CREATE TABLE test_ctas AS SELECT 1 AS age",
+                    ImmutableMultiset.builder()
+                            .add(GET_DATABASE)
+                            .add(CREATE_TABLE)
+                            .add(GET_TABLE)
+                            .build());
+        }
+        finally {
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_ctas");
+        }
+    }
+
+    @Test
+    public void testSelect()
+    {
+        try {
+            assertUpdate("CREATE TABLE test_select_from (id VARCHAR, age INT)");
+
+            assertGlueMetastoreApiInvocations("SELECT * FROM test_select_from",
+                    ImmutableMultiset.builder()
+                            .add(GET_TABLE)
+                            .build());
+        }
+        finally {
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_select_from");
+        }
+    }
+
+    @Test
+    public void testSelectWithFilter()
+    {
+        try {
+            assertUpdate("CREATE TABLE test_select_from_where AS SELECT 2 as age", 1);
+
+            assertGlueMetastoreApiInvocations("SELECT * FROM test_select_from_where WHERE age = 2",
+                    ImmutableMultiset.builder()
+                            .add(GET_TABLE)
+                            .build());
+        }
+        finally {
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_select_from_where");
+        }
+    }
+
+    @Test(enabled = false)
+    public void testSelectFromView()
+    {
+        try {
+            assertUpdate("CREATE TABLE test_select_view_table (id VARCHAR, age INT)");
+            assertUpdate("CREATE VIEW test_select_view_view AS SELECT id, age FROM test_select_view_table");
+
+            assertGlueMetastoreApiInvocations("SELECT * FROM test_select_view_view",
+                    ImmutableMultiset.builder()
+                            .addCopies(GET_TABLE, 2)
+                            .build());
+        }
+        finally {
+            getQueryRunner().execute("DROP VIEW IF EXISTS test_select_view_view");
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_select_view_table");
+        }
+    }
+
+    @Test(enabled = false)
+    public void testSelectFromViewWithFilter()
+    {
+        try {
+            assertUpdate("CREATE TABLE test_select_view_where_table AS SELECT 2 as age", 1);
+            assertUpdate("CREATE VIEW test_select_view_where_view AS SELECT age FROM test_select_view_where_table");
+
+            assertGlueMetastoreApiInvocations("SELECT * FROM test_select_view_where_view WHERE age = 2",
+                    ImmutableMultiset.builder()
+                            .addCopies(GET_TABLE, 2)
+                            .build());
+        }
+        finally {
+            getQueryRunner().execute("DROP VIEW IF EXISTS test_select_view_where_view");
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_select_view_where_view");
+        }
+    }
+
+    @Test(enabled = false)
+    public void testSelectFromMaterializedView()
+    {
+        try {
+            assertUpdate("CREATE TABLE test_select_mview_table (id VARCHAR, age INT)");
+            assertUpdate("CREATE MATERIALIZED VIEW test_select_mview_view AS SELECT id, age FROM test_select_mview_table");
+
+            assertGlueMetastoreApiInvocations("SELECT * FROM test_select_mview_view",
+                    ImmutableMultiset.builder()
+                            .addCopies(GET_TABLE, 3)
+                            .build());
+        }
+        finally {
+            getQueryRunner().execute("DROP MATERIALIZED VIEW IF EXISTS test_select_mview_view");
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_select_mview_table");
+        }
+    }
+
+    @Test(enabled = false)
+    public void testSelectFromMaterializedViewWithFilter()
+    {
+        try {
+            assertUpdate("CREATE TABLE test_select_mview_where_table AS SELECT 2 as age", 1);
+            assertUpdate("CREATE MATERIALIZED VIEW test_select_mview_where_view AS SELECT age FROM test_select_mview_where_table");
+
+            assertGlueMetastoreApiInvocations("SELECT * FROM test_select_mview_where_view WHERE age = 2",
+                    ImmutableMultiset.builder()
+                            .addCopies(GET_TABLE, 3)
+                            .build());
+        }
+        finally {
+            getQueryRunner().execute("DROP MATERIALIZED VIEW IF EXISTS test_select_mview_where_view");
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_select_mview_where_table");
+        }
+    }
+
+    @Test(enabled = false)
+    public void testRefreshMaterializedView()
+    {
+        try {
+            assertUpdate("CREATE TABLE test_refresh_mview_table (id VARCHAR, age INT)");
+            assertUpdate("CREATE MATERIALIZED VIEW test_refresh_mview_view AS SELECT id, age FROM test_refresh_mview_table");
+
+            assertGlueMetastoreApiInvocations("REFRESH MATERIALIZED VIEW test_refresh_mview_view",
+                    ImmutableMultiset.builder()
+                            .addCopies(GET_TABLE, 5)
+                            .build());
+        }
+        finally {
+            getQueryRunner().execute("DROP MATERIALIZED VIEW IF EXISTS test_refresh_mview_view");
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_refresh_mview_table");
+        }
+    }
+
+    @Test
+    public void testJoin()
+    {
+        try {
+            assertUpdate("CREATE TABLE test_join_t1 AS SELECT 2 as age, 'id1' AS id", 1);
+            assertUpdate("CREATE TABLE test_join_t2 AS SELECT 'name1' as name, 'id1' AS id", 1);
+
+            assertGlueMetastoreApiInvocations("SELECT name, age FROM test_join_t1 JOIN test_join_t2 ON test_join_t2.id = test_join_t1.id",
+                    ImmutableMultiset.builder()
+                            .addCopies(GET_TABLE, 2)
+                            .build());
+        }
+        finally {
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_join_t1");
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_join_t2");
+        }
+    }
+
+    @Test
+    public void testSelfJoin()
+    {
+        try {
+            assertUpdate("CREATE TABLE test_self_join_table AS SELECT 2 as age, 0 parent, 3 AS id", 1);
+
+            assertGlueMetastoreApiInvocations("SELECT child.age, parent.age FROM test_self_join_table child JOIN test_self_join_table parent ON child.parent = parent.id",
+                    ImmutableMultiset.builder()
+                            .add(GET_TABLE)
+                            .build());
+        }
+        finally {
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_self_join_table");
+        }
+    }
+
+    @Test
+    public void testExplainSelect()
+    {
+        try {
+            assertUpdate("CREATE TABLE test_explain AS SELECT 2 as age", 1);
+
+            assertGlueMetastoreApiInvocations("EXPLAIN SELECT * FROM test_explain",
+                    ImmutableMultiset.builder()
+                            .add(GET_TABLE)
+                            .build());
+        }
+        finally {
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_explain");
+        }
+    }
+
+    @Test
+    public void testShowStatsForTable()
+    {
+        try {
+            assertUpdate("CREATE TABLE test_show_stats AS SELECT 2 as age", 1);
+
+            assertGlueMetastoreApiInvocations("SHOW STATS FOR test_show_stats",
+                    ImmutableMultiset.builder()
+                            .add(GET_TABLE)
+                            .build());
+        }
+        finally {
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_show_stats");
+        }
+    }
+
+    @Test
+    public void testShowStatsForTableWithFilter()
+    {
+        try {
+            assertUpdate("CREATE TABLE test_show_stats_with_filter AS SELECT 2 as age", 1);
+
+            assertGlueMetastoreApiInvocations("SHOW STATS FOR (SELECT * FROM test_show_stats_with_filter where age >= 2)",
+                    ImmutableMultiset.builder()
+                            .add(GET_TABLE)
+                            .build());
+        }
+        finally {
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_show_stats_with_filter");
+        }
+    }
+
+    @Test
+    public void testSelectSystemTable()
+    {
+        try {
+            assertUpdate("CREATE TABLE test_select_snapshots AS SELECT 2 AS age", 1);
+
+            // select from $history
+            assertGlueMetastoreApiInvocations("SELECT * FROM \"test_select_snapshots$history\"",
+                    ImmutableMultiset.builder()
+                            .addCopies(GET_TABLE, 1)
+                            .build());
+
+            // select from $snapshots
+            assertGlueMetastoreApiInvocations("SELECT * FROM \"test_select_snapshots$snapshots\"",
+                    ImmutableMultiset.builder()
+                            .addCopies(GET_TABLE, 1)
+                            .build());
+
+            // select from $manifests
+            assertGlueMetastoreApiInvocations("SELECT * FROM \"test_select_snapshots$manifests\"",
+                    ImmutableMultiset.builder()
+                            .addCopies(GET_TABLE, 1)
+                            .build());
+
+            // select from $partitions
+            assertGlueMetastoreApiInvocations("SELECT * FROM \"test_select_snapshots$partitions\"",
+                    ImmutableMultiset.builder()
+                            .addCopies(GET_TABLE, 1)
+                            .build());
+
+            // select from $files
+            assertGlueMetastoreApiInvocations("SELECT * FROM \"test_select_snapshots$files\"",
+                    ImmutableMultiset.builder()
+                            .addCopies(GET_TABLE, 1)
+                            .build());
+
+            // select from $properties
+            assertGlueMetastoreApiInvocations("SELECT * FROM \"test_select_snapshots$properties\"",
+                    ImmutableMultiset.builder()
+                            .addCopies(GET_TABLE, 1)
+                            .build());
+
+            // This test should get updated if a new system table is added.
+            assertThat(TableType.values())
+                    .containsExactly(DATA, HISTORY, SNAPSHOTS, MANIFESTS, PARTITIONS, FILES, PROPERTIES);
+        }
+        finally {
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_select_snapshots");
+        }
+    }
+
+    private void assertGlueMetastoreApiInvocations(@Language("SQL") String query, Multiset<?> expectedInvocations)
+    {
+        Map<GlueMetastoreMethod, Integer> countsBefore = Arrays.stream(GlueMetastoreMethod.values())
+                .collect(toImmutableMap(
+                                Function.identity(),
+                                method -> method.getInvocationCount(catalogStats) +
+                                        method.getInvocationCount(tableOperationStats)));
+
+        getQueryRunner().execute(query);
+        Map<GlueMetastoreMethod, Integer> countsAfter = Arrays.stream(GlueMetastoreMethod.values())
+                .collect(toImmutableMap(
+                                Function.identity(),
+                                method -> method.getInvocationCount(catalogStats) +
+                                        method.getInvocationCount(tableOperationStats)));
+
+        Map<GlueMetastoreMethod, Integer> deltas = Arrays.stream(GlueMetastoreMethod.values())
+                .collect(Collectors.toMap(Function.identity(), method -> countsAfter.get(method) - countsBefore.get(method)));
+        ImmutableMultiset.Builder<GlueMetastoreMethod> builder = ImmutableMultiset.builder();
+        deltas.entrySet().stream().filter(entry -> entry.getValue() > 0).forEach(entry -> builder.setCount(entry.getKey(), entry.getValue()));
+        Multiset<GlueMetastoreMethod> actualInvocations = builder.build();
+
+        if (expectedInvocations.equals(actualInvocations)) {
+            return;
+        }
+
+        List<String> mismatchReport = Sets.union(expectedInvocations.elementSet(), actualInvocations.elementSet()).stream()
+                .filter(key -> expectedInvocations.count(key) != actualInvocations.count(key))
+                .flatMap(key -> {
+                    int expectedCount = expectedInvocations.count(key);
+                    int actualCount = actualInvocations.count(key);
+                    if (actualCount < expectedCount) {
+                        return Stream.of(format("%s more occurrences of %s", expectedCount - actualCount, key));
+                    }
+                    if (actualCount > expectedCount) {
+                        return Stream.of(format("%s fewer occurrences of %s", actualCount - expectedCount, key));
+                    }
+                    return Stream.of();
+                })
+                .collect(toImmutableList());
+
+        fail("Expected: \n\t\t" + join(",\n\t\t", mismatchReport));
+    }
+
+    @Retention(RUNTIME)
+    @Target({FIELD, PARAMETER, METHOD})
+    @Qualifier
+    public @interface CatalogStatsReference {}
+
+    @Retention(RUNTIME)
+    @Target({FIELD, PARAMETER, METHOD})
+    @Qualifier
+    public @interface TableOperationStatsReference {}
+
+    static class StealStatsModule
+            implements Module
+    {
+        private final AtomicReference<GlueMetastoreStats> catalogStatsReference;
+        private final AtomicReference<GlueMetastoreStats> tableOperationStatsReference;
+
+        public StealStatsModule(AtomicReference<GlueMetastoreStats> catalogStatsReference, AtomicReference<GlueMetastoreStats> tableOperationStatsReference)
+        {
+            this.catalogStatsReference = requireNonNull(catalogStatsReference, "catalogStatsReference is null");
+            this.tableOperationStatsReference = requireNonNull(tableOperationStatsReference, "tableOperationStatsReference is null");
+        }
+
+        @Override
+        public void configure(Binder binder)
+        {
+            binder.bind(new TypeLiteral<AtomicReference<GlueMetastoreStats>>() {}).annotatedWith(CatalogStatsReference.class).toInstance(catalogStatsReference);
+            binder.bind(new TypeLiteral<AtomicReference<GlueMetastoreStats>>() {}).annotatedWith(TableOperationStatsReference.class).toInstance(tableOperationStatsReference);
+
+            // Eager singleton to make singleton immediately as a dummy object to trigger code that will extract the stats out of the catalog factory
+            binder.bind(StealStats.class).asEagerSingleton();
+        }
+    }
+
+    static class StealStats
+    {
+        @Inject
+        StealStats(
+                NodeManager nodeManager,
+                @CatalogStatsReference AtomicReference<GlueMetastoreStats> catalogStatsReference,
+                @TableOperationStatsReference AtomicReference<GlueMetastoreStats> tableOperationStatsReference,
+                TrinoCatalogFactory factory,
+                IcebergTableOperationsProvider provider)
+        {
+            if (!nodeManager.getCurrentNode().isCoordinator()) {
+                // The test covers stats on the coordinator only.
+                return;
+            }
+
+            if (!catalogStatsReference.compareAndSet(null, ((TrinoGlueCatalogFactory) factory).getStats())) {
+                throw new RuntimeException("catalogStatsReference already set");
+            }
+            if (!tableOperationStatsReference.compareAndSet(null, ((GlueIcebergTableOperationsProvider) provider).getStats())) {
+                throw new RuntimeException("tableOperationStatsReference already set");
+            }
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
@@ -32,6 +32,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.inject.util.Modules.EMPTY_MODULE;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static io.trino.plugin.hive.metastore.file.FileHiveMetastore.createTestingFileHiveMetastore;
 import static io.trino.plugin.iceberg.TestIcebergMetadataFileOperations.FileType.MANIFEST;
@@ -81,7 +82,7 @@ public class TestIcebergMetadataFileOperations
         HiveMetastore metastore = createTestingFileHiveMetastore(baseDir);
 
         trackingFileIoProvider = new TrackingFileIoProvider(new HdfsFileIoProvider(HDFS_ENVIRONMENT));
-        queryRunner.installPlugin(new TestingIcebergPlugin(Optional.of(metastore), Optional.of(trackingFileIoProvider)));
+        queryRunner.installPlugin(new TestingIcebergPlugin(Optional.of(metastore), Optional.of(trackingFileIoProvider), EMPTY_MODULE));
         queryRunner.createCatalog("iceberg", "iceberg");
         queryRunner.installPlugin(new TpchPlugin());
         queryRunner.createCatalog("tpch", "tpch");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataListing.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataListing.java
@@ -44,6 +44,7 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.util.Optional;
 
+import static com.google.inject.util.Modules.EMPTY_MODULE;
 import static io.trino.spi.security.SelectedRole.Type.ROLE;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -79,7 +80,7 @@ public class TestIcebergMetadataListing
                         .setCatalogDirectory(baseDir.toURI().toString())
                         .setMetastoreUser("test"));
 
-        queryRunner.installPlugin(new TestingIcebergPlugin(Optional.of(metastore), Optional.empty()));
+        queryRunner.installPlugin(new TestingIcebergPlugin(Optional.of(metastore), Optional.empty(), EMPTY_MODULE));
         queryRunner.createCatalog("iceberg", "iceberg");
         queryRunner.installPlugin(new TestingHivePlugin(metastore));
         queryRunner.createCatalog("hive", "hive", ImmutableMap.of("hive.security", "sql-standard"));

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
@@ -39,6 +39,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.inject.util.Modules.EMPTY_MODULE;
 import static io.trino.plugin.iceberg.CountingAccessFileHiveMetastore.Methods.CREATE_TABLE;
 import static io.trino.plugin.iceberg.CountingAccessFileHiveMetastore.Methods.GET_DATABASE;
 import static io.trino.plugin.iceberg.CountingAccessFileHiveMetastore.Methods.GET_TABLE;
@@ -85,7 +86,7 @@ public class TestIcebergMetastoreAccessOperations
                         .setCatalogDirectory(baseDir.toURI().toString())
                         .setMetastoreUser("test"));
         metastore = new CountingAccessFileHiveMetastore(hiveMetastore);
-        queryRunner.installPlugin(new TestingIcebergPlugin(Optional.of(metastore), Optional.empty()));
+        queryRunner.installPlugin(new TestingIcebergPlugin(Optional.of(metastore), Optional.empty(), EMPTY_MODULE));
         queryRunner.createCatalog("iceberg", "iceberg");
 
         queryRunner.execute("CREATE SCHEMA test_schema");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcMetricsCollection.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcMetricsCollection.java
@@ -49,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.inject.util.Modules.EMPTY_MODULE;
 import static io.trino.SystemSessionProperties.MAX_DRIVERS_PER_TASK;
 import static io.trino.SystemSessionProperties.TASK_CONCURRENCY;
 import static io.trino.SystemSessionProperties.TASK_WRITER_COUNT;
@@ -105,7 +106,7 @@ public class TestIcebergOrcMetricsCollection
                 false,
                 false);
 
-        queryRunner.installPlugin(new TestingIcebergPlugin(Optional.of(metastore), Optional.empty()));
+        queryRunner.installPlugin(new TestingIcebergPlugin(Optional.of(metastore), Optional.empty(), EMPTY_MODULE));
         queryRunner.createCatalog("iceberg", "iceberg");
 
         queryRunner.installPlugin(new TpchPlugin());

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergProjectionPushdownPlans.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergProjectionPushdownPlans.java
@@ -39,6 +39,7 @@ import java.util.Set;
 import static com.google.common.base.Predicates.equalTo;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static com.google.inject.util.Modules.EMPTY_MODULE;
 import static io.trino.plugin.hive.metastore.file.FileHiveMetastore.createTestingFileHiveMetastore;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.any;
@@ -76,7 +77,7 @@ public class TestIcebergProjectionPushdownPlans
 
         queryRunner.createCatalog(
                 CATALOG,
-                new TestingIcebergConnectorFactory(Optional.of(metastore), Optional.empty()),
+                new TestingIcebergConnectorFactory(Optional.of(metastore), Optional.empty(), EMPTY_MODULE),
                 ImmutableMap.of());
 
         Database database = Database.builder()

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestMetadataQueryOptimization.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestMetadataQueryOptimization.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static com.google.inject.util.Modules.EMPTY_MODULE;
 import static io.trino.plugin.hive.metastore.file.FileHiveMetastore.createTestingFileHiveMetastore;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
@@ -58,7 +59,7 @@ public class TestMetadataQueryOptimization
 
         queryRunner.createCatalog(
                 ICEBERG_CATALOG,
-                new TestingIcebergConnectorFactory(Optional.of(metastore), Optional.empty()),
+                new TestingIcebergConnectorFactory(Optional.of(metastore), Optional.empty(), EMPTY_MODULE),
                 ImmutableMap.of());
 
         Database database = Database.builder()

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestingIcebergConnectorFactory.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestingIcebergConnectorFactory.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.iceberg;
 
+import com.google.inject.Module;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorContext;
@@ -21,7 +22,6 @@ import io.trino.spi.connector.ConnectorFactory;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.google.inject.util.Modules.EMPTY_MODULE;
 import static io.trino.plugin.iceberg.InternalIcebergConnectorFactory.createConnector;
 import static java.util.Objects.requireNonNull;
 
@@ -30,11 +30,13 @@ public class TestingIcebergConnectorFactory
 {
     private final Optional<HiveMetastore> metastore;
     private final Optional<FileIoProvider> fileIoProvider;
+    private final Module module;
 
-    public TestingIcebergConnectorFactory(Optional<HiveMetastore> metastore, Optional<FileIoProvider> fileIoProvider)
+    public TestingIcebergConnectorFactory(Optional<HiveMetastore> metastore, Optional<FileIoProvider> fileIoProvider, Module module)
     {
         this.metastore = requireNonNull(metastore, "metastore is null");
         this.fileIoProvider = requireNonNull(fileIoProvider, "fileIoProvider is null");
+        this.module = requireNonNull(module, "module is null");
     }
 
     @Override
@@ -46,6 +48,6 @@ public class TestingIcebergConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
-        return createConnector(catalogName, config, context, EMPTY_MODULE, metastore, fileIoProvider);
+        return createConnector(catalogName, config, context, module, metastore, fileIoProvider);
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestingIcebergPlugin.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestingIcebergPlugin.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableList;
+import com.google.inject.Module;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.spi.connector.ConnectorFactory;
 
@@ -28,11 +29,13 @@ public class TestingIcebergPlugin
 {
     private final Optional<HiveMetastore> metastore;
     private final Optional<FileIoProvider> fileIoProvider;
+    private final Module module;
 
-    public TestingIcebergPlugin(Optional<HiveMetastore> metastore, Optional<FileIoProvider> fileIoProvider)
+    public TestingIcebergPlugin(Optional<HiveMetastore> metastore, Optional<FileIoProvider> fileIoProvider, Module module)
     {
         this.metastore = requireNonNull(metastore, "metastore is null");
         this.fileIoProvider = requireNonNull(fileIoProvider, "fileIoProvider is null");
+        this.module = requireNonNull(module, "module is null");
     }
 
     @Override
@@ -41,6 +44,6 @@ public class TestingIcebergPlugin
         List<ConnectorFactory> connectorFactories = ImmutableList.copyOf(super.getConnectorFactories());
         verify(connectorFactories.size() == 1, "Unexpected connector factories: %s", connectorFactories);
 
-        return ImmutableList.of(new TestingIcebergConnectorFactory(metastore, fileIoProvider));
+        return ImmutableList.of(new TestingIcebergConnectorFactory(metastore, fileIoProvider, module));
     }
 }


### PR DESCRIPTION


## Description

Add in a test to count meta data class to Glue during standard Iceberg Catalog calls. Copying tests from analogous Iceberg with HiveMetastore test.
<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

improvement 

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

tests

> How would you describe this change to a non-technical end user or system administrator?

ensuring consistent/reasonable metadata service dependency during Iceberg operation. 

## Related issues, pull requests, and links
Provides code for. https://github.com/trinodb/trino/issues/11248
<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->
