### PR TITLE
Fix scheduling for splits with locality requirement in Tardigrade

### DIFF
--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchNodePartitioningProvider.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchNodePartitioningProvider.java
@@ -30,9 +30,11 @@ import java.util.Set;
 import java.util.function.ToIntFunction;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.spi.connector.ConnectorBucketNodeMap.createBucketNodeMap;
 import static io.trino.spi.type.BigintType.BIGINT;
-import static java.lang.Math.toIntExact;
+import static java.util.Comparator.comparing;
 
 public class TpchNodePartitioningProvider
         implements ConnectorNodePartitioningProvider
@@ -51,9 +53,18 @@ public class TpchNodePartitioningProvider
     public ConnectorBucketNodeMap getBucketNodeMap(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle)
     {
         Set<Node> nodes = nodeManager.getRequiredWorkerNodes();
-
-        // Split the data using split and skew by the number of nodes available.
-        return createBucketNodeMap(toIntExact((long) nodes.size() * splitsPerNode));
+        checkState(!nodes.isEmpty(), "No TPCH nodes available");
+        // sort to ensure the assignment is consistent with TpchSplitManager
+        List<Node> sortedNodes = nodes.stream()
+                .sorted(comparing(node -> node.getHostAndPort().toString()))
+                .collect(toImmutableList());
+        ImmutableList.Builder<Node> bucketToNode = ImmutableList.builder();
+        for (Node node : sortedNodes) {
+            for (int i = 0; i < splitsPerNode; i++) {
+                bucketToNode.add(node);
+            }
+        }
+        return createBucketNodeMap(bucketToNode.build());
     }
 
     @Override

--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchSplitManager.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchSplitManager.java
@@ -25,9 +25,12 @@ import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.connector.FixedSplitSource;
 
+import java.util.List;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Comparator.comparing;
 
 public class TpchSplitManager
         implements ConnectorSplitManager
@@ -55,9 +58,14 @@ public class TpchSplitManager
         int totalParts = nodes.size() * splitsPerNode;
         int partNumber = 0;
 
+        // sort to ensure the assignment is consistent with TpchNodePartitioningProvider
+        List<Node> sortedNodes = nodes.stream()
+                .sorted(comparing(node -> node.getHostAndPort().toString()))
+                .collect(toImmutableList());
+
         // Split the data using split and skew by the number of nodes available.
         ImmutableList.Builder<ConnectorSplit> splits = ImmutableList.builder();
-        for (Node node : nodes) {
+        for (Node node : sortedNodes) {
             for (int i = 0; i < splitsPerNode; i++) {
                 splits.add(new TpchSplit(partNumber, totalParts, ImmutableList.of(node.getHostAndPort())));
                 partNumber++;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

Fixes several problems related to scheduling of non remotely accessible splits

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core engine (Tardigrade)

> How would you describe this change to a non-technical end user or system administrator?

Fixes scheduling for non remotely accessible splits in certain corner cases. Prior this fix in some queries scanning over non remotely accessible splits might've been failing. 

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

() No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Tardigrade
* Fix scheduling for non remotely accessible splits 
```
