### PR TITLE
Estimate partition memory usage based on previous attempts

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -162,6 +162,7 @@ public final class SystemSessionProperties
     public static final String FAULT_TOLERANT_EXECUTION_MAX_TASK_SPLIT_COUNT = "fault_tolerant_execution_max_task_split_count";
     public static final String FAULT_TOLERANT_EXECUTION_TASK_MEMORY = "fault_tolerant_execution_task_memory";
     public static final String FAULT_TOLERANT_EXECUTION_TASK_MEMORY_GROWTH_FACTOR = "fault_tolerant_execution_task_memory_growth_factor";
+    public static final String FAULT_TOLERANT_EXECUTION_TASK_MEMORY_ESTIMATION_QUANTILE = "fault_tolerant_execution_task_memory_estimation_quantile";
     public static final String ADAPTIVE_PARTIAL_AGGREGATION_ENABLED = "adaptive_partial_aggregation_enabled";
     public static final String ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS = "adaptive_partial_aggregation_min_rows";
     public static final String ADAPTIVE_PARTIAL_AGGREGATION_UNIQUE_ROWS_RATIO_THRESHOLD = "adaptive_partial_aggregation_unique_rows_ratio_threshold";
@@ -776,6 +777,12 @@ public final class SystemSessionProperties
                         FAULT_TOLERANT_EXECUTION_TASK_MEMORY_GROWTH_FACTOR,
                         "Factor by which estimated task memory is increased if task execution runs out of memory; value is used allocating nodes for tasks execution",
                         memoryManagerConfig.getFaultTolerantExecutionTaskMemoryGrowthFactor(),
+                        false),
+                doubleProperty(
+                        FAULT_TOLERANT_EXECUTION_TASK_MEMORY_ESTIMATION_QUANTILE,
+                        "What quantile of memory usage of completed tasks to look at when estimating memory usage for upcoming tasks",
+                        memoryManagerConfig.getFaultTolerantExecutionTaskMemoryEstimationQuantile(),
+                        value -> validateDoubleRange(value, FAULT_TOLERANT_EXECUTION_TASK_MEMORY_ESTIMATION_QUANTILE, 0.0, 1.0),
                         false),
                 booleanProperty(
                         ADAPTIVE_PARTIAL_AGGREGATION_ENABLED,
@@ -1412,6 +1419,11 @@ public final class SystemSessionProperties
     public static double getFaultTolerantExecutionTaskMemoryGrowthFactor(Session session)
     {
         return session.getSystemProperty(FAULT_TOLERANT_EXECUTION_TASK_MEMORY_GROWTH_FACTOR, Double.class);
+    }
+
+    public static double getFaultTolerantExecutionTaskMemoryEstimationQuantile(Session session)
+    {
+        return session.getSystemProperty(FAULT_TOLERANT_EXECUTION_TASK_MEMORY_ESTIMATION_QUANTILE, Double.class);
     }
 
     public static boolean isAdaptivePartialAggregationEnabled(Session session)

--- a/core/trino-main/src/main/java/io/trino/execution/SqlQueryExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlQueryExecution.java
@@ -27,7 +27,7 @@ import io.trino.execution.QueryPreparer.PreparedQuery;
 import io.trino.execution.StateMachine.StateChangeListener;
 import io.trino.execution.scheduler.NodeAllocatorService;
 import io.trino.execution.scheduler.NodeScheduler;
-import io.trino.execution.scheduler.PartitionMemoryEstimator;
+import io.trino.execution.scheduler.PartitionMemoryEstimatorFactory;
 import io.trino.execution.scheduler.SplitSchedulerStats;
 import io.trino.execution.scheduler.SqlQueryScheduler;
 import io.trino.execution.scheduler.TaskDescriptorStorage;
@@ -102,7 +102,7 @@ public class SqlQueryExecution
     private final NodePartitioningManager nodePartitioningManager;
     private final NodeScheduler nodeScheduler;
     private final NodeAllocatorService nodeAllocatorService;
-    private final PartitionMemoryEstimator partitionMemoryEstimator;
+    private final PartitionMemoryEstimatorFactory partitionMemoryEstimatorFactory;
     private final List<PlanOptimizer> planOptimizers;
     private final PlanFragmenter planFragmenter;
     private final RemoteTaskFactory remoteTaskFactory;
@@ -137,7 +137,7 @@ public class SqlQueryExecution
             NodePartitioningManager nodePartitioningManager,
             NodeScheduler nodeScheduler,
             NodeAllocatorService nodeAllocatorService,
-            PartitionMemoryEstimator partitionMemoryEstimator,
+            PartitionMemoryEstimatorFactory partitionMemoryEstimatorFactory,
             List<PlanOptimizer> planOptimizers,
             PlanFragmenter planFragmenter,
             RemoteTaskFactory remoteTaskFactory,
@@ -166,7 +166,7 @@ public class SqlQueryExecution
             this.nodePartitioningManager = requireNonNull(nodePartitioningManager, "nodePartitioningManager is null");
             this.nodeScheduler = requireNonNull(nodeScheduler, "nodeScheduler is null");
             this.nodeAllocatorService = requireNonNull(nodeAllocatorService, "nodeAllocatorService is null");
-            this.partitionMemoryEstimator = requireNonNull(partitionMemoryEstimator, "partitionMemoryEstimator is null");
+            this.partitionMemoryEstimatorFactory = requireNonNull(partitionMemoryEstimatorFactory, "partitionMemoryEstimatorFactory is null");
             this.planOptimizers = requireNonNull(planOptimizers, "planOptimizers is null");
             this.planFragmenter = requireNonNull(planFragmenter, "planFragmenter is null");
             this.queryExecutor = requireNonNull(queryExecutor, "queryExecutor is null");
@@ -506,7 +506,7 @@ public class SqlQueryExecution
                 nodePartitioningManager,
                 nodeScheduler,
                 nodeAllocatorService,
-                partitionMemoryEstimator,
+                partitionMemoryEstimatorFactory,
                 remoteTaskFactory,
                 plan.isSummarizeTaskInfos(),
                 scheduleSplitBatchSize,
@@ -709,7 +709,7 @@ public class SqlQueryExecution
         private final NodePartitioningManager nodePartitioningManager;
         private final NodeScheduler nodeScheduler;
         private final NodeAllocatorService nodeAllocatorService;
-        private final PartitionMemoryEstimator partitionMemoryEstimator;
+        private final PartitionMemoryEstimatorFactory partitionMemoryEstimatorFactory;
         private final List<PlanOptimizer> planOptimizers;
         private final PlanFragmenter planFragmenter;
         private final RemoteTaskFactory remoteTaskFactory;
@@ -737,7 +737,7 @@ public class SqlQueryExecution
                 NodePartitioningManager nodePartitioningManager,
                 NodeScheduler nodeScheduler,
                 NodeAllocatorService nodeAllocatorService,
-                PartitionMemoryEstimator partitionMemoryEstimator,
+                PartitionMemoryEstimatorFactory partitionMemoryEstimatorFactory,
                 PlanOptimizersFactory planOptimizersFactory,
                 PlanFragmenter planFragmenter,
                 RemoteTaskFactory remoteTaskFactory,
@@ -766,7 +766,7 @@ public class SqlQueryExecution
             this.nodePartitioningManager = requireNonNull(nodePartitioningManager, "nodePartitioningManager is null");
             this.nodeScheduler = requireNonNull(nodeScheduler, "nodeScheduler is null");
             this.nodeAllocatorService = requireNonNull(nodeAllocatorService, "nodeAllocatorService is null");
-            this.partitionMemoryEstimator = requireNonNull(partitionMemoryEstimator, "partitionMemoryEstimator is null");
+            this.partitionMemoryEstimatorFactory = requireNonNull(partitionMemoryEstimatorFactory, "partitionMemoryEstimatorFactory is null");
             this.planFragmenter = requireNonNull(planFragmenter, "planFragmenter is null");
             this.remoteTaskFactory = requireNonNull(remoteTaskFactory, "remoteTaskFactory is null");
             this.queryExecutor = requireNonNull(queryExecutor, "queryExecutor is null");
@@ -807,7 +807,7 @@ public class SqlQueryExecution
                     nodePartitioningManager,
                     nodeScheduler,
                     nodeAllocatorService,
-                    partitionMemoryEstimator,
+                    partitionMemoryEstimatorFactory,
                     planOptimizers,
                     planFragmenter,
                     remoteTaskFactory,

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/ConstantPartitionMemoryEstimator.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/ConstantPartitionMemoryEstimator.java
@@ -17,6 +17,8 @@ import io.airlift.units.DataSize;
 import io.trino.Session;
 import io.trino.spi.ErrorCode;
 
+import java.util.Optional;
+
 public class ConstantPartitionMemoryEstimator
         implements PartitionMemoryEstimator
 {
@@ -33,4 +35,7 @@ public class ConstantPartitionMemoryEstimator
     {
         return previousMemoryRequirements;
     }
+
+    @Override
+    public void registerPartitionFinished(Session session, MemoryRequirements previousMemoryRequirements, DataSize peakMemoryUsage, boolean success, Optional<ErrorCode> errorCode) {}
 }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/ExponentialGrowthPartitionMemoryEstimator.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/ExponentialGrowthPartitionMemoryEstimator.java
@@ -18,6 +18,8 @@ import io.airlift.units.DataSize;
 import io.trino.Session;
 import io.trino.spi.ErrorCode;
 
+import java.util.Optional;
+
 import static io.trino.SystemSessionProperties.getFaultTolerantExecutionTaskMemoryGrowthFactor;
 import static io.trino.spi.StandardErrorCode.CLUSTER_OUT_OF_MEMORY;
 import static io.trino.spi.StandardErrorCode.EXCEEDED_LOCAL_MEMORY_LIMIT;
@@ -50,4 +52,7 @@ public class ExponentialGrowthPartitionMemoryEstimator
         return EXCEEDED_LOCAL_MEMORY_LIMIT.toErrorCode().equals(errorCode) // too many tasks from single query on a node
                 || CLUSTER_OUT_OF_MEMORY.toErrorCode().equals(errorCode); // too many tasks in general on a node
     }
+
+    @Override
+    public void registerPartitionFinished(Session session, MemoryRequirements previousMemoryRequirements, DataSize peakMemoryUsage, boolean success, Optional<ErrorCode> errorCode) {}
 }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/ExponentialGrowthPartitionMemoryEstimator.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/ExponentialGrowthPartitionMemoryEstimator.java
@@ -16,9 +16,9 @@ package io.trino.execution.scheduler;
 import com.google.common.collect.Ordering;
 import io.airlift.units.DataSize;
 import io.trino.Session;
-import io.trino.SystemSessionProperties;
 import io.trino.spi.ErrorCode;
 
+import static io.trino.SystemSessionProperties.getFaultTolerantExecutionTaskMemoryGrowthFactor;
 import static io.trino.spi.StandardErrorCode.CLUSTER_OUT_OF_MEMORY;
 import static io.trino.spi.StandardErrorCode.EXCEEDED_LOCAL_MEMORY_LIMIT;
 
@@ -39,7 +39,7 @@ public class ExponentialGrowthPartitionMemoryEstimator
         DataSize previousMemory = previousMemoryRequirements.getRequiredMemory();
         DataSize baseMemory = Ordering.natural().max(peakMemoryUsage, previousMemory);
         if (shouldIncreaseMemory(errorCode)) {
-            double growthFactor = SystemSessionProperties.getFaultTolerantExecutionTaskMemoryGrowthFactor(session);
+            double growthFactor = getFaultTolerantExecutionTaskMemoryGrowthFactor(session);
             return new MemoryRequirements(DataSize.of((long) (baseMemory.toBytes() * growthFactor), DataSize.Unit.BYTE), false);
         }
         return new MemoryRequirements(baseMemory, false);

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/FallbackToFullNodePartitionMemoryEstimator.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/FallbackToFullNodePartitionMemoryEstimator.java
@@ -17,6 +17,8 @@ import io.airlift.units.DataSize;
 import io.trino.Session;
 import io.trino.spi.ErrorCode;
 
+import java.util.Optional;
+
 import static io.trino.spi.StandardErrorCode.CLUSTER_OUT_OF_MEMORY;
 import static io.trino.spi.StandardErrorCode.EXCEEDED_LOCAL_MEMORY_LIMIT;
 
@@ -50,4 +52,7 @@ public class FallbackToFullNodePartitionMemoryEstimator
         return EXCEEDED_LOCAL_MEMORY_LIMIT.toErrorCode().equals(errorCode) // too many tasks from single query on a node
                 || CLUSTER_OUT_OF_MEMORY.toErrorCode().equals(errorCode); // too many tasks in general on a node
     }
+
+    @Override
+    public void registerPartitionFinished(Session session, MemoryRequirements previousMemoryRequirements, DataSize peakMemoryUsage, boolean success, Optional<ErrorCode> errorCode) {}
 }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/FaultTolerantStageScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/FaultTolerantStageScheduler.java
@@ -266,6 +266,7 @@ public class FaultTolerantStageScheduler
             TaskDescriptor taskDescriptor = taskDescriptorOptional.get();
 
             MemoryRequirements memoryRequirements = partitionMemoryRequirements.computeIfAbsent(partition, ignored -> partitionMemoryEstimator.getInitialMemoryRequirements(session, taskDescriptor.getNodeRequirements().getMemory()));
+            log.debug("Computed initial memory requirements for task from stage %s; requirements=%s; estimator=%s", stage.getStageId(), memoryRequirements, partitionMemoryEstimator);
             if (nodeLease == null) {
                 NodeRequirements nodeRequirements = taskDescriptor.getNodeRequirements();
                 nodeRequirements = nodeRequirements.withMemory(memoryRequirements.getRequiredMemory());
@@ -553,6 +554,7 @@ public class FaultTolerantStageScheduler
 
                                 // update memory limits for next attempt
                                 MemoryRequirements newMemoryLimits = partitionMemoryEstimator.getNextRetryMemoryRequirements(session, memoryLimits, taskStatus.getPeakMemoryReservation(), errorCode);
+                                log.debug("Computed next memory requirements for task from stage %s; previous=%s; new=%s; peak=%s; estimator=%s", stage.getStageId(), memoryLimits, newMemoryLimits, taskStatus.getPeakMemoryReservation(), partitionMemoryEstimator);
                                 partitionMemoryRequirements.put(partitionId, newMemoryLimits);
 
                                 // reschedule

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/PartitionMemoryEstimator.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/PartitionMemoryEstimator.java
@@ -18,6 +18,7 @@ import io.trino.Session;
 import io.trino.spi.ErrorCode;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
@@ -27,6 +28,8 @@ public interface PartitionMemoryEstimator
     MemoryRequirements getInitialMemoryRequirements(Session session, DataSize defaultMemoryLimit);
 
     MemoryRequirements getNextRetryMemoryRequirements(Session session, MemoryRequirements previousMemoryRequirements, DataSize peakMemoryUsage, ErrorCode errorCode);
+
+    void registerPartitionFinished(Session session, MemoryRequirements previousMemoryRequirements, DataSize peakMemoryUsage, boolean success, Optional<ErrorCode> errorCode);
 
     class MemoryRequirements
     {

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/PartitionMemoryEstimatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/PartitionMemoryEstimatorFactory.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.scheduler;
+
+@FunctionalInterface
+public interface PartitionMemoryEstimatorFactory
+{
+    PartitionMemoryEstimator createPartitionMemoryEstimator();
+}

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/SqlQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/SqlQueryScheduler.java
@@ -177,7 +177,7 @@ public class SqlQueryScheduler
     private final NodePartitioningManager nodePartitioningManager;
     private final NodeScheduler nodeScheduler;
     private final NodeAllocatorService nodeAllocatorService;
-    private final PartitionMemoryEstimator partitionMemoryEstimator;
+    private final PartitionMemoryEstimatorFactory partitionMemoryEstimatorFactory;
     private final int splitBatchSize;
     private final ExecutorService executor;
     private final ScheduledExecutorService schedulerExecutor;
@@ -216,7 +216,7 @@ public class SqlQueryScheduler
             NodePartitioningManager nodePartitioningManager,
             NodeScheduler nodeScheduler,
             NodeAllocatorService nodeAllocatorService,
-            PartitionMemoryEstimator partitionMemoryEstimator,
+            PartitionMemoryEstimatorFactory partitionMemoryEstimatorFactory,
             RemoteTaskFactory remoteTaskFactory,
             boolean summarizeTaskInfo,
             int splitBatchSize,
@@ -239,7 +239,7 @@ public class SqlQueryScheduler
         this.nodePartitioningManager = requireNonNull(nodePartitioningManager, "nodePartitioningManager is null");
         this.nodeScheduler = requireNonNull(nodeScheduler, "nodeScheduler is null");
         this.nodeAllocatorService = requireNonNull(nodeAllocatorService, "nodeAllocatorService is null");
-        this.partitionMemoryEstimator = requireNonNull(partitionMemoryEstimator, "partitionMemoryEstimator is null");
+        this.partitionMemoryEstimatorFactory = requireNonNull(partitionMemoryEstimatorFactory, "partitionMemoryEstimatorFactory is null");
         this.splitBatchSize = splitBatchSize;
         this.executor = requireNonNull(queryExecutor, "queryExecutor is null");
         this.schedulerExecutor = requireNonNull(schedulerExecutor, "schedulerExecutor is null");
@@ -355,7 +355,7 @@ public class SqlQueryScheduler
                         schedulerExecutor,
                         schedulerStats,
                         nodeAllocatorService,
-                        partitionMemoryEstimator);
+                        partitionMemoryEstimatorFactory);
                 break;
             case QUERY:
             case NONE:
@@ -1757,7 +1757,7 @@ public class SqlQueryScheduler
                 ScheduledExecutorService scheduledExecutorService,
                 SplitSchedulerStats schedulerStats,
                 NodeAllocatorService nodeAllocatorService,
-                PartitionMemoryEstimator partitionMemoryEstimator)
+                PartitionMemoryEstimatorFactory partitionMemoryEstimatorFactory)
         {
             taskDescriptorStorage.initialize(queryStateMachine.getQueryId());
             queryStateMachine.addStateChangeListener(state -> {
@@ -1821,7 +1821,7 @@ public class SqlQueryScheduler
                             taskSourceFactory,
                             nodeAllocator,
                             taskDescriptorStorage,
-                            partitionMemoryEstimator,
+                            partitionMemoryEstimatorFactory.createPartitionMemoryEstimator(),
                             taskLifecycleListener,
                             exchange,
                             bucketToPartitionCache.apply(fragment.getPartitioningScheme().getPartitioning().getHandle()).getBucketToPartitionMap(),

--- a/core/trino-main/src/main/java/io/trino/memory/MemoryManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/memory/MemoryManagerConfig.java
@@ -44,6 +44,7 @@ public class MemoryManagerConfig
     private DataSize maxQueryTotalMemory;
     private DataSize faultTolerantExecutionTaskMemory = DataSize.of(4, GIGABYTE);
     private double faultTolerantExecutionTaskMemoryGrowthFactor = 3.0;
+    private double faultTolerantExecutionTaskMemoryEstimationQuantile = 0.9;
     private LowMemoryKillerPolicy lowMemoryKillerPolicy = LowMemoryKillerPolicy.TOTAL_RESERVATION_ON_BLOCKED_NODES;
     private Duration killOnOutOfMemoryDelay = new Duration(5, MINUTES);
 
@@ -129,6 +130,22 @@ public class MemoryManagerConfig
     {
         checkArgument(faultTolerantExecutionTaskMemoryGrowthFactor >= 1.0, "faultTolerantExecutionTaskMemoryGrowthFactor must not be less than 1.0");
         this.faultTolerantExecutionTaskMemoryGrowthFactor = faultTolerantExecutionTaskMemoryGrowthFactor;
+        return this;
+    }
+
+    @NotNull
+    public double getFaultTolerantExecutionTaskMemoryEstimationQuantile()
+    {
+        return faultTolerantExecutionTaskMemoryEstimationQuantile;
+    }
+
+    @Config("fault-tolerant-execution-task-memory-estimation-quantile")
+    @ConfigDescription("What quantile of memory usage of completed tasks to look at when estimating memory usage for upcoming tasks")
+    public MemoryManagerConfig setFaultTolerantExecutionTaskMemoryEstimationQuantile(double faultTolerantExecutionTaskMemoryEstimationQuantile)
+    {
+        checkArgument(faultTolerantExecutionTaskMemoryEstimationQuantile >= 0.0 && faultTolerantExecutionTaskMemoryEstimationQuantile <= 1.0,
+                "fault-tolerant-execution-task-memory-estimation-quantile must not be in [0.0, 1.0] range");
+        this.faultTolerantExecutionTaskMemoryEstimationQuantile = faultTolerantExecutionTaskMemoryEstimationQuantile;
         return this;
     }
 

--- a/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
@@ -68,7 +68,7 @@ import io.trino.execution.scheduler.FixedCountNodeAllocatorService;
 import io.trino.execution.scheduler.FullNodeCapableNodeAllocatorService;
 import io.trino.execution.scheduler.NodeAllocatorService;
 import io.trino.execution.scheduler.NodeSchedulerConfig;
-import io.trino.execution.scheduler.PartitionMemoryEstimator;
+import io.trino.execution.scheduler.PartitionMemoryEstimatorFactory;
 import io.trino.execution.scheduler.SplitSchedulerStats;
 import io.trino.execution.scheduler.StageTaskSourceFactory;
 import io.trino.execution.scheduler.TaskDescriptorStorage;
@@ -227,21 +227,21 @@ public class CoordinatorModule
                 config -> FIXED_COUNT == config.getNodeAllocatorType(),
                 innerBinder -> {
                     innerBinder.bind(NodeAllocatorService.class).to(FixedCountNodeAllocatorService.class).in(Scopes.SINGLETON);
-                    innerBinder.bind(PartitionMemoryEstimator.class).to(ConstantPartitionMemoryEstimator.class).in(Scopes.SINGLETON);
+                    innerBinder.bind(PartitionMemoryEstimatorFactory.class).toInstance(ConstantPartitionMemoryEstimator::new);
                 }));
         install(conditionalModule(
                 NodeSchedulerConfig.class,
                 config -> FULL_NODE_CAPABLE == config.getNodeAllocatorType(),
                 innerBinder -> {
                     innerBinder.bind(NodeAllocatorService.class).to(FullNodeCapableNodeAllocatorService.class).in(Scopes.SINGLETON);
-                    innerBinder.bind(PartitionMemoryEstimator.class).to(FallbackToFullNodePartitionMemoryEstimator.class).in(Scopes.SINGLETON);
+                    innerBinder.bind(PartitionMemoryEstimatorFactory.class).toInstance(FallbackToFullNodePartitionMemoryEstimator::new);
                 }));
         install(conditionalModule(
                 NodeSchedulerConfig.class,
                 config -> BIN_PACKING == config.getNodeAllocatorType(),
                 innerBinder -> {
                     innerBinder.bind(NodeAllocatorService.class).to(BinPackingNodeAllocatorService.class).in(Scopes.SINGLETON);
-                    innerBinder.bind(PartitionMemoryEstimator.class).to(ExponentialGrowthPartitionMemoryEstimator.class).in(Scopes.SINGLETON);
+                    innerBinder.bind(PartitionMemoryEstimatorFactory.class).toInstance(ExponentialGrowthPartitionMemoryEstimator::new);
                 }));
 
         // node monitor

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestExponentialGrowthPartitionMemoryEstimator.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestExponentialGrowthPartitionMemoryEstimator.java
@@ -15,11 +15,17 @@ package io.trino.execution.scheduler;
 
 import io.airlift.units.DataSize;
 import io.trino.Session;
+import io.trino.execution.scheduler.PartitionMemoryEstimator.MemoryRequirements;
 import io.trino.spi.StandardErrorCode;
 import io.trino.testing.TestingSession;
 import org.testng.annotations.Test;
 
+import java.util.Optional;
+
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static io.trino.spi.StandardErrorCode.ADMINISTRATIVELY_PREEMPTED;
+import static io.trino.spi.StandardErrorCode.CLUSTER_OUT_OF_MEMORY;
+import static io.trino.spi.StandardErrorCode.EXCEEDED_LOCAL_MEMORY_LIMIT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestExponentialGrowthPartitionMemoryEstimator
@@ -32,48 +38,105 @@ public class TestExponentialGrowthPartitionMemoryEstimator
         Session session = TestingSession.testSessionBuilder().build();
 
         assertThat(estimator.getInitialMemoryRequirements(session, DataSize.of(107, MEGABYTE)))
-                .isEqualTo(new PartitionMemoryEstimator.MemoryRequirements(DataSize.of(107, MEGABYTE), false));
+                .isEqualTo(new MemoryRequirements(DataSize.of(107, MEGABYTE), false));
 
         // peak memory of failed task 10MB
         assertThat(
                 estimator.getNextRetryMemoryRequirements(
                         session,
-                        new PartitionMemoryEstimator.MemoryRequirements(DataSize.of(50, MEGABYTE), false),
+                        new MemoryRequirements(DataSize.of(50, MEGABYTE), false),
                         DataSize.of(10, MEGABYTE),
                         StandardErrorCode.CORRUPT_PAGE.toErrorCode()))
-                .isEqualTo(new PartitionMemoryEstimator.MemoryRequirements(DataSize.of(50, MEGABYTE), false));
+                .isEqualTo(new MemoryRequirements(DataSize.of(50, MEGABYTE), false));
 
         assertThat(
                 estimator.getNextRetryMemoryRequirements(
                         session,
-                        new PartitionMemoryEstimator.MemoryRequirements(DataSize.of(50, MEGABYTE), false),
+                        new MemoryRequirements(DataSize.of(50, MEGABYTE), false),
                         DataSize.of(10, MEGABYTE),
                         StandardErrorCode.CLUSTER_OUT_OF_MEMORY.toErrorCode()))
-                .isEqualTo(new PartitionMemoryEstimator.MemoryRequirements(DataSize.of(150, MEGABYTE), false));
+                .isEqualTo(new MemoryRequirements(DataSize.of(150, MEGABYTE), false));
 
         assertThat(
                 estimator.getNextRetryMemoryRequirements(
                         session,
-                        new PartitionMemoryEstimator.MemoryRequirements(DataSize.of(50, MEGABYTE), false),
+                        new MemoryRequirements(DataSize.of(50, MEGABYTE), false),
                         DataSize.of(10, MEGABYTE),
-                        StandardErrorCode.EXCEEDED_LOCAL_MEMORY_LIMIT.toErrorCode()))
-                .isEqualTo(new PartitionMemoryEstimator.MemoryRequirements(DataSize.of(150, MEGABYTE), false));
+                        EXCEEDED_LOCAL_MEMORY_LIMIT.toErrorCode()))
+                .isEqualTo(new MemoryRequirements(DataSize.of(150, MEGABYTE), false));
 
         // peak memory of failed task 70MB
         assertThat(
                 estimator.getNextRetryMemoryRequirements(
                         session,
-                        new PartitionMemoryEstimator.MemoryRequirements(DataSize.of(50, MEGABYTE), false),
+                        new MemoryRequirements(DataSize.of(50, MEGABYTE), false),
                         DataSize.of(70, MEGABYTE),
                         StandardErrorCode.CORRUPT_PAGE.toErrorCode()))
-                .isEqualTo(new PartitionMemoryEstimator.MemoryRequirements(DataSize.of(70, MEGABYTE), false));
+                .isEqualTo(new MemoryRequirements(DataSize.of(70, MEGABYTE), false));
 
         assertThat(
                 estimator.getNextRetryMemoryRequirements(
                         session,
-                        new PartitionMemoryEstimator.MemoryRequirements(DataSize.of(50, MEGABYTE), false),
+                        new MemoryRequirements(DataSize.of(50, MEGABYTE), false),
                         DataSize.of(70, MEGABYTE),
-                        StandardErrorCode.EXCEEDED_LOCAL_MEMORY_LIMIT.toErrorCode()))
-                .isEqualTo(new PartitionMemoryEstimator.MemoryRequirements(DataSize.of(210, MEGABYTE), false));
+                        EXCEEDED_LOCAL_MEMORY_LIMIT.toErrorCode()))
+                .isEqualTo(new MemoryRequirements(DataSize.of(210, MEGABYTE), false));
+
+        // register a couple successful attempts; 90th percentile is at 300MB
+        estimator.registerPartitionFinished(session, new MemoryRequirements(DataSize.of(100, MEGABYTE), false), DataSize.of(1000, MEGABYTE), true, Optional.empty());
+        estimator.registerPartitionFinished(session, new MemoryRequirements(DataSize.of(100, MEGABYTE), false), DataSize.of(300, MEGABYTE), true, Optional.empty());
+        estimator.registerPartitionFinished(session, new MemoryRequirements(DataSize.of(100, MEGABYTE), false), DataSize.of(300, MEGABYTE), true, Optional.empty());
+        estimator.registerPartitionFinished(session, new MemoryRequirements(DataSize.of(100, MEGABYTE), false), DataSize.of(300, MEGABYTE), true, Optional.empty());
+        estimator.registerPartitionFinished(session, new MemoryRequirements(DataSize.of(100, MEGABYTE), false), DataSize.of(300, MEGABYTE), true, Optional.empty());
+        estimator.registerPartitionFinished(session, new MemoryRequirements(DataSize.of(100, MEGABYTE), false), DataSize.of(300, MEGABYTE), true, Optional.empty());
+        estimator.registerPartitionFinished(session, new MemoryRequirements(DataSize.of(100, MEGABYTE), false), DataSize.of(300, MEGABYTE), true, Optional.empty());
+        estimator.registerPartitionFinished(session, new MemoryRequirements(DataSize.of(100, MEGABYTE), false), DataSize.of(300, MEGABYTE), true, Optional.empty());
+        estimator.registerPartitionFinished(session, new MemoryRequirements(DataSize.of(100, MEGABYTE), false), DataSize.of(300, MEGABYTE), true, Optional.empty());
+        estimator.registerPartitionFinished(session, new MemoryRequirements(DataSize.of(100, MEGABYTE), false), DataSize.of(300, MEGABYTE), true, Optional.empty());
+        estimator.registerPartitionFinished(session, new MemoryRequirements(DataSize.of(100, MEGABYTE), false), DataSize.of(100, MEGABYTE), true, Optional.empty());
+
+        // for initial we should pick estimate if greater than default
+        assertThat(estimator.getInitialMemoryRequirements(session, DataSize.of(100, MEGABYTE)))
+                .isEqualTo(new MemoryRequirements(DataSize.of(300, MEGABYTE), false));
+
+        // if default memory requirements is greater than estimate it should be picked still
+        assertThat(estimator.getInitialMemoryRequirements(session, DataSize.of(500, MEGABYTE)))
+                .isEqualTo(new MemoryRequirements(DataSize.of(500, MEGABYTE), false));
+
+        // for next we should still pick current initial if greater
+        assertThat(
+                estimator.getNextRetryMemoryRequirements(
+                        session,
+                        new MemoryRequirements(DataSize.of(50, MEGABYTE), false),
+                        DataSize.of(70, MEGABYTE),
+                        EXCEEDED_LOCAL_MEMORY_LIMIT.toErrorCode()))
+                .isEqualTo(new MemoryRequirements(DataSize.of(300, MEGABYTE), false));
+
+        // a couple oom errors are registered
+        estimator.registerPartitionFinished(session, new MemoryRequirements(DataSize.of(100, MEGABYTE), false), DataSize.of(200, MEGABYTE), false, Optional.of(EXCEEDED_LOCAL_MEMORY_LIMIT.toErrorCode()));
+        estimator.registerPartitionFinished(session, new MemoryRequirements(DataSize.of(100, MEGABYTE), false), DataSize.of(200, MEGABYTE), true, Optional.of(CLUSTER_OUT_OF_MEMORY.toErrorCode()));
+
+        // 90th percentile should be now at 200*3 (600)
+        assertThat(estimator.getInitialMemoryRequirements(session, DataSize.of(100, MEGABYTE)))
+                .isEqualTo(new MemoryRequirements(DataSize.of(600, MEGABYTE), false));
+
+        // a couple oom errors are registered with requested memory greater than peak
+        estimator.registerPartitionFinished(session, new MemoryRequirements(DataSize.of(300, MEGABYTE), false), DataSize.of(200, MEGABYTE), false, Optional.of(EXCEEDED_LOCAL_MEMORY_LIMIT.toErrorCode()));
+        estimator.registerPartitionFinished(session, new MemoryRequirements(DataSize.of(300, MEGABYTE), false), DataSize.of(200, MEGABYTE), false, Optional.of(EXCEEDED_LOCAL_MEMORY_LIMIT.toErrorCode()));
+        estimator.registerPartitionFinished(session, new MemoryRequirements(DataSize.of(300, MEGABYTE), false), DataSize.of(200, MEGABYTE), true, Optional.of(CLUSTER_OUT_OF_MEMORY.toErrorCode()));
+
+        // 90th percentile should be now at 300*3 (900)
+        assertThat(estimator.getInitialMemoryRequirements(session, DataSize.of(100, MEGABYTE)))
+                .isEqualTo(new MemoryRequirements(DataSize.of(900, MEGABYTE), false));
+
+        // other errors should not change estimate
+        estimator.registerPartitionFinished(session, new MemoryRequirements(DataSize.of(100, MEGABYTE), false), DataSize.of(500, MEGABYTE), false, Optional.of(ADMINISTRATIVELY_PREEMPTED.toErrorCode()));
+        estimator.registerPartitionFinished(session, new MemoryRequirements(DataSize.of(100, MEGABYTE), false), DataSize.of(500, MEGABYTE), false, Optional.of(ADMINISTRATIVELY_PREEMPTED.toErrorCode()));
+        estimator.registerPartitionFinished(session, new MemoryRequirements(DataSize.of(100, MEGABYTE), false), DataSize.of(500, MEGABYTE), false, Optional.of(ADMINISTRATIVELY_PREEMPTED.toErrorCode()));
+        estimator.registerPartitionFinished(session, new MemoryRequirements(DataSize.of(100, MEGABYTE), false), DataSize.of(500, MEGABYTE), false, Optional.of(ADMINISTRATIVELY_PREEMPTED.toErrorCode()));
+        estimator.registerPartitionFinished(session, new MemoryRequirements(DataSize.of(100, MEGABYTE), false), DataSize.of(500, MEGABYTE), false, Optional.of(ADMINISTRATIVELY_PREEMPTED.toErrorCode()));
+
+        assertThat(estimator.getInitialMemoryRequirements(session, DataSize.of(100, MEGABYTE)))
+                .isEqualTo(new MemoryRequirements(DataSize.of(900, MEGABYTE), false));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/memory/TestMemoryManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/memory/TestMemoryManagerConfig.java
@@ -40,7 +40,8 @@ public class TestMemoryManagerConfig
                 .setMaxQueryMemory(DataSize.of(20, GIGABYTE))
                 .setMaxQueryTotalMemory(DataSize.of(40, GIGABYTE))
                 .setFaultTolerantExecutionTaskMemory(DataSize.of(4, GIGABYTE))
-                .setFaultTolerantExecutionTaskMemoryGrowthFactor(3.0));
+                .setFaultTolerantExecutionTaskMemoryGrowthFactor(3.0)
+                .setFaultTolerantExecutionTaskMemoryEstimationQuantile(0.9));
     }
 
     @Test
@@ -53,6 +54,7 @@ public class TestMemoryManagerConfig
                 .put("query.max-total-memory", "3GB")
                 .put("fault-tolerant-execution-task-memory", "2GB")
                 .put("fault-tolerant-execution-task-memory-growth-factor", "17.3")
+                .put("fault-tolerant-execution-task-memory-estimation-quantile", "0.7")
                 .buildOrThrow();
 
         MemoryManagerConfig expected = new MemoryManagerConfig()
@@ -61,7 +63,8 @@ public class TestMemoryManagerConfig
                 .setMaxQueryMemory(DataSize.of(2, GIGABYTE))
                 .setMaxQueryTotalMemory(DataSize.of(3, GIGABYTE))
                 .setFaultTolerantExecutionTaskMemory(DataSize.of(2, GIGABYTE))
-                .setFaultTolerantExecutionTaskMemoryGrowthFactor(17.3);
+                .setFaultTolerantExecutionTaskMemoryGrowthFactor(17.3)
+                .setFaultTolerantExecutionTaskMemoryEstimationQuantile(0.7);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION

## Description

Estimate partition memory usage based on previous attempts.
This applies for execution with task-level retries when bin-packing node allocator is selected

> Is this change a fix, improvement, new feature, refactoring, or other?

improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core engine

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

