### PR TITLE
Add test class progress logging on CI

### DIFF
--- a/testing/trino-testing-services/src/main/java/io/trino/testng/services/ProgressLoggingListener.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testng/services/ProgressLoggingListener.java
@@ -15,6 +15,8 @@ package io.trino.testng.services;
 
 import com.google.common.base.Joiner;
 import io.airlift.log.Logger;
+import org.testng.IClassListener;
+import org.testng.ITestClass;
 import org.testng.ITestContext;
 import org.testng.ITestListener;
 import org.testng.ITestResult;
@@ -25,7 +27,7 @@ import java.math.RoundingMode;
 import static java.lang.String.format;
 
 public class ProgressLoggingListener
-        implements ITestListener
+        implements IClassListener, ITestListener
 {
     private static final Logger LOGGER = Logger.get(ProgressLoggingListener.class);
     private final boolean enabled;
@@ -106,6 +108,26 @@ public class ProgressLoggingListener
     {
     }
 
+    @Override
+    public void onBeforeClass(ITestClass testClass)
+    {
+        if (!enabled) {
+            return;
+        }
+
+        LOGGER.info("[BEFORE CLASS] %s", getName(testClass));
+    }
+
+    @Override
+    public void onAfterClass(ITestClass testClass)
+    {
+        if (!enabled) {
+            return;
+        }
+
+        LOGGER.info("[AFTER CLASS] %s", getName(testClass));
+    }
+
     private String formatTestName(ITestResult testCase)
     {
         // See LogTestDurationListener.getName
@@ -140,5 +162,10 @@ public class ProgressLoggingListener
     private static BigDecimal durationInSeconds(long millis)
     {
         return (new BigDecimal(millis)).divide(new BigDecimal(1000), 1, RoundingMode.HALF_UP);
+    }
+
+    private static String getName(ITestClass testClass)
+    {
+        return testClass.getName();
     }
 }


### PR DESCRIPTION
While going through the CI logs it can be helpful to pinpoint
the specific test class issuing errors on the logs.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

While going through the CI logs it can be helpful to pinpoint
the specific test class issuing errors on the logs.
If the JVM suddenly crashes while running the `@BeforeClass` setup methods, with the help of the current changes
it can be seen which specific class is causing these issue and reduce therefore the time needed to reproduce locally
the issue from the CI server. 

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Testing infrastructure.

> How would you describe this change to a non-technical end user or system administrator?

Pinpoint the test class causing JVM crashes while setting up the testing infrastructure for its test methods.

Look for:

- BEFORE CLASS
- AFTER CLASS

in the CI logs corresponding to the build of this PR.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:
