### PR TITLE
Add docs for table statistics support in SQL Server connector

### DIFF
--- a/docs/src/main/sphinx/connector/sqlserver.rst
+++ b/docs/src/main/sphinx/connector/sqlserver.rst
@@ -164,10 +164,50 @@ supports the following features:
 
 .. include:: alter-table-limitation.fragment
 
+
+Performance
+-----------
+
+The connector includes a number of performance improvements, detailed in the
+following sections.
+
+.. _sqlserver-table-statistics:
+
+Table statistics
+^^^^^^^^^^^^^^^^
+
+The SQL Server connector can use :doc:`table and column statistics
+</optimizer/statistics>` for :doc:`cost based optimizations
+</optimizer/cost-based-optimizations>`, to improve query processing performance
+based on the actual data in the data source.
+
+The statistics are collected by SQL Server and retrieved by the connector.
+
+The connector can use information stored in single-column statistics. SQL Server
+Database can automatically create column statistics for certain columns. If
+column statistics are not created automatically for a certain column, you can
+create them by executing the following statement in SQL Server Database.
+
+.. code-block:: sql
+
+    CREATE STATISTICS my_statistics_name ON table_schema.table_name (column_name);
+
+SQL Server Database routinely updates the statistics. In some cases, you may
+want to force statistics update (e.g. after defining new column statistics or
+after changing data in the table). You can do that by executing the following
+statement in SQL Server Database.
+
+.. code-block:: sql
+
+    UPDATE STATISTICS table_schema.table_name;
+
+Refer to SQL Server documentation for information about options, limitations and
+additional considerations.
+
 .. _sqlserver-pushdown:
 
 Pushdown
---------
+^^^^^^^^
 
 The connector supports pushdown for a number of operations:
 


### PR DESCRIPTION
## Description

Very similar to what we just did in MySQL connector in 376. Not sure if we somehow need to document that the stats are taken into account for join pushdown (which is already documented to be supported)

> Is this change a fix, improvement, new feature, refactoring, or other?

Docs for new feature.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

SQL Server connector

> How would you describe this change to a non-technical end user or system administrator?

Documentation for new feature of the connector that improves performance.

## Related issues, pull requests, and links

* Add docs needed for #11637

## Documentation

( ) No documentation is needed.
(✅) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(✅ ) No release notes entries required.
( ) Release notes entries required with the following suggested text:
