### PR TITLE
Remove redundant checks from DropSchemaTask

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/DropSchemaTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropSchemaTask.java
@@ -92,19 +92,7 @@ public class DropSchemaTask
     {
         QualifiedTablePrefix tablePrefix = new QualifiedTablePrefix(schema.getCatalogName(), schema.getSchemaName());
 
-        // These are best efforts checks that don't provide any guarantees against concurrent DDL operations
-        if (!metadata.listTables(session, tablePrefix).isEmpty()) {
-            return false;
-        }
-
-        if (!metadata.listViews(session, tablePrefix).isEmpty()) {
-            return false;
-        }
-
-        if (!metadata.listMaterializedViews(session, tablePrefix).isEmpty()) {
-            return false;
-        }
-
-        return true;
+        // This is a best effort check that doesn't provide any guarantees against concurrent DDL operations
+        return metadata.listTables(session, tablePrefix).isEmpty();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -142,7 +142,8 @@ public interface Metadata
     TableStatistics getTableStatistics(Session session, TableHandle tableHandle, Constraint constraint);
 
     /**
-     * Get the names that match the specified table prefix (never null).
+     * Get the relation names that match the specified table prefix (never null).
+     * This includes all relations (e.g. tables, views, materialized views).
      */
     List<QualifiedObjectName> listTables(Session session, QualifiedTablePrefix prefix);
 


### PR DESCRIPTION
`listTables` includes views and materialized views, so calling
`listViews` and `listMaterializedViews` is redundant.
