### PR TITLE
Support database event client in verifier

### DIFF
--- a/service/trino-verifier/pom.xml
+++ b/service/trino-verifier/pom.xml
@@ -95,6 +95,11 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>
@@ -135,6 +140,12 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/service/trino-verifier/src/main/java/io/trino/verifier/DatabaseEventClient.java
+++ b/service/trino-verifier/src/main/java/io/trino/verifier/DatabaseEventClient.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.verifier;
+
+import io.airlift.event.client.AbstractEventClient;
+import io.airlift.json.JsonCodec;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class DatabaseEventClient
+        extends AbstractEventClient
+{
+    private final VerifierQueryEventDao dao;
+    private final JsonCodec<List<String>> codec;
+
+    @Inject
+    public DatabaseEventClient(VerifierQueryEventDao dao, JsonCodec<List<String>> codec)
+    {
+        this.dao = requireNonNull(dao, "dao is null");
+        this.codec = requireNonNull(codec, "codec is null");
+    }
+
+    @PostConstruct
+    public void postConstruct()
+    {
+        dao.createTable();
+    }
+
+    @Override
+    protected <T> void postEvent(T event)
+    {
+        VerifierQueryEvent queryEvent = (VerifierQueryEvent) event;
+        VerifierQueryEventEntity entity = new VerifierQueryEventEntity(
+                queryEvent.getSuite(),
+                Optional.ofNullable(queryEvent.getRunId()),
+                Optional.ofNullable(queryEvent.getSource()),
+                Optional.ofNullable(queryEvent.getName()),
+                queryEvent.isFailed(),
+                Optional.ofNullable(queryEvent.getTestCatalog()),
+                Optional.ofNullable(queryEvent.getTestSchema()),
+                queryEvent.getTestSetupQueryIds().isEmpty() ? Optional.empty() : Optional.of(codec.toJson(queryEvent.getTestSetupQueryIds())),
+                Optional.ofNullable(queryEvent.getTestQueryId()),
+                queryEvent.getTestTeardownQueryIds().isEmpty() ? Optional.empty() : Optional.of(codec.toJson(queryEvent.getTestTeardownQueryIds())),
+                Optional.ofNullable(queryEvent.getControlCatalog()),
+                Optional.ofNullable(queryEvent.getControlSchema()),
+                queryEvent.getControlSetupQueryIds().isEmpty() ? Optional.empty() : Optional.of(codec.toJson(queryEvent.getControlSetupQueryIds())),
+                Optional.ofNullable(queryEvent.getControlQueryId()),
+                queryEvent.getControlTeardownQueryIds().isEmpty() ? Optional.empty() : Optional.of(codec.toJson(queryEvent.getControlTeardownQueryIds())),
+                Optional.ofNullable(queryEvent.getErrorMessage()));
+        dao.store(entity);
+    }
+}

--- a/service/trino-verifier/src/main/java/io/trino/verifier/Verifier.java
+++ b/service/trino-verifier/src/main/java/io/trino/verifier/Verifier.java
@@ -25,6 +25,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
@@ -33,6 +34,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.regex.Pattern;
 
 import static com.google.common.base.Throwables.getStackTraceAsString;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.spi.StandardErrorCode.PAGE_TRANSPORT_TIMEOUT;
 import static io.trino.spi.StandardErrorCode.REMOTE_TASK_MISMATCH;
 import static io.trino.spi.StandardErrorCode.TOO_MANY_REQUESTS_FAILED;
@@ -219,7 +221,15 @@ public class Verifier
                 queryPair.getTest().getPreQueries(),
                 queryPair.getTest().getQuery(),
                 queryPair.getTest().getPostQueries(),
+                validator.getTestPreQueryResults().stream()
+                        .map(QueryResult::getQueryId)
+                        .filter(Objects::nonNull)
+                        .collect(toImmutableList()),
                 test.getQueryId(),
+                validator.getTestPostQueryResults().stream()
+                        .map(QueryResult::getQueryId)
+                        .filter(Objects::nonNull)
+                        .collect(toImmutableList()),
                 optionalDurationToSeconds(test.getCpuTime()),
                 optionalDurationToSeconds(test.getWallTime()),
                 queryPair.getControl().getCatalog(),
@@ -227,7 +237,15 @@ public class Verifier
                 queryPair.getControl().getPreQueries(),
                 queryPair.getControl().getQuery(),
                 queryPair.getControl().getPostQueries(),
+                validator.getControlPreQueryResults().stream()
+                        .map(QueryResult::getQueryId)
+                        .filter(Objects::nonNull)
+                        .collect(toImmutableList()),
                 control.getQueryId(),
+                validator.getControlPostQueryResults().stream()
+                        .map(QueryResult::getQueryId)
+                        .filter(Objects::nonNull)
+                        .collect(toImmutableList()),
                 optionalDurationToSeconds(control.getCpuTime()),
                 optionalDurationToSeconds(control.getWallTime()),
                 errorMessage);

--- a/service/trino-verifier/src/main/java/io/trino/verifier/VerifierQueryEvent.java
+++ b/service/trino-verifier/src/main/java/io/trino/verifier/VerifierQueryEvent.java
@@ -36,7 +36,9 @@ public class VerifierQueryEvent
     private final List<String> testSetupQueries;
     private final String testQuery;
     private final List<String> testTeardownQueries;
+    private final List<String> testSetupQueryIds;
     private final String testQueryId;
+    private final List<String> testTeardownQueryIds;
     private final Double testCpuTimeSecs;
     private final Double testWallTimeSecs;
 
@@ -45,7 +47,9 @@ public class VerifierQueryEvent
     private final List<String> controlSetupQueries;
     private final String controlQuery;
     private final List<String> controlTeardownQueries;
+    private final List<String> controlSetupQueryIds;
     private final String controlQueryId;
+    private final List<String> controlTeardownQueryIds;
     private final Double controlCpuTimeSecs;
     private final Double controlWallTimeSecs;
 
@@ -62,7 +66,9 @@ public class VerifierQueryEvent
             List<String> testSetupQueries,
             String testQuery,
             List<String> testTeardownQueries,
+            List<String> testSetupQueryIds,
             String testQueryId,
+            List<String> testTeardownQueryIds,
             Double testCpuTimeSecs,
             Double testWallTimeSecs,
             String controlCatalog,
@@ -70,7 +76,9 @@ public class VerifierQueryEvent
             List<String> controlSetupQueries,
             String controlQuery,
             List<String> controlTeardownQueries,
+            List<String> controlSetupQueryIds,
             String controlQueryId,
+            List<String> controlTeardownQueryIds,
             Double controlCpuTimeSecs,
             Double controlWallTimeSecs,
             String errorMessage)
@@ -86,7 +94,9 @@ public class VerifierQueryEvent
         this.testSetupQueries = ImmutableList.copyOf(testSetupQueries);
         this.testQuery = testQuery;
         this.testTeardownQueries = ImmutableList.copyOf(testTeardownQueries);
+        this.testSetupQueryIds = ImmutableList.copyOf(testSetupQueryIds);
         this.testQueryId = testQueryId;
+        this.testTeardownQueryIds = ImmutableList.copyOf(testTeardownQueryIds);
         this.testCpuTimeSecs = testCpuTimeSecs;
         this.testWallTimeSecs = testWallTimeSecs;
 
@@ -95,7 +105,9 @@ public class VerifierQueryEvent
         this.controlSetupQueries = ImmutableList.copyOf(controlSetupQueries);
         this.controlQuery = controlQuery;
         this.controlTeardownQueries = ImmutableList.copyOf(controlTeardownQueries);
+        this.controlSetupQueryIds = ImmutableList.copyOf(controlSetupQueryIds);
         this.controlQueryId = controlQueryId;
+        this.controlTeardownQueryIds = ImmutableList.copyOf(controlTeardownQueryIds);
         this.controlCpuTimeSecs = controlCpuTimeSecs;
         this.controlWallTimeSecs = controlWallTimeSecs;
 
@@ -151,9 +163,21 @@ public class VerifierQueryEvent
     }
 
     @EventField
+    public List<String> getTestSetupQueryIds()
+    {
+        return testSetupQueryIds;
+    }
+
+    @EventField
     public String getTestQueryId()
     {
         return testQueryId;
+    }
+
+    @EventField
+    public List<String> getTestTeardownQueryIds()
+    {
+        return testTeardownQueryIds;
     }
 
     @EventField
@@ -187,9 +211,21 @@ public class VerifierQueryEvent
     }
 
     @EventField
+    public List<String> getControlSetupQueryIds()
+    {
+        return controlSetupQueryIds;
+    }
+
+    @EventField
     public String getControlQueryId()
     {
         return controlQueryId;
+    }
+
+    @EventField
+    public List<String> getControlTeardownQueryIds()
+    {
+        return controlTeardownQueryIds;
     }
 
     @EventField

--- a/service/trino-verifier/src/main/java/io/trino/verifier/VerifierQueryEventDao.java
+++ b/service/trino-verifier/src/main/java/io/trino/verifier/VerifierQueryEventDao.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.verifier;
+
+import org.jdbi.v3.sqlobject.customizer.BindBean;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+
+public interface VerifierQueryEventDao
+{
+    @SqlUpdate("CREATE TABLE IF NOT EXISTS verifier_query_events (\n" +
+            "  id BIGINT NOT NULL AUTO_INCREMENT,\n" +
+            "  suite VARCHAR(255) NOT NULL,\n" +
+            "  run_id VARCHAR(255) NULL,\n" +
+            "  source VARCHAR(255) NULL,\n" +
+            "  name VARCHAR(255) NULL,\n" +
+            "  failed BOOLEAN NOT NULL,\n" +
+            "  test_catalog VARCHAR(255) NULL,\n" +
+            "  test_schema VARCHAR(255) NULL,\n" +
+            "  test_setup_query_ids_json VARCHAR(255) NULL,\n" +
+            "  test_query_id VARCHAR(255) NULL,\n" +
+            "  test_teardown_query_ids_json VARCHAR(255) NULL,\n" +
+            "  control_catalog VARCHAR(255) NULL,\n" +
+            "  control_schema VARCHAR(255) NULL,\n" +
+            "  control_setup_query_ids_json VARCHAR(255) NULL,\n" +
+            "  control_query_id VARCHAR(255) NULL,\n" +
+            "  control_teardown_query_ids_json VARCHAR(255) NULL,\n" +
+            "  error_message VARCHAR(255) NULL,\n" +
+            "  PRIMARY KEY (id),\n" +
+            "  INDEX run_id_name_index(run_id, name)\n" +
+            ")")
+    void createTable();
+
+    @SqlUpdate("INSERT INTO verifier_query_events (\n" +
+            "  suite,\n" +
+            "  run_id,\n" +
+            "  source,\n" +
+            "  name,\n" +
+            "  failed,\n" +
+            "  test_catalog,\n" +
+            "  test_schema,\n" +
+            "  test_setup_query_ids_json,\n" +
+            "  test_query_id,\n" +
+            "  test_teardown_query_ids_json,\n" +
+            "  control_catalog,\n" +
+            "  control_schema,\n" +
+            "  control_setup_query_ids_json,\n" +
+            "  control_query_id,\n" +
+            "  control_teardown_query_ids_json,\n" +
+            "  error_message\n" +
+            ")\n" +
+            "VALUES (\n" +
+            "  :suite,\n" +
+            "  :runId,\n" +
+            "  :source,\n" +
+            "  :name,\n" +
+            "  :failed,\n" +
+            "  :testCatalog,\n" +
+            "  :testSchema,\n" +
+            "  :testSetupQueryIdsJson,\n" +
+            "  :testQueryId,\n" +
+            "  :testTeardownQueryIdsJson,\n" +
+            "  :controlCatalog,\n" +
+            "  :controlSchema,\n" +
+            "  :controlSetupQueryIdsJson,\n" +
+            "  :controlQueryId,\n" +
+            "  :controlTeardownQueryIdsJson,\n" +
+            "  :errorMessage\n" +
+            ")")
+    void store(@BindBean VerifierQueryEventEntity entity);
+}

--- a/service/trino-verifier/src/main/java/io/trino/verifier/VerifierQueryEventEntity.java
+++ b/service/trino-verifier/src/main/java/io/trino/verifier/VerifierQueryEventEntity.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.verifier;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class VerifierQueryEventEntity
+{
+    private final String suite;
+    private final Optional<String> runId;
+    private final Optional<String> source;
+    private final Optional<String> name;
+    private final boolean failed;
+
+    private final Optional<String> testCatalog;
+    private final Optional<String> testSchema;
+    private final Optional<String> testSetupQueryIdsJson;
+    private final Optional<String> testQueryId;
+    private final Optional<String> testTeardownQueryIdsJson;
+
+    private final Optional<String> controlCatalog;
+    private final Optional<String> controlSchema;
+    private final Optional<String> controlSetupQueryIdsJson;
+    private final Optional<String> controlQueryId;
+    private final Optional<String> controlTeardownQueryIdsJson;
+
+    private final Optional<String> errorMessage;
+
+    public VerifierQueryEventEntity(
+            String suite,
+            Optional<String> runId,
+            Optional<String> source,
+            Optional<String> name,
+            boolean failed,
+            Optional<String> testCatalog,
+            Optional<String> testSchema,
+            Optional<String> testSetupQueryIdsJson,
+            Optional<String> testQueryId,
+            Optional<String> testTeardownQueryIdsJson,
+            Optional<String> controlCatalog,
+            Optional<String> controlSchema,
+            Optional<String> controlSetupQueryIdsJson,
+            Optional<String> controlQueryId,
+            Optional<String> controlTeardownQueryIdsJson,
+            Optional<String> errorMessage)
+    {
+        this.suite = requireNonNull(suite, "suite is null");
+        this.runId = requireNonNull(runId, "runId is null");
+        this.source = requireNonNull(source, "source is null");
+        this.name = requireNonNull(name, "name is null");
+        this.failed = failed;
+        this.testCatalog = requireNonNull(testCatalog, "testCatalog is null");
+        this.testSchema = requireNonNull(testSchema, "testSchema is null");
+        this.testSetupQueryIdsJson = requireNonNull(testSetupQueryIdsJson, "testSetupQueryIdsJson is null");
+        this.testQueryId = requireNonNull(testQueryId, "testQueryId is null");
+        this.testTeardownQueryIdsJson = requireNonNull(testTeardownQueryIdsJson, "testTeardownQueryIdsJson is null");
+        this.controlCatalog = requireNonNull(controlCatalog, "controlCatalog is null");
+        this.controlSchema = requireNonNull(controlSchema, "controlSchema is null");
+        this.controlSetupQueryIdsJson = requireNonNull(controlSetupQueryIdsJson, "controlSetupQueryIdsJson is null");
+        this.controlQueryId = requireNonNull(controlQueryId, "controlQueryId is null");
+        this.controlTeardownQueryIdsJson = requireNonNull(controlTeardownQueryIdsJson, "controlTeardownQueryIdsJson is null");
+        this.errorMessage = requireNonNull(errorMessage, "errorMessage is null");
+    }
+
+    public String getSuite()
+    {
+        return suite;
+    }
+
+    public Optional<String> getRunId()
+    {
+        return runId;
+    }
+
+    public Optional<String> getSource()
+    {
+        return source;
+    }
+
+    public Optional<String> getName()
+    {
+        return name;
+    }
+
+    public boolean isFailed()
+    {
+        return failed;
+    }
+
+    public Optional<String> getTestCatalog()
+    {
+        return testCatalog;
+    }
+
+    public Optional<String> getTestSchema()
+    {
+        return testSchema;
+    }
+
+    public Optional<String> getTestSetupQueryIdsJson()
+    {
+        return testSetupQueryIdsJson;
+    }
+
+    public Optional<String> getTestQueryId()
+    {
+        return testQueryId;
+    }
+
+    public Optional<String> getTestTeardownQueryIdsJson()
+    {
+        return testTeardownQueryIdsJson;
+    }
+
+    public Optional<String> getControlCatalog()
+    {
+        return controlCatalog;
+    }
+
+    public Optional<String> getControlSchema()
+    {
+        return controlSchema;
+    }
+
+    public Optional<String> getControlSetupQueryIdsJson()
+    {
+        return controlSetupQueryIdsJson;
+    }
+
+    public Optional<String> getControlQueryId()
+    {
+        return controlQueryId;
+    }
+
+    public Optional<String> getControlTeardownQueryIdsJson()
+    {
+        return controlTeardownQueryIdsJson;
+    }
+
+    public Optional<String> getErrorMessage()
+    {
+        return errorMessage;
+    }
+}

--- a/service/trino-verifier/src/main/java/io/trino/verifier/VerifyCommand.java
+++ b/service/trino-verifier/src/main/java/io/trino/verifier/VerifyCommand.java
@@ -23,7 +23,6 @@ import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
-import com.google.inject.Provider;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
@@ -31,6 +30,7 @@ import com.google.inject.TypeLiteral;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.bootstrap.LifeCycleManager;
 import io.airlift.event.client.EventClient;
+import io.airlift.json.JsonModule;
 import io.airlift.log.Logger;
 import io.trino.sql.parser.ParsingOptions;
 import io.trino.sql.parser.SqlParser;
@@ -70,6 +70,8 @@ import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 import picocli.CommandLine.Spec;
+
+import javax.inject.Provider;
 
 import java.io.File;
 import java.io.IOException;
@@ -132,6 +134,7 @@ public class VerifyCommand
         }
 
         ImmutableList.Builder<Module> builder = ImmutableList.<Module>builder()
+                .add(new JsonModule())
                 .add(new PrestoVerifierModule())
                 .add(new DataSourceModule(this))
                 .addAll(getAdditionalModules());

--- a/service/trino-verifier/src/test/java/io/trino/verifier/TestDatabaseEventClient.java
+++ b/service/trino-verifier/src/test/java/io/trino/verifier/TestDatabaseEventClient.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.verifier;
+
+import io.airlift.json.JsonCodec;
+import io.airlift.json.JsonCodecFactory;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+import org.testcontainers.containers.MySQLContainer;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestDatabaseEventClient
+{
+    private static final VerifierQueryEvent FULL_EVENT = new VerifierQueryEvent(
+            "suite_full",
+            "runid",
+            "source",
+            "name",
+            true,
+            "testcatalog",
+            "testschema",
+            List.of("TEST_SETUP_QUERY_1", "TEST_SETUP_QUERY_2"),
+            "TEST_QUERY",
+            List.of("TEST_TEARDOWN_QUERY_1", "TEST_TEARDOWN_QUERY_2"),
+            List.of("TEST_SETUP_QUERY_ID_1", "TEST_SETUP_QUERY_ID_2"),
+            "TEST_QUERY_ID",
+            List.of("TEST_TEARDOWN_QUERY_ID_1", "TEST_TEARDOWN_QUERY_ID_2"),
+            1.1,
+            2.2,
+            "controlcatalog",
+            "controlschema",
+            List.of("CONTROL_SETUP_QUERY_1", "CONTROL_SETUP_QUERY_2"),
+            "CONTROL_QUERY",
+            List.of("CONTROL_TEARDOWN_QUERY_1", "CONTROL_TEARDOWN_QUERY_2"),
+            List.of("CONTROL_SETUP_QUERY_ID_1", "CONTROL_SETUP_QUERY_ID_2"),
+            "CONTROL_QUERY_ID",
+            List.of("CONTROL_TEARDOWN_QUERY_ID_1", "CONTROL_TEARDOWN_QUERY_ID_2"),
+            3.3,
+            4.4,
+            "error message");
+
+    private static final VerifierQueryEvent MINIMAL_EVENT = new VerifierQueryEvent(
+            "suite_minimal",
+            null,
+            null,
+            null,
+            false,
+            null,
+            null,
+            List.of(),
+            null,
+            List.of(),
+            List.of(),
+            null,
+            List.of(),
+            null,
+            null,
+            null,
+            null,
+            List.of(),
+            null,
+            List.of(),
+            List.of(),
+            null,
+            List.of(),
+            null,
+            null,
+            null);
+
+    private MySQLContainer<?> mysqlContainer;
+    private String mysqlContainerUrl;
+    private JsonCodec<List<String>> codec;
+    private DatabaseEventClient eventClient;
+
+    @BeforeClass
+    public void setup()
+    {
+        mysqlContainer = new MySQLContainer<>("mysql:8.0.12");
+        mysqlContainer.start();
+        mysqlContainerUrl = getJdbcUrl(mysqlContainer);
+        codec = new JsonCodecFactory().listJsonCodec(String.class);
+        VerifierQueryEventDao dao = Jdbi.create(() -> DriverManager.getConnection(mysqlContainerUrl))
+                .installPlugin(new SqlObjectPlugin())
+                .onDemand(VerifierQueryEventDao.class);
+        eventClient = new DatabaseEventClient(dao, codec);
+        eventClient.postConstruct();
+    }
+
+    private static String getJdbcUrl(MySQLContainer<?> container)
+    {
+        return format("%s?user=%s&password=%s&useSSL=false&allowPublicKeyRetrieval=true",
+                container.getJdbcUrl(),
+                container.getUsername(),
+                container.getPassword());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        if (mysqlContainer != null) {
+            mysqlContainer.close();
+            mysqlContainer = null;
+            mysqlContainerUrl = null;
+        }
+        codec = null;
+        eventClient = null;
+    }
+
+    @Test
+    public void testFull()
+            throws SQLException
+    {
+        eventClient.post(FULL_EVENT);
+
+        try (Connection connection = DriverManager.getConnection(mysqlContainerUrl)) {
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("SELECT * FROM verifier_query_events WHERE suite = 'suite_full'");
+                try (ResultSet resultSet = statement.getResultSet()) {
+                    assertTrue(resultSet.next());
+                    assertEquals(resultSet.getString("suite"), "suite_full");
+                    assertEquals(resultSet.getString("run_id"), "runid");
+                    assertEquals(resultSet.getString("source"), "source");
+                    assertEquals(resultSet.getString("name"), "name");
+                    assertTrue(resultSet.getBoolean("failed"));
+                    assertEquals(resultSet.getString("test_catalog"), "testcatalog");
+                    assertEquals(resultSet.getString("test_schema"), "testschema");
+                    assertEquals(resultSet.getString("test_setup_query_ids_json"), codec.toJson(FULL_EVENT.getTestSetupQueryIds()));
+                    assertEquals(resultSet.getString("test_query_id"), "TEST_QUERY_ID");
+                    assertEquals(resultSet.getString("test_teardown_query_ids_json"), codec.toJson(FULL_EVENT.getTestTeardownQueryIds()));
+                    assertEquals(resultSet.getString("control_catalog"), "controlcatalog");
+                    assertEquals(resultSet.getString("control_schema"), "controlschema");
+                    assertEquals(resultSet.getString("control_setup_query_ids_json"), codec.toJson(FULL_EVENT.getControlSetupQueryIds()));
+                    assertEquals(resultSet.getString("control_query_id"), "CONTROL_QUERY_ID");
+                    assertEquals(resultSet.getString("control_teardown_query_ids_json"), codec.toJson(FULL_EVENT.getControlTeardownQueryIds()));
+                    assertEquals(resultSet.getString("error_message"), "error message");
+                    assertFalse(resultSet.next());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testMinimal()
+            throws SQLException
+    {
+        eventClient.post(MINIMAL_EVENT);
+
+        try (Connection connection = DriverManager.getConnection(mysqlContainerUrl)) {
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("SELECT * FROM verifier_query_events WHERE suite = 'suite_minimal'");
+                try (ResultSet resultSet = statement.getResultSet()) {
+                    assertTrue(resultSet.next());
+                    assertEquals(resultSet.getString("suite"), "suite_minimal");
+                    assertNull(resultSet.getString("run_id"));
+                    assertNull(resultSet.getString("source"));
+                    assertNull(resultSet.getString("name"));
+                    assertFalse(resultSet.getBoolean("failed"));
+                    assertNull(resultSet.getString("test_catalog"));
+                    assertNull(resultSet.getString("test_schema"));
+                    assertNull(resultSet.getString("test_setup_query_ids_json"));
+                    assertNull(resultSet.getString("test_query_id"));
+                    assertNull(resultSet.getString("test_teardown_query_ids_json"));
+                    assertNull(resultSet.getString("control_catalog"));
+                    assertNull(resultSet.getString("control_schema"));
+                    assertNull(resultSet.getString("control_setup_query_ids_json"));
+                    assertNull(resultSet.getString("control_query_id"));
+                    assertNull(resultSet.getString("control_teardown_query_ids_json"));
+                    assertNull(resultSet.getString("error_message"));
+                    assertFalse(resultSet.next());
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

Support writing information about queries executed with verifier into a database

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

verifier

> How would you describe this change to a non-technical end user or system administrator?

Verifier is a tool that allows to replay queries on a Trino cluster for testing purposes. When verifier executes a query it generates an internal event containing query id and some basic statistics. This patch allows to configure verifier to store this information into a database. 

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

`-`

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

(verifier is currently not documented anywhere)

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
