### PR TITLE
Prevent DROP/RENAME TABLE IF EXISTS from silently ignoring views

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/DropTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropTableTask.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
+import static io.trino.spi.StandardErrorCode.GENERIC_USER_ERROR;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
 import static java.util.Objects.requireNonNull;
@@ -62,23 +63,17 @@ public class DropTableTask
         Session session = stateMachine.getSession();
         QualifiedObjectName originalTableName = createQualifiedObjectName(session, statement, statement.getTableName());
         if (metadata.isMaterializedView(session, originalTableName)) {
-            if (!statement.isExists()) {
-                throw semanticException(
-                        TABLE_NOT_FOUND,
-                        statement,
-                        "Table '%s' does not exist, but a materialized view with that name exists. Did you mean DROP MATERIALIZED VIEW %s?", originalTableName, originalTableName);
-            }
-            return immediateVoidFuture();
+            throw semanticException(
+                    GENERIC_USER_ERROR,
+                    statement,
+                    "Table '%s' does not exist, but a materialized view with that name exists. Did you mean DROP MATERIALIZED VIEW %s?", originalTableName, originalTableName);
         }
 
         if (metadata.isView(session, originalTableName)) {
-            if (!statement.isExists()) {
-                throw semanticException(
-                        TABLE_NOT_FOUND,
-                        statement,
-                        "Table '%s' does not exist, but a view with that name exists. Did you mean DROP VIEW %s?", originalTableName, originalTableName);
-            }
-            return immediateVoidFuture();
+            throw semanticException(
+                    GENERIC_USER_ERROR,
+                    statement,
+                    "Table '%s' does not exist, but a view with that name exists. Did you mean DROP VIEW %s?", originalTableName, originalTableName);
         }
 
         RedirectionAwareTableHandle redirectionAwareTableHandle = metadata.getRedirectionAwareTableHandle(session, originalTableName);

--- a/core/trino-main/src/main/java/io/trino/execution/RenameMaterializedViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameMaterializedViewTask.java
@@ -18,7 +18,6 @@ import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedObjectName;
-import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.RenameMaterializedView;
@@ -26,7 +25,6 @@ import io.trino.sql.tree.RenameMaterializedView;
 import javax.inject.Inject;
 
 import java.util.List;
-import java.util.Optional;
 
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
@@ -70,15 +68,14 @@ public class RenameMaterializedViewTask
                 throw semanticException(
                         TABLE_NOT_FOUND,
                         statement,
-                        "Materialized View '%s' does not exist, but a view with that name exists. Did you mean ALTER VIEW %s RENAME ...?", materializedViewName, materializedViewName);
+                        "Materialized View '%s' does not exist, but a view with that name exists. Did you mean ALTER VIEW %s RENAME TO ...?", materializedViewName, materializedViewName);
             }
 
-            Optional<TableHandle> table = metadata.getTableHandle(session, materializedViewName);
-            if (table.isPresent()) {
+            if (metadata.getTableHandle(session, materializedViewName).isPresent()) {
                 throw semanticException(
                         TABLE_NOT_FOUND,
                         statement,
-                        "Materialized View '%s' does not exist, but a table with that name exists. Did you mean ALTER TABLE %s RENAME ...?", materializedViewName, materializedViewName);
+                        "Materialized View '%s' does not exist, but a table with that name exists. Did you mean ALTER TABLE %s RENAME TO ...?", materializedViewName, materializedViewName);
             }
 
             if (statement.isExists()) {

--- a/core/trino-main/src/main/java/io/trino/execution/RenameTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameTableTask.java
@@ -76,7 +76,7 @@ public class RenameTableTask
                 throw semanticException(
                         TABLE_NOT_FOUND,
                         statement,
-                        "Table '%s' does not exist, but a materialized view with that name exists. Did you mean ALTER MATERIALIZED VIEW %s RENAME ...?", tableName, tableName);
+                        "Table '%s' does not exist, but a materialized view with that name exists. Did you mean ALTER MATERIALIZED VIEW %s RENAME TO ...?", tableName, tableName);
             }
             return immediateVoidFuture();
         }
@@ -86,7 +86,7 @@ public class RenameTableTask
                 throw semanticException(
                         TABLE_NOT_FOUND,
                         statement,
-                        "Table '%s' does not exist, but a view with that name exists. Did you mean ALTER VIEW %s RENAME ...?", tableName, tableName);
+                        "Table '%s' does not exist, but a view with that name exists. Did you mean ALTER VIEW %s RENAME TO ...?", tableName, tableName);
             }
             return immediateVoidFuture();
         }

--- a/core/trino-main/src/main/java/io/trino/execution/RenameTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameTableTask.java
@@ -34,6 +34,7 @@ import java.util.List;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.spi.StandardErrorCode.CATALOG_NOT_FOUND;
+import static io.trino.spi.StandardErrorCode.GENERIC_USER_ERROR;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.SYNTAX_ERROR;
 import static io.trino.spi.StandardErrorCode.TABLE_ALREADY_EXISTS;
@@ -72,23 +73,17 @@ public class RenameTableTask
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getSource());
 
         if (metadata.isMaterializedView(session, tableName)) {
-            if (!statement.isExists()) {
-                throw semanticException(
-                        TABLE_NOT_FOUND,
-                        statement,
-                        "Table '%s' does not exist, but a materialized view with that name exists. Did you mean ALTER MATERIALIZED VIEW %s RENAME TO ...?", tableName, tableName);
-            }
-            return immediateVoidFuture();
+            throw semanticException(
+                    GENERIC_USER_ERROR,
+                    statement,
+                    "Table '%s' does not exist, but a materialized view with that name exists. Did you mean ALTER MATERIALIZED VIEW %s RENAME TO ...?", tableName, tableName);
         }
 
         if (metadata.isView(session, tableName)) {
-            if (!statement.isExists()) {
-                throw semanticException(
-                        TABLE_NOT_FOUND,
-                        statement,
-                        "Table '%s' does not exist, but a view with that name exists. Did you mean ALTER VIEW %s RENAME TO ...?", tableName, tableName);
-            }
-            return immediateVoidFuture();
+            throw semanticException(
+                    GENERIC_USER_ERROR,
+                    statement,
+                    "Table '%s' does not exist, but a view with that name exists. Did you mean ALTER VIEW %s RENAME TO ...?", tableName, tableName);
         }
 
         RedirectionAwareTableHandle redirectionAwareTableHandle = metadata.getRedirectionAwareTableHandle(session, tableName);

--- a/core/trino-main/src/main/java/io/trino/execution/RenameViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameViewTask.java
@@ -18,7 +18,6 @@ import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedObjectName;
-import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.RenameView;
@@ -26,7 +25,6 @@ import io.trino.sql.tree.RenameView;
 import javax.inject.Inject;
 
 import java.util.List;
-import java.util.Optional;
 
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
@@ -69,16 +67,15 @@ public class RenameViewTask
             throw semanticException(
                     TABLE_NOT_FOUND,
                     statement,
-                    "View '%s' does not exist, but a materialized view with that name exists. Did you mean ALTER MATERIALIZED VIEW %s RENAME ...?", viewName, viewName);
+                    "View '%s' does not exist, but a materialized view with that name exists. Did you mean ALTER MATERIALIZED VIEW %s RENAME TO ...?", viewName, viewName);
         }
 
         if (!metadata.isView(session, viewName)) {
-            Optional<TableHandle> table = metadata.getTableHandle(session, viewName);
-            if (table.isPresent()) {
+            if (metadata.getTableHandle(session, viewName).isPresent()) {
                 throw semanticException(
                         TABLE_NOT_FOUND,
                         statement,
-                        "View '%s' does not exist, but a table with that name exists. Did you mean ALTER TABLE %s RENAME ...?", viewName, viewName);
+                        "View '%s' does not exist, but a table with that name exists. Did you mean ALTER TABLE %s RENAME TO ...?", viewName, viewName);
             }
 
             throw semanticException(TABLE_NOT_FOUND, statement, "View '%s' does not exist", viewName);

--- a/core/trino-main/src/test/java/io/trino/execution/TestDropTableTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestDropTableTask.java
@@ -23,6 +23,7 @@ import io.trino.sql.tree.QualifiedName;
 import org.testng.annotations.Test;
 
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
+import static io.trino.spi.StandardErrorCode.GENERIC_USER_ERROR;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -68,7 +69,7 @@ public class TestDropTableTask
         metadata.createView(testSession, asQualifiedObjectName(viewName), someView(), false);
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeDropTable(viewName, false)))
-                .hasErrorCode(TABLE_NOT_FOUND)
+                .hasErrorCode(GENERIC_USER_ERROR)
                 .hasMessage("Table '%s' does not exist, but a view with that name exists. Did you mean DROP VIEW %s?", viewName, viewName);
     }
 
@@ -78,8 +79,9 @@ public class TestDropTableTask
         QualifiedName viewName = qualifiedName("existing_view");
         metadata.createView(testSession, asQualifiedObjectName(viewName), someView(), false);
 
-        getFutureValue(executeDropTable(viewName, true));
-        // no exception
+        assertTrinoExceptionThrownBy(() -> getFutureValue(executeDropTable(viewName, true)))
+                .hasErrorCode(GENERIC_USER_ERROR)
+                .hasMessage("Table '%s' does not exist, but a view with that name exists. Did you mean DROP VIEW %s?", viewName, viewName);
     }
 
     @Test
@@ -89,7 +91,7 @@ public class TestDropTableTask
         metadata.createMaterializedView(testSession, asQualifiedObjectName(viewName), someMaterializedView(), false, false);
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeDropTable(viewName, false)))
-                .hasErrorCode(TABLE_NOT_FOUND)
+                .hasErrorCode(GENERIC_USER_ERROR)
                 .hasMessage("Table '%s' does not exist, but a materialized view with that name exists. Did you mean DROP MATERIALIZED VIEW %s?", viewName, viewName);
     }
 
@@ -99,8 +101,9 @@ public class TestDropTableTask
         QualifiedName viewName = qualifiedName("existing_materialized_view");
         metadata.createMaterializedView(testSession, asQualifiedObjectName(viewName), someMaterializedView(), false, false);
 
-        getFutureValue(executeDropTable(viewName, true));
-        // no exception
+        assertTrinoExceptionThrownBy(() -> getFutureValue(executeDropTable(viewName, true)))
+                .hasErrorCode(GENERIC_USER_ERROR)
+                .hasMessage("Table '%s' does not exist, but a materialized view with that name exists. Did you mean DROP MATERIALIZED VIEW %s?", viewName, viewName);
     }
 
     private ListenableFuture<Void> executeDropTable(QualifiedName tableName, boolean exists)

--- a/core/trino-main/src/test/java/io/trino/execution/TestRenameMaterializedViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestRenameMaterializedViewTask.java
@@ -71,7 +71,7 @@ public class TestRenameMaterializedViewTask
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameMaterializedView(asQualifiedName(tableName), qualifiedName("existing_table_new"))))
                 .hasErrorCode(TABLE_NOT_FOUND)
-                .hasMessage("Materialized View '%s' does not exist, but a table with that name exists. Did you mean ALTER TABLE %s RENAME ...?", tableName, tableName);
+                .hasMessage("Materialized View '%s' does not exist, but a table with that name exists. Did you mean ALTER TABLE %s RENAME TO ...?", tableName, tableName);
     }
 
     @Test
@@ -82,7 +82,7 @@ public class TestRenameMaterializedViewTask
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameMaterializedView(asQualifiedName(tableName), qualifiedName("existing_table_new"), true)))
                 .hasErrorCode(TABLE_NOT_FOUND)
-                .hasMessage("Materialized View '%s' does not exist, but a table with that name exists. Did you mean ALTER TABLE %s RENAME ...?", tableName, tableName);
+                .hasMessage("Materialized View '%s' does not exist, but a table with that name exists. Did you mean ALTER TABLE %s RENAME TO ...?", tableName, tableName);
     }
 
     @Test
@@ -106,7 +106,7 @@ public class TestRenameMaterializedViewTask
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameMaterializedView(viewName, qualifiedName("existing_view_new"))))
                 .hasErrorCode(TABLE_NOT_FOUND)
-                .hasMessage("Materialized View '%s' does not exist, but a view with that name exists. Did you mean ALTER VIEW catalog.schema.existing_view RENAME ...?", viewName);
+                .hasMessage("Materialized View '%s' does not exist, but a view with that name exists. Did you mean ALTER VIEW catalog.schema.existing_view RENAME TO ...?", viewName);
     }
 
     @Test
@@ -117,7 +117,7 @@ public class TestRenameMaterializedViewTask
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameMaterializedView(viewName, qualifiedName("existing_view_new"), true)))
                 .hasErrorCode(TABLE_NOT_FOUND)
-                .hasMessage("Materialized View '%s' does not exist, but a view with that name exists. Did you mean ALTER VIEW catalog.schema.existing_view RENAME ...?", viewName);
+                .hasMessage("Materialized View '%s' does not exist, but a view with that name exists. Did you mean ALTER VIEW catalog.schema.existing_view RENAME TO ...?", viewName);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/execution/TestRenameTableTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestRenameTableTask.java
@@ -70,7 +70,7 @@ public class TestRenameTableTask
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameTable(asQualifiedName(viewName), qualifiedName("existing_view_new"), false)))
                 .hasErrorCode(TABLE_NOT_FOUND)
-                .hasMessage("Table '%s' does not exist, but a view with that name exists. Did you mean ALTER VIEW %s RENAME ...?", viewName, viewName);
+                .hasMessage("Table '%s' does not exist, but a view with that name exists. Did you mean ALTER VIEW %s RENAME TO ...?", viewName, viewName);
     }
 
     @Test
@@ -91,7 +91,7 @@ public class TestRenameTableTask
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameTable(viewName, qualifiedName("existing_materialized_view_new"), false)))
                 .hasErrorCode(TABLE_NOT_FOUND)
-                .hasMessage("Table '%s' does not exist, but a materialized view with that name exists. Did you mean ALTER MATERIALIZED VIEW catalog.schema.existing_materialized_view RENAME ...?", viewName);
+                .hasMessage("Table '%s' does not exist, but a materialized view with that name exists. Did you mean ALTER MATERIALIZED VIEW catalog.schema.existing_materialized_view RENAME TO ...?", viewName);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/execution/TestRenameTableTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestRenameTableTask.java
@@ -23,6 +23,7 @@ import io.trino.sql.tree.RenameTable;
 import org.testng.annotations.Test;
 
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
+import static io.trino.spi.StandardErrorCode.GENERIC_USER_ERROR;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -69,7 +70,7 @@ public class TestRenameTableTask
         metadata.createView(testSession, viewName, someView(), false);
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameTable(asQualifiedName(viewName), qualifiedName("existing_view_new"), false)))
-                .hasErrorCode(TABLE_NOT_FOUND)
+                .hasErrorCode(GENERIC_USER_ERROR)
                 .hasMessage("Table '%s' does not exist, but a view with that name exists. Did you mean ALTER VIEW %s RENAME TO ...?", viewName, viewName);
     }
 
@@ -79,8 +80,9 @@ public class TestRenameTableTask
         QualifiedObjectName viewName = qualifiedObjectName("existing_view");
         metadata.createView(testSession, viewName, someView(), false);
 
-        getFutureValue(executeRenameTable(asQualifiedName(viewName), qualifiedName("existing_view_new"), true));
-        // no exception
+        assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameTable(asQualifiedName(viewName), qualifiedName("existing_view_new"), true)))
+                .hasErrorCode(GENERIC_USER_ERROR)
+                .hasMessage("Table '%s' does not exist, but a view with that name exists. Did you mean ALTER VIEW %s RENAME TO ...?", viewName, viewName);
     }
 
     @Test
@@ -90,7 +92,7 @@ public class TestRenameTableTask
         metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(viewName.toString()), someMaterializedView(), false, false);
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameTable(viewName, qualifiedName("existing_materialized_view_new"), false)))
-                .hasErrorCode(TABLE_NOT_FOUND)
+                .hasErrorCode(GENERIC_USER_ERROR)
                 .hasMessage("Table '%s' does not exist, but a materialized view with that name exists. Did you mean ALTER MATERIALIZED VIEW catalog.schema.existing_materialized_view RENAME TO ...?", viewName);
     }
 
@@ -100,8 +102,9 @@ public class TestRenameTableTask
         QualifiedName viewName = qualifiedName("existing_materialized_view");
         metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(viewName.toString()), someMaterializedView(), false, false);
 
-        getFutureValue(executeRenameTable(viewName, qualifiedName("existing_materialized_view_new"), true));
-        // no exception
+        assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameTable(viewName, qualifiedName("existing_materialized_view_new"), true)))
+                .hasErrorCode(GENERIC_USER_ERROR)
+                .hasMessage("Table '%s' does not exist, but a materialized view with that name exists. Did you mean ALTER MATERIALIZED VIEW catalog.schema.existing_materialized_view RENAME TO ...?", viewName);
     }
 
     private ListenableFuture<Void> executeRenameTable(QualifiedName source, QualifiedName target, boolean exists)

--- a/core/trino-main/src/test/java/io/trino/execution/TestRenameViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestRenameViewTask.java
@@ -61,7 +61,7 @@ public class TestRenameViewTask
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameView(asQualifiedName(tableName), qualifiedName("existing_table_new"))))
                 .hasErrorCode(TABLE_NOT_FOUND)
-                .hasMessage("View '%s' does not exist, but a table with that name exists. Did you mean ALTER TABLE %s RENAME ...?", tableName, tableName);
+                .hasMessage("View '%s' does not exist, but a table with that name exists. Did you mean ALTER TABLE %s RENAME TO ...?", tableName, tableName);
     }
 
     @Test
@@ -72,7 +72,7 @@ public class TestRenameViewTask
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameView(viewName, qualifiedName("existing_materialized_view_new"))))
                 .hasErrorCode(TABLE_NOT_FOUND)
-                .hasMessage("View '%s' does not exist, but a materialized view with that name exists. Did you mean ALTER MATERIALIZED VIEW catalog.schema.existing_materialized_view RENAME ...?", viewName);
+                .hasMessage("View '%s' does not exist, but a materialized view with that name exists. Did you mean ALTER MATERIALIZED VIEW catalog.schema.existing_materialized_view RENAME TO ...?", viewName);
     }
 
     private ListenableFuture<Void> executeRenameView(QualifiedName source, QualifiedName target)


### PR DESCRIPTION
## Description

Fixes: #9129 

## Documentation

(:white_check_mark:) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(:white_check_mark:) No release notes entries required.
( ) Release notes entries required with the following suggested text:
