### PR TITLE
Fix stats/cost caching of group-referenced plan nodes

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/ConnectorManager.java
+++ b/core/trino-main/src/main/java/io/trino/connector/ConnectorManager.java
@@ -33,7 +33,7 @@ import io.trino.metadata.ColumnPropertyManager;
 import io.trino.metadata.HandleResolver;
 import io.trino.metadata.InternalNodeManager;
 import io.trino.metadata.MaterializedViewPropertyManager;
-import io.trino.metadata.MetadataManager;
+import io.trino.metadata.Metadata;
 import io.trino.metadata.ProcedureRegistry;
 import io.trino.metadata.SchemaPropertyManager;
 import io.trino.metadata.SessionPropertyManager;
@@ -99,7 +99,7 @@ public class ConnectorManager
 {
     private static final Logger log = Logger.get(ConnectorManager.class);
 
-    private final MetadataManager metadataManager;
+    private final Metadata metadata;
     private final CatalogManager catalogManager;
     private final AccessControlManager accessControlManager;
     private final SplitManager splitManager;
@@ -139,7 +139,7 @@ public class ConnectorManager
 
     @Inject
     public ConnectorManager(
-            MetadataManager metadataManager,
+            Metadata metadata,
             CatalogManager catalogManager,
             AccessControlManager accessControlManager,
             SplitManager splitManager,
@@ -167,7 +167,7 @@ public class ConnectorManager
             TableProceduresPropertyManager tableProceduresPropertyManager,
             NodeSchedulerConfig nodeSchedulerConfig)
     {
-        this.metadataManager = metadataManager;
+        this.metadata = metadata;
         this.catalogManager = catalogManager;
         this.accessControlManager = accessControlManager;
         this.splitManager = splitManager;
@@ -254,7 +254,7 @@ public class ConnectorManager
 
         MaterializedConnector informationSchemaConnector = new MaterializedConnector(
                 createInformationSchemaCatalogName(catalogName),
-                new InformationSchemaConnector(catalogName.getCatalogName(), nodeManager, metadataManager, accessControlManager),
+                new InformationSchemaConnector(catalogName.getCatalogName(), nodeManager, metadata, accessControlManager),
                 () -> {});
 
         CatalogName systemId = createSystemTablesCatalogName(catalogName);
@@ -263,7 +263,7 @@ public class ConnectorManager
         if (nodeManager.getCurrentNode().isCoordinator()) {
             systemTablesProvider = new CoordinatorSystemTablesProvider(
                     transactionManager,
-                    metadataManager,
+                    metadata,
                     catalogName.getCatalogName(),
                     new StaticSystemTablesProvider(connector.getSystemTables()));
         }
@@ -394,7 +394,7 @@ public class ConnectorManager
                 new ConnectorAwareNodeManager(nodeManager, nodeInfo.getEnvironment(), catalogName, schedulerIncludeCoordinator),
                 versionEmbedder,
                 typeManager,
-                new InternalMetadataProvider(metadataManager, typeManager),
+                new InternalMetadataProvider(metadata, typeManager),
                 pageSorter,
                 pageIndexerFactory,
                 duplicatePluginClassLoaderFactory);

--- a/core/trino-main/src/main/java/io/trino/cost/CachingCostProvider.java
+++ b/core/trino-main/src/main/java/io/trino/cost/CachingCostProvider.java
@@ -98,7 +98,7 @@ public class CachingCostProvider
             return knownCost.get();
         }
 
-        PlanCostEstimate cost = calculateCost(memo.getNode(group));
+        PlanCostEstimate cost = getCost(memo.getNode(group));
         verify(memo.getCost(group).isEmpty(), "Group cost already set");
         memo.storeCost(group, cost);
         return cost;

--- a/core/trino-main/src/main/java/io/trino/cost/CachingStatsProvider.java
+++ b/core/trino-main/src/main/java/io/trino/cost/CachingStatsProvider.java
@@ -100,7 +100,7 @@ public final class CachingStatsProvider
             return stats.get();
         }
 
-        PlanNodeStatsEstimate groupStats = statsCalculator.calculateStats(memo.getNode(group), this, lookup, session, types);
+        PlanNodeStatsEstimate groupStats = getStats(memo.getNode(group));
         verify(memo.getStats(group).isEmpty(), "Group stats already set");
         memo.storeStats(group, groupStats);
         return groupStats;

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -352,7 +352,7 @@ public class LocalQueryRunner
         globalFunctionCatalog.addFunctions(new InternalFunctionBundle(new LiteralFunction(blockEncodingSerde)));
         globalFunctionCatalog.addFunctions(SystemFunctionBundle.create(featuresConfig, typeOperators, blockTypeOperators, nodeManager.getCurrentNode().getNodeVersion()));
         this.functionManager = new FunctionManager(globalFunctionCatalog);
-        MetadataManager metadata = new MetadataManager(
+        Metadata metadata = new MetadataManager(
                 featuresConfig,
                 new DisabledSystemSecurityMetadata(),
                 transactionManager,

--- a/core/trino-main/src/test/java/io/trino/metadata/CountingAccessMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/CountingAccessMetadata.java
@@ -1,0 +1,855 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.metadata;
+
+import com.google.common.collect.ConcurrentHashMultiset;
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.Multiset;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.slice.Slice;
+import io.trino.Session;
+import io.trino.connector.CatalogName;
+import io.trino.spi.connector.AggregateFunction;
+import io.trino.spi.connector.AggregationApplicationResult;
+import io.trino.spi.connector.BeginTableExecuteResult;
+import io.trino.spi.connector.CatalogSchemaName;
+import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorCapabilities;
+import io.trino.spi.connector.ConnectorOutputMetadata;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.Constraint;
+import io.trino.spi.connector.ConstraintApplicationResult;
+import io.trino.spi.connector.JoinApplicationResult;
+import io.trino.spi.connector.JoinCondition;
+import io.trino.spi.connector.JoinStatistics;
+import io.trino.spi.connector.JoinType;
+import io.trino.spi.connector.LimitApplicationResult;
+import io.trino.spi.connector.MaterializedViewFreshness;
+import io.trino.spi.connector.ProjectionApplicationResult;
+import io.trino.spi.connector.SampleApplicationResult;
+import io.trino.spi.connector.SampleType;
+import io.trino.spi.connector.SortItem;
+import io.trino.spi.connector.SystemTable;
+import io.trino.spi.connector.TableColumnsMetadata;
+import io.trino.spi.connector.TableScanRedirectApplicationResult;
+import io.trino.spi.connector.TopNApplicationResult;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.function.OperatorType;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.security.GrantInfo;
+import io.trino.spi.security.Identity;
+import io.trino.spi.security.Privilege;
+import io.trino.spi.security.RoleGrant;
+import io.trino.spi.security.TrinoPrincipal;
+import io.trino.spi.statistics.ComputedStatistics;
+import io.trino.spi.statistics.TableStatistics;
+import io.trino.spi.statistics.TableStatisticsMetadata;
+import io.trino.spi.type.Type;
+import io.trino.sql.analyzer.TypeSignatureProvider;
+import io.trino.sql.planner.PartitioningHandle;
+import io.trino.sql.tree.QualifiedName;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.Set;
+
+public class CountingAccessMetadata
+        implements Metadata
+{
+    public enum Methods
+    {
+        GET_TABLE_STATISTICS,
+    }
+
+    private final Metadata delegate;
+    private final ConcurrentHashMultiset<Methods> methodInvocations = ConcurrentHashMultiset.create();
+
+    public CountingAccessMetadata(Metadata delegate)
+    {
+        this.delegate = delegate;
+    }
+
+    public Multiset<Methods> getMethodInvocations()
+    {
+        return ImmutableMultiset.copyOf(methodInvocations);
+    }
+
+    public void resetCounters()
+    {
+        methodInvocations.clear();
+    }
+
+    @Override
+    public Set<ConnectorCapabilities> getConnectorCapabilities(Session session, CatalogName catalogName)
+    {
+        return delegate.getConnectorCapabilities(session, catalogName);
+    }
+
+    @Override
+    public boolean catalogExists(Session session, String catalogName)
+    {
+        return delegate.catalogExists(session, catalogName);
+    }
+
+    @Override
+    public boolean schemaExists(Session session, CatalogSchemaName schema)
+    {
+        return delegate.schemaExists(session, schema);
+    }
+
+    @Override
+    public List<String> listSchemaNames(Session session, String catalogName)
+    {
+        return delegate.listSchemaNames(session, catalogName);
+    }
+
+    @Override
+    public Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName tableName)
+    {
+        return delegate.getTableHandle(session, tableName);
+    }
+
+    @Override
+    public Optional<SystemTable> getSystemTable(Session session, QualifiedObjectName tableName)
+    {
+        return delegate.getSystemTable(session, tableName);
+    }
+
+    @Override
+    public Optional<TableHandle> getTableHandleForStatisticsCollection(Session session, QualifiedObjectName tableName, Map<String, Object> analyzeProperties)
+    {
+        return delegate.getTableHandleForStatisticsCollection(session, tableName, analyzeProperties);
+    }
+
+    @Override
+    public Optional<TableExecuteHandle> getTableHandleForExecute(Session session, TableHandle tableHandle, String procedureName, Map<String, Object> executeProperties)
+    {
+        return delegate.getTableHandleForExecute(session, tableHandle, procedureName, executeProperties);
+    }
+
+    @Override
+    public Optional<TableLayout> getLayoutForTableExecute(Session session, TableExecuteHandle tableExecuteHandle)
+    {
+        return delegate.getLayoutForTableExecute(session, tableExecuteHandle);
+    }
+
+    @Override
+    public BeginTableExecuteResult<TableExecuteHandle, TableHandle> beginTableExecute(Session session, TableExecuteHandle handle, TableHandle updatedSourceTableHandle)
+    {
+        return delegate.beginTableExecute(session, handle, updatedSourceTableHandle);
+    }
+
+    @Override
+    public void finishTableExecute(Session session, TableExecuteHandle handle, Collection<Slice> fragments, List<Object> tableExecuteState)
+    {
+        delegate.finishTableExecute(session, handle, fragments, tableExecuteState);
+    }
+
+    @Override
+    public void executeTableExecute(Session session, TableExecuteHandle handle)
+    {
+        delegate.executeTableExecute(session, handle);
+    }
+
+    @Override
+    public TableProperties getTableProperties(Session session, TableHandle handle)
+    {
+        return delegate.getTableProperties(session, handle);
+    }
+
+    @Override
+    public TableHandle makeCompatiblePartitioning(Session session, TableHandle table, PartitioningHandle partitioningHandle)
+    {
+        return delegate.makeCompatiblePartitioning(session, table, partitioningHandle);
+    }
+
+    @Override
+    public Optional<PartitioningHandle> getCommonPartitioning(Session session, PartitioningHandle left, PartitioningHandle right)
+    {
+        return delegate.getCommonPartitioning(session, left, right);
+    }
+
+    @Override
+    public Optional<Object> getInfo(Session session, TableHandle handle)
+    {
+        return delegate.getInfo(session, handle);
+    }
+
+    @Override
+    public TableSchema getTableSchema(Session session, TableHandle tableHandle)
+    {
+        return delegate.getTableSchema(session, tableHandle);
+    }
+
+    @Override
+    public TableMetadata getTableMetadata(Session session, TableHandle tableHandle)
+    {
+        return delegate.getTableMetadata(session, tableHandle);
+    }
+
+    @Override
+    public TableStatistics getTableStatistics(Session session, TableHandle tableHandle)
+    {
+        methodInvocations.add(Methods.GET_TABLE_STATISTICS);
+        return delegate.getTableStatistics(session, tableHandle);
+    }
+
+    @Override
+    public List<QualifiedObjectName> listTables(Session session, QualifiedTablePrefix prefix)
+    {
+        return delegate.listTables(session, prefix);
+    }
+
+    @Override
+    public Map<String, ColumnHandle> getColumnHandles(Session session, TableHandle tableHandle)
+    {
+        return delegate.getColumnHandles(session, tableHandle);
+    }
+
+    @Override
+    public ColumnMetadata getColumnMetadata(Session session, TableHandle tableHandle, ColumnHandle columnHandle)
+    {
+        return delegate.getColumnMetadata(session, tableHandle, columnHandle);
+    }
+
+    @Override
+    public List<TableColumnsMetadata> listTableColumns(Session session, QualifiedTablePrefix prefix)
+    {
+        return delegate.listTableColumns(session, prefix);
+    }
+
+    @Override
+    public void createSchema(Session session, CatalogSchemaName schema, Map<String, Object> properties, TrinoPrincipal principal)
+    {
+        delegate.createSchema(session, schema, properties, principal);
+    }
+
+    @Override
+    public void dropSchema(Session session, CatalogSchemaName schema)
+    {
+        delegate.dropSchema(session, schema);
+    }
+
+    @Override
+    public void renameSchema(Session session, CatalogSchemaName source, String target)
+    {
+        delegate.renameSchema(session, source, target);
+    }
+
+    @Override
+    public void setSchemaAuthorization(Session session, CatalogSchemaName source, TrinoPrincipal principal)
+    {
+        delegate.setSchemaAuthorization(session, source, principal);
+    }
+
+    @Override
+    public void createTable(Session session, String catalogName, ConnectorTableMetadata tableMetadata, boolean ignoreExisting)
+    {
+        delegate.createTable(session, catalogName, tableMetadata, ignoreExisting);
+    }
+
+    @Override
+    public void renameTable(Session session, TableHandle tableHandle, QualifiedObjectName newTableName)
+    {
+        delegate.renameTable(session, tableHandle, newTableName);
+    }
+
+    @Override
+    public void setTableProperties(Session session, TableHandle tableHandle, Map<String, Optional<Object>> properties)
+    {
+        delegate.setTableProperties(session, tableHandle, properties);
+    }
+
+    @Override
+    public void setTableComment(Session session, TableHandle tableHandle, Optional<String> comment)
+    {
+        delegate.setTableComment(session, tableHandle, comment);
+    }
+
+    @Override
+    public void setColumnComment(Session session, TableHandle tableHandle, ColumnHandle column, Optional<String> comment)
+    {
+        delegate.setColumnComment(session, tableHandle, column, comment);
+    }
+
+    @Override
+    public void renameColumn(Session session, TableHandle tableHandle, ColumnHandle source, String target)
+    {
+        delegate.renameColumn(session, tableHandle, source, target);
+    }
+
+    @Override
+    public void addColumn(Session session, TableHandle tableHandle, ColumnMetadata column)
+    {
+        delegate.addColumn(session, tableHandle, column);
+    }
+
+    @Override
+    public void setTableAuthorization(Session session, CatalogSchemaTableName table, TrinoPrincipal principal)
+    {
+        delegate.setTableAuthorization(session, table, principal);
+    }
+
+    @Override
+    public void dropColumn(Session session, TableHandle tableHandle, ColumnHandle column)
+    {
+        delegate.dropColumn(session, tableHandle, column);
+    }
+
+    @Override
+    public void dropTable(Session session, TableHandle tableHandle)
+    {
+        delegate.dropTable(session, tableHandle);
+    }
+
+    @Override
+    public void truncateTable(Session session, TableHandle tableHandle)
+    {
+        delegate.truncateTable(session, tableHandle);
+    }
+
+    @Override
+    public Optional<TableLayout> getNewTableLayout(Session session, String catalogName, ConnectorTableMetadata tableMetadata)
+    {
+        return delegate.getNewTableLayout(session, catalogName, tableMetadata);
+    }
+
+    @Override
+    public OutputTableHandle beginCreateTable(Session session, String catalogName, ConnectorTableMetadata tableMetadata, Optional<TableLayout> layout)
+    {
+        return delegate.beginCreateTable(session, catalogName, tableMetadata, layout);
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishCreateTable(Session session, OutputTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    {
+        return delegate.finishCreateTable(session, tableHandle, fragments, computedStatistics);
+    }
+
+    @Override
+    public Optional<TableLayout> getInsertLayout(Session session, TableHandle target)
+    {
+        return delegate.getInsertLayout(session, target);
+    }
+
+    @Override
+    public TableStatisticsMetadata getStatisticsCollectionMetadataForWrite(Session session, String catalogName, ConnectorTableMetadata tableMetadata)
+    {
+        return delegate.getStatisticsCollectionMetadataForWrite(session, catalogName, tableMetadata);
+    }
+
+    @Override
+    public TableStatisticsMetadata getStatisticsCollectionMetadata(Session session, String catalogName, ConnectorTableMetadata tableMetadata)
+    {
+        return delegate.getStatisticsCollectionMetadata(session, catalogName, tableMetadata);
+    }
+
+    @Override
+    public AnalyzeTableHandle beginStatisticsCollection(Session session, TableHandle tableHandle)
+    {
+        return delegate.beginStatisticsCollection(session, tableHandle);
+    }
+
+    @Override
+    public void finishStatisticsCollection(Session session, AnalyzeTableHandle tableHandle, Collection<ComputedStatistics> computedStatistics)
+    {
+        delegate.finishStatisticsCollection(session, tableHandle, computedStatistics);
+    }
+
+    @Override
+    public void cleanupQuery(Session session)
+    {
+        delegate.cleanupQuery(session);
+    }
+
+    @Override
+    public InsertTableHandle beginInsert(Session session, TableHandle tableHandle, List<ColumnHandle> columns)
+    {
+        return delegate.beginInsert(session, tableHandle, columns);
+    }
+
+    @Override
+    public boolean supportsMissingColumnsOnInsert(Session session, TableHandle tableHandle)
+    {
+        return delegate.supportsMissingColumnsOnInsert(session, tableHandle);
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishInsert(Session session, InsertTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    {
+        return delegate.finishInsert(session, tableHandle, fragments, computedStatistics);
+    }
+
+    @Override
+    public boolean delegateMaterializedViewRefreshToConnector(Session session, QualifiedObjectName viewName)
+    {
+        return delegate.delegateMaterializedViewRefreshToConnector(session, viewName);
+    }
+
+    @Override
+    public ListenableFuture<Void> refreshMaterializedView(Session session, QualifiedObjectName viewName)
+    {
+        return delegate.refreshMaterializedView(session, viewName);
+    }
+
+    @Override
+    public InsertTableHandle beginRefreshMaterializedView(Session session, TableHandle tableHandle, List<TableHandle> sourceTableHandles)
+    {
+        return delegate.beginRefreshMaterializedView(session, tableHandle, sourceTableHandles);
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishRefreshMaterializedView(Session session, TableHandle tableHandle, InsertTableHandle insertTableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics, List<TableHandle> sourceTableHandles)
+    {
+        return delegate.finishRefreshMaterializedView(session, tableHandle, insertTableHandle, fragments, computedStatistics, sourceTableHandles);
+    }
+
+    @Override
+    public ColumnHandle getDeleteRowIdColumnHandle(Session session, TableHandle tableHandle)
+    {
+        return delegate.getDeleteRowIdColumnHandle(session, tableHandle);
+    }
+
+    @Override
+    public ColumnHandle getUpdateRowIdColumnHandle(Session session, TableHandle tableHandle, List<ColumnHandle> updatedColumns)
+    {
+        return delegate.getUpdateRowIdColumnHandle(session, tableHandle, updatedColumns);
+    }
+
+    @Override
+    public Optional<TableHandle> applyDelete(Session session, TableHandle tableHandle)
+    {
+        return delegate.applyDelete(session, tableHandle);
+    }
+
+    @Override
+    public OptionalLong executeDelete(Session session, TableHandle tableHandle)
+    {
+        return delegate.executeDelete(session, tableHandle);
+    }
+
+    @Override
+    public TableHandle beginDelete(Session session, TableHandle tableHandle)
+    {
+        return delegate.beginDelete(session, tableHandle);
+    }
+
+    @Override
+    public void finishDelete(Session session, TableHandle tableHandle, Collection<Slice> fragments)
+    {
+        delegate.finishDelete(session, tableHandle, fragments);
+    }
+
+    @Override
+    public TableHandle beginUpdate(Session session, TableHandle tableHandle, List<ColumnHandle> updatedColumns)
+    {
+        return delegate.beginUpdate(session, tableHandle, updatedColumns);
+    }
+
+    @Override
+    public void finishUpdate(Session session, TableHandle tableHandle, Collection<Slice> fragments)
+    {
+        delegate.finishUpdate(session, tableHandle, fragments);
+    }
+
+    @Override
+    public Optional<CatalogName> getCatalogHandle(Session session, String catalogName)
+    {
+        return delegate.getCatalogHandle(session, catalogName);
+    }
+
+    @Override
+    public Map<String, Catalog> getCatalogs(Session session)
+    {
+        return delegate.getCatalogs(session);
+    }
+
+    @Override
+    public List<QualifiedObjectName> listViews(Session session, QualifiedTablePrefix prefix)
+    {
+        return delegate.listViews(session, prefix);
+    }
+
+    @Override
+    public Map<QualifiedObjectName, ViewInfo> getViews(Session session, QualifiedTablePrefix prefix)
+    {
+        return delegate.getViews(session, prefix);
+    }
+
+    @Override
+    public boolean isView(Session session, QualifiedObjectName viewName)
+    {
+        return delegate.isView(session, viewName);
+    }
+
+    @Override
+    public Optional<ViewDefinition> getView(Session session, QualifiedObjectName viewName)
+    {
+        return delegate.getView(session, viewName);
+    }
+
+    @Override
+    public Map<String, Object> getSchemaProperties(Session session, CatalogSchemaName schemaName)
+    {
+        return delegate.getSchemaProperties(session, schemaName);
+    }
+
+    @Override
+    public Optional<TrinoPrincipal> getSchemaOwner(Session session, CatalogSchemaName schemaName)
+    {
+        return delegate.getSchemaOwner(session, schemaName);
+    }
+
+    @Override
+    public void createView(Session session, QualifiedObjectName viewName, ViewDefinition definition, boolean replace)
+    {
+        delegate.createView(session, viewName, definition, replace);
+    }
+
+    @Override
+    public void renameView(Session session, QualifiedObjectName existingViewName, QualifiedObjectName newViewName)
+    {
+        delegate.renameView(session, existingViewName, newViewName);
+    }
+
+    @Override
+    public void setViewAuthorization(Session session, CatalogSchemaTableName view, TrinoPrincipal principal)
+    {
+        delegate.setViewAuthorization(session, view, principal);
+    }
+
+    @Override
+    public void dropView(Session session, QualifiedObjectName viewName)
+    {
+        delegate.dropView(session, viewName);
+    }
+
+    @Override
+    public Optional<ResolvedIndex> resolveIndex(Session session, TableHandle tableHandle, Set<ColumnHandle> indexableColumns, Set<ColumnHandle> outputColumns, TupleDomain<ColumnHandle> tupleDomain)
+    {
+        return delegate.resolveIndex(session, tableHandle, indexableColumns, outputColumns, tupleDomain);
+    }
+
+    @Override
+    public Optional<LimitApplicationResult<TableHandle>> applyLimit(Session session, TableHandle table, long limit)
+    {
+        return delegate.applyLimit(session, table, limit);
+    }
+
+    @Override
+    public Optional<ConstraintApplicationResult<TableHandle>> applyFilter(Session session, TableHandle table, Constraint constraint)
+    {
+        return delegate.applyFilter(session, table, constraint);
+    }
+
+    @Override
+    public Optional<ProjectionApplicationResult<TableHandle>> applyProjection(Session session, TableHandle table, List<ConnectorExpression> projections, Map<String, ColumnHandle> assignments)
+    {
+        return delegate.applyProjection(session, table, projections, assignments);
+    }
+
+    @Override
+    public Optional<SampleApplicationResult<TableHandle>> applySample(Session session, TableHandle table, SampleType sampleType, double sampleRatio)
+    {
+        return delegate.applySample(session, table, sampleType, sampleRatio);
+    }
+
+    @Override
+    public Optional<AggregationApplicationResult<TableHandle>> applyAggregation(Session session, TableHandle table, List<AggregateFunction> aggregations, Map<String, ColumnHandle> assignments, List<List<ColumnHandle>> groupingSets)
+    {
+        return delegate.applyAggregation(session, table, aggregations, assignments, groupingSets);
+    }
+
+    @Override
+    public Optional<JoinApplicationResult<TableHandle>> applyJoin(Session session, JoinType joinType, TableHandle left, TableHandle right, List<JoinCondition> joinConditions, Map<String, ColumnHandle> leftAssignments, Map<String, ColumnHandle> rightAssignments, JoinStatistics statistics)
+    {
+        return delegate.applyJoin(session, joinType, left, right, joinConditions, leftAssignments, rightAssignments, statistics);
+    }
+
+    @Override
+    public Optional<TopNApplicationResult<TableHandle>> applyTopN(Session session, TableHandle handle, long topNCount, List<SortItem> sortItems, Map<String, ColumnHandle> assignments)
+    {
+        return delegate.applyTopN(session, handle, topNCount, sortItems, assignments);
+    }
+
+    @Override
+    public void validateScan(Session session, TableHandle table)
+    {
+        delegate.validateScan(session, table);
+    }
+
+    @Override
+    public boolean isCatalogManagedSecurity(Session session, String catalog)
+    {
+        return delegate.isCatalogManagedSecurity(session, catalog);
+    }
+
+    @Override
+    public boolean roleExists(Session session, String role, Optional<String> catalog)
+    {
+        return delegate.roleExists(session, role, catalog);
+    }
+
+    @Override
+    public void createRole(Session session, String role, Optional<TrinoPrincipal> grantor, Optional<String> catalog)
+    {
+        delegate.createRole(session, role, grantor, catalog);
+    }
+
+    @Override
+    public void dropRole(Session session, String role, Optional<String> catalog)
+    {
+        delegate.dropRole(session, role, catalog);
+    }
+
+    @Override
+    public Set<String> listRoles(Session session, Optional<String> catalog)
+    {
+        return delegate.listRoles(session, catalog);
+    }
+
+    @Override
+    public Set<RoleGrant> listAllRoleGrants(Session session, Optional<String> catalog, Optional<Set<String>> roles, Optional<Set<String>> grantees, OptionalLong limit)
+    {
+        return delegate.listAllRoleGrants(session, catalog, roles, grantees, limit);
+    }
+
+    @Override
+    public Set<RoleGrant> listRoleGrants(Session session, Optional<String> catalog, TrinoPrincipal principal)
+    {
+        return delegate.listRoleGrants(session, catalog, principal);
+    }
+
+    @Override
+    public void grantRoles(Session session, Set<String> roles, Set<TrinoPrincipal> grantees, boolean adminOption, Optional<TrinoPrincipal> grantor, Optional<String> catalog)
+    {
+        delegate.grantRoles(session, roles, grantees, adminOption, grantor, catalog);
+    }
+
+    @Override
+    public void revokeRoles(Session session, Set<String> roles, Set<TrinoPrincipal> grantees, boolean adminOption, Optional<TrinoPrincipal> grantor, Optional<String> catalog)
+    {
+        delegate.revokeRoles(session, roles, grantees, adminOption, grantor, catalog);
+    }
+
+    @Override
+    public Set<RoleGrant> listApplicableRoles(Session session, TrinoPrincipal principal, Optional<String> catalog)
+    {
+        return delegate.listApplicableRoles(session, principal, catalog);
+    }
+
+    @Override
+    public Set<String> listEnabledRoles(Identity identity)
+    {
+        return delegate.listEnabledRoles(identity);
+    }
+
+    @Override
+    public Set<String> listEnabledRoles(Session session, String catalog)
+    {
+        return delegate.listEnabledRoles(session, catalog);
+    }
+
+    @Override
+    public void grantSchemaPrivileges(Session session, CatalogSchemaName schemaName, Set<Privilege> privileges, TrinoPrincipal grantee, boolean grantOption)
+    {
+        delegate.grantSchemaPrivileges(session, schemaName, privileges, grantee, grantOption);
+    }
+
+    @Override
+    public void denySchemaPrivileges(Session session, CatalogSchemaName schemaName, Set<Privilege> privileges, TrinoPrincipal grantee)
+    {
+        delegate.denySchemaPrivileges(session, schemaName, privileges, grantee);
+    }
+
+    @Override
+    public void revokeSchemaPrivileges(Session session, CatalogSchemaName schemaName, Set<Privilege> privileges, TrinoPrincipal grantee, boolean grantOption)
+    {
+        delegate.revokeSchemaPrivileges(session, schemaName, privileges, grantee, grantOption);
+    }
+
+    @Override
+    public void grantTablePrivileges(Session session, QualifiedObjectName tableName, Set<Privilege> privileges, TrinoPrincipal grantee, boolean grantOption)
+    {
+        delegate.grantTablePrivileges(session, tableName, privileges, grantee, grantOption);
+    }
+
+    @Override
+    public void denyTablePrivileges(Session session, QualifiedObjectName tableName, Set<Privilege> privileges, TrinoPrincipal grantee)
+    {
+        delegate.denyTablePrivileges(session, tableName, privileges, grantee);
+    }
+
+    @Override
+    public void revokeTablePrivileges(Session session, QualifiedObjectName tableName, Set<Privilege> privileges, TrinoPrincipal grantee, boolean grantOption)
+    {
+        delegate.revokeTablePrivileges(session, tableName, privileges, grantee, grantOption);
+    }
+
+    @Override
+    public List<GrantInfo> listTablePrivileges(Session session, QualifiedTablePrefix prefix)
+    {
+        return delegate.listTablePrivileges(session, prefix);
+    }
+
+    @Override
+    public Collection<FunctionMetadata> listFunctions()
+    {
+        return delegate.listFunctions();
+    }
+
+    @Override
+    public ResolvedFunction decodeFunction(QualifiedName name)
+    {
+        return delegate.decodeFunction(name);
+    }
+
+    @Override
+    public ResolvedFunction resolveFunction(Session session, QualifiedName name, List<TypeSignatureProvider> parameterTypes)
+    {
+        return delegate.resolveFunction(session, name, parameterTypes);
+    }
+
+    @Override
+    public ResolvedFunction resolveOperator(Session session, OperatorType operatorType, List<? extends Type> argumentTypes)
+            throws OperatorNotFoundException
+    {
+        return delegate.resolveOperator(session, operatorType, argumentTypes);
+    }
+
+    @Override
+    public ResolvedFunction getCoercion(Session session, Type fromType, Type toType)
+    {
+        return delegate.getCoercion(session, fromType, toType);
+    }
+
+    @Override
+    public ResolvedFunction getCoercion(Session session, OperatorType operatorType, Type fromType, Type toType)
+    {
+        return delegate.getCoercion(session, operatorType, fromType, toType);
+    }
+
+    @Override
+    public ResolvedFunction getCoercion(Session session, QualifiedName name, Type fromType, Type toType)
+    {
+        return delegate.getCoercion(session, name, fromType, toType);
+    }
+
+    @Override
+    public boolean isAggregationFunction(QualifiedName name)
+    {
+        return delegate.isAggregationFunction(name);
+    }
+
+    @Override
+    public FunctionMetadata getFunctionMetadata(ResolvedFunction resolvedFunction)
+    {
+        return delegate.getFunctionMetadata(resolvedFunction);
+    }
+
+    @Override
+    public AggregationFunctionMetadata getAggregationFunctionMetadata(ResolvedFunction resolvedFunction)
+    {
+        return delegate.getAggregationFunctionMetadata(resolvedFunction);
+    }
+
+    @Override
+    public void createMaterializedView(Session session, QualifiedObjectName viewName, MaterializedViewDefinition definition, boolean replace, boolean ignoreExisting)
+    {
+        delegate.createMaterializedView(session, viewName, definition, replace, ignoreExisting);
+    }
+
+    @Override
+    public void dropMaterializedView(Session session, QualifiedObjectName viewName)
+    {
+        delegate.dropMaterializedView(session, viewName);
+    }
+
+    @Override
+    public List<QualifiedObjectName> listMaterializedViews(Session session, QualifiedTablePrefix prefix)
+    {
+        return delegate.listMaterializedViews(session, prefix);
+    }
+
+    @Override
+    public Map<QualifiedObjectName, ViewInfo> getMaterializedViews(Session session, QualifiedTablePrefix prefix)
+    {
+        return delegate.getMaterializedViews(session, prefix);
+    }
+
+    @Override
+    public boolean isMaterializedView(Session session, QualifiedObjectName viewName)
+    {
+        return delegate.isMaterializedView(session, viewName);
+    }
+
+    @Override
+    public Optional<MaterializedViewDefinition> getMaterializedView(Session session, QualifiedObjectName viewName)
+    {
+        return delegate.getMaterializedView(session, viewName);
+    }
+
+    @Override
+    public MaterializedViewFreshness getMaterializedViewFreshness(Session session, QualifiedObjectName name)
+    {
+        return delegate.getMaterializedViewFreshness(session, name);
+    }
+
+    @Override
+    public void renameMaterializedView(Session session, QualifiedObjectName existingViewName, QualifiedObjectName newViewName)
+    {
+        delegate.renameMaterializedView(session, existingViewName, newViewName);
+    }
+
+    @Override
+    public void setMaterializedViewProperties(Session session, QualifiedObjectName viewName, Map<String, Optional<Object>> properties)
+    {
+        delegate.setMaterializedViewProperties(session, viewName, properties);
+    }
+
+    @Override
+    public Optional<TableScanRedirectApplicationResult> applyTableScanRedirect(Session session, TableHandle tableHandle)
+    {
+        return delegate.applyTableScanRedirect(session, tableHandle);
+    }
+
+    @Override
+    public RedirectionAwareTableHandle getRedirectionAwareTableHandle(Session session, QualifiedObjectName tableName)
+    {
+        return delegate.getRedirectionAwareTableHandle(session, tableName);
+    }
+
+    @Override
+    public RedirectionAwareTableHandle getRedirectionAwareTableHandle(Session session, QualifiedObjectName tableName, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion)
+    {
+        return delegate.getRedirectionAwareTableHandle(session, tableName, startVersion, endVersion);
+    }
+
+    @Override
+    public boolean isValidTableVersion(Session session, QualifiedObjectName tableName, TableVersion version)
+    {
+        return delegate.isValidTableVersion(session, tableName, version);
+    }
+
+    @Override
+    public Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName tableName, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion)
+    {
+        return delegate.getTableHandle(session, tableName, startVersion, endVersion);
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGetTableStatisticsOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGetTableStatisticsOperations.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultiset;
+import io.trino.execution.warnings.WarningCollector;
+import io.trino.metadata.CountingAccessMetadata;
+import io.trino.metadata.MetadataManager;
+import io.trino.plugin.hive.metastore.Database;
+import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.spi.security.PrincipalType;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.LocalQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Optional;
+
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static com.google.inject.util.Modules.EMPTY_MODULE;
+import static io.trino.plugin.hive.metastore.file.FileHiveMetastore.createTestingFileHiveMetastore;
+import static io.trino.sql.planner.LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.transaction.TransactionBuilder.transaction;
+import static org.assertj.core.api.Assertions.assertThat;
+
+// Cost-based optimizers' behaviors are affected by the statistics returned by the Connectors. Here is to count the getTableStatistics calls
+// when CBOs work with Iceberg Connector.
+@Test(singleThreaded = true) // counting metadata is a shared mutable state
+public class TestIcebergGetTableStatisticsOperations
+        extends AbstractTestQueryFramework
+{
+    private LocalQueryRunner localQueryRunner;
+    private CountingAccessMetadata metadata;
+    private File metastoreDir;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        localQueryRunner = LocalQueryRunner.builder(testSessionBuilder().build())
+                .withMetadataProvider((featuresConfig, systemSecurityMetadata, transactionManager, globalFunctionCatalog, typeManager)
+                        -> new CountingAccessMetadata(new MetadataManager(featuresConfig, systemSecurityMetadata, transactionManager, globalFunctionCatalog, typeManager)))
+                .build();
+        metadata = (CountingAccessMetadata) localQueryRunner.getMetadata();
+        localQueryRunner.installPlugin(new TpchPlugin());
+        localQueryRunner.createCatalog("tpch", "tpch", ImmutableMap.of());
+
+        metastoreDir = Files.createTempDirectory("test_iceberg_get_table_statistics_operations").toFile();
+        HiveMetastore metastore = createTestingFileHiveMetastore(metastoreDir);
+        localQueryRunner.createCatalog(
+                "iceberg",
+                new TestingIcebergConnectorFactory(Optional.of(metastore), Optional.empty(), EMPTY_MODULE),
+                ImmutableMap.of());
+        Database database = Database.builder()
+                .setDatabaseName("tiny")
+                .setOwnerName(Optional.of("public"))
+                .setOwnerType(Optional.of(PrincipalType.ROLE))
+                .build();
+        metastore.createDatabase(database);
+
+        localQueryRunner.execute("CREATE TABLE iceberg.tiny.orders AS SELECT * FROM tpch.tiny.orders");
+        localQueryRunner.execute("CREATE TABLE iceberg.tiny.lineitem AS SELECT * FROM tpch.tiny.lineitem");
+        localQueryRunner.execute("CREATE TABLE iceberg.tiny.customer AS SELECT * FROM tpch.tiny.customer");
+
+        return localQueryRunner;
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+            throws IOException
+    {
+        deleteRecursively(metastoreDir.toPath(), ALLOW_INSECURE);
+    }
+
+    @BeforeMethod
+    public void resetCounters()
+    {
+        metadata.resetCounters();
+    }
+
+    @Test
+    public void testTwoWayJoin()
+    {
+        planDistributedQuery("SELECT * " +
+                "FROM iceberg.tiny.orders o, iceberg.tiny.lineitem l " +
+                "WHERE o.orderkey = l.orderkey");
+        assertThat(metadata.getMethodInvocations()).containsExactlyInAnyOrderElementsOf(
+                ImmutableMultiset.<CountingAccessMetadata.Methods>builder()
+                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 6)
+                        .build());
+    }
+
+    @Test
+    public void testThreeWayJoin()
+    {
+        planDistributedQuery("SELECT * " +
+                "FROM iceberg.tiny.customer c, iceberg.tiny.orders o, iceberg.tiny.lineitem l " +
+                "WHERE o.orderkey = l.orderkey AND c.custkey = o.custkey");
+        assertThat(metadata.getMethodInvocations()).containsExactlyInAnyOrderElementsOf(
+                ImmutableMultiset.<CountingAccessMetadata.Methods>builder()
+                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 10)
+                        .build());
+    }
+
+    private void planDistributedQuery(@Language("SQL") String sql)
+    {
+        transaction(localQueryRunner.getTransactionManager(), localQueryRunner.getAccessControl())
+                .execute(localQueryRunner.getDefaultSession(), session -> {
+                    localQueryRunner.createPlan(session, sql, OPTIMIZED_AND_VALIDATED, false, WarningCollector.NOOP);
+                });
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGetTableStatisticsOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGetTableStatisticsOperations.java
@@ -107,7 +107,7 @@ public class TestIcebergGetTableStatisticsOperations
                 "WHERE o.orderkey = l.orderkey");
         assertThat(metadata.getMethodInvocations()).containsExactlyInAnyOrderElementsOf(
                 ImmutableMultiset.<CountingAccessMetadata.Methods>builder()
-                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 6)
+                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 4)
                         .build());
     }
 
@@ -119,7 +119,7 @@ public class TestIcebergGetTableStatisticsOperations
                 "WHERE o.orderkey = l.orderkey AND c.custkey = o.custkey");
         assertThat(metadata.getMethodInvocations()).containsExactlyInAnyOrderElementsOf(
                 ImmutableMultiset.<CountingAccessMetadata.Methods>builder()
-                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 10)
+                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 7)
                         .build());
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
@@ -159,8 +159,8 @@ public class TestIcebergMetadataFileOperations
 
         assertFileSystemAccesses("SELECT name, age FROM test_join_t1 JOIN test_join_t2 ON test_join_t2.id = test_join_t1.id",
                 ImmutableMultiset.builder()
-                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 12)
-                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 12)
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 8)
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 8)
                         .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM), 2)
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH), 2)
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM), 2)
@@ -177,8 +177,8 @@ public class TestIcebergMetadataFileOperations
 
         assertFileSystemAccesses("SELECT count(*) FROM test_join_partitioned_t1 t1 join test_join_partitioned_t2 t2 on t1.a = t2.foo",
                 ImmutableMultiset.builder()
-                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 12)
-                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 12)
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 8)
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 8)
                         .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM), 2)
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH), 2)
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM), 2)

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestGetTableStatisticsOperations.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestGetTableStatisticsOperations.java
@@ -66,7 +66,7 @@ public class TestGetTableStatisticsOperations
                 "WHERE o.orderkey = l.orderkey");
         assertThat(metadata.getMethodInvocations()).containsExactlyInAnyOrderElementsOf(
                 ImmutableMultiset.<CountingAccessMetadata.Methods>builder()
-                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 4)
+                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 2)
                         .build());
     }
 
@@ -78,7 +78,7 @@ public class TestGetTableStatisticsOperations
                 "WHERE o.orderkey = l.orderkey AND c.custkey = o.custkey");
         assertThat(metadata.getMethodInvocations()).containsExactlyInAnyOrderElementsOf(
                 ImmutableMultiset.<CountingAccessMetadata.Methods>builder()
-                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 6)
+                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 3)
                         .build());
     }
 

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestGetTableStatisticsOperations.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestGetTableStatisticsOperations.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultiset;
+import io.trino.execution.warnings.WarningCollector;
+import io.trino.metadata.CountingAccessMetadata;
+import io.trino.metadata.MetadataManager;
+import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.LocalQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static io.trino.sql.planner.LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.transaction.TransactionBuilder.transaction;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Test(singleThreaded = true) // counting metadata is a shared mutable state
+public class TestGetTableStatisticsOperations
+        extends AbstractTestQueryFramework
+{
+    private LocalQueryRunner localQueryRunner;
+    private CountingAccessMetadata metadata;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        localQueryRunner = LocalQueryRunner.builder(testSessionBuilder().build())
+                .withMetadataProvider((featuresConfig, systemSecurityMetadata, transactionManager, globalFunctionCatalog, typeManager)
+                        -> new CountingAccessMetadata(new MetadataManager(featuresConfig, systemSecurityMetadata, transactionManager, globalFunctionCatalog, typeManager)))
+                .build();
+        metadata = (CountingAccessMetadata) localQueryRunner.getMetadata();
+        localQueryRunner.installPlugin(new TpchPlugin());
+        localQueryRunner.createCatalog("tpch", "tpch", ImmutableMap.of());
+        return localQueryRunner;
+    }
+
+    @BeforeMethod
+    public void resetCounters()
+    {
+        metadata.resetCounters();
+    }
+
+    @Test
+    public void testTwoWayJoin()
+    {
+        planDistributedQuery("SELECT * " +
+                "FROM tpch.tiny.orders o, tpch.tiny.lineitem l " +
+                "WHERE o.orderkey = l.orderkey");
+        assertThat(metadata.getMethodInvocations()).containsExactlyInAnyOrderElementsOf(
+                ImmutableMultiset.<CountingAccessMetadata.Methods>builder()
+                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 4)
+                        .build());
+    }
+
+    @Test
+    public void testThreeWayJoin()
+    {
+        planDistributedQuery("SELECT * " +
+                "FROM tpch.tiny.customer c, tpch.tiny.orders o, tpch.tiny.lineitem l " +
+                "WHERE o.orderkey = l.orderkey AND c.custkey = o.custkey");
+        assertThat(metadata.getMethodInvocations()).containsExactlyInAnyOrderElementsOf(
+                ImmutableMultiset.<CountingAccessMetadata.Methods>builder()
+                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 6)
+                        .build());
+    }
+
+    private void planDistributedQuery(@Language("SQL") String sql)
+    {
+        transaction(localQueryRunner.getTransactionManager(), localQueryRunner.getAccessControl())
+                .execute(localQueryRunner.getDefaultSession(), session -> {
+                    localQueryRunner.createPlan(session, sql, OPTIMIZED_AND_VALIDATED, false, WarningCollector.NOOP);
+                });
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix/improvement.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Engine.

> How would you describe this change to a non-technical end user or system administrator?

Reduce Iceberg metadata processing during cost-based query optimizations. 

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

https://github.com/trinodb/trino/issues/11708
https://github.com/trinodb/trino/pull/8659

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# General
* Reduce computations on table statistics during cost-based query optimizations.
```
