### PR TITLE
Iceberg: Extended documentation for materialized view behavior

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -784,7 +784,12 @@ for the data files and partition the storage per day using the column
 Updating the data in the materialized view with
 :doc:`/sql/refresh-materialized-view` deletes the data from the storage table,
 and inserts the data that is the result of executing the materialized view
-query into the existing table.
+query into the existing table. Refreshing the materialized view will also store
+the snapshot-ids of all the tables that are part of the materialized
+view's query at that point in materialized view metadata. When the materialized 
+view is queried, the snapshot-ids are used to check if the data in the storage 
+table is up to date. If the data is outdated, the materialized view will behave 
+like a normal view and query the data directly from the base tables.
 
 .. warning::
 


### PR DESCRIPTION
## Description

This PR extends the documentation on iceberg materialized views. I recently dug deeper into understanding the behavior of views and materialized views on the iceberg connector and noticed a behavior I did not expect. After asking about the behavior in slack (see [https://trinodb.slack.com/archives/CGB0QHWSW/p1647589373377379](https://trinodb.slack.com/archives/CGB0QHWSW/p1647589373377379)) @raunaqmorarka clarified it to me.

To prevent other users from getting hung up on this, I wrote some more phrases about the behavior in the iceberg connector documentation.

> Is this change a fix, improvement, new feature, refactoring, or other?
Improvement to documentation

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
Iceberg Connector

## Related issues, pull requests, and links

[Discussion in Slack](https://trinodb.slack.com/archives/CGB0QHWSW/p1647589373377379)

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:
