### PR TITLE
Fix SourceDistributionTaskSource

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/StageTaskSourceFactory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/StageTaskSourceFactory.java
@@ -714,13 +714,13 @@ public class StageTaskSourceFactory
             List<TaskDescriptor> result = new ArrayList<>();
 
             while (true) {
-                boolean includeRemainder = splitSource.isFinished();
+                boolean splitSourceFinished = splitSource.isFinished();
 
                 result.addAll(getReadyTasks(
                         remotelyAccessibleSplitBuffer,
                         ImmutableList.of(),
                         new NodeRequirements(catalogRequirement, ImmutableSet.of(), taskMemory),
-                        includeRemainder));
+                        splitSourceFinished));
                 for (HostAddress remoteHost : locallyAccessibleSplitBuffer.keySet()) {
                     result.addAll(getReadyTasks(
                             locallyAccessibleSplitBuffer.get(remoteHost),
@@ -729,10 +729,10 @@ public class StageTaskSourceFactory
                                     .map(Map.Entry::getValue)
                                     .collect(toImmutableList()),
                             new NodeRequirements(catalogRequirement, ImmutableSet.of(remoteHost), taskMemory),
-                            includeRemainder));
+                            splitSourceFinished));
                 }
 
-                if (!result.isEmpty() || splitSource.isFinished()) {
+                if (!result.isEmpty() || splitSourceFinished) {
                     break;
                 }
 

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestingSplitSource.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestingSplitSource.java
@@ -33,11 +33,18 @@ public class TestingSplitSource
 {
     private final CatalogName catalogName;
     private final Iterator<Split> splits;
+    private int finishDelayRemainingIterations;
 
     public TestingSplitSource(CatalogName catalogName, List<Split> splits)
     {
+        this(catalogName, splits, 0);
+    }
+
+    public TestingSplitSource(CatalogName catalogName, List<Split> splits, int finishDelayIterations)
+    {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.splits = ImmutableList.copyOf(requireNonNull(splits, "splits is null")).iterator();
+        this.finishDelayRemainingIterations = finishDelayIterations;
     }
 
     @Override
@@ -70,7 +77,7 @@ public class TestingSplitSource
     @Override
     public boolean isFinished()
     {
-        return !splits.hasNext();
+        return !splits.hasNext() && finishDelayRemainingIterations-- <= 0;
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

When `SplitSource#isFinished` is arbitrary delayed it was possible that
the first check (`boolean includeRemainder = splitSource.isFinished()`)
returns `false`, yet the second check `if (!result.isEmpty() || splitSource.isFinished()) {`
returns `true` and breaks the execution loop without creating a task
with the most recent batch of split included.

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core

> How would you describe this change to a non-technical end user or system administrator?

In certain cases queries ran with Tardigrade might've returned incorrect results

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

https://github.com/trinodb/trino/issues/11368
https://github.com/trinodb/trino/issues/11825

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Core
* Fix bug when in certain rare cases Tardigrade queries might've returned incorrect results
```
