### PR TITLE
Drop support of resource over commit

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -72,7 +72,6 @@ public final class SystemSessionProperties
     public static final String QUERY_MAX_EXECUTION_TIME = "query_max_execution_time";
     public static final String QUERY_MAX_PLANNING_TIME = "query_max_planning_time";
     public static final String QUERY_MAX_RUN_TIME = "query_max_run_time";
-    public static final String RESOURCE_OVERCOMMIT = "resource_overcommit";
     public static final String QUERY_MAX_CPU_TIME = "query_max_cpu_time";
     public static final String QUERY_MAX_SCAN_PHYSICAL_BYTES = "query_max_scan_physical_bytes";
     public static final String QUERY_MAX_STAGE_COUNT = "query_max_stage_count";
@@ -334,11 +333,6 @@ public final class SystemSessionProperties
                         QUERY_MAX_SCAN_PHYSICAL_BYTES,
                         "Maximum scan physical bytes of a query",
                         queryManagerConfig.getQueryMaxScanPhysicalBytes().orElse(null),
-                        false),
-                booleanProperty(
-                        RESOURCE_OVERCOMMIT,
-                        "Use resources which are not guaranteed to be available to the query",
-                        false,
                         false),
                 integerProperty(
                         QUERY_MAX_STAGE_COUNT,
@@ -928,11 +922,6 @@ public final class SystemSessionProperties
     public static Duration getQueryMaxPlanningTime(Session session)
     {
         return session.getSystemProperty(QUERY_MAX_PLANNING_TIME, Duration.class);
-    }
-
-    public static boolean resourceOvercommit(Session session)
-    {
-        return session.getSystemProperty(RESOURCE_OVERCOMMIT, Boolean.class);
     }
 
     public static int getQueryMaxStageCount(Session session)

--- a/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
@@ -71,7 +71,6 @@ import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.concurrent.Threads.threadsNamed;
 import static io.trino.SystemSessionProperties.getQueryMaxMemoryPerNode;
-import static io.trino.SystemSessionProperties.resourceOvercommit;
 import static io.trino.collect.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.execution.SqlTask.createSqlTask;
 import static io.trino.spi.StandardErrorCode.ABANDONED_TASK;
@@ -397,9 +396,7 @@ public class SqlTaskManager
             long sessionQueryMaxMemoryPerNode = getQueryMaxMemoryPerNode(session).toBytes();
 
             // Session properties are only allowed to decrease memory limits, not increase them
-            queryContext.initializeMemoryLimits(
-                    resourceOvercommit(session),
-                    min(sessionQueryMaxMemoryPerNode, queryMaxMemoryPerNode));
+            queryContext.initializeMemoryLimits(min(sessionQueryMaxMemoryPerNode, queryMaxMemoryPerNode));
         }
 
         sqlTask.recordHeartbeat();

--- a/core/trino-main/src/main/java/io/trino/memory/QueryContext.java
+++ b/core/trino-main/src/main/java/io/trino/memory/QueryContext.java
@@ -132,17 +132,10 @@ public class QueryContext
     }
 
     // TODO: This method should be removed, and the correct limit set in the constructor. However, due to the way QueryContext is constructed the memory limit is not known in advance
-    public synchronized void initializeMemoryLimits(boolean resourceOverCommit, long maxUserMemory)
+    public synchronized void initializeMemoryLimits(long maxUserMemory)
     {
         checkArgument(maxUserMemory >= 0, "maxUserMemory must be >= 0, found: %s", maxUserMemory);
-        if (resourceOverCommit) {
-            // Allow the query to use the entire pool. This way the worker will kill the query, if it uses the entire local memory pool.
-            // The coordinator will kill the query if the cluster runs out of memory.
-            this.maxUserMemory = memoryPool.getMaxBytes();
-        }
-        else {
-            this.maxUserMemory = maxUserMemory;
-        }
+        this.maxUserMemory = maxUserMemory;
         memoryLimitsInitialized = true;
     }
 

--- a/docs/src/main/sphinx/security/file-system-access-control.rst
+++ b/docs/src/main/sphinx/security/file-system-access-control.rst
@@ -357,7 +357,7 @@ The example below defines the following table access policy:
 
 * Role ``admin`` can set all session property
 * User ``banned_user`` can not set any session properties
-* All users can set the ``resource_overcommit`` system session property, and the
+* All users can set the ``statistics_cpu_timer_enabled`` system session property, and the
   ``bucket_execution_enabled`` session property in the ``hive`` catalog.
 
 .. literalinclude:: session-property-access.json

--- a/docs/src/main/sphinx/security/session-property-access.json
+++ b/docs/src/main/sphinx/security/session-property-access.json
@@ -9,7 +9,7 @@
             "allow": false
         },
         {
-            "property": "resource_overcommit",
+            "property": "statistics_cpu_timer_enabled",
             "allow": true
         }
     ],

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestFileBasedSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestFileBasedSystemAccessControl.java
@@ -1077,9 +1077,9 @@ public class TestFileBasedSystemAccessControl
         assertAccessDenied(() -> accessControl.checkCanSetSystemSessionProperty(ALICE, "any"), SET_SYSTEM_SESSION_PROPERTY_ACCESS_DENIED_MESSAGE);
         assertAccessDenied(() -> accessControl.checkCanSetSystemSessionProperty(bannedUser, "any"), SET_SYSTEM_SESSION_PROPERTY_ACCESS_DENIED_MESSAGE);
 
-        accessControl.checkCanSetSystemSessionProperty(ADMIN, "resource_overcommit");
-        accessControl.checkCanSetSystemSessionProperty(ALICE, "resource_overcommit");
-        assertAccessDenied(() -> accessControl.checkCanSetSystemSessionProperty(bannedUser, "resource_overcommit"), SET_SYSTEM_SESSION_PROPERTY_ACCESS_DENIED_MESSAGE);
+        accessControl.checkCanSetSystemSessionProperty(ADMIN, "statistics_cpu_timer_enabled");
+        accessControl.checkCanSetSystemSessionProperty(ALICE, "statistics_cpu_timer_enabled");
+        assertAccessDenied(() -> accessControl.checkCanSetSystemSessionProperty(bannedUser, "statistics_cpu_timer_enabled"), SET_SYSTEM_SESSION_PROPERTY_ACCESS_DENIED_MESSAGE);
 
         accessControl.checkCanSetCatalogSessionProperty(ADMIN, "hive", "any");
         assertAccessDenied(() -> accessControl.checkCanSetCatalogSessionProperty(ALICE, "hive", "any"), SET_CATALOG_SESSION_PROPERTY_ACCESS_DENIED_MESSAGE);

--- a/testing/trino-benchmark/src/main/java/io/trino/benchmark/SqlTopNBenchmark.java
+++ b/testing/trino-benchmark/src/main/java/io/trino/benchmark/SqlTopNBenchmark.java
@@ -13,7 +13,6 @@
  */
 package io.trino.benchmark;
 
-import com.google.common.collect.ImmutableMap;
 import io.trino.testing.LocalQueryRunner;
 
 import static io.trino.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
@@ -33,7 +32,7 @@ public class SqlTopNBenchmark
 
     public static void main(String[] args)
     {
-        LocalQueryRunner localQueryRunner = createLocalQueryRunner(ImmutableMap.of("resource_overcommit", "true"));
+        LocalQueryRunner localQueryRunner = createLocalQueryRunner();
         for (int i = 0; i < 11; i++) {
             new SqlTopNBenchmark(localQueryRunner, (int) Math.pow(4, i)).runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
         }

--- a/testing/trino-benchmark/src/main/java/io/trino/benchmark/SqlTopNRankingBenchmark.java
+++ b/testing/trino-benchmark/src/main/java/io/trino/benchmark/SqlTopNRankingBenchmark.java
@@ -14,7 +14,6 @@
 package io.trino.benchmark;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.trino.testing.LocalQueryRunner;
 
 import static io.trino.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
@@ -38,7 +37,7 @@ public class SqlTopNRankingBenchmark
 
     public static void main(String[] args)
     {
-        LocalQueryRunner localQueryRunner = createLocalQueryRunner(ImmutableMap.of("resource_overcommit", "true"));
+        LocalQueryRunner localQueryRunner = createLocalQueryRunner();
         for (String function : ImmutableList.of("row_number", "rank")) {
             for (String partitions : ImmutableList.of("orderkey, partkey", "partkey", "linestatus")) {
                 for (int topN : ImmutableList.of(1, 100, 10_000)) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

Drop support for resource over commit

> Is this change a fix, improvement, new feature, refactoring, or other?

Other

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core engine

> How would you describe this change to a non-technical end user or system administrator?

Resource over commit has never been widely used and supported

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Core
* Drop obsolete `resource_overcommit` session property
```
