### PR TITLE
Replace assertTrue/assertFalse with AssertJ assertions

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -2093,7 +2093,7 @@ public abstract class BaseIcebergConnectorTest
         List<Long> values = LongStream.range(1L, 1010L).boxed()
                 .filter(index -> index != 20L)
                 .collect(toImmutableList());
-        assertTrue(values.size() > ICEBERG_DOMAIN_COMPACTION_THRESHOLD);
+        assertThat(values).hasSizeGreaterThan(ICEBERG_DOMAIN_COMPACTION_THRESHOLD);
         String valuesString = join(",", values.stream().map(Object::toString).collect(toImmutableList()));
         String inPredicate = "%s IN (" + valuesString + ")";
         assertQuery(

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMaterializedViews.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMaterializedViews.java
@@ -25,6 +25,7 @@ import io.trino.testing.MaterializedResult;
 import io.trino.testing.MaterializedRow;
 import io.trino.transaction.TransactionId;
 import io.trino.transaction.TransactionManager;
+import org.assertj.core.api.Condition;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -43,10 +44,9 @@ import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.UPDATE_TABLE;
 import static io.trino.testing.TestingAccessControlManager.privilege;
 import static io.trino.testing.assertions.Assert.assertEquals;
-import static io.trino.testing.assertions.Assert.assertFalse;
-import static io.trino.testing.assertions.Assert.assertTrue;
 import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.anyOf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -289,54 +289,54 @@ public class TestIcebergMaterializedViews
         MaterializedResult baseResult = computeActual("SELECT * from materialized_view_no_part");
         assertEquals(baseResult.getRowCount(), 6);
         String plan = getExplainPlan("SELECT * from materialized_view_no_part", ExplainType.Type.IO);
-        assertTrue(plan.contains("base_table1"));
+        assertThat(plan).contains("base_table1");
         assertUpdate("REFRESH MATERIALIZED VIEW materialized_view_no_part", 6);
         MaterializedResult viewResult = computeActual("SELECT * from materialized_view_no_part");
         assertEquals(viewResult.getRowCount(), 6);
         plan = getExplainPlan("SELECT * from materialized_view_no_part", ExplainType.Type.IO);
-        assertFalse(plan.contains("base_table1"));
+        assertThat(plan).doesNotContain("base_table1");
 
         baseResult = computeActual("SELECT * from materialized_view_agg");
         assertEquals(baseResult.getRowCount(), 3);
         plan = getExplainPlan("SELECT * from materialized_view_agg", ExplainType.Type.IO);
-        assertTrue(plan.contains("base_table1"));
+        assertThat(plan).contains("base_table1");
         assertUpdate("REFRESH MATERIALIZED VIEW materialized_view_agg", 3);
         viewResult = computeActual("SELECT * from materialized_view_agg");
         assertEquals(viewResult.getRowCount(), 3);
         plan = getExplainPlan("SELECT * from materialized_view_agg", ExplainType.Type.IO);
-        assertFalse(plan.contains("base_table1"));
+        assertThat(plan).doesNotContain("base_table1");
         assertQuery(session, "SELECT * from materialized_view_agg", "VALUES (DATE '2019-09-10', 2)," +
                 "(DATE '2019-09-08', 1), (DATE '2019-09-09', 3)");
 
         baseResult = computeActual("SELECT * from materialized_view_part");
         assertEquals(baseResult.getRowCount(), 3);
         plan = getExplainPlan("SELECT * from materialized_view_part", ExplainType.Type.IO);
-        assertTrue(plan.contains("base_table1"));
+        assertThat(plan).contains("base_table1");
         assertUpdate("REFRESH MATERIALIZED VIEW materialized_view_part", 3);
         viewResult = computeActual("SELECT * from materialized_view_part");
         assertEquals(viewResult.getRowCount(), 3);
         plan = getExplainPlan("SELECT * from materialized_view_part", ExplainType.Type.IO);
-        assertFalse(plan.contains("base_table1"));
+        assertThat(plan).doesNotContain("base_table1");
 
         baseResult = computeActual("SELECT * from materialized_view_join");
         assertEquals(baseResult.getRowCount(), 5);
         plan = getExplainPlan("SELECT * from materialized_view_join", ExplainType.Type.IO);
-        assertTrue(plan.contains("base_table1") && plan.contains("base_table2"));
+        assertThat(plan).contains("base_table1", "base_table2");
         assertUpdate("REFRESH MATERIALIZED VIEW materialized_view_join", 5);
         viewResult = computeActual("SELECT * from materialized_view_join");
         assertEquals(viewResult.getRowCount(), 5);
         plan = getExplainPlan("SELECT * from materialized_view_join", ExplainType.Type.IO);
-        assertFalse(plan.contains("base_table1") || plan.contains("base_table2"));
+        assertThat(plan).doesNotContain("base_table1", "base_table2");
 
         baseResult = computeActual("SELECT * from materialized_view_join_part");
         assertEquals(baseResult.getRowCount(), 4);
         plan = getExplainPlan("SELECT * from materialized_view_join_part", ExplainType.Type.IO);
-        assertTrue(plan.contains("base_table1") && plan.contains("base_table2"));
+        assertThat(plan).contains("base_table1", "base_table2");
         assertUpdate("REFRESH MATERIALIZED VIEW materialized_view_join_part", 4);
         viewResult = computeActual("SELECT * from materialized_view_join_part");
         assertEquals(viewResult.getRowCount(), 4);
         plan = getExplainPlan("SELECT * from materialized_view_join_part", ExplainType.Type.IO);
-        assertFalse(plan.contains("base_table1") || plan.contains("base_table2"));
+        assertThat(plan).doesNotContain("base_table1", "base_table2");
         assertQuery(session, "SELECT * from materialized_view_join_part", "VALUES (2, 'a', DATE '2019-09-09', 1), " +
                 "(0, 'a', DATE '2019-09-08', 2), (3, 'a', DATE '2019-09-09', 1), (1, 'a', DATE '2019-09-09', 1)");
 
@@ -373,26 +373,28 @@ public class TestIcebergMaterializedViews
 
         assertUpdate("INSERT INTO base_table3 VALUES (3, DATE '2019-09-09'), (4, DATE '2019-09-10'), (5, DATE '2019-09-10')", 3);
         String plan = getExplainPlan("SELECT * from materialized_view_part_stale", ExplainType.Type.IO);
-        assertTrue(plan.contains("base_table3"));
+        assertThat(plan).contains("base_table3");
 
         plan = getExplainPlan("SELECT * from materialized_view_join_stale", ExplainType.Type.IO);
-        assertTrue(plan.contains("base_table3") || plan.contains("base_table4"));
+        Condition<String> containsTable3 = new Condition<>(p -> p.contains("base_table3"), "base_table3");
+        Condition<String> containsTable4 = new Condition<>(p -> p.contains("base_table4"), "base_table4");
+        assertThat(plan).is(anyOf(containsTable3, containsTable4));
 
         plan = getExplainPlan("SELECT * from materialized_view_join_part_stale", ExplainType.Type.IO);
-        assertTrue(plan.contains("base_table3") || plan.contains("base_table4"));
+        assertThat(plan).is(anyOf(containsTable3, containsTable4));
 
         assertUpdate("REFRESH MATERIALIZED VIEW materialized_view_part_stale", 3);
         assertUpdate("REFRESH MATERIALIZED VIEW materialized_view_join_stale", 5);
         assertUpdate("REFRESH MATERIALIZED VIEW materialized_view_join_part_stale", 4);
 
         plan = getExplainPlan("SELECT * from materialized_view_part_stale", ExplainType.Type.IO);
-        assertFalse(plan.contains("base_table3"));
+        assertThat(plan).doesNotContain("base_table3");
 
         plan = getExplainPlan("SELECT * from materialized_view_join_stale", ExplainType.Type.IO);
-        assertFalse(plan.contains("base_table3") || plan.contains("base_table4"));
+        assertThat(plan).doesNotContain("base_table3", "base_table4");
 
         plan = getExplainPlan("SELECT * from materialized_view_join_part_stale", ExplainType.Type.IO);
-        assertFalse(plan.contains("base_table3") || plan.contains("base_table4"));
+        assertThat(plan).doesNotContain("base_table3", "base_table4");
 
         assertUpdate("DROP TABLE IF EXISTS base_table3");
         assertUpdate("DROP TABLE IF EXISTS base_table4");
@@ -418,11 +420,11 @@ public class TestIcebergMaterializedViews
 
         // This set of tests intend to test various SQL features in the context of materialized views. It also tests commands pertaining to materialized views.
         String plan = getExplainPlan("SELECT * from materialized_view_window", ExplainType.Type.IO);
-        assertFalse(plan.contains("base_table1"));
+        assertThat(plan).doesNotContain("base_table1");
         plan = getExplainPlan("SELECT * from materialized_view_union", ExplainType.Type.IO);
-        assertFalse(plan.contains("base_table1"));
+        assertThat(plan).doesNotContain("base_table1");
         plan = getExplainPlan("SELECT * from materialized_view_subquery", ExplainType.Type.IO);
-        assertFalse(plan.contains("base_table1"));
+        assertThat(plan).doesNotContain("base_table1");
 
         assertQueryFails("show create view  materialized_view_window",
                 "line 1:1: Relation 'iceberg.tpch.materialized_view_window' is a materialized view, not a view");
@@ -467,7 +469,7 @@ public class TestIcebergMaterializedViews
 
         assertUpdate("CREATE OR REPLACE MATERIALIZED VIEW materialized_view_replace as select sum(1) as num_rows from base_table2");
         String plan = getExplainPlan("SELECT * from materialized_view_replace", ExplainType.Type.IO);
-        assertTrue(plan.contains("base_table2"));
+        assertThat(plan).contains("base_table2");
         assertUpdate("REFRESH MATERIALIZED VIEW materialized_view_replace", 1);
         MaterializedResult viewResult = computeActual("SELECT * from materialized_view_replace");
         assertEquals(viewResult.getRowCount(), 1);
@@ -486,12 +488,12 @@ public class TestIcebergMaterializedViews
 
         // Unrefreshed 2nd level materialized view .. resolves to base table
         String plan = getExplainPlan("select * from materialized_view_level2", ExplainType.Type.IO);
-        assertTrue(plan.contains("base_table5"));
+        assertThat(plan).contains("base_table5");
         assertUpdate("refresh materialized view materialized_view_level2", 2);
         plan = getExplainPlan("select * from materialized_view_level2", ExplainType.Type.IO);
 
         // Refreshed 2nd level materialized view .. resolves to storage table
-        assertFalse(plan.contains("base_table5"));
+        assertThat(plan).doesNotContain("base_table5");
 
         // Re-refreshing 2nd level materialized view is a no-op
         assertUpdate("refresh materialized view materialized_view_level2", 0);
@@ -502,7 +504,7 @@ public class TestIcebergMaterializedViews
 
         // Refreshing the 2nd level (outer-most) materialized view does not refresh the 1st level (inner) materialized view.
         plan = getExplainPlan("select * from materialized_view_level1", ExplainType.Type.IO);
-        assertTrue(plan.contains("base_table5"));
+        assertThat(plan).contains("base_table5");
 
         assertUpdate("DROP TABLE IF EXISTS base_table5");
         assertUpdate("DROP MATERIALIZED VIEW materialized_view_level1");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergProjectionPushdownPlans.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergProjectionPushdownPlans.java
@@ -54,7 +54,7 @@ import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestIcebergProjectionPushdownPlans
         extends BasePushdownPlanTest
@@ -135,7 +135,7 @@ public class TestIcebergProjectionPushdownPlans
         Session session = getQueryRunner().getDefaultSession();
 
         Optional<TableHandle> tableHandle = getTableHandle(session, completeTableName);
-        assertTrue(tableHandle.isPresent(), "expected the table handle to be present");
+        assertThat(tableHandle).as("expected the table handle to be present").isPresent();
 
         Map<String, ColumnHandle> columns = getColumnHandles(session, completeTableName);
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergTableWithCustomLocation.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergTableWithCustomLocation.java
@@ -97,7 +97,7 @@ public class TestIcebergTableWithCustomLocation
         String tableName = "table_with_uuid";
         assertQuerySucceeds(format("CREATE TABLE %s as select 1 as val", tableName));
         Optional<Table> table = metastore.getTable("tpch", tableName);
-        assertTrue(table.isPresent(), "Table should exists");
+        assertThat(table).as("Table should exist").isPresent();
         String location = table.get().getStorage().getLocation();
         assertThat(location).matches(format(".*%s-[0-9a-f]{32}", tableName));
     }
@@ -131,18 +131,18 @@ public class TestIcebergTableWithCustomLocation
         String renamedName = "test_create_rename_drop_renamed";
         assertQuerySucceeds(format("CREATE TABLE %s as select 1 as val", tableName));
         Optional<Table> table = metastore.getTable("tpch", tableName);
-        assertTrue(table.isPresent(), "Table should exist");
+        assertThat(table).as("Table should exist").isPresent();
         String tableInitialLocation = table.get().getStorage().getLocation();
 
         assertQuerySucceeds(format("ALTER TABLE %s RENAME TO %s", tableName, renamedName));
         Optional<Table> renamedTable = metastore.getTable("tpch", renamedName);
-        assertTrue(renamedTable.isPresent(), "Table should exist");
+        assertThat(renamedTable).as("Table should exist").isPresent();
         String renamedTableLocation = renamedTable.get().getStorage().getLocation();
         assertEquals(renamedTableLocation, tableInitialLocation, "Location should not be changed");
 
         assertQuerySucceeds(format("DROP TABLE %s", renamedName));
-        assertFalse(metastore.getTable("tpch", tableName).isPresent(), "Initial table should not exists");
-        assertFalse(metastore.getTable("tpch", renamedName).isPresent(), "Renamed table should be dropped");
+        assertThat(metastore.getTable("tpch", tableName)).as("Initial table should not exist").isEmpty();
+        assertThat(metastore.getTable("tpch", renamedName)).as("Renamed table should be dropped").isEmpty();
     }
 
     @Test
@@ -152,18 +152,18 @@ public class TestIcebergTableWithCustomLocation
         String renamedName = "test_create_rename_create_renamed";
         assertQuerySucceeds(format("CREATE TABLE %s as select 1 as val", tableName));
         Optional<Table> table = metastore.getTable("tpch", tableName);
-        assertTrue(table.isPresent(), "Table should exist");
+        assertThat(table).as("Table should exist").isPresent();
         String tableInitialLocation = table.get().getStorage().getLocation();
 
         assertQuerySucceeds(format("ALTER TABLE %s RENAME TO %s", tableName, renamedName));
         Optional<Table> renamedTable = metastore.getTable("tpch", renamedName);
-        assertTrue(renamedTable.isPresent(), "Table should exist");
+        assertThat(renamedTable).as("Table should exist").isPresent();
         String renamedTableLocation = renamedTable.get().getStorage().getLocation();
         assertEquals(renamedTableLocation, tableInitialLocation, "Location should not be changed");
 
         assertQuerySucceeds(format("CREATE TABLE %s as select 1 as val", tableName));
         Optional<Table> recreatedTableWithInitialName = metastore.getTable("tpch", tableName);
-        assertTrue(recreatedTableWithInitialName.isPresent(), "Table should exist");
+        assertThat(recreatedTableWithInitialName).as("Table should exist").isPresent();
         String recreatedTableLocation = recreatedTableWithInitialName.get().getStorage().getLocation();
         assertNotEquals(tableInitialLocation, recreatedTableLocation, "Location should be different");
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergTableWithExternalLocation.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergTableWithExternalLocation.java
@@ -109,7 +109,7 @@ public class TestIcebergTableWithExternalLocation
         assertTrue(fileSystem.exists(new Path(dataFile.getFilePath())), "The data file should exist");
 
         assertQuerySucceeds(format("DROP TABLE %s", tableName));
-        assertFalse(metastore.getTable("tpch", tableName).isPresent(), "Table should be dropped");
+        assertThat(metastore.getTable("tpch", tableName)).as("Table should be dropped").isEmpty();
         assertFalse(fileSystem.exists(new Path(dataFile.getFilePath())), "The data file should have been removed");
         assertFalse(fileSystem.exists(tableLocation), "The directory corresponding to the dropped Iceberg table should not be removed because it may be shared with other tables");
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestMetricsWrapper.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestMetricsWrapper.java
@@ -29,8 +29,8 @@ import java.util.Set;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.json.JsonCodec.jsonCodec;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 public class TestMetricsWrapper
 {
@@ -66,7 +66,7 @@ public class TestMetricsWrapper
         Set<String> properties = getJsonProperties(MetricsWrapper.class);
         for (Method method : Metrics.class.getMethods()) {
             if (method.getDeclaringClass().equals(Method.class)) {
-                assertTrue(properties.contains(method.getName()), "Metrics method not in wrapper: " + method);
+                assertThat(properties).contains(method.getName());
             }
         }
     }


### PR DESCRIPTION
The reason for these improvements is because the AssertJ assertions generally
provide the actual values when an assertion fails.
This helps a lot when understanding why something failed on CI, while
`assertTrue`/`assertFalse` checks don't provide that kind of information
