### PR TITLE
Support setting Iceberg table format version

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -441,6 +441,10 @@ Property Name                                      Description
 
 ``location``                                       Optionally specifies the file system location URI for
                                                    the table.
+
+``format_version``                                 Optionally specifies the format version of the Iceberg
+                                                   specification to use for new tables; either ``1`` or ``2``.
+                                                   Defaults to ``1``. Version ``2`` is required for row level deletes.
 ================================================== ================================================================
 
 The table definition below specifies format Parquet, partitioning by columns ``c1`` and ``c2``,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -18,6 +18,7 @@ import io.airlift.configuration.ConfigDescription;
 import io.airlift.units.Duration;
 import io.trino.plugin.hive.HiveCompressionCodec;
 
+import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
@@ -30,6 +31,9 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class IcebergConfig
 {
+    public static final int FORMAT_VERSION_SUPPORT_MIN = 1;
+    public static final int FORMAT_VERSION_SUPPORT_MAX = 2;
+
     private IcebergFileFormat fileFormat = ORC;
     private HiveCompressionCodec compressionCodec = ZSTD;
     private boolean useFileSizeFromMetadata = true;
@@ -40,6 +44,7 @@ public class IcebergConfig
     private boolean tableStatisticsEnabled = true;
     private boolean projectionPushdownEnabled = true;
     private Optional<String> hiveCatalogName = Optional.empty();
+    private int formatVersion = FORMAT_VERSION_SUPPORT_MIN;
 
     public CatalogType getCatalogType()
     {
@@ -180,6 +185,21 @@ public class IcebergConfig
     public IcebergConfig setHiveCatalogName(String hiveCatalogName)
     {
         this.hiveCatalogName = Optional.ofNullable(hiveCatalogName);
+        return this;
+    }
+
+    @Min(FORMAT_VERSION_SUPPORT_MIN)
+    @Max(FORMAT_VERSION_SUPPORT_MAX)
+    public int getFormatVersion()
+    {
+        return formatVersion;
+    }
+
+    @Config("iceberg.format-version")
+    @ConfigDescription("Default Iceberg table format version")
+    public IcebergConfig setFormatVersion(int formatVersion)
+    {
+        this.formatVersion = formatVersion;
         return this;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableProperties.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableList;
+import io.trino.spi.TrinoException;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.type.ArrayType;
 
@@ -25,9 +26,14 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.iceberg.IcebergConfig.FORMAT_VERSION_SUPPORT_MAX;
+import static io.trino.plugin.iceberg.IcebergConfig.FORMAT_VERSION_SUPPORT_MIN;
+import static io.trino.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
 import static io.trino.spi.session.PropertyMetadata.enumProperty;
+import static io.trino.spi.session.PropertyMetadata.integerProperty;
 import static io.trino.spi.session.PropertyMetadata.stringProperty;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 
 public class IcebergTableProperties
@@ -35,6 +41,7 @@ public class IcebergTableProperties
     public static final String FILE_FORMAT_PROPERTY = "format";
     public static final String PARTITIONING_PROPERTY = "partitioning";
     public static final String LOCATION_PROPERTY = "location";
+    public static final String FORMAT_VERSION_PROPERTY = "format_version";
 
     private final List<PropertyMetadata<?>> tableProperties;
 
@@ -64,6 +71,12 @@ public class IcebergTableProperties
                         "File system location URI for the table",
                         null,
                         false))
+                .add(integerProperty(
+                        FORMAT_VERSION_PROPERTY,
+                        "Iceberg table format version",
+                        icebergConfig.getFormatVersion(),
+                        IcebergTableProperties::validateFormatVersion,
+                        false))
                 .build();
     }
 
@@ -87,5 +100,18 @@ public class IcebergTableProperties
     public static Optional<String> getTableLocation(Map<String, Object> tableProperties)
     {
         return Optional.ofNullable((String) tableProperties.get(LOCATION_PROPERTY));
+    }
+
+    public static int getFormatVersion(Map<String, Object> tableProperties)
+    {
+        return (int) tableProperties.get(FORMAT_VERSION_PROPERTY);
+    }
+
+    private static void validateFormatVersion(int version)
+    {
+        if (version < FORMAT_VERSION_SUPPORT_MIN || version > FORMAT_VERSION_SUPPORT_MAX) {
+            throw new TrinoException(INVALID_TABLE_PROPERTY,
+                    format("format_version must be between %d and %d", FORMAT_VERSION_SUPPORT_MIN, FORMAT_VERSION_SUPPORT_MAX));
+        }
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -105,6 +105,7 @@ import static org.apache.iceberg.BaseMetastoreTableOperations.TABLE_TYPE_PROP;
 import static org.apache.iceberg.LocationProviders.locationsFor;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
+import static org.apache.iceberg.TableProperties.FORMAT_VERSION;
 import static org.apache.iceberg.TableProperties.OBJECT_STORE_PATH;
 import static org.apache.iceberg.TableProperties.WRITE_DATA_LOCATION;
 import static org.apache.iceberg.TableProperties.WRITE_LOCATION_PROVIDER_IMPL;
@@ -401,6 +402,7 @@ public final class IcebergUtil
         ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.builderWithExpectedSize(2);
         IcebergFileFormat fileFormat = IcebergTableProperties.getFileFormat(tableMetadata.getProperties());
         propertiesBuilder.put(DEFAULT_FILE_FORMAT, fileFormat.toIceberg().toString());
+        propertiesBuilder.put(FORMAT_VERSION, Integer.toString(IcebergTableProperties.getFormatVersion(tableMetadata.getProperties())));
         if (tableMetadata.getComment().isPresent()) {
             propertiesBuilder.put(TABLE_COMMENT, tableMetadata.getComment().get());
         }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
@@ -45,7 +45,8 @@ public class TestIcebergConfig
                 .setDynamicFilteringWaitTimeout(new Duration(0, MINUTES))
                 .setTableStatisticsEnabled(true)
                 .setProjectionPushdownEnabled(true)
-                .setHiveCatalogName(null));
+                .setHiveCatalogName(null)
+                .setFormatVersion(1));
     }
 
     @Test
@@ -62,6 +63,7 @@ public class TestIcebergConfig
                 .put("iceberg.table-statistics-enabled", "false")
                 .put("iceberg.projection-pushdown-enabled", "false")
                 .put("iceberg.hive-catalog-name", "hive")
+                .put("iceberg.format-version", "2")
                 .buildOrThrow();
 
         IcebergConfig expected = new IcebergConfig()
@@ -74,7 +76,8 @@ public class TestIcebergConfig
                 .setDynamicFilteringWaitTimeout(Duration.valueOf("1h"))
                 .setTableStatisticsEnabled(false)
                 .setProjectionPushdownEnabled(false)
-                .setHiveCatalogName("hive");
+                .setHiveCatalogName("hive")
+                .setFormatVersion(2);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Allows setting the table format for newly created Iceberg tables. Defaults to v1.

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Feature

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Iceberg connector

> How would you describe this change to a non-technical end user or system administrator?

Allows creating either v1 or v2 Iceberg tables

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Iceberg
* Support creating tables with either Iceberg format version 1, or 2.
```
