### PR TITLE
Compute min/max for too long orc string columns

### DIFF
--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcWriter.java
@@ -183,7 +183,8 @@ public final class OrcWriter
                     compression,
                     maxCompressionBufferSize,
                     options.getMaxStringStatisticsLimit(),
-                    getBloomFilterBuilder(options, columnNames.get(fieldId)));
+                    getBloomFilterBuilder(options, columnNames.get(fieldId)),
+                    options.isShouldCompactMinMax());
             columnWriters.add(columnWriter);
 
             if (columnWriter instanceof SliceDictionaryColumnWriter) {

--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcWriterOptions.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcWriterOptions.java
@@ -61,6 +61,7 @@ public class OrcWriterOptions
     private final DataSize maxCompressionBufferSize;
     private final Set<String> bloomFilterColumns;
     private final double bloomFilterFpp;
+    private final boolean shouldCompactMinMax;
 
     public OrcWriterOptions()
     {
@@ -74,7 +75,8 @@ public class OrcWriterOptions
                 DEFAULT_MAX_STRING_STATISTICS_LIMIT,
                 DEFAULT_MAX_COMPRESSION_BUFFER_SIZE,
                 ImmutableSet.of(),
-                DEFAULT_BLOOM_FILTER_FPP);
+                DEFAULT_BLOOM_FILTER_FPP,
+                true);
     }
 
     private OrcWriterOptions(
@@ -87,7 +89,8 @@ public class OrcWriterOptions
             DataSize maxStringStatisticsLimit,
             DataSize maxCompressionBufferSize,
             Set<String> bloomFilterColumns,
-            double bloomFilterFpp)
+            double bloomFilterFpp,
+            boolean shouldCompactMinMax)
     {
         requireNonNull(stripeMinSize, "stripeMinSize is null");
         requireNonNull(stripeMaxSize, "stripeMaxSize is null");
@@ -109,6 +112,7 @@ public class OrcWriterOptions
         this.maxCompressionBufferSize = maxCompressionBufferSize;
         this.bloomFilterColumns = ImmutableSet.copyOf(bloomFilterColumns);
         this.bloomFilterFpp = bloomFilterFpp;
+        this.shouldCompactMinMax = shouldCompactMinMax;
     }
 
     public WriterIdentification getWriterIdentification()
@@ -231,6 +235,18 @@ public class OrcWriterOptions
                 .build();
     }
 
+    public boolean isShouldCompactMinMax()
+    {
+        return shouldCompactMinMax;
+    }
+
+    public OrcWriterOptions withShouldCompactMinMax(boolean shouldCompactMinMax)
+    {
+        return builderFrom(this)
+                .setShouldCompactMinMax(shouldCompactMinMax)
+                .build();
+    }
+
     @Override
     public String toString()
     {
@@ -269,6 +285,7 @@ public class OrcWriterOptions
         private DataSize maxCompressionBufferSize;
         private Set<String> bloomFilterColumns;
         private double bloomFilterFpp;
+        private boolean shouldCompactMinMax;
 
         private Builder(OrcWriterOptions options)
         {
@@ -284,6 +301,7 @@ public class OrcWriterOptions
             this.maxCompressionBufferSize = options.maxCompressionBufferSize;
             this.bloomFilterColumns = ImmutableSet.copyOf(options.bloomFilterColumns);
             this.bloomFilterFpp = options.bloomFilterFpp;
+            this.shouldCompactMinMax = options.shouldCompactMinMax;
         }
 
         public Builder setWriterIdentification(WriterIdentification writerIdentification)
@@ -346,6 +364,12 @@ public class OrcWriterOptions
             return this;
         }
 
+        public Builder setShouldCompactMinMax(boolean shouldCompactMinMax)
+        {
+            this.shouldCompactMinMax = shouldCompactMinMax;
+            return this;
+        }
+
         public OrcWriterOptions build()
         {
             return new OrcWriterOptions(
@@ -358,7 +382,8 @@ public class OrcWriterOptions
                     maxStringStatisticsLimit,
                     maxCompressionBufferSize,
                     bloomFilterColumns,
-                    bloomFilterFpp);
+                    bloomFilterFpp,
+                    shouldCompactMinMax);
         }
     }
 }

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/StringStatisticsBuilder.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/StringStatisticsBuilder.java
@@ -22,8 +22,13 @@ import java.util.Optional;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SliceUtf8.codePointToUtf8;
+import static io.airlift.slice.SliceUtf8.getCodePointAt;
+import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static io.trino.orc.metadata.statistics.StringStatistics.STRING_VALUE_BYTES_OVERHEAD;
+import static java.lang.Character.MAX_CODE_POINT;
 import static java.lang.Math.addExact;
+import static java.lang.System.arraycopy;
 import static java.util.Objects.requireNonNull;
 
 public class StringStatisticsBuilder
@@ -36,13 +41,26 @@ public class StringStatisticsBuilder
     private Slice maximum;
     private long sum;
     private final BloomFilterBuilder bloomFilterBuilder;
+    private final boolean shouldCompactMinMax;
 
     public StringStatisticsBuilder(int stringStatisticsLimitInBytes, BloomFilterBuilder bloomFilterBuilder)
     {
-        this(stringStatisticsLimitInBytes, 0, null, null, 0, bloomFilterBuilder);
+        this(stringStatisticsLimitInBytes, 0, null, null, 0, bloomFilterBuilder, true);
     }
 
-    private StringStatisticsBuilder(int stringStatisticsLimitInBytes, long nonNullValueCount, Slice minimum, Slice maximum, long sum, BloomFilterBuilder bloomFilterBuilder)
+    public StringStatisticsBuilder(int stringStatisticsLimitInBytes, BloomFilterBuilder bloomFilterBuilder, boolean shouldCompactMinMax)
+    {
+        this(stringStatisticsLimitInBytes, 0, null, null, 0, bloomFilterBuilder, shouldCompactMinMax);
+    }
+
+    private StringStatisticsBuilder(
+            int stringStatisticsLimitInBytes,
+            long nonNullValueCount,
+            Slice minimum,
+            Slice maximum,
+            long sum,
+            BloomFilterBuilder bloomFilterBuilder,
+            boolean shouldCompactMinMax)
     {
         this.stringStatisticsLimitInBytes = stringStatisticsLimitInBytes;
         this.nonNullValueCount = nonNullValueCount;
@@ -50,6 +68,7 @@ public class StringStatisticsBuilder
         this.maximum = maximum;
         this.sum = sum;
         this.bloomFilterBuilder = requireNonNull(bloomFilterBuilder, "bloomFilterBuilder");
+        this.shouldCompactMinMax = shouldCompactMinMax;
     }
 
     public long getNonNullValueCount()
@@ -112,8 +131,8 @@ public class StringStatisticsBuilder
         if (nonNullValueCount == 0) {
             return Optional.empty();
         }
-        minimum = dropStringMinMaxIfNecessary(minimum);
-        maximum = dropStringMinMaxIfNecessary(maximum);
+        minimum = computeStringMinMax(minimum, true);
+        maximum = computeStringMinMax(maximum, false);
         if (minimum == null && maximum == null) {
             // Create string stats only when min or max is not null.
             // This corresponds to the behavior of metadata reader.
@@ -158,10 +177,18 @@ public class StringStatisticsBuilder
         return stringStatisticsBuilder.buildStringStatistics();
     }
 
-    private Slice dropStringMinMaxIfNecessary(Slice minOrMax)
+    private Slice computeStringMinMax(Slice minOrMax, boolean isMin)
     {
-        if (minOrMax == null || minOrMax.length() > stringStatisticsLimitInBytes) {
+        if (minOrMax == null || (!shouldCompactMinMax && minOrMax.length() > stringStatisticsLimitInBytes)) {
             return null;
+        }
+        if (minOrMax.length() > stringStatisticsLimitInBytes) {
+            if (isMin) {
+                return StringCompactor.truncateMin(minOrMax, stringStatisticsLimitInBytes);
+            }
+            else {
+                return StringCompactor.truncateMax(minOrMax, stringStatisticsLimitInBytes);
+            }
         }
 
         // Do not hold the entire slice where the actual stats could be small
@@ -169,5 +196,68 @@ public class StringStatisticsBuilder
             return minOrMax;
         }
         return Slices.copyOf(minOrMax);
+    }
+
+    static final class StringCompactor
+    {
+        private static final int INDEX_NOT_FOUND = -1;
+
+        private StringCompactor() {}
+
+        public static Slice truncateMin(Slice slice, int maxBytes)
+        {
+            checkArgument(slice.length() > maxBytes);
+            int lastIndex = findLastCharacterInRange(slice, maxBytes);
+            if (lastIndex == INDEX_NOT_FOUND) {
+                return EMPTY_SLICE;
+            }
+            return slice.slice(0, lastIndex);
+        }
+
+        public static Slice truncateMax(Slice slice, int maxBytes)
+        {
+            int firstRemovedCharacterIndex = findLastCharacterInRange(slice, maxBytes);
+            int lastRetainedCharacterIndex = findLastCharacterInRange(slice, firstRemovedCharacterIndex - 1);
+            if (firstRemovedCharacterIndex == INDEX_NOT_FOUND || lastRetainedCharacterIndex == INDEX_NOT_FOUND) {
+                return EMPTY_SLICE;
+            }
+            int lastRetainedCharacter = getCodePointAt(slice, lastRetainedCharacterIndex);
+            while (lastRetainedCharacter == MAX_CODE_POINT && lastRetainedCharacterIndex > 0) {
+                lastRetainedCharacterIndex = findLastCharacterInRange(slice, lastRetainedCharacterIndex - 1);
+                if (lastRetainedCharacterIndex == INDEX_NOT_FOUND) {
+                    return EMPTY_SLICE;
+                }
+                lastRetainedCharacter = getCodePointAt(slice, lastRetainedCharacterIndex);
+            }
+
+            if (lastRetainedCharacterIndex == 0 && lastRetainedCharacter == MAX_CODE_POINT) {
+                // whole string is made of MAX_CODE_POINT characters, we cannot provide upper bound that is shorter than maxBytes
+                return EMPTY_SLICE;
+            }
+
+            lastRetainedCharacter++;
+            Slice sliceToAppend = codePointToUtf8(lastRetainedCharacter);
+            byte[] result = new byte[lastRetainedCharacterIndex + sliceToAppend.length()];
+            arraycopy(slice.byteArray(), slice.byteArrayOffset(), result, 0, lastRetainedCharacterIndex);
+            arraycopy(sliceToAppend.byteArray(), 0, result, lastRetainedCharacterIndex, sliceToAppend.length());
+            return Slices.wrappedBuffer(result);
+        }
+
+        private static int findLastCharacterInRange(Slice slice, int toInclusive)
+        {
+            int pos = toInclusive;
+            while (pos >= 0) {
+                if (isUtfBlockStartChar(slice.getByte(pos))) {
+                    return pos;
+                }
+                pos--;
+            }
+            return INDEX_NOT_FOUND;
+        }
+
+        private static boolean isUtfBlockStartChar(byte b)
+        {
+            return (b & 0xC0) != 0x80;
+        }
     }
 }

--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/ColumnWriters.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/ColumnWriters.java
@@ -47,7 +47,8 @@ public final class ColumnWriters
             CompressionKind compression,
             int bufferSize,
             DataSize stringStatisticsLimit,
-            Supplier<BloomFilterBuilder> bloomFilterBuilder)
+            Supplier<BloomFilterBuilder> bloomFilterBuilder,
+            boolean shouldCompactMinMax)
     {
         requireNonNull(type, "type is null");
         OrcType orcType = orcTypes.get(columnId);
@@ -92,12 +93,12 @@ public final class ColumnWriters
             case CHAR:
             case VARCHAR:
             case STRING:
-                return new SliceDictionaryColumnWriter(columnId, type, compression, bufferSize, () -> new StringStatisticsBuilder(toIntExact(stringStatisticsLimit.toBytes()), bloomFilterBuilder.get()));
+                return new SliceDictionaryColumnWriter(columnId, type, compression, bufferSize, () -> new StringStatisticsBuilder(toIntExact(stringStatisticsLimit.toBytes()), bloomFilterBuilder.get(), shouldCompactMinMax));
 
             case LIST: {
                 OrcColumnId fieldColumnIndex = orcType.getFieldTypeIndex(0);
                 Type fieldType = type.getTypeParameters().get(0);
-                ColumnWriter elementWriter = createColumnWriter(fieldColumnIndex, orcTypes, fieldType, compression, bufferSize, stringStatisticsLimit, bloomFilterBuilder);
+                ColumnWriter elementWriter = createColumnWriter(fieldColumnIndex, orcTypes, fieldType, compression, bufferSize, stringStatisticsLimit, bloomFilterBuilder, shouldCompactMinMax);
                 return new ListColumnWriter(columnId, compression, bufferSize, elementWriter);
             }
 
@@ -109,7 +110,8 @@ public final class ColumnWriters
                         compression,
                         bufferSize,
                         stringStatisticsLimit,
-                        bloomFilterBuilder);
+                        bloomFilterBuilder,
+                        shouldCompactMinMax);
                 ColumnWriter valueWriter = createColumnWriter(
                         orcType.getFieldTypeIndex(1),
                         orcTypes,
@@ -117,7 +119,8 @@ public final class ColumnWriters
                         compression,
                         bufferSize,
                         stringStatisticsLimit,
-                        bloomFilterBuilder);
+                        bloomFilterBuilder,
+                        shouldCompactMinMax);
                 return new MapColumnWriter(columnId, compression, bufferSize, keyWriter, valueWriter);
             }
 
@@ -126,7 +129,7 @@ public final class ColumnWriters
                 for (int fieldId = 0; fieldId < orcType.getFieldCount(); fieldId++) {
                     OrcColumnId fieldColumnIndex = orcType.getFieldTypeIndex(fieldId);
                     Type fieldType = type.getTypeParameters().get(fieldId);
-                    fieldWriters.add(createColumnWriter(fieldColumnIndex, orcTypes, fieldType, compression, bufferSize, stringStatisticsLimit, bloomFilterBuilder));
+                    fieldWriters.add(createColumnWriter(fieldColumnIndex, orcTypes, fieldType, compression, bufferSize, stringStatisticsLimit, bloomFilterBuilder, shouldCompactMinMax));
                 }
                 return new StructColumnWriter(columnId, compression, bufferSize, fieldWriters.build());
             }


### PR DESCRIPTION
## Description

> Is this change a fix, improvement, new feature, refactoring, or other?
improvement
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

it is a change to internal trino library
> How would you describe this change to a non-technical end user or system administrator?

It allows to create better statistics for ORC files that contains column of type VARCHAR. In some specific cases it may slightly improve performance of reading orc tables.

## Documentation

(.) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(.) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
