### PR TITLE
Register event listeners for default system access control

### DIFF
--- a/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
@@ -139,7 +139,7 @@ public class AccessControlManager
         List<File> configFiles = this.configFiles;
         if (configFiles.isEmpty()) {
             if (!CONFIG_FILE.exists()) {
-                setSystemAccessControl(defaultAccessControlName, ImmutableMap.of());
+                loadSystemAccessControl(defaultAccessControlName, ImmutableMap.of());
                 log.info("Using system access control: %s", defaultAccessControlName);
                 return;
             }
@@ -187,7 +187,7 @@ public class AccessControlManager
     }
 
     @VisibleForTesting
-    protected void setSystemAccessControl(String name, Map<String, String> properties)
+    public void loadSystemAccessControl(String name, Map<String, String> properties)
     {
         requireNonNull(name, "name is null");
         requireNonNull(properties, "properties is null");

--- a/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
@@ -200,6 +200,9 @@ public class AccessControlManager
             systemAccessControl = factory.create(ImmutableMap.copyOf(properties));
         }
 
+        systemAccessControl.getEventListeners()
+                .forEach(eventListenerManager::addEventListener);
+
         setSystemAccessControls(ImmutableList.of(systemAccessControl));
     }
 

--- a/core/trino-main/src/main/java/io/trino/testing/TestingAccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingAccessControlManager.java
@@ -144,11 +144,6 @@ public class TestingAccessControlManager
         this(transactionManager, eventListenerManager, new AccessControlConfig());
     }
 
-    public void loadSystemAccessControl(String name, Map<String, String> properties)
-    {
-        setSystemAccessControl(name, properties);
-    }
-
     public static TestingPrivilege privilege(String entityName, TestingPrivilegeType type)
     {
         return new TestingPrivilege(Optional.empty(), entityName, type);

--- a/core/trino-main/src/test/java/io/trino/security/TestAccessControlManager.java
+++ b/core/trino-main/src/test/java/io/trino/security/TestAccessControlManager.java
@@ -90,7 +90,7 @@ public class TestAccessControlManager
     public void testNoneSystemAccessControl()
     {
         AccessControlManager accessControlManager = createAccessControlManager(createTestTransactionManager());
-        accessControlManager.setSystemAccessControl(AllowAllSystemAccessControl.NAME, ImmutableMap.of());
+        accessControlManager.loadSystemAccessControl(AllowAllSystemAccessControl.NAME, ImmutableMap.of());
         accessControlManager.checkCanSetUser(Optional.empty(), USER_NAME);
     }
 
@@ -102,7 +102,7 @@ public class TestAccessControlManager
         TransactionManager transactionManager = createTestTransactionManager();
         AccessControlManager accessControlManager = createAccessControlManager(transactionManager);
 
-        accessControlManager.setSystemAccessControl(ReadOnlySystemAccessControl.NAME, ImmutableMap.of());
+        accessControlManager.loadSystemAccessControl(ReadOnlySystemAccessControl.NAME, ImmutableMap.of());
         accessControlManager.checkCanSetUser(Optional.of(PRINCIPAL), USER_NAME);
         accessControlManager.checkCanSetSystemSessionProperty(identity, "property");
 
@@ -139,7 +139,7 @@ public class TestAccessControlManager
 
         TestSystemAccessControlFactory accessControlFactory = new TestSystemAccessControlFactory("test");
         accessControlManager.addSystemAccessControlFactory(accessControlFactory);
-        accessControlManager.setSystemAccessControl("test", ImmutableMap.of());
+        accessControlManager.loadSystemAccessControl("test", ImmutableMap.of());
 
         accessControlManager.checkCanSetUser(Optional.of(PRINCIPAL), USER_NAME);
         assertEquals(accessControlFactory.getCheckedUserName(), USER_NAME);
@@ -154,7 +154,7 @@ public class TestAccessControlManager
 
         TestSystemAccessControlFactory accessControlFactory = new TestSystemAccessControlFactory("test");
         accessControlManager.addSystemAccessControlFactory(accessControlFactory);
-        accessControlManager.setSystemAccessControl("test", ImmutableMap.of());
+        accessControlManager.loadSystemAccessControl("test", ImmutableMap.of());
 
         transaction(transactionManager, accessControlManager)
                 .execute(transactionId -> {
@@ -171,7 +171,7 @@ public class TestAccessControlManager
 
             TestSystemAccessControlFactory accessControlFactory = new TestSystemAccessControlFactory("test");
             accessControlManager.addSystemAccessControlFactory(accessControlFactory);
-            accessControlManager.setSystemAccessControl("test", ImmutableMap.of());
+            accessControlManager.loadSystemAccessControl("test", ImmutableMap.of());
 
             queryRunner.createCatalog("catalog", MockConnectorFactory.create(), ImmutableMap.of());
             accessControlManager.addCatalogAccessControl(new CatalogName("catalog"), new DenyConnectorAccessControl());
@@ -218,7 +218,7 @@ public class TestAccessControlManager
                     };
                 }
             });
-            accessControlManager.setSystemAccessControl("test", ImmutableMap.of());
+            accessControlManager.loadSystemAccessControl("test", ImmutableMap.of());
 
             queryRunner.createCatalog("catalog", MockConnectorFactory.create(), ImmutableMap.of());
             accessControlManager.addCatalogAccessControl(new CatalogName("catalog"), new ConnectorAccessControl()
@@ -263,7 +263,7 @@ public class TestAccessControlManager
 
             TestSystemAccessControlFactory accessControlFactory = new TestSystemAccessControlFactory("test");
             accessControlManager.addSystemAccessControlFactory(accessControlFactory);
-            accessControlManager.setSystemAccessControl("test", ImmutableMap.of());
+            accessControlManager.loadSystemAccessControl("test", ImmutableMap.of());
 
             queryRunner.createCatalog("catalog", MockConnectorFactory.create(), ImmutableMap.of());
             accessControlManager.addCatalogAccessControl(new CatalogName("connector"), new DenyConnectorAccessControl());
@@ -289,7 +289,7 @@ public class TestAccessControlManager
 
         TestSystemAccessControlFactory accessControlFactory = new TestSystemAccessControlFactory("deny-all");
         accessControlManager.addSystemAccessControlFactory(accessControlFactory);
-        accessControlManager.setSystemAccessControl("deny-all", ImmutableMap.of());
+        accessControlManager.loadSystemAccessControl("deny-all", ImmutableMap.of());
 
         assertDenyExecuteProcedure(transactionManager, accessControlManager, "Access Denied: Cannot execute procedure connector.schema.procedure");
     }
@@ -300,7 +300,7 @@ public class TestAccessControlManager
         try (LocalQueryRunner queryRunner = LocalQueryRunner.create(TEST_SESSION)) {
             TransactionManager transactionManager = queryRunner.getTransactionManager();
             AccessControlManager accessControlManager = createAccessControlManager(transactionManager);
-            accessControlManager.setSystemAccessControl("allow-all", ImmutableMap.of());
+            accessControlManager.loadSystemAccessControl("allow-all", ImmutableMap.of());
 
             queryRunner.createCatalog("connector", MockConnectorFactory.create(), ImmutableMap.of());
             accessControlManager.addCatalogAccessControl(new CatalogName("connector"), new DenyConnectorAccessControl());
@@ -315,7 +315,7 @@ public class TestAccessControlManager
         try (LocalQueryRunner queryRunner = LocalQueryRunner.create(TEST_SESSION)) {
             TransactionManager transactionManager = queryRunner.getTransactionManager();
             AccessControlManager accessControlManager = createAccessControlManager(transactionManager);
-            accessControlManager.setSystemAccessControl("allow-all", ImmutableMap.of());
+            accessControlManager.loadSystemAccessControl("allow-all", ImmutableMap.of());
 
             queryRunner.createCatalog("connector", MockConnectorFactory.create(), ImmutableMap.of());
             accessControlManager.addCatalogAccessControl(new CatalogName("connector"), new AllowAllAccessControl());
@@ -384,7 +384,7 @@ public class TestAccessControlManager
 
         TestSystemAccessControlFactory accessControlFactory = new TestSystemAccessControlFactory("deny-all");
         accessControlManager.addSystemAccessControlFactory(accessControlFactory);
-        accessControlManager.setSystemAccessControl("deny-all", ImmutableMap.of());
+        accessControlManager.loadSystemAccessControl("deny-all", ImmutableMap.of());
 
         transaction(transactionManager, accessControlManager)
                 .execute(transactionId -> {
@@ -403,7 +403,7 @@ public class TestAccessControlManager
         CatalogManager catalogManager = new CatalogManager();
         TransactionManager transactionManager = createTestTransactionManager(catalogManager);
         AccessControlManager accessControlManager = createAccessControlManager(transactionManager);
-        accessControlManager.setSystemAccessControl("allow-all", ImmutableMap.of());
+        accessControlManager.loadSystemAccessControl("allow-all", ImmutableMap.of());
 
         transaction(transactionManager, accessControlManager)
                 .execute(transactionId -> {

--- a/core/trino-main/src/test/java/io/trino/security/TestAccessControlManager.java
+++ b/core/trino-main/src/test/java/io/trino/security/TestAccessControlManager.java
@@ -328,6 +328,45 @@ public class TestAccessControlManager
     }
 
     @Test
+    public void testRegisterSingleEventListenerForDefaultAccessControl()
+    {
+        EventListener expectedListener = new EventListener() {};
+
+        String defaultAccessControlName = "event-listening-default-access-control";
+        TestingEventListenerManager eventListenerManager = emptyEventListenerManager();
+        AccessControlManager accessControlManager = createAccessControlManager(
+                eventListenerManager,
+                defaultAccessControlName);
+        accessControlManager.addSystemAccessControlFactory(
+                eventListeningSystemAccessControlFactory(defaultAccessControlName, expectedListener));
+
+        accessControlManager.loadSystemAccessControl();
+
+        assertThat(eventListenerManager.getConfiguredEventListeners())
+                .contains(expectedListener);
+    }
+
+    @Test
+    public void testRegisterMultipleEventListenerForDefaultAccessControl()
+    {
+        EventListener firstListener = new EventListener() {};
+        EventListener secondListener = new EventListener() {};
+
+        String defaultAccessControlName = "event-listening-default-access-control";
+        TestingEventListenerManager eventListenerManager = emptyEventListenerManager();
+        AccessControlManager accessControlManager = createAccessControlManager(
+                eventListenerManager,
+                defaultAccessControlName);
+        accessControlManager.addSystemAccessControlFactory(
+                eventListeningSystemAccessControlFactory(defaultAccessControlName, firstListener, secondListener));
+
+        accessControlManager.loadSystemAccessControl();
+
+        assertThat(eventListenerManager.getConfiguredEventListeners())
+                .contains(firstListener, secondListener);
+    }
+
+    @Test
     public void testRegisterSingleEventListener()
             throws IOException
     {
@@ -434,6 +473,11 @@ public class TestAccessControlManager
     private AccessControlManager createAccessControlManager(EventListenerManager eventListenerManager, AccessControlConfig config)
     {
         return new AccessControlManager(createTestTransactionManager(), eventListenerManager, config, DefaultSystemAccessControl.NAME);
+    }
+
+    private AccessControlManager createAccessControlManager(EventListenerManager eventListenerManager, String defaultAccessControlName)
+    {
+        return new AccessControlManager(createTestTransactionManager(), eventListenerManager, new AccessControlConfig(), defaultAccessControlName);
     }
 
     private SystemAccessControlFactory eventListeningSystemAccessControlFactory(String name, EventListener... eventListeners)

--- a/core/trino-main/src/test/java/io/trino/security/TestFileBasedSystemAccessControl.java
+++ b/core/trino-main/src/test/java/io/trino/security/TestFileBasedSystemAccessControl.java
@@ -123,7 +123,7 @@ public class TestFileBasedSystemAccessControl
     {
         TransactionManager transactionManager = createTestTransactionManager();
         AccessControlManager accessControlManager = new AccessControlManager(transactionManager, emptyEventListenerManager(), new AccessControlConfig(), DefaultSystemAccessControl.NAME);
-        accessControlManager.setSystemAccessControl(
+        accessControlManager.loadSystemAccessControl(
                 FileBasedSystemAccessControl.NAME,
                 ImmutableMap.of("security.config-file", new File("../../docs/src/main/sphinx/security/user-impersonation.json").getAbsolutePath()));
 
@@ -785,7 +785,7 @@ public class TestFileBasedSystemAccessControl
         configFile.deleteOnExit();
         copy(new File(getResourcePath("catalog.json")), configFile);
 
-        accessControlManager.setSystemAccessControl(FileBasedSystemAccessControl.NAME, ImmutableMap.of(
+        accessControlManager.loadSystemAccessControl(FileBasedSystemAccessControl.NAME, ImmutableMap.of(
                 SECURITY_CONFIG_FILE, configFile.getAbsolutePath(),
                 SECURITY_REFRESH_PERIOD, "1ms"));
 
@@ -842,7 +842,7 @@ public class TestFileBasedSystemAccessControl
     {
         AccessControlManager accessControlManager = new AccessControlManager(transactionManager, emptyEventListenerManager(), new AccessControlConfig(), DefaultSystemAccessControl.NAME);
 
-        accessControlManager.setSystemAccessControl(FileBasedSystemAccessControl.NAME, ImmutableMap.of("security.config-file", getResourcePath(resourceName)));
+        accessControlManager.loadSystemAccessControl(FileBasedSystemAccessControl.NAME, ImmutableMap.of("security.config-file", getResourcePath(resourceName)));
 
         return accessControlManager;
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

It's a fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Its part of the core engine security

> Main problem

Right now if you extend and set default access control to something else using an optional binder, then there will be a problem because event listeners won't get registered.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
