### PR TITLE
Push down COALESCE in PostgreSQL connector

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushPredicateIntoTableScan.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushPredicateIntoTableScan.java
@@ -38,17 +38,15 @@ import io.trino.spi.predicate.NullableValue;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.Type;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
-import io.trino.sql.tree.ArithmeticBinaryExpression;
-import io.trino.sql.tree.Cast;
-import io.trino.sql.tree.CoalesceExpression;
+import io.trino.sql.tree.BooleanLiteral;
 import io.trino.sql.tree.ComparisonExpression;
 import io.trino.sql.tree.GenericLiteral;
 import io.trino.sql.tree.LogicalExpression;
 import io.trino.sql.tree.LongLiteral;
-import io.trino.sql.tree.NullLiteral;
 import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.StringLiteral;
 import io.trino.sql.tree.SymbolReference;
+import io.trino.sql.tree.TryExpression;
 import io.trino.testing.TestingTransactionHandle;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -59,10 +57,8 @@ import java.util.Optional;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.predicate.Domain.singleValue;
 import static io.trino.spi.type.BigintType.BIGINT;
-import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createVarcharType;
-import static io.trino.sql.analyzer.TypeSignatureTranslator.toSqlType;
 import static io.trino.sql.planner.TypeAnalyzer.createTestingTypeAnalyzer;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.constrainedTableScanWithTableLayout;
@@ -70,7 +66,6 @@ import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
 import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expression;
-import static io.trino.sql.tree.ArithmeticBinaryExpression.Operator.MODULUS;
 import static io.trino.sql.tree.ComparisonExpression.Operator.EQUAL;
 import static io.trino.sql.tree.LogicalExpression.Operator.AND;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -223,15 +218,7 @@ public class TestPushPredicateIntoTableScan
                                                         .build(),
                                                 new GenericLiteral("BIGINT", "42")),
                                         // non-translatable to connector expression
-                                        new CoalesceExpression(
-                                                new Cast(new NullLiteral(), toSqlType(BOOLEAN)),
-                                                new ComparisonExpression(
-                                                        EQUAL,
-                                                        new ArithmeticBinaryExpression(
-                                                                MODULUS,
-                                                                new SymbolReference("nationkey"),
-                                                                new GenericLiteral("BIGINT", "17")),
-                                                        new GenericLiteral("BIGINT", "44"))),
+                                        new TryExpression(new BooleanLiteral("false")),
                                         LogicalExpression.or(
                                                 new ComparisonExpression(
                                                         EQUAL,
@@ -256,13 +243,7 @@ public class TestPushPredicateIntoTableScan
                                                         .functionCallBuilder(QualifiedName.of("rand"))
                                                         .build(),
                                                 new GenericLiteral("BIGINT", "42")),
-                                        new ComparisonExpression(
-                                                EQUAL,
-                                                new ArithmeticBinaryExpression(
-                                                        MODULUS,
-                                                        new SymbolReference("nationkey"),
-                                                        new GenericLiteral("BIGINT", "17")),
-                                                new GenericLiteral("BIGINT", "44"))),
+                                        new TryExpression(new BooleanLiteral("false"))),
                                 constrainedTableScanWithTableLayout(
                                         "nation",
                                         ImmutableMap.of("nationkey", singleValue(BIGINT, (long) 44)),

--- a/core/trino-spi/src/main/java/io/trino/spi/expression/StandardFunctions.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/expression/StandardFunctions.java
@@ -82,4 +82,9 @@ public final class StandardFunctions
     public static final FunctionName NEGATE_FUNCTION_NAME = new FunctionName("$negate");
 
     public static final FunctionName LIKE_PATTERN_FUNCTION_NAME = new FunctionName("$like_pattern");
+
+    /**
+     * $coalesce is a function accepting more than or equals to two arguments
+     */
+    public static final FunctionName COALESCE_FUNCTION_NAME = new FunctionName("$coalesce");
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/RewriteCoalesce.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/RewriteCoalesce.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc.expression;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+
+import java.util.Optional;
+
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.spi.expression.StandardFunctions.COALESCE_FUNCTION_NAME;
+import static java.lang.String.format;
+import static java.lang.String.join;
+
+public class RewriteCoalesce
+        implements ConnectorExpressionRule<Call, String>
+{
+    private static final Capture<Call> CALL = newCapture();
+    private final Pattern<Call> pattern;
+
+    public RewriteCoalesce()
+    {
+        this.pattern = call()
+                .with(functionName().matching(name -> name.equals(COALESCE_FUNCTION_NAME)))
+                .capturedAs(CALL);
+    }
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public Optional<String> rewrite(Call call, Captures captures, RewriteContext<String> context)
+    {
+        ImmutableList.Builder<String> arguments = ImmutableList.builderWithExpectedSize(call.getArguments().size());
+        for (ConnectorExpression expression : captures.get(CALL).getArguments()) {
+            Optional<String> rewritten = context.defaultRewrite(expression);
+            if (rewritten.isEmpty()) {
+                return Optional.empty();
+            }
+            arguments.add(rewritten.get());
+        }
+
+        return Optional.of(format("COALESCE(%s)", join(",", arguments.build())));
+    }
+}

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -64,6 +64,7 @@ import io.trino.plugin.jdbc.aggregation.ImplementSum;
 import io.trino.plugin.jdbc.aggregation.ImplementVariancePop;
 import io.trino.plugin.jdbc.aggregation.ImplementVarianceSamp;
 import io.trino.plugin.jdbc.expression.JdbcConnectorExpressionRewriterBuilder;
+import io.trino.plugin.jdbc.expression.RewriteCoalesce;
 import io.trino.plugin.jdbc.expression.RewriteComparison;
 import io.trino.plugin.jdbc.mapping.IdentifierMapping;
 import io.trino.plugin.postgresql.PostgreSqlConfig.ArrayMapping;
@@ -301,6 +302,7 @@ public class PostgreSqlClient
                 .addStandardRules(this::quoted)
                 // TODO allow all comparison operators for numeric types
                 .add(new RewriteComparison(RewriteComparison.ComparisonOperator.EQUAL, RewriteComparison.ComparisonOperator.NOT_EQUAL))
+                .add(new RewriteCoalesce())
                 .withTypeClass("integer_type", ImmutableSet.of("tinyint", "smallint", "integer", "bigint"))
                 .map("$add(left: integer_type, right: integer_type)").to("left + right")
                 .map("$subtract(left: integer_type, right: integer_type)").to("left - right")


### PR DESCRIPTION
## Description

Push down `COALESCE` in PostgreSQL connector

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# PostgreSQL
* Improve performance of queries involving `COALESCE` by pushing expression
  computation to the underlying database. ({issue}`issuenumber`)
```
