### PR TITLE
Throw external error when metadata file is missing in Iceberg

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/TrinoS3FileSystem.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/TrinoS3FileSystem.java
@@ -78,6 +78,7 @@ import io.airlift.log.Logger;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.plugin.hive.util.FSDataInputStreamTail;
+import io.trino.spi.TrinoException;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
@@ -141,6 +142,7 @@ import static com.google.common.collect.Iterables.toArray;
 import static com.google.common.hash.Hashing.md5;
 import static io.airlift.concurrent.Threads.threadsNamed;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static io.trino.plugin.hive.HiveErrorCode.HIVE_FILE_NOT_FOUND;
 import static io.trino.plugin.hive.aws.AwsCurrentRegionHolder.getCurrentRegionFromEC2Metadata;
 import static io.trino.plugin.hive.util.RetryDriver.retry;
 import static java.lang.Math.max;
@@ -1186,7 +1188,7 @@ public class TrinoS3FileSystem
                                         case HTTP_RANGE_NOT_SATISFIABLE:
                                             throw new EOFException(CANNOT_SEEK_PAST_EOF);
                                         case HTTP_NOT_FOUND:
-                                            throw new UnrecoverableS3OperationException(path, e);
+                                            throw new UnrecoverableS3OperationException(path, new TrinoException(HIVE_FILE_NOT_FOUND, e));
                                     }
                                 }
                                 throw e;
@@ -1361,7 +1363,7 @@ public class TrinoS3FileSystem
                                             // ignore request for start past end of object
                                             return new ByteArrayInputStream(new byte[0]);
                                         case HTTP_NOT_FOUND:
-                                            throw new UnrecoverableS3OperationException(path, e);
+                                            throw new UnrecoverableS3OperationException(path, new TrinoException(HIVE_FILE_NOT_FOUND, e));
                                     }
                                 }
                                 throw e;

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractIcebergTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractIcebergTableOperations.java
@@ -14,8 +14,10 @@
 package io.trino.plugin.iceberg.catalog;
 
 import io.airlift.log.Logger;
+import io.trino.plugin.hive.HiveErrorCode;
 import io.trino.plugin.hive.metastore.Column;
 import io.trino.plugin.hive.metastore.StorageFormat;
+import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
 import org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe;
@@ -40,8 +42,10 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Throwables.getCausalChain;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.hive.HiveType.toHiveType;
+import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
 import static io.trino.plugin.iceberg.IcebergUtil.getLocationProvider;
 import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
@@ -213,9 +217,8 @@ public abstract class AbstractIcebergTableOperations
         Tasks.foreach(newLocation)
                 .retry(20)
                 .exponentialBackoff(100, 5000, 600000, 4.0)
-                .stopRetryOn(org.apache.iceberg.exceptions.NotFoundException.class) // qualified name, as this is NOT the io.trino.spi.connector.NotFoundException
-                .run(metadataLocation -> newMetadata.set(
-                        TableMetadataParser.read(fileIo, io().newInputFile(metadataLocation))));
+                .stopRetryOn(TrinoException.class)
+                .run(metadataLocation -> newMetadata.set(readTableMetadata(metadataLocation)));
 
         String newUUID = newMetadata.get().uuid();
         if (currentMetadata != null) {
@@ -227,6 +230,31 @@ public abstract class AbstractIcebergTableOperations
         currentMetadataLocation = newLocation;
         version = parseVersion(newLocation);
         shouldRefresh = false;
+    }
+
+    private TableMetadata readTableMetadata(String metadataLocation)
+    {
+        try {
+            return TableMetadataParser.read(fileIo, io().newInputFile(metadataLocation));
+        }
+        catch (Exception e) {
+            if (getCausalChain(e).stream().anyMatch(AbstractIcebergTableOperations::isNotFoundError)) {
+                throw new TrinoException(ICEBERG_INVALID_METADATA, e);
+            }
+            throw e;
+        }
+    }
+
+    private static boolean isNotFoundError(Throwable throwable)
+    {
+        if (throwable instanceof org.apache.iceberg.exceptions.NotFoundException) { // qualified name, as this is NOT the io.trino.spi.connector.NotFoundException
+            return true;
+        }
+        if (throwable instanceof TrinoException) {
+            return ((TrinoException) throwable).getErrorCode().equals(HiveErrorCode.HIVE_FILE_NOT_FOUND.toErrorCode());
+        }
+
+        return false;
     }
 
     protected static String newTableMetadataFilePath(TableMetadata meta, int newVersion)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
@@ -14,21 +14,32 @@
 package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableList;
+import io.trino.plugin.hive.HdfsEnvironment;
 import io.trino.testing.BaseConnectorSmokeTest;
 import io.trino.testing.TestingConnectorBehavior;
 import io.trino.testing.sql.TestTable;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.iceberg.FileFormat;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
+
+import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testng.Assert.assertNotNull;
 
 public abstract class BaseIcebergConnectorSmokeTest
         extends BaseConnectorSmokeTest
 {
     protected final FileFormat format;
+
+    protected abstract String getMetadataDirectory(String tableName);
 
     public BaseIcebergConnectorSmokeTest(FileFormat format)
     {
@@ -93,5 +104,44 @@ public abstract class BaseIcebergConnectorSmokeTest
             // Check whether the "$path" hidden column is correctly evaluated in the filter expression
             assertQuery(format("SELECT a FROM %s WHERE \"$path\" = '%s'", table.getName(), filePath), "VALUES 1");
         }
+    }
+
+    @Test
+    public void testListInformationSchemaMetadataNotFound()
+            throws Exception
+    {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_metadata_not_found", "(col integer)", ImmutableList.of())) {
+            HdfsEnvironment.HdfsContext context = new HdfsEnvironment.HdfsContext(getSession().toConnectorSession());
+            org.apache.hadoop.fs.Path metadataDir = new org.apache.hadoop.fs.Path(getMetadataDirectory(table.getName()));
+            FileSystem fileSystem = HDFS_ENVIRONMENT.getFileSystem(context, metadataDir);
+            org.apache.hadoop.fs.Path metadataFile = getMetadataJsonFile(fileSystem, metadataDir);
+            org.apache.hadoop.fs.Path renamedMetadataFile = new org.apache.hadoop.fs.Path(metadataFile + ".renamed");
+
+            fileSystem.rename(metadataFile, renamedMetadataFile);
+
+            assertQueryFails("SELECT * FROM " + table.getName(), "Failed to (read file|open input stream for file): .*");
+            assertQuerySucceeds("" +
+                    "SELECT table_name FROM information_schema.tables " +
+                    "WHERE table_catalog = 'iceberg' AND table_schema = 'tpch' AND table_name = '" + table.getName() + "'");
+
+            // Rename to the original path so that we can clean up in Glue tests
+            fileSystem.rename(renamedMetadataFile, metadataFile);
+        }
+    }
+
+    private org.apache.hadoop.fs.Path getMetadataJsonFile(FileSystem fileSystem, org.apache.hadoop.fs.Path metadataDir)
+            throws IOException
+    {
+        RemoteIterator<LocatedFileStatus> files = fileSystem.listFiles(metadataDir, false);
+        Path metadataFile = null;
+        while (files.hasNext()) {
+            LocatedFileStatus file = files.next();
+            if (file.getPath().toString().endsWith(".metadata.json")) {
+                metadataFile = file.getPath();
+                break;
+            }
+        }
+        assertNotNull(metadataFile);
+        return new org.apache.hadoop.fs.Path(metadataFile.toString());
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMinioConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMinioConnectorSmokeTest.java
@@ -84,4 +84,10 @@ public abstract class BaseIcebergMinioConnectorSmokeTest
                 format("ALTER SCHEMA %s RENAME TO %s", schemaName, schemaName + randomTableSuffix()),
                 "Hive metastore does not support renaming schemas");
     }
+
+    @Override
+    protected String getMetadataDirectory(String tableName)
+    {
+        return format("s3://%s/%s/%s/metadata", bucketName, schemaName, tableName);
+    }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConnectorSmokeTest.java
@@ -35,4 +35,16 @@ public class TestIcebergConnectorSmokeTest
                 .setInitialTables(REQUIRED_TPCH_TABLES)
                 .build();
     }
+
+    @Override
+    protected String getMetadataDirectory(String tableName)
+    {
+        return getDistributedQueryRunner().getCoordinator().getBaseDataDir()
+                .resolve("iceberg_data")
+                .resolve(getSession().getSchema().orElseThrow())
+                .resolve(tableName)
+                .resolve("metadata")
+                .toFile()
+                .getPath();
+    }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogConnectorSmokeTest.java
@@ -132,6 +132,12 @@ public class TestIcebergGlueCatalogConnectorSmokeTest
                 .hasStackTraceContaining("renameNamespace is not supported for Iceberg Glue catalogs");
     }
 
+    @Override
+    protected String getMetadataDirectory(String tableName)
+    {
+        return format("s3://%s/%s/%s.db/%s/metadata", bucketName, schemaName, schemaName, tableName);
+    }
+
     private String schemaPath()
     {
         return format("s3://%s/%s", bucketName, schemaName);


### PR DESCRIPTION
## Description

Throw external error when metadata file is missing in Iceberg
Fixes #11764

## Documentation

(x) No documentation is needed.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
