### PR TITLE
Count task failures for whole query

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/FaultTolerantStageScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/FaultTolerantStageScheduler.java
@@ -136,7 +136,7 @@ public class FaultTolerantStageScheduler
     @GuardedBy("this")
     private final Map<Integer, Integer> remainingAttemptsPerTask = new HashMap<>();
     @GuardedBy("this")
-    private Map<Integer, MemoryRequirements> partitionMemoryRequirements = new HashMap<>();
+    private final Map<Integer, MemoryRequirements> partitionMemoryRequirements = new HashMap<>();
 
     @GuardedBy("this")
     private Throwable failure;

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/FaultTolerantStageScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/FaultTolerantStageScheduler.java
@@ -59,6 +59,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -132,7 +133,7 @@ public class FaultTolerantStageScheduler
     @GuardedBy("this")
     private final Set<Integer> finishedPartitions = new HashSet<>();
     @GuardedBy("this")
-    private int remainingRetryAttemptsOverall;
+    private final AtomicInteger remainingRetryAttemptsOverall;
     @GuardedBy("this")
     private final Map<Integer, Integer> remainingAttemptsPerTask = new HashMap<>();
     @GuardedBy("this")
@@ -157,7 +158,7 @@ public class FaultTolerantStageScheduler
             Map<PlanFragmentId, Exchange> sourceExchanges,
             Optional<int[]> sourceBucketToPartitionMap,
             Optional<BucketNodeMap> sourceBucketNodeMap,
-            int taskRetryAttemptsOverall,
+            AtomicInteger remainingRetryAttemptsOverall,
             int taskRetryAttemptsPerTask)
     {
         checkArgument(!stage.getFragment().getStageExecutionDescriptor().isStageGroupedExecution(), "grouped execution is expected to be disabled");
@@ -175,8 +176,7 @@ public class FaultTolerantStageScheduler
         this.sourceExchanges = ImmutableMap.copyOf(requireNonNull(sourceExchanges, "sourceExchanges is null"));
         this.sourceBucketToPartitionMap = requireNonNull(sourceBucketToPartitionMap, "sourceBucketToPartitionMap is null");
         this.sourceBucketNodeMap = requireNonNull(sourceBucketNodeMap, "sourceBucketNodeMap is null");
-        checkArgument(taskRetryAttemptsOverall >= 0, "taskRetryAttemptsOverall must be greater than or equal to 0: %s", taskRetryAttemptsOverall);
-        this.remainingRetryAttemptsOverall = taskRetryAttemptsOverall;
+        this.remainingRetryAttemptsOverall = requireNonNull(remainingRetryAttemptsOverall, "remainingRetryAttemptsOverall is null");
         this.maxRetryAttemptsPerTask = taskRetryAttemptsPerTask;
     }
 
@@ -539,8 +539,10 @@ public class FaultTolerantStageScheduler
                             ErrorCode errorCode = failureInfo.getErrorCode();
 
                             int taskRemainingAttempts = remainingAttemptsPerTask.getOrDefault(partitionId, maxRetryAttemptsPerTask);
-                            if (remainingRetryAttemptsOverall > 0 && taskRemainingAttempts > 0 && (errorCode == null || errorCode.getType() != USER_ERROR)) {
-                                remainingRetryAttemptsOverall--;
+                            if (remainingRetryAttemptsOverall.get() > 0
+                                    && taskRemainingAttempts > 0
+                                    && (errorCode == null || errorCode.getType() != USER_ERROR)) {
+                                remainingRetryAttemptsOverall.decrementAndGet();
                                 remainingAttemptsPerTask.put(partitionId, taskRemainingAttempts - 1);
 
                                 // update memory limits for next attempt

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/SqlQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/SqlQueryScheduler.java
@@ -1784,6 +1784,8 @@ public class SqlQueryScheduler
 
                 ImmutableSet.Builder<PlanFragmentId> coordinatorConsumedFragmentsBuilder = ImmutableSet.builder();
 
+                checkArgument(taskRetryAttemptsOverall >= 0, "taskRetryAttemptsOverall must be greater than or equal to 0: %s", taskRetryAttemptsOverall);
+                AtomicInteger remainingTaskRetryAttemptsOverall = new AtomicInteger(taskRetryAttemptsOverall);
                 for (SqlStage stage : distributedStagesInReverseTopologicalOrder) {
                     PlanFragment fragment = stage.getFragment();
                     Optional<SqlStage> parentStage = stageManager.getParent(stage.getStageId());
@@ -1826,7 +1828,7 @@ public class SqlQueryScheduler
                             sourceExchanges.buildOrThrow(),
                             inputBucketToPartition.getBucketToPartitionMap(),
                             inputBucketToPartition.getBucketNodeMap(),
-                            taskRetryAttemptsOverall,
+                            remainingTaskRetryAttemptsOverall,
                             taskRetryAttemptsPerTask);
 
                     schedulers.add(scheduler);

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestFaultTolerantStageScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestFaultTolerantStageScheduler.java
@@ -60,6 +60,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.collect.Iterables.cycle;
 import static com.google.common.collect.Iterables.limit;
@@ -516,7 +517,7 @@ public class TestFaultTolerantStageScheduler
                 sourceExchanges,
                 Optional.empty(),
                 Optional.empty(),
-                retryAttempts,
+                new AtomicInteger(retryAttempts),
                 retryAttempts);
     }
 


### PR DESCRIPTION
Count task failures for whole query


## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:
