### PR TITLE
Use request handler to set Glue catalog id

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/DefaultGlueColumnStatisticsProviderFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/DefaultGlueColumnStatisticsProviderFactory.java
@@ -15,7 +15,6 @@ package io.trino.plugin.hive.metastore.glue;
 
 import com.amazonaws.services.glue.AWSGlueAsync;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 
 import java.util.concurrent.Executor;
@@ -25,17 +24,14 @@ import static java.util.Objects.requireNonNull;
 public class DefaultGlueColumnStatisticsProviderFactory
         implements GlueColumnStatisticsProviderFactory
 {
-    private final @Nullable String catalogId;
     private final Executor statisticsReadExecutor;
     private final Executor statisticsWriteExecutor;
 
     @Inject
     public DefaultGlueColumnStatisticsProviderFactory(
-            GlueHiveMetastoreConfig glueConfig,
             @ForGlueColumnStatisticsRead Executor statisticsReadExecutor,
             @ForGlueColumnStatisticsWrite Executor statisticsWriteExecutor)
     {
-        this.catalogId = requireNonNull(glueConfig, "glueConfig is null").getCatalogId().orElse(null);
         this.statisticsReadExecutor = requireNonNull(statisticsReadExecutor, "statisticsReadExecutor is null");
         this.statisticsWriteExecutor = requireNonNull(statisticsWriteExecutor, "statisticsWriteExecutor is null");
     }
@@ -45,7 +41,6 @@ public class DefaultGlueColumnStatisticsProviderFactory
     {
         return new DefaultGlueColumnStatisticsProvider(
                 glueClient,
-                catalogId,
                 statisticsReadExecutor,
                 statisticsWriteExecutor,
                 stats);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueCatalogIdRequestHandler.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueCatalogIdRequestHandler.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.metastore.glue;
+
+import com.amazonaws.AmazonWebServiceRequest;
+import com.amazonaws.handlers.RequestHandler2;
+import com.amazonaws.services.glue.model.BatchCreatePartitionRequest;
+import com.amazonaws.services.glue.model.BatchGetPartitionRequest;
+import com.amazonaws.services.glue.model.BatchUpdatePartitionRequest;
+import com.amazonaws.services.glue.model.CreateDatabaseRequest;
+import com.amazonaws.services.glue.model.CreateTableRequest;
+import com.amazonaws.services.glue.model.DeleteColumnStatisticsForPartitionRequest;
+import com.amazonaws.services.glue.model.DeleteColumnStatisticsForTableRequest;
+import com.amazonaws.services.glue.model.DeleteDatabaseRequest;
+import com.amazonaws.services.glue.model.DeletePartitionRequest;
+import com.amazonaws.services.glue.model.DeleteTableRequest;
+import com.amazonaws.services.glue.model.GetColumnStatisticsForPartitionRequest;
+import com.amazonaws.services.glue.model.GetColumnStatisticsForTableRequest;
+import com.amazonaws.services.glue.model.GetDatabaseRequest;
+import com.amazonaws.services.glue.model.GetDatabasesRequest;
+import com.amazonaws.services.glue.model.GetPartitionRequest;
+import com.amazonaws.services.glue.model.GetPartitionsRequest;
+import com.amazonaws.services.glue.model.GetTableRequest;
+import com.amazonaws.services.glue.model.GetTablesRequest;
+import com.amazonaws.services.glue.model.UpdateColumnStatisticsForPartitionRequest;
+import com.amazonaws.services.glue.model.UpdateColumnStatisticsForTableRequest;
+import com.amazonaws.services.glue.model.UpdateDatabaseRequest;
+import com.amazonaws.services.glue.model.UpdatePartitionRequest;
+import com.amazonaws.services.glue.model.UpdateTableRequest;
+
+import static java.util.Objects.requireNonNull;
+
+public class GlueCatalogIdRequestHandler
+        extends RequestHandler2
+{
+    private final String catalogId;
+
+    public GlueCatalogIdRequestHandler(String catalogId)
+    {
+        this.catalogId = requireNonNull(catalogId, "catalogId is null");
+    }
+
+    @Override
+    public AmazonWebServiceRequest beforeExecution(AmazonWebServiceRequest request)
+    {
+        if (request instanceof GetDatabasesRequest) {
+            return ((GetDatabasesRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof GetDatabaseRequest) {
+            return ((GetDatabaseRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof CreateDatabaseRequest) {
+            return ((CreateDatabaseRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof UpdateDatabaseRequest) {
+            return ((UpdateDatabaseRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof DeleteDatabaseRequest) {
+            return ((DeleteDatabaseRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof GetTablesRequest) {
+            return ((GetTablesRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof GetTableRequest) {
+            return ((GetTableRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof CreateTableRequest) {
+            return ((CreateTableRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof UpdateTableRequest) {
+            return ((UpdateTableRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof DeleteTableRequest) {
+            return ((DeleteTableRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof GetPartitionsRequest) {
+            return ((GetPartitionsRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof GetPartitionRequest) {
+            return ((GetPartitionRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof UpdatePartitionRequest) {
+            return ((UpdatePartitionRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof DeletePartitionRequest) {
+            return ((DeletePartitionRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof BatchGetPartitionRequest) {
+            return ((BatchGetPartitionRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof BatchCreatePartitionRequest) {
+            return ((BatchCreatePartitionRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof BatchUpdatePartitionRequest) {
+            return ((BatchUpdatePartitionRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof GetColumnStatisticsForTableRequest) {
+            return ((GetColumnStatisticsForTableRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof UpdateColumnStatisticsForTableRequest) {
+            return ((UpdateColumnStatisticsForTableRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof DeleteColumnStatisticsForTableRequest) {
+            return ((DeleteColumnStatisticsForTableRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof GetColumnStatisticsForPartitionRequest) {
+            return ((GetColumnStatisticsForPartitionRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof UpdateColumnStatisticsForPartitionRequest) {
+            return ((UpdateColumnStatisticsForPartitionRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof DeleteColumnStatisticsForPartitionRequest) {
+            return ((DeleteColumnStatisticsForPartitionRequest) request).withCatalogId(catalogId);
+        }
+        throw new IllegalArgumentException("Unsupported request: " + request);
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
@@ -221,7 +221,7 @@ public class TestHiveGlueMetastore
                 glueConfig,
                 DefaultAWSCredentialsProviderChain.getInstance(),
                 executor,
-                new DefaultGlueColumnStatisticsProviderFactory(glueConfig, executor, executor),
+                new DefaultGlueColumnStatisticsProviderFactory(executor, executor),
                 Optional.empty(),
                 new DefaultGlueMetastoreTableFilterProvider(
                         new MetastoreConfig()

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalogFactory.java
@@ -31,7 +31,6 @@ import javax.inject.Inject;
 
 import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.plugin.hive.metastore.glue.GlueHiveMetastore.createAsyncGlueClient;
 import static java.util.Objects.requireNonNull;
 
@@ -60,7 +59,6 @@ public class TrinoGlueCatalogFactory
         this.tableOperationsProvider = requireNonNull(tableOperationsProvider, "tableOperationsProvider is null");
         this.trinoVersion = requireNonNull(nodeVersion, "nodeVersion is null").toString();
         requireNonNull(glueConfig, "glueConfig is null");
-        checkArgument(glueConfig.getCatalogId().isEmpty(), "catalogId configuration is not supported");
         this.defaultSchemaLocation = glueConfig.getDefaultWarehouseDir();
         requireNonNull(credentialsProvider, "credentialsProvider is null");
         this.glueClient = createAsyncGlueClient(glueConfig, credentialsProvider, Optional.empty(), stats.newRequestMetricsCollector());

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPlugin.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPlugin.java
@@ -86,14 +86,14 @@ public class TestIcebergPlugin
                 new TestingConnectorContext()))
                 .hasMessageContaining("Error: Configuration property 'hive.metastore.uri' was not used");
 
-        assertThatThrownBy(() -> factory.create(
+        factory.create(
                 "test",
                 Map.of(
                         "iceberg.catalog.type", "glue",
                         "hive.metastore.glue.catalogid", "123",
                         "hive.metastore.glue.region", "us-east-1"),
-                new TestingConnectorContext()))
-                .hasMessageContaining("catalogId configuration is not supported");
+                new TestingConnectorContext())
+                .shutdown();
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestSharedGlueMetastore.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestSharedGlueMetastore.java
@@ -108,7 +108,7 @@ public class TestSharedGlueMetastore
                 new GlueHiveMetastoreConfig(),
                 DefaultAWSCredentialsProviderChain.getInstance(),
                 directExecutor(),
-                new DefaultGlueColumnStatisticsProviderFactory(new GlueHiveMetastoreConfig(), directExecutor(), directExecutor()),
+                new DefaultGlueColumnStatisticsProviderFactory(directExecutor(), directExecutor()),
                 Optional.empty(),
                 table -> true);
         queryRunner.installPlugin(new TestingHivePlugin(glueMetastore));


### PR DESCRIPTION
## Description

Use request handler to set Glue catalog id. This change adds support for Glue catalog id in Iceberg connector.
Fixes #11520

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Iceberg
* Support setting Glue metastore catalog id via `hive.metastore.glue.catalogid` configuration property. ({issue}`11520`)
```
