### PR TITLE
Estimate cost of inequality comparision filters

### DIFF
--- a/core/trino-main/src/main/java/io/trino/cost/ComparisonStatsCalculator.java
+++ b/core/trino-main/src/main/java/io/trino/cost/ComparisonStatsCalculator.java
@@ -22,7 +22,9 @@ import java.util.OptionalDouble;
 import static io.trino.cost.SymbolStatsEstimate.buildFrom;
 import static io.trino.util.MoreMath.averageExcludingNaNs;
 import static io.trino.util.MoreMath.max;
+import static io.trino.util.MoreMath.maxExcludeNaN;
 import static io.trino.util.MoreMath.min;
+import static io.trino.util.MoreMath.minExcludeNaN;
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
 import static java.lang.Double.POSITIVE_INFINITY;
@@ -31,6 +33,11 @@ import static java.lang.Double.isNaN;
 
 public final class ComparisonStatsCalculator
 {
+    // We assume uniform distribution of values within each range.
+    // Within the overlapping range, we assume that all pairs of distinct values from both ranges exist.
+    // Based on the above, we estimate that half of the pairs of values will match inequality predicate on average.
+    public static final double OVERLAPPING_RANGE_INEQUALITY_FILTER_COEFFICIENT = 0.5;
+
     private ComparisonStatsCalculator() {}
 
     public static PlanNodeStatsEstimate estimateExpressionToLiteralComparison(
@@ -164,6 +171,13 @@ public final class ComparisonStatsCalculator
             case LESS_THAN_OR_EQUAL:
             case GREATER_THAN:
             case GREATER_THAN_OR_EQUAL:
+                return estimateExpressionToExpressionInequality(
+                        operator,
+                        inputStatistics,
+                        leftExpressionStatistics,
+                        leftExpressionSymbol,
+                        rightExpressionStatistics,
+                        rightExpressionSymbol);
             case IS_DISTINCT_FROM:
                 return PlanNodeStatsEstimate.unknown();
         }
@@ -238,5 +252,129 @@ public final class ComparisonStatsCalculator
         leftExpressionSymbol.ifPresent(symbol -> result.addSymbolStatistics(symbol, leftNullsFiltered));
         rightExpressionSymbol.ifPresent(symbol -> result.addSymbolStatistics(symbol, rightNullsFiltered));
         return result.build();
+    }
+
+    private static PlanNodeStatsEstimate estimateExpressionToExpressionInequality(
+            ComparisonExpression.Operator operator,
+            PlanNodeStatsEstimate inputStatistics,
+            SymbolStatsEstimate leftExpressionStatistics,
+            Optional<Symbol> leftExpressionSymbol,
+            SymbolStatsEstimate rightExpressionStatistics,
+            Optional<Symbol> rightExpressionSymbol)
+    {
+        if (leftExpressionStatistics.isUnknown() || rightExpressionStatistics.isUnknown()) {
+            return PlanNodeStatsEstimate.unknown();
+        }
+        if (isNaN(leftExpressionStatistics.getNullsFraction()) && isNaN(rightExpressionStatistics.getNullsFraction())) {
+            return PlanNodeStatsEstimate.unknown();
+        }
+        if (leftExpressionStatistics.statisticRange().isEmpty() || rightExpressionStatistics.statisticRange().isEmpty()) {
+            return inputStatistics.mapOutputRowCount(rowCount -> 0.0);
+        }
+
+        // We don't know the correlation between NULLs, so we take the max nullsFraction from the expression statistics
+        // to make a conservative estimate (nulls are fully correlated) for the NULLs filter factor
+        double nullsFilterFactor = 1 - maxExcludeNaN(leftExpressionStatistics.getNullsFraction(), rightExpressionStatistics.getNullsFraction());
+        switch (operator) {
+            case LESS_THAN:
+            case LESS_THAN_OR_EQUAL:
+                return estimateExpressionLessThanOrEqualToExpression(
+                        inputStatistics,
+                        leftExpressionStatistics,
+                        leftExpressionSymbol,
+                        rightExpressionStatistics,
+                        rightExpressionSymbol,
+                        nullsFilterFactor);
+            case GREATER_THAN:
+            case GREATER_THAN_OR_EQUAL:
+                return estimateExpressionLessThanOrEqualToExpression(
+                        inputStatistics,
+                        rightExpressionStatistics,
+                        rightExpressionSymbol,
+                        leftExpressionStatistics,
+                        leftExpressionSymbol,
+                        nullsFilterFactor);
+            default:
+                throw new IllegalArgumentException("Unsupported inequality operator " + operator);
+        }
+    }
+
+    private static PlanNodeStatsEstimate estimateExpressionLessThanOrEqualToExpression(
+            PlanNodeStatsEstimate inputStatistics,
+            SymbolStatsEstimate leftExpressionStatistics,
+            Optional<Symbol> leftExpressionSymbol,
+            SymbolStatsEstimate rightExpressionStatistics,
+            Optional<Symbol> rightExpressionSymbol,
+            double nullsFilterFactor)
+    {
+        StatisticRange leftRange = StatisticRange.from(leftExpressionStatistics);
+        StatisticRange rightRange = StatisticRange.from(rightExpressionStatistics);
+        // left is always greater than right, no overlap
+        if (leftRange.getLow() > rightRange.getHigh()) {
+            return inputStatistics.mapOutputRowCount(rowCount -> 0.0);
+        }
+        // left is always lesser than right
+        if (leftRange.getHigh() < rightRange.getLow()) {
+            PlanNodeStatsEstimate.Builder estimate = PlanNodeStatsEstimate.buildFrom(inputStatistics);
+            leftExpressionSymbol.ifPresent(symbol -> estimate.addSymbolStatistics(
+                    symbol,
+                    leftExpressionStatistics.mapNullsFraction(nullsFraction -> 0.0)));
+            rightExpressionSymbol.ifPresent(symbol -> estimate.addSymbolStatistics(
+                    symbol,
+                    rightExpressionStatistics.mapNullsFraction(nullsFraction -> 0.0)));
+            return estimate.setOutputRowCount(inputStatistics.getOutputRowCount() * nullsFilterFactor)
+                    .build();
+        }
+
+        PlanNodeStatsEstimate.Builder estimate = PlanNodeStatsEstimate.buildFrom(inputStatistics);
+        double leftOverlappingRangeFraction = leftRange.overlapPercentWith(rightRange);
+        double leftAlwaysLessRangeFraction;
+        if (leftRange.getLow() < rightRange.getLow()) {
+            leftAlwaysLessRangeFraction = min(
+                    leftRange.overlapPercentWith(new StatisticRange(leftRange.getLow(), rightRange.getLow(), NaN)),
+                    // Prevents expanding NDVs in case range fractions addition goes beyond 1 for infinite ranges
+                    1 - leftOverlappingRangeFraction);
+        }
+        else {
+            leftAlwaysLessRangeFraction = 0;
+        }
+        leftExpressionSymbol.ifPresent(symbol -> estimate.addSymbolStatistics(
+                symbol,
+                SymbolStatsEstimate.builder()
+                        .setLowValue(leftRange.getLow())
+                        .setHighValue(minExcludeNaN(leftRange.getHigh(), rightRange.getHigh()))
+                        .setAverageRowSize(leftExpressionStatistics.getAverageRowSize())
+                        .setDistinctValuesCount(leftExpressionStatistics.getDistinctValuesCount() * (leftAlwaysLessRangeFraction + leftOverlappingRangeFraction))
+                        .setNullsFraction(0)
+                        .build()));
+
+        double rightOverlappingRangeFraction = rightRange.overlapPercentWith(leftRange);
+        double rightAlwaysGreaterRangeFraction;
+        if (leftRange.getHigh() < rightRange.getHigh()) {
+            rightAlwaysGreaterRangeFraction = min(
+                    rightRange.overlapPercentWith(new StatisticRange(leftRange.getHigh(), rightRange.getHigh(), NaN)),
+                    // Prevents expanding NDVs in case range fractions addition goes beyond 1 for infinite ranges
+                    1 - rightOverlappingRangeFraction);
+        }
+        else {
+            rightAlwaysGreaterRangeFraction = 0;
+        }
+        rightExpressionSymbol.ifPresent(symbol -> estimate.addSymbolStatistics(
+                symbol,
+                SymbolStatsEstimate.builder()
+                        .setLowValue(maxExcludeNaN(leftRange.getLow(), rightRange.getLow()))
+                        .setHighValue(rightRange.getHigh())
+                        .setAverageRowSize(rightExpressionStatistics.getAverageRowSize())
+                        .setDistinctValuesCount(rightExpressionStatistics.getDistinctValuesCount() * (rightOverlappingRangeFraction + rightAlwaysGreaterRangeFraction))
+                        .setNullsFraction(0)
+                        .build()));
+        double filterFactor =
+                // all left range values which are below right range are selected
+                leftAlwaysLessRangeFraction +
+                        // for pairs in overlapping range, only half of pairs are selected
+                        leftOverlappingRangeFraction * rightOverlappingRangeFraction * OVERLAPPING_RANGE_INEQUALITY_FILTER_COEFFICIENT +
+                        // all pairs where left value is in overlapping range and right value is above left range are selected
+                        leftOverlappingRangeFraction * rightAlwaysGreaterRangeFraction;
+        return estimate.setOutputRowCount(inputStatistics.getOutputRowCount() * nullsFilterFactor * filterFactor).build();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/cost/TestFilterStatsCalculator.java
+++ b/core/trino-main/src/test/java/io/trino/cost/TestFilterStatsCalculator.java
@@ -206,6 +206,34 @@ public class TestFilterStatsCalculator
     }
 
     @Test
+    public void testInequalityComparisonApproximation()
+    {
+        assertExpression("x > emptyRange").outputRowsCount(0);
+
+        assertExpression("x > y + 20").outputRowsCount(0);
+        assertExpression("x >= y + 20").outputRowsCount(0);
+        assertExpression("x < y - 25").outputRowsCount(0);
+        assertExpression("x <= y - 25").outputRowsCount(0);
+
+        double nullsFractionY = 0.5;
+        double inputRowCount = standardInputStatistics.getOutputRowCount();
+        double nonNullRowCount = inputRowCount * (1 - nullsFractionY);
+        SymbolStatsEstimate nonNullStatsX = xStats.mapNullsFraction(nullsFraction -> 0.0);
+        assertExpression("x > y - 25")
+                .outputRowsCount(nonNullRowCount)
+                .symbolStats("x", symbolAssert -> symbolAssert.isEqualTo(nonNullStatsX));
+        assertExpression("x >= y - 25")
+                .outputRowsCount(nonNullRowCount)
+                .symbolStats("x", symbolAssert -> symbolAssert.isEqualTo(nonNullStatsX));
+        assertExpression("x < y + 20")
+                .outputRowsCount(nonNullRowCount)
+                .symbolStats("x", symbolAssert -> symbolAssert.isEqualTo(nonNullStatsX));
+        assertExpression("x <= y + 20")
+                .outputRowsCount(nonNullRowCount)
+                .symbolStats("x", symbolAssert -> symbolAssert.isEqualTo(nonNullStatsX));
+    }
+
+    @Test
     public void testOrStats()
     {
         assertExpression("x < 0e0 OR x < DOUBLE '-7.5'")

--- a/testing/trino-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q72.plan.txt
+++ b/testing/trino-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q72.plan.txt
@@ -7,40 +7,40 @@ local exchange (GATHER, SINGLE, [])
                         join (LEFT, PARTITIONED):
                             remote exchange (REPARTITION, HASH, ["cs_order_number", "inv_item_sk"])
                                 join (LEFT, REPLICATED):
-                                    join (INNER, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, ["d_week_seq_4", "inv_item_sk"])
-                                            join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan inventory
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan warehouse
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["cs_item_sk", "d_week_seq"])
-                                                join (INNER, REPLICATED):
+                                    join (INNER, REPLICATED):
+                                        join (INNER, REPLICATED):
+                                            join (INNER, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, ["d_week_seq_4", "inv_item_sk"])
                                                     join (INNER, REPLICATED):
-                                                        join (INNER, REPLICATED):
-                                                            join (INNER, REPLICATED):
-                                                                join (INNER, REPLICATED):
-                                                                    scan catalog_sales
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan customer_demographics
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan household_demographics
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
+                                                        scan inventory
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
                                                                 scan date_dim
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan item
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPARTITION, HASH, ["cs_item_sk", "d_week_seq"])
+                                                        join (INNER, REPLICATED):
+                                                            join (INNER, REPLICATED):
+                                                                join (INNER, REPLICATED):
+                                                                    join (INNER, REPLICATED):
+                                                                        scan catalog_sales
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                                scan customer_demographics
+                                                                    local exchange (GATHER, SINGLE, [])
+                                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                                            scan household_demographics
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                        scan date_dim
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                    scan date_dim
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan warehouse
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan item
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
                                             scan promotion

--- a/testing/trino-benchto-benchmarks/src/test/resources/sql/presto/tpch/q04.plan.txt
+++ b/testing/trino-benchto-benchmarks/src/test/resources/sql/presto/tpch/q04.plan.txt
@@ -6,10 +6,11 @@ remote exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["orderpriority"])
                         partial aggregation over (orderpriority)
                             join (INNER, PARTITIONED):
-                                remote exchange (REPARTITION, HASH, ["orderkey"])
-                                    scan orders
                                 final aggregation over (orderkey_1)
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["orderkey_1"])
                                             partial aggregation over (orderkey_1)
                                                 scan lineitem
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPARTITION, HASH, ["orderkey"])
+                                        scan orders

--- a/testing/trino-benchto-benchmarks/src/test/resources/sql/presto/tpch/q21.plan.txt
+++ b/testing/trino-benchto-benchmarks/src/test/resources/sql/presto/tpch/q21.plan.txt
@@ -4,30 +4,29 @@ local exchange (GATHER, SINGLE, [])
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["name"])
                     partial aggregation over (name)
-                        single aggregation over (commitdate, exists, name, name_8, nationkey, orderkey, orderstatus, receiptdate, suppkey, unique)
+                        single aggregation over (commitdate, exists, name, name_8, nationkey, orderkey, orderstatus, receiptdate, suppkey_1, unique)
                             join (LEFT, PARTITIONED):
-                                final aggregation over (commitdate, name, name_8, nationkey, orderkey, orderstatus, receiptdate, suppkey, unique_49)
+                                final aggregation over (commitdate, name, name_8, nationkey, orderkey, orderstatus, receiptdate, suppkey_1, unique_49)
                                     local exchange (GATHER, SINGLE, [])
-                                        partial aggregation over (commitdate, name, name_8, nationkey, orderkey, orderstatus, receiptdate, suppkey, unique_49)
-                                            join (LEFT, PARTITIONED):
-                                                join (INNER, REPLICATED):
+                                        partial aggregation over (commitdate, name, name_8, nationkey, orderkey, orderstatus, receiptdate, suppkey_1, unique_49)
+                                            join (RIGHT, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, ["orderkey_11"])
+                                                    scan lineitem
+                                                local exchange (GATHER, SINGLE, [])
                                                     join (INNER, PARTITIONED):
                                                         remote exchange (REPARTITION, HASH, ["orderkey"])
-                                                            join (INNER, PARTITIONED):
-                                                                remote exchange (REPARTITION, HASH, ["suppkey"])
-                                                                    scan supplier
+                                                            join (INNER, REPLICATED):
+                                                                scan lineitem
                                                                 local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPARTITION, HASH, ["suppkey_1"])
-                                                                        scan lineitem
+                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                        join (INNER, REPLICATED):
+                                                                            scan supplier
+                                                                            local exchange (GATHER, SINGLE, [])
+                                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                                    scan nation
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPARTITION, HASH, ["orderkey_4"])
                                                                 scan orders
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan nation
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["orderkey_11"])
-                                                        scan lineitem
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["orderkey_29"])
                                         scan lineitem

--- a/testing/trino-tests/src/test/java/io/trino/tests/tpch/TestTpchDistributedStats.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/tpch/TestTpchDistributedStats.java
@@ -78,6 +78,18 @@ public class TestTpchDistributedStats
 
         statisticsAssertion.check("SELECT l_orderkey FROM lineitem GROUP BY l_orderkey HAVING sum(l_quantity) > 30",
                 checks -> checks.estimate(OUTPUT_ROW_COUNT, defaultTolerance()));
+
+        statisticsAssertion.check("SELECT * FROM lineitem WHERE l_receiptdate > l_commitdate",
+                checks -> checks.estimate(OUTPUT_ROW_COUNT, relativeError(-0.2, -0.18)));
+
+        statisticsAssertion.check("SELECT * FROM lineitem WHERE l_receiptdate >= l_commitdate",
+                checks -> checks.estimate(OUTPUT_ROW_COUNT, relativeError(-0.23, -0.2)));
+
+        statisticsAssertion.check("SELECT * FROM lineitem WHERE l_receiptdate < l_commitdate",
+                checks -> checks.estimate(OUTPUT_ROW_COUNT, relativeError(0.35, 0.38)));
+
+        statisticsAssertion.check("SELECT * FROM lineitem WHERE l_receiptdate <= l_commitdate",
+                checks -> checks.estimate(OUTPUT_ROW_COUNT, relativeError(0.3, 0.35)));
     }
 
     @Test

--- a/testing/trino-tests/src/test/java/io/trino/tests/tpch/TestTpchLocalStats.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/tpch/TestTpchLocalStats.java
@@ -238,12 +238,12 @@ public class TestTpchLocalStats
         // simple non-equi join
         statisticsAssertion.check("SELECT * FROM partsupp LEFT JOIN lineitem ON ps_partkey = l_partkey AND ps_suppkey < l_suppkey",
                 checks -> checks
-                        .estimate(OUTPUT_ROW_COUNT, relativeError(4.0))
+                        .estimate(OUTPUT_ROW_COUNT, relativeError(0.3, 0.4))
                         .verifyExactColumnStatistics("ps_partkey")
-                        .verifyColumnStatistics("l_partkey", relativeError(0.10))
+                        .verifyColumnStatistics("l_partkey", relativeError(0.7))
                         .verifyExactColumnStatistics("ps_suppkey")
-                        .verifyColumnStatistics("l_suppkey", relativeError(1.0))
-                        .verifyColumnStatistics("l_orderkey", relativeError(0.10)));
+                        .verifyColumnStatistics("l_suppkey", relativeError(0.7))
+                        .verifyColumnStatistics("l_orderkey", relativeError(0.7)));
     }
 
     @Test
@@ -293,12 +293,12 @@ public class TestTpchLocalStats
         // simple non-equi join
         statisticsAssertion.check("SELECT * FROM lineitem RIGHT JOIN partsupp ON ps_partkey = l_partkey AND ps_suppkey < l_suppkey",
                 checks -> checks
-                        .estimate(OUTPUT_ROW_COUNT, relativeError(4.0))
+                        .estimate(OUTPUT_ROW_COUNT, relativeError(0.3, 0.4))
                         .verifyExactColumnStatistics("ps_partkey")
-                        .verifyColumnStatistics("l_partkey", relativeError(0.10))
+                        .verifyColumnStatistics("l_partkey", relativeError(0.7))
                         .verifyExactColumnStatistics("ps_suppkey")
-                        .verifyColumnStatistics("l_suppkey", relativeError(1.0))
-                        .verifyColumnStatistics("l_orderkey", relativeError(0.10)));
+                        .verifyColumnStatistics("l_suppkey", relativeError(0.7))
+                        .verifyColumnStatistics("l_orderkey", relativeError(0.7)));
     }
 
     @Test
@@ -343,12 +343,12 @@ public class TestTpchLocalStats
         // simple non-equi join
         statisticsAssertion.check("SELECT * FROM lineitem FULL JOIN partsupp ON ps_partkey = l_partkey AND ps_suppkey < l_suppkey",
                 checks -> checks
-                        .estimate(OUTPUT_ROW_COUNT, relativeError(4.0))
-                        .verifyColumnStatistics("ps_partkey", relativeError(0.10))
-                        .verifyColumnStatistics("l_partkey", relativeError(0.10))
-                        .verifyColumnStatistics("ps_suppkey", relativeError(0.10))
-                        .verifyColumnStatistics("l_suppkey", relativeError(1.0))
-                        .verifyColumnStatistics("l_orderkey", relativeError(0.10)));
+                        .estimate(OUTPUT_ROW_COUNT, relativeError(0.4, 0.5))
+                        .verifyColumnStatistics("ps_partkey", relativeError(0.6))
+                        .verifyColumnStatistics("l_partkey", relativeError(0.6))
+                        .verifyColumnStatistics("ps_suppkey", relativeError(0.6))
+                        .verifyColumnStatistics("l_suppkey", relativeError(0.6))
+                        .verifyColumnStatistics("l_orderkey", relativeError(0.6)));
     }
 
     @Test


### PR DESCRIPTION
On top of https://github.com/trinodb/trino/pull/11469

## Description

When there is some overlap between the ranges of the
operands of an inequality expression, we approximate
it's cost assuming uniform distribution of values
within each range and that all pairs of distinct values
from both ranges exist.

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

CBO
> How would you describe this change to a non-technical end user or system administrator?

Improves query plans in the presence of inequality expressions

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Section
* Improve query plans in the presence of inequality expressions. ({issue}`11518`)
```
