### PR TITLE
Add support for WebIdentityTokenFileCredentialsProvider in exchange spooling

### DIFF
--- a/plugin/trino-exchange/pom.xml
+++ b/plugin/trino-exchange/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <awsjavasdk.version>2.17.102</awsjavasdk.version>
+        <awsjavasdk.version>2.17.151</awsjavasdk.version>
     </properties>
 
     <dependencyManagement>
@@ -113,6 +113,10 @@
                 <exclusion>
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-tcnative-classes</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/plugin/trino-exchange/pom.xml
+++ b/plugin/trino-exchange/pom.xml
@@ -131,6 +131,13 @@
             <artifactId>utils</artifactId>
         </dependency>
 
+        <!-- use of WebIdentityTokenFileCredentialsProvider requires the 'sts' module to be on the classpath -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- Trino SPI -->
         <dependency>
             <groupId>io.trino</groupId>

--- a/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/s3/ExchangeS3Config.java
+++ b/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/s3/ExchangeS3Config.java
@@ -35,6 +35,7 @@ public class ExchangeS3Config
     private String s3AwsSecretKey;
     private Optional<Region> s3Region = Optional.empty();
     private Optional<String> s3Endpoint = Optional.empty();
+    private boolean s3UseWebIdentityTokenCredentials;
     private int s3MaxErrorRetries = 3;
     // Default to S3 multi-part upload minimum size to avoid excessive memory consumption from buffering
     private DataSize s3UploadPartSize = DataSize.of(5, MEGABYTE);
@@ -88,6 +89,18 @@ public class ExchangeS3Config
     public ExchangeS3Config setS3Endpoint(String s3Endpoint)
     {
         this.s3Endpoint = Optional.ofNullable(s3Endpoint);
+        return this;
+    }
+
+    public boolean isS3UseWebIdentityTokenCredentials()
+    {
+        return s3UseWebIdentityTokenCredentials;
+    }
+
+    @Config("exchange.s3.use-web-identity-token-credentials")
+    public ExchangeS3Config setS3UseWebIdentityTokenCredentials(boolean s3UseWebIdentityTokenCredentials)
+    {
+        this.s3UseWebIdentityTokenCredentials = s3UseWebIdentityTokenCredentials;
         return this;
     }
 

--- a/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/s3/S3FileSystemExchangeStorage.java
+++ b/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/s3/S3FileSystemExchangeStorage.java
@@ -32,6 +32,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.retry.RetryPolicy;
@@ -362,6 +363,11 @@ public class S3FileSystemExchangeStorage
         if (config.getS3AwsAccessKey() != null && config.getS3AwsSecretKey() != null) {
             return StaticCredentialsProvider.create(AwsBasicCredentials.create(config.getS3AwsAccessKey(), config.getS3AwsSecretKey()));
         }
+
+        if (config.isS3UseWebIdentityTokenCredentials()) {
+            return WebIdentityTokenFileCredentialsProvider.create();
+        }
+
         return DefaultCredentialsProvider.create();
     }
 

--- a/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/s3/TestExchangeS3Config.java
+++ b/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/s3/TestExchangeS3Config.java
@@ -34,6 +34,7 @@ public class TestExchangeS3Config
                 .setS3AwsSecretKey(null)
                 .setS3Region(null)
                 .setS3Endpoint(null)
+                .setS3UseWebIdentityTokenCredentials(false)
                 .setS3MaxErrorRetries(3)
                 .setS3UploadPartSize(DataSize.of(5, MEGABYTE)));
     }
@@ -46,6 +47,7 @@ public class TestExchangeS3Config
                 .put("exchange.s3.aws-secret-key", "secret")
                 .put("exchange.s3.region", "us-west-1")
                 .put("exchange.s3.endpoint", "https://s3.us-east-1.amazonaws.com")
+                .put("exchange.s3.use-web-identity-token-credentials", "true")
                 .put("exchange.s3.max-error-retries", "8")
                 .put("exchange.s3.upload.part-size", "10MB")
                 .buildOrThrow();
@@ -55,6 +57,7 @@ public class TestExchangeS3Config
                 .setS3AwsSecretKey("secret")
                 .setS3Region("us-west-1")
                 .setS3Endpoint("https://s3.us-east-1.amazonaws.com")
+                .setS3UseWebIdentityTokenCredentials(true)
                 .setS3MaxErrorRetries(8)
                 .setS3UploadPartSize(DataSize.of(10, MEGABYTE));
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Feature.


> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

trino-exchange plugin

> How would you describe this change to a non-technical end user or system administrator?

This adds an explicit route to use WebIdentityTokenFileCredentialsProvider (which is particularly relevant in the context of EKS)

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
