### PR TITLE
Increase memory reclaimed waiting time in tests

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
@@ -124,7 +124,7 @@ public abstract class AbstractTestQueryFramework
         }
         DistributedQueryRunner distributedQueryRunner = (DistributedQueryRunner) queryRunner;
         assertEventually(
-                new Duration(10, SECONDS),
+                new Duration(30, SECONDS),
                 new Duration(1, SECONDS),
                 () -> {
                     List<TestingTrinoServer> servers = distributedQueryRunner.getServers();


### PR DESCRIPTION
We noticed that sometimes 10s is not enough for memory
to be released.

(test fix - no release notes or docs)