### PR TITLE
Process parameters for CREATE SCHEMA

### DIFF
--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
@@ -759,6 +759,16 @@ public abstract class DefaultTraversalVisitor<C>
     }
 
     @Override
+    protected Void visitCreateSchema(CreateSchema node, C context)
+    {
+        for (Property property : node.getProperties()) {
+            process(property, context);
+        }
+
+        return null;
+    }
+
+    @Override
     protected Void visitCreateTable(CreateTable node, C context)
     {
         for (TableElement tableElement : node.getElements()) {

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestMockConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestMockConnector.java
@@ -16,6 +16,7 @@ package io.trino.tests;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.trino.Session;
 import io.trino.connector.MockConnectorFactory;
 import io.trino.connector.MockConnectorPlugin;
 import io.trino.connector.MockConnectorTableHandle;
@@ -208,6 +209,16 @@ public class TestMockConnector
         assertUpdate("CREATE SCHEMA mock.test_schema WITH (boolean_schema_property = true)");
         assertThatThrownBy(() -> assertUpdate("CREATE SCHEMA mock.test_schema WITH (unknown_property = true)"))
                 .hasMessage("Catalog 'mock' schema property 'unknown_property' does not exist");
+    }
+
+    @Test
+    public void testExecuteWithSchemaProperties()
+    {
+        String query = "CREATE SCHEMA mock.test_schema WITH (boolean_schema_property = ?)";
+        Session session = Session.builder(getSession())
+                .addPreparedStatement("my_query", query)
+                .build();
+        computeActual(session, "EXECUTE my_query USING true");
     }
 
     @Test


### PR DESCRIPTION
## Description

Fix processing of parameters in schema properties for `CREATE SCHEMA` when executed as a prepared statement using `EXECUTE`.

## Documentation

(x) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# General
* Fix processing of prepared statement parameters in schema properties for `CREATE SCHEMA`. ({issue}`11485`)
```
