### PR TITLE
Delay scheduling task if there is not enough runtime memory on the node

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/BinPackingNodeAllocatorService.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/BinPackingNodeAllocatorService.java
@@ -311,7 +311,7 @@ public class BinPackingNodeAllocatorService
         private final NodesSnapshot nodesSnapshot;
         private final List<InternalNode> allNodesSorted;
         private final Map<String, Long> nodesRemainingMemory;
-        private final ImmutableMap<String, Long> nodePoolSizes;
+        private final Map<String, Long> nodePoolSizes;
         private final boolean scheduleOnCoordinator;
 
         public BinPackingSimulation(

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/BinPackingNodeAllocatorService.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/BinPackingNodeAllocatorService.java
@@ -137,7 +137,7 @@ public class BinPackingNodeAllocatorService
         }
 
         refreshNodePoolMemoryInfos();
-        executor.scheduleWithFixedDelay(this::refreshNodePoolMemoryInfos, 1, 5, TimeUnit.SECONDS);
+        executor.scheduleWithFixedDelay(this::refreshNodePoolMemoryInfos, 1, 1, TimeUnit.SECONDS);
     }
 
     @PreDestroy

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/BinPackingNodeAllocatorService.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/BinPackingNodeAllocatorService.java
@@ -48,7 +48,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
-import static com.clearspring.analytics.util.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/FaultTolerantStageScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/FaultTolerantStageScheduler.java
@@ -360,6 +360,7 @@ public class FaultTolerantStageScheduler
                         .collect(toImmutableListMultimap(Function.identity(), planNodeId -> Lifespan.taskWide())),
                 allSourcePlanNodeIds).orElseThrow(() -> new VerifyException("stage execution is expected to be active"));
 
+        nodeLease.attachTaskId(task.getTaskId());
         partitionToRemoteTaskMap.put(partition, task);
         runningTasks.put(task.getTaskId(), task);
         runningNodes.put(task.getTaskId(), nodeLease);

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeAllocator.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeAllocator.java
@@ -14,6 +14,7 @@
 package io.trino.execution.scheduler;
 
 import com.google.common.util.concurrent.ListenableFuture;
+import io.trino.execution.TaskId;
 import io.trino.metadata.InternalNode;
 
 import java.io.Closeable;
@@ -35,6 +36,8 @@ public interface NodeAllocator
     interface NodeLease
     {
         ListenableFuture<InternalNode> getNode();
+
+        default void attachTaskId(TaskId taskId) {}
 
         void release();
     }

--- a/core/trino-main/src/main/java/io/trino/memory/MemoryManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/memory/MemoryManagerConfig.java
@@ -44,6 +44,7 @@ public class MemoryManagerConfig
     private DataSize faultTolerantExecutionTaskMemory = DataSize.of(4, GIGABYTE);
     private double faultTolerantExecutionTaskMemoryGrowthFactor = 3.0;
     private double faultTolerantExecutionTaskMemoryEstimationQuantile = 0.9;
+    private DataSize faultTolerantExecutionTaskRuntimeMemoryEstimationOverhead = DataSize.of(1, GIGABYTE);
     private LowMemoryKillerPolicy lowMemoryKillerPolicy = LowMemoryKillerPolicy.TOTAL_RESERVATION_ON_BLOCKED_NODES;
     private Duration killOnOutOfMemoryDelay = new Duration(5, MINUTES);
 
@@ -113,6 +114,20 @@ public class MemoryManagerConfig
     public MemoryManagerConfig setFaultTolerantExecutionTaskMemory(DataSize faultTolerantExecutionTaskMemory)
     {
         this.faultTolerantExecutionTaskMemory = faultTolerantExecutionTaskMemory;
+        return this;
+    }
+
+    @NotNull
+    public DataSize getFaultTolerantExecutionTaskRuntimeMemoryEstimationOverhead()
+    {
+        return faultTolerantExecutionTaskRuntimeMemoryEstimationOverhead;
+    }
+
+    @Config("fault-tolerant-execution-task-runtime-memory-estimation-overhead")
+    @ConfigDescription("Extra memory to account for when estimating actual task runtime memory consumption")
+    public MemoryManagerConfig setFaultTolerantExecutionTaskRuntimeMemoryEstimationOverhead(DataSize faultTolerantExecutionTaskRuntimeMemoryEstimationOverhead)
+    {
+        this.faultTolerantExecutionTaskRuntimeMemoryEstimationOverhead = faultTolerantExecutionTaskRuntimeMemoryEstimationOverhead;
         return this;
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestBinPackingNodeAllocator.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestBinPackingNodeAllocator.java
@@ -20,6 +20,8 @@ import io.airlift.units.DataSize;
 import io.trino.Session;
 import io.trino.client.NodeVersion;
 import io.trino.connector.CatalogName;
+import io.trino.execution.StageId;
+import io.trino.execution.TaskId;
 import io.trino.memory.MemoryInfo;
 import io.trino.metadata.InMemoryNodeManager;
 import io.trino.metadata.InternalNode;
@@ -35,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
@@ -67,7 +70,9 @@ public class TestBinPackingNodeAllocator
     private static final List<CatalogName> ALL_CATALOGS = ImmutableList.of(CATALOG_1, CATALOG_2);
 
     private static final NodeRequirements REQ_32 = new NodeRequirements(Optional.empty(), Set.of(), DataSize.of(32, GIGABYTE));
+    private static final NodeRequirements REQ_20 = new NodeRequirements(Optional.empty(), Set.of(), DataSize.of(16, GIGABYTE));
     private static final NodeRequirements REQ_16 = new NodeRequirements(Optional.empty(), Set.of(), DataSize.of(16, GIGABYTE));
+    private static final NodeRequirements REQ_1 = new NodeRequirements(Optional.empty(), Set.of(), DataSize.of(1, GIGABYTE));
     private static final NodeRequirements REQ_NODE_1_32 = new NodeRequirements(Optional.empty(), Set.of(NODE_1_ADDRESS), DataSize.of(32, GIGABYTE));
     private static final NodeRequirements REQ_NODE_2_32 = new NodeRequirements(Optional.empty(), Set.of(NODE_2_ADDRESS), DataSize.of(32, GIGABYTE));
     private static final NodeRequirements REQ_CATALOG_1_32 = new NodeRequirements(Optional.of(CATALOG_1), Set.of(), DataSize.of(32, GIGABYTE));
@@ -76,24 +81,47 @@ public class TestBinPackingNodeAllocator
     private static final long TEST_TIMEOUT = BinPackingNodeAllocatorService.PROCESS_PENDING_ACQUIRES_DELAY_SECONDS * 1000 / 2;
 
     private BinPackingNodeAllocatorService nodeAllocatorService;
+    private ConcurrentHashMap<String, Optional<MemoryInfo>> workerMemoryInfos;
 
     private void setupNodeAllocatorService(InMemoryNodeManager nodeManager)
     {
         shutdownNodeAllocatorService(); // just in case
 
-        MemoryInfo memoryInfo = new MemoryInfo(4, new MemoryPoolInfo(DataSize.of(64, GIGABYTE).toBytes(), 0, 0, ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()));
-
-        Map<String, Optional<MemoryInfo>> workerMemoryInfos = ImmutableMap.of(
-                NODE_1.getNodeIdentifier(), Optional.of(memoryInfo),
-                NODE_2.getNodeIdentifier(), Optional.of(memoryInfo),
-                NODE_3.getNodeIdentifier(), Optional.of(memoryInfo),
-                NODE_4.getNodeIdentifier(), Optional.of(memoryInfo));
+        workerMemoryInfos = new ConcurrentHashMap<>();
+        MemoryInfo memoryInfo = buildWorkerMemoryInfo(DataSize.ofBytes(0), ImmutableMap.of());
+        workerMemoryInfos.put(NODE_1.getNodeIdentifier(), Optional.of(memoryInfo));
+        workerMemoryInfos.put(NODE_2.getNodeIdentifier(), Optional.of(memoryInfo));
+        workerMemoryInfos.put(NODE_3.getNodeIdentifier(), Optional.of(memoryInfo));
+        workerMemoryInfos.put(NODE_4.getNodeIdentifier(), Optional.of(memoryInfo));
 
         nodeAllocatorService = new BinPackingNodeAllocatorService(
                 nodeManager,
                 () -> workerMemoryInfos,
                 false);
         nodeAllocatorService.start();
+    }
+
+    private void updateWorkerUsedMemory(InternalNode node, DataSize usedMemory, Map<TaskId, DataSize> taskMemoryUsage)
+    {
+        workerMemoryInfos.put(node.getNodeIdentifier(), Optional.of(buildWorkerMemoryInfo(usedMemory, taskMemoryUsage)));
+    }
+
+    private MemoryInfo buildWorkerMemoryInfo(DataSize usedMemory, Map<TaskId, DataSize> taskMemoryUsage)
+    {
+        return new MemoryInfo(
+                4,
+                new MemoryPoolInfo(
+                        DataSize.of(64, GIGABYTE).toBytes(),
+                        usedMemory.toBytes(),
+                        0,
+                        ImmutableMap.of(),
+                        ImmutableMap.of(),
+                        ImmutableMap.of(),
+                        taskMemoryUsage.entrySet().stream()
+                                .collect(toImmutableMap(
+                                        entry -> entry.getKey().toString(),
+                                        entry -> entry.getValue().toBytes())),
+                        ImmutableMap.of()));
     }
 
     @AfterMethod(alwaysRun = true)
@@ -353,6 +381,166 @@ public class TestBinPackingNodeAllocator
             // pending acquisition should be unblocked
             assertEventually(() -> assertAcquired(acquire3));
         }
+    }
+
+    @Test(timeOut = TEST_TIMEOUT)
+    public void testAllocateNotEnoughRuntimeMemory()
+    {
+        InMemoryNodeManager nodeManager = testingNodeManager(basicNodesMap(NODE_1, NODE_2));
+        setupNodeAllocatorService(nodeManager);
+
+        try (NodeAllocator nodeAllocator = nodeAllocatorService.getNodeAllocator(SESSION)) {
+            // first allocation is fine
+            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_32);
+            assertAcquired(acquire1, NODE_1);
+            acquire1.attachTaskId(taskId(1));
+
+            // bump memory usage on NODE_1
+            updateWorkerUsedMemory(NODE_1,
+                    DataSize.of(33, GIGABYTE),
+                    ImmutableMap.of(taskId(1), DataSize.of(33, GIGABYTE)));
+            nodeAllocatorService.refreshNodePoolMemoryInfos();
+
+            // second allocation of 32GB should go to another node
+            NodeAllocator.NodeLease acquire2 = nodeAllocator.acquire(REQ_32);
+            assertAcquired(acquire2, NODE_2);
+            acquire2.attachTaskId(taskId(2));
+
+            // third allocation of 32GB should also use NODE_2 as there is not enough runtime memory on NODE_1
+            // second allocation of 32GB should go to another node
+            NodeAllocator.NodeLease acquire3 = nodeAllocator.acquire(REQ_32);
+            assertAcquired(acquire3, NODE_2);
+            acquire3.attachTaskId(taskId(3));
+
+            // fourth allocation of 16 should fit on NODE_1
+            NodeAllocator.NodeLease acquire4 = nodeAllocator.acquire(REQ_16);
+            assertAcquired(acquire4, NODE_1);
+            acquire4.attachTaskId(taskId(4));
+
+            // fifth allocation of 16 should should no longer fit on NODE_1. There is 16GB unreserved but only 15GB taking runtime usage into account
+            NodeAllocator.NodeLease acquire5 = nodeAllocator.acquire(REQ_16);
+            assertNotAcquired(acquire5);
+
+            // even tiny allocations should not fit now
+            NodeAllocator.NodeLease acquire6 = nodeAllocator.acquire(REQ_1);
+            assertNotAcquired(acquire6);
+
+            // if memory usage decreases on NODE_1 the pending 16GB allocation should complete
+            updateWorkerUsedMemory(NODE_1,
+                    DataSize.of(32, GIGABYTE),
+                    ImmutableMap.of(taskId(1), DataSize.of(32, GIGABYTE)));
+            nodeAllocatorService.refreshNodePoolMemoryInfos();
+            nodeAllocatorService.processPendingAcquires();
+            assertAcquired(acquire5, NODE_1);
+            acquire5.attachTaskId(taskId(5));
+
+            //  acquire6 should still be pending
+            assertNotAcquired(acquire6);
+        }
+    }
+
+    @Test(timeOut = TEST_TIMEOUT)
+    public void testAllocateRuntimeMemoryDiscrepancies()
+    {
+        InMemoryNodeManager nodeManager = testingNodeManager(basicNodesMap(NODE_1));
+
+        setupNodeAllocatorService(nodeManager);
+        // test when global memory usage on node is greater than per task usage
+        try (NodeAllocator nodeAllocator = nodeAllocatorService.getNodeAllocator(SESSION)) {
+            // first allocation is fine
+            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_32);
+            assertAcquired(acquire1, NODE_1);
+            acquire1.attachTaskId(taskId(1));
+
+            // bump memory usage on NODE_1; per-task usage is kept small
+            updateWorkerUsedMemory(NODE_1,
+                    DataSize.of(33, GIGABYTE),
+                    ImmutableMap.of(taskId(1), DataSize.of(4, GIGABYTE)));
+            nodeAllocatorService.refreshNodePoolMemoryInfos();
+
+            // global (greater) memory usage should take precedence
+            NodeAllocator.NodeLease acquire2 = nodeAllocator.acquire(REQ_32);
+            assertNotAcquired(acquire2);
+        }
+
+        setupNodeAllocatorService(nodeManager);
+        // test when global memory usage on node is smaller than per task usage
+        try (NodeAllocator nodeAllocator = nodeAllocatorService.getNodeAllocator(SESSION)) {
+            // first allocation is fine
+            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_32);
+            assertAcquired(acquire1, NODE_1);
+            acquire1.attachTaskId(taskId(1));
+
+            // bump memory usage on NODE_1; per-task usage is 33GB and global is 4GB
+            updateWorkerUsedMemory(NODE_1,
+                    DataSize.of(4, GIGABYTE),
+                    ImmutableMap.of(taskId(1), DataSize.of(33, GIGABYTE)));
+            nodeAllocatorService.refreshNodePoolMemoryInfos();
+
+            // per-task (greater) memory usage should take precedence
+            NodeAllocator.NodeLease acquire2 = nodeAllocator.acquire(REQ_32);
+            assertNotAcquired(acquire2);
+        }
+
+        setupNodeAllocatorService(nodeManager);
+        // test when per-task memory usage not present at all
+        try (NodeAllocator nodeAllocator = nodeAllocatorService.getNodeAllocator(SESSION)) {
+            // first allocation is fine
+            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_32);
+            assertAcquired(acquire1, NODE_1);
+            acquire1.attachTaskId(taskId(1));
+
+            // bump memory usage on NODE_1; per-task usage is 33GB and global is 4GB
+            updateWorkerUsedMemory(NODE_1, DataSize.of(33, GIGABYTE), ImmutableMap.of());
+            nodeAllocatorService.refreshNodePoolMemoryInfos();
+
+            // global memory usage should be used (not per-task usage)
+            NodeAllocator.NodeLease acquire2 = nodeAllocator.acquire(REQ_32);
+            assertNotAcquired(acquire2);
+        }
+    }
+
+    @Test(timeOut = TEST_TIMEOUT)
+    public void testSpaceReservedOnPrimaryNodeIfNoNodeWithEnoughRuntimeMemoryAvailable()
+    {
+        InMemoryNodeManager nodeManager = testingNodeManager(basicNodesMap(NODE_1, NODE_2));
+        setupNodeAllocatorService(nodeManager);
+
+        // test when global memory usage on node is greater than per task usage
+        try (NodeAllocator nodeAllocator = nodeAllocatorService.getNodeAllocator(SESSION)) {
+            // reserve 32GB on NODE_1 and 16GB on NODE_2
+            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_32);
+            assertAcquired(acquire1, NODE_1);
+            acquire1.attachTaskId(taskId(1));
+            NodeAllocator.NodeLease acquire2 = nodeAllocator.acquire(REQ_16);
+            assertAcquired(acquire2, NODE_2);
+            acquire2.attachTaskId(taskId(2));
+
+            // make actual usage on NODE_2 greater than on NODE_1
+            updateWorkerUsedMemory(NODE_1,
+                    DataSize.of(40, GIGABYTE),
+                    ImmutableMap.of(taskId(1), DataSize.of(40, GIGABYTE)));
+            updateWorkerUsedMemory(NODE_2,
+                    DataSize.of(41, GIGABYTE),
+                    ImmutableMap.of(taskId(2), DataSize.of(41, GIGABYTE)));
+            nodeAllocatorService.refreshNodePoolMemoryInfos();
+
+            // try to allocate 32GB task
+            // it will not fit on neither of nodes. space should be reserved on NODE_2 as it has more memory available
+            // when you do not take runtime memory into account
+            NodeAllocator.NodeLease acquire3 = nodeAllocator.acquire(REQ_32);
+            assertNotAcquired(acquire3);
+
+            // to check that is the case try to allocate 20GB; NODE_1 should be picked
+            NodeAllocator.NodeLease acquire4 = nodeAllocator.acquire(REQ_20);
+            assertAcquired(acquire4, NODE_1);
+            acquire4.attachTaskId(taskId(2));
+        }
+    }
+
+    private TaskId taskId(int partition)
+    {
+        return new TaskId(new StageId("test_query", 0), partition, 0);
     }
 
     private InMemoryNodeManager testingNodeManager(Map<InternalNode, List<CatalogName>> nodeMap)

--- a/core/trino-main/src/test/java/io/trino/memory/TestMemoryManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/memory/TestMemoryManagerConfig.java
@@ -24,6 +24,7 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertFullMappin
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.memory.MemoryManagerConfig.LowMemoryKillerPolicy.NONE;
 import static io.trino.memory.MemoryManagerConfig.LowMemoryKillerPolicy.TOTAL_RESERVATION_ON_BLOCKED_NODES;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -40,6 +41,7 @@ public class TestMemoryManagerConfig
                 .setMaxQueryMemory(DataSize.of(20, GIGABYTE))
                 .setMaxQueryTotalMemory(DataSize.of(40, GIGABYTE))
                 .setFaultTolerantExecutionTaskMemory(DataSize.of(4, GIGABYTE))
+                .setFaultTolerantExecutionTaskRuntimeMemoryEstimationOverhead(DataSize.of(1, GIGABYTE))
                 .setFaultTolerantExecutionTaskMemoryGrowthFactor(3.0)
                 .setFaultTolerantExecutionTaskMemoryEstimationQuantile(0.9));
     }
@@ -53,6 +55,7 @@ public class TestMemoryManagerConfig
                 .put("query.max-memory", "2GB")
                 .put("query.max-total-memory", "3GB")
                 .put("fault-tolerant-execution-task-memory", "2GB")
+                .put("fault-tolerant-execution-task-runtime-memory-estimation-overhead", "300MB")
                 .put("fault-tolerant-execution-task-memory-growth-factor", "17.3")
                 .put("fault-tolerant-execution-task-memory-estimation-quantile", "0.7")
                 .buildOrThrow();
@@ -63,6 +66,7 @@ public class TestMemoryManagerConfig
                 .setMaxQueryMemory(DataSize.of(2, GIGABYTE))
                 .setMaxQueryTotalMemory(DataSize.of(3, GIGABYTE))
                 .setFaultTolerantExecutionTaskMemory(DataSize.of(2, GIGABYTE))
+                .setFaultTolerantExecutionTaskRuntimeMemoryEstimationOverhead(DataSize.of(300, MEGABYTE))
                 .setFaultTolerantExecutionTaskMemoryGrowthFactor(17.3)
                 .setFaultTolerantExecutionTaskMemoryEstimationQuantile(0.7);
 


### PR DESCRIPTION
## Description

Delay scheduling task if there is not enough runtime memory on the node

Bin packing node allocator still works based on bin-packing paradigm of
requested memory allocation for tasks. Yet if there is not enough memory
at runtime (other tasks running one the node exceeded reservations) the
new tasks is not scheduled immediately.

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Engine

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

