### PR TITLE
Add delta catalog to development server

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Minio.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Minio.java
@@ -43,6 +43,7 @@ public class Minio
     private static final String MINIO_RELEASE = "RELEASE.2021-07-15T22-27-34Z";
 
     private static final int MINIO_PORT = 9080; // minio uses 9000 by default, which conflicts with hadoop
+    private static final int MINIO_CONSOLE_PORT = 9001;
 
     private final PortBinder portBinder;
 
@@ -74,12 +75,13 @@ public class Minio
                         .put("MINIO_ACCESS_KEY", MINIO_ACCESS_KEY)
                         .put("MINIO_SECRET_KEY", MINIO_SECRET_KEY)
                         .buildOrThrow())
-                .withCommand("server", "--address", format("0.0.0.0:%d", MINIO_PORT), "/data")
+                .withCommand("server", "--address", format("0.0.0.0:%d", MINIO_PORT), "--console-address", format("0.0.0.0:%d", MINIO_CONSOLE_PORT), "/data")
                 .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
                 .waitingFor(forSelectedPorts(MINIO_PORT))
                 .withStartupTimeout(Duration.ofMinutes(1));
 
         portBinder.exposePort(container, MINIO_PORT);
+        portBinder.exposePort(container, MINIO_CONSOLE_PORT);
 
         return container;
     }

--- a/testing/trino-server-dev/etc/catalog/delta.properties
+++ b/testing/trino-server-dev/etc/catalog/delta.properties
@@ -1,0 +1,19 @@
+connector.name=delta-lake
+
+# Configuration appropriate for Hive as started by product test environment, e.g.
+#  testing/bin/ptl env up --environment multinode-minio-data-lake --without-trino
+# On Mac, this additionally requires that you add "<your external IP> hadoop-master" to /etc/hosts
+hive.metastore.uri=thrift://localhost:9083
+
+# MinIO uses 9000 by default, but this change conflicts with Hadoop
+hive.s3.endpoint=http://localhost:9080
+hive.s3.path-style-access=true
+hive.s3.ssl.enabled=false
+hive.s3.aws-access-key=minio-access-key
+hive.s3.aws-secret-key=minio-secret-key
+
+# Fail-fast in development
+hive.metastore.thrift.client.max-retry-time=1s
+hive.s3.max-client-retries=1
+# Enable write support for all supported file systems in development
+delta.enable-non-concurrent-writes=true

--- a/testing/trino-server-dev/etc/config.properties
+++ b/testing/trino-server-dev/etc/config.properties
@@ -31,6 +31,7 @@ plugin.bundles=\
   ../../plugin/trino-resource-group-managers/pom.xml,\
   ../../plugin/trino-password-authenticators/pom.xml, \
   ../../plugin/trino-iceberg/pom.xml,\
+  ../../plugin/trino-delta-lake/pom.xml,\
   ../../plugin/trino-blackhole/pom.xml,\
   ../../plugin/trino-cassandra/pom.xml,\
   ../../plugin/trino-memory/pom.xml,\


### PR DESCRIPTION
This PR adds Delta Lake catalog settings for development purposes.


Now that Delta Lake is available as a connector we should provide a basic version of the catalog which can be used for development purposes.