### PR TITLE
Add job to cancel docs job when PRs are closed or merged

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -17,6 +17,6 @@ jobs:
         with:
           # Cancel workflow when PR closed. https://github.com/styfle/cancel-workflow-action#advanced-ignore-sha
           ignore_sha: true
-          # Note: workflow_id can be a Workflow ID (number) or Workflow File Name (string).
-          workflow_id: "ci.yml"
+          # Note: workflow_id can be a Workflow ID (number) or Workflow File Name (string) or a comma-separated list of those.
+          workflow_id: "ci.yml,docs.yml"
           access_token: ${{ github.token }}


### PR DESCRIPTION
## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.