### PR TITLE
Write null value instead of current time ObjectId in MongoDB

### DIFF
--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSink.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSink.java
@@ -121,9 +121,6 @@ public class MongoPageSink
     private Object getObjectValue(Type type, Block block, int position)
     {
         if (block.isNull(position)) {
-            if (type.equals(OBJECT_ID)) {
-                return new ObjectId();
-            }
             return null;
         }
 

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorTest.java
@@ -401,7 +401,7 @@ public abstract class BaseMongoConnectorTest
 
         // IS NULL
         assertQuery("SELECT i FROM " + inlineTable + " WHERE one IS NULL", "VALUES 10, 15");
-        assertQuery("SELECT i FROM tmp_objectid WHERE one IS NULL", "SELECT 0 WHERE false"); // NULL gets replaced with new unique ObjectId in MongoPageSink, this affects other test cases
+        assertQuery("SELECT i FROM tmp_objectid WHERE one IS NULL", "VALUES 10, 15");
 
         // CAST AS varchar
         assertQuery(
@@ -416,8 +416,8 @@ public abstract class BaseMongoConnectorTest
         assertQuery("SELECT i FROM " + inlineTable + " WHERE one IS DISTINCT FROM two", "VALUES 12, 14, 15");
         assertQuery("SELECT i FROM " + inlineTable + " WHERE one IS NOT DISTINCT FROM two", "VALUES 10, 11, 13");
 
-        assertQuery("SELECT i FROM tmp_objectid WHERE one IS DISTINCT FROM two", "VALUES 10, 12, 14, 15");
-        assertQuery("SELECT i FROM tmp_objectid WHERE one IS NOT DISTINCT FROM two", "VALUES 11, 13");
+        assertQuery("SELECT i FROM tmp_objectid WHERE one IS DISTINCT FROM two", "VALUES 12, 14, 15");
+        assertQuery("SELECT i FROM tmp_objectid WHERE one IS NOT DISTINCT FROM two", "VALUES 10, 11, 13");
 
         // Join on ObjectId
         assertQuery(


### PR DESCRIPTION
## Description

Write null value instead of current time ObjectId in MongoDB

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
