### PR TITLE
Iceberg: validating schema exists when create table

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -60,6 +60,7 @@ import io.trino.spi.connector.MaterializedViewFreshness;
 import io.trino.spi.connector.MaterializedViewNotFoundException;
 import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.connector.RetryMode;
+import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
 import io.trino.spi.connector.SystemTable;
@@ -465,6 +466,10 @@ public class IcebergMetadata
     @Override
     public ConnectorOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, Optional<ConnectorTableLayout> layout, RetryMode retryMode)
     {
+        String schemaName = tableMetadata.getTable().getSchemaName();
+        if (!schemaExists(session, schemaName)) {
+            throw new SchemaNotFoundException(schemaName);
+        }
         verify(transaction == null, "transaction already set");
         transaction = newCreateTableTransaction(catalog, tableMetadata, session);
         return new IcebergWritableTableHandle(

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -964,6 +964,28 @@ public abstract class BaseIcebergConnectorTest
     }
 
     @Test
+    public void testCreateTableWithLocationAndSchemaNotExists()
+    {
+        File tempDir = getDistributedQueryRunner().getCoordinator().getBaseDataDir().toFile();
+        String tempDirPath = tempDir.toURI().toASCIIString() + randomTableSuffix();
+
+        assertQueryFails(
+                format("CREATE TABLE any_schema.test_create_table_with_location (x bigint) WITH (location = '%s')", tempDirPath),
+                "Schema any_schema not found");
+    }
+
+    @Test
+    public void testCreateTableAsSelectWithLocationAndSchemaNotExists()
+    {
+        File tempDir = getDistributedQueryRunner().getCoordinator().getBaseDataDir().toFile();
+        String tempDirPath = tempDir.toURI().toASCIIString() + randomTableSuffix();
+
+        assertQueryFails(
+                format("CREATE TABLE any_schema.test_ctas_with_location WITH (location = '%s') AS SELECT * FROM tpch.tiny.orders", tempDirPath),
+                "Schema any_schema not found");
+    }
+
+    @Test
     public void testRollbackSnapshot()
     {
         assertUpdate("CREATE TABLE test_rollback (col0 INTEGER, col1 BIGINT)");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
@@ -41,6 +41,7 @@ import java.util.stream.Stream;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.inject.util.Modules.EMPTY_MODULE;
 import static io.trino.plugin.iceberg.CountingAccessFileHiveMetastore.Methods.CREATE_TABLE;
+import static io.trino.plugin.iceberg.CountingAccessFileHiveMetastore.Methods.GET_ALL_DATABASES;
 import static io.trino.plugin.iceberg.CountingAccessFileHiveMetastore.Methods.GET_DATABASE;
 import static io.trino.plugin.iceberg.CountingAccessFileHiveMetastore.Methods.GET_TABLE;
 import static io.trino.plugin.iceberg.CountingAccessFileHiveMetastore.Methods.REPLACE_TABLE;
@@ -98,6 +99,7 @@ public class TestIcebergMetastoreAccessOperations
     {
         assertMetastoreInvocations("CREATE TABLE test_create (id VARCHAR, age INT)",
                 ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
                         .add(CREATE_TABLE)
                         .add(GET_DATABASE)
                         .add(GET_TABLE)
@@ -109,6 +111,7 @@ public class TestIcebergMetastoreAccessOperations
     {
         assertMetastoreInvocations("CREATE TABLE test_ctas AS SELECT 1 AS age",
                 ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
                         .add(GET_DATABASE)
                         .add(CREATE_TABLE)
                         .add(GET_TABLE)


### PR DESCRIPTION
I find that I can direct create an iceberg FileMetastore table with property "location" when the schema is not exists.
Example:
Although the schema named 'db' is not exists, I can create a table 'db'.'table'。