### PR TITLE
Fix close idempotency for JDBC PreparedStatement

### DIFF
--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
@@ -772,6 +772,11 @@ public class TrinoConnection
         }
     }
 
+    void removePreparedStatement(String name)
+    {
+        preparedStatements.remove(name);
+    }
+
     private void registerStatement(TrinoStatement statement)
     {
         checkState(statements.add(statement), "Statement is already registered");

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoPreparedStatement.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoPreparedStatement.java
@@ -123,7 +123,7 @@ public class TrinoPreparedStatement
     public void close()
             throws SQLException
     {
-        super.execute(format("DEALLOCATE PREPARE %s", statementName));
+        optionalConnection().ifPresent(x -> x.removePreparedStatement(statementName));
         super.close();
     }
 

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoStatement.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoStatement.java
@@ -637,6 +637,11 @@ public class TrinoStatement
         return connection;
     }
 
+    protected final Optional<TrinoConnection> optionalConnection()
+    {
+        return Optional.ofNullable(connection.get());
+    }
+
     private void closeResultSet()
             throws SQLException
     {

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcPreparedStatement.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcPreparedStatement.java
@@ -398,6 +398,17 @@ public class TestJdbcPreparedStatement
     }
 
     @Test
+    public void testCloseIdempotency()
+            throws Exception
+    {
+        try (Connection connection = createConnection()) {
+            PreparedStatement statement = connection.prepareStatement("SELECT 123");
+            statement.close();
+            statement.close();
+        }
+    }
+
+    @Test
     public void testLargePreparedStatement()
             throws Exception
     {


### PR DESCRIPTION
## Description

Fix the behavior of `PreparedStatement.close()` so that it may be called multiple times without throwing an exception on subsequent invocations, which is required per the JDBC specification:

> Calling the method close on a Statement object that is already closed has no effect.

## Documentation

(x) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# JDBC driver

* Allow `PreparedStatement.close()` to be called multiple times. ({issue}`11620`)
```
