### PR TITLE
Avoid the usage of specific column names in Glue filter expression

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
@@ -104,6 +104,7 @@ import static io.trino.spi.statistics.ColumnStatisticType.NUMBER_OF_DISTINCT_VAL
 import static io.trino.spi.statistics.ColumnStatisticType.NUMBER_OF_NON_NULL_VALUES;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.lang.String.format;
 import static java.lang.System.currentTimeMillis;
 import static java.util.Locale.ENGLISH;
@@ -307,6 +308,61 @@ public class TestHiveGlueMetastore
         }
         finally {
             dropTable(tablePartitionFormat);
+        }
+    }
+
+    @Test
+    public void testGetPartitionsWithFilterUsingReservedKeywordsAsColumnName()
+            throws Exception
+    {
+        SchemaTableName tableName = temporaryTable("get_partitions_with_filter_using_reserved_keyword_column_name");
+        try {
+            String reservedKeywordPartitionColumnName = "key";
+            String regularColumnPartitionName = "int_partition";
+            List<ColumnMetadata> columns = ImmutableList.<ColumnMetadata>builder()
+                    .add(new ColumnMetadata("t_string", createUnboundedVarcharType()))
+                    .add(new ColumnMetadata(reservedKeywordPartitionColumnName, createUnboundedVarcharType()))
+                    .add(new ColumnMetadata(regularColumnPartitionName, BIGINT))
+                    .build();
+            List<String> partitionedBy = ImmutableList.of(reservedKeywordPartitionColumnName, regularColumnPartitionName);
+
+            doCreateEmptyTable(tableName, ORC, columns, partitionedBy);
+
+            HiveMetastoreClosure metastoreClient = new HiveMetastoreClosure(getMetastoreClient());
+            Table table = metastoreClient.getTable(tableName.getSchemaName(), tableName.getTableName())
+                    .orElseThrow(() -> new TableNotFoundException(tableName));
+
+            String partitionName1 = makePartName(ImmutableList.of(reservedKeywordPartitionColumnName, regularColumnPartitionName), ImmutableList.of("value1", "1"));
+            String partitionName2 = makePartName(ImmutableList.of(reservedKeywordPartitionColumnName, regularColumnPartitionName), ImmutableList.of("value2", "2"));
+
+            List<PartitionWithStatistics> partitions = ImmutableList.of(partitionName1, partitionName2)
+                    .stream()
+                    .map(partitionName -> new PartitionWithStatistics(createDummyPartition(table, partitionName), partitionName, PartitionStatistics.empty()))
+                    .collect(toImmutableList());
+            metastoreClient.addPartitions(tableName.getSchemaName(), tableName.getTableName(), partitions);
+            metastoreClient.updatePartitionStatistics(tableName.getSchemaName(), tableName.getTableName(), partitionName1, currentStatistics -> EMPTY_TABLE_STATISTICS);
+            metastoreClient.updatePartitionStatistics(tableName.getSchemaName(), tableName.getTableName(), partitionName2, currentStatistics -> EMPTY_TABLE_STATISTICS);
+
+            Optional<List<String>> partitionNames = metastoreClient.getPartitionNamesByFilter(
+                    tableName.getSchemaName(),
+                    tableName.getTableName(),
+                    ImmutableList.of(reservedKeywordPartitionColumnName, regularColumnPartitionName),
+                    TupleDomain.withColumnDomains(ImmutableMap.of(regularColumnPartitionName, Domain.singleValue(BIGINT, 2L))));
+            assertTrue(partitionNames.isPresent());
+            assertEquals(partitionNames.get(), ImmutableList.of("key=value2/int_partition=2"));
+
+            // KEY is a reserved keyword in the grammar of the SQL parser used internally by Glue API
+            // and therefore should not be used in the partition filter
+            partitionNames = metastoreClient.getPartitionNamesByFilter(
+                    tableName.getSchemaName(),
+                    tableName.getTableName(),
+                    ImmutableList.of(reservedKeywordPartitionColumnName, regularColumnPartitionName),
+                    TupleDomain.withColumnDomains(ImmutableMap.of(reservedKeywordPartitionColumnName, Domain.singleValue(VARCHAR, utf8Slice("value1")))));
+            assertTrue(partitionNames.isPresent());
+            assertEquals(partitionNames.get(), ImmutableList.of("key=value1/int_partition=1", "key=value2/int_partition=2"));
+        }
+        finally {
+            dropTable(tableName);
         }
     }
 


### PR DESCRIPTION
AWS Glue considers invalid the usage of the column name "key"
within the filter passed to the API for retrieving the partitions
of the table. Avoid therefore to create a filter containing
clauses containing the column name "key".

The benefit of this approach is that the get-partitions call
is not anymore erroneous. The downside of this change is that
in the special case of dealing with a partition column having
the name "key", there may be more partitions than needed
retrieved.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Hive connector

> How would you describe this change to a non-technical end user or system administrator?

AWS Glue API has a peculiar behaviour when dealing with column name "key" in the filter passed to retrieve the partitions of the Glue Table.

Details here: https://repost.aws/questions/QUEk4KCevPSK2_2TQSVprQMA/aws-glue-api-get-partitions-cant-seem-to-cope-with-the-partition-column-name-key-in-the-filter

Avoid therefore to use clauses in the AWS Glue filter which contain "key" as column name.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Glue
* Avoid the usage of specific column names in Glue filter expression for get-partitions calls
```
