### PR TITLE
to_iso8601 with timezone incorrect during dst hour

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamptz/ToIso8601.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamptz/ToIso8601.java
@@ -24,9 +24,9 @@ import io.trino.type.Constraint;
 import io.trino.type.DateTimes;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
 import static io.airlift.slice.Slices.utf8Slice;
@@ -73,14 +73,14 @@ public final class ToIso8601
 
     private static String format(int precision, long epochMillis, int picosOfMilli, ZoneId zoneId)
     {
-        LocalDateTime dateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), zoneId);
         long picoFraction = ((long) getMillisOfSecond(epochMillis)) * PICOSECONDS_PER_MILLISECOND + picosOfMilli;
 
-        ZoneOffset offset = zoneId.getRules().getValidOffsets(dateTime).get(0);
+        ZonedDateTime dateTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), zoneId);
+        ZoneOffset offset = dateTime.getOffset();
         if (offset.getTotalSeconds() % 60 != 0) {
             throw new TrinoException(INVALID_ARGUMENTS, "Timezone with non-zero seconds offset cannot be rendered as ISO8601: " + offset.getId());
         }
 
-        return DateTimes.formatTimestamp(precision, dateTime, picoFraction, ISO8601_FORMATTER, builder -> builder.append(offset));
+        return DateTimes.formatTimestamp(precision, dateTime.toLocalDateTime(), picoFraction, ISO8601_FORMATTER, builder -> builder.append(offset));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamptz/TestTimestampWithTimeZone.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamptz/TestTimestampWithTimeZone.java
@@ -1987,6 +1987,67 @@ public class TestTimestampWithTimeZone
                 .hasType(createVarcharType(41))
                 .isEqualTo("2020-05-01T12:34:56.123456789012+05:45");
 
+        // Following test will verify all precisions for timestamps fall in the DST gap
+        assertThat(assertions.expression("to_iso8601(TIMESTAMP '2020-11-01 07:00:00 UTC' AT TIME ZONE 'America/Chicago')"))
+                .hasType(createVarcharType(28))
+                .isEqualTo("2020-11-01T01:00:00-06:00");
+
+        assertThat(assertions.expression("to_iso8601(TIMESTAMP '2020-11-01 07:00:00.1 UTC' AT TIME ZONE 'America/Chicago')"))
+                .hasType(createVarcharType(30))
+                .isEqualTo("2020-11-01T01:00:00.1-06:00");
+
+        assertThat(assertions.expression("to_iso8601(TIMESTAMP '2020-11-01 07:00:00.12 UTC' AT TIME ZONE 'America/Chicago')"))
+                .hasType(createVarcharType(31))
+                .isEqualTo("2020-11-01T01:00:00.12-06:00");
+
+        assertThat(assertions.expression("to_iso8601(TIMESTAMP '2020-11-01 07:00:00.00 UTC' AT TIME ZONE 'America/Chicago')"))
+                .hasType(createVarcharType(31))
+                .isEqualTo("2020-11-01T01:00:00.00-06:00");
+
+        assertThat(assertions.expression("to_iso8601(TIMESTAMP '2020-11-01 07:00:00.123 UTC' AT TIME ZONE 'America/Chicago')"))
+                .hasType(createVarcharType(32))
+                .isEqualTo("2020-11-01T01:00:00.123-06:00");
+
+        assertThat(assertions.expression("to_iso8601(TIMESTAMP '2020-11-01 07:00:00.1234 UTC' AT TIME ZONE 'America/Chicago')"))
+                .hasType(createVarcharType(33))
+                .isEqualTo("2020-11-01T01:00:00.1234-06:00");
+
+        assertThat(assertions.expression("to_iso8601(TIMESTAMP '2020-11-01 07:00:00.12345 UTC' AT TIME ZONE 'America/Chicago')"))
+                .hasType(createVarcharType(34))
+                .isEqualTo("2020-11-01T01:00:00.12345-06:00");
+
+        assertThat(assertions.expression("to_iso8601(TIMESTAMP '2020-11-01 07:00:00.123456 UTC' AT TIME ZONE 'America/Chicago')"))
+                .hasType(createVarcharType(35))
+                .isEqualTo("2020-11-01T01:00:00.123456-06:00");
+
+        assertThat(assertions.expression("to_iso8601(TIMESTAMP '2020-11-01 07:00:00.1234567 UTC' AT TIME ZONE 'America/Chicago')"))
+                .hasType(createVarcharType(36))
+                .isEqualTo("2020-11-01T01:00:00.1234567-06:00");
+
+        assertThat(assertions.expression("to_iso8601(TIMESTAMP '2020-11-01 07:00:00.12345678 UTC' AT TIME ZONE 'America/Chicago')"))
+                .hasType(createVarcharType(37))
+                .isEqualTo("2020-11-01T01:00:00.12345678-06:00");
+
+        assertThat(assertions.expression("to_iso8601(TIMESTAMP '2020-11-01 07:00:00.123456789 UTC' AT TIME ZONE 'America/Chicago')"))
+                .hasType(createVarcharType(38))
+                .isEqualTo("2020-11-01T01:00:00.123456789-06:00");
+
+        assertThat(assertions.expression("to_iso8601(TIMESTAMP '2020-11-01 07:00:00.1234567890 UTC' AT TIME ZONE 'America/Chicago')"))
+                .hasType(createVarcharType(39))
+                .isEqualTo("2020-11-01T01:00:00.1234567890-06:00");
+
+        assertThat(assertions.expression("to_iso8601(TIMESTAMP '2020-11-01 07:00:00.12345678901 UTC' AT TIME ZONE 'America/Chicago')"))
+                .hasType(createVarcharType(40))
+                .isEqualTo("2020-11-01T01:00:00.12345678901-06:00");
+
+        assertThat(assertions.expression("to_iso8601(TIMESTAMP '2020-11-01 07:00:00.123456789012 UTC' AT TIME ZONE 'America/Chicago')"))
+                .hasType(createVarcharType(41))
+                .isEqualTo("2020-11-01T01:00:00.123456789012-06:00");
+
+        assertThat(assertions.expression("to_iso8601(TIMESTAMP '2020-11-01 07:00:00.000000000000 UTC' AT TIME ZONE 'America/Chicago')"))
+                .hasType(createVarcharType(41))
+                .isEqualTo("2020-11-01T01:00:00.000000000000-06:00");
+
         // Zulu offset
         assertThat(assertions.expression("to_iso8601(TIMESTAMP '2020-05-01 12:34:56 +00:00')"))
                 .hasType(createVarcharType(28))


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
a fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

this change is for the scalar function to_iso8601.

> How would you describe this change to a non-technical end user or system administrator?
pick a valid time even if there's ambiguity

## Related issues, pull requests, and links
Fixes https://github.com/trinodb/trino/issues/11619

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #11619
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix incorrect result for {func}`to_iso8601` when the timestamp is in the 
  daylight savings transition region. ({issue}`11619`)
```
