### PR TITLE
Document aggregation pushdown in Oracle connector

### DIFF
--- a/docs/src/main/sphinx/connector/oracle.rst
+++ b/docs/src/main/sphinx/connector/oracle.rst
@@ -398,6 +398,29 @@ The connector supports pushdown for a number of operations:
 * :ref:`limit-pushdown`
 * :ref:`topn-pushdown`
 
+In addition, the connector supports :ref:`aggregation-pushdown` for the
+following functions:
+
+* :func:`avg()`
+* :func:`count()`, also ``count(distinct x)``
+* :func:`max()`
+* :func:`min()`
+* :func:`sum()`
+
+Pushdown is only supported for ``DOUBLE`` type columns with the
+following functions:
+
+* :func:`stddev()` and :func:`stddev_samp()`
+* :func:`stddev_pop()`
+* :func:`var_pop()`
+* :func:`variance()` and :func:`var_samp()`
+
+Pushdown is only supported for ``REAL`` or ``DOUBLE`` type column
+with the following functions:
+
+* :func:`covar_samp()`
+* :func:`covar_pop()`
+
 .. _oracle-predicate-pushdown:
 
 Predicate pushdown support


### PR DESCRIPTION
## Description

Add list of functions that can be pushed down to Oracle with aggregation pushdown.

> Is this change a fix, improvement, new feature, refactoring, or other?

Documentation fix. 

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Oracle connector.

> How would you describe this change to a non-technical end user or system administrator?

Add details to Oracle connector documentation. 

## Related issues, pull requests, and links

* Related to https://github.com/trinodb/trino/pull/11657 which omitted the doc update.

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:
