### PR TITLE
Add information for connection properties in SingleStore documentation

### DIFF
--- a/docs/src/main/sphinx/connector/memsql.rst
+++ b/docs/src/main/sphinx/connector/memsql.rst
@@ -14,6 +14,8 @@ To connect to SingleStore, you need:
 * Network access from the Trino coordinator and workers to SingleStore. Port
   3306 is the default port.
 
+.. _singlestore-configuration:
+
 Configuration
 -------------
 
@@ -29,6 +31,17 @@ connection properties as appropriate for your setup:
     connection-url=jdbc:singlestore://example.net:3306
     connection-user=root
     connection-password=secret
+
+The ``connection-url`` defines the connection information and parameters to pass
+to the SingleStore JDBC driver. The supported parameters for the URL are
+available in the `SingleStore JDBC driver documentation
+<https://docs.singlestore.com/db/v7.6/en/developer-resources/connect-with-application-development-tools/connect-with-java-jdbc/the-singlestore-jdbc-driver.html#connection-string-parameters>`_.
+
+The ``connection-user`` and ``connection-password`` are typically required and
+determine the user credentials for the connection, often a service user. You can
+use :doc:`secrets </security/secrets>` to avoid actual values in the catalog
+properties files.
+
 
 .. _singlestore-tls:
 


### PR DESCRIPTION
## Description

Add info for connection parameters via JDBC driver to the configuration section. Identical wording is already used in the SQL Server docs and found helpful there by users.
 
This will also allow linking to the section in the release notes for 374 where we are changing the driver. 

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement 

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Documentation

> How would you describe this change to a non-technical end user or system administrator?

See above

## Related issues, pull requests, and links

* Related to #11301 
* And #11417

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:
