### PR TITLE
Upgrade Alluxio client to 2.7.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1411,7 +1411,7 @@
             <dependency>
                 <groupId>org.alluxio</groupId>
                 <artifactId>alluxio-shaded-client</artifactId>
-                <version>2.6.2</version>
+                <version>2.7.3</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
The new version addresses CVE-2022-23848, which may or may not affect
Trino.
