### PR TITLE
Support UInt8, UInt16, UInt32 and UInt64 types in ClickHouse

### DIFF
--- a/docs/src/main/sphinx/connector/clickhouse.rst
+++ b/docs/src/main/sphinx/connector/clickhouse.rst
@@ -167,6 +167,7 @@ ClickHouse        Trino             Notes
 ``Int16``         ``SMALLINT``      ``SMALLINT`` and ``INT2`` are aliases of ``Int16``
 ``Int32``         ``INTEGER``       ``INT``, ``INT4`` and ``INTEGER`` are aliases of ``Int32``
 ``Int64``         ``BIGINT``        ``BIGINT`` is an alias of ``Int64``
+``UInt32``        ``BIGINT``
 ``UInt64``        ``DECIMAL(20,0)``
 ``Float32``       ``REAL``          ``FLOAT`` is an alias of ``Float32``
 ``Float64``       ``DOUBLE``        ``DOUBLE`` is an alias of ``Float64``

--- a/docs/src/main/sphinx/connector/clickhouse.rst
+++ b/docs/src/main/sphinx/connector/clickhouse.rst
@@ -167,6 +167,7 @@ ClickHouse        Trino             Notes
 ``Int16``         ``SMALLINT``      ``SMALLINT`` and ``INT2`` are aliases of ``Int16``
 ``Int32``         ``INTEGER``       ``INT``, ``INT4`` and ``INTEGER`` are aliases of ``Int32``
 ``Int64``         ``BIGINT``        ``BIGINT`` is an alias of ``Int64``
+``UInt16``        ``INTEGER``
 ``UInt32``        ``BIGINT``
 ``UInt64``        ``DECIMAL(20,0)``
 ``Float32``       ``REAL``          ``FLOAT`` is an alias of ``Float32``

--- a/docs/src/main/sphinx/connector/clickhouse.rst
+++ b/docs/src/main/sphinx/connector/clickhouse.rst
@@ -167,6 +167,7 @@ ClickHouse        Trino             Notes
 ``Int16``         ``SMALLINT``      ``SMALLINT`` and ``INT2`` are aliases of ``Int16``
 ``Int32``         ``INTEGER``       ``INT``, ``INT4`` and ``INTEGER`` are aliases of ``Int32``
 ``Int64``         ``BIGINT``        ``BIGINT`` is an alias of ``Int64``
+``UInt8``         ``SMALLINT``
 ``UInt16``        ``INTEGER``
 ``UInt32``        ``BIGINT``
 ``UInt64``        ``DECIMAL(20,0)``

--- a/docs/src/main/sphinx/connector/clickhouse.rst
+++ b/docs/src/main/sphinx/connector/clickhouse.rst
@@ -167,6 +167,7 @@ ClickHouse        Trino             Notes
 ``Int16``         ``SMALLINT``      ``SMALLINT`` and ``INT2`` are aliases of ``Int16``
 ``Int32``         ``INTEGER``       ``INT``, ``INT4`` and ``INTEGER`` are aliases of ``Int32``
 ``Int64``         ``BIGINT``        ``BIGINT`` is an alias of ``Int64``
+``UInt64``        ``DECIMAL(20,0)``
 ``Float32``       ``REAL``          ``FLOAT`` is an alias of ``Float32``
 ``Float64``       ``DOUBLE``        ``DOUBLE`` is an alias of ``Float64``
 ``Decimal``       ``DECIMAL``

--- a/docs/src/main/sphinx/connector/clickhouse.rst
+++ b/docs/src/main/sphinx/connector/clickhouse.rst
@@ -160,26 +160,26 @@ Type mapping
 
 The data type mappings are as follows:
 
-================= =============== ===================================================================================================
-ClickHouse        Trino           Notes
-================= =============== ===================================================================================================
-``Int8``          ``TINYINT``     ``TINYINT``, ``BOOL``, ``BOOLEAN`` and ``INT1`` are aliases of ``Int8``
-``Int16``         ``SMALLINT``    ``SMALLINT`` and ``INT2`` are aliases of ``Int16``
-``Int32``         ``INTEGER``     ``INT``, ``INT4`` and ``INTEGER`` are aliases of ``Int32``
-``Int64``         ``BIGINT``      ``BIGINT`` is an alias of ``Int64``
-``Float32``       ``REAL``        ``FLOAT`` is an alias of ``Float32``
-``Float64``       ``DOUBLE``      ``DOUBLE`` is an alias of ``Float64``
+================= ================= ===================================================================================================
+ClickHouse        Trino             Notes
+================= ================= ===================================================================================================
+``Int8``          ``TINYINT``       ``TINYINT``, ``BOOL``, ``BOOLEAN`` and ``INT1`` are aliases of ``Int8``
+``Int16``         ``SMALLINT``      ``SMALLINT`` and ``INT2`` are aliases of ``Int16``
+``Int32``         ``INTEGER``       ``INT``, ``INT4`` and ``INTEGER`` are aliases of ``Int32``
+``Int64``         ``BIGINT``        ``BIGINT`` is an alias of ``Int64``
+``Float32``       ``REAL``          ``FLOAT`` is an alias of ``Float32``
+``Float64``       ``DOUBLE``        ``DOUBLE`` is an alias of ``Float64``
 ``Decimal``       ``DECIMAL``
-``FixedString``   ``VARBINARY``   Enabling ``clickhouse.map-string-as-varchar`` config property changes the mapping to ``VARCHAR``
-``String``        ``VARBINARY``   Enabling ``clickhouse.map-string-as-varchar`` config property changes the mapping to ``VARCHAR``
+``FixedString``   ``VARBINARY``     Enabling ``clickhouse.map-string-as-varchar`` config property changes the mapping to ``VARCHAR``
+``String``        ``VARBINARY``     Enabling ``clickhouse.map-string-as-varchar`` config property changes the mapping to ``VARCHAR``
 ``Date``          ``DATE``
 ``DateTime``      ``TIMESTAMP``
 ``IPv4``          ``IPADDRESS``
 ``IPv6``          ``IPADDRESS``
 ``Enum8``         ``VARCHAR``
 ``Enum16``        ``VARCHAR``
-``UUID``           ``UUID``
-================= =============== ===================================================================================================
+``UUID``          ``UUID``
+================= ================= ===================================================================================================
 
 .. include:: jdbc-type-mapping.fragment
 

--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
@@ -163,6 +163,9 @@ public class ClickHouseClient
 {
     private static final Splitter TABLE_PROPERTY_SPLITTER = Splitter.on(',').omitEmptyStrings().trimResults();
 
+    private static final long UINT32_MIN_VALUE = 0L;
+    private static final long UINT32_MAX_VALUE = 4294967295L;
+
     private static final DecimalType UINT64_TYPE = createDecimalType(20, 0);
     private static final BigDecimal UINT64_MIN_VALUE = BigDecimal.ZERO;
     private static final BigDecimal UINT64_MAX_VALUE = new BigDecimal("18446744073709551615");
@@ -474,6 +477,8 @@ public class ClickHouseClient
         ClickHouseColumn column = ClickHouseColumn.of("", jdbcTypeName);
         ClickHouseDataType columnDataType = column.getDataType();
         switch (columnDataType) {
+            case UInt32:
+                return Optional.of(ColumnMapping.longMapping(BIGINT, ResultSet::getLong, uInt32WriteFunction()));
             case UInt64:
                 return Optional.of(ColumnMapping.objectMapping(
                         UINT64_TYPE,
@@ -641,6 +646,17 @@ public class ClickHouseClient
         }
         // include more than one column
         return Optional.of("(" + String.join(",", prop) + ")");
+    }
+
+    private static LongWriteFunction uInt32WriteFunction()
+    {
+        return (preparedStatement, parameterIndex, value) -> {
+            // ClickHouse stores incorrect results when the values are out of supported range.
+            if (value < UINT32_MIN_VALUE || value > UINT32_MAX_VALUE) {
+                throw new TrinoException(INVALID_ARGUMENTS, format("Value must be between %s and %s in ClickHouse: %s", UINT32_MIN_VALUE, UINT32_MAX_VALUE, value));
+            }
+            preparedStatement.setLong(parameterIndex, value);
+        };
     }
 
     private static ObjectWriteFunction uInt64WriteFunction()

--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.InetAddresses;
+import com.google.common.primitives.Shorts;
 import io.airlift.slice.Slice;
 import io.trino.plugin.base.aggregation.AggregateFunctionRewriter;
 import io.trino.plugin.base.aggregation.AggregateFunctionRule;
@@ -163,6 +164,9 @@ public class ClickHouseClient
         extends BaseJdbcClient
 {
     private static final Splitter TABLE_PROPERTY_SPLITTER = Splitter.on(',').omitEmptyStrings().trimResults();
+
+    private static final long UINT8_MIN_VALUE = 0L;
+    private static final long UINT8_MAX_VALUE = 255L;
 
     private static final long UINT16_MIN_VALUE = 0L;
     private static final long UINT16_MAX_VALUE = 65535L;
@@ -481,6 +485,8 @@ public class ClickHouseClient
         ClickHouseColumn column = ClickHouseColumn.of("", jdbcTypeName);
         ClickHouseDataType columnDataType = column.getDataType();
         switch (columnDataType) {
+            case UInt8:
+                return Optional.of(ColumnMapping.longMapping(SMALLINT, ResultSet::getShort, uInt8WriteFunction()));
             case UInt16:
                 return Optional.of(ColumnMapping.longMapping(INTEGER, ResultSet::getInt, uInt16WriteFunction()));
             case UInt32:
@@ -652,6 +658,17 @@ public class ClickHouseClient
         }
         // include more than one column
         return Optional.of("(" + String.join(",", prop) + ")");
+    }
+
+    private static LongWriteFunction uInt8WriteFunction()
+    {
+        return (statement, index, value) -> {
+            // ClickHouse stores incorrect results when the values are out of supported range.
+            if (value < UINT8_MIN_VALUE || value > UINT8_MAX_VALUE) {
+                throw new TrinoException(INVALID_ARGUMENTS, format("Value must be between %s and %s in ClickHouse: %s", UINT8_MIN_VALUE, UINT8_MAX_VALUE, value));
+            }
+            statement.setShort(index, Shorts.checkedCast(value));
+        };
     }
 
     private static LongWriteFunction uInt16WriteFunction()


### PR DESCRIPTION
## Description

Support UInt8, UInt16, UInt32, UInt64 types in ClickHouse
Request in the community Slack: https://trinodb.slack.com/archives/CGB0QHWSW/p1647319914845359

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# ClickHouse
* Add support for `uint8`, `uint16`, `uint32` and `uint64` types. ({issue}`11490`)
```
