### PR TITLE
TrinoHiveCatalog listTables should list all tables

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataListing.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataListing.java
@@ -136,6 +136,7 @@ public class TestIcebergMetadataListing
                         "'iceberg_materialized_view', " +
                         "'" + storageTable.getTableName() + "', " +
                         "'iceberg_view', " +
+                        "'hive_table', " +
                         "'hive_view'");
     }
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergHiveMetadataListing.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergHiveMetadataListing.java
@@ -86,6 +86,7 @@ public class TestIcebergHiveMetadataListing
                             .add(row("iceberg_materialized_view"))
                             .add(row(storageTable))
                             .add(row("iceberg_view"))
+                            .add(row("hive_table"))
                             // Iceberg connector supports Trino views created via Hive connector
                             .add(row("hive_view"))
                             .build());

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergHiveTablesCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergHiveTablesCompatibility.java
@@ -112,4 +112,22 @@ public class TestIcebergHiveTablesCompatibility
         onTrino().executeQuery("DROP TABLE hive.default." + hiveTableName);
         onTrino().executeQuery("DROP TABLE iceberg.default." + icebergTableName);
     }
+
+    @Test(groups = {ICEBERG, STORAGE_FORMATS, HMS_ONLY})
+    public void testHiveListsIcebergTable()
+    {
+        String tableName = "test_hive_lists_iceberg_table_" + randomTableSuffix();
+        onTrino().executeQuery("CREATE TABLE iceberg.default." + tableName + "(a bigint)");
+        assertThat(onTrino().executeQuery("SHOW TABLES FROM hive.default")).contains(row(tableName));
+        onTrino().executeQuery("DROP TABLE iceberg.default." + tableName);
+    }
+
+    @Test(groups = {ICEBERG, STORAGE_FORMATS, HMS_ONLY})
+    public void testIcebergListsHiveTable()
+    {
+        String tableName = "test_iceberg_lists_hive_table_" + randomTableSuffix();
+        onTrino().executeQuery("CREATE TABLE hive.default." + tableName + "(a bigint)");
+        assertThat(onTrino().executeQuery("SHOW TABLES FROM iceberg.default")).contains(row(tableName));
+        onTrino().executeQuery("DROP TABLE hive.default." + tableName);
+    }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergHiveViewsCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergHiveViewsCompatibility.java
@@ -72,30 +72,28 @@ public class TestIcebergHiveViewsCompatibility
             // select some random catalog so we are not biased towards iceberg.default during assertions
             onTrino().executeQuery("USE tpch.tiny");
 
-            // both hive and iceberg catalogs should list all the views.
+            // both hive and iceberg catalogs should list all the tables and views.
+            ImmutableList<QueryAssert.Row> newlyCreated = ImmutableList.<QueryAssert.Row>builder()
+                    .add(row("hive_table"))
+                    .add(row("iceberg_table"))
+                    .add(row("hive_view_qualified_hive"))
+                    .add(row("hive_view_unqualified_hive"))
+                    .add(row("hive_view_qualified_iceberg"))
+                    .add(row("iceberg_view_qualified_hive"))
+                    .add(row("iceberg_view_qualified_iceberg"))
+                    .add(row("iceberg_view_unqualified_iceberg"))
+                    .build();
+
             assertThat(onTrino().executeQuery("SHOW TABLES FROM hive.default"))
                     .containsOnly(ImmutableList.<QueryAssert.Row>builder()
                             .addAll(hivePreexistingTables)
-                            .add(row("hive_table"))
-                            .add(row("iceberg_table")) // TODO: should this be filtered out?
-                            .add(row("hive_view_qualified_hive"))
-                            .add(row("hive_view_unqualified_hive"))
-                            .add(row("hive_view_qualified_iceberg"))
-                            .add(row("iceberg_view_qualified_hive"))
-                            .add(row("iceberg_view_qualified_iceberg"))
-                            .add(row("iceberg_view_unqualified_iceberg"))
+                            .addAll(newlyCreated)
                             .build());
 
             assertThat(onTrino().executeQuery("SHOW TABLES FROM iceberg.default"))
                     .containsOnly(ImmutableList.<QueryAssert.Row>builder()
                             .addAll(icebergPreexistingTables)
-                            .add(row("iceberg_table"))
-                            .add(row("hive_view_qualified_hive"))
-                            .add(row("hive_view_unqualified_hive"))
-                            .add(row("hive_view_qualified_iceberg"))
-                            .add(row("iceberg_view_qualified_hive"))
-                            .add(row("iceberg_view_qualified_iceberg"))
-                            .add(row("iceberg_view_unqualified_iceberg"))
+                            .addAll(newlyCreated)
                             .build());
 
             // try to access all views via hive catalog

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergRedirectionToHive.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergRedirectionToHive.java
@@ -357,16 +357,14 @@ public class TestIcebergRedirectionToHive
         createHiveTable(hiveTableName, false);
 
         assertTableComment("hive", "default", tableName).isNull();
-        // TODO: support redirects from Iceberg to Hive
-        assertThat(readTableComment("iceberg", "default", tableName)).hasNoRows();
+        assertTableComment("iceberg", "default", tableName).isNull();
 
         // TODO: support redirects from Iceberg to Hive
         assertQueryFailure(() -> onTrino().executeQuery("COMMENT ON TABLE " + icebergTableName + " IS 'This is my table, there are many like it but this one is mine'"))
                 .hasMessageMatching("\\QQuery failed (#\\E\\S+\\Q): Not an Iceberg table: default." + tableName);
 
         assertTableComment("hive", "default", tableName).isNull();
-        // TODO: support redirects from Iceberg to Hive
-        assertThat(readTableComment("iceberg", "default", tableName)).hasNoRows();
+        assertTableComment("iceberg", "default", tableName).isNull();
 
         onTrino().executeQuery("DROP TABLE " + hiveTableName);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Excluding non-Iceberg tables makes a schema seem empty
when it is not.

Revert of https://github.com/trinodb/trino/pull/1354

One situation that is confusing right now is dropping a schema that has only hive tables in it. `DROP SCHEMA iceberg.my_schema` will fail because the schema is not empty (in that case the exception comes from the HMS, not Trino because Trino thinks the schema is empty).  A `SHOW TABLES FROM iceberg.my_schema` would come back empty.

it'll also be relevant for table redirections https://github.com/trinodb/trino/pull/11356. In order to redirect a table, the iceberg catalog needs to know it exists.

This also brings the iceberg connector in line with the Hive connector. Listing shows all available tables in the HMS.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Iceberg Connector with HMS

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Section
* List all tables when using the Iceberg HMS catalog
```
