### PR TITLE
Change the type of UNSUPPORTED_TABLE_TYPE to EXTERNAL

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/StandardErrorCode.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/StandardErrorCode.java
@@ -13,6 +13,7 @@
  */
 package io.trino.spi;
 
+import static io.trino.spi.ErrorType.EXTERNAL;
 import static io.trino.spi.ErrorType.INSUFFICIENT_RESOURCES;
 import static io.trino.spi.ErrorType.INTERNAL_ERROR;
 import static io.trino.spi.ErrorType.USER_ERROR;
@@ -129,7 +130,6 @@ public enum StandardErrorCode
     MISSING_ROW_PATTERN(106, USER_ERROR),
     INVALID_WINDOW_MEASURE(107, USER_ERROR),
     STACK_OVERFLOW(108, USER_ERROR),
-    UNSUPPORTED_TABLE_TYPE(109, USER_ERROR),
 
     GENERIC_INTERNAL_ERROR(65536, INTERNAL_ERROR),
     TOO_MANY_REQUESTS_FAILED(65537, INTERNAL_ERROR),
@@ -173,6 +173,7 @@ public enum StandardErrorCode
     EXCEEDED_SCAN_LIMIT(131081, INSUFFICIENT_RESOURCES),
     EXCEEDED_TASK_DESCRIPTOR_STORAGE_CAPACITY(131082, INSUFFICIENT_RESOURCES),
 
+    UNSUPPORTED_TABLE_TYPE(133001, EXTERNAL),
     /**/;
 
     // Connectors can use error codes starting at the range 0x0100_0000

--- a/core/trino-spi/src/test/java/io/trino/spi/TestStandardErrorCode.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/TestStandardErrorCode.java
@@ -23,6 +23,7 @@ import static io.airlift.testing.Assertions.assertGreaterThan;
 import static io.airlift.testing.Assertions.assertLessThan;
 import static io.trino.spi.StandardErrorCode.GENERIC_INSUFFICIENT_RESOURCES;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static io.trino.spi.StandardErrorCode.UNSUPPORTED_TABLE_TYPE;
 import static java.util.Arrays.asList;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -61,7 +62,7 @@ public class TestStandardErrorCode
             StandardErrorCode code = iterator.next();
             int current = code(code);
             assertGreaterThan(current, previous, "Code is out of order: " + code);
-            if ((code != GENERIC_INTERNAL_ERROR) && (code != GENERIC_INSUFFICIENT_RESOURCES)) {
+            if (code != GENERIC_INTERNAL_ERROR && code != GENERIC_INSUFFICIENT_RESOURCES && code != UNSUPPORTED_TABLE_TYPE) {
                 assertEquals(current, previous + 1, "Code is not sequential: " + code);
             }
             previous = current;


### PR DESCRIPTION
### Introduction

`TestHiveGlueMetastore.testHideDeltaLakeTables` fails with:

```
2022-03-29T16:42:59.8133306Z [ERROR] com.starburstdata.presto.plugin.hive.metastore.glue.TestHiveGlueMetastoreWithFallbackingColumnStatistics.testHideDeltaLakeTables  Time elapsed: 4.876 s  <<< FAILURE!
2022-03-29T16:42:59.8140389Z io.trino.spi.TrinoException: Not a Hive table 'test_schema.some_iceberg_table'
2022-03-29T16:42:59.8142580Z 	at io.trino.plugin.hive.HiveMetadata.doGetTableMetadata(HiveMetadata.java:564)
2022-03-29T16:42:59.8146127Z 	at io.trino.plugin.hive.HiveMetadata.getTableMetadata(HiveMetadata.java:546)
2022-03-29T16:42:59.8148900Z 	at io.trino.plugin.hive.HiveMetadata.lambda$streamTableColumns$15(HiveMetadata.java:744)
```

The commit introducing this issue in Trino 375

https://github.com/trinodb/trino/commit/f817f0a92ec59fe3db2edbb576ea52027a8d761a

### Implementation details

`UNSUPPORTED_TABLE_TYPE` error code was initially introduced to
provide a more generic approach than
`HiveErrorCode.HIVE_UNSUPPORTED_FORMAT` to dealing with
the situation of selecting a table of an unsupported type
from a shared metastore (e.g. : Hive, Glue).

The internal logic from `HiveMetadata.streamTableColumns` however
made use of the error type of `HiveErrorCode.HIVE_UNSUPPORTED_FORMAT`
which is `EXTERNAL`. Due to this reason, the error type of
`UNSUPPORTED_TABLE_TYPE` will be changed as well to `EXTERNAL`.

