### PR TITLE
Skip unsupported table type when streaming columns in Hive metadata

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -52,6 +52,7 @@ import io.trino.plugin.hive.statistics.HiveStatisticsProvider;
 import io.trino.plugin.hive.util.HiveBucketing;
 import io.trino.plugin.hive.util.HiveUtil;
 import io.trino.plugin.hive.util.HiveWriteUtils;
+import io.trino.spi.ErrorCode;
 import io.trino.spi.ErrorType;
 import io.trino.spi.StandardErrorCode;
 import io.trino.spi.TrinoException;
@@ -752,11 +753,12 @@ public class HiveMetadata
                 return Stream.empty();
             }
             catch (TrinoException e) {
+                ErrorCode errorCode = e.getErrorCode();
                 // Skip this table if there's a failure due to Hive, a bad Serde, or bad metadata
-                if (!e.getErrorCode().getType().equals(ErrorType.EXTERNAL)) {
-                    throw e;
+                if (errorCode.getType().equals(ErrorType.EXTERNAL) || errorCode.equals(UNSUPPORTED_TABLE_TYPE.toErrorCode())) {
+                    return Stream.empty();
                 }
-                return Stream.empty();
+                throw e;
             }
         });
     }


### PR DESCRIPTION
## Description

Skip unsupported table type when streaming columns in Hive metadata. This fixes  failing `TestSharedGlueMetastore.testReadInformationSchema` test.  All tests of #11539 passed, but Glue tests weren't triggered because of PR from forked branch. 

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required **_if this PR ships with 375_**
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
