### PR TITLE
Deprecate passing constraints to getTableStatistics

### DIFF
--- a/core/trino-main/src/main/java/io/trino/cost/TableScanStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/TableScanStatsRule.java
@@ -17,8 +17,6 @@ import io.trino.Session;
 import io.trino.matching.Pattern;
 import io.trino.metadata.Metadata;
 import io.trino.spi.connector.ColumnHandle;
-import io.trino.spi.connector.Constraint;
-import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.statistics.ColumnStatistics;
 import io.trino.spi.statistics.TableStatistics;
 import io.trino.spi.type.FixedWidthType;
@@ -63,10 +61,7 @@ public class TableScanStatsRule
             return node.getStatistics();
         }
 
-        // TODO Construct predicate like AddExchanges's LayoutConstraintEvaluator
-        Constraint constraint = new Constraint(TupleDomain.all());
-
-        TableStatistics tableStatistics = metadata.getTableStatistics(session, node.getTable(), constraint);
+        TableStatistics tableStatistics = metadata.getTableStatistics(session, node.getTable());
 
         Map<Symbol, SymbolStatsEstimate> outputSymbolStats = new HashMap<>();
 

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -139,9 +139,9 @@ public interface Metadata
     TableMetadata getTableMetadata(Session session, TableHandle tableHandle);
 
     /**
-     * Return statistics for specified table for given filtering contraint.
+     * Return statistics for specified table.
      */
-    TableStatistics getTableStatistics(Session session, TableHandle tableHandle, Constraint constraint);
+    TableStatistics getTableStatistics(Session session, TableHandle tableHandle);
 
     /**
      * Get the relation names that match the specified table prefix (never null).

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -466,11 +466,11 @@ public final class MetadataManager
     }
 
     @Override
-    public TableStatistics getTableStatistics(Session session, TableHandle tableHandle, Constraint constraint)
+    public TableStatistics getTableStatistics(Session session, TableHandle tableHandle)
     {
         CatalogName catalogName = tableHandle.getCatalogName();
         ConnectorMetadata metadata = getMetadata(session, catalogName);
-        TableStatistics tableStatistics = metadata.getTableStatistics(session.toConnectorSession(catalogName), tableHandle.getConnectorHandle(), constraint);
+        TableStatistics tableStatistics = metadata.getTableStatistics(session.toConnectorSession(catalogName), tableHandle.getConnectorHandle());
         verifyNotNull(tableStatistics, "%s returned null tableStatistics for %s", metadata, tableHandle);
         return tableStatistics;
     }

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -198,7 +198,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public TableStatistics getTableStatistics(Session session, TableHandle tableHandle, Constraint constraint)
+    public TableStatistics getTableStatistics(Session session, TableHandle tableHandle)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -266,10 +266,21 @@ public interface ConnectorMetadata
 
     /**
      * Get statistics for table for given filtering constraint.
+     *
+     * @deprecated Use {@link #getTableStatistics(ConnectorSession, ConnectorTableHandle)}
      */
+    @Deprecated
     default TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, Constraint constraint)
     {
         return TableStatistics.empty();
+    }
+
+    /**
+     * Get statistics for table.
+     */
+    default TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        return getTableStatistics(session, tableHandle, Constraint.alwaysTrue());
     }
 
     /**

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -320,6 +320,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getTableStatistics(session, tableHandle);
+        }
+    }
+
+    @Override
     public void addColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnMetadata column)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
@@ -811,10 +811,11 @@ public class DefaultJdbcMetadata
     }
 
     @Override
-    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, Constraint constraint)
+    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         JdbcTableHandle handle = (JdbcTableHandle) tableHandle;
-        return jdbcClient.getTableStatistics(session, handle, constraint.getSummary());
+        // TODO passing constraint to getTableStatistics is deprecated, remove it from the JdbcClient interface
+        return jdbcClient.getTableStatistics(session, handle, Constraint.alwaysTrue().getSummary());
     }
 
     @Override

--- a/plugin/trino-blackhole/src/main/java/io/trino/plugin/blackhole/BlackHoleMetadata.java
+++ b/plugin/trino-blackhole/src/main/java/io/trino/plugin/blackhole/BlackHoleMetadata.java
@@ -32,7 +32,6 @@ import io.trino.spi.connector.ConnectorTableLayout;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTableProperties;
 import io.trino.spi.connector.ConnectorViewDefinition;
-import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
@@ -169,7 +168,7 @@ public class BlackHoleMetadata
     }
 
     @Override
-    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, Constraint constraint)
+    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         BlackHoleTableHandle table = (BlackHoleTableHandle) tableHandle;
         TableStatistics.Builder tableStats = TableStatistics.builder();

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -521,12 +521,12 @@ public class DeltaLakeMetadata
     }
 
     @Override
-    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, Constraint constraint)
+    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         if (!isTableStatisticsEnabled(session)) {
             return TableStatistics.empty();
         }
-        return metastore.getTableStatistics(session, (DeltaLakeTableHandle) tableHandle, constraint);
+        return metastore.getTableStatistics(session, (DeltaLakeTableHandle) tableHandle);
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/DeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/DeltaLakeMetastore.java
@@ -23,7 +23,6 @@ import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.PrincipalPrivileges;
 import io.trino.plugin.hive.metastore.Table;
 import io.trino.spi.connector.ConnectorSession;
-import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.statistics.TableStatistics;
 
@@ -58,7 +57,7 @@ public interface DeltaLakeMetastore
 
     List<AddFileEntry> getValidDataFiles(SchemaTableName table, ConnectorSession session);
 
-    TableStatistics getTableStatistics(ConnectorSession session, DeltaLakeTableHandle tableHandle, Constraint constraint);
+    TableStatistics getTableStatistics(ConnectorSession session, DeltaLakeTableHandle tableHandle);
 
     HiveMetastore getHiveMetastore();
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
@@ -32,7 +32,6 @@ import io.trino.plugin.hive.metastore.Table;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorSession;
-import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.predicate.TupleDomain;
@@ -213,7 +212,7 @@ public class HiveMetastoreBackedDeltaLakeMetastore
     }
 
     @Override
-    public TableStatistics getTableStatistics(ConnectorSession session, DeltaLakeTableHandle tableHandle, Constraint constraint)
+    public TableStatistics getTableStatistics(ConnectorSession session, DeltaLakeTableHandle tableHandle)
     {
         TableSnapshot tableSnapshot = getSnapshot(tableHandle.getSchemaTableName(), session);
 
@@ -238,7 +237,7 @@ public class HiveMetastoreBackedDeltaLakeMetastore
                 .filter(column -> column.getColumnType() == PARTITION_KEY)
                 .forEach(column -> partitioningColumnsDistinctValues.put(column, new HashSet<>()));
 
-        if (tableHandle.getEnforcedPartitionConstraint().isNone() || tableHandle.getNonPartitionConstraint().isNone() || constraint.getSummary().isNone()) {
+        if (tableHandle.getEnforcedPartitionConstraint().isNone() || tableHandle.getNonPartitionConstraint().isNone()) {
             return createZeroStatistics(columns);
         }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
@@ -295,7 +295,7 @@ public class TestDeltaLakeSplitManager
         }
 
         @Override
-        public TableStatistics getTableStatistics(ConnectorSession session, DeltaLakeTableHandle tableHandle, Constraint constraint)
+        public TableStatistics getTableStatistics(ConnectorSession session, DeltaLakeTableHandle tableHandle)
         {
             throw new UnsupportedOperationException("Unimplemented");
         }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreStatistics.java
@@ -52,7 +52,6 @@ import io.trino.plugin.hive.parquet.ParquetReaderConfig;
 import io.trino.plugin.hive.parquet.ParquetWriterConfig;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
-import io.trino.spi.connector.Constraint;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.security.PrincipalType;
@@ -186,7 +185,7 @@ public class TestDeltaLakeMetastoreStatistics
     public void testStatisticsNaN()
     {
         DeltaLakeTableHandle tableHandle = registerTable("nan");
-        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle, Constraint.alwaysTrue());
+        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle);
         assertEquals(stats.getRowCount(), Estimate.of(1));
         assertEquals(stats.getColumnStatistics().size(), 1);
 
@@ -198,7 +197,7 @@ public class TestDeltaLakeMetastoreStatistics
     public void testStatisticsInf()
     {
         DeltaLakeTableHandle tableHandle = registerTable("positive_infinity");
-        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle, Constraint.alwaysTrue());
+        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle);
         ColumnStatistics columnStatistics = stats.getColumnStatistics().get(COLUMN_HANDLE);
         assertEquals(columnStatistics.getRange().get().getMin(), POSITIVE_INFINITY);
         assertEquals(columnStatistics.getRange().get().getMax(), POSITIVE_INFINITY);
@@ -208,7 +207,7 @@ public class TestDeltaLakeMetastoreStatistics
     public void testStatisticsNegInf()
     {
         DeltaLakeTableHandle tableHandle = registerTable("negative_infinity");
-        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle, Constraint.alwaysTrue());
+        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle);
         ColumnStatistics columnStatistics = stats.getColumnStatistics().get(COLUMN_HANDLE);
         assertEquals(columnStatistics.getRange().get().getMin(), NEGATIVE_INFINITY);
         assertEquals(columnStatistics.getRange().get().getMax(), NEGATIVE_INFINITY);
@@ -218,7 +217,7 @@ public class TestDeltaLakeMetastoreStatistics
     public void testStatisticsNegZero()
     {
         DeltaLakeTableHandle tableHandle = registerTable("negative_zero");
-        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle, Constraint.alwaysTrue());
+        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle);
         ColumnStatistics columnStatistics = stats.getColumnStatistics().get(COLUMN_HANDLE);
         assertEquals(columnStatistics.getRange().get().getMin(), -0.0d);
         assertEquals(columnStatistics.getRange().get().getMax(), -0.0d);
@@ -229,7 +228,7 @@ public class TestDeltaLakeMetastoreStatistics
     {
         // Stats with NaN values cannot be used
         DeltaLakeTableHandle tableHandle = registerTable("infinity_nan");
-        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle, Constraint.alwaysTrue());
+        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle);
         ColumnStatistics columnStatistics = stats.getColumnStatistics().get(COLUMN_HANDLE);
         assertEquals(columnStatistics.getRange().get().getMin(), POSITIVE_INFINITY);
         assertEquals(columnStatistics.getRange().get().getMax(), POSITIVE_INFINITY);
@@ -240,7 +239,7 @@ public class TestDeltaLakeMetastoreStatistics
     {
         // Stats with NaN values cannot be used
         DeltaLakeTableHandle tableHandle = registerTable("negative_infinity_nan");
-        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle, Constraint.alwaysTrue());
+        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle);
         ColumnStatistics columnStatistics = stats.getColumnStatistics().get(COLUMN_HANDLE);
         assertEquals(columnStatistics.getRange().get().getMin(), NEGATIVE_INFINITY);
         assertEquals(columnStatistics.getRange().get().getMax(), POSITIVE_INFINITY);
@@ -251,7 +250,7 @@ public class TestDeltaLakeMetastoreStatistics
     {
         // Stats with NaN values cannot be used
         DeltaLakeTableHandle tableHandle = registerTable("zero_nan");
-        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle, Constraint.alwaysTrue());
+        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle);
         ColumnStatistics columnStatistics = stats.getColumnStatistics().get(COLUMN_HANDLE);
         assertEquals(columnStatistics.getRange().get().getMin(), 0.0);
         assertEquals(columnStatistics.getRange().get().getMax(), POSITIVE_INFINITY);
@@ -261,7 +260,7 @@ public class TestDeltaLakeMetastoreStatistics
     public void testStatisticsZeroAndInfinity()
     {
         DeltaLakeTableHandle tableHandle = registerTable("zero_infinity");
-        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle, Constraint.alwaysTrue());
+        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle);
         ColumnStatistics columnStatistics = stats.getColumnStatistics().get(COLUMN_HANDLE);
         assertEquals(columnStatistics.getRange().get().getMin(), 0.0);
         assertEquals(columnStatistics.getRange().get().getMax(), POSITIVE_INFINITY);
@@ -271,7 +270,7 @@ public class TestDeltaLakeMetastoreStatistics
     public void testStatisticsZeroAndNegativeInfinity()
     {
         DeltaLakeTableHandle tableHandle = registerTable("zero_negative_infinity");
-        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle, Constraint.alwaysTrue());
+        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle);
         ColumnStatistics columnStatistics = stats.getColumnStatistics().get(COLUMN_HANDLE);
         assertEquals(columnStatistics.getRange().get().getMin(), NEGATIVE_INFINITY);
         assertEquals(columnStatistics.getRange().get().getMax(), 0.0);
@@ -282,7 +281,7 @@ public class TestDeltaLakeMetastoreStatistics
     {
         // Stats with NaN values cannot be used. This transaction combines a file with NaN min/max values with one with 0.0 min/max values
         DeltaLakeTableHandle tableHandle = registerTable("nan_multi_file");
-        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle, Constraint.alwaysTrue());
+        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle);
         ColumnStatistics columnStatistics = stats.getColumnStatistics().get(COLUMN_HANDLE);
         assertEquals(columnStatistics.getRange(), Optional.empty());
     }
@@ -291,7 +290,7 @@ public class TestDeltaLakeMetastoreStatistics
     public void testStatisticsMultipleFiles()
     {
         DeltaLakeTableHandle tableHandle = registerTable("basic_multi_file");
-        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle, Constraint.alwaysTrue());
+        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle);
         ColumnStatistics columnStatistics = stats.getColumnStatistics().get(COLUMN_HANDLE);
         assertEquals(columnStatistics.getRange().get().getMin(), -42.0);
         assertEquals(columnStatistics.getRange().get().getMax(), 42.0);
@@ -310,7 +309,7 @@ public class TestDeltaLakeMetastoreStatistics
                 tableHandle.getAnalyzeHandle(),
                 0,
                 false);
-        stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandleWithUnenforcedConstraint, Constraint.alwaysTrue());
+        stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandleWithUnenforcedConstraint);
         columnStatistics = stats.getColumnStatistics().get(COLUMN_HANDLE);
         assertEquals(columnStatistics.getRange().get().getMin(), 0.0);
         assertEquals(columnStatistics.getRange().get().getMax(), 42.0);
@@ -349,9 +348,8 @@ public class TestDeltaLakeMetastoreStatistics
                 0,
                 false);
         // If either the table handle's constraint or the provided Constraint are none, it will cause a 0 record count to be reported
-        assertEmptyStats(deltaLakeMetastore.getTableStatistics(SESSION, tableHandleWithNoneEnforcedConstraint, Constraint.alwaysTrue()));
-        assertEmptyStats(deltaLakeMetastore.getTableStatistics(SESSION, tableHandleWithNoneUnenforcedConstraint, Constraint.alwaysTrue()));
-        assertEmptyStats(deltaLakeMetastore.getTableStatistics(SESSION, tableHandle, Constraint.alwaysFalse()));
+        assertEmptyStats(deltaLakeMetastore.getTableStatistics(SESSION, tableHandleWithNoneEnforcedConstraint));
+        assertEmptyStats(deltaLakeMetastore.getTableStatistics(SESSION, tableHandleWithNoneUnenforcedConstraint));
     }
 
     private void assertEmptyStats(TableStatistics tableStatistics)
@@ -367,7 +365,7 @@ public class TestDeltaLakeMetastoreStatistics
     {
         // The transaction log for this table was created so that the checkpoints only write struct statistics, not json statistics
         DeltaLakeTableHandle tableHandle = registerTable("parquet_struct_statistics");
-        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle, Constraint.alwaysTrue());
+        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle);
         assertEquals(stats.getRowCount(), Estimate.of(9));
 
         Map<ColumnHandle, ColumnStatistics> statisticsMap = stats.getColumnStatistics();
@@ -423,7 +421,7 @@ public class TestDeltaLakeMetastoreStatistics
         // The transaction log for this table was created so that the checkpoints only write struct statistics, not json statistics
         // The table has a REAL and DOUBLE columns each with 9 values, one of them being NaN
         DeltaLakeTableHandle tableHandle = registerTable("parquet_struct_statistics_nan");
-        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle, Constraint.alwaysTrue());
+        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle);
         assertEquals(stats.getRowCount(), Estimate.of(9));
 
         Map<ColumnHandle, ColumnStatistics> statisticsMap = stats.getColumnStatistics();
@@ -442,7 +440,7 @@ public class TestDeltaLakeMetastoreStatistics
         // The transaction log for this table was created so that the checkpoints only write struct statistics, not json statistics
         // The table has one INTEGER column 'i' where 3 of the 9 values are null
         DeltaLakeTableHandle tableHandle = registerTable("parquet_struct_statistics_null_count");
-        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle, Constraint.alwaysTrue());
+        TableStatistics stats = deltaLakeMetastore.getTableStatistics(SESSION, tableHandle);
         assertEquals(stats.getRowCount(), Estimate.of(9));
 
         Map<ColumnHandle, ColumnStatistics> statisticsMap = stats.getColumnStatistics();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -772,7 +772,7 @@ public class HiveMetadata
     }
 
     @Override
-    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, Constraint constraint)
+    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         if (!isStatisticsEnabled(session)) {
             return TableStatistics.empty();
@@ -783,7 +783,7 @@ public class HiveMetadata
                 .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
         Map<String, Type> columnTypes = columns.entrySet().stream()
                 .collect(toImmutableMap(Map.Entry::getKey, entry -> getColumnMetadata(session, tableHandle, entry.getValue()).getType()));
-        HivePartitionResult partitionResult = partitionManager.getPartitions(metastore, tableHandle, constraint);
+        HivePartitionResult partitionResult = partitionManager.getPartitions(metastore, tableHandle, Constraint.alwaysTrue());
         // If partitions are not loaded, then don't generate table statistics.
         // Note that the computation is not persisted in the table handle, so can be redone many times
         // TODO: https://github.com/trinodb/trino/issues/10980.

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -1429,7 +1429,7 @@ public abstract class AbstractTestHive
             ConnectorMetadata metadata = transaction.getMetadata();
             ConnectorSession session = newSession();
             ConnectorTableHandle tableHandle = getTableHandle(metadata, tableName);
-            TableStatistics tableStatistics = metadata.getTableStatistics(session, tableHandle, Constraint.alwaysTrue());
+            TableStatistics tableStatistics = metadata.getTableStatistics(session, tableHandle);
 
             assertFalse(tableStatistics.getRowCount().isUnknown(), "row count is unknown");
 
@@ -3436,8 +3436,8 @@ public abstract class AbstractTestHive
                 ConnectorMetadata metadata = transaction.getMetadata();
 
                 ConnectorTableHandle tableHandle = metadata.getTableHandle(session, tableName);
-                TableStatistics unsampledStatistics = metadata.getTableStatistics(sampleSize(2), tableHandle, Constraint.alwaysTrue());
-                TableStatistics sampledStatistics = metadata.getTableStatistics(sampleSize(1), tableHandle, Constraint.alwaysTrue());
+                TableStatistics unsampledStatistics = metadata.getTableStatistics(sampleSize(2), tableHandle);
+                TableStatistics sampledStatistics = metadata.getTableStatistics(sampleSize(1), tableHandle);
                 assertEquals(sampledStatistics, unsampledStatistics);
             }
         }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1157,7 +1157,7 @@ public class IcebergMetadata
     }
 
     @Override
-    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, Constraint constraint)
+    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         if (!isStatisticsEnabled(session)) {
             return TableStatistics.empty();
@@ -1165,7 +1165,7 @@ public class IcebergMetadata
 
         IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
         Table icebergTable = catalog.loadTable(session, handle.getSchemaTableName());
-        return TableStatisticsMaker.getTableStatistics(typeManager, constraint, handle, icebergTable);
+        return TableStatisticsMaker.getTableStatistics(typeManager, handle, icebergTable);
     }
 
     @Override

--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryMetadata.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryMetadata.java
@@ -34,7 +34,6 @@ import io.trino.spi.connector.ConnectorTableLayout;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTableProperties;
 import io.trino.spi.connector.ConnectorViewDefinition;
-import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.LimitApplicationResult;
 import io.trino.spi.connector.RetryMode;
 import io.trino.spi.connector.SampleApplicationResult;
@@ -393,7 +392,7 @@ public class MemoryMetadata
     }
 
     @Override
-    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, Constraint constraint)
+    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         List<MemoryDataFragment> dataFragments = getDataFragments(((MemoryTableHandle) tableHandle).getId());
         long rows = dataFragments.stream()

--- a/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsMetadata.java
+++ b/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsMetadata.java
@@ -24,7 +24,6 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTableProperties;
-import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
 import io.trino.spi.statistics.TableStatistics;
@@ -127,7 +126,7 @@ public class TpcdsMetadata
     }
 
     @Override
-    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, Constraint constraint)
+    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         TpcdsTableHandle tpcdsTableHandle = (TpcdsTableHandle) tableHandle;
 

--- a/plugin/trino-tpcds/src/test/java/io/trino/plugin/tpcds/TestTpcdsMetadataStatistics.java
+++ b/plugin/trino-tpcds/src/test/java/io/trino/plugin/tpcds/TestTpcdsMetadataStatistics.java
@@ -30,7 +30,6 @@ import org.testng.annotations.Test;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import static io.trino.spi.connector.Constraint.alwaysTrue;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -50,7 +49,7 @@ public class TestTpcdsMetadataStatistics
                         .forEach(table -> {
                             SchemaTableName schemaTableName = new SchemaTableName(schemaName, table.getName());
                             ConnectorTableHandle tableHandle = metadata.getTableHandle(session, schemaTableName);
-                            TableStatistics tableStatistics = metadata.getTableStatistics(session, tableHandle, alwaysTrue());
+                            TableStatistics tableStatistics = metadata.getTableStatistics(session, tableHandle);
                             assertTrue(tableStatistics.getRowCount().isUnknown());
                             assertTrue(tableStatistics.getColumnStatistics().isEmpty());
                         }));
@@ -64,7 +63,7 @@ public class TestTpcdsMetadataStatistics
                         .forEach(table -> {
                             SchemaTableName schemaTableName = new SchemaTableName(schemaName, table.getName());
                             ConnectorTableHandle tableHandle = metadata.getTableHandle(session, schemaTableName);
-                            TableStatistics tableStatistics = metadata.getTableStatistics(session, tableHandle, alwaysTrue());
+                            TableStatistics tableStatistics = metadata.getTableStatistics(session, tableHandle);
                             assertFalse(tableStatistics.getRowCount().isUnknown());
                             for (ColumnHandle column : metadata.getColumnHandles(session, tableHandle).values()) {
                                 assertTrue(tableStatistics.getColumnStatistics().containsKey(column));
@@ -78,7 +77,7 @@ public class TestTpcdsMetadataStatistics
     {
         SchemaTableName schemaTableName = new SchemaTableName("sf1", Table.CALL_CENTER.getName());
         ConnectorTableHandle tableHandle = metadata.getTableHandle(session, schemaTableName);
-        TableStatistics tableStatistics = metadata.getTableStatistics(session, tableHandle, alwaysTrue());
+        TableStatistics tableStatistics = metadata.getTableStatistics(session, tableHandle);
 
         estimateAssertion.assertClose(tableStatistics.getRowCount(), Estimate.of(6), "Row count does not match");
 
@@ -148,7 +147,7 @@ public class TestTpcdsMetadataStatistics
     {
         SchemaTableName schemaTableName = new SchemaTableName("sf1", Table.WEB_SITE.getName());
         ConnectorTableHandle tableHandle = metadata.getTableHandle(session, schemaTableName);
-        TableStatistics tableStatistics = metadata.getTableStatistics(session, tableHandle, alwaysTrue());
+        TableStatistics tableStatistics = metadata.getTableStatistics(session, tableHandle);
 
         Map<String, ColumnHandle> columnHandles = metadata.getColumnHandles(session, tableHandle);
 

--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchMetadata.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchMetadata.java
@@ -271,16 +271,14 @@ public class TpchMetadata
     }
 
     @Override
-    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, Constraint constraint)
+    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        TupleDomain<ColumnHandle> filter = constraint.getSummary().intersect(((TpchTableHandle) tableHandle).getConstraint());
-
         TpchTableHandle tpchTableHandle = (TpchTableHandle) tableHandle;
         String tableName = tpchTableHandle.getTableName();
         TpchTable<?> tpchTable = TpchTable.getTable(tableName);
         Map<TpchColumn<?>, List<Object>> columnValuesRestrictions = ImmutableMap.of();
         if (predicatePushdownEnabled) {
-            columnValuesRestrictions = getColumnValuesRestrictions(tpchTable, filter);
+            columnValuesRestrictions = getColumnValuesRestrictions(tpchTable, tpchTableHandle.getConstraint());
         }
         Optional<TableStatisticsData> optionalTableStatisticsData = statisticsEstimator.estimateStats(tpchTable, columnValuesRestrictions, tpchTableHandle.getScaleFactor());
 

--- a/plugin/trino-tpch/src/test/java/io/trino/plugin/tpch/TestTpchMetadata.java
+++ b/plugin/trino-tpch/src/test/java/io/trino/plugin/tpch/TestTpchMetadata.java
@@ -173,7 +173,11 @@ public class TestTpchMetadata
     private void testTableStats(String schema, TpchTable<?> table, Constraint constraint, double expectedRowCount)
     {
         TpchTableHandle tableHandle = tpchMetadata.getTableHandle(session, new SchemaTableName(schema, table.getTableName()));
-        TableStatistics tableStatistics = tpchMetadata.getTableStatistics(session, tableHandle, constraint);
+        Optional<ConstraintApplicationResult<ConnectorTableHandle>> result = tpchMetadata.applyFilter(session, tableHandle, constraint);
+        if (result.isPresent()) {
+            tableHandle = (TpchTableHandle) result.get().getHandle();
+        }
+        TableStatistics tableStatistics = tpchMetadata.getTableStatistics(session, tableHandle);
 
         double actualRowCountValue = tableStatistics.getRowCount().getValue();
         assertEquals(tableStatistics.getRowCount(), Estimate.of(actualRowCountValue));
@@ -274,7 +278,11 @@ public class TestTpchMetadata
     private void testColumnStats(String schema, TpchTable<?> table, TpchColumn<?> column, Constraint constraint, ColumnStatistics expected)
     {
         TpchTableHandle tableHandle = tpchMetadata.getTableHandle(session, new SchemaTableName(schema, table.getTableName()));
-        TableStatistics tableStatistics = tpchMetadata.getTableStatistics(session, tableHandle, constraint);
+        Optional<ConstraintApplicationResult<ConnectorTableHandle>> result = tpchMetadata.applyFilter(session, tableHandle, constraint);
+        if (result.isPresent()) {
+            tableHandle = (TpchTableHandle) result.get().getHandle();
+        }
+        TableStatistics tableStatistics = tpchMetadata.getTableStatistics(session, tableHandle);
         ColumnHandle columnHandle = tpchMetadata.getColumnHandles(session, tableHandle).get(column.getSimplifiedColumnName());
 
         ColumnStatistics actual = tableStatistics.getColumnStatistics().get(columnHandle);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->
Deprecate passing constraints to `ConnectorMetadata.getTableStatistics()`, because it always received `Constraints.alwaysTrue()`. Connectors should handle constraints in `applyFilter()`, which prepare the table handle that later will be passed to `getTableStatistics()`.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

other, mostly refactor but it makes SPI changes

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

spi

> How would you describe this change to a non-technical end user or system administrator?

n/a

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related comment: https://github.com/trinodb/trino/pull/7140#issuecomment-789676485
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# SPI
* Deprecate passing constraints to `ConnectorMetadata.getTableStatistics()`. Constraints can be associated with the table handle in `ConnectorMetadata.applyFilter()`. ({issue}`issuenumber`)
```
