### PR TITLE
Use same operator type for index join builders

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/index/IndexBuildDriverFactoryProvider.java
+++ b/core/trino-main/src/main/java/io/trino/operator/index/IndexBuildDriverFactoryProvider.java
@@ -83,7 +83,7 @@ public class IndexBuildDriverFactoryProvider
                 false,
                 ImmutableList.<OperatorFactory>builder()
                         .addAll(coreOperatorFactories)
-                        .add(new PagesIndexBuilderOperatorFactory(outputOperatorId, planNodeId, indexSnapshotBuilder))
+                        .add(new PagesIndexBuilderOperatorFactory(outputOperatorId, planNodeId, indexSnapshotBuilder, "IndexBuilder"))
                         .build(),
                 OptionalInt.empty(),
                 UNGROUPED_EXECUTION);
@@ -99,7 +99,7 @@ public class IndexBuildDriverFactoryProvider
             operatorFactories.add(dynamicTupleFilterFactory.get().filterWithTuple(indexKeyTuple));
         }
 
-        operatorFactories.add(new PageBufferOperatorFactory(outputOperatorId, planNodeId, pageBuffer));
+        operatorFactories.add(new PageBufferOperatorFactory(outputOperatorId, planNodeId, pageBuffer, "IndexBuilder"));
 
         return new DriverFactory(pipelineId, inputDriver, false, operatorFactories.build(), OptionalInt.empty(), UNGROUPED_EXECUTION);
     }

--- a/core/trino-main/src/main/java/io/trino/operator/index/PageBufferOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/index/PageBufferOperator.java
@@ -33,18 +33,20 @@ public class PageBufferOperator
         private final int operatorId;
         private final PlanNodeId planNodeId;
         private final PageBuffer pageBuffer;
+        private final String operatorType;
 
-        public PageBufferOperatorFactory(int operatorId, PlanNodeId planNodeId, PageBuffer pageBuffer)
+        public PageBufferOperatorFactory(int operatorId, PlanNodeId planNodeId, PageBuffer pageBuffer, String operatorType)
         {
             this.operatorId = operatorId;
             this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
             this.pageBuffer = requireNonNull(pageBuffer, "pageBuffer is null");
+            this.operatorType = requireNonNull(operatorType, "operatorType is null");
         }
 
         @Override
         public Operator createOperator(DriverContext driverContext)
         {
-            OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, PageBufferOperator.class.getSimpleName());
+            OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, operatorType);
             return new PageBufferOperator(operatorContext, pageBuffer);
         }
 
@@ -56,7 +58,7 @@ public class PageBufferOperator
         @Override
         public OperatorFactory duplicate()
         {
-            return new PageBufferOperatorFactory(operatorId, planNodeId, pageBuffer);
+            return new PageBufferOperatorFactory(operatorId, planNodeId, pageBuffer, operatorType);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/index/PagesIndexBuilderOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/index/PagesIndexBuilderOperator.java
@@ -35,13 +35,15 @@ public class PagesIndexBuilderOperator
         private final int operatorId;
         private final PlanNodeId planNodeId;
         private final IndexSnapshotBuilder indexSnapshotBuilder;
+        private final String operatorType;
         private boolean closed;
 
-        public PagesIndexBuilderOperatorFactory(int operatorId, PlanNodeId planNodeId, IndexSnapshotBuilder indexSnapshotBuilder)
+        public PagesIndexBuilderOperatorFactory(int operatorId, PlanNodeId planNodeId, IndexSnapshotBuilder indexSnapshotBuilder, String operatorType)
         {
             this.operatorId = operatorId;
             this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
             this.indexSnapshotBuilder = requireNonNull(indexSnapshotBuilder, "indexSnapshotBuilder is null");
+            this.operatorType = requireNonNull(operatorType, "operatorType is null");
         }
 
         @Override
@@ -49,7 +51,7 @@ public class PagesIndexBuilderOperator
         {
             checkState(!closed, "Factory is already closed");
 
-            OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, PagesIndexBuilderOperator.class.getSimpleName());
+            OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, operatorType);
             return new PagesIndexBuilderOperator(operatorContext, indexSnapshotBuilder);
         }
 
@@ -62,7 +64,7 @@ public class PagesIndexBuilderOperator
         @Override
         public OperatorFactory duplicate()
         {
-            return new PagesIndexBuilderOperatorFactory(operatorId, planNodeId, indexSnapshotBuilder);
+            return new PagesIndexBuilderOperatorFactory(operatorId, planNodeId, indexSnapshotBuilder, operatorType);
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/join/TestHashJoinOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/TestHashJoinOperator.java
@@ -553,7 +553,7 @@ public class TestHashJoinOperator
             ValuesOperatorFactory valuesOperatorFactory = new ValuesOperatorFactory(17, new PlanNodeId("values"), probePages.build());
 
             PageBuffer pageBuffer = new PageBuffer(10);
-            PageBufferOperatorFactory pageBufferOperatorFactory = new PageBufferOperatorFactory(18, new PlanNodeId("pageBuffer"), pageBuffer);
+            PageBufferOperatorFactory pageBufferOperatorFactory = new PageBufferOperatorFactory(18, new PlanNodeId("pageBuffer"), pageBuffer, "PageBuffer");
 
             Driver joinDriver = Driver.createDriver(joinDriverContext,
                     valuesOperatorFactory.createOperator(joinDriverContext),


### PR DESCRIPTION
This prevents failures when adding operator stats
(operators at same pipeline index should have same type).

fixes https://github.com/trinodb/trino/issues/6220