### PR TITLE
Fix `retry_max_delay` session property definition

### DIFF
--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
@@ -143,7 +143,7 @@ queries/tasks are no longer retried in the event of repeated failures:
    * - ``retry-max-delay``
      - Maximum time that a failed query must wait before it is retried.
        Wait time is increased on each subsequent query failure. May be
-       overridden with the ``retry_initial_delay`` :ref:`session property
+       overridden with the ``retry_max_delay`` :ref:`session property
        <session-properties-definition>`.
      - ``1m``
      - Only ``QUERY``


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

* Edit definition to reflect the correct session property

> Is this change a fix, improvement, new feature, refactoring, or other? Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? Admin

> How would you describe this change to a non-technical end user or system administrator? Fixed incorrect session property within property definition.

## Related issues, pull requests, and links

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

