### PR TITLE
Simplify node listing in FullNodeCapableNodeAllocatorService

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/InMemoryNodeManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/InMemoryNodeManager.java
@@ -74,6 +74,18 @@ public class InMemoryNodeManager
         listeners.forEach(listener -> listener.accept(allNodes));
     }
 
+    public void removeNode(InternalNode node)
+    {
+        for (CatalogName catalog : ImmutableSet.copyOf(remoteNodes.keySet())) {
+            removeNode(catalog, node);
+        }
+    }
+
+    public void removeNode(CatalogName catalogName, InternalNode node)
+    {
+        remoteNodes.remove(catalogName, node);
+    }
+
     @Override
     public Set<InternalNode> getNodes(NodeState state)
     {


### PR DESCRIPTION
Previously NodeScheduler and NodeSelector were used for listing
nodes in FullNodeCapableNodeAllocatorService. Those abstractions were not
well suited for the job. They stattisfied much vaster set of
responsibilities, while we needed just a simple listing way of listing
all nodes (or all nodes which has given catalog installed).
The fact that NodeSelector was Session dependant made code even more
complex without any real reason as the code paths we accessed were not
really session dependent.

This PR switches node listing to be based on InternalNodeManager which
is lower down the stack.

## Description

> Is this change a fix, improvement, new feature, refactoring, or other?

refactor

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core query engine

> How would you describe this change to a non-technical end user or system administrator?

N/A

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

