### PR TITLE
Enable failure recovery for Delta connector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,6 +383,7 @@ jobs:
             - { modules: plugin/trino-cassandra }
             - { modules: plugin/trino-clickhouse }
             - { modules: plugin/trino-delta-lake }
+            - { modules: plugin/trino-delta-lake, profile: test-failure-recovery }
             - { modules: plugin/trino-hive }
             - { modules: plugin/trino-hive, profile: test-parquet }
             - { modules: plugin/trino-hive, profile: test-failure-recovery }

--- a/plugin/trino-delta-lake/pom.xml
+++ b/plugin/trino-delta-lake/pom.xml
@@ -197,6 +197,18 @@
         </dependency>
 
         <!-- for testing -->
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-exchange</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-exchange</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>io.trino</groupId>
@@ -240,6 +252,12 @@
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing-containers</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -289,6 +307,18 @@
             <artifactId>azure-storage-blob</artifactId>
             <version>12.10.0</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <!-- conflicts with newer version of netty coming from AWS S3 cli via trino-exchange -->
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-classes-epoll</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- conflicts with newer version of netty coming from AWS S3 cli via trino-exchange -->
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-native-epoll</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -380,7 +410,20 @@
                                 <exclude>**/TestDeltaLakeAdlsStorage.java</exclude>
                                 <exclude>**/TestDeltaLakeAdlsConnectorSmokeTest.java</exclude>
                                 <exclude>**/TestDeltaLakeGlueMetastore.java</exclude>
+                                <exclude>**/TestDelta*FailureRecoveryTest.java</exclude>
                             </excludes>
+                        </configuration>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.basepom.maven</groupId>
+                        <artifactId>duplicate-finder-maven-plugin</artifactId>
+                        <configuration>
+                            <ignoredResourcePatterns>
+                                <!-- com.amazonaws:aws-java-sdk-core and software.amazon.awssdk:sdk-core MIME type file duplicate-->
+                                <ignoredResourcePattern>mime.types</ignoredResourcePattern>
+                                <ignoredResourcePattern>about.html</ignoredResourcePattern>
+                            </ignoredResourcePatterns>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -405,5 +448,25 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <id>test-failure-recovery</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <!-- Failure recovery tests spend most of the time waiting for a retry -->
+                            <threadCount>4</threadCount>
+                            <includes>
+                                <include>**/TestDelta*FailureRecoveryTest.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
     </profiles>
 </project>

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeColumnHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeColumnHandle.java
@@ -18,10 +18,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.type.Type;
+import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
 import java.util.Optional;
 
+import static io.airlift.slice.SizeOf.estimatedSizeOf;
 import static io.trino.plugin.deltalake.DeltaHiveTypeTranslator.toHiveType;
 import static io.trino.plugin.deltalake.DeltaLakeColumnType.SYNTHESIZED;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -32,6 +34,8 @@ import static java.util.Objects.requireNonNull;
 public class DeltaLakeColumnHandle
         implements ColumnHandle
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(DeltaLakeColumnHandle.class).instanceSize();
+
     public static final String ROW_ID_COLUMN_NAME = "$row_id";
     public static final Type ROW_ID_COLUMN_TYPE = BIGINT;
 
@@ -90,6 +94,12 @@ public class DeltaLakeColumnHandle
         return Objects.equals(this.name, other.name) &&
                 Objects.equals(this.type, other.type) &&
                 this.columnType == other.columnType;
+    }
+
+    public long getRetainedSizeInBytes()
+    {
+        // type is not accounted for as the instances are cached (by TypeRegistry) and shared
+        return INSTANCE_SIZE + estimatedSizeOf(name);
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeInsertTableHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeInsertTableHandle.java
@@ -32,6 +32,7 @@ public class DeltaLakeInsertTableHandle
     private final MetadataEntry metadataEntry;
     private final List<DeltaLakeColumnHandle> inputColumns;
     private final long readVersion;
+    private final boolean retriesEnabled;
 
     @JsonCreator
     public DeltaLakeInsertTableHandle(
@@ -40,7 +41,8 @@ public class DeltaLakeInsertTableHandle
             @JsonProperty("location") String location,
             @JsonProperty("metadataEntry") MetadataEntry metadataEntry,
             @JsonProperty("inputColumns") List<DeltaLakeColumnHandle> inputColumns,
-            @JsonProperty("readVersion") long readVersion)
+            @JsonProperty("readVersion") long readVersion,
+            @JsonProperty("retriesEnabled") boolean retriesEnabled)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -48,6 +50,7 @@ public class DeltaLakeInsertTableHandle
         this.inputColumns = ImmutableList.copyOf(inputColumns);
         this.location = requireNonNull(location, "location is null");
         this.readVersion = readVersion;
+        this.retriesEnabled = retriesEnabled;
     }
 
     @JsonProperty
@@ -84,5 +87,11 @@ public class DeltaLakeInsertTableHandle
     public long getReadVersion()
     {
         return readVersion;
+    }
+
+    @JsonProperty
+    public boolean isRetriesEnabled()
+    {
+        return retriesEnabled;
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -74,6 +74,7 @@ import io.trino.spi.connector.ConnectorTableProperties;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.ConstraintApplicationResult;
 import io.trino.spi.connector.ProjectionApplicationResult;
+import io.trino.spi.connector.RetryMode;
 import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
@@ -99,6 +100,7 @@ import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.VarcharType;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 
@@ -107,9 +109,12 @@ import javax.annotation.Nullable;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -167,6 +172,7 @@ import static io.trino.spi.StandardErrorCode.INVALID_ANALYZE_PROPERTY;
 import static io.trino.spi.StandardErrorCode.INVALID_SCHEMA_PROPERTY;
 import static io.trino.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.connector.RetryMode.NO_RETRIES;
 import static io.trino.spi.connector.SchemaTableName.schemaTableName;
 import static io.trino.spi.predicate.Range.greaterThanOrEqual;
 import static io.trino.spi.predicate.Range.lessThanOrEqual;
@@ -345,7 +351,8 @@ public class DeltaLakeMetadata
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                tableSnapshot.getVersion());
+                tableSnapshot.getVersion(),
+                false);
     }
 
     @Override
@@ -675,7 +682,7 @@ public class DeltaLakeMetadata
     }
 
     @Override
-    public DeltaLakeOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, Optional<ConnectorTableLayout> layout)
+    public DeltaLakeOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, Optional<ConnectorTableLayout> layout, RetryMode retryMode)
     {
         validateTableColumns(tableMetadata);
 
@@ -941,7 +948,7 @@ public class DeltaLakeMetadata
     }
 
     @Override
-    public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> columns)
+    public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> columns, RetryMode retryMode)
     {
         DeltaLakeTableHandle table = (DeltaLakeTableHandle) tableHandle;
         if (!allowWrite(session, table)) {
@@ -968,7 +975,8 @@ public class DeltaLakeMetadata
                     tableLocation,
                     table.getMetadataEntry(),
                     inputColumns,
-                    getMandatoryCurrentVersion(fileSystem, new Path(tableLocation)));
+                    getMandatoryCurrentVersion(fileSystem, new Path(tableLocation)),
+                    retryMode != NO_RETRIES);
         }
         catch (IOException e) {
             throw new TrinoException(GENERIC_INTERNAL_ERROR, e);
@@ -1002,6 +1010,10 @@ public class DeltaLakeMetadata
                 .map(Slice::getBytes)
                 .map(dataFileInfoCodec::fromJson)
                 .collect(toImmutableList());
+
+        if (handle.isRetriesEnabled()) {
+            cleanExtraOutputFiles(session, handle.getLocation(), dataFileInfos);
+        }
 
         boolean writeCommitted = false;
         try {
@@ -1058,7 +1070,7 @@ public class DeltaLakeMetadata
     }
 
     @Override
-    public ConnectorTableHandle beginDelete(ConnectorSession session, ConnectorTableHandle tableHandle)
+    public ConnectorTableHandle beginDelete(ConnectorSession session, ConnectorTableHandle tableHandle, RetryMode retryMode)
     {
         DeltaLakeTableHandle handle = (DeltaLakeTableHandle) tableHandle;
         if (!allowWrite(session, handle)) {
@@ -1075,7 +1087,8 @@ public class DeltaLakeMetadata
                 handle.getEnforcedPartitionConstraint(),
                 handle.getNonPartitionConstraint(),
                 handle.getProjectedColumns(),
-                handle.getReadVersion());
+                handle.getReadVersion(),
+                retryMode != NO_RETRIES);
     }
 
     @Override
@@ -1109,7 +1122,7 @@ public class DeltaLakeMetadata
     }
 
     @Override
-    public ConnectorTableHandle beginUpdate(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> updatedColumns)
+    public ConnectorTableHandle beginUpdate(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> updatedColumns, RetryMode retryMode)
     {
         DeltaLakeTableHandle handle = (DeltaLakeTableHandle) tableHandle;
         if (!allowWrite(session, handle)) {
@@ -1141,7 +1154,8 @@ public class DeltaLakeMetadata
                 handle.getProjectedColumns(),
                 updatedColumnHandles,
                 unmodifiedColumns,
-                handle.getReadVersion());
+                handle.getReadVersion(),
+                retryMode != NO_RETRIES);
     }
 
     @Override
@@ -1155,7 +1169,8 @@ public class DeltaLakeMetadata
             ConnectorSession session,
             ConnectorTableHandle connectorTableHandle,
             String procedureName,
-            Map<String, Object> executeProperties)
+            Map<String, Object> executeProperties,
+            RetryMode retryMode)
     {
         DeltaLakeTableHandle tableHandle = (DeltaLakeTableHandle) connectorTableHandle;
 
@@ -1169,13 +1184,13 @@ public class DeltaLakeMetadata
 
         switch (procedureId) {
             case OPTIMIZE:
-                return getTableHandleForOptimize(tableHandle, executeProperties);
+                return getTableHandleForOptimize(tableHandle, executeProperties, retryMode);
         }
 
         throw new IllegalArgumentException("Unknown procedure: " + procedureId);
     }
 
-    private Optional<ConnectorTableExecuteHandle> getTableHandleForOptimize(DeltaLakeTableHandle tableHandle, Map<String, Object> executeProperties)
+    private Optional<ConnectorTableExecuteHandle> getTableHandleForOptimize(DeltaLakeTableHandle tableHandle, Map<String, Object> executeProperties, RetryMode retryMode)
     {
         DataSize maxScannedFileSize = (DataSize) executeProperties.get("file_size_threshold");
 
@@ -1191,7 +1206,8 @@ public class DeltaLakeMetadata
                         columns,
                         tableHandle.getMetadataEntry().getOriginalPartitionColumns(),
                         maxScannedFileSize,
-                        Optional.empty()),
+                        Optional.empty(),
+                        retryMode != NO_RETRIES),
                 tableHandle.getLocation()));
     }
 
@@ -1286,6 +1302,10 @@ public class DeltaLakeMetadata
                 .map(dataFileInfoCodec::fromJson)
                 .collect(toImmutableList());
 
+        if (optimizeHandle.isRetriesEnabled()) {
+            cleanExtraOutputFiles(session, executeHandle.getTableLocation(), dataFileInfos);
+        }
+
         boolean writeCommitted = false;
         try {
             TransactionLogWriter transactionLogWriter = transactionLogWriterFactory.newWriter(session, tableLocation);
@@ -1371,6 +1391,10 @@ public class DeltaLakeMetadata
                 .map(Slice::getBytes)
                 .map(deleteResultJsonCodec::fromJson)
                 .collect(toImmutableList());
+
+        if (handle.isRetriesEnabled()) {
+            cleanExtraOutputFilesForUpdate(session, handle.getLocation(), updateResults);
+        }
 
         String tableLocation = metastore.getTableLocation(handle.getSchemaTableName(), session);
 
@@ -1589,7 +1613,8 @@ public class DeltaLakeMetadata
                 tableHandle.getUpdatedColumns(),
                 tableHandle.getUpdateRowIdColumns(),
                 Optional.empty(),
-                tableHandle.getReadVersion());
+                tableHandle.getReadVersion(),
+                tableHandle.isRetriesEnabled());
 
         if (tableHandle.getEnforcedPartitionConstraint().equals(newHandle.getEnforcedPartitionConstraint()) &&
                 tableHandle.getNonPartitionConstraint().equals(newHandle.getNonPartitionConstraint())) {
@@ -1710,7 +1735,8 @@ public class DeltaLakeMetadata
                 Optional.empty(),
                 Optional.empty(),
                 Optional.of(analyzeHandle),
-                version);
+                version,
+                false);
     }
 
     @Override
@@ -1812,6 +1838,96 @@ public class DeltaLakeMetadata
                 analyzeHandle.getColumns());
 
         statisticsAccess.updateDeltaLakeStatistics(session, location, mergedDeltaLakeStatistics);
+    }
+
+    private void cleanExtraOutputFiles(ConnectorSession session, String baseLocation, List<DataFileInfo> validDataFiles)
+    {
+        Set<String> writtenFilePaths = validDataFiles.stream()
+                .map(dataFileInfo -> baseLocation + "/" + dataFileInfo.getPath())
+                .collect(toImmutableSet());
+
+        cleanExtraOutputFiles(session, writtenFilePaths);
+    }
+
+    private void cleanExtraOutputFilesForUpdate(ConnectorSession session, String baseLocation, List<DeltaLakeUpdateResult> validUpdateResults)
+    {
+        Set<String> writtenFilePaths = validUpdateResults.stream()
+                .map(DeltaLakeUpdateResult::getNewFile)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .map(dataFileInfo -> baseLocation + "/" + dataFileInfo.getPath())
+                .collect(toImmutableSet());
+
+        cleanExtraOutputFiles(session, writtenFilePaths);
+    }
+
+    private void cleanExtraOutputFiles(ConnectorSession session, Set<String> validWrittenFilePaths)
+    {
+        HdfsContext hdfsContext = new HdfsContext(session);
+
+        Set<String> fileLocations = validWrittenFilePaths.stream()
+                .map(path -> {
+                    int fileNameSeparatorPos = path.lastIndexOf("/");
+                    verify(fileNameSeparatorPos != -1 && fileNameSeparatorPos != 0, "invalid data file path: %s", path);
+                    return path.substring(0, fileNameSeparatorPos);
+                })
+                .collect(toImmutableSet());
+
+        for (String location : fileLocations) {
+            cleanExtraOutputFiles(hdfsContext, session.getQueryId(), location, validWrittenFilePaths);
+        }
+    }
+
+    private void cleanExtraOutputFiles(HdfsContext hdfsContext, String queryId, String location, Set<String> filesToKeep)
+    {
+        Deque<String> filesToDelete = new ArrayDeque<>();
+        try {
+            LOG.debug("Deleting failed attempt files from %s for query %s", location, queryId);
+            FileSystem fileSystem = hdfsEnvironment.getFileSystem(hdfsContext, new Path(location));
+            if (!fileSystem.exists(new Path(location))) {
+                // directory may not exist if no files were actually written
+                return;
+            }
+
+            // files within given partition are written flat into location; we need to list recursively
+            RemoteIterator<LocatedFileStatus> iterator = fileSystem.listFiles(new Path(location), false);
+            while (iterator.hasNext()) {
+                Path file = iterator.next().getPath();
+                if (isFileCreatedByQuery(file.getName(), queryId) && !filesToKeep.contains(location + "/" + file.getName())) {
+                    filesToDelete.add(file.getName());
+                }
+            }
+
+            if (filesToDelete.isEmpty()) {
+                return;
+            }
+
+            LOG.info("Found %s files to delete and %s to retain in location %s for query %s", filesToDelete.size(), filesToKeep.size(), location, queryId);
+            ImmutableList.Builder<String> deletedFilesBuilder = ImmutableList.builder();
+            Iterator<String> filesToDeleteIterator = filesToDelete.iterator();
+            while (filesToDeleteIterator.hasNext()) {
+                String fileName = filesToDeleteIterator.next();
+                LOG.debug("Deleting failed attempt file %s/%s for query %s", location, fileName, queryId);
+                fileSystem.delete(new Path(location, fileName), false);
+                deletedFilesBuilder.add(fileName);
+                filesToDeleteIterator.remove();
+            }
+
+            List<String> deletedFiles = deletedFilesBuilder.build();
+            if (!deletedFiles.isEmpty()) {
+                LOG.info("Deleted failed attempt files %s from %s for query %s", deletedFiles, location, queryId);
+            }
+        }
+        catch (IOException e) {
+            throw new TrinoException(GENERIC_INTERNAL_ERROR,
+                    format("Could not clean up extraneous output files; remaining files: %s", filesToDelete), e);
+        }
+    }
+
+    private boolean isFileCreatedByQuery(String fileName, String queryId)
+    {
+        verify(!queryId.contains("-"), "queryId(%s) should not contain hyphens", queryId);
+        return fileName.startsWith(queryId + "-");
     }
 
     private static Map<String, DeltaLakeColumnStatistics> toDeltaLakeColumnStatistics(Collection<ComputedStatistics> computedStatistics)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSink.java
@@ -375,7 +375,7 @@ public class DeltaLakePageSink
                 partitionName = Optional.of(partName);
             }
 
-            String fileName = randomUUID().toString();
+            String fileName = session.getQueryId() + "-" + randomUUID();
             filePath = new Path(filePath, fileName);
 
             FileWriter fileWriter;

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTableHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTableHandle.java
@@ -52,6 +52,7 @@ public class DeltaLakeTableHandle
     private final TupleDomain<DeltaLakeColumnHandle> nonPartitionConstraint;
     private final Optional<WriteType> writeType;
     private final long readVersion;
+    private final boolean retriesEnabled;
 
     private final Optional<Set<ColumnHandle>> projectedColumns;
     // UPDATE only: The list of columns being updated
@@ -79,7 +80,8 @@ public class DeltaLakeTableHandle
             @JsonProperty("updatedColumns") Optional<List<DeltaLakeColumnHandle>> updatedColumns,
             @JsonProperty("updateRowIdColumns") Optional<List<DeltaLakeColumnHandle>> updateRowIdColumns,
             @JsonProperty("analyzeHandle") Optional<AnalyzeHandle> analyzeHandle,
-            @JsonProperty("readVersion") long readVersion)
+            @JsonProperty("readVersion") long readVersion,
+            @JsonProperty("retriesEnabled") boolean retriesEnabled)
     {
         this(
                 schemaName,
@@ -95,7 +97,8 @@ public class DeltaLakeTableHandle
                 analyzeHandle,
                 false,
                 Optional.empty(),
-                readVersion);
+                readVersion,
+                retriesEnabled);
     }
 
     public DeltaLakeTableHandle(
@@ -112,7 +115,8 @@ public class DeltaLakeTableHandle
             Optional<AnalyzeHandle> analyzeHandle,
             boolean recordScannedFiles,
             Optional<DataSize> maxScannedFileSize,
-            long readVersion)
+            long readVersion,
+            boolean retriesEnabled)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -130,6 +134,7 @@ public class DeltaLakeTableHandle
         this.recordScannedFiles = recordScannedFiles;
         this.maxScannedFileSize = requireNonNull(maxScannedFileSize, "maxScannedFileSize is null");
         this.readVersion = readVersion;
+        this.retriesEnabled = retriesEnabled;
     }
 
     public static DeltaLakeTableHandle forDelete(
@@ -140,7 +145,8 @@ public class DeltaLakeTableHandle
             TupleDomain<DeltaLakeColumnHandle> enforcedConstraint,
             TupleDomain<DeltaLakeColumnHandle> unenforcedConstraint,
             Optional<Set<ColumnHandle>> projectedColumns,
-            long readVersion)
+            long readVersion,
+            boolean retriesEnabled)
     {
         return new DeltaLakeTableHandle(
                 schemaName,
@@ -154,7 +160,8 @@ public class DeltaLakeTableHandle
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                readVersion);
+                readVersion,
+                retriesEnabled);
     }
 
     public static DeltaLakeTableHandle forUpdate(
@@ -167,7 +174,8 @@ public class DeltaLakeTableHandle
             Optional<Set<ColumnHandle>> projectedColumns,
             List<DeltaLakeColumnHandle> updatedColumns,
             List<DeltaLakeColumnHandle> updateRowIdColumns,
-            long readVersion)
+            long readVersion,
+            boolean retriesEnabled)
     {
         checkArgument(!updatedColumns.isEmpty(), "Update must specify at least one column to set");
         return new DeltaLakeTableHandle(
@@ -182,7 +190,8 @@ public class DeltaLakeTableHandle
                 Optional.of(updatedColumns),
                 Optional.of(updateRowIdColumns),
                 Optional.empty(),
-                readVersion);
+                readVersion,
+                retriesEnabled);
     }
 
     public DeltaLakeTableHandle withProjectedColumns(Set<ColumnHandle> projectedColumns)
@@ -199,7 +208,8 @@ public class DeltaLakeTableHandle
                 getUpdatedColumns(),
                 getUpdateRowIdColumns(),
                 getAnalyzeHandle(),
-                getReadVersion());
+                getReadVersion(),
+                isRetriesEnabled());
     }
 
     public DeltaLakeTableHandle forOptimize(boolean recordScannedFiles, DataSize maxScannedFileSize)
@@ -218,7 +228,8 @@ public class DeltaLakeTableHandle
                 analyzeHandle,
                 recordScannedFiles,
                 Optional.of(maxScannedFileSize),
-                readVersion);
+                readVersion,
+                false);
     }
 
     @JsonProperty
@@ -306,6 +317,12 @@ public class DeltaLakeTableHandle
         return readVersion;
     }
 
+    @JsonProperty
+    public boolean isRetriesEnabled()
+    {
+        return retriesEnabled;
+    }
+
     public SchemaTableName getSchemaTableName()
     {
         return new SchemaTableName(schemaName, tableName);
@@ -341,7 +358,8 @@ public class DeltaLakeTableHandle
                 Objects.equals(updateRowIdColumns, that.updateRowIdColumns) &&
                 Objects.equals(analyzeHandle, that.analyzeHandle) &&
                 Objects.equals(maxScannedFileSize, that.maxScannedFileSize) &&
-                readVersion == that.readVersion;
+                readVersion == that.readVersion &&
+                retriesEnabled == that.retriesEnabled;
     }
 
     @Override
@@ -361,6 +379,7 @@ public class DeltaLakeTableHandle
                 analyzeHandle,
                 recordScannedFiles,
                 maxScannedFileSize,
-                readVersion);
+                readVersion,
+                retriesEnabled);
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/DeltaTableOptimizeHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/DeltaTableOptimizeHandle.java
@@ -34,6 +34,7 @@ public class DeltaTableOptimizeHandle
     private final List<String> originalPartitionColumns;
     private final DataSize maxScannedFileSize;
     private final Optional<Long> currentVersion;
+    private final boolean retriesEnabled;
 
     @JsonCreator
     public DeltaTableOptimizeHandle(
@@ -41,13 +42,15 @@ public class DeltaTableOptimizeHandle
             List<DeltaLakeColumnHandle> tableColumns,
             List<String> originalPartitionColumns,
             DataSize maxScannedFileSize,
-            Optional<Long> currentVersion)
+            Optional<Long> currentVersion,
+            boolean retriesEnabled)
     {
         this.metadataEntry = requireNonNull(metadataEntry, "metadataEntry is null");
         this.tableColumns = ImmutableList.copyOf(requireNonNull(tableColumns, "tableColumns is null"));
         this.originalPartitionColumns = ImmutableList.copyOf(requireNonNull(originalPartitionColumns, "originalPartitionColumns is null"));
         this.maxScannedFileSize = requireNonNull(maxScannedFileSize, "maxScannedFileSize is null");
         this.currentVersion = requireNonNull(currentVersion, "currentVersion is null");
+        this.retriesEnabled = retriesEnabled;
     }
 
     public DeltaTableOptimizeHandle withCurrentVersion(long currentVersion)
@@ -58,7 +61,8 @@ public class DeltaTableOptimizeHandle
                 tableColumns,
                 originalPartitionColumns,
                 maxScannedFileSize,
-                Optional.of(currentVersion));
+                Optional.of(currentVersion),
+                retriesEnabled);
     }
 
     @JsonProperty
@@ -92,5 +96,11 @@ public class DeltaTableOptimizeHandle
     public DataSize getMaxScannedFileSize()
     {
         return maxScannedFileSize;
+    }
+
+    @JsonProperty
+    public boolean isRetriesEnabled()
+    {
+        return retriesEnabled;
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaFailureRecoveryTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaFailureRecoveryTest.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import io.trino.operator.RetryPolicy;
+import io.trino.spi.ErrorType;
+import io.trino.testing.BaseFailureRecoveryTest;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.execution.FailureInjector.FAILURE_INJECTION_MESSAGE;
+import static io.trino.execution.FailureInjector.InjectedFailureType.TASK_FAILURE;
+import static io.trino.execution.FailureInjector.InjectedFailureType.TASK_GET_RESULTS_REQUEST_FAILURE;
+import static io.trino.execution.FailureInjector.InjectedFailureType.TASK_GET_RESULTS_REQUEST_TIMEOUT;
+import static io.trino.execution.FailureInjector.InjectedFailureType.TASK_MANAGEMENT_REQUEST_FAILURE;
+import static io.trino.execution.FailureInjector.InjectedFailureType.TASK_MANAGEMENT_REQUEST_TIMEOUT;
+import static java.lang.String.format;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+public abstract class BaseDeltaFailureRecoveryTest
+        extends BaseFailureRecoveryTest
+{
+    protected BaseDeltaFailureRecoveryTest(RetryPolicy retryPolicy)
+    {
+        super(retryPolicy);
+    }
+
+    @Override
+    protected boolean areWriteRetriesSupported()
+    {
+        return true;
+    }
+
+    @Override
+    public void testDelete()
+    {
+        // Test method is overriden because method from superclass assumes more complex plan for `DELETE` query.
+        // Assertions do not play well if plan consists of just two fragments.
+
+        Optional<String> setupQuery = Optional.of("CREATE TABLE <table> AS SELECT * FROM orders");
+        Optional<String> cleanupQuery = Optional.of("DROP TABLE <table>");
+        String deleteQuery = "DELETE FROM <table> WHERE orderkey = 1";
+
+        assertThatQuery(deleteQuery)
+                .withSetupQuery(setupQuery)
+                .withCleanupQuery(cleanupQuery)
+                .experiencing(TASK_FAILURE, Optional.of(ErrorType.INTERNAL_ERROR))
+                .at(boundaryCoordinatorStage())
+                .failsAlways(failure -> failure.hasMessageContaining(FAILURE_INJECTION_MESSAGE));
+
+        assertThatQuery(deleteQuery)
+                .withSetupQuery(setupQuery)
+                .withCleanupQuery(cleanupQuery)
+                .experiencing(TASK_FAILURE, Optional.of(ErrorType.INTERNAL_ERROR))
+                .at(rootStage())
+                .failsAlways(failure -> failure.hasMessageContaining(FAILURE_INJECTION_MESSAGE));
+
+        assertThatQuery(deleteQuery)
+                .withSetupQuery(setupQuery)
+                .withCleanupQuery(cleanupQuery)
+                .experiencing(TASK_FAILURE, Optional.of(ErrorType.INTERNAL_ERROR))
+                .at(leafStage())
+                .failsWithoutRetries(failure -> failure.hasMessageContaining(FAILURE_INJECTION_MESSAGE))
+                .finishesSuccessfully();
+
+        // note: this is effectively same as test with `leafStage`. Should it be dropped?
+        assertThatQuery(deleteQuery)
+                .withSetupQuery(setupQuery)
+                .withCleanupQuery(cleanupQuery)
+                .experiencing(TASK_FAILURE, Optional.of(ErrorType.INTERNAL_ERROR))
+                .at(boundaryDistributedStage())
+                .failsWithoutRetries(failure -> failure.hasMessageContaining(FAILURE_INJECTION_MESSAGE))
+                .finishesSuccessfully();
+
+        // DELETE plan is too simplistic for testing with `intermediateDistributedStage`
+        assertThatThrownBy(() ->
+                assertThatQuery(deleteQuery)
+                        .withSetupQuery(setupQuery)
+                        .withCleanupQuery(cleanupQuery)
+                        .experiencing(TASK_FAILURE, Optional.of(ErrorType.INTERNAL_ERROR))
+                        .at(intermediateDistributedStage())
+                        .failsWithoutRetries(failure -> failure.hasMessageContaining(FAILURE_INJECTION_MESSAGE)))
+                .hasMessageContaining("stage not found");
+
+        assertThatQuery(deleteQuery)
+                .withSetupQuery(setupQuery)
+                .withCleanupQuery(cleanupQuery)
+                .experiencing(TASK_MANAGEMENT_REQUEST_FAILURE)
+                .at(boundaryDistributedStage())
+                .failsWithoutRetries(failure -> failure.hasMessageFindingMatch("Error 500 Internal Server Error|Error closing remote buffer, expected 204 got 500"))
+                .finishesSuccessfully();
+
+        assertThatQuery(deleteQuery)
+                .withSetupQuery(setupQuery)
+                .withCleanupQuery(cleanupQuery)
+                .experiencing(TASK_GET_RESULTS_REQUEST_FAILURE)
+                .at(boundaryDistributedStage())
+                .failsWithoutRetries(failure -> failure.hasMessageFindingMatch("Error 500 Internal Server Error|Error closing remote buffer, expected 204 got 500"))
+                .finishesSuccessfully();
+
+        assertThatQuery(deleteQuery)
+                .withSetupQuery(setupQuery)
+                .withCleanupQuery(cleanupQuery)
+                .experiencing(TASK_MANAGEMENT_REQUEST_TIMEOUT)
+                .at(boundaryDistributedStage())
+                .failsWithoutRetries(failure -> failure.hasMessageContaining("Encountered too many errors talking to a worker node"))
+                .finishesSuccessfully();
+
+        assertThatQuery(deleteQuery)
+                .withSetupQuery(setupQuery)
+                .withCleanupQuery(cleanupQuery)
+                .experiencing(TASK_GET_RESULTS_REQUEST_TIMEOUT)
+                .at(boundaryDistributedStage())
+                .failsWithoutRetries(failure -> failure.hasMessageContaining("Encountered too many errors talking to a worker node"))
+                .finishesSuccessfully();
+    }
+
+    @Override
+    public void testUpdate()
+    {
+        // Test method is overriden because method from superclass assumes more complex plan for `UPDATE` query.
+        // Assertions do not play well if plan consists of just two fragments.
+
+        Optional<String> setupQuery = Optional.of("CREATE TABLE <table> AS SELECT * FROM orders");
+        Optional<String> cleanupQuery = Optional.of("DROP TABLE <table>");
+        String updateQuery = "UPDATE <table> SET shippriority = 101 WHERE custkey = 1";
+
+        assertThatQuery(updateQuery)
+                .withSetupQuery(setupQuery)
+                .withCleanupQuery(cleanupQuery)
+                .experiencing(TASK_FAILURE, Optional.of(ErrorType.INTERNAL_ERROR))
+                .at(boundaryCoordinatorStage())
+                .failsAlways(failure -> failure.hasMessageContaining(FAILURE_INJECTION_MESSAGE));
+
+        assertThatQuery(updateQuery)
+                .withSetupQuery(setupQuery)
+                .withCleanupQuery(cleanupQuery)
+                .experiencing(TASK_FAILURE, Optional.of(ErrorType.INTERNAL_ERROR))
+                .at(rootStage())
+                .failsAlways(failure -> failure.hasMessageContaining(FAILURE_INJECTION_MESSAGE));
+
+        assertThatQuery(updateQuery)
+                .withSetupQuery(setupQuery)
+                .withCleanupQuery(cleanupQuery)
+                .experiencing(TASK_FAILURE, Optional.of(ErrorType.INTERNAL_ERROR))
+                .at(leafStage())
+                .failsWithoutRetries(failure -> failure.hasMessageContaining(FAILURE_INJECTION_MESSAGE))
+                .finishesSuccessfully();
+
+        assertThatQuery(updateQuery)
+                .withSetupQuery(setupQuery)
+                .withCleanupQuery(cleanupQuery)
+                .experiencing(TASK_FAILURE, Optional.of(ErrorType.INTERNAL_ERROR))
+                .at(boundaryDistributedStage())
+                .failsWithoutRetries(failure -> failure.hasMessageContaining(FAILURE_INJECTION_MESSAGE))
+                .finishesSuccessfully();
+
+        // UPDATE plan is too simplistic for testing with `intermediateDistributedStage`
+        assertThatThrownBy(() ->
+                assertThatQuery(updateQuery)
+                        .withSetupQuery(setupQuery)
+                        .withCleanupQuery(cleanupQuery)
+                        .experiencing(TASK_FAILURE, Optional.of(ErrorType.INTERNAL_ERROR))
+                        .at(intermediateDistributedStage())
+                        .failsWithoutRetries(failure -> failure.hasMessageContaining(FAILURE_INJECTION_MESSAGE)))
+                .hasMessageContaining("stage not found");
+
+        assertThatQuery(updateQuery)
+                .withSetupQuery(setupQuery)
+                .withCleanupQuery(cleanupQuery)
+                .experiencing(TASK_MANAGEMENT_REQUEST_FAILURE)
+                .at(boundaryDistributedStage())
+                .failsWithoutRetries(failure -> failure.hasMessageFindingMatch("Error 500 Internal Server Error|Error closing remote buffer, expected 204 got 500"))
+                .finishesSuccessfully();
+
+        assertThatQuery(updateQuery)
+                .withSetupQuery(setupQuery)
+                .withCleanupQuery(cleanupQuery)
+                .experiencing(TASK_GET_RESULTS_REQUEST_FAILURE)
+                .at(boundaryDistributedStage())
+                .failsWithoutRetries(failure -> failure.hasMessageFindingMatch("Error 500 Internal Server Error|Error closing remote buffer, expected 204 got 500"))
+                .finishesSuccessfully();
+
+        assertThatQuery(updateQuery)
+                .withSetupQuery(setupQuery)
+                .withCleanupQuery(cleanupQuery)
+                .experiencing(TASK_MANAGEMENT_REQUEST_TIMEOUT)
+                .at(boundaryDistributedStage())
+                .failsWithoutRetries(failure -> failure.hasMessageContaining("Encountered too many errors talking to a worker node"))
+                .finishesSuccessfully();
+
+        assertThatQuery(updateQuery)
+                .withSetupQuery(setupQuery)
+                .withCleanupQuery(cleanupQuery)
+                .experiencing(TASK_GET_RESULTS_REQUEST_TIMEOUT)
+                .at(boundaryDistributedStage())
+                .failsWithoutRetries(failure -> failure.hasMessageContaining("Encountered too many errors talking to a worker node"))
+                .finishesSuccessfully();
+    }
+
+    @Override
+    // materialized views are currently not implemented by Delta connector
+    public void testRefreshMaterializedView()
+    {
+        assertThatThrownBy(super::testRefreshMaterializedView)
+                .hasMessageContaining("This connector does not support creating materialized views");
+    }
+
+    @Override
+    protected void createPartitionedLineitemTable(String tableName, List<String> columns, String partitionColumn)
+    {
+        String sql = format(
+                "CREATE TABLE %s WITH (partitioned_by = array['%s']) AS SELECT %s FROM tpch.tiny.lineitem",
+                tableName,
+                partitionColumn,
+                String.join(",", columns));
+        getQueryRunner().execute(sql);
+    }
+
+    @Test(invocationCount = INVOCATION_COUNT)
+    public void testCreatePartitionedTable()
+    {
+        testTableModification(
+                Optional.empty(),
+                "CREATE TABLE <table> WITH (partitioned_by = ARRAY['p']) AS SELECT *, 'partition1' p FROM orders",
+                Optional.of("DROP TABLE <table>"));
+    }
+
+    @Test(invocationCount = INVOCATION_COUNT)
+    public void testInsertIntoNewPartition()
+    {
+        testTableModification(
+                Optional.of("CREATE TABLE <table> WITH (partitioned_by = ARRAY['p']) AS SELECT *, 'partition1' p FROM orders"),
+                "INSERT INTO <table> SELECT *, 'partition2' p FROM orders",
+                Optional.of("DROP TABLE <table>"));
+    }
+
+    @Test(invocationCount = INVOCATION_COUNT)
+    public void testInsertIntoExistingPartition()
+    {
+        testTableModification(
+                Optional.of("CREATE TABLE <table> WITH (partitioned_by = ARRAY['p']) AS SELECT *, 'partition1' p FROM orders"),
+                "INSERT INTO <table> SELECT *, 'partition1' p FROM orders",
+                Optional.of("DROP TABLE <table>"));
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
@@ -26,6 +26,7 @@ import io.trino.testing.QueryRunner;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.plugin.deltalake.DeltaLakeConnectorFactory.CONNECTOR_NAME;
@@ -87,7 +88,7 @@ public final class DeltaLakeQueryRunner
     public static DistributedQueryRunner createS3DeltaLakeQueryRunner(String catalogName, String schemaName, Map<String, String> connectorProperties, String minioAddress, TestingHadoop testingHadoop)
             throws Exception
     {
-        return createS3DeltaLakeQueryRunner(catalogName, schemaName, ImmutableMap.of(), connectorProperties, minioAddress, testingHadoop);
+        return createS3DeltaLakeQueryRunner(catalogName, schemaName, ImmutableMap.of(), connectorProperties, minioAddress, testingHadoop, queryRunner -> {});
     }
 
     public static DistributedQueryRunner createS3DeltaLakeQueryRunner(
@@ -96,7 +97,8 @@ public final class DeltaLakeQueryRunner
             Map<String, String> extraProperties,
             Map<String, String> connectorProperties,
             String minioAddress,
-            TestingHadoop testingHadoop)
+            TestingHadoop testingHadoop,
+            Consumer<QueryRunner> additionalSetup)
             throws Exception
     {
         return createDockerizedDeltaLakeQueryRunner(
@@ -110,7 +112,8 @@ public final class DeltaLakeQueryRunner
                         .put("hive.s3.path-style-access", "true")
                         .putAll(connectorProperties)
                         .buildOrThrow(),
-                testingHadoop);
+                testingHadoop,
+                additionalSetup);
     }
 
     public static QueryRunner createAbfsDeltaLakeQueryRunner(
@@ -160,6 +163,24 @@ public final class DeltaLakeQueryRunner
             TestingHadoop testingHadoop)
             throws Exception
     {
+        return createDockerizedDeltaLakeQueryRunner(
+                catalogName,
+                schemaName,
+                extraProperties,
+                connectorProperties,
+                testingHadoop,
+                queryRunner -> {});
+    }
+
+    public static DistributedQueryRunner createDockerizedDeltaLakeQueryRunner(
+            String catalogName,
+            String schemaName,
+            Map<String, String> extraProperties,
+            Map<String, String> connectorProperties,
+            TestingHadoop testingHadoop,
+            Consumer<QueryRunner> additionalSetup)
+            throws Exception
+    {
         Session session = testSessionBuilder()
                 .setCatalog(catalogName)
                 .setSchema(schemaName)
@@ -167,6 +188,7 @@ public final class DeltaLakeQueryRunner
 
         DistributedQueryRunner.Builder<?> builder = DistributedQueryRunner.builder(session);
         extraProperties.forEach(builder::addExtraProperty);
+        builder.setAdditionalSetup(additionalSetup);
         DistributedQueryRunner queryRunner = builder.build();
 
         queryRunner.installPlugin(new TpchPlugin());
@@ -236,7 +258,8 @@ public final class DeltaLakeQueryRunner
                         ImmutableMap.of("http-server.http.port", "8080"),
                         ImmutableMap.of(),
                         dockerizedMinioDataLake.getMinioAddress(),
-                        dockerizedMinioDataLake.getTestingHadoop());
+                        dockerizedMinioDataLake.getTestingHadoop(),
+                        runner -> {});
 
                 Thread.sleep(10);
                 Logger log = Logger.get(DeltaLakeQueryRunner.class);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
@@ -325,7 +325,8 @@ public class TestDeltaLakeMetadata
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                0);
+                0,
+                false);
 
         assertThatThrownBy(() -> deltaLakeMetadataFactory.create(SESSION.getIdentity())
                 .getInsertLayout(SESSION, missingTableHandle))
@@ -449,7 +450,8 @@ public class TestDeltaLakeMetadata
                 Optional.of(ImmutableList.of(BOOLEAN_COLUMN_HANDLE)),
                 Optional.of(ImmutableList.of(DOUBLE_COLUMN_HANDLE)),
                 Optional.empty(),
-                0);
+                0,
+                false);
     }
 
     private static TupleDomain<DeltaLakeColumnHandle> createConstrainedColumnsTuple(

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
@@ -77,7 +77,8 @@ public class TestDeltaLakeSplitManager
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
-            0);
+            0,
+            false);
 
     @Test
     public void testInitialSplits()

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaTaskFailureRecoveryTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaTaskFailureRecoveryTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.operator.RetryPolicy;
+import io.trino.plugin.deltalake.util.DockerizedMinioDataLake;
+import io.trino.plugin.exchange.FileSystemExchangePlugin;
+import io.trino.plugin.exchange.containers.MinioStorage;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import io.trino.tpch.TpchTable;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.trino.plugin.deltalake.DeltaLakeDockerizedMinioDataLake.createDockerizedMinioDataLakeForDeltaLake;
+import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.DELTA_CATALOG;
+import static io.trino.plugin.exchange.containers.MinioStorage.getExchangeManagerProperties;
+import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestDeltaTaskFailureRecoveryTest
+        extends BaseDeltaFailureRecoveryTest
+{
+    private static final String SCHEMA = "task_failure_recovery";
+    private final String bucketName = "test-delta-lake-task-failure-recovery-" + randomTableSuffix();
+
+    protected TestDeltaTaskFailureRecoveryTest()
+    {
+        super(RetryPolicy.TASK);
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner(
+            List<TpchTable<?>> requiredTpchTables,
+            Map<String, String> configProperties,
+            Map<String, String> coordinatorProperties)
+            throws Exception
+    {
+        DockerizedMinioDataLake dockerizedMinioDataLake = closeAfterClass(createDockerizedMinioDataLakeForDeltaLake(bucketName));
+        MinioStorage minioStorage = closeAfterClass(new MinioStorage("test-exchange-spooling-" + randomTableSuffix()));
+        minioStorage.start();
+
+        DistributedQueryRunner queryRunner = DeltaLakeQueryRunner.createS3DeltaLakeQueryRunner(
+                DELTA_CATALOG,
+                SCHEMA,
+                ImmutableMap.<String, String>builder()
+                        .putAll(configProperties)
+                        // currently not supported for fault tolerant execution mode
+                        .put("enable-dynamic-filtering", "false")
+                        .buildOrThrow(),
+                coordinatorProperties,
+                ImmutableMap.of("delta.enable-non-concurrent-writes", "true"),
+                dockerizedMinioDataLake.getMinioAddress(),
+                dockerizedMinioDataLake.getTestingHadoop(),
+                runner -> {
+                    runner.installPlugin(new FileSystemExchangePlugin());
+                    runner.loadExchangeManager("filesystem", getExchangeManagerProperties(minioStorage));
+                });
+        queryRunner.execute(format("CREATE SCHEMA %s WITH (location = 's3://%s/%s')", SCHEMA, bucketName, SCHEMA));
+        requiredTpchTables.forEach(table -> queryRunner.execute(format("CREATE TABLE %s AS SELECT * FROM tpch.tiny.%1$s", table.getTableName())));
+
+        return queryRunner;
+    }
+
+    @Override
+    public void testJoinDynamicFilteringEnabled()
+    {
+        assertThatThrownBy(super::testJoinDynamicFilteringEnabled)
+                .hasMessageContaining("Dynamic filtering is not supported with automatic task retries enabled");
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestTransactionLogAccess.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestTransactionLogAccess.java
@@ -142,7 +142,8 @@ public class TestTransactionLogAccess
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                0);
+                0,
+                false);
 
         tableSnapshot = transactionLogAccess.loadSnapshot(tableHandle.getSchemaTableName(), tableLocation, SESSION);
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreStatistics.java
@@ -179,7 +179,8 @@ public class TestDeltaLakeMetastoreStatistics
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                0);
+                0,
+                false);
     }
 
     @Test
@@ -308,7 +309,8 @@ public class TestDeltaLakeMetastoreStatistics
                 tableHandle.getUpdatedColumns(),
                 tableHandle.getUpdateRowIdColumns(),
                 tableHandle.getAnalyzeHandle(),
-                0);
+                0,
+                false);
         stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandleWithUnenforcedConstraint, Constraint.alwaysTrue());
         columnStatistics = stats.getColumnStatistics().get(COLUMN_HANDLE);
         assertEquals(columnStatistics.getRange().get().getMin(), 0.0);
@@ -331,7 +333,8 @@ public class TestDeltaLakeMetastoreStatistics
                 tableHandle.getUpdatedColumns(),
                 tableHandle.getUpdateRowIdColumns(),
                 tableHandle.getAnalyzeHandle(),
-                0);
+                0,
+                false);
         DeltaLakeTableHandle tableHandleWithNoneUnenforcedConstraint = new DeltaLakeTableHandle(
                 tableHandle.getSchemaName(),
                 tableHandle.getTableName(),
@@ -344,7 +347,8 @@ public class TestDeltaLakeMetastoreStatistics
                 tableHandle.getUpdatedColumns(),
                 tableHandle.getUpdateRowIdColumns(),
                 tableHandle.getAnalyzeHandle(),
-                0);
+                0,
+                false);
         // If either the table handle's constraint or the provided Constraint are none, it will cause a 0 record count to be reported
         assertEmptyStats(deltaLakeMetastore.getTableStatistics(SESSION, tableHandleWithNoneEnforcedConstraint, Constraint.alwaysTrue()));
         assertEmptyStats(deltaLakeMetastore.getTableStatistics(SESSION, tableHandleWithNoneUnenforcedConstraint, Constraint.alwaysTrue()));

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveFailureRecoveryTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveFailureRecoveryTest.java
@@ -156,4 +156,14 @@ public abstract class BaseHiveFailureRecoveryTest
                     Optional.of("DROP TABLE <table>"));
         }).hasMessageContaining("Deletes must match whole partitions for non-transactional tables");
     }
+
+    @Override
+    protected Session enableDynamicFiltering(boolean enabled)
+    {
+        Session session = super.enableDynamicFiltering(enabled);
+        return Session.builder(session)
+                // Ensure probe side scan wait until DF is collected
+                .setCatalogSessionProperty(session.getCatalog().orElseThrow(), "dynamic_filtering_wait_timeout", "1h")
+                .build();
+    }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveFailureRecoveryTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveFailureRecoveryTest.java
@@ -16,7 +16,6 @@ package io.trino.plugin.hive;
 import io.trino.Session;
 import io.trino.operator.RetryPolicy;
 import io.trino.testing.BaseFailureRecoveryTest;
-import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -42,7 +41,7 @@ public abstract class BaseHiveFailureRecoveryTest
     @Override
     protected void createPartitionedLineitemTable(String tableName, List<String> columns, String partitionColumn)
     {
-        @Language("SQL") String sql = format(
+        String sql = format(
                 "CREATE TABLE %s WITH (format = 'TEXTFILE', partitioned_by=array['%s']) AS SELECT %s FROM tpch.tiny.lineitem",
                 tableName,
                 partitionColumn,

--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -228,13 +228,13 @@
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-exchange</artifactId>
-            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-exchange</artifactId>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergFailureRecoveryTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergFailureRecoveryTest.java
@@ -15,7 +15,6 @@ package io.trino.plugin.iceberg;
 
 import io.trino.operator.RetryPolicy;
 import io.trino.testing.BaseFailureRecoveryTest;
-import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -62,7 +61,7 @@ public abstract class BaseIcebergFailureRecoveryTest
     @Override
     protected void createPartitionedLineitemTable(String tableName, List<String> columns, String partitionColumn)
     {
-        @Language("SQL") String sql = format(
+        String sql = format(
                 "CREATE TABLE %s WITH (partitioning=array['%s']) AS SELECT %s FROM tpch.tiny.lineitem",
                 tableName,
                 partitionColumn,

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseFailureRecoveryTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseFailureRecoveryTest.java
@@ -266,7 +266,7 @@ public abstract class BaseFailureRecoveryTest
     {
         testTableModification(
                 Optional.of("CREATE TABLE <table> AS SELECT * FROM orders"),
-                "DELETE FROM orders WHERE orderkey = 1",
+                "DELETE FROM <table> WHERE orderkey = 1",
                 Optional.of("DROP TABLE <table>"));
     }
 
@@ -275,7 +275,7 @@ public abstract class BaseFailureRecoveryTest
     {
         testTableModification(
                 Optional.of("CREATE TABLE <table> AS SELECT * FROM orders"),
-                "DELETE FROM orders WHERE custkey IN (SELECT custkey FROM customer WHERE nationkey = 1)",
+                "DELETE FROM <table> WHERE custkey IN (SELECT custkey FROM customer WHERE nationkey = 1)",
                 Optional.of("DROP TABLE <table>"));
     }
 
@@ -284,7 +284,7 @@ public abstract class BaseFailureRecoveryTest
     {
         testTableModification(
                 Optional.of("CREATE TABLE <table> AS SELECT * FROM orders"),
-                "UPDATE orders SET shippriority = 101 WHERE custkey = 1",
+                "UPDATE <table> SET shippriority = 101 WHERE custkey = 1",
                 Optional.of("DROP TABLE <table>"));
     }
 
@@ -293,7 +293,7 @@ public abstract class BaseFailureRecoveryTest
     {
         testTableModification(
                 Optional.of("CREATE TABLE <table> AS SELECT * FROM orders"),
-                "UPDATE orders SET shippriority = 101 WHERE custkey = (SELECT min(custkey) FROM customer)",
+                "UPDATE <table> SET shippriority = 101 WHERE custkey = (SELECT min(custkey) FROM customer)",
                 Optional.of("DROP TABLE <table>"));
     }
 

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseFailureRecoveryTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseFailureRecoveryTest.java
@@ -812,14 +812,13 @@ public abstract class BaseFailureRecoveryTest
         return requireNonNull(statementStats.getRootStage(), "root stage is null");
     }
 
-    private Session enableDynamicFiltering(boolean enabled)
+    protected Session enableDynamicFiltering(boolean enabled)
     {
         Session defaultSession = getQueryRunner().getDefaultSession();
         return Session.builder(defaultSession)
                 .setSystemProperty(ENABLE_DYNAMIC_FILTERING, Boolean.toString(enabled))
                 .setSystemProperty(JOIN_REORDERING_STRATEGY, NONE.name())
                 .setSystemProperty(JOIN_DISTRIBUTION_TYPE, PARTITIONED.name())
-                .setCatalogSessionProperty(defaultSession.getCatalog().orElseThrow(), "dynamic_filtering_wait_timeout", "1h")
                 .build();
     }
 }

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseFailureRecoveryTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseFailureRecoveryTest.java
@@ -456,7 +456,7 @@ public abstract class BaseFailureRecoveryTest
                 .finishesSuccessfully();
     }
 
-    private FailureRecoveryAssert assertThatQuery(String query)
+    protected FailureRecoveryAssert assertThatQuery(String query)
     {
         return new FailureRecoveryAssert(query);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Enable failure recovery and test coverage for it for Delta connector


> Is this change a fix, improvement, new feature, refactoring, or other?

improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Delta connector

## Related issues, pull requests, and links

FIxes: #11591

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Delta
* Allow running queries performing DML on Delta tables with fault-tolerant
  execution. ({issue}`11591`)
```
