### PR TITLE
Return 0 instead of row count in Cassandra completed bytes

### DIFF
--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraRecordCursor.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraRecordCursor.java
@@ -34,7 +34,6 @@ public class CassandraRecordCursor
     private final List<CassandraType> cassandraTypes;
     private final ResultSet rs;
     private Row currentRow;
-    private long count;
 
     public CassandraRecordCursor(CassandraSession cassandraSession, List<CassandraType> cassandraTypes, String cql)
     {
@@ -48,7 +47,6 @@ public class CassandraRecordCursor
     {
         if (!rs.isExhausted()) {
             currentRow = rs.one();
-            count++;
             return true;
         }
         return false;
@@ -68,7 +66,7 @@ public class CassandraRecordCursor
     @Override
     public long getCompletedBytes()
     {
-        return count;
+        return 0;
     }
 
     @Override


### PR DESCRIPTION
## Description

Return 0 instead of row count in Cassandra completed bytes. Cassandra Java driver doesn't expose the data size.

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Cassandra
* Return `0` instead of row count in completed bytes. ({issue}`11644`)
```
