### PR TITLE
Avoid selecting unrelated schemas from the information_schema

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseSharedMetastoreTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseSharedMetastoreTest.java
@@ -52,19 +52,19 @@ public abstract class BaseSharedMetastoreTest
     @Test
     public void testReadInformationSchema()
     {
-        assertThat(query("SELECT table_schema FROM hive.information_schema.tables WHERE table_name = 'region'"))
+        assertThat(query("SELECT table_schema FROM hive.information_schema.tables WHERE table_name = 'region' AND table_schema='" + schema + "'"))
                 .skippingTypesCheck()
                 .containsAll("VALUES '" + schema + "'");
-        assertThat(query("SELECT table_schema FROM iceberg.information_schema.tables WHERE table_name = 'nation'"))
+        assertThat(query("SELECT table_schema FROM iceberg.information_schema.tables WHERE table_name = 'nation' AND table_schema='" + schema + "'"))
                 .skippingTypesCheck()
                 .containsAll("VALUES '" + schema + "'");
-        assertThat(query("SELECT table_schema FROM hive_with_redirections.information_schema.tables WHERE table_name = 'region'"))
+        assertThat(query("SELECT table_schema FROM hive_with_redirections.information_schema.tables WHERE table_name = 'region' AND table_schema='" + schema + "'"))
                 .skippingTypesCheck()
                 .containsAll("VALUES '" + schema + "'");
-        assertThat(query("SELECT table_schema FROM hive_with_redirections.information_schema.tables WHERE table_name = 'nation'"))
+        assertThat(query("SELECT table_schema FROM hive_with_redirections.information_schema.tables WHERE table_name = 'nation' AND table_schema='" + schema + "'"))
                 .skippingTypesCheck()
                 .containsAll("VALUES '" + schema + "'");
-        assertThat(query("SELECT table_schema FROM iceberg_with_redirections.information_schema.tables WHERE table_name = 'region'"))
+        assertThat(query("SELECT table_schema FROM iceberg_with_redirections.information_schema.tables WHERE table_name = 'region' AND table_schema='" + schema + "'"))
                 .skippingTypesCheck()
                 .containsAll("VALUES '" + schema + "'");
 


### PR DESCRIPTION
## Description

`io.trino.plugin.iceberg.TestSharedHiveMetastore` is based on AWS Glue. When trying to select all the table schemas on which is found a table named `region` or `nation` the routine may find a lot of unrelated schemas.

Moreover in the context of enabled table redirections, the tables retrieved for listing are inspected one by one in `MetadataManager#listTables` method. If one of the tables to be inspected, gets dropped, the test  `io.trino.plugin.iceberg.BaseSharedMetastoreTest#testReadInformationSchema` fails.

```
Caused by: org.apache.iceberg.exceptions.RuntimeIOException: Failed to read file: HdfsInputFile{delegate=s3://***/iceberg_smoke_test_qkp9dzmdph/iceberg_smoke_test_qkp9dzmdph.db/nation/metadata/00000-862c01c1-eeb0-43bd-95f3-e1e7bd058336.metadata.json, identity=ConnectorIdentity{user='user', groups=[], principal=user, enabledSystemroles=[], extraCredentials=[]}}
	at org.apache.iceberg.TableMetadataParser.read(TableMetadataParser.java:253)
	at io.trino.plugin.iceberg.catalog.AbstractIcebergTableOperations.lambda$refreshFromMetadataLocation$1(AbstractIcebergTableOperations.java:218)
	at org.apache.iceberg.util.Tasks$Builder.runTaskWithRetry(Tasks.java:404)
	at org.apache.iceberg.util.Tasks$Builder.runSingleThreaded(Tasks.java:214)
	at org.apache.iceberg.util.Tasks$Builder.run(Tasks.java:198)
	at org.apache.iceberg.util.Tasks$Builder.run(Tasks.java:190)
	at io.trino.plugin.iceberg.catalog.AbstractIcebergTableOperations.refreshFromMetadataLocation(AbstractIcebergTableOperations.java:217)
	at io.trino.plugin.iceberg.catalog.AbstractIcebergTableOperations.refresh(AbstractIcebergTableOperations.java:122)
	at io.trino.plugin.iceberg.catalog.AbstractIcebergTableOperations.current(AbstractIcebergTableOperations.java:110)
	at io.trino.plugin.iceberg.catalog.glue.TrinoGlueCatalog.lambda$loadTable$5(TrinoGlueCatalog.java:274)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1705)
	at io.trino.plugin.iceberg.catalog.glue.TrinoGlueCatalog.loadTable(TrinoGlueCatalog.java:264)
	at io.trino.plugin.iceberg.IcebergMetadata.getTableHandle(IcebergMetadata.java:217)
	at io.trino.plugin.iceberg.IcebergMetadata.getTableHandle(IcebergMetadata.java:160)
	at io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata.getTableHandle(ClassLoaderSafeConnectorMetadata.java:182)
	at io.trino.metadata.MetadataManager.lambda$getTableHandle$5(MetadataManager.java:279)
	at java.base/java.util.Optional.flatMap(Optional.java:294)
	at io.trino.metadata.MetadataManager.getTableHandle(MetadataManager.java:259)
	at io.trino.metadata.MetadataManager.getRedirectionAwareTableHandle(MetadataManager.java:1484)
	at io.trino.metadata.MetadataManager.getRedirectionAwareTableHandle(MetadataManager.java:1476)
	at io.trino.metadata.MetadataManager.isExistingRelationForListing(MetadataManager.java:544)
	at io.trino.metadata.MetadataManager.listTables(MetadataManager.java:510)
	at io.trino.metadata.MetadataListing.listTables(MetadataListing.java:112)
	at io.trino.connector.informationschema.InformationSchemaPageSource.addTablesRecords(InformationSchemaPageSource.java:281)
	at io.trino.connector.informationschema.InformationSchemaPageSource.buildPages(InformationSchemaPageSource.java:219)
```

This is not a fix for the issue, but rather a patch to avoid having the Glue test which rely on shared metastore infrastructure to fail.

## Related issues

https://github.com/trinodb/trino/issues/9400


PR fixing this issue https://github.com/trinodb/trino/pull/11790