### PR TITLE
Fix JDBC case insensitive schema mapping documentation

### DIFF
--- a/docs/src/main/sphinx/connector/jdbc-case-insensitive-matching.fragment
+++ b/docs/src/main/sphinx/connector/jdbc-case-insensitive-matching.fragment
@@ -16,11 +16,11 @@ schemas/tables to their respective Trino schemas/tables:
   {
     "schemas": [
       {
-        "remote": "CaseSensitiveName",
+        "remoteSchema": "CaseSensitiveName",
         "mapping": "case_insensitive_1"
       },
       {
-        "remote": "cASEsENSITIVEnAME",
+        "remoteSchema": "cASEsENSITIVEnAME",
         "mapping": "case_insensitive_2"
       }],
     "tables": [


### PR DESCRIPTION
## Description

Fix JDBC case insensitive schema mapping documentation
https://github.com/trinodb/trino/blob/master/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/mapping/SchemaMappingRule.java

## Documentation

(x) Sufficient documentation is included in this PR.

## Release notes

(x) No release notes entries required.
