### PR TITLE
Ignore finished tasks when computing memory usage for stage

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/StageStateMachine.java
+++ b/core/trino-main/src/main/java/io/trino/execution/StageStateMachine.java
@@ -374,9 +374,9 @@ public class StageStateMachine
 
         long cumulativeUserMemory = 0;
         long failedCumulativeUserMemory = 0;
-        long userMemoryReservation = 0;
-        long revocableMemoryReservation = 0;
-        long totalMemoryReservation = 0;
+        long userMemoryReservation = currentUserMemory.get();
+        long revocableMemoryReservation = currentRevocableMemory.get();
+        long totalMemoryReservation = currentTotalMemory.get();
         long peakUserMemoryReservation = peakUserMemory.get();
         long peakRevocableMemoryReservation = peakRevocableMemory.get();
 
@@ -458,12 +458,6 @@ public class StageStateMachine
             if (taskState == TaskState.FAILED) {
                 failedCumulativeUserMemory += taskStats.getCumulativeUserMemory();
             }
-
-            long taskUserMemory = taskStats.getUserMemoryReservation().toBytes();
-            long taskRevocableMemory = taskStats.getRevocableMemoryReservation().toBytes();
-            userMemoryReservation += taskUserMemory;
-            revocableMemoryReservation += taskRevocableMemory;
-            totalMemoryReservation += taskUserMemory + taskRevocableMemory;
 
             totalScheduledTime += taskStats.getTotalScheduledTime().roundTo(NANOSECONDS);
             totalCpuTime += taskStats.getTotalCpuTime().roundTo(NANOSECONDS);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Ignore finished tasks when computing memory usage for stage.
Without the fix stage level statistics for peak and current memory were off when task retries happened.

> Is this change a fix, improvement, new feature, refactoring, or other?

bugfix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

engine


## Related issues, pull requests, and links

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Engine
* Fix stage memory statistics reporting for queries running with `retry-policy` set to `TASK`. ({issue}`11801`)
```
