### PR TITLE
Push down information on collection reason

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -441,7 +441,7 @@ public interface Metadata
 
     Optional<LimitApplicationResult<TableHandle>> applyLimit(Session session, TableHandle table, long limit);
 
-    Optional<ConstraintApplicationResult<TableHandle>> applyFilter(Session session, TableHandle table, Constraint constraint);
+    Optional<ConstraintApplicationResult<TableHandle>> applyFilter(Session session, TableHandle table, Constraint constraint, Set<ColumnHandle> remainingPredicateColumns);
 
     Optional<ProjectionApplicationResult<TableHandle>> applyProjection(Session session, TableHandle table, List<ConnectorExpression> projections, Map<String, ColumnHandle> assignments);
 

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -447,6 +447,11 @@ public interface Metadata
 
     Optional<SampleApplicationResult<TableHandle>> applySample(Session session, TableHandle table, SampleType sampleType, double sampleRatio);
 
+    /**
+     * If the query has a filter, push the final (after prune) projected columns into connector
+     */
+    Optional<TableHandle> applyProjectedColumns(Session session, TableHandle table, Set<ColumnHandle> columns);
+
     Optional<AggregationApplicationResult<TableHandle>> applyAggregation(
             Session session,
             TableHandle table,

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -1672,13 +1672,13 @@ public final class MetadataManager
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<TableHandle>> applyFilter(Session session, TableHandle table, Constraint constraint)
+    public Optional<ConstraintApplicationResult<TableHandle>> applyFilter(Session session, TableHandle table, Constraint constraint, Set<ColumnHandle> remainingPredicateColumns)
     {
         CatalogName catalogName = table.getCatalogName();
         ConnectorMetadata metadata = getMetadata(session, catalogName);
 
         ConnectorSession connectorSession = session.toConnectorSession(catalogName);
-        return metadata.applyFilter(connectorSession, table.getConnectorHandle(), constraint)
+        return metadata.applyFilter(connectorSession, table.getConnectorHandle(), constraint, remainingPredicateColumns)
                 .map(result -> result.transform(handle -> new TableHandle(catalogName, handle, table.getTransaction())));
     }
 

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -1701,6 +1701,17 @@ public final class MetadataManager
                 });
     }
 
+    @Override
+    public Optional<TableHandle> applyProjectedColumns(Session session, TableHandle table, Set<ColumnHandle> columns)
+    {
+        CatalogName catalogName = table.getCatalogName();
+        ConnectorMetadata metadata = getMetadata(session, catalogName);
+
+        ConnectorSession connectorSession = session.toConnectorSession(catalogName);
+        return metadata.applyProjectedColumns(connectorSession, table.getConnectorHandle(), columns)
+                .map(result -> new TableHandle(catalogName, result, table.getTransaction()));
+    }
+
     //
     // Roles and Grants
     //

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -167,6 +167,7 @@ import io.trino.sql.planner.iterative.rule.PushPartialAggregationThroughJoin;
 import io.trino.sql.planner.iterative.rule.PushPredicateIntoTableScan;
 import io.trino.sql.planner.iterative.rule.PushPredicateThroughProjectIntoRowNumber;
 import io.trino.sql.planner.iterative.rule.PushPredicateThroughProjectIntoWindow;
+import io.trino.sql.planner.iterative.rule.PushProjectedColumns;
 import io.trino.sql.planner.iterative.rule.PushProjectionIntoTableScan;
 import io.trino.sql.planner.iterative.rule.PushProjectionThroughExchange;
 import io.trino.sql.planner.iterative.rule.PushProjectionThroughUnion;
@@ -892,6 +893,14 @@ public class PlanOptimizers
                         .add(new PushRemoteExchangeThroughAssignUniqueId())
                         .add(new InlineProjections(plannerContext, typeAnalyzer))
                         .build()));
+
+        // Should be run after all the executions of PruneProjectColumns and PushPredicateIntoTableScan
+        builder.add(new IterativeOptimizer(
+                plannerContext,
+                ruleStats,
+                statsCalculator,
+                costCalculator,
+                ImmutableSet.of(new PushProjectedColumns(metadata))));
 
         // Optimizers above this don't understand local exchanges, so be careful moving this.
         builder.add(new AddLocalExchanges(plannerContext, typeAnalyzer));

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushProjectedColumns.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushProjectedColumns.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import io.trino.Session;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.metadata.Metadata;
+import io.trino.metadata.TableHandle;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.sql.planner.SymbolsExtractor;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.plan.FilterNode;
+import io.trino.sql.planner.plan.ProjectNode;
+import io.trino.sql.planner.plan.TableScanNode;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static io.trino.SystemSessionProperties.isAllowPushdownIntoConnectors;
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.sql.planner.plan.Patterns.filter;
+import static io.trino.sql.planner.plan.Patterns.project;
+import static io.trino.sql.planner.plan.Patterns.source;
+import static io.trino.sql.planner.plan.Patterns.tableScan;
+import static java.util.Objects.requireNonNull;
+
+/**
+ *  If the query has a filter, push the final (after prune) projected columns into connector
+ */
+public class PushProjectedColumns
+        implements Rule<ProjectNode>
+{
+    private static final Capture<TableScanNode> TABLE_SCAN = newCapture();
+    private static final Capture<FilterNode> FILTER = newCapture();
+    private static final Pattern<ProjectNode> PATTERN = project()
+            .with(source().matching(filter().capturedAs(FILTER)
+                    .with(source().matching(tableScan().capturedAs(TABLE_SCAN)))));
+
+    private final Metadata metadata;
+
+    public PushProjectedColumns(Metadata metadata)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
+    @Override
+    public Pattern<ProjectNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isAllowPushdownIntoConnectors(session);
+    }
+
+    @Override
+    public Result apply(ProjectNode projectNode, Captures captures, Context context)
+    {
+        TableScanNode tableScan = captures.get(TABLE_SCAN);
+        FilterNode filter = captures.get(FILTER);
+
+        Set<ColumnHandle> columns = projectNode.getAssignments().getExpressions().stream()
+                .flatMap(expression -> SymbolsExtractor.extractAll(expression).stream())
+                .map(symbol -> tableScan.getAssignments().get(symbol))
+                .collect(Collectors.toSet());
+
+        Optional<TableHandle> result = metadata.applyProjectedColumns(context.getSession(), tableScan.getTable(), columns);
+
+        if (result.isEmpty()) {
+            return Result.empty();
+        }
+
+        TableScanNode newTableScan = new TableScanNode(
+                tableScan.getId(),
+                result.get(),
+                tableScan.getOutputSymbols(),
+                tableScan.getAssignments(),
+                tableScan.getEnforcedConstraint(),
+                tableScan.getStatistics(),
+                tableScan.isUpdateTarget(),
+                tableScan.getUseConnectorNodePartitioning());
+        FilterNode newFilterNode = new FilterNode(filter.getId(), newTableScan, filter.getPredicate());
+        ProjectNode newProjectNode = new ProjectNode(projectNode.getId(), newFilterNode, projectNode.getAssignments());
+        return Result.ofPlanNode(newProjectNode);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -540,7 +540,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<TableHandle>> applyFilter(Session session, TableHandle table, Constraint constraint)
+    public Optional<ConstraintApplicationResult<TableHandle>> applyFilter(Session session, TableHandle table, Constraint constraint, Set<ColumnHandle> remainingPredicateColumns)
     {
         return Optional.empty();
     }

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -777,6 +777,12 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
+    public Optional<TableHandle> applyProjectedColumns(Session session, TableHandle table, Set<ColumnHandle> columns)
+    {
+        return Optional.empty();
+    }
+
+    @Override
     public Optional<TopNApplicationResult<TableHandle>> applyTopN(Session session, TableHandle handle, long topNFunctions, List<SortItem> sortItems, Map<String, ColumnHandle> assignments)
     {
         return Optional.empty();

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -992,6 +992,12 @@ public interface ConnectorMetadata
         return Optional.empty();
     }
 
+    default Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(
+            ConnectorSession session, ConnectorTableHandle tableHandle, Constraint constraint, Set<ColumnHandle> remainingPredicateColumns)
+    {
+        return applyFilter(session, tableHandle, constraint);
+    }
+
     /**
      * Attempt to push down the provided projections into the table.
      * <p>

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -1064,6 +1064,11 @@ public interface ConnectorMetadata
         return Optional.empty();
     }
 
+    default Optional<ConnectorTableHandle> applyProjectedColumns(ConnectorSession session, ConnectorTableHandle handle, Set<ColumnHandle> columns)
+    {
+        return Optional.empty();
+    }
+
     /**
      * Attempt to push down the sampling into the table.
      * <p>

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -854,6 +854,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint constraint, Set<ColumnHandle> remainingPredicateColumns)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.applyFilter(session, table, constraint, remainingPredicateColumns);
+        }
+    }
+
+    @Override
     public Optional<ProjectionApplicationResult<ConnectorTableHandle>> applyProjection(ConnectorSession session, ConnectorTableHandle table, List<ConnectorExpression> projections, Map<String, ColumnHandle> assignments)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -878,6 +878,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public Optional<ConnectorTableHandle> applyProjectedColumns(ConnectorSession session, ConnectorTableHandle table, Set<ColumnHandle> columns)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.applyProjectedColumns(session, table, columns);
+        }
+    }
+
+    @Override
     public Optional<AggregationApplicationResult<ConnectorTableHandle>> applyAggregation(
             ConnectorSession session,
             ConnectorTableHandle table,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -155,6 +155,7 @@ import static java.lang.String.format;
 import static java.lang.String.join;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.createTempDirectory;
+import static java.util.Collections.emptySet;
 import static java.util.Collections.nCopies;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
@@ -3407,7 +3408,7 @@ public abstract class BaseHiveConnectorTest
                     QualifiedObjectName name = new QualifiedObjectName(catalog, TPCH_SCHEMA, tableName);
                     TableHandle table = metadata.getTableHandle(transactionSession, name)
                             .orElseThrow(() -> new AssertionError("table not found: " + name));
-                    table = metadata.applyFilter(transactionSession, table, Constraint.alwaysTrue())
+                    table = metadata.applyFilter(transactionSession, table, Constraint.alwaysTrue(), emptySet())
                             .orElseThrow(() -> new AssertionError("applyFilter did not return a result"))
                             .getHandle();
                     return propertyGetter.apply((HiveTableHandle) table.getConnectorHandle());

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -106,6 +106,7 @@ import static io.trino.tpch.TpchTable.LINE_ITEM;
 import static io.trino.transaction.TransactionBuilder.transaction;
 import static java.lang.String.format;
 import static java.lang.String.join;
+import static java.util.Collections.emptySet;
 import static java.util.Collections.nCopies;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
@@ -2187,7 +2188,7 @@ public abstract class BaseIcebergConnectorTest
                     filter.entrySet().stream()
                             .collect(toImmutableMap(entry -> columns.get(entry.getKey()), Map.Entry::getValue)));
 
-            Optional<ConstraintApplicationResult<TableHandle>> result = metadata.applyFilter(session, table, new Constraint(domains));
+            Optional<ConstraintApplicationResult<TableHandle>> result = metadata.applyFilter(session, table, new Constraint(domains), emptySet());
 
             assertTrue(result.isEmpty() == (expectedUnenforcedPredicate == null && expectedEnforcedPredicate == null));
 


### PR DESCRIPTION
We’re using these 2 commits internally and think they might be helpful for the community as well.
In our use case, for some splits, certain predicate domains can be fully handled and for other splits, they can’t be.
Because of the nature of `applyFilter()`, we declare the entire predicate as `remainingFilter` \ `remainingExpression`.
When encountering a split in which a column’s predicate can be fully handled, we want to know if Trino required to collect this column only for the sake of filtering the connector’s data. In other words, we want to know if this column is being collected only because we returned the entire predicate as remaining at `ConstraintApplicationResult`. If we find out that this is the case, we return a `RunLengthEncodedBlock` with a random value that complies with the filter. This way we spare a lot of work fetching and transferring data.
We believe that this can be helpful for other connectors as well, for example- in the case of `parquet` \ `orc` file, the Reader can tell if the entire RowGroup/Stripe complies with the predicate by looking at the minimum and maximum statistics. So instead of utilizing the statistics just to return an empty result when the predicate doesn't match, the Reader would be able to return a pre-filled result (same as for partitioned columns) when the predicate contains the entire RowGroup/Stripe.