### PR TITLE
Remove OOM killer delay minimum duration restriction

### DIFF
--- a/core/trino-main/src/main/java/io/trino/memory/MemoryManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/memory/MemoryManagerConfig.java
@@ -18,7 +18,6 @@ import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.DefunctConfig;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
-import io.airlift.units.MinDuration;
 
 import javax.validation.constraints.NotNull;
 
@@ -60,7 +59,6 @@ public class MemoryManagerConfig
     }
 
     @NotNull
-    @MinDuration("5s")
     public Duration getKillOnOutOfMemoryDelay()
     {
         return killOnOutOfMemoryDelay;

--- a/core/trino-main/src/test/java/io/trino/memory/TestMemoryManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/memory/TestMemoryManagerConfig.java
@@ -48,7 +48,7 @@ public class TestMemoryManagerConfig
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("query.low-memory-killer.policy", "none")
-                .put("query.low-memory-killer.delay", "20s")
+                .put("query.low-memory-killer.delay", "0s")
                 .put("query.max-memory", "2GB")
                 .put("query.max-total-memory", "3GB")
                 .put("fault-tolerant-execution-task-memory", "2GB")
@@ -57,7 +57,7 @@ public class TestMemoryManagerConfig
 
         MemoryManagerConfig expected = new MemoryManagerConfig()
                 .setLowMemoryKillerPolicy(NONE)
-                .setKillOnOutOfMemoryDelay(new Duration(20, SECONDS))
+                .setKillOnOutOfMemoryDelay(new Duration(0, SECONDS))
                 .setMaxQueryMemory(DataSize.of(2, GIGABYTE))
                 .setMaxQueryTotalMemory(DataSize.of(3, GIGABYTE))
                 .setFaultTolerantExecutionTaskMemory(DataSize.of(2, GIGABYTE))


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

For Tardigrade it doesn't make much sense to introduce an artificial
delay before killing a task to unblock a blocked node

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core

> How would you describe this change to a non-technical end user or system administrator?

`-`

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

`-`

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
