### PR TITLE
Improve test resource to File conversion

### DIFF
--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriverAuth.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriverAuth.java
@@ -68,7 +68,7 @@ public class TestTrinoDriverAuth
 
         URL resource = getClass().getClassLoader().getResource("33.privateKey");
         assertNotNull(resource, "key directory not found");
-        File keyDir = new File(resource.getFile()).getAbsoluteFile().getParentFile();
+        File keyDir = new File(resource.toURI()).getAbsoluteFile().getParentFile();
 
         defaultKey = hmacShaKeyFor(getMimeDecoder().decode(asCharSource(new File(keyDir, "default-key.key"), US_ASCII).read().getBytes(US_ASCII)));
         hmac222 = hmacShaKeyFor(getMimeDecoder().decode(asCharSource(new File(keyDir, "222.key"), US_ASCII).read().getBytes(US_ASCII)));

--- a/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
@@ -146,7 +146,7 @@ public class TestResourceSecurity
 
     static {
         try {
-            JWK_PRIVATE_KEY = PemReader.loadPrivateKey(new File(Resources.getResource("jwk/jwk-rsa-private.pem").getPath()), Optional.empty());
+            JWK_PRIVATE_KEY = PemReader.loadPrivateKey(new File(Resources.getResource("jwk/jwk-rsa-private.pem").toURI()), Optional.empty());
         }
         catch (Exception e) {
             throw new RuntimeException(e);

--- a/core/trino-main/src/test/java/io/trino/server/security/jwt/TestJwkDecoder.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/jwt/TestJwkDecoder.java
@@ -186,11 +186,11 @@ public class TestJwkDecoder
         RSAPublicKey publicKey = (RSAPublicKey) keys.get("test-rsa");
         assertNotNull(publicKey);
 
-        RSAPublicKey expectedPublicKey = (RSAPublicKey) PemReader.loadPublicKey(new File(Resources.getResource("jwk/jwk-rsa-public.pem").getPath()));
+        RSAPublicKey expectedPublicKey = (RSAPublicKey) PemReader.loadPublicKey(new File(Resources.getResource("jwk/jwk-rsa-public.pem").toURI()));
         assertEquals(publicKey.getPublicExponent(), expectedPublicKey.getPublicExponent());
         assertEquals(publicKey.getModulus(), expectedPublicKey.getModulus());
 
-        PrivateKey privateKey = PemReader.loadPrivateKey(new File(Resources.getResource("jwk/jwk-rsa-private.pem").getPath()), Optional.empty());
+        PrivateKey privateKey = PemReader.loadPrivateKey(new File(Resources.getResource("jwk/jwk-rsa-private.pem").toURI()), Optional.empty());
         String jwt = newJwtBuilder()
                 .signWith(privateKey)
                 .setHeaderParam(JwsHeader.KEY_ID, "test-rsa")
@@ -319,14 +319,14 @@ public class TestJwkDecoder
 
         assertSame(publicKey.getParams(), expectedSpec);
 
-        ECPublicKey expectedPublicKey = (ECPublicKey) PemReader.loadPublicKey(new File(Resources.getResource("jwk/" + keyName + "-public.pem").getPath()));
+        ECPublicKey expectedPublicKey = (ECPublicKey) PemReader.loadPublicKey(new File(Resources.getResource("jwk/" + keyName + "-public.pem").toURI()));
         assertEquals(publicKey.getW(), expectedPublicKey.getW());
         assertEquals(publicKey.getParams().getCurve(), expectedPublicKey.getParams().getCurve());
         assertEquals(publicKey.getParams().getGenerator(), expectedPublicKey.getParams().getGenerator());
         assertEquals(publicKey.getParams().getOrder(), expectedPublicKey.getParams().getOrder());
         assertEquals(publicKey.getParams().getCofactor(), expectedPublicKey.getParams().getCofactor());
 
-        PrivateKey privateKey = PemReader.loadPrivateKey(new File(Resources.getResource("jwk/" + keyName + "-private.pem").getPath()), Optional.empty());
+        PrivateKey privateKey = PemReader.loadPrivateKey(new File(Resources.getResource("jwk/" + keyName + "-private.pem").toURI()), Optional.empty());
         String jwt = newJwtBuilder()
                 .signWith(privateKey)
                 .setHeaderParam(JwsHeader.KEY_ID, keyName)

--- a/core/trino-main/src/test/java/io/trino/server/ui/TestWebUi.java
+++ b/core/trino-main/src/test/java/io/trino/server/ui/TestWebUi.java
@@ -143,7 +143,7 @@ public class TestWebUi
 
     static {
         try {
-            JWK_PRIVATE_KEY = PemReader.loadPrivateKey(new File(Resources.getResource("jwk/jwk-rsa-private.pem").getPath()), Optional.empty());
+            JWK_PRIVATE_KEY = PemReader.loadPrivateKey(new File(Resources.getResource("jwk/jwk-rsa-private.pem").toURI()), Optional.empty());
         }
         catch (Exception e) {
             throw new RuntimeException(e);

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestFileBasedAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestFileBasedAccessControl.java
@@ -31,6 +31,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.net.URISyntaxException;
 import java.util.EnumSet;
 import java.util.Map;
 import java.util.Optional;
@@ -477,8 +478,13 @@ public class TestFileBasedAccessControl
 
     private static ConnectorAccessControl createAccessControl(String fileName)
     {
-        File configFile = new File(getResource(fileName).getPath());
-        return new FileBasedAccessControl(new CatalogName("test_catalog"), configFile);
+        try {
+            File configFile = new File(getResource(fileName).toURI());
+            return new FileBasedAccessControl(new CatalogName("test_catalog"), configFile);
+        }
+        catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private static void assertDenied(ThrowingRunnable runnable)

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestReadJsonTransactionLog.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestReadJsonTransactionLog.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.math.BigInteger;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Objects;
@@ -100,7 +101,8 @@ public class TestReadJsonTransactionLog
 
     private Stream<String> readJsonTransactionLogs(String location)
     {
-        File[] files = new File(getClass().getClassLoader().getResource(location).getPath()).listFiles((dir, name) -> name.matches("[0-9]{20}\\.json"));
+        File directory = directoryForResource(location);
+        File[] files = directory.listFiles((dir, name) -> name.matches("[0-9]{20}\\.json"));
         verify(files != null);
         return Arrays.stream(files)
                 .sorted()
@@ -128,6 +130,16 @@ public class TestReadJsonTransactionLog
         }
         catch (JsonProcessingException e) {
             throw new RuntimeException("Failed to parse " + json, e);
+        }
+    }
+
+    private File directoryForResource(String location)
+    {
+        try {
+            return new File(getClass().getClassLoader().getResource(location).toURI());
+        }
+        catch (URISyntaxException e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/statistics/TestDeltaLakeFileStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/statistics/TestDeltaLakeFileStatistics.java
@@ -43,7 +43,6 @@ import org.apache.hadoop.fs.Path;
 import org.testng.annotations.Test;
 
 import java.io.File;
-import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -80,9 +79,9 @@ public class TestDeltaLakeFileStatistics
 
     @Test
     public void testParseJsonStatistics()
-            throws IOException
+            throws Exception
     {
-        File statsFile = new File(getClass().getResource("all_type_statistics.json").getFile());
+        File statsFile = new File(getClass().getResource("all_type_statistics.json").toURI());
         DeltaLakeFileStatistics fileStatistics = objectMapper.readValue(statsFile, DeltaLakeJsonFileStatistics.class);
         testStatisticsValues(fileStatistics);
     }
@@ -91,7 +90,7 @@ public class TestDeltaLakeFileStatistics
     public void testParseParquetStatistics()
             throws Exception
     {
-        File statsFile = new File(getClass().getResource("/databricks/pruning/parquet_struct_statistics/_delta_log/00000000000000000010.checkpoint.parquet").getFile());
+        File statsFile = new File(getClass().getResource("/databricks/pruning/parquet_struct_statistics/_delta_log/00000000000000000010.checkpoint.parquet").toURI());
         Path checkpointPath = new Path(statsFile.toURI());
 
         TypeManager typeManager = TESTING_TYPE_MANAGER;


### PR DESCRIPTION
`new File(url.getPath())` and `new File(url.getFile())` work incorrectly
when url (such as test resource) happens to be something else than
`file://`. The `new File(url.toURI())` conversion does all the proper
checks.