### PR TITLE
Bind session properties in TestDeltaLakeGlueMetastore

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaLakeGlueMetastore.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaLakeGlueMetastore.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.io.Files;
 import com.google.common.io.Resources;
 import com.google.inject.Injector;
+import com.google.inject.Scopes;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.bootstrap.LifeCycleManager;
 import io.airlift.json.JsonModule;
@@ -116,6 +117,7 @@ public class TestDeltaLakeGlueMetastore
                 // connector modules
                 new DeltaLakeMetastoreModule(),
                 new DeltaLakeModule(),
+                binder -> binder.bind(DeltaLakeSessionProperties.class).in(Scopes.SINGLETON),
                 // test setup
                 binder -> {
                     binder.bind(HdfsEnvironment.class).toInstance(HDFS_ENVIRONMENT);


### PR DESCRIPTION
## Description

Bind session properties in TestDeltaLakeGlueMetastore. The test is consistency failing in master branch. 

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
