### PR TITLE
Improve formatting of unnest in plan printer

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
@@ -1141,11 +1141,18 @@ public class PlanPrinter
                     .map(UnnestNode.Mapping::getInput)
                     .collect(toImmutableList());
 
+            Optional<String> replicate = node.getReplicateSymbols().isEmpty()
+                    ? Optional.empty()
+                    : Optional.of("replicate=" + formatOutputs(types, node.getReplicateSymbols()));
+            Optional<String> unnest = Optional.of("unnest=" + formatOutputs(types, unnestInputs));
+            Optional<String> filter = node.getFilter().map(filterExpression -> "filter=" + filterExpression);
             addNode(
                     node,
                     name,
-                    format("[replicate=%s, unnest=%s", formatOutputs(types, node.getReplicateSymbols()), formatOutputs(types, unnestInputs))
-                            + (node.getFilter().isPresent() ? format(", filter=%s]", node.getFilter().get()) : "]"));
+                    Stream.of(replicate, unnest, filter)
+                            .filter(Optional::isPresent)
+                            .map(Optional::get)
+                            .collect(joining(", ", "[", "]")));
             return processChildren(node, context);
         }
 


### PR DESCRIPTION
## Description

When no symbols are replicated from unnest, the printed plan
currently shows
"Unnest[replicate=, unnest=names:array(varchar(25))]"
This change improves it to
"Unnest[unnest=names:array(varchar(25))]"

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

improvement
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

query planner
> How would you describe this change to a non-technical end user or system administrator?

Improve formatting of unnest in plan printer
## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text: