### PR TITLE
Add javadoc to RecordCursor.getCompletedBytes method

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/RecordCursor.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/RecordCursor.java
@@ -21,6 +21,10 @@ import java.io.Closeable;
 public interface RecordCursor
         extends Closeable
 {
+    /**
+     * Gets the number of input bytes processed by this record cursor so far.
+     * If size is not available, this method should return zero.
+     */
     long getCompletedBytes();
 
     /**

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSource.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSource.java
@@ -90,7 +90,6 @@ public class MongoPageSource
     private final List<String> columnNames;
     private final List<Type> columnTypes;
     private Document currentDoc;
-    private long count;
     private boolean finished;
 
     private final PageBuilder pageBuilder;
@@ -111,7 +110,7 @@ public class MongoPageSource
     @Override
     public long getCompletedBytes()
     {
-        return count;
+        return 0;
     }
 
     @Override
@@ -136,14 +135,12 @@ public class MongoPageSource
     public Page getNextPage()
     {
         verify(pageBuilder.isEmpty());
-        count = 0;
         for (int i = 0; i < ROWS_PER_REQUEST; i++) {
             if (!cursor.hasNext()) {
                 finished = true;
                 break;
             }
             currentDoc = cursor.next();
-            count++;
 
             pageBuilder.declarePosition();
             for (int column = 0; column < columnTypes.size(); column++) {


### PR DESCRIPTION
## Description

Add javadoc to RecordCursor.getCompletedBytes method and fix MongoPageSource.getCompletedBytes

## Documentation

(x) No documentation is needed.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# MongoDB
* Return `0` instead of row count in completed bytes. ({issue}`11679`)
```
