### PR TITLE
Revert "Update maven to 3.8.5"

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.8.4/apache-maven-3.8.4-bin.zip


### PR DESCRIPTION
This reverts commit 1cfa4f618954a33b7a1bbbc06f25ef20c7c3c53e.

Maven 3.8.5 fails to build trino-server-rpm and has a few regressions.
See https://issues.apache.org/jira/browse/MNG-7432 for example.

## Related issues, pull requests, and links

Fixes https://github.com/trinodb/trino/issues/11531
See https://github.com/trinodb/trino/pull/11495 which is being reverted.

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
