### PR TITLE
Increase default value of hive.metastore.glue.max-connections from 5 to 30.

### DIFF
--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -559,7 +559,7 @@ Property Name                                        Description
                                                      where Trino is running, defaults to ``false``.
 
 ``hive.metastore.glue.max-connections``              Max number of concurrent connections to Glue,
-                                                     defaults to ``5``.
+                                                     defaults to ``30``.
 
 ``hive.metastore.glue.max-error-retries``            Maximum number of error retries for the Glue client,
                                                      defaults to ``10``.

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastoreConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastoreConfig.java
@@ -30,7 +30,7 @@ public class GlueHiveMetastoreConfig
     private Optional<String> glueEndpointUrl = Optional.empty();
     private boolean pinGlueClientToCurrentRegion;
     private int maxGlueErrorRetries = 10;
-    private int maxGlueConnections = 5;
+    private int maxGlueConnections = 30;
     private Optional<String> defaultWarehouseDir = Optional.empty();
     private Optional<String> iamRole = Optional.empty();
     private Optional<String> externalId = Optional.empty();

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
@@ -31,7 +31,7 @@ public class TestGlueHiveMetastoreConfig
                 .setGlueRegion(null)
                 .setGlueEndpointUrl(null)
                 .setPinGlueClientToCurrentRegion(false)
-                .setMaxGlueConnections(5)
+                .setMaxGlueConnections(30)
                 .setMaxGlueErrorRetries(10)
                 .setDefaultWarehouseDir(null)
                 .setIamRole(null)


### PR DESCRIPTION


<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->
Bump up default value of max glue connections from 5 to 30. Reduces awshttpclientpoolpendingcount and improves query speed.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
Hive connector.

> How would you describe this change to a non-technical end user or system administrator?
Increase concurrent connections to Glue, so as to improve query speed of Hive connector

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

() No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
