### PR TITLE
Remove SQL data management url and add link to insert

### DIFF
--- a/docs/src/main/sphinx/connector/memory.rst
+++ b/docs/src/main/sphinx/connector/memory.rst
@@ -51,7 +51,7 @@ stored in memory. In addition to the :ref:`globally available
 <sql-globally-available>` and :ref:`read operation <sql-read-operations>`
 statements, the connector supports the following features:
 
-* :ref:`sql-data-management`
+* :doc:`/sql/insert`
 * :doc:`/sql/create-table`
 * :doc:`/sql/create-table-as`
 * :doc:`/sql/drop-table`


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

* Remove url for Data management
* Add a specific url for INSERT

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other? Fix/improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific) Memory connector

> How would you describe this change to a non-technical end user or system administrator? Specifying which data management commands are supported. 

## Related issues, pull requests, and links

* Error was reported in the Slack troubleshooting channel, here's the [thread](https://trinodb.slack.com/archives/CGB0QHWSW/p1646997954848359) with the info.

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

