### PR TITLE
Add View support to the Iceberg Glue Catalog

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
@@ -167,6 +167,11 @@ public final class ViewReaderUtil
         @Override
         public ConnectorViewDefinition decodeViewData(String viewData, Table table, CatalogName catalogName)
         {
+            return decodeViewData(viewData);
+        }
+
+        public static ConnectorViewDefinition decodeViewData(String viewData)
+        {
             checkCondition(viewData.startsWith(VIEW_PREFIX), HIVE_INVALID_VIEW_DATA, "View data missing prefix: %s", viewData);
             checkCondition(viewData.endsWith(VIEW_SUFFIX), HIVE_INVALID_VIEW_DATA, "View data missing suffix: %s", viewData);
             viewData = viewData.substring(VIEW_PREFIX.length());

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
@@ -16,6 +16,8 @@ package io.trino.plugin.iceberg.catalog;
 import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.hive.HdfsEnvironment;
 import io.trino.plugin.hive.HiveMetadata;
+import io.trino.plugin.hive.HiveViewNotSupportedException;
+import io.trino.plugin.hive.ViewReaderUtil;
 import io.trino.plugin.iceberg.ColumnIdentity;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
@@ -34,8 +36,11 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.plugin.hive.HiveMetadata.TABLE_COMMENT;
 import static io.trino.plugin.hive.ViewReaderUtil.PRESTO_VIEW_FLAG;
+import static io.trino.plugin.hive.ViewReaderUtil.isHiveOrPrestoView;
+import static io.trino.plugin.hive.ViewReaderUtil.isPrestoView;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_FILESYSTEM_ERROR;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static java.lang.String.format;
@@ -152,10 +157,49 @@ public abstract class AbstractTrinoCatalog
         }
     }
 
+    protected Optional<ConnectorViewDefinition> getView(
+            SchemaTableName viewName,
+            Optional<String> viewOriginalText,
+            String tableType,
+            Map<String, String> tableParameters,
+            Optional<String> tableOwner)
+    {
+        if (!isView(tableType, tableParameters)) {
+            // Filter out Tables and Materialized Views
+            return Optional.empty();
+        }
+
+        if (!isPrestoView(tableParameters)) {
+            // Hive views are not compatible
+            throw new HiveViewNotSupportedException(viewName);
+        }
+
+        checkArgument(viewOriginalText.isPresent(), "viewOriginalText must be present");
+        ConnectorViewDefinition definition = ViewReaderUtil.PrestoViewReader.decodeViewData(viewOriginalText.get());
+        // use owner from table metadata if it exists
+        if (tableOwner.isPresent() && !definition.isRunAsInvoker()) {
+            definition = new ConnectorViewDefinition(
+                    definition.getOriginalSql(),
+                    definition.getCatalog(),
+                    definition.getSchema(),
+                    definition.getColumns(),
+                    definition.getComment(),
+                    tableOwner,
+                    false);
+        }
+        return Optional.of(definition);
+    }
+
+    private static boolean isView(String tableType, Map<String, String> tableParameters)
+
+    {
+        return isHiveOrPrestoView(tableType) && PRESTO_VIEW_COMMENT.equals(tableParameters.get(TABLE_COMMENT));
+    }
+
     protected Map<String, String> createViewProperties(ConnectorSession session)
     {
         return ImmutableMap.<String, String>builder()
-                .put(PRESTO_VIEW_FLAG, "true")
+                .put(PRESTO_VIEW_FLAG, "true") // Ensures compatibility with views created by the Hive connector
                 .put(TRINO_CREATED_BY, TRINO_CREATED_BY_VALUE)
                 .put(PRESTO_VERSION_NAME, trinoVersion)
                 .put(PRESTO_QUERY_ID_NAME, session.getQueryId())

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
@@ -13,10 +13,13 @@
  */
 package io.trino.plugin.iceberg.catalog;
 
+import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.hive.HdfsEnvironment;
+import io.trino.plugin.hive.HiveMetadata;
 import io.trino.plugin.iceberg.ColumnIdentity;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.SchemaTableName;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -32,7 +35,9 @@ import java.util.Map;
 import java.util.Optional;
 
 import static io.trino.plugin.hive.HiveMetadata.TABLE_COMMENT;
+import static io.trino.plugin.hive.ViewReaderUtil.PRESTO_VIEW_FLAG;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_FILESYSTEM_ERROR;
+import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
@@ -42,14 +47,25 @@ import static org.apache.iceberg.Transactions.createTableTransaction;
 public abstract class AbstractTrinoCatalog
         implements TrinoCatalog
 {
+    // Be compatible with views defined by the Hive connector, which can be useful under certain conditions.
+    protected static final String TRINO_CREATED_BY = HiveMetadata.TRINO_CREATED_BY;
+    protected static final String TRINO_CREATED_BY_VALUE = "Trino Iceberg connector";
+    protected static final String PRESTO_VIEW_COMMENT = HiveMetadata.PRESTO_VIEW_COMMENT;
+    protected static final String PRESTO_VERSION_NAME = HiveMetadata.PRESTO_VERSION_NAME;
+    protected static final String PRESTO_QUERY_ID_NAME = HiveMetadata.PRESTO_QUERY_ID_NAME;
+    protected static final String PRESTO_VIEW_EXPANDED_TEXT_MARKER = HiveMetadata.PRESTO_VIEW_EXPANDED_TEXT_MARKER;
+
     protected final IcebergTableOperationsProvider tableOperationsProvider;
+    private final String trinoVersion;
     private final boolean useUniqueTableLocation;
 
     protected AbstractTrinoCatalog(
             IcebergTableOperationsProvider tableOperationsProvider,
+            String trinoVersion,
             boolean useUniqueTableLocation)
     {
         this.tableOperationsProvider = requireNonNull(tableOperationsProvider, "tableOperationsProvider is null");
+        this.trinoVersion = requireNonNull(trinoVersion, "trinoVersion is null");
         this.useUniqueTableLocation = useUniqueTableLocation;
     }
 
@@ -70,6 +86,26 @@ public abstract class AbstractTrinoCatalog
     {
         Table icebergTable = loadTable(session, schemaTableName);
         icebergTable.updateSchema().updateColumnDoc(columnIdentity.getName(), comment.orElse(null)).commit();
+    }
+
+    @Override
+    public Map<SchemaTableName, ConnectorViewDefinition> getViews(ConnectorSession session, Optional<String> namespace)
+    {
+        ImmutableMap.Builder<SchemaTableName, ConnectorViewDefinition> views = ImmutableMap.builder();
+        for (SchemaTableName name : listViews(session, namespace)) {
+            try {
+                getView(session, name).ifPresent(view -> views.put(name, view));
+            }
+            catch (TrinoException e) {
+                if (e.getErrorCode().equals(TABLE_NOT_FOUND.toErrorCode())) {
+                    // Ignore view that was dropped during query execution (race condition)
+                }
+                else {
+                    throw e;
+                }
+            }
+        }
+        return views.buildOrThrow();
     }
 
     protected Transaction newCreateTableTransaction(
@@ -114,5 +150,16 @@ public abstract class AbstractTrinoCatalog
         catch (IOException e) {
             throw new TrinoException(ICEBERG_FILESYSTEM_ERROR, format("Failed to delete directory %s of the table %s", tableLocation, schemaTableName), e);
         }
+    }
+
+    protected Map<String, String> createViewProperties(ConnectorSession session)
+    {
+        return ImmutableMap.<String, String>builder()
+                .put(PRESTO_VIEW_FLAG, "true")
+                .put(TRINO_CREATED_BY, TRINO_CREATED_BY_VALUE)
+                .put(PRESTO_VERSION_NAME, trinoVersion)
+                .put(PRESTO_QUERY_ID_NAME, session.getQueryId())
+                .put(TABLE_COMMENT, PRESTO_VIEW_COMMENT)
+                .buildOrThrow();
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/TrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/TrinoCatalog.java
@@ -101,7 +101,7 @@ public interface TrinoCatalog
 
     Map<SchemaTableName, ConnectorViewDefinition> getViews(ConnectorSession session, Optional<String> namespace);
 
-    Optional<ConnectorViewDefinition> getView(ConnectorSession session, SchemaTableName viewIdentifier);
+    Optional<ConnectorViewDefinition> getView(ConnectorSession session, SchemaTableName viewName);
 
     List<SchemaTableName> listMaterializedViews(ConnectorSession session, Optional<String> namespace);
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergUtil.java
@@ -15,10 +15,14 @@ package io.trino.plugin.iceberg.catalog.glue;
 
 import com.amazonaws.services.glue.model.TableInput;
 
+import javax.annotation.Nullable;
+
 import java.util.Map;
 import java.util.Optional;
 
+import static io.trino.plugin.hive.HiveMetadata.PRESTO_VIEW_EXPANDED_TEXT_MARKER;
 import static org.apache.hadoop.hive.metastore.TableType.EXTERNAL_TABLE;
+import static org.apache.hadoop.hive.metastore.TableType.VIRTUAL_VIEW;
 
 public final class GlueIcebergUtil
 {
@@ -32,5 +36,16 @@ public final class GlueIcebergUtil
                 .withParameters(parameters)
                 // Iceberg does not distinguish managed and external tables, all tables are treated the same and marked as EXTERNAL
                 .withTableType(EXTERNAL_TABLE.name());
+    }
+
+    public static TableInput getViewTableInput(String viewName, String viewOriginalText, @Nullable String owner, Map<String, String> parameters)
+    {
+        return new TableInput()
+                .withName(viewName)
+                .withTableType(VIRTUAL_VIEW.name())
+                .withViewOriginalText(viewOriginalText)
+                .withViewExpandedText(PRESTO_VIEW_EXPANDED_TEXT_MARKER)
+                .withOwner(owner)
+                .withParameters(parameters);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -89,12 +89,13 @@ public class TrinoGlueCatalog
     public TrinoGlueCatalog(
             HdfsEnvironment hdfsEnvironment,
             IcebergTableOperationsProvider tableOperationsProvider,
+            String trinoVersion,
             AWSGlueAsync glueClient,
             GlueMetastoreStats stats,
             Optional<String> defaultSchemaLocation,
             boolean useUniqueTableLocation)
     {
-        super(tableOperationsProvider, useUniqueTableLocation);
+        super(tableOperationsProvider, trinoVersion, useUniqueTableLocation);
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.glueClient = requireNonNull(glueClient, "glueClient is null");
         this.stats = requireNonNull(stats, "stats is null");

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -412,7 +412,7 @@ public class TrinoGlueCatalog
     }
 
     @Override
-    public Optional<ConnectorViewDefinition> getView(ConnectorSession session, SchemaTableName viewIdentifier)
+    public Optional<ConnectorViewDefinition> getView(ConnectorSession session, SchemaTableName viewName)
     {
         return Optional.empty();
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalogFactory.java
@@ -16,6 +16,7 @@ package io.trino.plugin.iceberg.catalog.glue;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.glue.AWSGlueAsync;
 import io.trino.plugin.hive.HdfsEnvironment;
+import io.trino.plugin.hive.NodeVersion;
 import io.trino.plugin.hive.metastore.glue.GlueHiveMetastoreConfig;
 import io.trino.plugin.hive.metastore.glue.GlueMetastoreStats;
 import io.trino.plugin.iceberg.IcebergConfig;
@@ -39,6 +40,7 @@ public class TrinoGlueCatalogFactory
 {
     private final HdfsEnvironment hdfsEnvironment;
     private final IcebergTableOperationsProvider tableOperationsProvider;
+    private final String trinoVersion;
     private final Optional<String> defaultSchemaLocation;
     private final AWSGlueAsync glueClient;
     private final boolean isUniqueTableLocation;
@@ -48,6 +50,7 @@ public class TrinoGlueCatalogFactory
     public TrinoGlueCatalogFactory(
             HdfsEnvironment hdfsEnvironment,
             IcebergTableOperationsProvider tableOperationsProvider,
+            NodeVersion nodeVersion,
             GlueHiveMetastoreConfig glueConfig,
             AWSCredentialsProvider credentialsProvider,
             IcebergConfig icebergConfig,
@@ -55,6 +58,7 @@ public class TrinoGlueCatalogFactory
     {
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.tableOperationsProvider = requireNonNull(tableOperationsProvider, "tableOperationsProvider is null");
+        this.trinoVersion = requireNonNull(nodeVersion, "nodeVersion is null").toString();
         requireNonNull(glueConfig, "glueConfig is null");
         checkArgument(glueConfig.getCatalogId().isEmpty(), "catalogId configuration is not supported");
         this.defaultSchemaLocation = glueConfig.getDefaultWarehouseDir();
@@ -75,6 +79,6 @@ public class TrinoGlueCatalogFactory
     @Override
     public TrinoCatalog create(ConnectorIdentity identity)
     {
-        return new TrinoGlueCatalog(hdfsEnvironment, tableOperationsProvider, glueClient, stats, defaultSchemaLocation, isUniqueTableLocation);
+        return new TrinoGlueCatalog(hdfsEnvironment, tableOperationsProvider, trinoVersion, glueClient, stats, defaultSchemaLocation, isUniqueTableLocation);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
@@ -446,17 +446,17 @@ public class TrinoHiveCatalog
     }
 
     @Override
-    public Optional<ConnectorViewDefinition> getView(ConnectorSession session, SchemaTableName viewIdentifier)
+    public Optional<ConnectorViewDefinition> getView(ConnectorSession session, SchemaTableName viewName)
     {
-        if (isHiveSystemSchema(viewIdentifier.getSchemaName())) {
+        if (isHiveSystemSchema(viewName.getSchemaName())) {
             return Optional.empty();
         }
-        return metastore.getTable(viewIdentifier.getSchemaName(), viewIdentifier.getTableName())
+        return metastore.getTable(viewName.getSchemaName(), viewName.getTableName())
                 .filter(table -> HiveMetadata.PRESTO_VIEW_COMMENT.equals(table.getParameters().get(TABLE_COMMENT))) // filter out materialized views
                 .filter(ViewReaderUtil::canDecodeView)
                 .map(view -> {
                     if (!isPrestoView(view)) {
-                        throw new HiveViewNotSupportedException(viewIdentifier);
+                        throw new HiveViewNotSupportedException(viewName);
                     }
 
                     ConnectorViewDefinition definition = viewReader

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
@@ -128,7 +128,6 @@ public class TrinoHiveCatalog
     private final boolean deleteSchemaLocationsFallback;
 
     private final Map<SchemaTableName, TableMetadata> tableMetadataCache = new ConcurrentHashMap<>();
-    private final ViewReaderUtil.PrestoViewReader viewReader = new ViewReaderUtil.PrestoViewReader();
 
     public TrinoHiveCatalog(
             CatalogName catalogName,
@@ -459,8 +458,7 @@ public class TrinoHiveCatalog
                         throw new HiveViewNotSupportedException(viewName);
                     }
 
-                    ConnectorViewDefinition definition = viewReader
-                            .decodeViewData(view.getViewOriginalText().get(), view, catalogName);
+                    ConnectorViewDefinition definition = ViewReaderUtil.PrestoViewReader.decodeViewData(view.getViewOriginalText().get());
                     // use owner from table metadata if it exists
                     if (view.getOwner().isPresent() && !definition.isRunAsInvoker()) {
                         definition = new ConnectorViewDefinition(

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGlueCatalogAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGlueCatalogAccessOperations.java
@@ -159,7 +159,7 @@ public class TestIcebergGlueCatalogAccessOperations
 
             assertGlueMetastoreApiInvocations("SELECT * FROM test_select_from",
                     ImmutableMultiset.builder()
-                            .add(GET_TABLE)
+                            .addCopies(GET_TABLE, 2)
                             .build());
         }
         finally {
@@ -175,7 +175,7 @@ public class TestIcebergGlueCatalogAccessOperations
 
             assertGlueMetastoreApiInvocations("SELECT * FROM test_select_from_where WHERE age = 2",
                     ImmutableMultiset.builder()
-                            .add(GET_TABLE)
+                            .addCopies(GET_TABLE, 2)
                             .build());
         }
         finally {
@@ -183,7 +183,7 @@ public class TestIcebergGlueCatalogAccessOperations
         }
     }
 
-    @Test(enabled = false)
+    @Test
     public void testSelectFromView()
     {
         try {
@@ -192,7 +192,7 @@ public class TestIcebergGlueCatalogAccessOperations
 
             assertGlueMetastoreApiInvocations("SELECT * FROM test_select_view_view",
                     ImmutableMultiset.builder()
-                            .addCopies(GET_TABLE, 2)
+                            .addCopies(GET_TABLE, 3)
                             .build());
         }
         finally {
@@ -201,7 +201,7 @@ public class TestIcebergGlueCatalogAccessOperations
         }
     }
 
-    @Test(enabled = false)
+    @Test
     public void testSelectFromViewWithFilter()
     {
         try {
@@ -210,12 +210,12 @@ public class TestIcebergGlueCatalogAccessOperations
 
             assertGlueMetastoreApiInvocations("SELECT * FROM test_select_view_where_view WHERE age = 2",
                     ImmutableMultiset.builder()
-                            .addCopies(GET_TABLE, 2)
+                            .addCopies(GET_TABLE, 3)
                             .build());
         }
         finally {
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_select_view_where_table");
             getQueryRunner().execute("DROP VIEW IF EXISTS test_select_view_where_view");
-            getQueryRunner().execute("DROP TABLE IF EXISTS test_select_view_where_view");
         }
     }
 
@@ -282,7 +282,7 @@ public class TestIcebergGlueCatalogAccessOperations
 
             assertGlueMetastoreApiInvocations("SELECT name, age FROM test_join_t1 JOIN test_join_t2 ON test_join_t2.id = test_join_t1.id",
                     ImmutableMultiset.builder()
-                            .addCopies(GET_TABLE, 2)
+                            .addCopies(GET_TABLE, 4)
                             .build());
         }
         finally {
@@ -299,7 +299,7 @@ public class TestIcebergGlueCatalogAccessOperations
 
             assertGlueMetastoreApiInvocations("SELECT child.age, parent.age FROM test_self_join_table child JOIN test_self_join_table parent ON child.parent = parent.id",
                     ImmutableMultiset.builder()
-                            .add(GET_TABLE)
+                            .addCopies(GET_TABLE, 3)
                             .build());
         }
         finally {
@@ -315,7 +315,7 @@ public class TestIcebergGlueCatalogAccessOperations
 
             assertGlueMetastoreApiInvocations("EXPLAIN SELECT * FROM test_explain",
                     ImmutableMultiset.builder()
-                            .add(GET_TABLE)
+                            .addCopies(GET_TABLE, 2)
                             .build());
         }
         finally {
@@ -331,7 +331,7 @@ public class TestIcebergGlueCatalogAccessOperations
 
             assertGlueMetastoreApiInvocations("SHOW STATS FOR test_show_stats",
                     ImmutableMultiset.builder()
-                            .add(GET_TABLE)
+                            .addCopies(GET_TABLE, 2)
                             .build());
         }
         finally {
@@ -347,7 +347,7 @@ public class TestIcebergGlueCatalogAccessOperations
 
             assertGlueMetastoreApiInvocations("SHOW STATS FOR (SELECT * FROM test_show_stats_with_filter where age >= 2)",
                     ImmutableMultiset.builder()
-                            .add(GET_TABLE)
+                            .addCopies(GET_TABLE, 2)
                             .build());
         }
         finally {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGlueCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGlueCatalogConnectorSmokeTest.java
@@ -123,14 +123,6 @@ public class TestIcebergGlueCatalogConnectorSmokeTest
 
     @Test
     @Override
-    public void testView()
-    {
-        assertThatThrownBy(super::testView)
-                .hasStackTraceContaining("createView is not supported for Iceberg Glue catalogs");
-    }
-
-    @Test
-    @Override
     public void testMaterializedView()
     {
         assertThatThrownBy(super::testMaterializedView)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestTrinoGlueCatalogTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestTrinoGlueCatalogTest.java
@@ -61,6 +61,7 @@ public class TestTrinoGlueCatalogTest
         return new TrinoGlueCatalog(
                 hdfsEnvironment,
                 new GlueIcebergTableOperationsProvider(new HdfsFileIoProvider(hdfsEnvironment), new GlueMetastoreStats(), new GlueHiveMetastoreConfig(), DefaultAWSCredentialsProviderChain.getInstance()),
+                "test",
                 AWSGlueAsyncClientBuilder.defaultClient(),
                 new GlueMetastoreStats(),
                 Optional.empty(),
@@ -84,6 +85,7 @@ public class TestTrinoGlueCatalogTest
         TrinoCatalog catalogWithDefaultLocation = new TrinoGlueCatalog(
                 hdfsEnvironment,
                 new GlueIcebergTableOperationsProvider(new HdfsFileIoProvider(hdfsEnvironment), new GlueMetastoreStats(), new GlueHiveMetastoreConfig(), DefaultAWSCredentialsProviderChain.getInstance()),
+                "test",
                 AWSGlueAsyncClientBuilder.defaultClient(),
                 new GlueMetastoreStats(),
                 Optional.of(tmpDirectory.toAbsolutePath().toString()),


### PR DESCRIPTION
## Description

Supports Views and Materialized View for Iceberg Glue.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Feature

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Iceberg Connector

> How would you describe this change to a non-technical end user or system administrator?

Add the ability to create/delete/rename/list views and materialized views when using the Iceberg connector with Glue.

## Related issues, pull requests, and links

https://github.com/trinodb/trino/pull/10845

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
