### PR TITLE
Fix calculation error in deepInstanceSize of BlockBuilderStatus

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/block/BlockBuilderStatus.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/BlockBuilderStatus.java
@@ -15,15 +15,11 @@ package io.trino.spi.block;
 
 import org.openjdk.jol.info.ClassLayout;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class BlockBuilderStatus
 {
-    public static final int INSTANCE_SIZE = deepInstanceSize(BlockBuilderStatus.class);
+    public static final int INSTANCE_SIZE = ClassLayout.parseClass(BlockBuilderStatus.class).instanceSize() + PageBuilderStatus.INSTANCE_SIZE;
 
     private final PageBuilderStatus pageBuilderStatus;
 
@@ -52,32 +48,5 @@ public class BlockBuilderStatus
         buffer.append(", currentSize=").append(currentSize);
         buffer.append('}');
         return buffer.toString();
-    }
-
-    /**
-     * Computes the size of an instance of this class assuming that all reference fields are non-null
-     */
-    private static int deepInstanceSize(Class<?> clazz)
-    {
-        if (clazz.isArray()) {
-            throw new IllegalArgumentException(format("Cannot determine size of %s because it contains an array", clazz.getSimpleName()));
-        }
-        if (clazz.isInterface()) {
-            throw new IllegalArgumentException(format("%s is an interface", clazz.getSimpleName()));
-        }
-        if (Modifier.isAbstract(clazz.getModifiers())) {
-            throw new IllegalArgumentException(format("%s is abstract", clazz.getSimpleName()));
-        }
-        if (!clazz.getSuperclass().equals(Object.class)) {
-            throw new IllegalArgumentException(format("Cannot determine size of a subclass. %s extends from %s", clazz.getSimpleName(), clazz.getSuperclass().getSimpleName()));
-        }
-
-        int size = ClassLayout.parseClass(clazz).instanceSize();
-        for (Field field : clazz.getDeclaredFields()) {
-            if (!field.getType().isPrimitive()) {
-                size += deepInstanceSize(field.getType());
-            }
-        }
-        return size;
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/PageBuilderStatus.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/PageBuilderStatus.java
@@ -13,8 +13,12 @@
  */
 package io.trino.spi.block;
 
+import org.openjdk.jol.info.ClassLayout;
+
 public class PageBuilderStatus
 {
+    public static final int INSTANCE_SIZE = ClassLayout.parseClass(PageBuilderStatus.class).instanceSize();
+
     public static final int DEFAULT_MAX_PAGE_SIZE_IN_BYTES = 1024 * 1024;
 
     private final int maxPageSizeInBytes;


### PR DESCRIPTION
Currently, in the `deepInstanceSize` function of `BlockBuilderStatus` class, we recursively calculate the size of one `BlockBuilderStatus` instance. However, we should exclude the `static` field which is not the size for one instance, it's the size for the whole class and is shared by each intance.

Besides, we should also exclude the synthetic field in this class, especially if you use something like `jacoco` in `maven` which is used to calculate code coverage. `jacoco` in `maven` will add some synthetic fields in class, and if we use the current `deepInstanceSize` function of `BlockBuilderStatus` class, we will get some errors like the following picture:

<img width="402" alt="image" src="https://user-images.githubusercontent.com/16079446/160730194-6ed4a32b-ccd1-4af5-bcb9-d62dd99000ef.png">

I was confused about this error at first, I didn't explicitly declare `boolean[]` in this class. Then I print all the fields for the class, I got the following:

![image](https://user-images.githubusercontent.com/16079446/160730450-a25d0245-a99a-471f-bebc-8b70e35fa74e.png)

The last one field: `boolean[] $jacocoData` is not declared in my class which is a synthetic field and generated by `jacoco` in `maven`, so when I iterate the fields in this class using Class<?>.getDeclaredFields() method, we will get this unexpected one. When we keep recursively calling `deepInstanceSize` function for this `boolean[] $jacocoData` field, we will get the `IllegalArgumentException` in the first picture.
