### PR TITLE
Don't check input in trino-cli in batch mode

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/Query.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/Query.java
@@ -151,7 +151,7 @@ public class Query
         WarningsPrinter warningsPrinter = new PrintStreamWarningsPrinter(errorChannel);
 
         if (showProgress) {
-            statusPrinter = new StatusPrinter(client, errorChannel, debug);
+            statusPrinter = new StatusPrinter(client, errorChannel, debug, usePager);
             statusPrinter.printInitialStatusUpdates(terminal);
         }
         else {

--- a/client/trino-cli/src/main/java/io/trino/cli/StatusPrinter.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/StatusPrinter.java
@@ -62,13 +62,15 @@ public class StatusPrinter
     private final ConsolePrinter console;
 
     private boolean debug;
+    private boolean checkInput;
 
-    public StatusPrinter(StatementClient client, PrintStream out, boolean debug)
+    public StatusPrinter(StatementClient client, PrintStream out, boolean debug, boolean checkInput)
     {
         this.client = client;
         this.out = out;
         this.console = new ConsolePrinter(out);
         this.debug = debug;
+        this.checkInput = checkInput;
     }
 
 /*
@@ -106,20 +108,22 @@ Spilled: 20GB
                     // check if time to update screen
                     boolean update = nanosSince(lastPrint).getValue(SECONDS) >= 0.5;
 
-                    // check for keyboard input
-                    int key = readKey(terminal);
-                    if (key == CTRL_P) {
-                        client.cancelLeafStage();
-                    }
-                    else if (key == CTRL_C) {
-                        updateScreen(warningsPrinter);
-                        update = false;
-                        client.close();
-                    }
-                    else if (toUpperCase(key) == 'D') {
-                        debug = !debug;
-                        console.resetScreen();
-                        update = true;
+                    if (checkInput) {
+                        // check for keyboard input
+                        int key = readKey(terminal);
+                        if (key == CTRL_P) {
+                            client.cancelLeafStage();
+                        }
+                        else if (key == CTRL_C) {
+                            updateScreen(warningsPrinter);
+                            update = false;
+                            client.close();
+                        }
+                        else if (toUpperCase(key) == 'D') {
+                            debug = !debug;
+                            console.resetScreen();
+                            update = true;
+                        }
                     }
 
                     // update screen
@@ -140,7 +144,9 @@ Spilled: 20GB
         }
         finally {
             console.resetScreen();
-            discardKeys(terminal);
+            if (checkInput) {
+                discardKeys(terminal);
+            }
             terminal.setAttributes(originalAttributes);
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->
Trino CLI can be run with `--execute`, `--file` or by passing queries to stdin. It's not necessary to check for input in these cases. If `--progress` is also used, trino-cli checks for user input, and introduces a delay in executing queries. Only when queries are passed to stdin, there's no tty, and there's no delay.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

cli client

> How would you describe this change to a non-technical end user or system administrator?

When `trino-cli` is run in batch mode but with `--progress`, there's no unnecessary delay in executing queries.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
