### PR TITLE
Support predicate pushdown on boolean column in MongoDB

### DIFF
--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
@@ -461,6 +461,10 @@ public class MongoSession
         requireNonNull(type, "type is null");
         checkArgument(Primitives.wrap(type.getJavaType()).isInstance(trinoNativeValue), "%s (%s) is not a valid representation for %s", trinoNativeValue, trinoNativeValue.getClass(), type);
 
+        if (type == BOOLEAN) {
+            return Optional.of(trinoNativeValue);
+        }
+
         if (type == TINYINT) {
             return Optional.of((long) SignedBytes.checkedCast(((Long) trinoNativeValue)));
         }

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorTest.java
@@ -532,6 +532,19 @@ public abstract class BaseMongoConnectorTest
     }
 
     @Test
+    public void testBooleanPredicates()
+    {
+        assertUpdate("CREATE TABLE boolean_predicates(id integer, value boolean)");
+        assertUpdate("INSERT INTO boolean_predicates VALUES(1, true)", 1);
+        assertUpdate("INSERT INTO boolean_predicates VALUES(2, false)", 1);
+
+        assertQuery("SELECT id FROM boolean_predicates WHERE value = true", "VALUES 1");
+        assertQuery("SELECT id FROM boolean_predicates WHERE value = false", "VALUES 2");
+
+        assertUpdate("DROP TABLE boolean_predicates");
+    }
+
+    @Test
     public void testNullPredicates()
     {
         assertUpdate("CREATE TABLE test.null_predicates(name varchar, value integer)");

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoSession.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoSession.java
@@ -31,6 +31,7 @@ import static io.trino.spi.predicate.Range.greaterThanOrEqual;
 import static io.trino.spi.predicate.Range.lessThan;
 import static io.trino.spi.predicate.Range.range;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.util.Arrays.asList;
 import static org.testng.Assert.assertEquals;
@@ -40,6 +41,7 @@ public class TestMongoSession
     private static final MongoColumnHandle COL1 = new MongoColumnHandle("col1", BIGINT, false, Optional.empty());
     private static final MongoColumnHandle COL2 = new MongoColumnHandle("col2", createUnboundedVarcharType(), false, Optional.empty());
     private static final MongoColumnHandle COL3 = new MongoColumnHandle("col3", createUnboundedVarcharType(), false, Optional.empty());
+    private static final MongoColumnHandle COL4 = new MongoColumnHandle("col4", BOOLEAN, false, Optional.empty());
 
     @Test
     public void testBuildQuery()
@@ -103,6 +105,16 @@ public class TestMongoSession
         Document expected = new Document("$or", asList(
                 new Document(COL1.getName(), new Document("$gt", 200L)),
                 new Document(COL1.getName(), new Document("$eq", null))));
+        assertEquals(query, expected);
+    }
+
+    @Test
+    public void testBooleanPredicatePushdown()
+    {
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(ImmutableMap.of(COL4, Domain.singleValue(BOOLEAN, true)));
+
+        Document query = MongoSession.buildQuery(tupleDomain);
+        Document expected = new Document().append(COL4.getName(), new Document("$eq", true));
         assertEquals(query, expected);
     }
 }


### PR DESCRIPTION
## Description

Support predicate pushdown on boolean column in MongoDB
Fixes #11536

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# MongoDB
* Support predicate pushdown on `boolean` column. ({issue}`11556`)
```
