### PR TITLE
Enforce connector and SPI version match for Trino-maintained plugins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # checkout all commits, as the build result depends on `git describe` equivalent
       - uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
@@ -102,6 +104,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # checkout all commits: it's not needed here, but it's needed almost always, so let's do this for completeness
       - name: Web UI Checks
         run: core/trino-main/bin/check_webui.sh
 
@@ -521,6 +525,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # checkout all commits, as the build result depends on `git describe` equivalent
       - uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
@@ -634,6 +640,8 @@ jobs:
     needs: build-pt
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # checkout all commits, as the build result depends on `git describe` equivalent
       - uses: actions/setup-java@v2
         with:
           distribution: 'zulu'

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -106,4 +106,23 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>io/trino/spi/trino-spi-version.txt</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>io/trino/spi/trino-spi-version.txt</exclude>
+                </excludes>
+            </resource>
+        </resources>
+    </build>
 </project>

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorContext.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorContext.java
@@ -31,6 +31,17 @@ public interface ConnectorContext
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Version of the SPI.
+     * <p>
+     * Note: this is not necessarily same as {@code getNodeManager().getCurrentNode().getVersion()}, which returns
+     * the engine version.
+     */
+    default String getSpiVersion()
+    {
+        return SpiVersionHolder.SPI_VERSION;
+    }
+
     default TypeManager getTypeManager()
     {
         throw new UnsupportedOperationException();

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/SpiVersionHolder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/SpiVersionHolder.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.connector;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.net.URL;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+// Separate class to isolate static initialization
+final class SpiVersionHolder
+{
+    private SpiVersionHolder() {}
+
+    static final String SPI_VERSION;
+
+    static {
+        try {
+            URL resource = ConnectorContext.class.getClassLoader().getResource("io/trino/spi/trino-spi-version.txt");
+            requireNonNull(resource, "version resource not found");
+            try (InputStream inputStream = resource.openStream();
+                    BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, UTF_8))) {
+                String spiVersion = reader.readLine();
+                if (spiVersion == null || spiVersion.isBlank() || reader.readLine() != null) {
+                    throw new IllegalStateException("Malformed version resource");
+                }
+                SPI_VERSION = spiVersion.strip();
+            }
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/core/trino-spi/src/main/resources/io/trino/spi/trino-spi-version.txt
+++ b/core/trino-spi/src/main/resources/io/trino/spi/trino-spi-version.txt
@@ -1,0 +1,1 @@
+${project.version}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/Versions.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/Versions.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base;
+
+import io.trino.spi.connector.ConnectorContext;
+import io.trino.spi.connector.ConnectorFactory;
+
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public final class Versions
+{
+    private Versions() {}
+
+    /**
+     * Check if the SPI version of the Trino server matches exactly the SPI version the connector plugin was built for.
+     * Using plugins built for a different version of Trino may fail at runtime, especially if plugin author
+     * chooses not to maintain compatibility with older SPI versions, as happens for plugins maintained together with
+     * the Trino project.
+     */
+    public static void checkSpiVersion(ConnectorContext context, ConnectorFactory connectorFactory)
+    {
+        String spiVersion = context.getSpiVersion();
+        Optional<String> pluginVersion = getPluginMavenVersion(connectorFactory);
+
+        if (pluginVersion.isEmpty()) {
+            // Assume we're in tests. In tests, plugin version is unknown and SPI version may be known, e.g. when running single module's tests from maven.
+            return;
+        }
+
+        checkState(
+                spiVersion.equals(pluginVersion.get()),
+                format(
+                        "Trino SPI version %s does not match %s connector version %s. The connector cannot be used with SPI version other than it was compiled for.",
+                        spiVersion,
+                        connectorFactory.getName(),
+                        pluginVersion.get()));
+    }
+
+    private static Optional<String> getPluginMavenVersion(ConnectorFactory connectorFactory)
+    {
+        String specificationVersion = connectorFactory.getClass().getPackage().getSpecificationVersion();
+        String implementationVersion = connectorFactory.getClass().getPackage().getImplementationVersion();
+        if (specificationVersion == null && implementationVersion == null) {
+            // The information comes from jar's Manifest and is not present e.g. when running tests, or from an IDE.
+            return Optional.empty();
+        }
+
+        requireNonNull(specificationVersion, "specificationVersion not present when implementationVersion is present");
+        requireNonNull(implementationVersion, "implementationVersion not present when specificationVersion is present");
+
+        // Implementation version comes from Manifest and is defined in Airbase as equivalent to `git describe` output.
+        if (implementationVersion.matches(".*-(\\d+)-g([0-9a-f]+)(-dirty)?$")) {
+            // Specification version comes from Manifest and is the project version with `-SNAPSHOT` stripped, and .0 added (if not present).
+            return Optional.of(specificationVersion.replaceAll("\\.0$", "") + "-SNAPSHOT");
+        }
+        return Optional.of(implementationVersion);
+    }
+}

--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloConnectorFactory.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloConnectorFactory.java
@@ -23,6 +23,7 @@ import io.trino.spi.connector.ConnectorFactory;
 
 import java.util.Map;
 
+import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.util.Objects.requireNonNull;
 
 public class AccumuloConnectorFactory
@@ -42,6 +43,7 @@ public class AccumuloConnectorFactory
         requireNonNull(catalogName, "catalogName is null");
         requireNonNull(config, "config is null");
         requireNonNull(context, "context is null");
+        checkSpiVersion(context, this);
 
         Bootstrap app = new Bootstrap(
                 new JsonModule(),

--- a/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopConnectorFactory.java
+++ b/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopConnectorFactory.java
@@ -28,6 +28,7 @@ import io.trino.spi.connector.ConnectorFactory;
 import java.util.Map;
 
 import static io.airlift.configuration.ConditionalModule.conditionalModule;
+import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.util.Objects.requireNonNull;
 
 public class AtopConnectorFactory
@@ -52,6 +53,7 @@ public class AtopConnectorFactory
     public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
     {
         requireNonNull(requiredConfig, "requiredConfig is null");
+        checkSpiVersion(context, this);
 
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             Bootstrap app = new Bootstrap(

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcConnectorFactory.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcConnectorFactory.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.util.Objects.requireNonNull;
 
 public class JdbcConnectorFactory
@@ -62,6 +63,7 @@ public class JdbcConnectorFactory
     public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
     {
         requireNonNull(requiredConfig, "requiredConfig is null");
+        checkSpiVersion(context, this);
 
         Bootstrap app = new Bootstrap(
                 binder -> binder.bind(TypeManager.class).toInstance(context.getTypeManager()),

--- a/plugin/trino-bigquery/pom.xml
+++ b/plugin/trino-bigquery/pom.xml
@@ -60,6 +60,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-plugin-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>bootstrap</artifactId>
         </dependency>

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorFactory.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorFactory.java
@@ -24,6 +24,7 @@ import io.trino.spi.type.TypeManager;
 
 import java.util.Map;
 
+import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.util.Objects.requireNonNull;
 
 public class BigQueryConnectorFactory
@@ -40,6 +41,7 @@ public class BigQueryConnectorFactory
     {
         requireNonNull(catalogName, "catalogName is null");
         requireNonNull(config, "config is null");
+        checkSpiVersion(context, this);
 
         Bootstrap app = new Bootstrap(
                 new JsonModule(),

--- a/plugin/trino-blackhole/src/main/java/io/trino/plugin/blackhole/BlackHoleConnectorFactory.java
+++ b/plugin/trino-blackhole/src/main/java/io/trino/plugin/blackhole/BlackHoleConnectorFactory.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 
 public class BlackHoleConnectorFactory
@@ -36,6 +37,8 @@ public class BlackHoleConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
     {
+        checkSpiVersion(context, this);
+
         ListeningScheduledExecutorService executorService = listeningDecorator(newSingleThreadScheduledExecutor(daemonThreadsNamed("blackhole")));
         return new BlackHoleConnector(
                 new BlackHoleMetadata(),

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraConnectorFactory.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraConnectorFactory.java
@@ -24,6 +24,7 @@ import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
 
+import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.util.Objects.requireNonNull;
 
 public class CassandraConnectorFactory
@@ -39,6 +40,7 @@ public class CassandraConnectorFactory
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
         requireNonNull(config, "config is null");
+        checkSpiVersion(context, this);
 
         Bootstrap app = new Bootstrap(
                 new MBeanModule(),

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConnectorFactory.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConnectorFactory.java
@@ -22,6 +22,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 
 import static com.google.common.base.Throwables.throwIfUnchecked;
+import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.util.Objects.requireNonNull;
 
 public class DeltaLakeConnectorFactory
@@ -45,6 +46,8 @@ public class DeltaLakeConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
+        checkSpiVersion(context, this);
+
         ClassLoader classLoader = context.duplicatePluginClassLoader();
         try {
             Class<?> moduleClass = classLoader.loadClass(Module.class.getName());

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchConnectorFactory.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchConnectorFactory.java
@@ -27,6 +27,7 @@ import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
 
+import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.util.Objects.requireNonNull;
 
 public class ElasticsearchConnectorFactory
@@ -45,6 +46,7 @@ public class ElasticsearchConnectorFactory
     {
         requireNonNull(catalogName, "catalogName is null");
         requireNonNull(config, "config is null");
+        checkSpiVersion(context, this);
 
         Bootstrap app = new Bootstrap(
                 new MBeanModule(),

--- a/plugin/trino-example-http/src/main/java/io/trino/plugin/example/ExampleConnectorFactory.java
+++ b/plugin/trino-example-http/src/main/java/io/trino/plugin/example/ExampleConnectorFactory.java
@@ -23,6 +23,7 @@ import io.trino.spi.connector.ConnectorFactory;
 
 import java.util.Map;
 
+import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.util.Objects.requireNonNull;
 
 public class ExampleConnectorFactory
@@ -38,6 +39,7 @@ public class ExampleConnectorFactory
     public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
     {
         requireNonNull(requiredConfig, "requiredConfig is null");
+        checkSpiVersion(context, this);
 
         // A plugin is not required to use Guice; it is just very convenient
         Bootstrap app = new Bootstrap(

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsConnectorFactory.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsConnectorFactory.java
@@ -23,6 +23,7 @@ import io.trino.spi.connector.ConnectorFactory;
 
 import java.util.Map;
 
+import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.util.Objects.requireNonNull;
 
 public class SheetsConnectorFactory
@@ -38,6 +39,7 @@ public class SheetsConnectorFactory
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
         requireNonNull(config, "config is null");
+        checkSpiVersion(context, this);
 
         Bootstrap app = new Bootstrap(
                 new JsonModule(),

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConnectorFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConnectorFactory.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Throwables.throwIfUnchecked;
+import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.util.Objects.requireNonNull;
 
 public class HiveConnectorFactory
@@ -54,6 +55,8 @@ public class HiveConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
+        checkSpiVersion(context, this);
+
         ClassLoader classLoader = context.duplicatePluginClassLoader();
         try {
             Object moduleInstance = classLoader.loadClass(module.getName()).getConstructor().newInstance();

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConnectorFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConnectorFactory.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.base.Throwables.throwIfUnchecked;
+import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.util.Objects.requireNonNull;
 
 public class IcebergConnectorFactory
@@ -50,6 +51,8 @@ public class IcebergConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
+        checkSpiVersion(context, this);
+
         ClassLoader classLoader = context.duplicatePluginClassLoader();
         try {
             Object moduleInstance = classLoader.loadClass(module.getName()).getConstructor().newInstance();

--- a/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxConnectorFactory.java
+++ b/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxConnectorFactory.java
@@ -25,6 +25,7 @@ import io.trino.spi.connector.ConnectorFactory;
 import java.util.Map;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.trino.plugin.base.Versions.checkSpiVersion;
 
 public class JmxConnectorFactory
         implements ConnectorFactory
@@ -38,6 +39,8 @@ public class JmxConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
+        checkSpiVersion(context, this);
+
         Bootstrap app = new Bootstrap(
                 new MBeanServerModule(),
                 binder -> {

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConnectorFactory.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConnectorFactory.java
@@ -27,6 +27,7 @@ import io.trino.spi.type.TypeManager;
 
 import java.util.Map;
 
+import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.util.Objects.requireNonNull;
 
 public class KafkaConnectorFactory
@@ -50,6 +51,7 @@ public class KafkaConnectorFactory
     {
         requireNonNull(catalogName, "catalogName is null");
         requireNonNull(config, "config is null");
+        checkSpiVersion(context, this);
 
         Bootstrap app = new Bootstrap(
                 new CatalogNameModule(catalogName),

--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisConnectorFactory.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisConnectorFactory.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Throwables.throwIfUnchecked;
+import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.util.Objects.requireNonNull;
 
 public class KinesisConnectorFactory
@@ -45,6 +46,7 @@ public class KinesisConnectorFactory
     {
         requireNonNull(catalogName, "catalogName is null");
         requireNonNull(config, "config is null");
+        checkSpiVersion(context, this);
 
         try {
             Bootstrap app = new Bootstrap(

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduConnectorFactory.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduConnectorFactory.java
@@ -22,6 +22,7 @@ import io.trino.spi.connector.ConnectorFactory;
 
 import java.util.Map;
 
+import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.util.Objects.requireNonNull;
 
 public class KuduConnectorFactory
@@ -41,6 +42,7 @@ public class KuduConnectorFactory
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
         requireNonNull(config, "config is null");
+        checkSpiVersion(context, this);
 
         Bootstrap app = new Bootstrap(
                 new JsonModule(),

--- a/plugin/trino-local-file/pom.xml
+++ b/plugin/trino-local-file/pom.xml
@@ -24,6 +24,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-plugin-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>bootstrap</artifactId>
         </dependency>

--- a/plugin/trino-local-file/src/main/java/io/trino/plugin/localfile/LocalFileConnectorFactory.java
+++ b/plugin/trino-local-file/src/main/java/io/trino/plugin/localfile/LocalFileConnectorFactory.java
@@ -22,6 +22,7 @@ import io.trino.spi.connector.ConnectorFactory;
 
 import java.util.Map;
 
+import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.util.Objects.requireNonNull;
 
 public class LocalFileConnectorFactory
@@ -37,6 +38,7 @@ public class LocalFileConnectorFactory
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
         requireNonNull(config, "config is null");
+        checkSpiVersion(context, this);
 
         Bootstrap app = new Bootstrap(
                 binder -> binder.bind(NodeManager.class).toInstance(context.getNodeManager()),

--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryConnectorFactory.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryConnectorFactory.java
@@ -22,6 +22,7 @@ import io.trino.spi.connector.ConnectorFactory;
 
 import java.util.Map;
 
+import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.util.Objects.requireNonNull;
 
 public class MemoryConnectorFactory
@@ -37,6 +38,7 @@ public class MemoryConnectorFactory
     public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
     {
         requireNonNull(requiredConfig, "requiredConfig is null");
+        checkSpiVersion(context, this);
 
         // A plugin is not required to use Guice; it is just very convenient
         Bootstrap app = new Bootstrap(

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoConnectorFactory.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoConnectorFactory.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.util.Objects.requireNonNull;
 
 public class MongoConnectorFactory
@@ -48,6 +49,7 @@ public class MongoConnectorFactory
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
         requireNonNull(config, "config is null");
+        checkSpiVersion(context, this);
 
         Bootstrap app = new Bootstrap(
                 new JsonModule(),

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixConnectorFactory.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixConnectorFactory.java
@@ -25,6 +25,7 @@ import io.trino.spi.type.TypeManager;
 
 import java.util.Map;
 
+import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.util.Objects.requireNonNull;
 
 public class PhoenixConnectorFactory
@@ -47,6 +48,7 @@ public class PhoenixConnectorFactory
     public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
     {
         requireNonNull(requiredConfig, "requiredConfig is null");
+        checkSpiVersion(context, this);
 
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             Bootstrap app = new Bootstrap(

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixConnectorFactory.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixConnectorFactory.java
@@ -25,6 +25,7 @@ import io.trino.spi.type.TypeManager;
 
 import java.util.Map;
 
+import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.util.Objects.requireNonNull;
 
 public class PhoenixConnectorFactory
@@ -47,6 +48,7 @@ public class PhoenixConnectorFactory
     public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
     {
         requireNonNull(requiredConfig, "requiredConfig is null");
+        checkSpiVersion(context, this);
 
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             Bootstrap app = new Bootstrap(

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotConnectorFactory.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotConnectorFactory.java
@@ -28,6 +28,7 @@ import org.weakref.jmx.guice.MBeanModule;
 import java.util.Map;
 import java.util.Optional;
 
+import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.util.Objects.requireNonNull;
 
 public class PinotConnectorFactory
@@ -51,6 +52,7 @@ public class PinotConnectorFactory
     {
         requireNonNull(catalogName, "catalogName is null");
         requireNonNull(config, "config is null");
+        checkSpiVersion(context, this);
 
         ImmutableList.Builder<Module> modulesBuilder = ImmutableList.<Module>builder()
                 .add(new JsonModule())

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusConnectorFactory.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusConnectorFactory.java
@@ -24,6 +24,7 @@ import io.trino.spi.connector.ConnectorFactory;
 import java.util.Map;
 
 import static com.google.common.base.Throwables.throwIfUnchecked;
+import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.util.Objects.requireNonNull;
 
 public class PrometheusConnectorFactory
@@ -39,6 +40,8 @@ public class PrometheusConnectorFactory
     public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
     {
         requireNonNull(requiredConfig, "requiredConfig is null");
+        checkSpiVersion(context, this);
+
         try {
             // A plugin is not required to use Guice; it is just very convenient
             Bootstrap app = new Bootstrap(

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorConnectorFactory.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorConnectorFactory.java
@@ -36,6 +36,7 @@ import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.util.Objects.requireNonNull;
 
 public class RaptorConnectorFactory
@@ -62,6 +63,8 @@ public class RaptorConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
+        checkSpiVersion(context, this);
+
         Bootstrap app = new Bootstrap(
                 new CatalogNameModule(catalogName),
                 new JsonModule(),

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisConnectorFactory.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisConnectorFactory.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.util.Objects.requireNonNull;
 
 public class RedisConnectorFactory
@@ -52,6 +53,7 @@ public class RedisConnectorFactory
     {
         requireNonNull(catalogName, "catalogName is null");
         requireNonNull(config, "config is null");
+        checkSpiVersion(context, this);
 
         Bootstrap app = new Bootstrap(
                 new JsonModule(),

--- a/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftConnectorFactory.java
+++ b/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftConnectorFactory.java
@@ -27,6 +27,7 @@ import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
 
+import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.util.Objects.requireNonNull;
 
 public class ThriftConnectorFactory
@@ -50,6 +51,8 @@ public class ThriftConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
+        checkSpiVersion(context, this);
+
         Bootstrap app = new Bootstrap(
                 new MBeanModule(),
                 new MBeanServerModule(),

--- a/plugin/trino-tpcds/pom.xml
+++ b/plugin/trino-tpcds/pom.xml
@@ -18,6 +18,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-plugin-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.trino.tpcds</groupId>
             <artifactId>tpcds</artifactId>
         </dependency>
@@ -40,6 +45,19 @@
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
+        </dependency>
+
+        <!-- used by tests but also needed transitively -->
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log-manager</artifactId>
+            <scope>runtime</scope>
         </dependency>
 
         <!-- Trino SPI -->
@@ -102,18 +120,6 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>joni</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>log</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>log-manager</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsConnectorFactory.java
+++ b/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsConnectorFactory.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkState;
+import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.Integer.parseInt;
 
@@ -57,6 +58,8 @@ public class TpcdsConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
+        checkSpiVersion(context, this);
+
         int splitsPerNode = getSplitsPerNode(config);
         NodeManager nodeManager = context.getNodeManager();
         return new Connector()

--- a/plugin/trino-tpch/pom.xml
+++ b/plugin/trino-tpch/pom.xml
@@ -18,6 +18,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-plugin-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.trino.tpch</groupId>
             <artifactId>tpch</artifactId>
         </dependency>

--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchConnectorFactory.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchConnectorFactory.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.lang.Boolean.FALSE;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
@@ -76,6 +77,8 @@ public class TpchConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> properties, ConnectorContext context)
     {
+        checkSpiVersion(context, this);
+
         int splitsPerNode = getSplitsPerNode(properties);
         ColumnNaming columnNaming = ColumnNaming.valueOf(properties.getOrDefault(TPCH_COLUMN_NAMING_PROPERTY, ColumnNaming.SIMPLIFIED.name()).toUpperCase(ENGLISH));
         DecimalTypeMapping decimalTypeMapping = DecimalTypeMapping.valueOf(properties.getOrDefault(TPCH_DOUBLE_TYPE_MAPPING_PROPERTY, DecimalTypeMapping.DOUBLE.name()).toUpperCase(ENGLISH));

--- a/testing/trino-testing/pom.xml
+++ b/testing/trino-testing/pom.xml
@@ -40,6 +40,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-plugin-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-spi</artifactId>
         </dependency>
 

--- a/testing/trino-testing/src/main/java/io/trino/testing/tpch/IndexedTpchConnectorFactory.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/tpch/IndexedTpchConnectorFactory.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.util.Objects.requireNonNull;
 
 public class IndexedTpchConnectorFactory
@@ -60,6 +61,8 @@ public class IndexedTpchConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> properties, ConnectorContext context)
     {
+        checkSpiVersion(context, this);
+
         int splitsPerNode = getSplitsPerNode(properties);
         TpchIndexedData indexedData = new TpchIndexedData(indexSpec);
         NodeManager nodeManager = context.getNodeManager();


### PR DESCRIPTION
While SPI intends to be backwards compatible, the plugins bundled with
the project do not intend to be compatible with any other engine or SPI
version than the ones they were build for.  Sometimes users end up
deploying a plugin version that does not match the SPI version. This
can lead to hard to explain exceptions or even correctness problems,
especially if the connector relies on an engine feature that is not
present.

This commit adds version checks to all plugins bundled with the project.
