### PR TITLE
Checkout with fetch-depth 0 in docs tests

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -73,6 +73,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # checkout all commits, as the build result depends on `git describe` equivalent
       - uses: actions/setup-java@v2
         with:
           distribution: 'zulu'


### PR DESCRIPTION
## Description

Fix failing docs CI. Tested in #11835

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
