### PR TITLE
Split spooling partition output file into multiple files when size is large 

### DIFF
--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
@@ -293,6 +293,13 @@ for your storage solution.
      - The minimum buffer pool size for an exchange sink. The larger the buffer
        pool size, the larger the write parallelism and memory usage.
      - ``10``
+   * - ``exchange.sink-buffers-per-partition``
+     - The number of buffers per partition in the buffer pool. The larger the
+       buffer pool size, the larger the write parallelism and memory usage.
+     - ``2``
+   * - ``exchange.sink-max-file-size``
+     - Max size of files written by exchange sinks.
+     - ``1GB``
    * - ``exchange.source-concurrent-reader``
      - The number of concurrent readers to read from spooling storage. The
        larger the number of concurrent readers, the larger the read parallelism

--- a/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/FileSystemExchangeConfig.java
+++ b/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/FileSystemExchangeConfig.java
@@ -20,6 +20,7 @@ import io.airlift.units.DataSize;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
+import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
 public class FileSystemExchangeConfig
@@ -32,6 +33,7 @@ public class FileSystemExchangeConfig
     private DataSize maxPageStorageSize = DataSize.of(16, MEGABYTE);
     private int exchangeSinkBufferPoolMinSize = 10;
     private int exchangeSinkBuffersPerPartition = 2;
+    private DataSize exchangeSinkMaxFileSize = DataSize.of(1, GIGABYTE);
     private int exchangeSourceConcurrentReaders = 4;
 
     @NotNull
@@ -96,6 +98,20 @@ public class FileSystemExchangeConfig
     public FileSystemExchangeConfig setExchangeSinkBuffersPerPartition(int exchangeSinkBuffersPerPartition)
     {
         this.exchangeSinkBuffersPerPartition = exchangeSinkBuffersPerPartition;
+        return this;
+    }
+
+    @NotNull
+    public DataSize getExchangeSinkMaxFileSize()
+    {
+        return exchangeSinkMaxFileSize;
+    }
+
+    @Config("exchange.sink-max-file-size")
+    @ConfigDescription("Max size of files written by exchange sinks")
+    public FileSystemExchangeConfig setExchangeSinkMaxFileSize(DataSize exchangeSinkMaxFileSize)
+    {
+        this.exchangeSinkMaxFileSize = exchangeSinkMaxFileSize;
         return this;
     }
 

--- a/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/FileSystemExchangeSink.java
+++ b/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/FileSystemExchangeSink.java
@@ -30,6 +30,8 @@ import javax.crypto.SecretKey;
 
 import java.net.URI;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
@@ -40,6 +42,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.addExceptionCallback;
 import static io.airlift.concurrent.MoreFutures.addSuccessCallback;
@@ -68,7 +72,9 @@ public class FileSystemExchangeSink
     private final URI outputDirectory;
     private final int outputPartitionCount;
     private final Optional<SecretKey> secretKey;
-    private final int maxPageStorageSize;
+    private final boolean preserveRecordsOrder;
+    private final int maxPageStorageSizeInBytes;
+    private final long maxFileSizeInBytes;
     private final BufferPool bufferPool;
 
     private final Map<Integer, BufferedStorageWriter> writersMap = new ConcurrentHashMap<>();
@@ -80,16 +86,23 @@ public class FileSystemExchangeSink
             URI outputDirectory,
             int outputPartitionCount,
             Optional<SecretKey> secretKey,
-            int maxPageStorageSize,
+            boolean preserveRecordsOrder,
+            int maxPageStorageSizeInBytes,
             int exchangeSinkBufferPoolMinSize,
-            int exchangeSinkBuffersPerPartition)
+            int exchangeSinkBuffersPerPartition,
+            long maxFileSizeInBytes)
     {
+        checkArgument(maxPageStorageSizeInBytes <= maxFileSizeInBytes,
+                format("maxPageStorageSizeInBytes %s exceeded maxFileSizeInBytes %s", succinctBytes(maxPageStorageSizeInBytes), succinctBytes(maxFileSizeInBytes)));
+
         this.exchangeStorage = requireNonNull(exchangeStorage, "exchangeStorage is null");
         this.outputDirectory = requireNonNull(outputDirectory, "outputDirectory is null");
         this.outputPartitionCount = outputPartitionCount;
         this.secretKey = requireNonNull(secretKey, "secretKey is null");
-        this.maxPageStorageSize = maxPageStorageSize;
-        // double buffering to overlap computation and I/O
+        this.preserveRecordsOrder = preserveRecordsOrder;
+        this.maxPageStorageSizeInBytes = maxPageStorageSizeInBytes;
+        this.maxFileSizeInBytes = maxFileSizeInBytes;
+        // buffer pooling to overlap computation and I/O
         this.bufferPool = new BufferPool(max(outputPartitionCount * exchangeSinkBuffersPerPartition, exchangeSinkBufferPoolMinSize), exchangeStorage.getWriteBufferSize());
     }
 
@@ -107,11 +120,6 @@ public class FileSystemExchangeSink
 
         checkArgument(partitionId < outputPartitionCount, "partition id is expected to be less than %s: %s", outputPartitionCount, partitionId);
 
-        int requiredPageStorageSize = data.length() + Integer.BYTES;
-        if (requiredPageStorageSize > maxPageStorageSize) {
-            throw new TrinoException(NOT_SUPPORTED, format("Max row size of %s exceeded: %s", succinctBytes(maxPageStorageSize), succinctBytes(requiredPageStorageSize)));
-        }
-
         // Ensure no new writers can be created after `closed` is set to true
         BufferedStorageWriter writer;
         synchronized (this) {
@@ -125,8 +133,16 @@ public class FileSystemExchangeSink
 
     private BufferedStorageWriter createWriter(int partitionId)
     {
-        URI outputPath = outputDirectory.resolve(partitionId + DATA_FILE_SUFFIX);
-        return new BufferedStorageWriter(exchangeStorage.createExchangeStorageWriter(outputPath, secretKey), bufferPool, failure);
+        return new BufferedStorageWriter(
+                exchangeStorage,
+                outputDirectory,
+                secretKey,
+                preserveRecordsOrder,
+                partitionId,
+                bufferPool,
+                failure,
+                maxPageStorageSizeInBytes,
+                maxFileSizeInBytes);
     }
 
     @Override
@@ -207,40 +223,111 @@ public class FileSystemExchangeSink
     {
         private static final int INSTANCE_SIZE = ClassLayout.parseClass(BufferedStorageWriter.class).instanceSize();
 
-        private final ExchangeStorageWriter storageWriter;
+        private final FileSystemExchangeStorage exchangeStorage;
+        private final URI outputDirectory;
+        private final Optional<SecretKey> secretKey;
+        private final boolean preserveRecordsOrder;
+        private final int partitionId;
         private final BufferPool bufferPool;
         private final AtomicReference<Throwable> failure;
+        private final int maxPageStorageSizeInBytes;
+        private final long maxFileSizeInBytes;
 
         @GuardedBy("this")
+        private ExchangeStorageWriter currentWriter;
+        @GuardedBy("this")
+        private long currentFileSize;
+        @GuardedBy("this")
         private SliceOutput currentBuffer;
+        @GuardedBy("this")
+        private final List<ExchangeStorageWriter> writers = new ArrayList<>();
+        @GuardedBy("this")
+        private boolean closed;
 
-        public BufferedStorageWriter(ExchangeStorageWriter storageWriter, BufferPool bufferPool, AtomicReference<Throwable> failure)
+        public BufferedStorageWriter(
+                FileSystemExchangeStorage exchangeStorage,
+                URI outputDirectory,
+                Optional<SecretKey> secretKey,
+                boolean preserveRecordsOrder,
+                int partitionId,
+                BufferPool bufferPool,
+                AtomicReference<Throwable> failure,
+                int maxPageStorageSizeInBytes,
+                long maxFileSizeInBytes)
         {
-            this.storageWriter = requireNonNull(storageWriter, "storageWriter is null");
+            this.exchangeStorage = requireNonNull(exchangeStorage, "exchangeStorage is null");
+            this.outputDirectory = requireNonNull(outputDirectory, "outputDirectory is null");
+            this.secretKey = requireNonNull(secretKey, "secretKey is null");
+            this.preserveRecordsOrder = preserveRecordsOrder;
+            this.partitionId = partitionId;
             this.bufferPool = requireNonNull(bufferPool, "bufferPool is null");
             this.failure = requireNonNull(failure, "failure is null");
+            this.maxPageStorageSizeInBytes = maxPageStorageSizeInBytes;
+            this.maxFileSizeInBytes = maxFileSizeInBytes;
+
+            setupWriterForNextPart();
         }
 
         public synchronized void write(Slice data)
         {
+            if (closed) {
+                return;
+            }
+
+            int requiredPageStorageSize = Integer.BYTES + data.length();
+            if (requiredPageStorageSize > maxPageStorageSizeInBytes) {
+                throw new TrinoException(NOT_SUPPORTED, format("Max row size of %s exceeded: %s", succinctBytes(maxPageStorageSizeInBytes), succinctBytes(requiredPageStorageSize)));
+            }
+
+            if (currentFileSize + requiredPageStorageSize > maxFileSizeInBytes && !preserveRecordsOrder) {
+                flushIfNeeded(true);
+                setupWriterForNextPart();
+                currentFileSize = 0;
+                currentBuffer = null;
+            }
+
             writeInternal(Slices.wrappedIntArray(data.length()));
             writeInternal(data);
+
+            currentFileSize += requiredPageStorageSize;
         }
 
         public synchronized ListenableFuture<Void> finish()
         {
+            if (closed) {
+                return immediateFailedFuture(new IllegalStateException("BufferedStorageWriter has already closed"));
+            }
+
             flushIfNeeded(true);
-            return storageWriter.finish();
+            if (writers.size() == 1) {
+                return currentWriter.finish();
+            }
+            return asVoid(Futures.allAsList(writers.stream().map(ExchangeStorageWriter::finish).collect(toImmutableList())));
         }
 
         public synchronized ListenableFuture<Void> abort()
         {
-            return storageWriter.abort();
+            if (closed) {
+                return immediateVoidFuture();
+            }
+            closed = true;
+
+            if (writers.size() == 1) {
+                return currentWriter.abort();
+            }
+            return asVoid(Futures.allAsList(writers.stream().map(ExchangeStorageWriter::abort).collect(toImmutableList())));
         }
 
         public synchronized long getRetainedSize()
         {
-            return INSTANCE_SIZE + storageWriter.getRetainedSize();
+            return INSTANCE_SIZE + estimatedSizeOf(writers, ExchangeStorageWriter::getRetainedSize);
+        }
+
+        private void setupWriterForNextPart()
+        {
+            currentWriter = exchangeStorage.createExchangeStorageWriter(
+                    outputDirectory.resolve(partitionId + "_" + writers.size() + DATA_FILE_SUFFIX), secretKey);
+            writers.add(currentWriter);
         }
 
         private void writeInternal(Slice slice)
@@ -269,7 +356,7 @@ public class FileSystemExchangeSink
                 if (!buffer.isWritable()) {
                     currentBuffer = null;
                 }
-                ListenableFuture<Void> writeFuture = storageWriter.write(buffer.slice());
+                ListenableFuture<Void> writeFuture = currentWriter.write(buffer.slice());
                 writeFuture.addListener(() -> bufferPool.offer(buffer), directExecutor());
                 addExceptionCallback(writeFuture, throwable -> failure.compareAndSet(null, throwable));
             }

--- a/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/FileSystemExchangeSink.java
+++ b/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/FileSystemExchangeSink.java
@@ -28,8 +28,6 @@ import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 import javax.crypto.SecretKey;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.net.URI;
 import java.util.ArrayDeque;
 import java.util.Map;
@@ -128,12 +126,7 @@ public class FileSystemExchangeSink
     private BufferedStorageWriter createWriter(int partitionId)
     {
         URI outputPath = outputDirectory.resolve(partitionId + DATA_FILE_SUFFIX);
-        try {
-            return new BufferedStorageWriter(exchangeStorage.createExchangeStorageWriter(outputPath, secretKey), bufferPool, failure);
-        }
-        catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        return new BufferedStorageWriter(exchangeStorage.createExchangeStorageWriter(outputPath, secretKey), bufferPool, failure);
     }
 
     @Override

--- a/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/FileSystemExchangeStorage.java
+++ b/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/FileSystemExchangeStorage.java
@@ -30,7 +30,7 @@ public interface FileSystemExchangeStorage
 
     ExchangeStorageReader createExchangeStorageReader(Queue<ExchangeSourceFile> sourceFiles, int maxPageStorageSize);
 
-    ExchangeStorageWriter createExchangeStorageWriter(URI file, Optional<SecretKey> secretKey) throws IOException;
+    ExchangeStorageWriter createExchangeStorageWriter(URI file, Optional<SecretKey> secretKey);
 
     boolean exists(URI file) throws IOException;
 

--- a/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/AbstractTestExchangeManager.java
+++ b/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/AbstractTestExchangeManager.java
@@ -47,11 +47,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class AbstractTestExchangeManager
 {
-    private static final String SMALL_PAGE = "a".repeat(toIntExact(DataSize.of(123, BYTE).toBytes()));
-    private static final String MEDIUM_PAGE = "b".repeat(toIntExact(DataSize.of(66, KILOBYTE).toBytes()));
-    private static final String LARGE_PAGE = "c".repeat(toIntExact(DataSize.of(5, MEGABYTE).toBytes()) - Integer.BYTES);
-    private static final String MAX_PAGE = "d".repeat(toIntExact(DataSize.of(16, MEGABYTE).toBytes()) - Integer.BYTES);
-
     private ExchangeManager exchangeManager;
 
     @BeforeClass
@@ -168,6 +163,11 @@ public abstract class AbstractTestExchangeManager
     public void testLargePages()
             throws Exception
     {
+        String smallPage = "a".repeat(toIntExact(DataSize.of(123, BYTE).toBytes()));
+        String mediumPage = "b".repeat(toIntExact(DataSize.of(66, KILOBYTE).toBytes()));
+        String largePage = "c".repeat(toIntExact(DataSize.of(5, MEGABYTE).toBytes()) - Integer.BYTES);
+        String maxPage = "d".repeat(toIntExact(DataSize.of(16, MEGABYTE).toBytes()) - Integer.BYTES);
+
         Exchange exchange = exchangeManager.createExchange(new ExchangeContext(new QueryId("query"), createRandomExchangeId()), 3);
         ExchangeSinkHandle sinkHandle0 = exchange.addSink(0);
         ExchangeSinkHandle sinkHandle1 = exchange.addSink(1);
@@ -178,8 +178,8 @@ public abstract class AbstractTestExchangeManager
         writeData(
                 sinkInstanceHandle,
                 new ImmutableListMultimap.Builder<Integer, String>()
-                        .putAll(0, ImmutableList.of(SMALL_PAGE))
-                        .putAll(1, ImmutableList.of(MAX_PAGE, MEDIUM_PAGE))
+                        .putAll(0, ImmutableList.of(smallPage))
+                        .putAll(1, ImmutableList.of(maxPage, mediumPage))
                         .putAll(2, ImmutableList.of())
                         .build(),
                 true);
@@ -189,9 +189,9 @@ public abstract class AbstractTestExchangeManager
         writeData(
                 sinkInstanceHandle,
                 new ImmutableListMultimap.Builder<Integer, String>()
-                        .putAll(0, ImmutableList.of(MEDIUM_PAGE))
-                        .putAll(1, ImmutableList.of(LARGE_PAGE))
-                        .putAll(2, ImmutableList.of(SMALL_PAGE))
+                        .putAll(0, ImmutableList.of(mediumPage))
+                        .putAll(1, ImmutableList.of(largePage))
+                        .putAll(2, ImmutableList.of(smallPage))
                         .build(),
                 true);
         exchange.sinkFinished(sinkInstanceHandle);
@@ -200,9 +200,9 @@ public abstract class AbstractTestExchangeManager
         writeData(
                 sinkInstanceHandle,
                 new ImmutableListMultimap.Builder<Integer, String>()
-                        .putAll(0, ImmutableList.of(LARGE_PAGE, MAX_PAGE))
-                        .putAll(1, ImmutableList.of(SMALL_PAGE))
-                        .putAll(2, ImmutableList.of(MAX_PAGE, LARGE_PAGE, MEDIUM_PAGE))
+                        .putAll(0, ImmutableList.of(largePage, maxPage))
+                        .putAll(1, ImmutableList.of(smallPage))
+                        .putAll(2, ImmutableList.of(maxPage, largePage, mediumPage))
                         .build(),
                 true);
         exchange.sinkFinished(sinkInstanceHandle);
@@ -214,13 +214,13 @@ public abstract class AbstractTestExchangeManager
                 .collect(toImmutableMap(ExchangeSourceHandle::getPartitionId, Function.identity()));
 
         assertThat(readData(partitions.get(0)))
-                .containsExactlyInAnyOrder(SMALL_PAGE, MEDIUM_PAGE, LARGE_PAGE, MAX_PAGE);
+                .containsExactlyInAnyOrder(smallPage, mediumPage, largePage, maxPage);
 
         assertThat(readData(partitions.get(1)))
-                .containsExactlyInAnyOrder(SMALL_PAGE, MEDIUM_PAGE, LARGE_PAGE, MAX_PAGE);
+                .containsExactlyInAnyOrder(smallPage, mediumPage, largePage, maxPage);
 
         assertThat(readData(partitions.get(2)))
-                .containsExactlyInAnyOrder(SMALL_PAGE, MEDIUM_PAGE, LARGE_PAGE, MAX_PAGE);
+                .containsExactlyInAnyOrder(smallPage, mediumPage, largePage, maxPage);
 
         exchange.close();
     }

--- a/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/TestFileSystemExchangeConfig.java
+++ b/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/TestFileSystemExchangeConfig.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
 public class TestFileSystemExchangeConfig
@@ -35,6 +36,7 @@ public class TestFileSystemExchangeConfig
                 .setMaxPageStorageSize(DataSize.of(16, MEGABYTE))
                 .setExchangeSinkBufferPoolMinSize(10)
                 .setExchangeSinkBuffersPerPartition(2)
+                .setExchangeSinkMaxFileSize(DataSize.of(1, GIGABYTE))
                 .setExchangeSourceConcurrentReaders(4));
     }
 
@@ -47,6 +49,7 @@ public class TestFileSystemExchangeConfig
                 .put("exchange.max-page-storage-size", "32MB")
                 .put("exchange.sink-buffer-pool-min-size", "20")
                 .put("exchange.sink-buffers-per-partition", "3")
+                .put("exchange.sink-max-file-size", "2GB")
                 .put("exchange.source-concurrent-readers", "10")
                 .buildOrThrow();
 
@@ -56,6 +59,7 @@ public class TestFileSystemExchangeConfig
                 .setMaxPageStorageSize(DataSize.of(32, MEGABYTE))
                 .setExchangeSinkBufferPoolMinSize(20)
                 .setExchangeSinkBuffersPerPartition(3)
+                .setExchangeSinkMaxFileSize(DataSize.of(2, GIGABYTE))
                 .setExchangeSourceConcurrentReaders(10);
 
         assertFullMapping(properties, expected);

--- a/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/containers/MinioStorage.java
+++ b/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/containers/MinioStorage.java
@@ -89,6 +89,8 @@ public class MinioStorage
                 .put("exchange.base-directory", "s3n://" + minioStorage.getBucketName())
                 // TODO: enable exchange encryption after https is supported for Trino MinIO
                 .put("exchange.encryption-enabled", "false")
+                // to trigger file split in some tests
+                .put("exchange.sink-max-file-size", "16MB")
                 .put("exchange.s3.aws-access-key", MinioStorage.ACCESS_KEY)
                 .put("exchange.s3.aws-secret-key", MinioStorage.SECRET_KEY)
                 .put("exchange.s3.region", "us-east-1")

--- a/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/local/TestLocalFileSystemExchangeManager.java
+++ b/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/local/TestLocalFileSystemExchangeManager.java
@@ -25,6 +25,8 @@ public class TestLocalFileSystemExchangeManager
     protected ExchangeManager createExchangeManager()
     {
         return new FileSystemExchangeManagerFactory().create(ImmutableMap.of(
-                "exchange.base-directory", System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager"));
+                "exchange.base-directory", System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager",
+                // to trigger file split in some tests
+                "exchange.sink-max-file-size", "16MB"));
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFaultTolerantExecutionConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFaultTolerantExecutionConnectorTest.java
@@ -52,13 +52,13 @@ public class TestHiveFaultTolerantExecutionConnectorTest
     @Override
     public void testTargetMaxFileSize()
     {
-        testTargetMaxFileSize(1);
+        testTargetMaxFileSize(9);
     }
 
     @Override
     public void testTargetMaxFileSizePartitioned()
     {
-        testTargetMaxFileSizePartitioned(1);
+        testTargetMaxFileSizePartitioned(9);
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

trino-exchange plugin

> How would you describe this change to a non-technical end user or system administrator?

In fault tolerant execution, if spooling file is large, we actually want it to be split into multiple reasonably sized files such that we can exploit more parallelism when reading the data. This PR splits large spooling files based on target size.

Suppose target size is 1GB, and previously we write a single file named `0.data` of 3.2GB, after this change, we will write four files named `0_0.data`, `0_1.data`, `0_2.data`, `0_3.data`, in the form of `{partitionId}_{partNum}.data`, the sizes will be approximately 1GB, 1GB, 1GB, 0.2GB.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

() No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
() Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
