### PR TITLE
Add missing support for LongTimeWithTimeZone in InMemoryRecordSet

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/InMemoryRecordSet.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/InMemoryRecordSet.java
@@ -18,6 +18,7 @@ import io.airlift.slice.Slices;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.Int128;
+import io.trino.spi.type.LongTimeWithTimeZone;
 import io.trino.spi.type.LongTimestamp;
 import io.trino.spi.type.LongTimestampWithTimeZone;
 import io.trino.spi.type.RowType;
@@ -315,6 +316,9 @@ public class InMemoryRecordSet
             }
             else if (value instanceof LongTimestampWithTimeZone) {
                 completedBytes += LongTimestampWithTimeZone.INSTANCE_SIZE;
+            }
+            else if (value instanceof LongTimeWithTimeZone) {
+                completedBytes += LongTimeWithTimeZone.INSTANCE_SIZE;
             }
             else if (value instanceof Int128) {
                 completedBytes += Int128.INSTANCE_SIZE;

--- a/core/trino-spi/src/main/java/io/trino/spi/type/LongTimeWithTimeZone.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/LongTimeWithTimeZone.java
@@ -13,6 +13,8 @@
  */
 package io.trino.spi.type;
 
+import org.openjdk.jol.info.ClassLayout;
+
 import java.util.Objects;
 
 import static io.trino.spi.type.TimeWithTimeZoneTypes.normalize;
@@ -20,6 +22,8 @@ import static io.trino.spi.type.TimeWithTimeZoneTypes.normalize;
 public final class LongTimeWithTimeZone
         implements Comparable<LongTimeWithTimeZone>
 {
+    public static final int INSTANCE_SIZE = ClassLayout.parseClass(LongTimeWithTimeZone.class).instanceSize();
+
     private final long picoseconds;
     private final int offsetMinutes;
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
spi and core

> How would you describe this change to a non-technical end user or system administrator?
This will allow some third-party connectors to support time with time zone with highest possible precision

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
