### PR TITLE
Return correct nullable value in information_schema.columns

### DIFF
--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
@@ -658,6 +658,7 @@ public class TestTrinoDatabaseMetaData
                 assertEquals(rs.getString("TABLE_SCHEM"), "information_schema");
                 assertEquals(rs.getString("TABLE_NAME"), "tables");
                 assertEquals(rs.getString("COLUMN_NAME"), "table_name");
+                assertEquals(rs.getString("IS_NULLABLE"), "YES");
                 assertEquals(rs.getInt("DATA_TYPE"), Types.VARCHAR);
                 assertTrue(rs.next());
                 assertEquals(rs.getString("TABLE_CAT"), "hive");
@@ -721,6 +722,14 @@ public class TestTrinoDatabaseMetaData
                 assertTrue(rs.next());
                 assertEquals(rs.getString("COLUMN_NAME"), "table_name");
                 assertFalse(rs.next());
+            }
+        }
+
+        try (Connection connection = createConnection()) {
+            try (ResultSet rs = connection.getMetaData().getColumns(TEST_CATALOG, "tiny", "supplier", "suppkey")) {
+                assertColumnMetadata(rs);
+                assertTrue(rs.next());
+                assertEquals(rs.getString("IS_NULLABLE"), "NO");
             }
         }
 

--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
@@ -263,7 +263,7 @@ public class InformationSchemaPageSource
                         column.getName(),
                         ordinalPosition,
                         null,
-                        "YES",
+                        column.isNullable() ? "YES" : "NO",
                         getDisplayLabel(column.getType(), isOmitDateTimeTypePrecision(session)),
                         column.getComment(),
                         column.getExtraInfo(),

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/ColumnJdbcTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/ColumnJdbcTable.java
@@ -326,7 +326,7 @@ public class ColumnJdbcTable
                     null,
                     charOctetLength(column.getType()),
                     ordinalPosition,
-                    "",
+                    column.isNullable() ? "YES" : "NO",
                     null,
                     null,
                     null,

--- a/testing/trino-product-tests/src/main/resources/io/trino/tests/product/jdbc/get_nation_columns.result
+++ b/testing/trino-product-tests/src/main/resources/io/trino/tests/product/jdbc/get_nation_columns.result
@@ -1,5 +1,5 @@
 -- delimiter: |; ignoreOrder: false; ignoreExcessRows: false;
-hive|default|nation|n_nationkey|-5|bigint|19|0|null|10|2|null|null|null|null|null|1||null|null|null|null|null|null|
-hive|default|nation|n_name|12|varchar(25)|25|0|null|null|2|null|null|null|null|25|2||null|null|null|null|null|null|
-hive|default|nation|n_regionkey|-5|bigint|19|0|null|10|2|null|null|null|null|null|3||null|null|null|null|null|null|
-hive|default|nation|n_comment|12|varchar(152)|152|0|null|null|2|null|null|null|null|152|4||null|null|null|null|null|null|
+hive|default|nation|n_nationkey|-5|bigint|19|0|null|10|2|null|null|null|null|null|1|YES|null|null|null|null|null|null|
+hive|default|nation|n_name|12|varchar(25)|25|0|null|null|2|null|null|null|null|25|2|YES|null|null|null|null|null|null|
+hive|default|nation|n_regionkey|-5|bigint|19|0|null|10|2|null|null|null|null|null|3|YES|null|null|null|null|null|null|
+hive|default|nation|n_comment|12|varchar(152)|152|0|null|null|2|null|null|null|null|152|4|YES|null|null|null|null|null|null|

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestInformationSchemaConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestInformationSchemaConnector.java
@@ -39,7 +39,8 @@ public class TestInformationSchemaConnector
         assertQuery("SELECT count(*) FROM tpch.information_schema.columns", "VALUES 589");
         assertQuery("SELECT * FROM tpch.information_schema.schemata ORDER BY 1 DESC, 2 DESC LIMIT 1", "VALUES ('tpch', 'tiny')");
         assertQuery("SELECT * FROM tpch.information_schema.tables ORDER BY 1 DESC, 2 DESC, 3 DESC, 4 DESC LIMIT 1", "VALUES ('tpch', 'tiny', 'supplier', 'BASE TABLE')");
-        assertQuery("SELECT * FROM tpch.information_schema.columns ORDER BY 1 DESC, 2 DESC, 3 DESC, 4 DESC LIMIT 1", "VALUES ('tpch', 'tiny', 'supplier', 'suppkey', 1, NULL, 'YES', 'bigint')");
+        assertQuery("SELECT * FROM tpch.information_schema.columns ORDER BY 1 DESC, 2 DESC, 3 DESC, 4 DESC LIMIT 1", "VALUES ('tpch', 'tiny', 'supplier', 'suppkey', 1, NULL, 'NO', 'bigint')");
+        assertQuery("SELECT * FROM test_catalog.information_schema.columns ORDER BY 1 DESC, 2 DESC, 3 DESC, 4 DESC LIMIT 1", "VALUES ('test_catalog', 'test_schema2', 'test_table999', 'column_99', 100, NULL, 'YES', 'varchar')");
         assertQuery("SELECT count(*) FROM test_catalog.information_schema.columns", "VALUES 300040");
     }
 


### PR DESCRIPTION
## Description

Return correct nullable value in information_schema.columns
Fixes #6400

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# General
* Fix incorrect `is_nullable` value in `information_schema.columns` and `system.jdbc.columns` tables. ({issue}`11613`)
```
