### PR TITLE
Fix incorrect check for unnest node in DetermineJoinDistributionType

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DetermineJoinDistributionType.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DetermineJoinDistributionType.java
@@ -32,8 +32,8 @@ import io.trino.sql.planner.optimizations.PlanNodeSearcher;
 import io.trino.sql.planner.plan.JoinNode;
 import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.TableScanNode;
+import io.trino.sql.planner.plan.UnnestNode;
 import io.trino.sql.planner.plan.ValuesNode;
-import io.trino.sql.tree.Unnest;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -108,7 +108,7 @@ public class DetermineJoinDistributionType
     static double getSourceTablesSizeInBytes(PlanNode node, Lookup lookup, StatsProvider statsProvider, TypeProvider typeProvider)
     {
         boolean hasExpandingNodes = PlanNodeSearcher.searchFrom(node, lookup)
-                .where(isInstanceOfAny(JoinNode.class, Unnest.class))
+                .where(isInstanceOfAny(JoinNode.class, UnnestNode.class))
                 .matches();
         if (hasExpandingNodes) {
             return Double.NaN;

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestDetermineJoinDistributionType.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestDetermineJoinDistributionType.java
@@ -32,6 +32,7 @@ import io.trino.sql.planner.plan.JoinNode.DistributionType;
 import io.trino.sql.planner.plan.JoinNode.Type;
 import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.sql.planner.plan.TableScanNode;
+import io.trino.sql.planner.plan.UnnestNode;
 import io.trino.sql.planner.plan.ValuesNode;
 import io.trino.testing.TestingMetadata.TestingColumnHandle;
 import org.testng.annotations.AfterClass;
@@ -828,6 +829,18 @@ public class TestDetermineJoinDistributionType
                                 INNER,
                                 planBuilder.values(sourceSymbol1),
                                 planBuilder.values(sourceSymbol2)),
+                        noLookup(),
+                        node -> sourceStatsEstimate1,
+                        planBuilder.getTypes()),
+                NaN);
+
+        // unnest node
+        assertEquals(
+                getSourceTablesSizeInBytes(
+                        planBuilder.unnest(
+                                ImmutableList.of(),
+                                ImmutableList.of(new UnnestNode.Mapping(sourceSymbol1, ImmutableList.of(sourceSymbol1))),
+                                planBuilder.values(sourceSymbol1)),
                         noLookup(),
                         node -> sourceStatsEstimate1,
                         planBuilder.getTypes()),


### PR DESCRIPTION
## Description

Current code was failing to detect unnest node in source table size
calculation. This can result in the join side with an unnest on top
of a small table to get used on the build side or broadcast even though
unnest could expand the build size.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

fix
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

CBO
> How would you describe this change to a non-technical end user or system administrator?

Prevents the CBO from picking a potentially worse join order when one of the sides has an unnest operation.
## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix join ordering in case of a join with unnest on one side. ({issue}`11629`)
```
