### PR TITLE
Improve query result processing

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/CsvPrinter.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/CsvPrinter.java
@@ -76,13 +76,16 @@ public class CsvPrinter
     public void printRows(List<List<?>> rows, boolean complete)
             throws IOException
     {
+        String[] array = null;
         if (needHeader) {
             needHeader = false;
-            writer.writeNext(toStrings(fieldNames));
+            array = toStrings(fieldNames, array);
+            writer.writeNext(array);
         }
 
         for (List<?> row : rows) {
-            writer.writeNext(toStrings(row));
+            array = toStrings(row, array);
+            writer.writeNext(array);
             checkError();
         }
     }
@@ -104,10 +107,13 @@ public class CsvPrinter
         }
     }
 
-    private static String[] toStrings(List<?> values)
+    private static String[] toStrings(List<?> values, String[] array)
     {
-        String[] array = new String[values.size()];
-        for (int i = 0; i < values.size(); i++) {
+        int rowSize = values.size();
+        if (array == null || rowSize != array.length) {
+            array = new String[rowSize];
+        }
+        for (int i = 0; i < rowSize; i++) {
             array[i] = formatValue(values.get(i));
         }
         return array;

--- a/client/trino-cli/src/main/java/io/trino/cli/JsonPrinter.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/JsonPrinter.java
@@ -40,17 +40,19 @@ public class JsonPrinter
     public void printRows(List<List<?>> rows, boolean complete)
             throws IOException
     {
-        JsonFactory jsonFactory = new JsonFactory();
-        for (List<?> row : rows) {
-            JsonGenerator jsonGenerator = jsonFactory.createGenerator(writer);
-            jsonGenerator.writeStartObject();
-            for (int position = 0; position < row.size(); position++) {
-                String columnName = fieldNames.get(position);
-                jsonGenerator.writeObjectField(columnName, formatValue(row.get(position)));
+        JsonFactory jsonFactory = new JsonFactory().configure(JsonGenerator.Feature.AUTO_CLOSE_TARGET, false);
+        try (JsonGenerator jsonGenerator = jsonFactory.createGenerator(writer)) {
+            jsonGenerator.setRootValueSeparator(null);
+            for (List<?> row : rows) {
+                jsonGenerator.writeStartObject();
+                for (int position = 0; position < row.size(); position++) {
+                    String columnName = fieldNames.get(position);
+                    jsonGenerator.writeObjectField(columnName, formatValue(row.get(position)));
+                }
+                jsonGenerator.writeEndObject();
+                jsonGenerator.writeRaw('\n');
+                jsonGenerator.flush();
             }
-            jsonGenerator.writeEndObject();
-            jsonGenerator.writeRaw('\n');
-            jsonGenerator.flush();
         }
     }
 

--- a/client/trino-client/src/main/java/io/trino/client/JsonCodec.java
+++ b/client/trino-client/src/main/java/io/trino/client/JsonCodec.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Type;
 import java.util.function.Supplier;
 
@@ -66,5 +68,11 @@ public class JsonCodec<T>
             throws JsonProcessingException
     {
         return mapper.readerFor(javaType).readValue(json);
+    }
+
+    public T fromJson(InputStream inputStream)
+            throws IOException, JsonProcessingException
+    {
+        return mapper.readerFor(javaType).readValue(inputStream);
     }
 }

--- a/client/trino-client/src/main/java/io/trino/client/Row.java
+++ b/client/trino-client/src/main/java/io/trino/client/Row.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nullable;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -77,11 +76,25 @@ public final class Row
         return new Builder();
     }
 
+    public static Builder builderWithExpectedSize(int fields)
+    {
+        return new Builder(fields);
+    }
+
     public static final class Builder
     {
-        private List<RowField> fields = new ArrayList<>();
+        private final ImmutableList.Builder<RowField> fields;
+        private int size;
 
-        private Builder() {}
+        private Builder()
+        {
+            this.fields = ImmutableList.builder();
+        }
+
+        private Builder(int fields)
+        {
+            this.fields = ImmutableList.builderWithExpectedSize(fields);
+        }
 
         public Builder addField(String name, @Nullable Object value)
         {
@@ -95,14 +108,13 @@ public final class Row
 
         private Builder addField(Optional<String> name, @Nullable Object value)
         {
-            int ordinal = fields.size();
-            fields.add(new RowField(ordinal, name, value));
+            fields.add(new RowField(size++, name, value));
             return this;
         }
 
         public Row build()
         {
-            return new Row(fields);
+            return new Row(fields.build());
         }
     }
 }

--- a/client/trino-client/src/main/java/io/trino/client/StatementClientV1.java
+++ b/client/trino-client/src/main/java/io/trino/client/StatementClientV1.java
@@ -350,13 +350,12 @@ class StatementClientV1
                 return false;
             }
 
-            Duration sinceStart = Duration.nanosSince(start);
-            if (attempts > 0 && sinceStart.compareTo(requestTimeoutNanos) > 0) {
-                state.compareAndSet(State.RUNNING, State.CLIENT_ERROR);
-                throw new RuntimeException(format("Error fetching next (attempts: %s, duration: %s)", attempts, sinceStart), cause);
-            }
-
             if (attempts > 0) {
+                Duration sinceStart = Duration.nanosSince(start);
+                if (sinceStart.compareTo(requestTimeoutNanos) > 0) {
+                    state.compareAndSet(State.RUNNING, State.CLIENT_ERROR);
+                    throw new RuntimeException(format("Error fetching next (attempts: %s, duration: %s)", attempts, sinceStart), cause);
+                }
                 // back-off on retry
                 try {
                     MILLISECONDS.sleep(attempts * 100);

--- a/client/trino-client/src/main/java/io/trino/client/auth/external/HttpTokenPoller.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/external/HttpTokenPoller.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.time.Duration;
+import java.util.OptionalLong;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -137,7 +138,7 @@ public class HttpTokenPoller
             return response.getValue().toResult();
         }
 
-        String message = format("Request to %s failed: %s [Error: %s]", request.url(), response, response.getResponseBody());
+        String message = format("Request to %s failed: %s [Error: %s]", request.url(), response, response.getResponseBody().orElse("<Response Too Large>"));
 
         if (response.getStatusCode() == HTTP_UNAVAILABLE) {
             throw new IOException(message);
@@ -150,7 +151,7 @@ public class HttpTokenPoller
             throws IOException
     {
         try {
-            return execute(TOKEN_POLL_CODEC, client.get(), request);
+            return execute(TOKEN_POLL_CODEC, client.get(), request, OptionalLong.empty());
         }
         catch (UncheckedIOException e) {
             throw e.getCause();

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/AbstractTrinoResultSet.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/AbstractTrinoResultSet.java
@@ -17,6 +17,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.io.BaseEncoding;
 import io.trino.client.ClientTypeSignature;
 import io.trino.client.ClientTypeSignatureParameter;
@@ -61,7 +62,6 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -171,10 +171,13 @@ abstract class AbstractTrinoResultSet
                     .add("row", io.trino.client.Row.class, Row.class, (type, clientRow) -> (Row) convertFromClientRepresentation(type, clientRow))
                     .add("row", io.trino.client.Row.class, Map.class, (type, clientRow) -> {
                         Row row = (Row) convertFromClientRepresentation(type, clientRow);
-                        Map<String, Object> result = new HashMap<>();
-                        for (RowField field : row.getFields()) {
-                            String name = field.getName()
-                                    .orElseGet(() -> "field" + field.getOrdinal());
+                        List<RowField> fields = row.getFields();
+                        Map<String, Object> result = Maps.newHashMapWithExpectedSize(fields.size());
+                        for (RowField field : fields) {
+                            String name = field.getName().orElse(null);
+                            if (name == null) {
+                                name = "field" + field.getOrdinal();
+                            }
                             if (result.containsKey(name)) {
                                 throw new SQLException("Duplicate field name: " + name);
                             }
@@ -661,8 +664,9 @@ abstract class AbstractTrinoResultSet
         switch (columnType.getRawType()) {
             case "array": {
                 ClientTypeSignature elementType = getOnlyElement(columnType.getArgumentsAsTypeSignatures());
-                List<Object> converted = Lists.newArrayListWithExpectedSize(((List<?>) value).size());
-                for (Object element : (List<?>) value) {
+                List<?> listValue = (List<?>) value;
+                List<Object> converted = Lists.newArrayListWithExpectedSize(listValue.size());
+                for (Object element : listValue) {
                     converted.add(convertFromClientRepresentation(elementType, element));
                 }
                 return unmodifiableList(converted);
@@ -673,8 +677,9 @@ abstract class AbstractTrinoResultSet
                 verify(typeSignatures.size() == 2, "Unexpected map parameters: %s", typeSignatures);
                 ClientTypeSignature keyType = typeSignatures.get(0);
                 ClientTypeSignature valueType = typeSignatures.get(1);
-                Map<Object, Object> converted = new HashMap<>();
-                for (Map.Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
+                Map<?, ?> mapValue = (Map<?, ?>) value;
+                Map<Object, Object> converted = Maps.newHashMapWithExpectedSize(mapValue.size());
+                for (Map.Entry<?, ?> entry : mapValue.entrySet()) {
                     converted.put(convertFromClientRepresentation(keyType, entry.getKey()), convertFromClientRepresentation(valueType, entry.getValue()));
                 }
                 return unmodifiableMap(converted);
@@ -684,8 +689,8 @@ abstract class AbstractTrinoResultSet
                 io.trino.client.Row row = (io.trino.client.Row) value;
                 List<io.trino.client.RowField> fields = row.getFields();
                 List<ClientTypeSignatureParameter> typeArguments = columnType.getArguments();
-                Row.Builder builder = Row.builder();
                 verify(fields.size() == typeArguments.size(), "Type mismatch: %s, %s", row, columnType);
+                Row.Builder builder = Row.builderWithExpectedSize(fields.size());
                 for (int i = 0; i < fields.size(); i++) {
                     io.trino.client.RowField field = fields.get(i);
                     ClientTypeSignatureParameter clientTypeSignatureParameter = typeArguments.get(i);
@@ -1934,7 +1939,7 @@ abstract class AbstractTrinoResultSet
 
     private static Map<String, Integer> getFieldMap(List<Column> columns)
     {
-        Map<String, Integer> map = new HashMap<>();
+        Map<String, Integer> map = Maps.newHashMapWithExpectedSize(columns.size());
         for (int i = 0; i < columns.size(); i++) {
             String name = columns.get(i).getName().toLowerCase(ENGLISH);
             if (!map.containsKey(name)) {
@@ -1946,7 +1951,7 @@ abstract class AbstractTrinoResultSet
 
     private static List<ColumnInfo> getColumnInfo(List<Column> columns)
     {
-        ImmutableList.Builder<ColumnInfo> list = ImmutableList.builder();
+        ImmutableList.Builder<ColumnInfo> list = ImmutableList.builderWithExpectedSize(columns.size());
         for (Column column : columns) {
             ColumnInfo.Builder builder = new ColumnInfo.Builder()
                     .setCatalogName("") // TODO

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/Row.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/Row.java
@@ -13,13 +13,14 @@
  */
 package io.trino.jdbc;
 
+import com.google.common.collect.ImmutableList;
+
 import javax.annotation.Nullable;
 
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 // A public facade for Row from trino-client
@@ -34,9 +35,12 @@ public final class Row
 
     public List<RowField> getFields()
     {
-        return row.getFields().stream()
-                .map(RowField::new)
-                .collect(toImmutableList());
+        List<io.trino.client.RowField> fields = row.getFields();
+        ImmutableList.Builder<RowField> results = ImmutableList.builderWithExpectedSize(fields.size());
+        for (io.trino.client.RowField field : fields) {
+            results.add(new RowField(field));
+        }
+        return results.build();
     }
 
     @Override
@@ -69,12 +73,25 @@ public final class Row
         return new Builder();
     }
 
+    public static Builder builderWithExpectedSize(int fields)
+    {
+        return new Builder(fields);
+    }
+
     // A public facade for Row.Builder from trino-client
     public static final class Builder
     {
-        private final io.trino.client.Row.Builder builder = io.trino.client.Row.builder();
+        private final io.trino.client.Row.Builder builder;
 
-        private Builder() {}
+        private Builder()
+        {
+            builder = io.trino.client.Row.builder();
+        }
+
+        private Builder(int fields)
+        {
+            builder = io.trino.client.Row.builderWithExpectedSize(fields);
+        }
 
         public Builder addField(String name, @Nullable Object value)
         {

--- a/core/trino-main/src/main/java/io/trino/server/protocol/QueryResultRows.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/QueryResultRows.java
@@ -16,6 +16,7 @@ package io.trino.server.protocol;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
 import io.trino.Session;
 import io.trino.client.ClientCapabilities;
 import io.trino.client.Column;
@@ -40,7 +41,6 @@ import javax.annotation.Nullable;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -59,7 +59,6 @@ import static java.lang.String.format;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toList;
 
 public class QueryResultRows
         implements Iterable<List<Object>>
@@ -131,11 +130,11 @@ public class QueryResultRows
 
     private static long countRows(List<Page> pages)
     {
-        return pages.stream()
-                .map(Page::getPositionCount)
-                .map(Integer::longValue)
-                .reduce(Long::sum)
-                .orElse(0L);
+        long rows = 0;
+        for (Page page : pages) {
+            rows += page.getPositionCount();
+        }
+        return rows;
     }
 
     @Override
@@ -221,7 +220,7 @@ public class QueryResultRows
             checkArgument(columns != null && types != null, "columns and types must be present at the same time");
             checkArgument(columns.size() == types.size(), "columns and types size mismatch");
 
-            ImmutableList.Builder<ColumnAndType> builder = ImmutableList.builder();
+            ImmutableList.Builder<ColumnAndType> builder = ImmutableList.builderWithExpectedSize(columns.size());
 
             for (int i = 0; i < columns.size(); i++) {
                 builder.add(new ColumnAndType(i, columns.get(i), types.get(i)));
@@ -329,11 +328,12 @@ public class QueryResultRows
                 Block block = currentPage.getBlock(channel);
 
                 try {
+                    Object value = type.getObjectValue(results.session, block, inPageIndex);
                     if (results.supportsParametricDateTime) {
-                        row.add(channel, type.getObjectValue(results.session, block, inPageIndex));
+                        row.add(channel, value);
                     }
                     else {
-                        row.add(channel, getLegacyValue(type.getObjectValue(results.session, block, inPageIndex), type));
+                        row.add(channel, getLegacyValue(value, type));
                     }
                 }
                 catch (Throwable throwable) {
@@ -375,32 +375,34 @@ public class QueryResultRows
                     return value;
                 }
 
-                return unmodifiableList(((List<Object>) value).stream()
-                        .map(element -> getLegacyValue(element, elementType))
-                        .collect(toList()));
+                List<Object> listValue = (List<Object>) value;
+                List<Object> legacyValues = new ArrayList<>(listValue.size());
+                for (Object element : listValue) {
+                    legacyValues.add(getLegacyValue(element, elementType));
+                }
+
+                return unmodifiableList(legacyValues);
             }
 
             if (type instanceof MapType) {
                 Type keyType = ((MapType) type).getKeyType();
                 Type valueType = ((MapType) type).getValueType();
 
-                Map<Object, Object> result = new HashMap<>();
-                ((Map<Object, Object>) value).forEach((key, val) -> result.put(getLegacyValue(key, keyType), getLegacyValue(val, valueType)));
+                Map<Object, Object> mapValue = (Map<Object, Object>) value;
+                Map<Object, Object> result = Maps.newHashMapWithExpectedSize(mapValue.size());
+                mapValue.forEach((key, val) -> result.put(getLegacyValue(key, keyType), getLegacyValue(val, valueType)));
                 return unmodifiableMap(result);
             }
 
             if (type instanceof RowType) {
                 List<RowType.Field> fields = ((RowType) type).getFields();
                 List<Object> values = (List<Object>) value;
-                List<Type> types = fields.stream()
-                        .map(RowType.Field::getType)
-                        .collect(toImmutableList());
 
                 List<Object> result = new ArrayList<>(values.size());
                 for (int i = 0; i < values.size(); i++) {
-                    result.add(i, getLegacyValue(values.get(i), types.get(i)));
+                    result.add(getLegacyValue(values.get(i), fields.get(i).getType()));
                 }
-                return result;
+                return unmodifiableList(result);
             }
 
             return value;


### PR DESCRIPTION
Improve performance of client / server query results handling by removing unnecessary copies allocations and overheads. Overall query execution time for a host-local trino client running a `SELECT * FROM tpch.sf100.lineitem` query to `/dev/null` and without compression enabled is reduced by 25%.

## Description

> Is this change a fix, improvement, new feature, refactoring, or other?

Performance improvement achieved through refactoring

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core engine and Client Libraries

> How would you describe this change to a non-technical end user or system administrator?

A non-technical end user or system administrator should not need to understand the details of this change.

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:
