### PR TITLE
Improve isBlocked logic in DeduplicatingDirectExchangeBuffer

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/DeduplicatingDirectExchangeBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DeduplicatingDirectExchangeBuffer.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.io.Closer;
 import com.google.common.util.concurrent.FluentFuture;
 import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.log.Logger;
@@ -141,7 +142,14 @@ public class DeduplicatingDirectExchangeBuffer
         }
 
         if (!outputReady.isDone()) {
-            return nonCancellationPropagating(outputReady);
+            return nonCancellationPropagating(Futures.transformAsync(outputReady, ignored -> {
+                synchronized (this) {
+                    if (outputSource != null) {
+                        return outputSource.isBlocked();
+                    }
+                    return immediateVoidFuture();
+                }
+            }, directExecutor()));
         }
 
         checkState(outputSource != null, "outputSource is expected to be set");
@@ -821,7 +829,10 @@ public class DeduplicatingDirectExchangeBuffer
                 return immediateVoidFuture();
             }
             if (!exchangeSourceFuture.isDone()) {
-                return nonCancellationPropagating(asVoid(exchangeSourceFuture));
+                return nonCancellationPropagating(asVoid(Futures.transformAsync(
+                        exchangeSourceFuture,
+                        exchangeSource -> toListenableFuture(exchangeSource.isBlocked()),
+                        directExecutor())));
             }
             if (exchangeSource != null) {
                 CompletableFuture<Void> blocked = exchangeSource.isBlocked();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core engine.

> How would you describe this change to a non-technical end user or system administrator?

Currently, there are multiple async I/Os in `DeduplicatingDirectExchangeBuffer`. Currently, `isBlocked` may simply return a future representing the first async I/O, despite we have subsequent async I/Os depending on the first. Therefore it's necessary to use `transformAsync` to represent the chain of async I/Os.
## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
