### PR TITLE
Push down IF in PostgreSQL connector

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestConnectorExpressionTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestConnectorExpressionTranslator.java
@@ -29,6 +29,7 @@ import io.trino.sql.tree.ArithmeticBinaryExpression;
 import io.trino.sql.tree.ArithmeticUnaryExpression;
 import io.trino.sql.tree.ComparisonExpression;
 import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.IfExpression;
 import io.trino.sql.tree.IsNotNullPredicate;
 import io.trino.sql.tree.IsNullPredicate;
 import io.trino.sql.tree.LikePredicate;
@@ -52,6 +53,7 @@ import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.spi.expression.StandardFunctions.IF_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.IS_NULL_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.LIKE_PATTERN_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.NEGATE_FUNCTION_NAME;
@@ -179,6 +181,31 @@ public class TestConnectorExpressionTranslator
                         BOOLEAN,
                         ConnectorExpressionTranslator.functionNameForComparisonOperator(operator),
                         List.of(new Variable("double_symbol_1", DOUBLE), new Variable("double_symbol_2", DOUBLE))));
+    }
+
+    @Test(dataProvider = "testTranslateComparisonExpressionDataProvider")
+    public void testTranslateIf(ComparisonExpression.Operator operator)
+    {
+        assertTranslationRoundTrips(
+                new IfExpression(
+                        new ComparisonExpression(operator, new SymbolReference("double_symbol_1"), new SymbolReference("double_symbol_2")),
+                        new SymbolReference("double_symbol_1"),
+                        new SymbolReference("double_symbol_2")),
+                new Call(DOUBLE,
+                        IF_FUNCTION_NAME,
+                        List.of(new Call(BOOLEAN, ConnectorExpressionTranslator.functionNameForComparisonOperator(operator), List.of(new Variable("double_symbol_1", DOUBLE), new Variable("double_symbol_2", DOUBLE))),
+                                new Variable("double_symbol_1", DOUBLE),
+                                new Variable("double_symbol_2", DOUBLE))));
+
+        assertTranslationRoundTrips(
+                new IfExpression(
+                        new ComparisonExpression(operator, new SymbolReference("double_symbol_1"), new SymbolReference("double_symbol_2")),
+                        new SymbolReference("double_symbol_1"),
+                        null),
+                new Call(DOUBLE,
+                        IF_FUNCTION_NAME,
+                        List.of(new Call(BOOLEAN, ConnectorExpressionTranslator.functionNameForComparisonOperator(operator), List.of(new Variable("double_symbol_1", DOUBLE), new Variable("double_symbol_2", DOUBLE))),
+                                new Variable("double_symbol_1", DOUBLE))));
     }
 
     @DataProvider

--- a/core/trino-spi/src/main/java/io/trino/spi/expression/StandardFunctions.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/expression/StandardFunctions.java
@@ -45,6 +45,11 @@ public final class StandardFunctions
     public static final FunctionName GREATER_THAN_OPERATOR_FUNCTION_NAME = new FunctionName("$greater_than");
     public static final FunctionName GREATER_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME = new FunctionName("$greater_than_or_equal");
     public static final FunctionName IS_DISTINCT_FROM_OPERATOR_FUNCTION_NAME = new FunctionName("$is_distinct_from");
+    /**
+     * $if is a function accepting 2 arguments - condition and trueValue, or 3 arguments - condition, trueValue and falseValue.
+     * Evaluates and returns true_value if condition is true, otherwise evaluates and returns false_value.
+     */
+    public static final FunctionName IF_FUNCTION_NAME = new FunctionName("$if");
 
     /**
      * Arithmetic addition.

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -290,6 +290,8 @@ public class PostgreSqlClient
                 .map("$not(value: boolean)").to("NOT value")
                 .map("$is_null(value)").to("value IS NULL")
                 .map("$nullif(first, second)").to("NULLIF(first, second)")
+                .map("$if(condition, trueValue)").to("CASE WHEN condition THEN trueValue END")
+                .map("$if(condition, trueValue, falseValue)").to("CASE WHEN condition THEN trueValue ELSE falseValue END")
                 .build();
 
         JdbcTypeHandle bigintTypeHandle = new JdbcTypeHandle(Types.BIGINT, Optional.of("bigint"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());


### PR DESCRIPTION
## Description

Push down `IF` in PostgreSQL connector. 
Relates to #11699

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# PostgreSQL
* Improve performance of queries involving `IF` by pushing expression
  computation to the underlying database. ({issue}`11533`)
```
