### PR TITLE
Support comments when building column definition in ClickHouse

### DIFF
--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
@@ -377,6 +377,9 @@ public class ClickHouseClient
             // By default, the clickhouse column is not allowed to be null
             sb.append(toWriteMapping(session, column.getType()).getDataType());
         }
+        if (column.getComment() != null) {
+            sb.append(format(" COMMENT '%s'", column.getComment()));
+        }
         return sb.toString();
     }
 
@@ -401,9 +404,6 @@ public class ClickHouseClient
     @Override
     public void addColumn(ConnectorSession session, JdbcTableHandle handle, ColumnMetadata column)
     {
-        if (column.getComment() != null) {
-            throw new TrinoException(NOT_SUPPORTED, "This connector does not support adding columns with comments");
-        }
         try (Connection connection = connectionFactory.openConnection(session)) {
             String remoteColumnName = getIdentifierMapping().toRemoteColumnName(connection, column.getName());
             String sql = format(

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
@@ -48,6 +48,7 @@ import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 public class TestClickHouseConnectorTest
@@ -178,7 +179,16 @@ public class TestClickHouseConnectorTest
     @Override
     public void testAddColumnWithComment()
     {
-        throw new SkipException("Clickhouse connector does not support specifying a comment when adding a column");
+        // Override because the default storage type doesn't support adding columns
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_add_col_desc_", "(a_varchar varchar NOT NULL) WITH (engine = 'MergeTree', order_by = ARRAY['a_varchar'])")) {
+            String tableName = table.getName();
+
+            assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN b_varchar varchar COMMENT 'test new column comment'");
+            assertThat(getColumnComment(tableName, "b_varchar")).isEqualTo("test new column comment");
+
+            assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN empty_comment varchar COMMENT ''");
+            assertNull(getColumnComment(tableName, "empty_comment"));
+        }
     }
 
     @Test
@@ -231,6 +241,15 @@ public class TestClickHouseConnectorTest
                         "col_default Nullable(Int64) DEFAULT 43," +
                         "col_nonnull_default Int64 DEFAULT 42," +
                         "col_required2 Int64) ENGINE=Log");
+    }
+
+    @Test
+    public void testCreateTableWithColumnComment()
+    {
+        // TODO (https://github.com/trinodb/trino/issues/11162) Merge into BaseConnectorTest
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_column_comment", "(col integer COMMENT 'column comment')")) {
+            assertEquals(getColumnComment(table.getName(), "col"), "column comment");
+        }
     }
 
     @Override


### PR DESCRIPTION
## Description

Support comments when building column definition in ClickHouse

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# ClickHouse
* Add support for column comments when creating new tables. ({issue}`11606`)
* Add support for column comments when adding new columns. ({issue}`11606`)
```
