### PR TITLE
Allow configuration duration for completion of dynamic filters in Delta

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.rst
+++ b/docs/src/main/sphinx/connector/delta-lake.rst
@@ -108,6 +108,9 @@ values. Typical usage does not require you to configure them.
       - Name of the catalog to which ``SELECT`` queries are redirected when a
         Hive table is detected.
       -
+    * - ``delta.dynamic-filtering.wait-timeout``
+      - Duration to wait for completion of dynamic filters during split generation
+      -
     * - ``delta.table-statistics-enabled``
       - Enables :ref:`Table statistics <delta-lake-table-statistics>` for
         performance improvements.

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConfig.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConfig.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class DeltaLakeConfig
 {
@@ -53,6 +54,7 @@ public class DeltaLakeConfig
     private boolean ignoreCheckpointWriteFailures;
     private Duration vacuumMinRetention = new Duration(7, DAYS);
     private Optional<String> hiveCatalogName = Optional.empty();
+    private Duration dynamicFilteringWaitTimeout = new Duration(0, SECONDS);
     private boolean tableStatisticsEnabled = true;
     private boolean extendedStatisticsEnabled = true;
     private HiveCompressionCodec compressionCodec = HiveCompressionCodec.SNAPPY;
@@ -253,6 +255,20 @@ public class DeltaLakeConfig
     public DeltaLakeConfig setCheckpointRowStatisticsWritingEnabled(boolean checkpointRowStatisticsWritingEnabled)
     {
         this.checkpointRowStatisticsWritingEnabled = checkpointRowStatisticsWritingEnabled;
+        return this;
+    }
+
+    @NotNull
+    public Duration getDynamicFilteringWaitTimeout()
+    {
+        return dynamicFilteringWaitTimeout;
+    }
+
+    @Config("delta.dynamic-filtering.wait-timeout")
+    @ConfigDescription("Duration to wait for completion of dynamic filters during split generation")
+    public DeltaLakeConfig setDynamicFilteringWaitTimeout(Duration dynamicFilteringWaitTimeout)
+    {
+        this.dynamicFilteringWaitTimeout = dynamicFilteringWaitTimeout;
         return this;
     }
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSessionProperties.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSessionProperties.java
@@ -52,6 +52,7 @@ public final class DeltaLakeSessionProperties
     // This property is not supported by Delta Lake and exists solely for technical reasons.
     @Deprecated
     private static final String TIMESTAMP_PRECISION = "timestamp_precision";
+    private static final String DYNAMIC_FILTERING_WAIT_TIMEOUT = "dynamic_filtering_wait_timeout";
     private static final String TABLE_STATISTICS_ENABLED = "statistics_enabled";
     private static final String EXTENDED_STATISTICS_ENABLED = "extended_statistics_enabled";
 
@@ -118,6 +119,11 @@ public final class DeltaLakeSessionProperties
                         MILLISECONDS,
                         value -> { throw new IllegalStateException("The property cannot be set"); },
                         true),
+                durationProperty(
+                        DYNAMIC_FILTERING_WAIT_TIMEOUT,
+                        "Duration to wait for completion of dynamic filters during split generation",
+                        deltaLakeConfig.getDynamicFilteringWaitTimeout(),
+                        false),
                 booleanProperty(
                         TABLE_STATISTICS_ENABLED,
                         "Expose table statistics",
@@ -185,6 +191,11 @@ public final class DeltaLakeSessionProperties
     public static DataSize getParquetWriterPageSize(ConnectorSession session)
     {
         return session.getProperty(PARQUET_WRITER_PAGE_SIZE, DataSize.class);
+    }
+
+    public static Duration getDynamicFilteringWaitTimeout(ConnectorSession session)
+    {
+        return session.getProperty(DYNAMIC_FILTERING_WAIT_TIMEOUT, Duration.class);
     }
 
     public static boolean isTableStatisticsEnabled(ConnectorSession session)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
@@ -51,6 +51,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.plugin.deltalake.DeltaLakeMetadata.createStatisticsPredicate;
+import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getDynamicFilteringWaitTimeout;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getMaxInitialSplitSize;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getMaxSplitSize;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.extractSchema;
@@ -110,6 +111,7 @@ public class DeltaLakeSplitManager
                 maxSplitsPerSecond,
                 maxOutstandingSplits,
                 dynamicFilter,
+                getDynamicFilteringWaitTimeout(session),
                 deltaLakeTableHandle.isRecordScannedFiles());
 
         return new ClassLoaderSafeConnectorSplitSource(splitSource, Thread.currentThread().getContextClassLoader());

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConfig.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConfig.java
@@ -27,6 +27,8 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDe
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class TestDeltaLakeConfig
 {
@@ -49,6 +51,7 @@ public class TestDeltaLakeConfig
                 .setCheckpointRowStatisticsWritingEnabled(true)
                 .setVacuumMinRetention(new Duration(7, DAYS))
                 .setHiveCatalogName(null)
+                .setDynamicFilteringWaitTimeout(new Duration(0, SECONDS))
                 .setTableStatisticsEnabled(true)
                 .setExtendedStatisticsEnabled(true)
                 .setCompressionCodec(HiveCompressionCodec.SNAPPY));
@@ -73,6 +76,7 @@ public class TestDeltaLakeConfig
                 .put("delta.checkpoint-row-statistics-writing.enabled", "false")
                 .put("delta.vacuum.min-retention", "13h")
                 .put("delta.hive-catalog-name", "hive")
+                .put("delta.dynamic-filtering.wait-timeout", "30m")
                 .put("delta.table-statistics-enabled", "false")
                 .put("delta.extended-statistics.enabled", "false")
                 .put("delta.compression-codec", "GZIP")
@@ -94,6 +98,7 @@ public class TestDeltaLakeConfig
                 .setCheckpointRowStatisticsWritingEnabled(false)
                 .setVacuumMinRetention(new Duration(13, HOURS))
                 .setHiveCatalogName("hive")
+                .setDynamicFilteringWaitTimeout(new Duration(30, MINUTES))
                 .setTableStatisticsEnabled(false)
                 .setExtendedStatisticsEnabled(false)
                 .setCompressionCodec(HiveCompressionCodec.GZIP);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeDynamicPartitionPruningTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeDynamicPartitionPruningTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.sql.planner.OptimizerConfig.JoinDistributionType;
+import io.trino.testing.BaseDynamicPartitionPruningTest;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import io.trino.tpch.TpchTable;
+import org.testng.SkipException;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.util.List;
+
+import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.DELTA_CATALOG;
+import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.createDeltaLakeQueryRunner;
+import static java.lang.String.format;
+import static java.util.stream.Collectors.joining;
+
+public class TestDeltaLakeDynamicPartitionPruningTest
+        extends BaseDynamicPartitionPruningTest
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = createDeltaLakeQueryRunner(EXTRA_PROPERTIES, ImmutableMap.of(
+                "delta.dynamic-filtering.wait-timeout", "1h",
+                "delta.enable-non-concurrent-writes", "true"));
+        for (TpchTable<?> table : REQUIRED_TABLES) {
+            queryRunner.execute(format("CREATE TABLE %1$s.tpch.%2$s AS SELECT * FROM tpch.tiny.%2$s", DELTA_CATALOG, table.getTableName()));
+        }
+        return queryRunner;
+    }
+
+    @Override
+    public void testJoinDynamicFilteringMultiJoinOnBucketedTables(JoinDistributionType joinDistributionType)
+    {
+        throw new SkipException("Delta Lake does not support bucketing");
+    }
+
+    @Override
+    protected void createLineitemTable(String tableName, List<String> columns, List<String> partitionColumns)
+    {
+        String sql = format(
+                "CREATE TABLE %s WITH (partitioned_by=ARRAY[%s]) AS SELECT %s FROM tpch.tiny.lineitem",
+                tableName,
+                partitionColumns.stream().map(column -> "'" + column + "'").collect(joining(",")),
+                String.join(",", columns));
+        getQueryRunner().execute(sql);
+    }
+
+    @Override
+    protected void createPartitionedTable(String tableName, List<String> columns, List<String> partitionColumns)
+    {
+        String sql = format(
+                "CREATE TABLE %s (%s) WITH (location='%s', partitioned_by=ARRAY[%s])",
+                tableName,
+                String.join(",", columns),
+                createTableLocation(tableName),
+                partitionColumns.stream().map(column -> "'" + column + "'").collect(joining(",")));
+        getQueryRunner().execute(sql);
+    }
+
+    @Override
+    protected void createPartitionedAndBucketedTable(String tableName, List<String> columns, List<String> partitionColumns, List<String> bucketColumns)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    private static URI createTableLocation(String tableName)
+    {
+        try {
+            return Files.createTempDirectory(tableName).toFile().toURI();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Allow configuration duration for completion of dynamic filters in Delta
Fixes #11600

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Delta Lake
* Allow setting duration for completion of dynamic filters 
  via the `delta.dynamic-filtering.wait-timeout` configuration property. ({issue}`11600`)
```
