### PR TITLE
add docs for jdbc extra credentials, fixing #1910

### DIFF
--- a/docs/src/main/sphinx/connector/clickhouse.rst
+++ b/docs/src/main/sphinx/connector/clickhouse.rst
@@ -38,6 +38,8 @@ appropriate for your setup:
     connection-user=exampleuser
     connection-password=examplepassword
 
+.. include:: jdbc-extra-credentials.fragment
+
 .. note::
 
     Trino uses the new ClickHouse driver(``com.clickhouse.jdbc.ClickHouseDriver``)

--- a/docs/src/main/sphinx/connector/druid.rst
+++ b/docs/src/main/sphinx/connector/druid.rst
@@ -43,6 +43,8 @@ secured by basic authentication by updating the URL and adding credentials:
     connection-user=root
     connection-password=secret
 
+.. include:: jdbc-extra-credentials.fragment
+
 Now you can access your Druid database in Trino with the ``druiddb`` catalog
 name from the properties file.
 

--- a/docs/src/main/sphinx/connector/jdbc-extra-credentials.fragment
+++ b/docs/src/main/sphinx/connector/jdbc-extra-credentials.fragment
@@ -1,0 +1,19 @@
+In some cases, users may want to hide the credentials from the configuration file for security considerations. They can use ``user-credential-name`` and ``password-credential-name`` to specify the credential keys instead of the actual credentials. Then when querying, the connector can get the actual credentials from the connection string or command-line arguments with the keys:
+
+
+.. code-block:: none
+
+    user-credential-name=extra-credential-name
+    password-credential-name=extra-credential-password
+
+users can pass the credentials to the connector with ``--extra-credential`` arguments:
+
+.. code-block:: shell
+
+    ./trino --server <trino url> --catalog <catalog name> --extra-credential 'extra-credential-name=admin' --extra-credential 'extra-credential-password=password'
+
+and in code users can pass the credentials to the connector by placing it in the connection string:
+
+.. code-block:: java
+
+    String url = "jdbc:trino://<trino url>/<catalog name>?extraCredentials=extra-credential-name:admin;extra-credential-password:password"

--- a/docs/src/main/sphinx/connector/jdbc-extra-credentials.fragment
+++ b/docs/src/main/sphinx/connector/jdbc-extra-credentials.fragment
@@ -6,14 +6,4 @@ In some cases, users may want to hide the credentials from the configuration fil
     user-credential-name=extra-credential-name
     password-credential-name=extra-credential-password
 
-users can pass the credentials to the connector with ``--extra-credential`` arguments:
-
-.. code-block:: shell
-
-    ./trino --server <trino url> --catalog <catalog name> --extra-credential 'extra-credential-name=admin' --extra-credential 'extra-credential-password=password'
-
-and in code users can pass the credentials to the connector by placing it in the connection string:
-
-.. code-block:: java
-
-    String url = "jdbc:trino://<trino url>/<catalog name>?extraCredentials=extra-credential-name:admin;extra-credential-password:password"
+Users can pass the extra credentials via ``--extra-credential`` with :doc:`/installation/cli` and ``extraCredentials`` with :doc:`/installation/jdbc`.

--- a/docs/src/main/sphinx/connector/memsql.rst
+++ b/docs/src/main/sphinx/connector/memsql.rst
@@ -42,10 +42,12 @@ available in the `SingleStore JDBC driver documentation
 <https://docs.singlestore.com/db/v7.6/en/developer-resources/connect-with-application-development-tools/connect-with-java-jdbc/the-singlestore-jdbc-driver.html#connection-string-parameters>`_.
 
 The ``connection-user`` and ``connection-password`` are typically required and
-determine the user credentials for the connection, often a service user. You can
-use :doc:`secrets </security/secrets>` to avoid actual values in the catalog
-properties files.
+determine the user credentials for the connection, often a service user. 
 
+.. include:: jdbc-extra-credentials.fragment
+
+You can also use other solutions mentioned in :doc:`secrets </security/secrets>` 
+to avoid actual values in the catalog properties files.
 
 .. _singlestore-tls:
 

--- a/docs/src/main/sphinx/connector/mysql.rst
+++ b/docs/src/main/sphinx/connector/mysql.rst
@@ -50,9 +50,12 @@ the server, and serves as a `workaround for a known issue
     connection-url=jdbc:mysql://example.net:3306?serverTimezone=UTC
 
 The ``connection-user`` and ``connection-password`` are typically required and
-determine the user credentials for the connection, often a service user. You can
-use :doc:`secrets </security/secrets>` to avoid actual values in the catalog
-properties files.
+determine the user credentials for the connection, often a service user. 
+
+.. include:: jdbc-extra-credentials.fragment
+
+You can also use other solutions mentioned in :doc:`secrets </security/secrets>` 
+to avoid actual values in the catalog properties files.
 
 .. _mysql-tls:
 

--- a/docs/src/main/sphinx/connector/oracle.rst
+++ b/docs/src/main/sphinx/connector/oracle.rst
@@ -46,9 +46,11 @@ Database JDBC driver documentation
 for more information.
 
 The ``connection-user`` and ``connection-password`` are typically required and
-determine the user credentials for the connection, often a service user. You can
-use :doc:`secrets </security/secrets>` to avoid actual values in the catalog
-properties files.
+determine the user credentials for the connection, often a service user. 
+
+.. include:: jdbc-extra-credentials.fragment
+
+You can also use other solutions mentioned in :doc:`secrets </security/secrets>` to avoid actual values in the catalog properties files.
 
 .. note::
     Oracle does not expose metadata comment via ``REMARKS`` column by default

--- a/docs/src/main/sphinx/connector/phoenix.rst
+++ b/docs/src/main/sphinx/connector/phoenix.rst
@@ -75,6 +75,8 @@ Property Name                                      Required   Description
 
 .. include:: non-transactional-insert.fragment
 
+.. include:: jdbc-extra-credentials.fragment
+
 Querying Phoenix tables
 -------------------------
 

--- a/docs/src/main/sphinx/connector/postgresql.rst
+++ b/docs/src/main/sphinx/connector/postgresql.rst
@@ -46,9 +46,12 @@ can have adverse effects on the connector behavior or not work with the
 connector.
 
 The ``connection-user`` and ``connection-password`` are typically required and
-determine the user credentials for the connection, often a service user. You can
-use :doc:`secrets </security/secrets>` to avoid actual values in the catalog
-properties files.
+determine the user credentials for the connection, often a service user. 
+
+.. include:: jdbc-extra-credentials.fragment
+
+You can also use other solutions mentioned in :doc:`secrets </security/secrets>` 
+to avoid actual values in the catalog properties files.
 
 .. _postgresql-tls:
 

--- a/docs/src/main/sphinx/connector/redshift.rst
+++ b/docs/src/main/sphinx/connector/redshift.rst
@@ -78,6 +78,8 @@ catalog named ``sales`` using the configured connector.
 
 .. include:: non-transactional-insert.fragment
 
+.. include:: jdbc-extra-credentials.fragment
+
 Querying Redshift
 -----------------
 

--- a/docs/src/main/sphinx/connector/sqlserver.rst
+++ b/docs/src/main/sphinx/connector/sqlserver.rst
@@ -90,6 +90,8 @@ catalog named ``sales`` using the configured connector.
 
 .. include:: non-transactional-insert.fragment
 
+.. include:: jdbc-extra-credentials.fragment
+
 Querying SQL Server
 -------------------
 

--- a/docs/src/main/sphinx/installation/cli.rst
+++ b/docs/src/main/sphinx/installation/cli.rst
@@ -173,6 +173,8 @@ mode:
     - Sets the username for :ref:`cli-username-password-auth`. Defaults to your
       operating system username. You can override the default username,
       if your cluster uses a different username or authentication mechanism.
+  * - ``--extra-credential``
+    - Sets the extra credential keys, multiple extra credential keys can be used with format ``--extra-credential 'extra-credential-name=admin' --extra-credential 'extra-credential-password=password'``
 
 .. _cli-tls:
 

--- a/docs/src/main/sphinx/installation/cli.rst
+++ b/docs/src/main/sphinx/installation/cli.rst
@@ -174,7 +174,7 @@ mode:
       operating system username. You can override the default username,
       if your cluster uses a different username or authentication mechanism.
   * - ``--extra-credential``
-    - Sets the extra credential keys, multiple extra credential keys can be used with format ``--extra-credential 'extra-credential-name=admin' --extra-credential 'extra-credential-password=password'``
+    - Sets the extra credential keys, multiple extra credential keys can be used with format ``--extra-credential 'extra-credential-name=admin' --extra-credential 'extra-credential-password=password'``.
 
 .. _cli-tls:
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

This is an improvement on docs.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

No, only adding docs

> How would you describe this change to a non-technical end user or system administrator?

N/A

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
-->
* Fixes #1910 

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(*) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(*) Release notes entries required with the following suggested text:

```markdown
# Section
* Adding docs for JDBC connector extra credentials ({issue}`1910`)
```
