### PR TITLE
Remove wrong annotation

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
@@ -64,7 +64,6 @@ public class PageProcessor
 
     private int projectBatchSize;
 
-    @VisibleForTesting
     public PageProcessor(Optional<PageFilter> filter, List<? extends PageProjection> projections, OptionalInt initialBatchSize)
     {
         this(filter, projections, initialBatchSize, new ExpressionProfiler());


### PR DESCRIPTION
I found the constructor of PageProcessor is not only used in test case, so should we remove that `@VisibleForTesting` annotation?