### PR TITLE
Allow fetching file based access provider rules via http(s) url

### DIFF
--- a/docs/src/main/sphinx/security/file-system-access-control.rst
+++ b/docs/src/main/sphinx/security/file-system-access-control.rst
@@ -28,7 +28,8 @@ Configuration
 To use the access control plugin, add an ``etc/access-control.properties`` file
 containing two required properties: ``access-control.name``, which must be set
 to ``file``, and ``security.config-file``, which must be set to the location
-of the config file. For example, if a config file named ``rules.json`` resides
+of the config file. The configuration file location can either point to the local
+disc or to a rest endpoint. For example, if a config file named ``rules.json`` resides
 in ``etc``, add an ``etc/access-control.properties`` with the following
 contents:
 
@@ -37,9 +38,23 @@ contents:
    access-control.name=file
    security.config-file=etc/rules.json
 
+If the config should be loaded via the rest endpoint ``http://trino-test/config`` and
+is wrapped into a JSON object and available via the ``data`` key ``etc/access-control.properties``
+should look like this:
+
+.. code-block:: text
+
+   access-control.name=file
+   security.config-file=http://trino-test/config
+   security.json-pointer=/data
+
 The config file is specified in JSON format. It contains rules that define which
 users have access to which resources. The rules are read from top to bottom and
-the first matching rule is applied. If no rule matches, access is denied.
+the first matching rule is applied. If no rule matches, access is denied. A JSON
+pointer (RFC 6901) can be specified using the ``security.json-pointer`` property
+to specify a nested object inside the JSON content containing the rules. Per default,
+the file is assumed to contain a single object defining the rules rendering
+the specification of ``security.json-pointer`` unnecessary in that case.
 
 Refresh
 --------

--- a/lib/trino-plugin-toolkit/pom.xml
+++ b/lib/trino-plugin-toolkit/pom.xml
@@ -35,6 +35,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>http-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>json</artifactId>
         </dependency>
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
@@ -28,12 +28,12 @@ import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.security.ViewExpression;
 import io.trino.spi.type.Type;
 
-import java.io.File;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -44,7 +44,6 @@ import static io.trino.plugin.base.security.TableAccessControlRule.TablePrivileg
 import static io.trino.plugin.base.security.TableAccessControlRule.TablePrivilege.OWNERSHIP;
 import static io.trino.plugin.base.security.TableAccessControlRule.TablePrivilege.SELECT;
 import static io.trino.plugin.base.security.TableAccessControlRule.TablePrivilege.UPDATE;
-import static io.trino.plugin.base.util.JsonUtils.parseJson;
 import static io.trino.spi.function.FunctionKind.TABLE;
 import static io.trino.spi.security.AccessDeniedException.denyAddColumn;
 import static io.trino.spi.security.AccessDeniedException.denyCommentColumn;
@@ -105,12 +104,12 @@ public class FileBasedAccessControl
     private final List<SessionPropertyAccessControlRule> sessionPropertyRules;
     private final Set<AnySchemaPermissionsRule> anySchemaPermissionsRules;
 
-    public FileBasedAccessControl(CatalogName catalogName, File configFile)
+    public FileBasedAccessControl(CatalogName catalogName, Supplier<AccessControlRules> rulesProvider)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null").toString();
 
-        AccessControlRules rules = parseJson(configFile.toPath(), AccessControlRules.class);
-        checkArgument(!rules.hasRoleRules(), "File connector access control does not support role rules: %s", configFile);
+        AccessControlRules rules = rulesProvider.get();
+        checkArgument(!rules.hasRoleRules(), "File connector access control does not support role rules!");
 
         this.schemaRules = rules.getSchemaRules();
         this.tableRules = rules.getTableRules();

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControlConfig.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControlConfig.java
@@ -14,33 +14,46 @@
 package io.trino.plugin.base.security;
 
 import io.airlift.configuration.Config;
-import io.airlift.configuration.validation.FileExists;
+import io.airlift.configuration.ConfigDescription;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDuration;
 
 import javax.validation.constraints.NotNull;
 
-import java.io.File;
-
 public class FileBasedAccessControlConfig
 {
     public static final String SECURITY_CONFIG_FILE = "security.config-file";
+    public static final String SECURITY_JSON_POINTER = "security.json-pointer";
     public static final String SECURITY_REFRESH_PERIOD = "security.refresh-period";
 
-    private File configFile;
+    private String configFilePath;
+    private String jsonPointer = "";
     private Duration refreshPeriod;
 
     @NotNull
-    @FileExists
-    public File getConfigFile()
+    public String getConfigFilePath()
     {
-        return configFile;
+        return configFilePath;
     }
 
     @Config(SECURITY_CONFIG_FILE)
-    public FileBasedAccessControlConfig setConfigFile(File configFile)
+    public FileBasedAccessControlConfig setConfigFilePath(String configFilePath)
     {
-        this.configFile = configFile;
+        this.configFilePath = configFilePath;
+        return this;
+    }
+
+    @NotNull
+    public String getJsonPointer()
+    {
+        return jsonPointer;
+    }
+
+    @Config(SECURITY_JSON_POINTER)
+    @ConfigDescription("JSON pointer (RFC 6901) to mappings inside JSON config")
+    public FileBasedAccessControlConfig setJsonPointer(String jsonPointer)
+    {
+        this.jsonPointer = jsonPointer;
         return this;
     }
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControlModule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControlModule.java
@@ -15,43 +15,72 @@ package io.trino.plugin.base.security;
 
 import com.google.inject.Binder;
 import com.google.inject.Inject;
-import com.google.inject.Module;
 import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.TypeLiteral;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.airlift.log.Logger;
+import io.airlift.units.Duration;
 import io.trino.plugin.base.CatalogName;
 import io.trino.spi.connector.ConnectorAccessControl;
 
-import java.io.File;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import static com.google.common.base.Suppliers.memoizeWithExpiration;
 import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class FileBasedAccessControlModule
-        implements Module
+        extends AbstractConfigurationAwareModule
 {
     private static final Logger log = Logger.get(FileBasedAccessControlModule.class);
 
     @Override
-    public void configure(Binder binder)
+    public void setup(Binder binder)
     {
+        bindRules(binder);
         configBinder(binder).bindConfig(FileBasedAccessControlConfig.class);
+    }
+
+    private void bindRules(Binder binder)
+    {
+        FileBasedAccessControlConfig configuration = buildConfigObject(FileBasedAccessControlConfig.class);
+        if (FileBasedAccessControlUtils.isRest(configuration)) {
+            binder.bind(new TypeLiteral<Supplier<AccessControlRules>>() {})
+                    .to(RestFileBasedAccessControlRulesProvider.class)
+                    .in(Scopes.SINGLETON);
+            httpClientBinder(binder).bindHttpClient("security-http-client", ForAccessControlRules.class)
+                    .withConfigDefaults(config -> config
+                            .setRequestTimeout(Duration.succinctDuration(10, TimeUnit.SECONDS))
+                            .setSelectorCount(1)
+                            .setMinThreads(1));
+        }
+        else {
+            binder.bind(new TypeLiteral<Supplier<AccessControlRules>>() {})
+                    .toProvider(() -> new LocalFileAccessControlRulesProvider<>(configuration, AccessControlRules.class))
+                    .in(Scopes.SINGLETON);
+        }
     }
 
     @Inject
     @Provides
-    public ConnectorAccessControl getConnectorAccessControl(CatalogName catalogName, FileBasedAccessControlConfig config)
+    public ConnectorAccessControl getConnectorAccessControl(
+            CatalogName catalogName,
+            FileBasedAccessControlConfig config,
+            Supplier<AccessControlRules> rulesProvider)
     {
-        File configFile = config.getConfigFile();
+        String configFilePath = config.getConfigFilePath();
         if (config.getRefreshPeriod() != null) {
             return ForwardingConnectorAccessControl.of(memoizeWithExpiration(
                     () -> {
-                        log.info("Refreshing access control for catalog '%s' from: %s", catalogName, configFile);
-                        return new FileBasedAccessControl(catalogName, configFile);
+                        log.info("Refreshing access control for catalog '%s' from: %s", catalogName, configFilePath);
+                        return new FileBasedAccessControl(catalogName, rulesProvider);
                     },
                     config.getRefreshPeriod().toMillis(),
                     MILLISECONDS));
         }
-        return new FileBasedAccessControl(catalogName, configFile);
+        return new FileBasedAccessControl(catalogName, rulesProvider);
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControlUtils.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControlUtils.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.security;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.trino.plugin.base.util.JsonUtils;
+
+public final class FileBasedAccessControlUtils
+{
+    private FileBasedAccessControlUtils()
+    {
+    }
+
+    public static boolean isRest(FileBasedAccessControlConfig config)
+    {
+        return config.getConfigFilePath().startsWith("https://") || config.getConfigFilePath().startsWith("http://");
+    }
+
+    public static <R> R parseJSONString(String jsonString, String jsonPointer, Class<R> clazz)
+    {
+        JsonNode node = JsonUtils.parseJson(jsonString);
+        JsonNode mappingsNode = node.at(jsonPointer);
+        return JsonUtils.jsonTreeToValue(mappingsNode, clazz);
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
@@ -18,10 +18,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.log.Logger;
-import io.airlift.units.Duration;
 import io.trino.plugin.base.security.CatalogAccessControlRule.AccessMode;
 import io.trino.plugin.base.security.TableAccessControlRule.TablePrivilege;
-import io.trino.spi.TrinoException;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.CatalogSchemaRoutineName;
 import io.trino.spi.connector.CatalogSchemaTableName;
@@ -37,30 +35,23 @@ import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.security.ViewExpression;
 import io.trino.spi.type.Type;
 
-import java.nio.file.Paths;
 import java.security.Principal;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.regex.Pattern;
 
-import static com.google.common.base.Suppliers.memoizeWithExpiration;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.trino.plugin.base.security.CatalogAccessControlRule.AccessMode.ALL;
 import static io.trino.plugin.base.security.CatalogAccessControlRule.AccessMode.READ_ONLY;
-import static io.trino.plugin.base.security.FileBasedAccessControlConfig.SECURITY_REFRESH_PERIOD;
 import static io.trino.plugin.base.security.TableAccessControlRule.TablePrivilege.DELETE;
 import static io.trino.plugin.base.security.TableAccessControlRule.TablePrivilege.GRANT_SELECT;
 import static io.trino.plugin.base.security.TableAccessControlRule.TablePrivilege.INSERT;
 import static io.trino.plugin.base.security.TableAccessControlRule.TablePrivilege.OWNERSHIP;
 import static io.trino.plugin.base.security.TableAccessControlRule.TablePrivilege.SELECT;
 import static io.trino.plugin.base.security.TableAccessControlRule.TablePrivilege.UPDATE;
-import static io.trino.plugin.base.util.JsonUtils.parseJson;
-import static io.trino.spi.StandardErrorCode.CONFIGURATION_INVALID;
 import static io.trino.spi.function.FunctionKind.TABLE;
 import static io.trino.spi.security.AccessDeniedException.denyAddColumn;
 import static io.trino.spi.security.AccessDeniedException.denyCatalogAccess;
@@ -116,9 +107,7 @@ import static io.trino.spi.security.AccessDeniedException.denyTruncateTable;
 import static io.trino.spi.security.AccessDeniedException.denyUpdateTableColumns;
 import static io.trino.spi.security.AccessDeniedException.denyViewQuery;
 import static io.trino.spi.security.AccessDeniedException.denyWriteSystemInformationAccess;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class FileBasedSystemAccessControl
         implements SystemAccessControl
@@ -202,77 +191,12 @@ public class FileBasedSystemAccessControl
         {
             requireNonNull(config, "config is null");
 
-            Bootstrap bootstrap = new Bootstrap(
-                    binder -> configBinder(binder).bindConfig(FileBasedAccessControlConfig.class));
+            Bootstrap bootstrap = new Bootstrap(new FileBasedSystemAccessControlModule(config));
             Injector injector = bootstrap
                     .doNotInitializeLogging()
                     .setRequiredConfigurationProperties(config)
                     .initialize();
-            FileBasedAccessControlConfig fileBasedAccessControlConfig = injector.getInstance(FileBasedAccessControlConfig.class);
-            String configFileName = fileBasedAccessControlConfig.getConfigFile().getPath();
-
-            if (config.containsKey(SECURITY_REFRESH_PERIOD)) {
-                Duration refreshPeriod;
-                try {
-                    refreshPeriod = fileBasedAccessControlConfig.getRefreshPeriod();
-                }
-                catch (IllegalArgumentException e) {
-                    throw invalidRefreshPeriodException(config, configFileName);
-                }
-                if (refreshPeriod.toMillis() == 0) {
-                    throw invalidRefreshPeriodException(config, configFileName);
-                }
-                return ForwardingSystemAccessControl.of(memoizeWithExpiration(
-                        () -> {
-                            log.info("Refreshing system access control from %s", configFileName);
-                            return create(configFileName);
-                        },
-                        refreshPeriod.toMillis(),
-                        MILLISECONDS));
-            }
-            return create(configFileName);
-        }
-
-        private static TrinoException invalidRefreshPeriodException(Map<String, String> config, String configFileName)
-        {
-            return new TrinoException(
-                    CONFIGURATION_INVALID,
-                    format("Invalid duration value '%s' for property '%s' in '%s'", config.get(SECURITY_REFRESH_PERIOD), SECURITY_REFRESH_PERIOD, configFileName));
-        }
-
-        private static SystemAccessControl create(String configFileName)
-        {
-            FileBasedSystemAccessControlRules rules = parseJson(Paths.get(configFileName), FileBasedSystemAccessControlRules.class);
-            List<CatalogAccessControlRule> catalogAccessControlRules;
-            if (rules.getCatalogRules().isPresent()) {
-                ImmutableList.Builder<CatalogAccessControlRule> catalogRulesBuilder = ImmutableList.builder();
-                catalogRulesBuilder.addAll(rules.getCatalogRules().get());
-
-                // Hack to allow Trino Admin to access the "system" catalog for retrieving server status.
-                // todo Change userRegex from ".*" to one particular user that Trino Admin will be restricted to run as
-                catalogRulesBuilder.add(new CatalogAccessControlRule(
-                        ALL,
-                        Optional.of(Pattern.compile(".*")),
-                        Optional.empty(),
-                        Optional.empty(),
-                        Optional.of(Pattern.compile("system"))));
-                catalogAccessControlRules = catalogRulesBuilder.build();
-            }
-            else {
-                // if no rules are defined then all access is allowed
-                catalogAccessControlRules = ImmutableList.of(CatalogAccessControlRule.ALLOW_ALL);
-            }
-            return FileBasedSystemAccessControl.builder()
-                    .setCatalogRules(catalogAccessControlRules)
-                    .setQueryAccessRules(rules.getQueryAccessRules())
-                    .setImpersonationRules(rules.getImpersonationRules())
-                    .setPrincipalUserMatchRules(rules.getPrincipalUserMatchRules())
-                    .setSystemInformationRules(rules.getSystemInformationRules())
-                    .setSchemaRules(rules.getSchemaRules().orElse(ImmutableList.of(CatalogSchemaAccessControlRule.ALLOW_ALL)))
-                    .setTableRules(rules.getTableRules().orElse(ImmutableList.of(CatalogTableAccessControlRule.ALLOW_ALL)))
-                    .setSessionPropertyRules(rules.getSessionPropertyRules().orElse(ImmutableList.of(SessionPropertyAccessControlRule.ALLOW_ALL)))
-                    .setCatalogSessionPropertyRules(rules.getCatalogSessionPropertyRules().orElse(ImmutableList.of(CatalogSessionPropertyAccessControlRule.ALLOW_ALL)))
-                    .build();
+            return injector.getInstance(SystemAccessControl.class);
         }
     }
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
-import io.airlift.log.Logger;
 import io.trino.plugin.base.security.CatalogAccessControlRule.AccessMode;
 import io.trino.plugin.base.security.TableAccessControlRule.TablePrivilege;
 import io.trino.spi.connector.CatalogSchemaName;
@@ -112,8 +111,6 @@ import static java.util.Objects.requireNonNull;
 public class FileBasedSystemAccessControl
         implements SystemAccessControl
 {
-    private static final Logger log = Logger.get(FileBasedSystemAccessControl.class);
-
     public static final String NAME = "file";
     private static final String INFORMATION_SCHEMA_NAME = "information_schema";
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControlModule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControlModule.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.security;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Binder;
+import com.google.inject.Inject;
+import com.google.inject.Provides;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.airlift.configuration.ConfigurationFactory;
+import io.airlift.log.Logger;
+import io.airlift.units.Duration;
+import io.trino.spi.TrinoException;
+import io.trino.spi.security.SystemAccessControl;
+
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Suppliers.memoizeWithExpiration;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.trino.plugin.base.security.CatalogAccessControlRule.AccessMode.ALL;
+import static io.trino.plugin.base.security.FileBasedAccessControlConfig.SECURITY_REFRESH_PERIOD;
+import static io.trino.plugin.base.util.JsonUtils.parseJson;
+import static io.trino.spi.StandardErrorCode.CONFIGURATION_INVALID;
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class FileBasedSystemAccessControlModule
+        extends AbstractConfigurationAwareModule
+{
+    private static final Logger log = Logger.get(FileBasedSystemAccessControlModule.class);
+    private static final String HTTP_CLIENT_NAME = "access-control";
+
+    public FileBasedSystemAccessControlModule(Map<String, String> config)
+    {
+        super();
+        this.setConfigurationFactory(new ConfigurationFactory(config));
+    }
+
+    @Override
+    public void setup(Binder binder)
+    {
+        configBinder(binder).bindConfig(FileBasedAccessControlConfig.class);
+    }
+
+    @Inject
+    @Provides
+    public SystemAccessControl getSystemAccessControl(FileBasedAccessControlConfig config)
+    {
+        String configFileName = config.getConfigFile().getPath();
+
+        if (config.getRefreshPeriod() != null) {
+            Duration refreshPeriod;
+            try {
+                refreshPeriod = config.getRefreshPeriod();
+            }
+            catch (IllegalArgumentException e) {
+                throw invalidRefreshPeriodException(config, configFileName);
+            }
+            if (refreshPeriod.toMillis() == 0) {
+                throw invalidRefreshPeriodException(config, configFileName);
+            }
+            return ForwardingSystemAccessControl.of(memoizeWithExpiration(
+                    () -> {
+                        log.info("Refreshing system access control from %s", configFileName);
+                        return create(configFileName);
+                    },
+                    refreshPeriod.toMillis(),
+                    MILLISECONDS));
+        }
+        return create(configFileName);
+    }
+
+    private static TrinoException invalidRefreshPeriodException(FileBasedAccessControlConfig config, String configFileName)
+    {
+        return new TrinoException(
+                CONFIGURATION_INVALID,
+                format("Invalid duration value '%s' for property '%s' in '%s'", config.getRefreshPeriod(), SECURITY_REFRESH_PERIOD, configFileName));
+    }
+
+    private static SystemAccessControl create(String configFileName) {
+        FileBasedSystemAccessControlRules rules = parseJson(Paths.get(configFileName), FileBasedSystemAccessControlRules.class);
+        List<CatalogAccessControlRule> catalogAccessControlRules;
+        if (rules.getCatalogRules().isPresent()) {
+            ImmutableList.Builder<CatalogAccessControlRule> catalogRulesBuilder = ImmutableList.builder();
+            catalogRulesBuilder.addAll(rules.getCatalogRules().get());
+
+            // Hack to allow Trino Admin to access the "system" catalog for retrieving server status.
+            // todo Change userRegex from ".*" to one particular user that Trino Admin will be restricted to run as
+            catalogRulesBuilder.add(new CatalogAccessControlRule(
+                    ALL,
+                    Optional.of(Pattern.compile(".*")),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.of(Pattern.compile("system"))));
+            catalogAccessControlRules = catalogRulesBuilder.build();
+        } else {
+            // if no rules are defined then all access is allowed
+            catalogAccessControlRules = ImmutableList.of(CatalogAccessControlRule.ALLOW_ALL);
+        }
+        return FileBasedSystemAccessControl.builder()
+                .setCatalogRules(catalogAccessControlRules)
+                .setQueryAccessRules(rules.getQueryAccessRules())
+                .setImpersonationRules(rules.getImpersonationRules())
+                .setPrincipalUserMatchRules(rules.getPrincipalUserMatchRules())
+                .setSystemInformationRules(rules.getSystemInformationRules())
+                .setSchemaRules(rules.getSchemaRules().orElse(ImmutableList.of(CatalogSchemaAccessControlRule.ALLOW_ALL)))
+                .setTableRules(rules.getTableRules().orElse(ImmutableList.of(CatalogTableAccessControlRule.ALLOW_ALL)))
+                .setSessionPropertyRules(rules.getSessionPropertyRules().orElse(ImmutableList.of(SessionPropertyAccessControlRule.ALLOW_ALL)))
+                .setCatalogSessionPropertyRules(rules.getCatalogSessionPropertyRules().orElse(ImmutableList.of(CatalogSessionPropertyAccessControlRule.ALLOW_ALL)))
+                .build();
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForAccessControlRules.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForAccessControlRules.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.security;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@BindingAnnotation
+public @interface ForAccessControlRules {
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/LocalFileAccessControlRulesProvider.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/LocalFileAccessControlRulesProvider.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.security;
+
+import io.airlift.log.Logger;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.function.Supplier;
+
+import static io.trino.plugin.base.security.FileBasedAccessControlUtils.parseJSONString;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class LocalFileAccessControlRulesProvider<R>
+        extends RulesProvider<R>
+{
+    private static final Logger log = Logger.get(LocalFileAccessControlRulesProvider.class);
+    private final File configFile;
+
+    public LocalFileAccessControlRulesProvider(FileBasedAccessControlConfig config, Class<R> clazz)
+    {
+        super(config, clazz);
+        this.configFile = new File(config.getConfigFilePath());
+        if (!Files.isReadable(configFile.toPath())) {
+            throw new IllegalArgumentException(format("configFile %s does not exist or is not readable",
+                    configFile.getAbsoluteFile()));
+        }
+    }
+
+    @Override
+    protected String getRawJsonString()
+    {
+        log.info("Retrieving config from file %s", configFile);
+        try {
+            return Files.readString(configFile.toPath());
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException("Failed to read file: " + configFile, e);
+        }
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/RestAccessControlRulesProvider.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/RestAccessControlRulesProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.security;
+
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.HttpStatus;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.StringResponseHandler.StringResponse;
+
+import java.net.URI;
+import java.util.function.Supplier;
+
+import static io.airlift.http.client.Request.Builder.prepareGet;
+import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
+import static io.trino.plugin.base.security.FileBasedAccessControlUtils.parseJSONString;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class RestAccessControlRulesProvider<R>
+        extends RulesProvider<R>
+{
+    private final URI configUri;
+    private final HttpClient httpClient;
+
+    public RestAccessControlRulesProvider(FileBasedAccessControlConfig config,
+            HttpClient httpClient,
+            Class<R> clazz)
+    {
+        super(config, clazz);
+        this.configUri = URI.create(config.getConfigFilePath());
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+    }
+
+    @Override
+    protected String getRawJsonString()
+    {
+        Request request = prepareGet().setUri(configUri).build();
+        StringResponse response = httpClient.execute(request, createStringResponseHandler());
+        int status = response.getStatusCode();
+        if (status != HttpStatus.OK.code()) {
+            throw new IllegalStateException(format("Request to '%s' returned unexpected status code: '%d'", configUri, status));
+        }
+        return response.getBody();
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/RestFileBasedAccessControlRulesProvider.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/RestFileBasedAccessControlRulesProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.security;
+
+import io.airlift.http.client.HttpClient;
+
+public class RestFileBasedAccessControlRulesProvider
+        extends RestAccessControlRulesProvider<AccessControlRules>
+{
+    public RestFileBasedAccessControlRulesProvider(
+            FileBasedAccessControlConfig config, @ForAccessControlRules HttpClient httpClient)
+    {
+        super(config, httpClient, AccessControlRules.class);
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/RestFileBasedSystemAccessControlRulesProvider.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/RestFileBasedSystemAccessControlRulesProvider.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.security;
+
+import com.google.inject.Inject;
+import io.airlift.http.client.HttpClient;
+
+public class RestFileBasedSystemAccessControlRulesProvider
+        extends RestAccessControlRulesProvider<FileBasedSystemAccessControlRules>
+{
+    @Inject
+    public RestFileBasedSystemAccessControlRulesProvider(
+            FileBasedAccessControlConfig config, @ForAccessControlRules HttpClient httpClient)
+    {
+        super(config, httpClient, FileBasedSystemAccessControlRules.class);
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/RulesProvider.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/RulesProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.security;
+
+import java.util.function.Supplier;
+
+import static io.trino.plugin.base.security.FileBasedAccessControlUtils.parseJSONString;
+import static java.util.Objects.requireNonNull;
+
+public abstract class RulesProvider<R>
+        implements Supplier<R>
+{
+    protected final String jsonPointer;
+    protected final Class<R> clazz;
+
+    public RulesProvider(FileBasedAccessControlConfig config, Class<R> clazz) {
+        this.clazz = requireNonNull(clazz);
+        this.jsonPointer = requireNonNull(config.getJsonPointer());
+    }
+
+    protected abstract String getRawJsonString();
+
+    @Override
+    public R get()
+    {
+        return parseJSONString(getRawJsonString(), jsonPointer, clazz);
+    }
+}

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestFileBasedAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestFileBasedAccessControl.java
@@ -33,8 +33,6 @@ import org.testng.Assert.ThrowingRunnable;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.io.File;
-import java.net.URISyntaxException;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -493,7 +491,7 @@ public class TestFileBasedAccessControl
     public void testInvalidRules()
     {
         assertThatThrownBy(() -> createAccessControl("invalid.json"))
-                .hasMessageContaining("Invalid JSON");
+                .hasMessageContaining("Failed to parse JSON");
     }
 
     @Test
@@ -553,13 +551,11 @@ public class TestFileBasedAccessControl
 
     private static ConnectorAccessControl createAccessControl(String fileName)
     {
-        try {
-            File configFile = new File(getResource(fileName).toURI());
-            return new FileBasedAccessControl(new CatalogName("test_catalog"), configFile);
-        }
-        catch (URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
+        FileBasedAccessControlConfig config = new FileBasedAccessControlConfig()
+                .setConfigFilePath(getResource(fileName).getPath());
+
+        return new FileBasedAccessControl(new CatalogName("test_catalog"),
+                new LocalFileAccessControlRulesProvider<>(config, AccessControlRules.class));
     }
 
     private static void assertDenied(ThrowingRunnable runnable)

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestFileBasedSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestFileBasedSystemAccessControl.java
@@ -37,6 +37,7 @@ import org.testng.annotations.Test;
 import javax.security.auth.kerberos.KerberosPrincipal;
 
 import java.io.File;
+import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
@@ -1398,13 +1399,13 @@ public class TestFileBasedSystemAccessControl
         sleep(2);
 
         assertThatThrownBy(() -> accessControl.checkCanCreateView(alice, aliceView))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageStartingWith("Invalid JSON file");
+                .isInstanceOf(UncheckedIOException.class)
+                .hasMessageStartingWith("Failed to parse JSON");
 
         // test if file based cached control was not cached somewhere
         assertThatThrownBy(() -> accessControl.checkCanCreateView(alice, aliceView))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageStartingWith("Invalid JSON file");
+                .isInstanceOf(UncheckedIOException.class)
+                .hasMessageStartingWith("Failed to parse JSON");
 
         copy(new File(getResourcePath("file-based-system-catalog.json")), configFile);
         sleep(2);
@@ -1416,7 +1417,7 @@ public class TestFileBasedSystemAccessControl
     public void parseUnknownRules()
     {
         assertThatThrownBy(() -> newFileBasedSystemAccessControl("file-based-system-security-config-file-with-unknown-rules.json"))
-                .hasMessageContaining("Invalid JSON");
+                .hasMessageContaining("Failed to parse JSON");
     }
 
     private SystemAccessControl newFileBasedSystemAccessControl(String resourceName)

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestFileBasedSystemAccessControlModule.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestFileBasedSystemAccessControlModule.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.security;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.ConfigurationException;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
+import com.sun.net.httpserver.HttpServer;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.HttpClientConfig;
+import io.airlift.units.Duration;
+import io.trino.spi.QueryId;
+import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.security.Identity;
+import io.trino.spi.security.SystemAccessControl;
+import io.trino.spi.security.SystemSecurityContext;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestFileBasedSystemAccessControlModule
+{
+    private static final Identity alice = Identity.forUser("alice").withGroups(ImmutableSet.of("staff")).build();
+    private static final CatalogSchemaTableName aliceView = new CatalogSchemaTableName("alice-catalog", "schema", "view");
+    private static final Optional<QueryId> queryId = Optional.empty();
+
+    private static final SystemSecurityContext ALICE = new SystemSecurityContext(alice, queryId);
+
+    @Test
+    public void noHttpClientConfigForLocalFile()
+    {
+        Injector injector = initModule(ImmutableMap.of(
+                "security.config-file", getResourcePath("file-based-system-catalog.json")));
+        SystemAccessControl accessControl = injector.getInstance(SystemAccessControl.class);
+        accessControl.checkCanCreateView(ALICE, aliceView);
+        Supplier<FileBasedSystemAccessControlRules> provider = injector.getInstance(
+                Key.get(new TypeLiteral<Supplier<FileBasedSystemAccessControlRules>>() {}));
+        assertTrue(provider instanceof LocalFileAccessControlRulesProvider);
+        assertThatThrownBy(() -> injector.getInstance(Key.get(HttpClient.class, ForAccessControlRules.class)))
+                .isInstanceOf(ConfigurationException.class).hasMessageContaining("is not explicitly bound");
+        assertThatThrownBy(() -> injector.getInstance(Key.get(HttpClientConfig.class)))
+                .isInstanceOf(ConfigurationException.class).hasMessageContaining("is not explicitly bound");
+    }
+
+    @Test
+    public void httpClientConfigForRestFile()
+            throws IOException
+    {
+        byte[] response = Files.readAllBytes(Path.of(
+            getResourcePath("file-based-system-catalog.json")));
+
+        try (TestingHttpServer testingHttpServer = new TestingHttpServer(2002, response)) {
+            Injector injector = initModule(ImmutableMap.of(
+                    "security.config-file", "http://localhost:2002/test",
+                    "access-control.http-client.connect-timeout", "123ms"));
+            SystemAccessControl accessControl = injector.getInstance(SystemAccessControl.class);
+            accessControl.checkCanCreateView(ALICE, aliceView);
+            Supplier<FileBasedSystemAccessControlRules> provider =
+                    injector.getInstance(Key.get(new TypeLiteral<Supplier<FileBasedSystemAccessControlRules>>() {}));
+            assertTrue(provider instanceof RestFileBasedSystemAccessControlRulesProvider);
+            HttpClientConfig httpConfig = injector.getInstance(Key.get(HttpClientConfig.class));
+            assertEquals(httpConfig.getConnectTimeout(), new Duration(123, TimeUnit.MILLISECONDS));
+        }
+        catch (Exception ex) {
+            throw new IllegalStateException("Could not close testingHttpServer!", ex);
+        }
+    }
+
+    private static Injector initModule(Map<String, String> config)
+    {
+        requireNonNull(config, "config is null");
+
+        FileBasedSystemAccessControlModule module = new FileBasedSystemAccessControlModule(config);
+        Bootstrap bootstrap = new Bootstrap(module);
+        Injector injector = bootstrap
+                .doNotInitializeLogging()
+                .setRequiredConfigurationProperties(config)
+                .initialize();
+
+        return injector;
+    }
+
+    private String getResourcePath(String resourceName)
+    {
+        return requireNonNull(this.getClass().getClassLoader().getResource(resourceName), "Resource does not exist: " + resourceName).getPath();
+    }
+
+    private static class TestingHttpServer
+            implements AutoCloseable
+    {
+        private final HttpServer httpServer;
+
+        TestingHttpServer(int port, byte[] response)
+                throws IOException
+        {
+            httpServer = HttpServer.create(new InetSocketAddress(port), 0);
+            httpServer.createContext("/test", exchange ->
+            {
+                exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, response.length);
+                exchange.getResponseBody().write(response);
+                exchange.close();
+            });
+            httpServer.start();
+        }
+
+        @Override
+        public void close()
+                throws Exception
+        {
+            httpServer.stop(0);
+        }
+    }
+}

--- a/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopConnectorFactory.java
+++ b/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopConnectorFactory.java
@@ -15,6 +15,7 @@ package io.trino.plugin.atop;
 
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
+import io.airlift.configuration.ConfigurationFactory;
 import io.airlift.json.JsonModule;
 import io.trino.plugin.atop.AtopConnectorConfig.AtopSecurity;
 import io.trino.plugin.base.CatalogNameModule;
@@ -68,7 +69,10 @@ public class AtopConnectorFactory
                             AtopConnectorConfig.class,
                             config -> config.getSecurity() == AtopSecurity.FILE,
                             binder -> {
-                                binder.install(new FileBasedAccessControlModule());
+                                FileBasedAccessControlModule module = new FileBasedAccessControlModule();
+                                module.setConfigurationFactory(new ConfigurationFactory(requiredConfig));
+                                module.configure(binder);
+                                binder.install(module);
                                 binder.install(new JsonModule());
                             }));
 

--- a/plugin/trino-example-http/pom.xml
+++ b/plugin/trino-example-http/pom.xml
@@ -38,6 +38,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>node</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
@@ -99,12 +104,6 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>http-server</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>node</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

This PR will extend the capabilities of `FileBasedAccessControl` and `FileSystemBasedAccessControl` to get the configuration either via a local file or from a remote URL. This is necessary if secret management systems such as [Vault](https://www.vaultproject.io) are used.  
The PR adapts the concept already proven effective and in line with general trino best practices in https://github.com/trinodb/trino/pull/6210 .

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

Is this change a fix, improvement, new feature, refactoring, or other?
> It is an improvement extending access control capabilities.

Is this a change to the core query engine, a connector, client library, or the SPI interfaces?
> This specifically changes the file based access control and file based system access control capabilities located in `trino-plugin-toolkit`.

How would you describe this change to a non-technical end user or system administrator?
> It is now possible to receive the access control rules / configurations for the file based access control and file based system access control via HTTP or HTTPS from a configurable URL.

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Security
* Allow fetching file based (system) access provider rules via http(s) url
```
