### PR TITLE
Edit `log.path` definition and remove default value

### DIFF
--- a/docs/src/main/sphinx/admin/properties-logging.rst
+++ b/docs/src/main/sphinx/admin/properties-logging.rst
@@ -6,11 +6,10 @@ Logging properties
 ^^^^^^^^^^^^
 
 * **Type:** :ref:`prop-type-string`
-* **Default value:** ``var/log/server.log``
 
 The path to the log file used by Trino. The path is relative to the data
-directory, configured by the launcher script as detailed in
-:ref:`running_trino`.
+directory, configured to ``var/log/server.log`` by the launcher script as
+detailed in :ref:`running_trino`.
 
 ``log.max-history``
 ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

* Edit definition to mention that the ``var/log/server.log`` is configured by the launching script
* Remove default value, it is not defined in airlift

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other? Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? Logging properties

> How would you describe this change to a non-technical end user or system administrator? See description

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:
