### PR TITLE
Extend Delta Lake statistics support

### DIFF
--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriverAuth.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriverAuth.java
@@ -68,7 +68,7 @@ public class TestTrinoDriverAuth
 
         URL resource = getClass().getClassLoader().getResource("33.privateKey");
         assertNotNull(resource, "key directory not found");
-        File keyDir = new File(resource.getFile()).getAbsoluteFile().getParentFile();
+        File keyDir = new File(resource.toURI()).getAbsoluteFile().getParentFile();
 
         defaultKey = hmacShaKeyFor(getMimeDecoder().decode(asCharSource(new File(keyDir, "default-key.key"), US_ASCII).read().getBytes(US_ASCII)));
         hmac222 = hmacShaKeyFor(getMimeDecoder().decode(asCharSource(new File(keyDir, "222.key"), US_ASCII).read().getBytes(US_ASCII)));

--- a/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
@@ -146,7 +146,7 @@ public class TestResourceSecurity
 
     static {
         try {
-            JWK_PRIVATE_KEY = PemReader.loadPrivateKey(new File(Resources.getResource("jwk/jwk-rsa-private.pem").getPath()), Optional.empty());
+            JWK_PRIVATE_KEY = PemReader.loadPrivateKey(new File(Resources.getResource("jwk/jwk-rsa-private.pem").toURI()), Optional.empty());
         }
         catch (Exception e) {
             throw new RuntimeException(e);

--- a/core/trino-main/src/test/java/io/trino/server/security/jwt/TestJwkDecoder.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/jwt/TestJwkDecoder.java
@@ -186,11 +186,11 @@ public class TestJwkDecoder
         RSAPublicKey publicKey = (RSAPublicKey) keys.get("test-rsa");
         assertNotNull(publicKey);
 
-        RSAPublicKey expectedPublicKey = (RSAPublicKey) PemReader.loadPublicKey(new File(Resources.getResource("jwk/jwk-rsa-public.pem").getPath()));
+        RSAPublicKey expectedPublicKey = (RSAPublicKey) PemReader.loadPublicKey(new File(Resources.getResource("jwk/jwk-rsa-public.pem").toURI()));
         assertEquals(publicKey.getPublicExponent(), expectedPublicKey.getPublicExponent());
         assertEquals(publicKey.getModulus(), expectedPublicKey.getModulus());
 
-        PrivateKey privateKey = PemReader.loadPrivateKey(new File(Resources.getResource("jwk/jwk-rsa-private.pem").getPath()), Optional.empty());
+        PrivateKey privateKey = PemReader.loadPrivateKey(new File(Resources.getResource("jwk/jwk-rsa-private.pem").toURI()), Optional.empty());
         String jwt = newJwtBuilder()
                 .signWith(privateKey)
                 .setHeaderParam(JwsHeader.KEY_ID, "test-rsa")
@@ -319,14 +319,14 @@ public class TestJwkDecoder
 
         assertSame(publicKey.getParams(), expectedSpec);
 
-        ECPublicKey expectedPublicKey = (ECPublicKey) PemReader.loadPublicKey(new File(Resources.getResource("jwk/" + keyName + "-public.pem").getPath()));
+        ECPublicKey expectedPublicKey = (ECPublicKey) PemReader.loadPublicKey(new File(Resources.getResource("jwk/" + keyName + "-public.pem").toURI()));
         assertEquals(publicKey.getW(), expectedPublicKey.getW());
         assertEquals(publicKey.getParams().getCurve(), expectedPublicKey.getParams().getCurve());
         assertEquals(publicKey.getParams().getGenerator(), expectedPublicKey.getParams().getGenerator());
         assertEquals(publicKey.getParams().getOrder(), expectedPublicKey.getParams().getOrder());
         assertEquals(publicKey.getParams().getCofactor(), expectedPublicKey.getParams().getCofactor());
 
-        PrivateKey privateKey = PemReader.loadPrivateKey(new File(Resources.getResource("jwk/" + keyName + "-private.pem").getPath()), Optional.empty());
+        PrivateKey privateKey = PemReader.loadPrivateKey(new File(Resources.getResource("jwk/" + keyName + "-private.pem").toURI()), Optional.empty());
         String jwt = newJwtBuilder()
                 .signWith(privateKey)
                 .setHeaderParam(JwsHeader.KEY_ID, keyName)

--- a/core/trino-main/src/test/java/io/trino/server/ui/TestWebUi.java
+++ b/core/trino-main/src/test/java/io/trino/server/ui/TestWebUi.java
@@ -143,7 +143,7 @@ public class TestWebUi
 
     static {
         try {
-            JWK_PRIVATE_KEY = PemReader.loadPrivateKey(new File(Resources.getResource("jwk/jwk-rsa-private.pem").getPath()), Optional.empty());
+            JWK_PRIVATE_KEY = PemReader.loadPrivateKey(new File(Resources.getResource("jwk/jwk-rsa-private.pem").toURI()), Optional.empty());
         }
         catch (Exception e) {
             throw new RuntimeException(e);

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestFileBasedAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestFileBasedAccessControl.java
@@ -31,6 +31,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.net.URISyntaxException;
 import java.util.EnumSet;
 import java.util.Map;
 import java.util.Optional;
@@ -477,8 +478,13 @@ public class TestFileBasedAccessControl
 
     private static ConnectorAccessControl createAccessControl(String fileName)
     {
-        File configFile = new File(getResource(fileName).getPath());
-        return new FileBasedAccessControl(new CatalogName("test_catalog"), configFile);
+        try {
+            File configFile = new File(getResource(fileName).toURI());
+            return new FileBasedAccessControl(new CatalogName("test_catalog"), configFile);
+        }
+        catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private static void assertDenied(ThrowingRunnable runnable)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeAccessControlMetadataFactory.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeAccessControlMetadataFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.plugin.hive.security.AccessControlMetadata;
+
+public interface DeltaLakeAccessControlMetadataFactory
+{
+    DeltaLakeAccessControlMetadataFactory SYSTEM = metastore -> new AccessControlMetadata() {
+        @Override
+        public boolean isUsingSystemSecurity()
+        {
+            return true;
+        }
+    };
+
+    AccessControlMetadata create(HiveMetastore metastore);
+}

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConnector.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConnector.java
@@ -20,6 +20,7 @@ import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
 import io.trino.plugin.hive.HiveTransactionHandle;
 import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.ConnectorNodePartitioningProvider;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
@@ -36,6 +37,7 @@ import io.trino.spi.transaction.IsolationLevel;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.Verify.verify;
@@ -59,6 +61,7 @@ public class DeltaLakeConnector
     private final List<PropertyMetadata<?>> schemaProperties;
     private final List<PropertyMetadata<?>> tableProperties;
     private final List<PropertyMetadata<?>> analyzeProperties;
+    private final Optional<ConnectorAccessControl> accessControl;
     private final Set<EventListener> eventListeners;
     // Delta lake is not transactional but we use Trino transaction boundaries to create a per-query
     // caching Hive metastore clients. DeltaLakeTransactionManager is used to store those.
@@ -77,6 +80,7 @@ public class DeltaLakeConnector
             List<PropertyMetadata<?>> schemaProperties,
             List<PropertyMetadata<?>> tableProperties,
             List<PropertyMetadata<?>> analyzeProperties,
+            Optional<ConnectorAccessControl> accessControl,
             Set<EventListener> eventListeners,
             DeltaLakeTransactionManager transactionManager)
     {
@@ -95,6 +99,7 @@ public class DeltaLakeConnector
         this.schemaProperties = ImmutableList.copyOf(requireNonNull(schemaProperties, "schemaProperties is null"));
         this.tableProperties = ImmutableList.copyOf(requireNonNull(tableProperties, "tableProperties is null"));
         this.analyzeProperties = ImmutableList.copyOf(requireNonNull(analyzeProperties, "analyzeProperties is null"));
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.eventListeners = ImmutableSet.copyOf(requireNonNull(eventListeners, "eventListeners is null"));
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
     }
@@ -170,6 +175,12 @@ public class DeltaLakeConnector
     public List<PropertyMetadata<?>> getAnalyzeProperties()
     {
         return analyzeProperties;
+    }
+
+    @Override
+    public ConnectorAccessControl getAccessControl()
+    {
+        return accessControl.orElseThrow(UnsupportedOperationException::new);
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadataFactory.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadataFactory.java
@@ -45,6 +45,7 @@ public class DeltaLakeMetadataFactory
     private final TransactionLogWriterFactory transactionLogWriterFactory;
     private final NodeManager nodeManager;
     private final CheckpointWriterManager checkpointWriterManager;
+    private final DeltaLakeRedirectionsProvider deltaLakeRedirectionsProvider;
     private final CachingExtendedStatisticsAccess statisticsAccess;
     private final int domainCompactionThreshold;
     private final boolean hideNonDeltaLakeTables;
@@ -67,6 +68,7 @@ public class DeltaLakeMetadataFactory
             TransactionLogWriterFactory transactionLogWriterFactory,
             NodeManager nodeManager,
             CheckpointWriterManager checkpointWriterManager,
+            DeltaLakeRedirectionsProvider deltaLakeRedirectionsProvider,
             CachingExtendedStatisticsAccess statisticsAccess,
             HiveConfig hiveConfig)
     {
@@ -79,6 +81,7 @@ public class DeltaLakeMetadataFactory
         this.transactionLogWriterFactory = requireNonNull(transactionLogWriterFactory, "transactionLogWriterFactory is null");
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
         this.checkpointWriterManager = requireNonNull(checkpointWriterManager, "checkpointWriterManager is null");
+        this.deltaLakeRedirectionsProvider = requireNonNull(deltaLakeRedirectionsProvider, "deltaLakeRedirectionsProvider is null");
         this.statisticsAccess = requireNonNull(statisticsAccess, "statisticsAccess is null");
         requireNonNull(deltaLakeConfig, "deltaLakeConfig is null");
         this.domainCompactionThreshold = deltaLakeConfig.getDomainCompactionThreshold();
@@ -116,6 +119,7 @@ public class DeltaLakeMetadataFactory
                 checkpointWritingInterval,
                 ignoreCheckpointWriteFailures,
                 deleteSchemaLocationsFallback,
+                deltaLakeRedirectionsProvider,
                 statisticsAccess);
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadataFactory.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadataFactory.java
@@ -40,6 +40,7 @@ public class DeltaLakeMetadataFactory
     private final HdfsEnvironment hdfsEnvironment;
     private final TransactionLogAccess transactionLogAccess;
     private final TypeManager typeManager;
+    private final DeltaLakeAccessControlMetadataFactory accessControlMetadataFactory;
     private final JsonCodec<DataFileInfo> dataFileInfoCodec;
     private final JsonCodec<DeltaLakeUpdateResult> updateResultJsonCodec;
     private final TransactionLogWriterFactory transactionLogWriterFactory;
@@ -61,6 +62,7 @@ public class DeltaLakeMetadataFactory
             HdfsEnvironment hdfsEnvironment,
             TransactionLogAccess transactionLogAccess,
             TypeManager typeManager,
+            DeltaLakeAccessControlMetadataFactory accessControlMetadataFactory,
             DeltaLakeConfig deltaLakeConfig,
             @HideNonDeltaLakeTables boolean hideNonDeltaLakeTables,
             JsonCodec<DataFileInfo> dataFileInfoCodec,
@@ -76,6 +78,7 @@ public class DeltaLakeMetadataFactory
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.transactionLogAccess = requireNonNull(transactionLogAccess, "transactionLogAccess is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.accessControlMetadataFactory = requireNonNull(accessControlMetadataFactory, "accessControlMetadataFactory is null");
         this.dataFileInfoCodec = requireNonNull(dataFileInfoCodec, "dataFileInfoCodec is null");
         this.updateResultJsonCodec = requireNonNull(updateResultJsonCodec, "updateResultJsonCodec is null");
         this.transactionLogWriterFactory = requireNonNull(transactionLogWriterFactory, "transactionLogWriterFactory is null");
@@ -108,6 +111,7 @@ public class DeltaLakeMetadataFactory
                 deltaLakeMetastore,
                 hdfsEnvironment,
                 typeManager,
+                accessControlMetadataFactory.create(cachingHiveMetastore),
                 domainCompactionThreshold,
                 hideNonDeltaLakeTables,
                 unsafeWritesEnabled,

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeModule.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeModule.java
@@ -108,7 +108,8 @@ public class DeltaLakeModule
 
         binder.bind(DeltaLakeTransactionManager.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorSplitManager.class).to(DeltaLakeSplitManager.class).in(Scopes.SINGLETON);
-        binder.bind(ConnectorPageSourceProvider.class).to(DeltaLakePageSourceProvider.class).in(Scopes.SINGLETON);
+        newOptionalBinder(binder, ConnectorPageSourceProvider.class)
+                .setDefault().to(DeltaLakePageSourceProvider.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorPageSinkProvider.class).to(DeltaLakePageSinkProvider.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorNodePartitioningProvider.class).to(DeltaLakeNodePartitioningProvider.class).in(Scopes.SINGLETON);
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeModule.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeModule.java
@@ -72,6 +72,7 @@ import java.util.function.BiFunction;
 
 import static com.google.inject.multibindings.MapBinder.newMapBinder;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.json.JsonCodecBinder.jsonCodecBinder;
@@ -132,6 +133,9 @@ public class DeltaLakeModule
         // Azure
         logSynchronizerMapBinder.addBinding("abfs").to(AzureTransactionLogSynchronizer.class).in(Scopes.SINGLETON);
         logSynchronizerMapBinder.addBinding("abfss").to(AzureTransactionLogSynchronizer.class).in(Scopes.SINGLETON);
+
+        newOptionalBinder(binder, DeltaLakeRedirectionsProvider.class)
+                .setDefault().toInstance(DeltaLakeRedirectionsProvider.NOOP);
 
         jsonCodecBinder(binder).bindJsonCodec(DataFileInfo.class);
         jsonCodecBinder(binder).bindJsonCodec(DeltaLakeUpdateResult.class);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeModule.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeModule.java
@@ -21,6 +21,7 @@ import com.google.inject.multibindings.MapBinder;
 import com.google.inject.multibindings.Multibinder;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.trino.plugin.base.CatalogName;
+import io.trino.plugin.base.security.ConnectorAccessControlModule;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
 import io.trino.plugin.deltalake.metastore.DeltaLakeMetastore;
 import io.trino.plugin.deltalake.procedure.DropExtendedStatsProcedure;
@@ -92,6 +93,10 @@ public class DeltaLakeModule
         binder.bind(MetastoreConfig.class).toInstance(new MetastoreConfig()); // currently not configurable
         configBinder(binder).bindConfig(ParquetReaderConfig.class);
         configBinder(binder).bindConfig(ParquetWriterConfig.class);
+
+        install(new ConnectorAccessControlModule());
+        newOptionalBinder(binder, DeltaLakeAccessControlMetadataFactory.class)
+                .setDefault().toInstance(DeltaLakeAccessControlMetadataFactory.SYSTEM);
 
         Multibinder<SystemTableProvider> systemTableProviders = newSetBinder(binder, SystemTableProvider.class);
         systemTableProviders.addBinding().to(PropertiesSystemTableProvider.class).in(Scopes.SINGLETON);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePlugin.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePlugin.java
@@ -13,13 +13,11 @@
  */
 package io.trino.plugin.deltalake;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Module;
+import io.trino.plugin.hive.HiveConnectorFactory.EmptyModule;
 import io.trino.spi.Plugin;
 import io.trino.spi.connector.ConnectorFactory;
-
-import java.util.Optional;
 
 public class DeltaLakePlugin
         implements Plugin
@@ -27,12 +25,11 @@ public class DeltaLakePlugin
     @Override
     public Iterable<ConnectorFactory> getConnectorFactories()
     {
-        return ImmutableList.of(getConnectorFactory(Optional.empty()));
+        return ImmutableList.of(getConnectorFactory(EmptyModule.class));
     }
 
-    @VisibleForTesting
-    ConnectorFactory getConnectorFactory(Optional<Module> extensions)
+    public ConnectorFactory getConnectorFactory(Class<? extends Module> module)
     {
-        return new DeltaLakeConnectorFactory(extensions);
+        return new DeltaLakeConnectorFactory(module);
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeRedirectionsProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeRedirectionsProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.TableScanRedirectApplicationResult;
+
+import java.util.Optional;
+
+public interface DeltaLakeRedirectionsProvider
+{
+    DeltaLakeRedirectionsProvider NOOP = (session, tableHandle) -> Optional.empty();
+
+    Optional<TableScanRedirectApplicationResult> getTableScanRedirection(ConnectorSession session, DeltaLakeTableHandle tableHandle);
+}

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/InternalDeltaLakeConnectorFactory.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/InternalDeltaLakeConnectorFactory.java
@@ -54,7 +54,6 @@ import io.trino.spi.type.TypeManager;
 import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -64,21 +63,12 @@ public final class InternalDeltaLakeConnectorFactory
 {
     private InternalDeltaLakeConnectorFactory() {}
 
-    public static Connector createConnector(
-            String catalogName,
-            Map<String, String> config,
-            ConnectorContext context,
-            Optional<Module> extensions)
-    {
-        return createConnector(catalogName, config, context, extensions.orElse(binder -> {}));
-    }
-
     @VisibleForTesting
     public static Connector createConnector(
             String catalogName,
             Map<String, String> config,
             ConnectorContext context,
-            Module extraModule)
+            Module module)
     {
         ClassLoader classLoader = InternalDeltaLakeConnectorFactory.class.getClassLoader();
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
@@ -102,7 +92,7 @@ public final class InternalDeltaLakeConnectorFactory
                         binder.bind(CatalogName.class).toInstance(new CatalogName(catalogName));
                         newSetBinder(binder, EventListener.class);
                     },
-                    extraModule);
+                    module);
 
             Injector injector = app
                     .doNotInitializeLogging()

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogAccess.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogAccess.java
@@ -98,11 +98,10 @@ public class TransactionLogAccess
     public TransactionLogAccess(
             TypeManager typeManager,
             CheckpointSchemaManager checkpointSchemaManager,
-            DeltaLakeConfig config,
+            DeltaLakeConfig deltaLakeConfig,
             FileFormatDataSourceStats fileFormatDataSourceStats,
             HdfsEnvironment hdfsEnvironment,
-            ParquetReaderConfig parquetReaderConfig,
-            DeltaLakeConfig deltaLakeConfig)
+            ParquetReaderConfig parquetReaderConfig)
     {
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.checkpointSchemaManager = requireNonNull(checkpointSchemaManager, "checkpointSchemaManager is null");
@@ -113,12 +112,12 @@ public class TransactionLogAccess
         this.checkpointRowStatisticsWritingEnabled = deltaLakeConfig.isCheckpointRowStatisticsWritingEnabled();
 
         tableSnapshots = EvictableCacheBuilder.newBuilder()
-                .expireAfterWrite(config.getMetadataCacheTtl().toMillis(), TimeUnit.MILLISECONDS)
+                .expireAfterWrite(deltaLakeConfig.getMetadataCacheTtl().toMillis(), TimeUnit.MILLISECONDS)
                 .recordStats()
                 .build();
         activeDataFileCache = EvictableCacheBuilder.newBuilder()
                 .weigher((Weigher<String, DeltaLakeDataFileCacheEntry>) (key, value) -> Ints.saturatedCast(estimatedSizeOf(key) + value.getRetainedSizeInBytes()))
-                .maximumWeight(config.getDataFileCacheSize().toBytes())
+                .maximumWeight(deltaLakeConfig.getDataFileCacheSize().toBytes())
                 .recordStats()
                 .build();
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/AbstractTestDeltaLakeCreateTableStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/AbstractTestDeltaLakeCreateTableStatistics.java
@@ -532,8 +532,7 @@ public abstract class AbstractTestDeltaLakeCreateTableStatistics
                 new DeltaLakeConfig(),
                 new FileFormatDataSourceStats(),
                 hdfsEnvironment,
-                new ParquetReaderConfig(),
-                new DeltaLakeConfig());
+                new ParquetReaderConfig());
 
         return transactionLogAccess.getActiveFiles(
                 transactionLogAccess.loadSnapshot(new SchemaTableName(SCHEMA, tableName), new Path(format("s3://%s/%s", bucketName, tableName)), SESSION), SESSION);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePerTransactionMetastoreCache.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePerTransactionMetastoreCache.java
@@ -72,7 +72,7 @@ public class TestDeltaLakePerTransactionMetastoreCache
 
     private static final String TEST_DELTA_CONNECTOR_NAME = "TEST_DELTA_LAKE";
 
-    private Map<String, Long> hiveMetastoreInvocationCounts = new ConcurrentHashMap<>();
+    private final Map<String, Long> hiveMetastoreInvocationCounts = new ConcurrentHashMap<>();
 
     @AfterClass(alwaysRun = true)
     public final void close()

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePerTransactionMetastoreCache.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePerTransactionMetastoreCache.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.deltalake;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.reflect.Reflection;
 import com.google.inject.Binder;
@@ -35,10 +34,6 @@ import io.trino.plugin.hive.metastore.thrift.ThriftMetastore;
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreAuthenticationModule;
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreClientFactory;
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreConfig;
-import io.trino.spi.Plugin;
-import io.trino.spi.connector.Connector;
-import io.trino.spi.connector.ConnectorContext;
-import io.trino.spi.connector.ConnectorFactory;
 import io.trino.spi.security.ConnectorIdentity;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.tpch.TpchEntity;
@@ -69,8 +64,6 @@ public class TestDeltaLakePerTransactionMetastoreCache
 {
     private static final String BUCKET_NAME = "delta-lake-per-transaction-metastore-cache";
     private DockerizedMinioDataLake dockerizedMinioDataLake;
-
-    private static final String TEST_DELTA_CONNECTOR_NAME = "TEST_DELTA_LAKE";
 
     private final Map<String, Long> hiveMetastoreInvocationCounts = new ConcurrentHashMap<>();
 
@@ -104,70 +97,51 @@ public class TestDeltaLakePerTransactionMetastoreCache
 
         DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
 
-        queryRunner.installPlugin(new Plugin() {
-            @Override
-            public Iterable<ConnectorFactory> getConnectorFactories()
-            {
-                return ImmutableList.of(new ConnectorFactory() {
+        queryRunner.installPlugin(new TestingDeltaLakePlugin(
+                new AbstractConfigurationAwareModule()
+                {
                     @Override
-                    public String getName()
+                    protected void setup(Binder binder)
                     {
-                        return TEST_DELTA_CONNECTOR_NAME;
+                        newOptionalBinder(binder, ThriftMetastoreClientFactory.class).setDefault().to(DefaultThriftMetastoreClientFactory.class).in(Scopes.SINGLETON);
+                        binder.bind(MetastoreLocator.class).to(StaticMetastoreLocator.class).in(Scopes.SINGLETON);
+                        configBinder(binder).bindConfig(StaticMetastoreConfig.class);
+                        configBinder(binder).bindConfig(ThriftMetastoreConfig.class);
+                        binder.bind(ThriftMetastore.class).to(ThriftHiveMetastore.class).in(Scopes.SINGLETON);
+                        newExporter(binder).export(ThriftMetastore.class).as((generator) -> generator.generatedNameOf(ThriftHiveMetastore.class));
+                        install(new ThriftMetastoreAuthenticationModule());
+                        binder.bind(Boolean.class).annotatedWith(HideNonDeltaLakeTables.class).toInstance(false);
+                        binder.bind(BridgingHiveMetastoreFactory.class).in(Scopes.SINGLETON);
                     }
 
-                    @Override
-                    public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
+                    @Provides
+                    @Singleton
+                    @RawHiveMetastoreFactory
+                    public HiveMetastoreFactory getCountingHiveMetastoreFactory(BridgingHiveMetastoreFactory bridgingHiveMetastoreFactory)
                     {
-                        return InternalDeltaLakeConnectorFactory.createConnector(
-                                catalogName,
-                                config,
-                                context,
-                                new AbstractConfigurationAwareModule() {
-                                    @Override
-                                    protected void setup(Binder binder)
-                                    {
-                                        newOptionalBinder(binder, ThriftMetastoreClientFactory.class).setDefault().to(DefaultThriftMetastoreClientFactory.class).in(Scopes.SINGLETON);
-                                        binder.bind(MetastoreLocator.class).to(StaticMetastoreLocator.class).in(Scopes.SINGLETON);
-                                        configBinder(binder).bindConfig(StaticMetastoreConfig.class);
-                                        configBinder(binder).bindConfig(ThriftMetastoreConfig.class);
-                                        binder.bind(ThriftMetastore.class).to(ThriftHiveMetastore.class).in(Scopes.SINGLETON);
-                                        newExporter(binder).export(ThriftMetastore.class).as((generator) -> generator.generatedNameOf(ThriftHiveMetastore.class));
-                                        install(new ThriftMetastoreAuthenticationModule());
-                                        binder.bind(Boolean.class).annotatedWith(HideNonDeltaLakeTables.class).toInstance(false);
-                                        binder.bind(BridgingHiveMetastoreFactory.class).in(Scopes.SINGLETON);
-                                    }
+                        return new HiveMetastoreFactory()
+                        {
+                            @Override
+                            public boolean isImpersonationEnabled()
+                            {
+                                return false;
+                            }
 
-                                    @Provides
-                                    @Singleton
-                                    @RawHiveMetastoreFactory
-                                    public HiveMetastoreFactory getCountingHiveMetastoreFactory(BridgingHiveMetastoreFactory bridgingHiveMetastoreFactory)
-                                    {
-                                        return new HiveMetastoreFactory() {
-                                            @Override
-                                            public boolean isImpersonationEnabled()
-                                            {
-                                                return false;
-                                            }
-
-                                            @Override
-                                            public HiveMetastore createMetastore(Optional<ConnectorIdentity> identity)
-                                            {
-                                                HiveMetastore bridgingHiveMetastore = bridgingHiveMetastoreFactory.createMetastore(identity);
-                                                // bind HiveMetastore which counts method executions
-                                                return Reflection.newProxy(HiveMetastore.class, (proxy, method, args) -> {
-                                                    String methodName = method.getName();
-                                                    long count = hiveMetastoreInvocationCounts.getOrDefault(methodName, 0L);
-                                                    hiveMetastoreInvocationCounts.put(methodName, count + 1);
-                                                    return method.invoke(bridgingHiveMetastore, args);
-                                                });
-                                            }
-                                        };
-                                    }
+                            @Override
+                            public HiveMetastore createMetastore(Optional<ConnectorIdentity> identity)
+                            {
+                                HiveMetastore bridgingHiveMetastore = bridgingHiveMetastoreFactory.createMetastore(identity);
+                                // bind HiveMetastore which counts method executions
+                                return Reflection.newProxy(HiveMetastore.class, (proxy, method, args) -> {
+                                    String methodName = method.getName();
+                                    long count = hiveMetastoreInvocationCounts.getOrDefault(methodName, 0L);
+                                    hiveMetastoreInvocationCounts.put(methodName, count + 1);
+                                    return method.invoke(bridgingHiveMetastore, args);
                                 });
+                            }
+                        };
                     }
-                });
-            }
-        });
+                }));
 
         ImmutableMap.Builder<String, String> deltaLakeProperties = ImmutableMap.builder();
         deltaLakeProperties.put("hive.metastore.uri", dockerizedMinioDataLake.getTestingHadoop().getMetastoreAddress());
@@ -181,7 +155,7 @@ public class TestDeltaLakePerTransactionMetastoreCache
             deltaLakeProperties.put("hive.per-transaction-metastore-cache-maximum-size", "1");
         }
 
-        queryRunner.createCatalog(DELTA_CATALOG, TEST_DELTA_CONNECTOR_NAME, deltaLakeProperties.buildOrThrow());
+        queryRunner.createCatalog(DELTA_CATALOG, "delta-lake", deltaLakeProperties.buildOrThrow());
 
         if (createdDeltaLake) {
             List<TpchTable<? extends TpchEntity>> tpchTables = List.of(TpchTable.NATION, TpchTable.REGION);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePlugin.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePlugin.java
@@ -28,6 +28,14 @@ public class TestDeltaLakePlugin
     @Test
     public void testCreateConnector()
     {
+        Plugin plugin = new DeltaLakePlugin();
+        ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
+        factory.create("test", ImmutableMap.of("hive.metastore.uri", "thrift://foo:1234"), new TestingConnectorContext());
+    }
+
+    @Test
+    public void testCreateTestingConnector()
+    {
         Plugin plugin = new TestingDeltaLakePlugin();
         ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
         factory.create("test", ImmutableMap.of("hive.metastore.uri", "thrift://foo:1234"), new TestingConnectorContext());
@@ -36,7 +44,7 @@ public class TestDeltaLakePlugin
     @Test
     public void testThriftMetastore()
     {
-        Plugin plugin = new TestingDeltaLakePlugin();
+        Plugin plugin = new DeltaLakePlugin();
         ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
         factory.create(
                 "test",
@@ -61,7 +69,7 @@ public class TestDeltaLakePlugin
     @Test
     public void testGlueMetastore()
     {
-        Plugin plugin = new TestingDeltaLakePlugin();
+        Plugin plugin = new DeltaLakePlugin();
         ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
         factory.create(
                 "test",
@@ -87,7 +95,7 @@ public class TestDeltaLakePlugin
     @Test
     public void testAlluxioMetastore()
     {
-        Plugin plugin = new TestingDeltaLakePlugin();
+        Plugin plugin = new DeltaLakePlugin();
         ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
 
         assertThatThrownBy(() -> factory.create(

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestPredicatePushdown.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestPredicatePushdown.java
@@ -205,17 +205,6 @@ public class TestPredicatePushdown
                 .getFullQueryInfo(query).getQueryStats().getProcessedInputPositions();
     }
 
-    // For checking preconditions in tests
-    private void checkSqlState(String actual, String expected, String message)
-    {
-        try {
-            assertQuery(actual, expected);
-        }
-        catch (AssertionError e) {
-            throw new IllegalStateException(message, e);
-        }
-    }
-
     /**
      * Represents a table stored as data in the test resources.
      */

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestReadJsonTransactionLog.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestReadJsonTransactionLog.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.math.BigInteger;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Objects;
@@ -100,7 +101,8 @@ public class TestReadJsonTransactionLog
 
     private Stream<String> readJsonTransactionLogs(String location)
     {
-        File[] files = new File(getClass().getClassLoader().getResource(location).getPath()).listFiles((dir, name) -> name.matches("[0-9]{20}\\.json"));
+        File directory = directoryForResource(location);
+        File[] files = directory.listFiles((dir, name) -> name.matches("[0-9]{20}\\.json"));
         verify(files != null);
         return Arrays.stream(files)
                 .sorted()
@@ -128,6 +130,16 @@ public class TestReadJsonTransactionLog
         }
         catch (JsonProcessingException e) {
             throw new RuntimeException("Failed to parse " + json, e);
+        }
+    }
+
+    private File directoryForResource(String location)
+    {
+        try {
+            return new File(getClass().getClassLoader().getResource(location).toURI());
+        }
+        catch (URISyntaxException e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestingDeltaLakePlugin.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestingDeltaLakePlugin.java
@@ -16,14 +16,12 @@ package io.trino.plugin.deltalake;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.connector.ConnectorFactory;
 
-import java.util.Optional;
-
 public class TestingDeltaLakePlugin
         extends DeltaLakePlugin
 {
     @Override
     public Iterable<ConnectorFactory> getConnectorFactories()
     {
-        return ImmutableList.of(getConnectorFactory(Optional.of(new TestingDeltaLakeExtensionsModule())));
+        return ImmutableList.of(getConnectorFactory(TestingDeltaLakeExtensionsModule.class));
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TrackingTransactionLogAccess.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TrackingTransactionLogAccess.java
@@ -35,12 +35,12 @@ public class TrackingTransactionLogAccess
             ConnectorSession session,
             TypeManager typeManager,
             CheckpointSchemaManager checkpointSchemaManager,
-            DeltaLakeConfig config,
+            DeltaLakeConfig deltaLakeConfig,
             FileFormatDataSourceStats fileFormatDataSourceStats,
             HdfsEnvironment hdfsEnvironment,
             ParquetReaderConfig parquetReaderConfig)
     {
-        super(typeManager, checkpointSchemaManager, config, fileFormatDataSourceStats, hdfsEnvironment, parquetReaderConfig, new DeltaLakeConfig());
+        super(typeManager, checkpointSchemaManager, deltaLakeConfig, fileFormatDataSourceStats, hdfsEnvironment, parquetReaderConfig);
         this.fileSystem = new AccessTrackingFileSystem(super.getFileSystem(tableLocation, new SchemaTableName("schema", tableName), session));
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreStatistics.java
@@ -117,8 +117,7 @@ public class TestDeltaLakeMetastoreStatistics
                 new DeltaLakeConfig(),
                 fileFormatDataSourceStats,
                 hdfsEnvironment,
-                new ParquetReaderConfig(),
-                new DeltaLakeConfig());
+                new ParquetReaderConfig());
 
         File tmpDir = Files.createTempDir();
         File metastoreDir = new File(tmpDir, "metastore");

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/statistics/TestDeltaLakeFileStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/statistics/TestDeltaLakeFileStatistics.java
@@ -43,7 +43,6 @@ import org.apache.hadoop.fs.Path;
 import org.testng.annotations.Test;
 
 import java.io.File;
-import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -80,9 +79,9 @@ public class TestDeltaLakeFileStatistics
 
     @Test
     public void testParseJsonStatistics()
-            throws IOException
+            throws Exception
     {
-        File statsFile = new File(getClass().getResource("all_type_statistics.json").getFile());
+        File statsFile = new File(getClass().getResource("all_type_statistics.json").toURI());
         DeltaLakeFileStatistics fileStatistics = objectMapper.readValue(statsFile, DeltaLakeJsonFileStatistics.class);
         testStatisticsValues(fileStatistics);
     }
@@ -91,7 +90,7 @@ public class TestDeltaLakeFileStatistics
     public void testParseParquetStatistics()
             throws Exception
     {
-        File statsFile = new File(getClass().getResource("/databricks/pruning/parquet_struct_statistics/_delta_log/00000000000000000010.checkpoint.parquet").getFile());
+        File statsFile = new File(getClass().getResource("/databricks/pruning/parquet_struct_statistics/_delta_log/00000000000000000010.checkpoint.parquet").toURI());
         Path checkpointPath = new Path(statsFile.toURI());
 
         TypeManager typeManager = TESTING_TYPE_MANAGER;

--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,19 @@
 
             <dependency>
                 <groupId>io.trino</groupId>
+                <artifactId>trino-delta-lake</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.trino</groupId>
+                <artifactId>trino-delta-lake</artifactId>
+                <type>test-jar</type>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.trino</groupId>
                 <artifactId>trino-elasticsearch</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
Let Delta Lake connector leverage additional statistics collected by
Starburst to improve query performance. Also, when table is explicitly
analyzed, delete outdated Starburst to prevent bad query plans due to
incorrect statistics data, if user actively uses Trino and Starburst.

This also includes some additional refactors.