### PR TITLE
Add access control to drop_extended_stats and vacuum in Delta Lake

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/DropExtendedStatsProcedure.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/DropExtendedStatsProcedure.java
@@ -17,6 +17,7 @@ import io.trino.plugin.deltalake.DeltaLakeMetadata;
 import io.trino.plugin.deltalake.DeltaLakeMetadataFactory;
 import io.trino.plugin.deltalake.statistics.DeltaLakeStatisticsAccess;
 import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.procedure.Procedure;
@@ -42,6 +43,7 @@ public class DropExtendedStatsProcedure
             DropExtendedStatsProcedure.class,
             "dropStats",
             ConnectorSession.class,
+            ConnectorAccessControl.class,
             // Schema name and table name
             String.class,
             String.class);
@@ -68,7 +70,7 @@ public class DropExtendedStatsProcedure
                 PROCEDURE_METHOD.bindTo(this));
     }
 
-    public void dropStats(ConnectorSession session, String schema, String table)
+    public void dropStats(ConnectorSession session, ConnectorAccessControl accessControl, String schema, String table)
     {
         checkProcedureArgument(schema != null, "schema_name cannot be null");
         checkProcedureArgument(table != null, "table_name cannot be null");
@@ -78,6 +80,7 @@ public class DropExtendedStatsProcedure
         if (metadata.getTableHandle(session, name) == null) {
             throw new TrinoException(INVALID_PROCEDURE_ARGUMENT, format("Table '%s' does not exist", name));
         }
+        accessControl.checkCanInsertIntoTable(null, name);
         statsAccess.deleteDeltaLakeStatistics(session, metadata.getMetastore().getTableLocation(name, session));
     }
 }


### PR DESCRIPTION
## Description

Add access control to `drop_extended_stats` and `vacuum` procedures in Delta Lake

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Delta Lake
* Add access control to `drop_extended_stats` and `vacuum` procedures. ({issue}`11633`)
```
