### PR TITLE
Choose smaller input on build side of partitioned join

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DetermineJoinDistributionType.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DetermineJoinDistributionType.java
@@ -15,6 +15,7 @@
 package io.trino.sql.planner.iterative.rule;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
 import io.airlift.units.DataSize;
 import io.trino.cost.CostComparator;
@@ -26,6 +27,7 @@ import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
 import io.trino.sql.planner.OptimizerConfig.JoinDistributionType;
 import io.trino.sql.planner.TypeProvider;
+import io.trino.sql.planner.iterative.GroupReference;
 import io.trino.sql.planner.iterative.Lookup;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.optimizations.PlanNodeSearcher;
@@ -37,6 +39,7 @@ import io.trino.sql.planner.plan.ValuesNode;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static io.trino.SystemSessionProperties.getJoinDistributionType;
 import static io.trino.SystemSessionProperties.getJoinMaxBroadcastTableSize;
@@ -50,12 +53,16 @@ import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
 import static io.trino.sql.planner.plan.JoinNode.Type.LEFT;
 import static io.trino.sql.planner.plan.JoinNode.Type.RIGHT;
 import static io.trino.sql.planner.plan.Patterns.join;
+import static java.lang.Double.NaN;
+import static java.lang.Double.isNaN;
 import static java.util.Objects.requireNonNull;
 
 public class DetermineJoinDistributionType
         implements Rule<JoinNode>
 {
     private static final Pattern<JoinNode> PATTERN = join().matching(joinNode -> joinNode.getDistributionType().isEmpty());
+    private static final List<Class<? extends PlanNode>> EXPANDING_NODE_CLASSES = ImmutableList.of(JoinNode.class, UnnestNode.class);
+    private static final double SIZE_DIFFERENCE_THRESHOLD = 8;
 
     private final CostComparator costComparator;
     private final TaskCountEstimator taskCountEstimator;
@@ -107,10 +114,10 @@ public class DetermineJoinDistributionType
     static double getSourceTablesSizeInBytes(PlanNode node, Lookup lookup, StatsProvider statsProvider, TypeProvider typeProvider)
     {
         boolean hasExpandingNodes = PlanNodeSearcher.searchFrom(node, lookup)
-                .whereIsInstanceOfAny(JoinNode.class, UnnestNode.class)
+                .whereIsInstanceOfAny(EXPANDING_NODE_CLASSES)
                 .matches();
         if (hasExpandingNodes) {
-            return Double.NaN;
+            return NaN;
         }
 
         List<PlanNode> sourceNodes = PlanNodeSearcher.searchFrom(node, lookup)
@@ -119,6 +126,58 @@ public class DetermineJoinDistributionType
 
         return sourceNodes.stream()
                 .mapToDouble(sourceNode -> statsProvider.getStats(sourceNode).getOutputSizeInBytes(sourceNode.getOutputSymbols(), typeProvider))
+                .sum();
+    }
+
+    private static double getFirstKnownOutputSizeInBytes(PlanNode node, Context context)
+    {
+        return getFirstKnownOutputSizeInBytes(node, context.getLookup(), context.getStatsProvider(), context.getSymbolAllocator().getTypes());
+    }
+
+    /**
+     * Recursively looks for the first source node with a known estimate and uses that to return an approximate output size.
+     * Returns NaN if an un-estimated expanding node (Join or Unnest) is encountered.
+     * The amount of reduction in size from un-estimated non-expanding nodes (e.g. an un-estimated filter or aggregation)
+     * is not accounted here. We make use of the first available estimate and make decision about flipping join sides only if
+     * we find a large difference in output size of both sides.
+     */
+    @VisibleForTesting
+    static double getFirstKnownOutputSizeInBytes(PlanNode node, Lookup lookup, StatsProvider statsProvider, TypeProvider typeProvider)
+    {
+        return Stream.of(node)
+                .flatMap(planNode -> {
+                    if (planNode instanceof GroupReference) {
+                        return lookup.resolveGroup(node);
+                    }
+                    return Stream.of(planNode);
+                })
+                .mapToDouble(resolvedNode -> {
+                    double outputSizeInBytes = statsProvider.getStats(resolvedNode).getOutputSizeInBytes(
+                            resolvedNode.getOutputSymbols(),
+                            typeProvider);
+                    if (!isNaN(outputSizeInBytes)) {
+                        return outputSizeInBytes;
+                    }
+
+                    if (EXPANDING_NODE_CLASSES.stream().anyMatch(clazz -> clazz.isInstance(resolvedNode))) {
+                        return NaN;
+                    }
+
+                    List<PlanNode> sourceNodes = resolvedNode.getSources();
+                    if (sourceNodes.isEmpty()) {
+                        return NaN;
+                    }
+
+                    double sourcesOutputSizeInBytes = 0;
+                    for (PlanNode sourceNode : sourceNodes) {
+                        double firstKnownOutputSizeInBytes = getFirstKnownOutputSizeInBytes(sourceNode, lookup, statsProvider, typeProvider);
+                        if (isNaN(firstKnownOutputSizeInBytes)) {
+                            return NaN;
+                        }
+                        sourcesOutputSizeInBytes += firstKnownOutputSizeInBytes;
+                    }
+                    return sourcesOutputSizeInBytes;
+                })
                 .sum();
     }
 
@@ -149,9 +208,10 @@ public class DetermineJoinDistributionType
         }
 
         boolean isLeftSideSmall = getSourceTablesSizeInBytes(joinNode.getLeft(), context) <= joinMaxBroadcastTableSize.toBytes();
-        if (isLeftSideSmall && !mustPartition(joinNode.flipChildren())) {
+        JoinNode flippedJoin = joinNode.flipChildren();
+        if (isLeftSideSmall && !mustPartition(flippedJoin)) {
             // choose join left side with small source tables as replicated build side
-            return joinNode.flipChildren().withDistributionType(REPLICATED);
+            return flippedJoin.withDistributionType(REPLICATED);
         }
 
         if (isRightSideSmall) {
@@ -161,7 +221,23 @@ public class DetermineJoinDistributionType
 
         if (isLeftSideSmall) {
             // left side is small enough, but must be partitioned
-            return joinNode.flipChildren().withDistributionType(PARTITIONED);
+            return flippedJoin.withDistributionType(PARTITIONED);
+        }
+
+        // Flip join sides if one side is smaller than the other by more than SIZE_DIFFERENCE_THRESHOLD times.
+        // We use 8x factor because getFirstKnownOutputSizeInBytes may not have accounted for the reduction in the size of
+        // the output from a filter or aggregation due to lack of estimates.
+        // We use getFirstKnownOutputSizeInBytes instead of getSourceTablesSizeInBytes to account for the reduction in
+        // output size from the operators between the join and the table scan as much as possible when comparing the sizes of the join sides.
+        double leftOutputSizeInBytes = getFirstKnownOutputSizeInBytes(joinNode.getLeft(), context);
+        double rightOutputSizeInBytes = getFirstKnownOutputSizeInBytes(joinNode.getRight(), context);
+        // All the REPLICATED cases were handled in the code above, so now we only consider PARTITIONED cases here
+        if (rightOutputSizeInBytes * SIZE_DIFFERENCE_THRESHOLD < leftOutputSizeInBytes && !mustReplicate(joinNode, context)) {
+            return joinNode.withDistributionType(PARTITIONED);
+        }
+
+        if (leftOutputSizeInBytes * SIZE_DIFFERENCE_THRESHOLD < rightOutputSizeInBytes && !mustReplicate(flippedJoin, context)) {
+            return flippedJoin.withDistributionType(PARTITIONED);
         }
 
         // neither side is small enough, choose syntactic join order

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PlanNodeSearcher.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PlanNodeSearcher.java
@@ -28,6 +28,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.sql.planner.iterative.Lookup.noLookup;
 import static io.trino.sql.planner.plan.ChildReplacer.replaceChildren;
+import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
 
 public class PlanNodeSearcher
@@ -60,6 +61,11 @@ public class PlanNodeSearcher
 
     @SafeVarargs
     public final PlanNodeSearcher whereIsInstanceOfAny(Class<? extends PlanNode>... classes)
+    {
+        return whereIsInstanceOfAny(asList(classes));
+    }
+
+    public final PlanNodeSearcher whereIsInstanceOfAny(List<Class<? extends PlanNode>> classes)
     {
         Predicate<PlanNode> predicate = alwaysFalse();
         for (Class<?> clazz : classes) {

--- a/testing/trino-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q23.plan.txt
+++ b/testing/trino-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q23.plan.txt
@@ -5,12 +5,6 @@ final aggregation over ()
                 join (INNER, PARTITIONED):
                     remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk"])
                         join (INNER, PARTITIONED):
-                            remote exchange (REPARTITION, HASH, ["cs_item_sk"])
-                                join (INNER, REPLICATED):
-                                    scan catalog_sales
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPLICATE, BROADCAST, [])
-                                            scan date_dim
                             final aggregation over (ss_item_sk)
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["ss_item_sk"])
@@ -28,6 +22,13 @@ final aggregation over ()
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                                         scan item
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["cs_item_sk"])
+                                    join (INNER, REPLICATED):
+                                        scan catalog_sales
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim
                     single aggregation over (ss_customer_sk_35)
                         cross join (can skip output duplicates):
                             final aggregation over (ss_customer_sk_35)
@@ -62,12 +63,6 @@ final aggregation over ()
                 join (INNER, PARTITIONED):
                     remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk"])
                         join (INNER, PARTITIONED):
-                            remote exchange (REPARTITION, HASH, ["ws_item_sk"])
-                                join (INNER, REPLICATED):
-                                    scan web_sales
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPLICATE, BROADCAST, [])
-                                            scan date_dim
                             final aggregation over (ss_item_sk_163)
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["ss_item_sk_163"])
@@ -85,6 +80,13 @@ final aggregation over ()
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                                         scan item
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["ws_item_sk"])
+                                    join (INNER, REPLICATED):
+                                        scan web_sales
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim
                     single aggregation over (ss_customer_sk_246)
                         cross join (can skip output duplicates):
                             final aggregation over (ss_customer_sk_246)

--- a/testing/trino-benchto-benchmarks/src/test/resources/sql/presto/tpch/q09.plan.txt
+++ b/testing/trino-benchto-benchmarks/src/test/resources/sql/presto/tpch/q09.plan.txt
@@ -12,11 +12,11 @@ remote exchange (GATHER, SINGLE, [])
                                             join (INNER, PARTITIONED):
                                                 remote exchange (REPARTITION, HASH, ["suppkey_5"])
                                                     join (INNER, PARTITIONED):
-                                                        remote exchange (REPARTITION, HASH, ["partkey"])
-                                                            scan part
+                                                        remote exchange (REPARTITION, HASH, ["partkey_4"])
+                                                            scan lineitem
                                                         local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPARTITION, HASH, ["partkey_4"])
-                                                                scan lineitem
+                                                            remote exchange (REPARTITION, HASH, ["partkey"])
+                                                                scan part
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPARTITION, HASH, ["suppkey"])
                                                         scan supplier

--- a/testing/trino-benchto-benchmarks/src/test/resources/sql/presto/tpch/q13.plan.txt
+++ b/testing/trino-benchto-benchmarks/src/test/resources/sql/presto/tpch/q13.plan.txt
@@ -8,9 +8,9 @@ remote exchange (GATHER, SINGLE, [])
                             final aggregation over (custkey)
                                 local exchange (GATHER, SINGLE, [])
                                     partial aggregation over (custkey)
-                                        join (LEFT, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["custkey"])
-                                                scan customer
+                                        join (RIGHT, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, ["custkey_1"])
+                                                scan orders
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["custkey_1"])
-                                                    scan orders
+                                                remote exchange (REPARTITION, HASH, ["custkey"])
+                                                    scan customer


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

When there is a large difference in size of input between the join sides,
choose the smaller input on the build side. This can result in better
join ordering when there is a repartitioned join on top of input sources
with unestimated terms.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

CBO
> How would you describe this change to a non-technical end user or system administrator?

Improves join ordering in the presence of unestimated terms.
## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Section
* Choose smaller input on build side of repartitioned join in the presence on unestimated terms. ({issue}`11584`)
```
