### PR TITLE
Fix typo: Not --> Note

### DIFF
--- a/docs/src/main/sphinx/functions/comparison.rst
+++ b/docs/src/main/sphinx/functions/comparison.rst
@@ -59,7 +59,7 @@ evaluate any orderable type.  For example, a ``VARCHAR``::
 
     SELECT 'Paul' BETWEEN 'John' AND 'Ringo'; -- true
 
-Not that the value, min, and max parameters to ``BETWEEN`` and ``NOT
+Note that the value, min, and max parameters to ``BETWEEN`` and ``NOT
 BETWEEN`` must be the same type.  For example, Trino will produce an
 error if you ask it if John is between 2.3 and 35.2.
 


### PR DESCRIPTION
Just a typo.
 - Not that the value, min, and max parameters to ``BETWEEN`` and ``NOT
BETWEEN`` must be the same type.

Should be:

 - Note that the value, min, and max parameters to ``BETWEEN`` and ``NOT
BETWEEN`` must be the same type.