### PR TITLE
Enable auto purge default catalog property

### DIFF
--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -399,6 +399,11 @@ Property Name                                      Description                  
                                                    Set to ``false`` to disable statistics. Disabling statistics
                                                    means that :doc:`/optimizer/cost-based-optimizations` can
                                                    not make smart decisions about the query plan.
+
+``hive.auto-purge``                                Set the default value for the auto_purge table property for   ``false``
+                                                   managed tables.
+                                                   See the :ref:`hive_table_properties` for more information
+                                                   on auto_purge.
 ================================================== ============================================================ ============
 
 ORC format configuration properties

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
@@ -168,6 +168,7 @@ public class HiveConfig
 
     private boolean sizeBasedSplitWeightsEnabled = true;
     private double minimumAssignedSplitWeight = 0.05;
+    private boolean autoPurge;
 
     public boolean isSingleStatementWritesOnly()
     {
@@ -1193,6 +1194,18 @@ public class HiveConfig
     public HiveConfig setDeltaLakeCatalogName(String deltaLakeCatalogName)
     {
         this.deltaLakeCatalogName = Optional.ofNullable(deltaLakeCatalogName);
+        return this;
+    }
+
+    public boolean isAutoPurge()
+    {
+        return this.autoPurge;
+    }
+
+    @Config("hive.auto-purge")
+    public HiveConfig setAutoPurge(boolean autoPurge)
+    {
+        this.autoPurge = autoPurge;
         return this;
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableProperties.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableProperties.java
@@ -155,7 +155,7 @@ public class HiveTableProperties
                 stringProperty(CSV_QUOTE, "CSV quote character", null, false),
                 stringProperty(CSV_ESCAPE, "CSV escape character", null, false),
                 booleanProperty(TRANSACTIONAL, "Table is transactional", null, false),
-                booleanProperty(AUTO_PURGE, "Skip trash when table or partition is deleted", null, false));
+                booleanProperty(AUTO_PURGE, "Skip trash when table or partition is deleted", config.isAutoPurge(), false));
     }
 
     public List<PropertyMetadata<?>> getTableProperties()

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
@@ -111,7 +111,8 @@ public class TestHiveConfig
                 .setIcebergCatalogName(null)
                 .setSizeBasedSplitWeightsEnabled(true)
                 .setMinimumAssignedSplitWeight(0.05)
-                .setDeltaLakeCatalogName(null));
+                .setDeltaLakeCatalogName(null)
+                .setAutoPurge(false));
     }
 
     @Test
@@ -194,6 +195,7 @@ public class TestHiveConfig
                 .put("hive.size-based-split-weights-enabled", "false")
                 .put("hive.minimum-assigned-split-weight", "1.0")
                 .put("hive.delta-lake-catalog-name", "delta")
+                .put("hive.auto-purge", "true")
                 .buildOrThrow();
 
         HiveConfig expected = new HiveConfig()
@@ -272,7 +274,8 @@ public class TestHiveConfig
                 .setIcebergCatalogName("iceberg")
                 .setSizeBasedSplitWeightsEnabled(false)
                 .setMinimumAssignedSplitWeight(1.0)
-                .setDeltaLakeCatalogName("delta");
+                .setDeltaLakeCatalogName("delta")
+                .setAutoPurge(true);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->
This is the continuation of effort done as part of https://github.com/trinodb/trino/pull/9457
Enabled hive.managed-table-auto-purge-default optional property at catalog level & will be enforced if auto_purge at table level is not set. This serves as default value for table property auto_purge & removes the
need to set auto_purge each and every time managed table is created. As mentioned in https://github.com/trinodb/trino/issues/11575 user is also seeing issue trino:> drop table withacid;
Query failed: The following metastore delete operations failed: drop table with acid
io.trino.spi.TrinoException: The following metastore delete operations failed: drop table withacid
This is happening as auto_purge is not set to true. hive.managed-table-auto-purge-default optional parameter gives flexibility to admin to enforce this at catalog level
there by apply to all the tables that will be created.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

This change is a improvement.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

This is a change to Hive connector

> How would you describe this change to a non-technical end user or system administrator?

auto_purge = true allows to skip trash & speed up the dropping managed tables for hive connector. Current implementation requires user to specify the flag during the table creation. With this change
it gives the flexibility to set the auto_purge at catalog level.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->
Related Issue: https://github.com/trinodb/trino/issues/11575
Related PR: https://github.com/trinodb/trino/pull/9457
<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
() Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( x) No release notes entries required.
() Release notes entries required with the following suggested text:
