### PR TITLE
Translate all possible expression conjuncts into connector

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPredicateIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPredicateIntoTableScan.java
@@ -25,6 +25,7 @@ import io.trino.metadata.Metadata;
 import io.trino.metadata.TableHandle;
 import io.trino.metadata.TableProperties;
 import io.trino.metadata.TableProperties.TablePartitioning;
+import io.trino.plugin.base.expression.ConnectorExpressions;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.ConstraintApplicationResult;
@@ -32,7 +33,6 @@ import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.Type;
-import io.trino.sql.ExpressionUtils;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.planner.ConnectorExpressionTranslator;
 import io.trino.sql.planner.DomainTranslator;
@@ -41,6 +41,7 @@ import io.trino.sql.planner.LiteralEncoder;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.SymbolAllocator;
 import io.trino.sql.planner.TypeAnalyzer;
+import io.trino.sql.planner.TypeProvider;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.plan.FilterNode;
 import io.trino.sql.planner.plan.PlanNode;
@@ -177,15 +178,15 @@ public class PushPredicateIntoTableScan
                 .transformKeys(node.getAssignments()::get)
                 .intersect(node.getEnforcedConstraint());
 
-        Map<NodeRef<Expression>, Type> remainingExpressionTypes = typeAnalyzer.getTypes(session, symbolAllocator.getTypes(), decomposedPredicate.getRemainingExpression());
-        Optional<ConnectorExpression> connectorExpression = new ConnectorExpressionTranslator.SqlToConnectorExpressionTranslator(session, remainingExpressionTypes, plannerContext)
-                .process(decomposedPredicate.getRemainingExpression());
-        Map<String, ColumnHandle> connectorExpressionAssignments = connectorExpression
-                .map(ignored ->
-                        node.getAssignments()
-                                .entrySet().stream()
-                                .collect(toImmutableMap(entry -> entry.getKey().getName(), Map.Entry::getValue)))
-                .orElse(ImmutableMap.of());
+        ConnectorExpressionTranslation expressionTranslation = translateConjunctsToConnectorExpression(
+                session,
+                plannerContext,
+                typeAnalyzer,
+                symbolAllocator.getTypes(),
+                decomposedPredicate.getRemainingExpression());
+        Map<String, ColumnHandle> connectorExpressionAssignments = node.getAssignments()
+                .entrySet().stream()
+                .collect(toImmutableMap(entry -> entry.getKey().getName(), Map.Entry::getValue));
 
         Map<ColumnHandle, Symbol> assignments = ImmutableBiMap.copyOf(node.getAssignments()).inverse();
 
@@ -204,18 +205,18 @@ public class PushPredicateIntoTableScan
                             // Simplify the tuple domain to avoid creating an expression with too many nodes,
                             // which would be expensive to evaluate in the call to isCandidate below.
                             domainTranslator.toPredicate(session, newDomain.simplify().transformKeys(assignments::get))));
-            constraint = new Constraint(newDomain, connectorExpression.orElse(TRUE), connectorExpressionAssignments, evaluator::isCandidate, evaluator.getArguments());
+            constraint = new Constraint(newDomain, expressionTranslation.getConnectorExpression(), connectorExpressionAssignments, evaluator::isCandidate, evaluator.getArguments());
         }
         else {
             // Currently, invoking the expression interpreter is very expensive.
             // TODO invoke the interpreter unconditionally when the interpreter becomes cheap enough.
-            constraint = new Constraint(newDomain, connectorExpression.orElse(TRUE), connectorExpressionAssignments);
+            constraint = new Constraint(newDomain, expressionTranslation.getConnectorExpression(), connectorExpressionAssignments);
         }
 
         // check if new domain is wider than domain already provided by table scan
         if (constraint.predicate().isEmpty() &&
                 // TODO do we need to track enforced ConnectorExpression in TableScanNode?
-                TRUE.equals(connectorExpression.orElse(TRUE)) &&
+                TRUE.equals(expressionTranslation.getConnectorExpression()) &&
                 newDomain.contains(node.getEnforcedConstraint())) {
             Expression resultingPredicate = createResultingPredicate(
                     plannerContext,
@@ -273,19 +274,14 @@ public class PushPredicateIntoTableScan
                 node.getUseConnectorNodePartitioning());
 
         Expression remainingDecomposedPredicate;
-        if (remainingConnectorExpression.isEmpty() || remainingConnectorExpression.equals(connectorExpression)) {
+        if (remainingConnectorExpression.isEmpty() || remainingConnectorExpression.get().equals(expressionTranslation.getConnectorExpression())) {
             remainingDecomposedPredicate = decomposedPredicate.getRemainingExpression();
         }
         else {
             Map<String, Symbol> variableMappings = assignments.values().stream()
                     .collect(toImmutableMap(Symbol::getName, Function.identity()));
             Expression translatedExpression = ConnectorExpressionTranslator.translate(session, remainingConnectorExpression.get(), plannerContext, variableMappings, new LiteralEncoder(plannerContext));
-            if (connectorExpression.isEmpty()) {
-                remainingDecomposedPredicate = ExpressionUtils.combineConjuncts(plannerContext.getMetadata(), translatedExpression, decomposedPredicate.getRemainingExpression());
-            }
-            else {
-                remainingDecomposedPredicate = translatedExpression;
-            }
+            remainingDecomposedPredicate = combineConjuncts(plannerContext.getMetadata(), translatedExpression, expressionTranslation.getRemainingExpression());
         }
 
         Expression resultingPredicate = createResultingPredicate(
@@ -351,6 +347,36 @@ public class PushPredicateIntoTableScan
                 combineConjuncts(metadata, dynamicFilters),
                 combineConjuncts(metadata, deterministicPredicates),
                 combineConjuncts(metadata, nonDeterministicPredicate));
+    }
+
+    private static ConnectorExpressionTranslation translateConjunctsToConnectorExpression(
+            Session session,
+            PlannerContext plannerContext,
+            TypeAnalyzer typeAnalyzer,
+            TypeProvider types,
+            Expression expression)
+    {
+        Map<NodeRef<Expression>, Type> remainingExpressionTypes = typeAnalyzer.getTypes(session, types, expression);
+        ConnectorExpressionTranslator.SqlToConnectorExpressionTranslator translator = new ConnectorExpressionTranslator.SqlToConnectorExpressionTranslator(
+                session,
+                remainingExpressionTypes,
+                plannerContext);
+
+        List<Expression> conjuncts = extractConjuncts(expression);
+        List<Expression> remaining = new ArrayList<>();
+        List<ConnectorExpression> converted = new ArrayList<>(conjuncts.size());
+        for (Expression conjunct : conjuncts) {
+            Optional<ConnectorExpression> connectorExpression = translator.process(conjunct);
+            if (connectorExpression.isPresent()) {
+                converted.add(connectorExpression.get());
+            }
+            else {
+                remaining.add(conjunct);
+            }
+        }
+        return new ConnectorExpressionTranslation(
+                combineConjuncts(plannerContext.getMetadata(), remaining),
+                ConnectorExpressions.and(converted));
     }
 
     static Expression createResultingPredicate(
@@ -440,6 +466,28 @@ public class PushPredicateIntoTableScan
         public Expression getNonDeterministicPredicate()
         {
             return nonDeterministicPredicate;
+        }
+    }
+
+    private static class ConnectorExpressionTranslation
+    {
+        private final Expression remainingExpression;
+        private final ConnectorExpression connectorExpression;
+
+        public ConnectorExpressionTranslation(Expression remainingExpression, ConnectorExpression connectorExpression)
+        {
+            this.remainingExpression = requireNonNull(remainingExpression, "remainingExpression is null");
+            this.connectorExpression = requireNonNull(connectorExpression, "connectorExpression is null");
+        }
+
+        public Expression getRemainingExpression()
+        {
+            return remainingExpression;
+        }
+
+        public ConnectorExpression getConnectorExpression()
+        {
+            return connectorExpression;
         }
     }
 }


### PR DESCRIPTION
Before the change, `PushPredicateIntoTableScan` would pass
`ConnectorExpression` to `ConnectorMetadata` if and only if
`decomposedPredicate.getRemainingExpression()` was fully convertible to
`ConnectorExpression`.

After the change, all translatable individual conjuncts are passed to
the connector.
