### PR TITLE
Fix incorrect $bucket for mismatch bucket queries

### DIFF
--- a/client/trino-cli/pom.xml
+++ b/client/trino-cli/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/client/trino-cli/pom.xml
+++ b/client/trino-cli/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/client/trino-client/pom.xml
+++ b/client/trino-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/client/trino-client/pom.xml
+++ b/client/trino-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/client/trino-jdbc/pom.xml
+++ b/client/trino-jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/client/trino-jdbc/pom.xml
+++ b/client/trino-jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/trino-main/pom.xml
+++ b/core/trino-main/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/trino-main/pom.xml
+++ b/core/trino-main/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/trino-main/src/main/java/io/trino/execution/QueryManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryManagerConfig.java
@@ -77,7 +77,7 @@ public class QueryManagerConfig
 
     private RetryPolicy retryPolicy = RetryPolicy.NONE;
     private int queryRetryAttempts = 4;
-    private int taskRetryAttemptsPerTask = 2;
+    private int taskRetryAttemptsPerTask = 4;
     private int taskRetryAttemptsOverall = Integer.MAX_VALUE;
     private Duration retryInitialDelay = new Duration(10, SECONDS);
     private Duration retryMaxDelay = new Duration(1, MINUTES);

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/StageTaskSourceFactory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/StageTaskSourceFactory.java
@@ -714,13 +714,13 @@ public class StageTaskSourceFactory
             List<TaskDescriptor> result = new ArrayList<>();
 
             while (true) {
-                boolean includeRemainder = splitSource.isFinished();
+                boolean splitSourceFinished = splitSource.isFinished();
 
                 result.addAll(getReadyTasks(
                         remotelyAccessibleSplitBuffer,
                         ImmutableList.of(),
                         new NodeRequirements(catalogRequirement, ImmutableSet.of(), taskMemory),
-                        includeRemainder));
+                        splitSourceFinished));
                 for (HostAddress remoteHost : locallyAccessibleSplitBuffer.keySet()) {
                     result.addAll(getReadyTasks(
                             locallyAccessibleSplitBuffer.get(remoteHost),
@@ -729,10 +729,10 @@ public class StageTaskSourceFactory
                                     .map(Map.Entry::getValue)
                                     .collect(toImmutableList()),
                             new NodeRequirements(catalogRequirement, ImmutableSet.of(remoteHost), taskMemory),
-                            includeRemainder));
+                            splitSourceFinished));
                 }
 
-                if (!result.isEmpty() || splitSource.isFinished()) {
+                if (!result.isEmpty() || splitSourceFinished) {
                     break;
                 }
 

--- a/core/trino-main/src/main/java/io/trino/memory/MemoryManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/memory/MemoryManagerConfig.java
@@ -43,7 +43,7 @@ public class MemoryManagerConfig
     // enforced against user + system memory allocations (default is maxQueryMemory * 2)
     private DataSize maxQueryTotalMemory;
     private DataSize faultTolerantExecutionTaskMemory = DataSize.of(4, GIGABYTE);
-    private double faultTolerantExecutionTaskMemoryGrowthFactor = 2.0;
+    private double faultTolerantExecutionTaskMemoryGrowthFactor = 3.0;
     private LowMemoryKillerPolicy lowMemoryKillerPolicy = LowMemoryKillerPolicy.TOTAL_RESERVATION_ON_BLOCKED_NODES;
     private Duration killOnOutOfMemoryDelay = new Duration(5, MINUTES);
 

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/AggregationAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/AggregationAnalyzer.java
@@ -59,6 +59,7 @@ import io.trino.sql.tree.SimpleCaseExpression;
 import io.trino.sql.tree.SortItem;
 import io.trino.sql.tree.SubqueryExpression;
 import io.trino.sql.tree.SubscriptExpression;
+import io.trino.sql.tree.Trim;
 import io.trino.sql.tree.TryExpression;
 import io.trino.sql.tree.VariableDefinition;
 import io.trino.sql.tree.WhenClause;
@@ -326,6 +327,12 @@ class AggregationAnalyzer
         protected Boolean visitQuantifiedComparisonExpression(QuantifiedComparisonExpression node, Void context)
         {
             return process(node.getValue(), context) && process(node.getSubquery(), context);
+        }
+
+        @Override
+        protected Boolean visitTrim(Trim node, Void context)
+        {
+            return process(node.getTrimSource(), context) && (node.getTrimCharacter().isEmpty() || process(node.getTrimCharacter().get(), context));
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -186,7 +186,7 @@ public class Analysis
     private final Map<NodeRef<Expression>, Type> sortKeyCoercionsForFrameBoundComparison = new LinkedHashMap<>();
     private final Map<NodeRef<Expression>, ResolvedFunction> frameBoundCalculations = new LinkedHashMap<>();
     private final Map<NodeRef<Relation>, List<Type>> relationCoercions = new LinkedHashMap<>();
-    private final Map<NodeRef<FunctionCall>, RoutineEntry> resolvedFunctions = new LinkedHashMap<>();
+    private final Map<NodeRef<Expression>, RoutineEntry> resolvedFunctions = new LinkedHashMap<>();
     private final Map<NodeRef<Identifier>, LambdaArgumentDeclaration> lambdaArgumentReferences = new LinkedHashMap<>();
 
     private final Map<Field, ColumnHandle> columns = new LinkedHashMap<>();
@@ -623,12 +623,12 @@ public class Analysis
                                 columnMaskScopes.isEmpty()));
     }
 
-    public ResolvedFunction getResolvedFunction(FunctionCall function)
+    public ResolvedFunction getResolvedFunction(Expression node)
     {
-        return resolvedFunctions.get(NodeRef.of(function)).getFunction();
+        return resolvedFunctions.get(NodeRef.of(node)).getFunction();
     }
 
-    public void addResolvedFunction(FunctionCall node, ResolvedFunction function, String authorization)
+    public void addResolvedFunction(Expression node, ResolvedFunction function, String authorization)
     {
         resolvedFunctions.put(NodeRef.of(node), new RoutineEntry(function, authorization));
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/ResolvedFunctionCallRewriter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ResolvedFunctionCallRewriter.java
@@ -29,7 +29,7 @@ public final class ResolvedFunctionCallRewriter
 {
     private ResolvedFunctionCallRewriter() {}
 
-    public static Expression rewriteResolvedFunctions(Expression expression, Map<NodeRef<FunctionCall>, ResolvedFunction> resolvedFunctions)
+    public static Expression rewriteResolvedFunctions(Expression expression, Map<NodeRef<Expression>, ResolvedFunction> resolvedFunctions)
     {
         return ExpressionTreeRewriter.rewriteWith(new Visitor(resolvedFunctions), expression);
     }
@@ -37,9 +37,9 @@ public final class ResolvedFunctionCallRewriter
     private static class Visitor
             extends ExpressionRewriter<Void>
     {
-        private final Map<NodeRef<FunctionCall>, ResolvedFunction> resolvedFunctions;
+        private final Map<NodeRef<Expression>, ResolvedFunction> resolvedFunctions;
 
-        public Visitor(Map<NodeRef<FunctionCall>, ResolvedFunction> resolvedFunctions)
+        public Visitor(Map<NodeRef<Expression>, ResolvedFunction> resolvedFunctions)
         {
             this.resolvedFunctions = requireNonNull(resolvedFunctions, "resolvedFunctions is null");
         }

--- a/core/trino-main/src/test/java/io/trino/execution/TestQueryManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestQueryManagerConfig.java
@@ -65,7 +65,7 @@ public class TestQueryManagerConfig
                 .setRetryPolicy(RetryPolicy.NONE)
                 .setQueryRetryAttempts(4)
                 .setTaskRetryAttemptsOverall(Integer.MAX_VALUE)
-                .setTaskRetryAttemptsPerTask(2)
+                .setTaskRetryAttemptsPerTask(4)
                 .setRetryInitialDelay(new Duration(10, SECONDS))
                 .setRetryMaxDelay(new Duration(1, MINUTES))
                 .setFaultTolerantExecutionTargetTaskInputSize(DataSize.of(1, GIGABYTE))

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestExponentialGrowthPartitionMemoryEstimator.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestExponentialGrowthPartitionMemoryEstimator.java
@@ -49,7 +49,7 @@ public class TestExponentialGrowthPartitionMemoryEstimator
                         new PartitionMemoryEstimator.MemoryRequirements(DataSize.of(50, MEGABYTE), false),
                         DataSize.of(10, MEGABYTE),
                         StandardErrorCode.CLUSTER_OUT_OF_MEMORY.toErrorCode()))
-                .isEqualTo(new PartitionMemoryEstimator.MemoryRequirements(DataSize.of(100, MEGABYTE), false));
+                .isEqualTo(new PartitionMemoryEstimator.MemoryRequirements(DataSize.of(150, MEGABYTE), false));
 
         assertThat(
                 estimator.getNextRetryMemoryRequirements(
@@ -57,7 +57,7 @@ public class TestExponentialGrowthPartitionMemoryEstimator
                         new PartitionMemoryEstimator.MemoryRequirements(DataSize.of(50, MEGABYTE), false),
                         DataSize.of(10, MEGABYTE),
                         StandardErrorCode.EXCEEDED_LOCAL_MEMORY_LIMIT.toErrorCode()))
-                .isEqualTo(new PartitionMemoryEstimator.MemoryRequirements(DataSize.of(100, MEGABYTE), false));
+                .isEqualTo(new PartitionMemoryEstimator.MemoryRequirements(DataSize.of(150, MEGABYTE), false));
 
         // peak memory of failed task 70MB
         assertThat(
@@ -74,6 +74,6 @@ public class TestExponentialGrowthPartitionMemoryEstimator
                         new PartitionMemoryEstimator.MemoryRequirements(DataSize.of(50, MEGABYTE), false),
                         DataSize.of(70, MEGABYTE),
                         StandardErrorCode.EXCEEDED_LOCAL_MEMORY_LIMIT.toErrorCode()))
-                .isEqualTo(new PartitionMemoryEstimator.MemoryRequirements(DataSize.of(140, MEGABYTE), false));
+                .isEqualTo(new PartitionMemoryEstimator.MemoryRequirements(DataSize.of(210, MEGABYTE), false));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestingSplitSource.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestingSplitSource.java
@@ -33,11 +33,18 @@ public class TestingSplitSource
 {
     private final CatalogName catalogName;
     private final Iterator<Split> splits;
+    private int finishDelayRemainingIterations;
 
     public TestingSplitSource(CatalogName catalogName, List<Split> splits)
     {
+        this(catalogName, splits, 0);
+    }
+
+    public TestingSplitSource(CatalogName catalogName, List<Split> splits, int finishDelayIterations)
+    {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.splits = ImmutableList.copyOf(requireNonNull(splits, "splits is null")).iterator();
+        this.finishDelayRemainingIterations = finishDelayIterations;
     }
 
     @Override
@@ -70,7 +77,7 @@ public class TestingSplitSource
     @Override
     public boolean isFinished()
     {
-        return !splits.hasNext();
+        return !splits.hasNext() && finishDelayRemainingIterations-- <= 0;
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/memory/TestMemoryManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/memory/TestMemoryManagerConfig.java
@@ -40,7 +40,7 @@ public class TestMemoryManagerConfig
                 .setMaxQueryMemory(DataSize.of(20, GIGABYTE))
                 .setMaxQueryTotalMemory(DataSize.of(40, GIGABYTE))
                 .setFaultTolerantExecutionTaskMemory(DataSize.of(4, GIGABYTE))
-                .setFaultTolerantExecutionTaskMemoryGrowthFactor(2.0));
+                .setFaultTolerantExecutionTaskMemoryGrowthFactor(3.0));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestStringFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestStringFunctions.java
@@ -667,39 +667,6 @@ public class TestStringFunctions
     }
 
     @Test
-    public void testTrim()
-    {
-        assertFunction("TRIM('')", createVarcharType(0), "");
-        assertFunction("TRIM('   ')", createVarcharType(3), "");
-        assertFunction("TRIM('  hello  ')", createVarcharType(9), "hello");
-        assertFunction("TRIM('  hello')", createVarcharType(7), "hello");
-        assertFunction("TRIM('hello  ')", createVarcharType(7), "hello");
-        assertFunction("TRIM(' hello world ')", createVarcharType(13), "hello world");
-
-        assertFunction("TRIM('\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 ')", createVarcharType(10), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
-        assertFunction("TRIM('\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ')", createVarcharType(9), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
-        assertFunction("TRIM(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ')", createVarcharType(9), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
-        assertFunction("TRIM('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B')", createVarcharType(9), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
-        assertFunction("TRIM(' \u2028 \u4FE1\u5FF5 \u7231 \u5E0C\u671B')", createVarcharType(10), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
-    }
-
-    @Test
-    public void testCharTrim()
-    {
-        assertFunction("TRIM(CAST('' AS CHAR(20)))", createVarcharType(20), "");
-        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)))", createVarcharType(9), "hello");
-        assertFunction("TRIM(CAST('  hello' AS CHAR(7)))", createVarcharType(7), "hello");
-        assertFunction("TRIM(CAST('hello  ' AS CHAR(7)))", createVarcharType(7), "hello");
-        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)))", createVarcharType(13), "hello world");
-
-        assertFunction("TRIM(CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 ' AS CHAR(10)))", createVarcharType(10), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
-        assertFunction("TRIM(CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ' AS CHAR(9)))", createVarcharType(9), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
-        assertFunction("TRIM(CAST(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ' AS CHAR(9)))", createVarcharType(9), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
-        assertFunction("TRIM(CAST('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(9)))", createVarcharType(9), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
-        assertFunction("TRIM(CAST(' \u2028 \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(10)))", createVarcharType(10), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
-    }
-
-    @Test
     public void testLeftTrimParametrized()
     {
         assertFunction("LTRIM('', '')", createVarcharType(0), "");
@@ -804,58 +771,6 @@ public class TestStringFunctions
 
         // non latin characters
         assertFunction("RTRIM(CAST('\u017a\u00f3\u0142\u0107' AS CHAR(4)), '\u0107\u0142')", createVarcharType(4), "\u017a\u00f3");
-    }
-
-    @Test
-    public void testTrimParametrized()
-    {
-        assertFunction("TRIM('', '')", createVarcharType(0), "");
-        assertFunction("TRIM('   ', '')", createVarcharType(3), "   ");
-        assertFunction("TRIM('  hello  ', '')", createVarcharType(9), "  hello  ");
-        assertFunction("TRIM('  hello  ', ' ')", createVarcharType(9), "hello");
-        assertFunction("TRIM('  hello  ', 'he ')", createVarcharType(9), "llo");
-        assertFunction("TRIM('  hello  ', 'lo ')", createVarcharType(9), "he");
-        assertFunction("TRIM('  hello', ' ')", createVarcharType(7), "hello");
-        assertFunction("TRIM('hello  ', ' ')", createVarcharType(7), "hello");
-        assertFunction("TRIM('hello  ', 'l o')", createVarcharType(7), "he");
-        assertFunction("TRIM('hello  ', 'l')", createVarcharType(7), "hello  ");
-        assertFunction("TRIM(' hello world ', ' ')", createVarcharType(13), "hello world");
-        assertFunction("TRIM(' hello world ', ' ld')", createVarcharType(13), "hello wor");
-        assertFunction("TRIM(' hello world ', ' eh')", createVarcharType(13), "llo world");
-        assertFunction("TRIM(' hello world ', ' ehlowrd')", createVarcharType(13), "");
-        assertFunction("TRIM(' hello world ', ' x')", createVarcharType(13), "hello world");
-
-        // non latin characters
-        assertFunction("TRIM('\u017a\u00f3\u0142\u0107', '\u0107\u017a')", createVarcharType(4), "\u00f3\u0142");
-
-        // invalid utf-8 characters
-        assertFunction("CAST(TRIM(utf8(from_hex('81')), ' ') AS VARBINARY)", VARBINARY, varbinary(0x81));
-        assertFunction("CAST(TRIM(CONCAT(utf8(from_hex('81')), ' '), ' ') AS VARBINARY)", VARBINARY, varbinary(0x81));
-        assertFunction("CAST(TRIM(CONCAT(' ', utf8(from_hex('81'))), ' ') AS VARBINARY)", VARBINARY, varbinary(0x81));
-        assertFunction("CAST(TRIM(CONCAT(' ', utf8(from_hex('81')), ' '), ' ') AS VARBINARY)", VARBINARY, varbinary(0x81));
-        assertInvalidFunction("TRIM('hello world', utf8(from_hex('81')))", "Invalid UTF-8 encoding in characters: �");
-        assertInvalidFunction("TRIM('hello world', utf8(from_hex('3281')))", "Invalid UTF-8 encoding in characters: 2�");
-    }
-
-    @Test
-    public void testCharTrimParametrized()
-    {
-        assertFunction("TRIM(CAST('' AS CHAR(1)), '')", createVarcharType(1), "");
-        assertFunction("TRIM(CAST('   ' AS CHAR(3)), '')", createVarcharType(3), "");
-        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)), '')", createVarcharType(9), "  hello");
-        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)), ' ')", createVarcharType(9), "hello");
-        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)), 'he ')", createVarcharType(9), "llo");
-        assertFunction("TRIM(CAST('  hello' AS CHAR(7)), ' ')", createVarcharType(7), "hello");
-        assertFunction("TRIM(CAST('  hello' AS CHAR(7)), 'e h')", createVarcharType(7), "llo");
-        assertFunction("TRIM(CAST('hello  ' AS CHAR(7)), 'l')", createVarcharType(7), "hello");
-        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' ')", createVarcharType(13), "hello world");
-        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' eh')", createVarcharType(13), "llo world");
-        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' ehlowrd')", createVarcharType(13), "");
-        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' x')", createVarcharType(13), "hello world");
-        assertFunction("TRIM(CAST('abc def' AS CHAR(7)), 'def')", createVarcharType(7), "abc");
-
-        // non latin characters
-        assertFunction("TRIM(CAST('\u017a\u00f3\u0142\u0107' AS CHAR(4)), '\u017a\u0107\u0142')", createVarcharType(4), "\u00f3");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestConnectorExpressionTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestConnectorExpressionTranslator.java
@@ -25,9 +25,11 @@ import io.trino.spi.expression.FunctionName;
 import io.trino.spi.expression.StandardFunctions;
 import io.trino.spi.expression.Variable;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
 import io.trino.sql.tree.ArithmeticBinaryExpression;
 import io.trino.sql.tree.ArithmeticUnaryExpression;
 import io.trino.sql.tree.BetweenPredicate;
+import io.trino.sql.tree.Cast;
 import io.trino.sql.tree.ComparisonExpression;
 import io.trino.sql.tree.DoubleLiteral;
 import io.trino.sql.tree.Expression;
@@ -55,6 +57,7 @@ import java.util.stream.Stream;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.expression.StandardFunctions.AND_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.CAST_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.GREATER_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.IS_NULL_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.LESS_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME;
@@ -73,6 +76,7 @@ import static io.trino.spi.type.RowType.rowType;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.createVarcharType;
+import static io.trino.sql.analyzer.TypeSignatureTranslator.toSqlType;
 import static io.trino.sql.planner.ConnectorExpressionTranslator.translate;
 import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
 import static io.trino.sql.planner.TypeAnalyzer.createTestingTypeAnalyzer;
@@ -86,7 +90,7 @@ public class TestConnectorExpressionTranslator
     private static final Session TEST_SESSION = TestingSession.testSessionBuilder().build();
     private static final TypeAnalyzer TYPE_ANALYZER = createTestingTypeAnalyzer(PLANNER_CONTEXT);
     private static final Type ROW_TYPE = rowType(field("int_symbol_1", INTEGER), field("varchar_symbol_1", createVarcharType(5)));
-    private static final Type VARCHAR_TYPE = createVarcharType(25);
+    private static final VarcharType VARCHAR_TYPE = createVarcharType(25);
     private static final LiteralEncoder LITERAL_ENCODER = new LiteralEncoder(PLANNER_CONTEXT);
 
     private static final Map<Symbol, Type> symbols = ImmutableMap.<Symbol, Type>builder()
@@ -328,6 +332,37 @@ public class TestConnectorExpressionTranslator
                         NULLIF_FUNCTION_NAME,
                         List.of(new Variable("varchar_symbol_1", VARCHAR_TYPE),
                                 new Variable("varchar_symbol_1", VARCHAR_TYPE))));
+    }
+
+    @Test
+    public void testTranslateCast()
+    {
+        assertTranslationRoundTrips(
+                new Cast(new SymbolReference("varchar_symbol_1"), toSqlType(VARCHAR_TYPE)),
+                new Call(
+                        VARCHAR_TYPE,
+                        CAST_FUNCTION_NAME,
+                        List.of(new Variable("varchar_symbol_1", VARCHAR_TYPE))));
+
+        // type-only
+        VarcharType longerVarchar = createVarcharType(VARCHAR_TYPE.getBoundedLength() + 1);
+        assertTranslationToConnectorExpression(
+                TEST_SESSION,
+                new Cast(new SymbolReference("varchar_symbol_1"), toSqlType(longerVarchar), false, true),
+                new Call(
+                        longerVarchar,
+                        CAST_FUNCTION_NAME,
+                        List.of(new Variable("varchar_symbol_1", VARCHAR_TYPE))));
+
+        // TRY_CAST is not translated
+        assertTranslationToConnectorExpression(
+                TEST_SESSION,
+                new Cast(
+                        new SymbolReference("varchar_symbol_1"),
+                        toSqlType(BIGINT),
+                        true,
+                        true),
+                Optional.empty());
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
@@ -16,6 +16,7 @@ package io.trino.sql.query;
 import com.google.common.collect.ImmutableList;
 import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
+import io.trino.metadata.FunctionBundle;
 import io.trino.spi.type.SqlTime;
 import io.trino.spi.type.SqlTimeWithTimeZone;
 import io.trino.spi.type.SqlTimestamp;
@@ -93,6 +94,11 @@ public class QueryAssertions
     public Session getDefaultSession()
     {
         return runner.getDefaultSession();
+    }
+
+    public void addFunctions(FunctionBundle functionBundle)
+    {
+        runner.addFunctions(functionBundle);
     }
 
     public AssertProvider<QueryAssert> query(@Language("SQL") String query)

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestTrim.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestTrim.java
@@ -1,0 +1,339 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import io.trino.metadata.InternalFunctionBundle;
+import io.trino.operator.scalar.TestStringFunctions;
+import io.trino.spi.TrinoException;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+public class TestTrim
+{
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    public void init()
+    {
+        assertions = new QueryAssertions();
+        assertions.addFunctions(InternalFunctionBundle.builder()
+                .scalars(TestStringFunctions.class) // To use utf8 function
+                .build());
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testLeftTrim()
+    {
+        assertFunction("TRIM(LEADING FROM '')", "CAST('' AS VARCHAR(0))");
+        assertFunction("TRIM(LEADING FROM '   ')", "CAST('' AS VARCHAR(3))");
+        assertFunction("TRIM(LEADING FROM '  hello  ')", "CAST('hello  ' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING FROM '  hello')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(LEADING FROM 'hello  ')", "CAST('hello  ' AS VARCHAR(7))");
+        assertFunction("TRIM(LEADING FROM ' hello world ')", "CAST('hello world ' AS VARCHAR(13))");
+
+        assertFunction("TRIM(LEADING FROM '\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING FROM ' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B ' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING FROM '  \u4FE1\u5FF5 \u7231 \u5E0C\u671B')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING FROM ' \u2028 \u4FE1\u5FF5 \u7231 \u5E0C\u671B')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(10))");
+    }
+
+    @Test
+    public void testCharLeftTrim()
+    {
+        assertFunction("TRIM(LEADING FROM CAST('' AS CHAR(20)))", "CAST('' AS VARCHAR(20))");
+        assertFunction("TRIM(LEADING FROM CAST('' AS CHAR(20)))", "CAST('' AS VARCHAR(20))");
+        assertFunction("TRIM(LEADING FROM CAST('  hello  ' AS CHAR(9)))", "CAST('hello' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING FROM CAST('  hello' AS CHAR(7)))", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(LEADING FROM CAST('hello  ' AS CHAR(7)))", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(LEADING FROM CAST(' hello world ' AS CHAR(13)))", "CAST('hello world' AS VARCHAR(13))");
+
+        assertFunction("TRIM(LEADING FROM CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ' AS CHAR(9)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING FROM CAST(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ' AS CHAR(9)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING FROM CAST('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(9)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING FROM CAST(' \u2028 \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(10)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(10))");
+    }
+
+    @Test
+    public void testRightTrim()
+    {
+        assertFunction("TRIM(TRAILING FROM '')", "CAST('' AS VARCHAR(0))");
+        assertFunction("TRIM(TRAILING FROM '   ')", "CAST('' AS VARCHAR(3))");
+        assertFunction("TRIM(TRAILING FROM '  hello  ')", "CAST('  hello' AS VARCHAR(9))");
+        assertFunction("TRIM(TRAILING FROM '  hello')", "CAST('  hello' AS VARCHAR(7))");
+        assertFunction("TRIM(TRAILING FROM 'hello  ')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(TRAILING FROM ' hello world ')", "CAST(' hello world' AS VARCHAR(13))");
+
+        assertFunction("TRIM(TRAILING FROM '\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 ')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(10))");
+        assertFunction("TRIM(TRAILING FROM '\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(TRAILING FROM ' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ')", "CAST(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(TRAILING FROM '  \u4FE1\u5FF5 \u7231 \u5E0C\u671B')", "CAST('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+    }
+
+    @Test
+    public void testCharRightTrim()
+    {
+        assertFunction("TRIM(TRAILING FROM CAST('' AS CHAR(20)))", "CAST('' AS VARCHAR(20))");
+        assertFunction("TRIM(TRAILING FROM CAST('  hello  ' AS CHAR(9)))", "CAST('  hello' AS VARCHAR(9))");
+        assertFunction("TRIM(TRAILING FROM CAST('  hello' AS CHAR(7)))", "CAST('  hello' AS VARCHAR(7))");
+        assertFunction("TRIM(TRAILING FROM CAST('hello  ' AS CHAR(7)))", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(TRAILING FROM CAST(' hello world ' AS CHAR(13)))", "CAST(' hello world' AS VARCHAR(13))");
+
+        assertFunction("TRIM(TRAILING FROM CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 ' AS CHAR(10)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(10))");
+        assertFunction("TRIM(TRAILING FROM CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ' AS CHAR(9)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(TRAILING FROM CAST(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ' AS CHAR(9)))", "CAST(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(TRAILING FROM CAST('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(9)))", "CAST('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+    }
+
+    @Test
+    public void testLeftTrimParametrized()
+    {
+        assertFunction("TRIM(LEADING '' FROM '')", "CAST('' AS VARCHAR(0))");
+        assertFunction("TRIM(LEADING '' FROM '   ')", "CAST('   ' AS VARCHAR(3))");
+        assertFunction("TRIM(LEADING '' FROM '  hello  ')", "CAST('  hello  ' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING ' ' FROM '  hello  ')", "CAST('hello  ' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING CHAR ' ' FROM '  hello  ')", "CAST('hello  ' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING 'he ' FROM '  hello  ')", "CAST('llo  ' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING ' ' FROM '  hello')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(LEADING 'e h' FROM '  hello')", "CAST('llo' AS VARCHAR(7))");
+        assertFunction("TRIM(LEADING 'l' FROM 'hello  ')", "CAST('hello  ' AS VARCHAR(7))");
+        assertFunction("TRIM(LEADING ' ' FROM ' hello world ')", "CAST('hello world ' AS VARCHAR(13))");
+        assertFunction("TRIM(LEADING ' eh' FROM ' hello world ')", "CAST('llo world ' AS VARCHAR(13))");
+        assertFunction("TRIM(LEADING ' ehlowrd' FROM ' hello world ')", "CAST('' AS VARCHAR(13))");
+        assertFunction("TRIM(LEADING ' x' FROM ' hello world ')", "CAST('hello world ' AS VARCHAR(13))");
+
+        // non latin characters
+        assertFunction("TRIM(LEADING '\u00f3\u017a' FROM '\u017a\u00f3\u0142\u0107')", "CAST('\u0142\u0107' AS VARCHAR(4))");
+
+        // invalid utf-8 characters
+        assertInvalidFunction("TRIM(LEADING utf8(from_hex('3281')) FROM 'hello wolrd')", "Invalid UTF-8 encoding in characters: 2�");
+    }
+
+    @Test
+    public void testCharLeftTrimParametrized()
+    {
+        assertFunction("TRIM(LEADING '' FROM CAST('' AS CHAR(1)))", "CAST('' AS VARCHAR(1))");
+        assertFunction("TRIM(LEADING '' FROM CAST('   ' AS CHAR(3)))", "CAST('' AS VARCHAR(3))");
+        assertFunction("TRIM(LEADING '' FROM CAST('  hello  ' AS CHAR(9)))", "CAST('  hello' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING ' ' FROM CAST('  hello  ' AS CHAR(9)))", "CAST('hello' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING 'he ' FROM CAST('  hello  ' AS CHAR(9)))", "CAST('llo' AS VARCHAR(9))");
+        assertFunction("TRIM(LEADING ' ' FROM CAST('  hello' AS CHAR(7)))", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(LEADING 'e h' FROM CAST('  hello' AS CHAR(7)))", "CAST('llo' AS VARCHAR(7))");
+        assertFunction("TRIM(LEADING 'l' FROM CAST('hello  ' AS CHAR(7)))", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(LEADING ' ' FROM CAST(' hello world ' AS CHAR(13)))", "CAST('hello world' AS VARCHAR(13))");
+        assertFunction("TRIM(LEADING ' eh' FROM CAST(' hello world ' AS CHAR(13)))", "CAST('llo world' AS VARCHAR(13))");
+        assertFunction("TRIM(LEADING ' ehlowrd' FROM CAST(' hello world ' AS CHAR(13)))", "CAST('' AS VARCHAR(13))");
+        assertFunction("TRIM(LEADING ' x' FROM CAST(' hello world ' AS CHAR(13)))", "CAST('hello world' AS VARCHAR(13))");
+
+        // non latin characters
+        assertFunction("TRIM(LEADING '\u00f3\u017a' FROM CAST('\u017a\u00f3\u0142\u0107' AS CHAR(4)))", "CAST('\u0142\u0107' AS VARCHAR(4))");
+    }
+
+    @Test
+    public void testRightTrimParametrized()
+    {
+        assertFunction("TRIM(TRAILING '' FROM '')", "CAST('' AS VARCHAR(0))");
+        assertFunction("TRIM(TRAILING '' FROM '   ')", "CAST('   ' AS VARCHAR(3))");
+        assertFunction("TRIM(TRAILING '' FROM '  hello  ')", "CAST('  hello  ' AS VARCHAR(9))");
+        assertFunction("TRIM(TRAILING ' ' FROM '  hello  ')", "CAST('  hello' AS VARCHAR(9))");
+        assertFunction("TRIM(TRAILING 'lo ' FROM '  hello  ')", "CAST('  he' AS VARCHAR(9))");
+        assertFunction("TRIM(TRAILING ' ' FROM 'hello  ')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(TRAILING 'l o' FROM 'hello  ')", "CAST('he' AS VARCHAR(7))");
+        assertFunction("TRIM(TRAILING 'l' FROM 'hello  ')", "CAST('hello  ' AS VARCHAR(7))");
+        assertFunction("TRIM(TRAILING ' ' FROM ' hello world ')", "CAST(' hello world' AS VARCHAR(13))");
+        assertFunction("TRIM(TRAILING ' ld' FROM ' hello world ')", "CAST(' hello wor' AS VARCHAR(13))");
+        assertFunction("TRIM(TRAILING ' ehlowrd' FROM ' hello world ')", "CAST('' AS VARCHAR(13))");
+        assertFunction("TRIM(TRAILING ' x' FROM ' hello world ')", "CAST(' hello world' AS VARCHAR(13))");
+        assertFunction("TRIM(TRAILING 'def' FROM CAST('abc def' AS CHAR(7)))", "CAST('abc' AS VARCHAR(7))");
+
+        // non latin characters
+        assertFunction("TRIM(TRAILING '\u0107\u0142' FROM '\u017a\u00f3\u0142\u0107')", "CAST('\u017a\u00f3' AS VARCHAR(4))");
+
+        // invalid utf-8 characters
+        assertInvalidFunction("TRIM(TRAILING utf8(from_hex('81')) FROM 'hello world')", "Invalid UTF-8 encoding in characters: �");
+        assertInvalidFunction("TRIM(TRAILING utf8(from_hex('3281')) FROM 'hello world')", "Invalid UTF-8 encoding in characters: 2�");
+    }
+
+    @Test
+    public void testTrim()
+    {
+        assertFunction("TRIM('')", "CAST('' AS VARCHAR(0))");
+        assertFunction("TRIM('   ')", "CAST('' AS VARCHAR(3))");
+        assertFunction("TRIM('  hello  ')", "CAST('hello' AS VARCHAR(9))");
+        assertFunction("TRIM('  hello')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM('hello  ')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(' hello world ')", "CAST('hello world' AS VARCHAR(13))");
+        assertFunction("TRIM(BOTH FROM '')", "CAST('' AS VARCHAR(0))");
+        assertFunction("TRIM(BOTH FROM '   ')", "CAST('' AS VARCHAR(3))");
+        assertFunction("TRIM(BOTH FROM '  hello  ')", "CAST('hello' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH FROM '  hello')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(BOTH FROM 'hello  ')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(BOTH FROM ' hello world ')", "CAST('hello world' AS VARCHAR(13))");
+        assertFunction("TRIM(' ' FROM '')", "CAST('' AS VARCHAR(0))");
+        assertFunction("TRIM(' ' FROM '   ')", "CAST('' AS VARCHAR(3))");
+        assertFunction("TRIM(' ' FROM '  hello  ')", "CAST('hello' AS VARCHAR(9))");
+        assertFunction("TRIM(' ' FROM '  hello')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(' ' FROM 'hello  ')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(' ' FROM ' hello world ')", "CAST('hello world' AS VARCHAR(13))");
+
+        assertFunction("TRIM('\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 ')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(10))");
+        assertFunction("TRIM('\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(' \u2028 \u4FE1\u5FF5 \u7231 \u5E0C\u671B')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(10))");
+        assertFunction("TRIM(BOTH FROM '\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 ')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(10))");
+        assertFunction("TRIM(BOTH FROM '\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH FROM ' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH FROM '  \u4FE1\u5FF5 \u7231 \u5E0C\u671B')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH FROM ' \u2028 \u4FE1\u5FF5 \u7231 \u5E0C\u671B')", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(10))");
+    }
+
+    @Test
+    public void testCharTrim()
+    {
+        assertFunction("TRIM(CAST('' AS CHAR(20)))", "CAST('' AS VARCHAR(20))");
+        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)))", "CAST('hello' AS VARCHAR(9))");
+        assertFunction("TRIM(CAST('  hello' AS CHAR(7)))", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(CAST('hello  ' AS CHAR(7)))", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)))", "CAST('hello world' AS VARCHAR(13))");
+        assertFunction("TRIM(BOTH FROM CAST('' AS CHAR(20)))", "CAST('' AS VARCHAR(20))");
+        assertFunction("TRIM(BOTH FROM CAST('  hello  ' AS CHAR(9)))", "CAST('hello' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH FROM CAST('  hello' AS CHAR(7)))", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(BOTH FROM CAST('hello  ' AS CHAR(7)))", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(BOTH FROM CAST(' hello world ' AS CHAR(13)))", "CAST('hello world' AS VARCHAR(13))");
+
+        assertFunction("TRIM(CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 ' AS CHAR(10)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(10))");
+        assertFunction("TRIM(CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ' AS CHAR(9)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(CAST(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ' AS CHAR(9)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(CAST('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(9)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(CAST(' \u2028 \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(10)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(10))");
+        assertFunction("TRIM(BOTH FROM CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 ' AS CHAR(10)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(10))");
+        assertFunction("TRIM(BOTH FROM CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ' AS CHAR(9)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH FROM CAST(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ' AS CHAR(9)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH FROM CAST('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(9)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH FROM CAST(' \u2028 \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(10)))", "CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS VARCHAR(10))");
+    }
+
+    @Test
+    public void testCharTrimParametrized()
+    {
+        assertFunction("TRIM(CAST('' AS CHAR(1)), '')", "CAST('' AS VARCHAR(1))");
+        assertFunction("TRIM(CAST('   ' AS CHAR(3)), '')", "CAST('' AS VARCHAR(3))");
+        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)), '')", "CAST('  hello' AS VARCHAR(9))");
+        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)), ' ')", "CAST('hello' AS VARCHAR(9))");
+        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)), 'he ')", "CAST('llo' AS VARCHAR(9))");
+        assertFunction("TRIM(CAST('  hello' AS CHAR(7)), ' ')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(CAST('  hello' AS CHAR(7)), 'e h')", "CAST('llo' AS VARCHAR(7))");
+        assertFunction("TRIM(CAST('hello  ' AS CHAR(7)), 'l')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' ')", "CAST('hello world' AS VARCHAR(13))");
+        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' eh')", "CAST('llo world' AS VARCHAR(13))");
+        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' ehlowrd')", "CAST('' AS VARCHAR(13))");
+        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' x')", "CAST('hello world' AS VARCHAR(13))");
+        assertFunction("TRIM(CAST('abc def' AS CHAR(7)), 'def')", "CAST('abc' AS VARCHAR(7))");
+        assertFunction("TRIM(BOTH '' FROM CAST('' AS CHAR(1)))", "CAST('' AS VARCHAR(1))");
+        assertFunction("TRIM(BOTH '' FROM CAST('   ' AS CHAR(3)))", "CAST('' AS VARCHAR(3))");
+        assertFunction("TRIM(BOTH '' FROM CAST('  hello  ' AS CHAR(9)))", "CAST('  hello' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH ' ' FROM CAST('  hello  ' AS CHAR(9)))", "CAST('hello' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH 'he ' FROM CAST('  hello  ' AS CHAR(9)))", "CAST('llo' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH ' ' FROM CAST('  hello' AS CHAR(7)))", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(BOTH 'e h' FROM CAST('  hello' AS CHAR(7)))", "CAST('llo' AS VARCHAR(7))");
+        assertFunction("TRIM(BOTH 'l' FROM CAST('hello  ' AS CHAR(7)))", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(BOTH ' ' FROM CAST(' hello world ' AS CHAR(13)))", "CAST('hello world' AS VARCHAR(13))");
+        assertFunction("TRIM(BOTH ' eh' FROM CAST(' hello world ' AS CHAR(13)))", "CAST('llo world' AS VARCHAR(13))");
+        assertFunction("TRIM(BOTH ' ehlowrd' FROM CAST(' hello world ' AS CHAR(13)))", "CAST('' AS VARCHAR(13))");
+        assertFunction("TRIM(BOTH ' x' FROM CAST(' hello world ' AS CHAR(13)))", "CAST('hello world' AS VARCHAR(13))");
+        assertFunction("TRIM(BOTH 'def' FROM CAST('abc def' AS CHAR(7)))", "CAST('abc' AS VARCHAR(7))");
+
+        // non latin characters
+        assertFunction("TRIM(CAST('\u017a\u00f3\u0142\u0107' AS CHAR(4)), '\u017a\u0107\u0142')", "CAST('\u00f3' AS VARCHAR(4))");
+        assertFunction("TRIM(BOTH '\u017a\u0107\u0142' FROM CAST('\u017a\u00f3\u0142\u0107' AS CHAR(4)))", "CAST('\u00f3' AS VARCHAR(4))");
+    }
+
+    @Test
+    public void testTrimParametrized()
+    {
+        assertFunction("TRIM('', '')", "CAST('' AS VARCHAR(0))");
+        assertFunction("TRIM('   ', '')", "CAST('   ' AS VARCHAR(3))");
+        assertFunction("TRIM('  hello  ', '')", "CAST('  hello  ' AS VARCHAR(9))");
+        assertFunction("TRIM('  hello  ', ' ')", "CAST('hello' AS VARCHAR(9))");
+        assertFunction("TRIM('  hello  ', 'he ')", "CAST('llo' AS VARCHAR(9))");
+        assertFunction("TRIM('  hello  ', 'lo ')", "CAST('he' AS VARCHAR(9))");
+        assertFunction("TRIM('  hello', ' ')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM('hello  ', ' ')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM('hello  ', 'l o')", "CAST('he' AS VARCHAR(7))");
+        assertFunction("TRIM('hello  ', 'l')", "CAST('hello  ' AS VARCHAR(7))");
+        assertFunction("TRIM(' hello world ', ' ')", "CAST('hello world' AS VARCHAR(13))");
+        assertFunction("TRIM(' hello world ', ' ld')", "CAST('hello wor' AS VARCHAR(13))");
+        assertFunction("TRIM(' hello world ', ' eh')", "CAST('llo world' AS VARCHAR(13))");
+        assertFunction("TRIM(' hello world ', ' ehlowrd')", "CAST('' AS VARCHAR(13))");
+        assertFunction("TRIM(' hello world ', ' x')", "CAST('hello world' AS VARCHAR(13))");
+        assertFunction("TRIM(BOTH '' FROM '')", "CAST('' AS VARCHAR(0))");
+        assertFunction("TRIM(BOTH '' FROM '   ')", "CAST('   ' AS VARCHAR(3))");
+        assertFunction("TRIM(BOTH '' FROM '  hello  ')", "CAST('  hello  ' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH ' ' FROM '  hello  ')", "CAST('hello' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH 'he ' FROM '  hello  ')", "CAST('llo' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH 'lo ' FROM '  hello  ')", "CAST('he' AS VARCHAR(9))");
+        assertFunction("TRIM(BOTH ' ' FROM '  hello')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(BOTH ' ' FROM 'hello  ')", "CAST('hello' AS VARCHAR(7))");
+        assertFunction("TRIM(BOTH 'l o' FROM 'hello  ')", "CAST('he' AS VARCHAR(7))");
+        assertFunction("TRIM(BOTH 'l' FROM 'hello  ')", "CAST('hello  ' AS VARCHAR(7))");
+        assertFunction("TRIM(BOTH ' ' FROM ' hello world ')", "CAST('hello world' AS VARCHAR(13))");
+        assertFunction("TRIM(BOTH ' ld' FROM ' hello world ')", "CAST('hello wor' AS VARCHAR(13))");
+        assertFunction("TRIM(BOTH ' eh' FROM ' hello world ')", "CAST('llo world' AS VARCHAR(13))");
+        assertFunction("TRIM(BOTH ' ehlowrd' FROM ' hello world ')", "CAST('' AS VARCHAR(13))");
+        assertFunction("TRIM(BOTH ' x' FROM ' hello world ')", "CAST('hello world' AS VARCHAR(13))");
+
+        // non latin characters
+        assertFunction("TRIM('\u017a\u00f3\u0142\u0107', '\u0107\u017a')", "CAST('\u00f3\u0142' AS VARCHAR(4))");
+        assertFunction("TRIM(BOTH '\u0107\u017a' FROM '\u017a\u00f3\u0142\u0107')", "CAST('\u00f3\u0142' AS VARCHAR(4))");
+
+        // invalid utf-8 characters
+        assertFunction("CAST(TRIM(utf8(from_hex('81')), ' ') AS VARBINARY)", "x'81'");
+        assertFunction("CAST(TRIM(CONCAT(utf8(from_hex('81')), ' '), ' ') AS VARBINARY)", "x'81'");
+        assertFunction("CAST(TRIM(CONCAT(' ', utf8(from_hex('81'))), ' ') AS VARBINARY)", "x'81'");
+        assertFunction("CAST(TRIM(CONCAT(' ', utf8(from_hex('81')), ' '), ' ') AS VARBINARY)", "x'81'");
+        assertInvalidFunction("TRIM('hello world', utf8(from_hex('81')))", "Invalid UTF-8 encoding in characters: �");
+        assertInvalidFunction("TRIM('hello world', utf8(from_hex('3281')))", "Invalid UTF-8 encoding in characters: 2�");
+        assertInvalidFunction("TRIM(BOTH utf8(from_hex('3281')) FROM 'hello world')", "Invalid UTF-8 encoding in characters: 2�");
+    }
+
+    private void assertFunction(@Language("SQL") String actual, @Language("SQL") String expected)
+    {
+        assertThat(assertions.query("SELECT " + actual)).matches("SELECT " + expected);
+    }
+
+    private void assertInvalidFunction(@Language("SQL") String actual, String message)
+    {
+        assertThatThrownBy(() -> assertions.query("SELECT " + actual))
+                .isInstanceOf(TrinoException.class)
+                .hasMessage(message)
+                .extracting(e -> ((TrinoException) e).getErrorCode().getCode())
+                .isEqualTo(INVALID_FUNCTION_ARGUMENT.toErrorCode().getCode());
+    }
+}

--- a/core/trino-parser/pom.xml
+++ b/core/trino-parser/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/trino-parser/pom.xml
+++ b/core/trino-parser/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4
+++ b/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4
@@ -328,6 +328,12 @@ sampleType
     | SYSTEM
     ;
 
+trimsSpecification
+    : LEADING
+    | TRAILING
+    | BOTH
+    ;
+
 listAggOverflowBehavior
     : ERROR
     | TRUNCATE string? listaggCountIndication
@@ -477,6 +483,9 @@ primaryExpression
     | name=CURRENT_CATALOG                                                                #currentCatalog
     | name=CURRENT_SCHEMA                                                                 #currentSchema
     | name=CURRENT_PATH                                                                   #currentPath
+    | TRIM '(' (trimsSpecification? trimChar=valueExpression? FROM)?
+        trimSource=valueExpression ')'                                                    #trim
+    | TRIM '(' trimSource=valueExpression ',' trimChar=valueExpression ')'                #trim
     | SUBSTRING '(' valueExpression FROM valueExpression (FOR valueExpression)? ')'       #substring
     | NORMALIZE '(' valueExpression (',' normalForm)? ')'                                 #normalize
     | EXTRACT '(' identifier FROM valueExpression ')'                                     #extract
@@ -707,7 +716,7 @@ number
 nonReserved
     // IMPORTANT: this rule must only contain tokens. Nested rules are not supported. See SqlParser.exitNonReserved
     : ADD | ADMIN | AFTER | ALL | ANALYZE | ANY | ARRAY | ASC | AT | AUTHORIZATION
-    | BERNOULLI
+    | BERNOULLI | BOTH
     | CALL | CASCADE | CATALOGS | COLUMN | COLUMNS | COMMENT | COMMIT | COMMITTED | COUNT | CURRENT
     | DATA | DATE | DAY | DEFAULT | DEFINE | DEFINER | DESC | DISTRIBUTED | DOUBLE
     | EMPTY | ERROR | EXCLUDING | EXPLAIN
@@ -716,7 +725,7 @@ nonReserved
     | HOUR
     | IF | IGNORE | INCLUDING | INITIAL | INPUT | INTERVAL | INVOKER | IO | ISOLATION
     | JSON
-    | LAST | LATERAL | LEVEL | LIMIT | LOCAL | LOGICAL
+    | LAST | LATERAL | LEADING | LEVEL | LIMIT | LOCAL | LOGICAL
     | MAP | MATCH | MATCHED | MATCHES | MATCH_RECOGNIZE | MATERIALIZED | MEASURES | MERGE | MINUTE | MONTH
     | NEXT | NFC | NFD | NFKC | NFKD | NO | NONE | NULLIF | NULLS
     | OF | OFFSET | OMIT | ONE | ONLY | OPTION | ORDINALITY | OUTPUT | OVER | OVERFLOW
@@ -724,7 +733,7 @@ nonReserved
     | RANGE | READ | REFRESH | RENAME | REPEATABLE | REPLACE | RESET | RESPECT | RESTRICT | REVOKE | ROLE | ROLES | ROLLBACK | ROW | ROWS | RUNNING
     | SCHEMA | SCHEMAS | SECOND | SECURITY | SEEK | SERIALIZABLE | SESSION | SET | SETS
     | SHOW | SOME | START | STATS | SUBSET | SUBSTRING | SYSTEM
-    | TABLES | TABLESAMPLE | TEXT | TIES | TIME | TIMESTAMP | TO | TRANSACTION | TRUNCATE | TRY_CAST | TYPE
+    | TABLES | TABLESAMPLE | TEXT | TIES | TIME | TIMESTAMP | TO | TRAILING | TRANSACTION | TRUNCATE | TRY_CAST | TYPE
     | UNBOUNDED | UNCOMMITTED | UNMATCHED | UPDATE | USE | USER
     | VALIDATE | VERBOSE | VERSION | VIEW
     | WINDOW | WITHIN | WITHOUT | WORK | WRITE
@@ -747,6 +756,7 @@ AT: 'AT';
 AUTHORIZATION: 'AUTHORIZATION';
 BERNOULLI: 'BERNOULLI';
 BETWEEN: 'BETWEEN';
+BOTH: 'BOTH';
 BY: 'BY';
 CALL: 'CALL';
 CASCADE: 'CASCADE';
@@ -837,6 +847,7 @@ JOIN: 'JOIN';
 JSON: 'JSON';
 LAST: 'LAST';
 LATERAL: 'LATERAL';
+LEADING: 'LEADING';
 LEFT: 'LEFT';
 LEVEL: 'LEVEL';
 LIKE: 'LIKE';
@@ -941,7 +952,9 @@ TIES: 'TIES';
 TIME: 'TIME';
 TIMESTAMP: 'TIMESTAMP';
 TO: 'TO';
+TRAILING: 'TRAILING';
 TRANSACTION: 'TRANSACTION';
+TRIM: 'TRIM';
 TRUE: 'TRUE';
 TRUNCATE: 'TRUNCATE';
 TRY_CAST: 'TRY_CAST';

--- a/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
@@ -90,6 +90,7 @@ import io.trino.sql.tree.SubscriptExpression;
 import io.trino.sql.tree.SymbolReference;
 import io.trino.sql.tree.TimeLiteral;
 import io.trino.sql.tree.TimestampLiteral;
+import io.trino.sql.tree.Trim;
 import io.trino.sql.tree.TryExpression;
 import io.trino.sql.tree.TypeParameter;
 import io.trino.sql.tree.WhenClause;
@@ -189,6 +190,16 @@ public final class ExpressionFormatter
         protected String visitCurrentPath(CurrentPath node, Void context)
         {
             return "CURRENT_PATH";
+        }
+
+        @Override
+        protected String visitTrim(Trim node, Void context)
+        {
+            if (!node.getTrimCharacter().isPresent()) {
+                return format("trim(%s FROM %s)", node.getSpecification(), process(node.getTrimSource(), context));
+            }
+
+            return format("trim(%s %s FROM %s)", node.getSpecification(), process(node.getTrimCharacter().get(), context), process(node.getTrimSource(), context));
         }
 
         @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
@@ -352,6 +352,11 @@ public abstract class AstVisitor<R, C>
         return visitExpression(node, context);
     }
 
+    protected R visitTrim(Trim node, C context)
+    {
+        return visitExpression(node, context);
+    }
+
     protected R visitNullIfExpression(NullIfExpression node, C context)
     {
         return visitExpression(node, context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
@@ -97,6 +97,15 @@ public abstract class DefaultTraversalVisitor<C>
     }
 
     @Override
+    protected Void visitTrim(Trim node, C context)
+    {
+        process(node.getTrimSource(), context);
+        node.getTrimCharacter().ifPresent(trimChar -> process(trimChar, context));
+
+        return null;
+    }
+
+    @Override
     protected Void visitFormat(Format node, C context)
     {
         for (Expression argument : node.getArguments()) {

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionRewriter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionRewriter.java
@@ -210,6 +210,11 @@ public class ExpressionRewriter<C>
         return rewriteExpression(node, context, treeRewriter);
     }
 
+    public Expression rewriteTrim(Trim node, C context, ExpressionTreeRewriter<C> treeRewriter)
+    {
+        return rewriteExpression(node, context, treeRewriter);
+    }
+
     public Expression rewriteFormat(Format node, C context, ExpressionTreeRewriter<C> treeRewriter)
     {
         return rewriteExpression(node, context, treeRewriter);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Trim.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Trim.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class Trim
+        extends Expression
+{
+    private final Specification specification;
+    private final Expression trimSource;
+    private final Optional<Expression> trimCharacter;
+
+    public Trim(Specification specification, Expression trimSource, Optional<Expression> trimCharacter)
+    {
+        this(Optional.empty(), specification, trimSource, trimCharacter);
+    }
+
+    public Trim(NodeLocation location, Specification specification, Expression trimSource, Optional<Expression> trimCharacter)
+    {
+        this(Optional.of(location), specification, trimSource, trimCharacter);
+    }
+
+    private Trim(Optional<NodeLocation> location, Specification specification, Expression trimSource, Optional<Expression> trimCharacter)
+    {
+        super(location);
+        this.specification = requireNonNull(specification, "specification is null");
+        this.trimSource = requireNonNull(trimSource, "trimSource is null");
+        this.trimCharacter = requireNonNull(trimCharacter, "trimCharacter is null");
+    }
+
+    public Specification getSpecification()
+    {
+        return specification;
+    }
+
+    public Expression getTrimSource()
+    {
+        return trimSource;
+    }
+
+    public Optional<Expression> getTrimCharacter()
+    {
+        return trimCharacter;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitTrim(this, context);
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        ImmutableList.Builder<Node> nodes = ImmutableList.builder();
+        nodes.add(trimSource);
+        trimCharacter.ifPresent(nodes::add);
+        return nodes.build();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Trim that = (Trim) o;
+        return specification == that.specification &&
+                Objects.equals(trimSource, that.trimSource) &&
+                Objects.equals(trimCharacter, that.trimCharacter);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(specification, trimSource, trimCharacter);
+    }
+
+    @Override
+    public boolean shallowEquals(Node other)
+    {
+        if (!sameClass(this, other)) {
+            return false;
+        }
+
+        Trim otherTrim = (Trim) other;
+        return specification == otherTrim.specification;
+    }
+
+    public enum Specification
+    {
+        BOTH("trim"),
+        LEADING("ltrim"),
+        TRAILING("rtrim");
+
+        private final String functionName;
+
+        Specification(String functionName)
+        {
+            this.functionName = requireNonNull(functionName, "functionName is null");
+        }
+
+        public String getFunctionName()
+        {
+            return functionName;
+        }
+    }
+}

--- a/core/trino-server-main/pom.xml
+++ b/core/trino-server-main/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/trino-server-main/pom.xml
+++ b/core/trino-server-main/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/trino-server-rpm/pom.xml
+++ b/core/trino-server-rpm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/trino-server-rpm/pom.xml
+++ b/core/trino-server-rpm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/trino-server/pom.xml
+++ b/core/trino-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/trino-server/pom.xml
+++ b/core/trino-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/trino-spi/src/main/java/io/trino/spi/expression/StandardFunctions.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/expression/StandardFunctions.java
@@ -38,6 +38,11 @@ public final class StandardFunctions
      */
     public static final FunctionName NULLIF_FUNCTION_NAME = new FunctionName("$nullif");
 
+    /**
+     * $cast function result type is determined by the {@link Call#getType()}
+     */
+    public static final FunctionName CAST_FUNCTION_NAME = new FunctionName("$cast");
+
     public static final FunctionName EQUAL_OPERATOR_FUNCTION_NAME = new FunctionName("$equal");
     public static final FunctionName NOT_EQUAL_OPERATOR_FUNCTION_NAME = new FunctionName("$not_equal");
     public static final FunctionName LESS_THAN_OPERATOR_FUNCTION_NAME = new FunctionName("$less_than");

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
     </parent>
 
     <artifactId>trino-docs</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
     </parent>
 
     <artifactId>trino-docs</artifactId>

--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
@@ -132,7 +132,7 @@ queries/tasks are no longer retried in the event of repeated failures:
    * - ``task-retry-attempts-per-task``
      - Maximum number of times Trino may attempt to retry a single task before
        declaring the query as failed.
-     - ``2``
+     - ``4``
      - Only ``TASK``
    * - ``retry-initial-delay``
      - Minimum time that a failed query must wait before it is retried. May be

--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -788,7 +788,12 @@ for the data files and partition the storage per day using the column
 Updating the data in the materialized view with
 :doc:`/sql/refresh-materialized-view` deletes the data from the storage table,
 and inserts the data that is the result of executing the materialized view
-query into the existing table.
+query into the existing table. Refreshing the materialized view will also store
+the snapshot-ids of all the tables that are part of the materialized
+view's query at that point in materialized view metadata. When the materialized 
+view is queried, the snapshot-ids are used to check if the data in the storage 
+table is up to date. If the data is outdated, the materialized view will behave 
+like a normal view and query the data directly from the base tables.
 
 .. warning::
 

--- a/docs/src/main/sphinx/language/reserved.rst
+++ b/docs/src/main/sphinx/language/reserved.rst
@@ -75,6 +75,7 @@ Keyword                        SQL:2016      SQL-92
 ``SKIP``                       reserved
 ``TABLE``                      reserved      reserved
 ``THEN``                       reserved      reserved
+``TRIM``                       reserved      reserved
 ``TRUE``                       reserved      reserved
 ``UESCAPE``                    reserved
 ``UNION``                      reserved      reserved

--- a/lib/trino-array/pom.xml
+++ b/lib/trino-array/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-array/pom.xml
+++ b/lib/trino-array/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-collect/pom.xml
+++ b/lib/trino-collect/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-collect/pom.xml
+++ b/lib/trino-collect/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-geospatial-toolkit/pom.xml
+++ b/lib/trino-geospatial-toolkit/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-geospatial-toolkit/pom.xml
+++ b/lib/trino-geospatial-toolkit/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-matching/pom.xml
+++ b/lib/trino-matching/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-matching/pom.xml
+++ b/lib/trino-matching/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-memory-context/pom.xml
+++ b/lib/trino-memory-context/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-memory-context/pom.xml
+++ b/lib/trino-memory-context/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-orc/pom.xml
+++ b/lib/trino-orc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-orc/pom.xml
+++ b/lib/trino-orc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-parquet/pom.xml
+++ b/lib/trino-parquet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-parquet/pom.xml
+++ b/lib/trino-parquet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-plugin-toolkit/pom.xml
+++ b/lib/trino-plugin-toolkit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-plugin-toolkit/pom.xml
+++ b/lib/trino-plugin-toolkit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-rcfile/pom.xml
+++ b/lib/trino-rcfile/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-rcfile/pom.xml
+++ b/lib/trino-rcfile/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-record-decoder/pom.xml
+++ b/lib/trino-record-decoder/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-record-decoder/pom.xml
+++ b/lib/trino-record-decoder/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-accumulo-iterators/pom.xml
+++ b/plugin/trino-accumulo-iterators/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-accumulo-iterators/pom.xml
+++ b/plugin/trino-accumulo-iterators/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-accumulo/pom.xml
+++ b/plugin/trino-accumulo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-accumulo/pom.xml
+++ b/plugin/trino-accumulo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-atop/pom.xml
+++ b/plugin/trino-atop/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-atop/pom.xml
+++ b/plugin/trino-atop/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-base-jdbc/pom.xml
+++ b/plugin/trino-base-jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-base-jdbc/pom.xml
+++ b/plugin/trino-base-jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-bigquery/pom.xml
+++ b/plugin/trino-bigquery/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-bigquery/pom.xml
+++ b/plugin/trino-bigquery/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-blackhole/pom.xml
+++ b/plugin/trino-blackhole/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-blackhole/pom.xml
+++ b/plugin/trino-blackhole/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-cassandra/pom.xml
+++ b/plugin/trino-cassandra/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-cassandra/pom.xml
+++ b/plugin/trino-cassandra/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-clickhouse/pom.xml
+++ b/plugin/trino-clickhouse/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-clickhouse/pom.xml
+++ b/plugin/trino-clickhouse/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-delta-lake/pom.xml
+++ b/plugin/trino-delta-lake/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-delta-lake/pom.xml
+++ b/plugin/trino-delta-lake/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-druid/pom.xml
+++ b/plugin/trino-druid/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-druid/pom.xml
+++ b/plugin/trino-druid/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-elasticsearch/pom.xml
+++ b/plugin/trino-elasticsearch/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-elasticsearch/pom.xml
+++ b/plugin/trino-elasticsearch/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-example-http/pom.xml
+++ b/plugin/trino-example-http/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-example-http/pom.xml
+++ b/plugin/trino-example-http/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-exchange/pom.xml
+++ b/plugin/trino-exchange/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-exchange/pom.xml
+++ b/plugin/trino-exchange/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-geospatial/pom.xml
+++ b/plugin/trino-geospatial/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-geospatial/pom.xml
+++ b/plugin/trino-geospatial/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-google-sheets/pom.xml
+++ b/plugin/trino-google-sheets/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-google-sheets/pom.xml
+++ b/plugin/trino-google-sheets/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-hive-hadoop2/pom.xml
+++ b/plugin/trino-hive-hadoop2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-hive-hadoop2/pom.xml
+++ b/plugin/trino-hive-hadoop2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-hive/pom.xml
+++ b/plugin/trino-hive/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-hive/pom.xml
+++ b/plugin/trino-hive/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveNodePartitioningProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveNodePartitioningProvider.java
@@ -122,7 +122,7 @@ public class HiveNodePartitioningProvider
             ConnectorSession session,
             ConnectorPartitioningHandle partitioningHandle)
     {
-        return value -> ((HiveSplit) value).getBucketNumber()
+        return value -> ((HiveSplit) value).getReadBucketNumber()
                 .orElseThrow(() -> new IllegalArgumentException("Bucket number not set in split"));
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceProvider.java
@@ -177,7 +177,7 @@ public class HivePageSourceProvider
                 hiveSplit.getBucketConversion().map(BucketConversion::getBucketColumnHandles).orElse(ImmutableList.of()),
                 hiveSplit.getTableToPartitionMapping(),
                 path,
-                hiveSplit.getBucketNumber(),
+                hiveSplit.getTableBucketNumber(),
                 hiveSplit.getEstimatedFileSize(),
                 hiveSplit.getFileModifiedTime());
 
@@ -198,7 +198,7 @@ public class HivePageSourceProvider
                 configuration,
                 session,
                 path,
-                hiveSplit.getBucketNumber(),
+                hiveSplit.getTableBucketNumber(),
                 hiveSplit.getStart(),
                 hiveSplit.getLength(),
                 hiveSplit.getEstimatedFileSize(),
@@ -235,7 +235,7 @@ public class HivePageSourceProvider
                         hiveSplit.getStatementId(),
                         source,
                         typeManager,
-                        hiveSplit.getBucketNumber(),
+                        hiveSplit.getTableBucketNumber(),
                         path,
                         originalFile,
                         orcFileWriterFactory.get(),
@@ -259,7 +259,7 @@ public class HivePageSourceProvider
             Configuration configuration,
             ConnectorSession session,
             Path path,
-            OptionalInt bucketNumber,
+            OptionalInt tableBucketNumber,
             long start,
             long length,
             long estimatedFileSize,
@@ -281,8 +281,8 @@ public class HivePageSourceProvider
 
         List<ColumnMapping> regularAndInterimColumnMappings = ColumnMapping.extractRegularAndInterimColumnMappings(columnMappings);
 
-        Optional<BucketAdaptation> bucketAdaptation = createBucketAdaptation(bucketConversion, bucketNumber, regularAndInterimColumnMappings);
-        Optional<BucketValidator> bucketValidator = createBucketValidator(path, bucketValidation, bucketNumber, regularAndInterimColumnMappings);
+        Optional<BucketAdaptation> bucketAdaptation = createBucketAdaptation(bucketConversion, tableBucketNumber, regularAndInterimColumnMappings);
+        Optional<BucketValidator> bucketValidator = createBucketValidator(path, bucketValidation, tableBucketNumber, regularAndInterimColumnMappings);
 
         for (HivePageSourceFactory pageSourceFactory : pageSourceFactories) {
             List<HiveColumnHandle> desiredColumns = toColumnHandles(regularAndInterimColumnMappings, true, typeManager);
@@ -298,7 +298,7 @@ public class HivePageSourceProvider
                     desiredColumns,
                     effectivePredicate,
                     acidInfo,
-                    bucketNumber,
+                    tableBucketNumber,
                     originalFile,
                     transaction);
 
@@ -386,11 +386,11 @@ public class HivePageSourceProvider
 
     private static boolean shouldSkipBucket(HiveTableHandle hiveTable, HiveSplit hiveSplit, DynamicFilter dynamicFilter)
     {
-        if (hiveSplit.getBucketNumber().isEmpty()) {
+        if (hiveSplit.getTableBucketNumber().isEmpty()) {
             return false;
         }
         Optional<HiveBucketFilter> hiveBucketFilter = getHiveBucketFilter(hiveTable, dynamicFilter.getCurrentPredicate());
-        return hiveBucketFilter.map(filter -> !filter.getBucketsToKeep().contains(hiveSplit.getBucketNumber().getAsInt())).orElse(false);
+        return hiveBucketFilter.map(filter -> !filter.getBucketsToKeep().contains(hiveSplit.getTableBucketNumber().getAsInt())).orElse(false);
     }
 
     private static boolean shouldSkipSplit(List<ColumnMapping> columnMappings, DynamicFilter dynamicFilter)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplit.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplit.java
@@ -52,7 +52,8 @@ public class HiveSplit
     private final String database;
     private final String table;
     private final String partitionName;
-    private final OptionalInt bucketNumber;
+    private final OptionalInt readBucketNumber;
+    private final OptionalInt tableBucketNumber;
     private final int statementId;
     private final boolean forceLocalScheduling;
     private final TableToPartitionMapping tableToPartitionMapping;
@@ -76,7 +77,8 @@ public class HiveSplit
             @JsonProperty("schema") Properties schema,
             @JsonProperty("partitionKeys") List<HivePartitionKey> partitionKeys,
             @JsonProperty("addresses") List<HostAddress> addresses,
-            @JsonProperty("bucketNumber") OptionalInt bucketNumber,
+            @JsonProperty("readBucketNumber") OptionalInt readBucketNumber,
+            @JsonProperty("tableBucketNumber") OptionalInt tableBucketNumber,
             @JsonProperty("statementId") int statementId,
             @JsonProperty("forceLocalScheduling") boolean forceLocalScheduling,
             @JsonProperty("tableToPartitionMapping") TableToPartitionMapping tableToPartitionMapping,
@@ -97,7 +99,8 @@ public class HiveSplit
         requireNonNull(schema, "schema is null");
         requireNonNull(partitionKeys, "partitionKeys is null");
         requireNonNull(addresses, "addresses is null");
-        requireNonNull(bucketNumber, "bucketNumber is null");
+        requireNonNull(readBucketNumber, "readBucketNumber is null");
+        requireNonNull(tableBucketNumber, "tableBucketNumber is null");
         requireNonNull(tableToPartitionMapping, "tableToPartitionMapping is null");
         requireNonNull(bucketConversion, "bucketConversion is null");
         requireNonNull(bucketValidation, "bucketValidation is null");
@@ -114,7 +117,8 @@ public class HiveSplit
         this.schema = schema;
         this.partitionKeys = ImmutableList.copyOf(partitionKeys);
         this.addresses = ImmutableList.copyOf(addresses);
-        this.bucketNumber = bucketNumber;
+        this.readBucketNumber = readBucketNumber;
+        this.tableBucketNumber = tableBucketNumber;
         this.statementId = statementId;
         this.forceLocalScheduling = forceLocalScheduling;
         this.tableToPartitionMapping = tableToPartitionMapping;
@@ -194,9 +198,15 @@ public class HiveSplit
     }
 
     @JsonProperty
-    public OptionalInt getBucketNumber()
+    public OptionalInt getReadBucketNumber()
     {
-        return bucketNumber;
+        return readBucketNumber;
+    }
+
+    @JsonProperty
+    public OptionalInt getTableBucketNumber()
+    {
+        return tableBucketNumber;
     }
 
     @JsonProperty
@@ -271,7 +281,8 @@ public class HiveSplit
                 + estimatedSizeOf(database)
                 + estimatedSizeOf(table)
                 + estimatedSizeOf(partitionName)
-                + sizeOf(bucketNumber)
+                + sizeOf(readBucketNumber)
+                + sizeOf(tableBucketNumber)
                 + tableToPartitionMapping.getEstimatedSizeInBytes()
                 + sizeOf(bucketConversion, BucketConversion::getRetainedSizeInBytes)
                 + sizeOf(bucketValidation, BucketValidation::getRetainedSizeInBytes)
@@ -317,7 +328,7 @@ public class HiveSplit
         private final int tableBucketCount;
         private final int partitionBucketCount;
         private final List<HiveColumnHandle> bucketColumnNames;
-        // bucketNumber is needed, but can be found in bucketNumber field of HiveSplit.
+        // tableBucketNumber is needed, but can be found in tableBucketNumber field of HiveSplit.
 
         @JsonCreator
         public BucketConversion(

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitManager.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitManager.java
@@ -219,6 +219,14 @@ public class HiveSplitManager
         // sort partitions
         partitions = Ordering.natural().onResultOf(HivePartition::getPartitionId).reverse().sortedCopy(partitions);
 
+        if (bucketHandle.isPresent()) {
+            if (bucketHandle.get().getReadBucketCount() > bucketHandle.get().getTableBucketCount()) {
+                throw new TrinoException(
+                        GENERIC_INTERNAL_ERROR,
+                        "readBucketCount (%s) is greater than the tableBucketCount (%s) which generally points to an issue in plan generation");
+            }
+        }
+
         Iterable<HivePartitionMetadata> hivePartitions = getPartitionMetadata(session, metastore, table, tableName, partitions, bucketHandle.map(HiveBucketHandle::toTableBucketProperty));
 
         // Only one thread per partition is usable when a table is not transactional

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitSource.java
@@ -299,7 +299,7 @@ class HiveSplitSource
                     databaseName, tableName, succinctBytes(maxOutstandingSplitsBytes), getBufferedInternalSplitCount()));
         }
         bufferedInternalSplitCount.incrementAndGet();
-        OptionalInt bucketNumber = split.getBucketNumber();
+        OptionalInt bucketNumber = split.getReadBucketNumber();
         return queues.offer(bucketNumber, split);
     }
 
@@ -400,7 +400,8 @@ class HiveSplitSource
                         internalSplit.getSchema(),
                         internalSplit.getPartitionKeys(),
                         block.getAddresses(),
-                        internalSplit.getBucketNumber(),
+                        internalSplit.getReadBucketNumber(),
+                        internalSplit.getTableBucketNumber(),
                         internalSplit.getStatementId(),
                         internalSplit.isForceLocalScheduling(),
                         internalSplit.getTableToPartitionMapping(),

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/InternalHiveSplit.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/InternalHiveSplit.java
@@ -53,7 +53,8 @@ public class InternalHiveSplit
     private final List<HivePartitionKey> partitionKeys;
     private final List<InternalHiveBlock> blocks;
     private final String partitionName;
-    private final OptionalInt bucketNumber;
+    private final OptionalInt readBucketNumber;
+    private final OptionalInt tableBucketNumber;
     // This supplier returns an unused statementId, to guarantee that created split
     // files do not collide.  Successive calls return the the next sequential integer,
     // starting with zero.
@@ -81,7 +82,8 @@ public class InternalHiveSplit
             Properties schema,
             List<HivePartitionKey> partitionKeys,
             List<InternalHiveBlock> blocks,
-            OptionalInt bucketNumber,
+            OptionalInt readBucketNumber,
+            OptionalInt tableBucketNumber,
             Supplier<Integer> statementIdSupplier,
             boolean splittable,
             boolean forceLocalScheduling,
@@ -100,7 +102,8 @@ public class InternalHiveSplit
         requireNonNull(schema, "schema is null");
         requireNonNull(partitionKeys, "partitionKeys is null");
         requireNonNull(blocks, "blocks is null");
-        requireNonNull(bucketNumber, "bucketNumber is null");
+        requireNonNull(readBucketNumber, "readBucketNumber is null");
+        requireNonNull(tableBucketNumber, "tableBucketNumber is null");
         requireNonNull(statementIdSupplier, "statementIdSupplier is null");
         requireNonNull(tableToPartitionMapping, "tableToPartitionMapping is null");
         requireNonNull(bucketConversion, "bucketConversion is null");
@@ -117,7 +120,8 @@ public class InternalHiveSplit
         this.schema = schema;
         this.partitionKeys = ImmutableList.copyOf(partitionKeys);
         this.blocks = ImmutableList.copyOf(blocks);
-        this.bucketNumber = bucketNumber;
+        this.readBucketNumber = readBucketNumber;
+        this.tableBucketNumber = tableBucketNumber;
         this.statementIdSupplier = statementIdSupplier;
         this.statementId = statementIdSupplier.get();
         this.splittable = splittable;
@@ -175,9 +179,14 @@ public class InternalHiveSplit
         return partitionName;
     }
 
-    public OptionalInt getBucketNumber()
+    public OptionalInt getReadBucketNumber()
     {
-        return bucketNumber;
+        return readBucketNumber;
+    }
+
+    public OptionalInt getTableBucketNumber()
+    {
+        return tableBucketNumber;
     }
 
     public int getStatementId()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/DefaultGlueColumnStatisticsProviderFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/DefaultGlueColumnStatisticsProviderFactory.java
@@ -15,7 +15,6 @@ package io.trino.plugin.hive.metastore.glue;
 
 import com.amazonaws.services.glue.AWSGlueAsync;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 
 import java.util.concurrent.Executor;
@@ -25,17 +24,14 @@ import static java.util.Objects.requireNonNull;
 public class DefaultGlueColumnStatisticsProviderFactory
         implements GlueColumnStatisticsProviderFactory
 {
-    private final @Nullable String catalogId;
     private final Executor statisticsReadExecutor;
     private final Executor statisticsWriteExecutor;
 
     @Inject
     public DefaultGlueColumnStatisticsProviderFactory(
-            GlueHiveMetastoreConfig glueConfig,
             @ForGlueColumnStatisticsRead Executor statisticsReadExecutor,
             @ForGlueColumnStatisticsWrite Executor statisticsWriteExecutor)
     {
-        this.catalogId = requireNonNull(glueConfig, "glueConfig is null").getCatalogId().orElse(null);
         this.statisticsReadExecutor = requireNonNull(statisticsReadExecutor, "statisticsReadExecutor is null");
         this.statisticsWriteExecutor = requireNonNull(statisticsWriteExecutor, "statisticsWriteExecutor is null");
     }
@@ -45,7 +41,6 @@ public class DefaultGlueColumnStatisticsProviderFactory
     {
         return new DefaultGlueColumnStatisticsProvider(
                 glueClient,
-                catalogId,
                 statisticsReadExecutor,
                 statisticsWriteExecutor,
                 stats);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueCatalogIdRequestHandler.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueCatalogIdRequestHandler.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.metastore.glue;
+
+import com.amazonaws.AmazonWebServiceRequest;
+import com.amazonaws.handlers.RequestHandler2;
+import com.amazonaws.services.glue.model.BatchCreatePartitionRequest;
+import com.amazonaws.services.glue.model.BatchGetPartitionRequest;
+import com.amazonaws.services.glue.model.BatchUpdatePartitionRequest;
+import com.amazonaws.services.glue.model.CreateDatabaseRequest;
+import com.amazonaws.services.glue.model.CreateTableRequest;
+import com.amazonaws.services.glue.model.DeleteColumnStatisticsForPartitionRequest;
+import com.amazonaws.services.glue.model.DeleteColumnStatisticsForTableRequest;
+import com.amazonaws.services.glue.model.DeleteDatabaseRequest;
+import com.amazonaws.services.glue.model.DeletePartitionRequest;
+import com.amazonaws.services.glue.model.DeleteTableRequest;
+import com.amazonaws.services.glue.model.GetColumnStatisticsForPartitionRequest;
+import com.amazonaws.services.glue.model.GetColumnStatisticsForTableRequest;
+import com.amazonaws.services.glue.model.GetDatabaseRequest;
+import com.amazonaws.services.glue.model.GetDatabasesRequest;
+import com.amazonaws.services.glue.model.GetPartitionRequest;
+import com.amazonaws.services.glue.model.GetPartitionsRequest;
+import com.amazonaws.services.glue.model.GetTableRequest;
+import com.amazonaws.services.glue.model.GetTablesRequest;
+import com.amazonaws.services.glue.model.UpdateColumnStatisticsForPartitionRequest;
+import com.amazonaws.services.glue.model.UpdateColumnStatisticsForTableRequest;
+import com.amazonaws.services.glue.model.UpdateDatabaseRequest;
+import com.amazonaws.services.glue.model.UpdatePartitionRequest;
+import com.amazonaws.services.glue.model.UpdateTableRequest;
+
+import static java.util.Objects.requireNonNull;
+
+public class GlueCatalogIdRequestHandler
+        extends RequestHandler2
+{
+    private final String catalogId;
+
+    public GlueCatalogIdRequestHandler(String catalogId)
+    {
+        this.catalogId = requireNonNull(catalogId, "catalogId is null");
+    }
+
+    @Override
+    public AmazonWebServiceRequest beforeExecution(AmazonWebServiceRequest request)
+    {
+        if (request instanceof GetDatabasesRequest) {
+            return ((GetDatabasesRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof GetDatabaseRequest) {
+            return ((GetDatabaseRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof CreateDatabaseRequest) {
+            return ((CreateDatabaseRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof UpdateDatabaseRequest) {
+            return ((UpdateDatabaseRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof DeleteDatabaseRequest) {
+            return ((DeleteDatabaseRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof GetTablesRequest) {
+            return ((GetTablesRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof GetTableRequest) {
+            return ((GetTableRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof CreateTableRequest) {
+            return ((CreateTableRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof UpdateTableRequest) {
+            return ((UpdateTableRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof DeleteTableRequest) {
+            return ((DeleteTableRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof GetPartitionsRequest) {
+            return ((GetPartitionsRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof GetPartitionRequest) {
+            return ((GetPartitionRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof UpdatePartitionRequest) {
+            return ((UpdatePartitionRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof DeletePartitionRequest) {
+            return ((DeletePartitionRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof BatchGetPartitionRequest) {
+            return ((BatchGetPartitionRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof BatchCreatePartitionRequest) {
+            return ((BatchCreatePartitionRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof BatchUpdatePartitionRequest) {
+            return ((BatchUpdatePartitionRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof GetColumnStatisticsForTableRequest) {
+            return ((GetColumnStatisticsForTableRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof UpdateColumnStatisticsForTableRequest) {
+            return ((UpdateColumnStatisticsForTableRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof DeleteColumnStatisticsForTableRequest) {
+            return ((DeleteColumnStatisticsForTableRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof GetColumnStatisticsForPartitionRequest) {
+            return ((GetColumnStatisticsForPartitionRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof UpdateColumnStatisticsForPartitionRequest) {
+            return ((UpdateColumnStatisticsForPartitionRequest) request).withCatalogId(catalogId);
+        }
+        if (request instanceof DeleteColumnStatisticsForPartitionRequest) {
+            return ((DeleteColumnStatisticsForPartitionRequest) request).withCatalogId(catalogId);
+        }
+        throw new IllegalArgumentException("Unsupported request: " + request);
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -1731,6 +1731,83 @@ public abstract class AbstractTestHive
     }
 
     @Test
+    public void testBucketedTableEvolutionWithDifferentReadBucketCount()
+            throws Exception
+    {
+        for (HiveStorageFormat storageFormat : createTableFormats) {
+            SchemaTableName temporaryBucketEvolutionTable = temporaryTable("bucket_evolution");
+            try {
+                doTestBucketedTableEvolutionWithDifferentReadCount(storageFormat, temporaryBucketEvolutionTable);
+            }
+            finally {
+                dropTable(temporaryBucketEvolutionTable);
+            }
+        }
+    }
+
+    private void doTestBucketedTableEvolutionWithDifferentReadCount(HiveStorageFormat storageFormat, SchemaTableName tableName)
+            throws Exception
+    {
+        int rowCount = 100;
+        int bucketCount = 16;
+
+        // Produce a table with a partition with bucket count different but compatible with the table bucket count
+        createEmptyTable(
+                tableName,
+                storageFormat,
+                ImmutableList.of(
+                        new Column("id", HIVE_LONG, Optional.empty()),
+                        new Column("name", HIVE_STRING, Optional.empty())),
+                ImmutableList.of(new Column("pk", HIVE_STRING, Optional.empty())),
+                Optional.of(new HiveBucketProperty(ImmutableList.of("id"), BUCKETING_V1, 4, ImmutableList.of())));
+        // write a 4-bucket partition
+        MaterializedResult.Builder bucket8Builder = MaterializedResult.resultBuilder(SESSION, BIGINT, VARCHAR, VARCHAR);
+        IntStream.range(0, rowCount).forEach(i -> bucket8Builder.row((long) i, String.valueOf(i), "four"));
+        insertData(tableName, bucket8Builder.build());
+
+        // Alter the bucket count to 16
+        alterBucketProperty(tableName, Optional.of(new HiveBucketProperty(ImmutableList.of("id"), BUCKETING_V1, bucketCount, ImmutableList.of())));
+
+        MaterializedResult result;
+        try (Transaction transaction = newTransaction()) {
+            ConnectorMetadata metadata = transaction.getMetadata();
+            ConnectorSession session = newSession();
+            metadata.beginQuery(session);
+
+            ConnectorTableHandle tableHandle = getTableHandle(metadata, tableName);
+
+            // read entire table
+            List<ColumnHandle> columnHandles = ImmutableList.<ColumnHandle>builder()
+                    .addAll(metadata.getColumnHandles(session, tableHandle).values())
+                    .build();
+
+            List<ConnectorSplit> splits = getAllSplits(getSplits(splitManager, transaction, session, tableHandle));
+            assertEquals(splits.size(), 16);
+
+            ImmutableList.Builder<MaterializedRow> allRows = ImmutableList.builder();
+            for (ConnectorSplit split : splits) {
+                try (ConnectorPageSource pageSource = pageSourceProvider.createPageSource(transaction.getTransactionHandle(), session, split, tableHandle, columnHandles, DynamicFilter.EMPTY)) {
+                    MaterializedResult intermediateResult = materializeSourceDataStream(session, pageSource, getTypes(columnHandles));
+                    allRows.addAll(intermediateResult.getMaterializedRows());
+                }
+            }
+            result = new MaterializedResult(allRows.build(), getTypes(columnHandles));
+
+            assertEquals(result.getRowCount(), rowCount);
+
+            Map<String, Integer> columnIndex = indexColumns(columnHandles);
+            int nameColumnIndex = columnIndex.get("name");
+            int bucketColumnIndex = columnIndex.get(BUCKET_COLUMN_NAME);
+            for (MaterializedRow row : result.getMaterializedRows()) {
+                String name = (String) row.getField(nameColumnIndex);
+                int bucket = (int) row.getField(bucketColumnIndex);
+
+                assertEquals(bucket, Integer.parseInt(name) % bucketCount);
+            }
+        }
+    }
+
+    @Test
     public void testBucketedTableEvolution()
             throws Exception
     {

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -4623,6 +4623,48 @@ public abstract class BaseHiveConnectorTest
         }
     }
 
+    @Test
+    public void testMismatchedBucketWithBucketPredicate()
+    {
+        try {
+            assertUpdate(
+                    "CREATE TABLE test_mismatch_bucketing8\n" +
+                            "WITH (bucket_count = 8, bucketed_by = ARRAY['key8']) AS\n" +
+                            "SELECT custkey key8, comment value8 FROM orders",
+                    15000);
+            assertUpdate(
+                    "CREATE TABLE test_mismatch_bucketing32\n" +
+                            "WITH (bucket_count = 32, bucketed_by = ARRAY['key32']) AS\n" +
+                            "SELECT custkey key32, comment value32 FROM orders",
+                    15000);
+
+            Session withMismatchOptimization = Session.builder(getSession())
+                    .setSystemProperty(COLOCATED_JOIN, "true")
+                    .setCatalogSessionProperty(catalog, "optimize_mismatched_bucket_count", "true")
+                    .build();
+            Session withoutMismatchOptimization = Session.builder(getSession())
+                    .setSystemProperty(COLOCATED_JOIN, "true")
+                    .setCatalogSessionProperty(catalog, "optimize_mismatched_bucket_count", "false")
+                    .build();
+
+            @Language("SQL") String query = "SELECT count(*) AS count\n" +
+                    "FROM (\n" +
+                    "  SELECT key32\n" +
+                    "  FROM test_mismatch_bucketing32\n" +
+                    "  WHERE \"$bucket\" between 16 AND 31\n" +
+                    ") a\n" +
+                    "JOIN test_mismatch_bucketing8 b\n" +
+                    "ON a.key32 = b.key8";
+
+            assertQuery(withMismatchOptimization, query, "SELECT 130361");
+            assertQuery(withoutMismatchOptimization, query, "SELECT 130361");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS test_mismatch_bucketing8");
+            assertUpdate("DROP TABLE IF EXISTS test_mismatch_bucketing32");
+        }
+    }
+
     @DataProvider
     public Object[][] timestampPrecisionAndValues()
     {

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileMetastore.java
@@ -72,6 +72,12 @@ public class TestHiveFileMetastore
     }
 
     @Override
+    public void testBucketedTableEvolutionWithDifferentReadBucketCount()
+    {
+        // FileHiveMetastore only supports replaceTable() for views
+    }
+
+    @Override
     public void testTransactionDeleteInsert()
     {
         // FileHiveMetastore has various incompatibilities

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSink.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSink.java
@@ -236,6 +236,7 @@ public class TestHivePageSink
                 ImmutableList.of(),
                 ImmutableList.of(),
                 OptionalInt.empty(),
+                OptionalInt.empty(),
                 0,
                 false,
                 TableToPartitionMapping.empty(),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveSplit.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveSplit.java
@@ -72,6 +72,7 @@ public class TestHiveSplit
                 partitionKeys,
                 addresses,
                 OptionalInt.empty(),
+                OptionalInt.empty(),
                 0,
                 true,
                 TableToPartitionMapping.mapColumnsByIndex(ImmutableMap.of(1, new HiveTypeName("string"))),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveSplitSource.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveSplitSource.java
@@ -391,6 +391,7 @@ public class TestHiveSplitSource
                     ImmutableList.of(),
                     ImmutableList.of(new InternalHiveBlock(0, fileSize.toBytes(), ImmutableList.of())),
                     bucketNumber,
+                    bucketNumber,
                     () -> 0,
                     true,
                     false,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestNodeLocalDynamicSplitPruning.java
@@ -129,6 +129,7 @@ public class TestNodeLocalDynamicSplitPruning
                 ImmutableList.of(new HivePartitionKey(PARTITION_COLUMN.getName(), "42")),
                 ImmutableList.of(),
                 OptionalInt.of(1),
+                OptionalInt.of(1),
                 0,
                 false,
                 TableToPartitionMapping.empty(),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/AbstractFileFormat.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/AbstractFileFormat.java
@@ -147,6 +147,7 @@ public abstract class AbstractFileFormat
                 ImmutableList.of(),
                 ImmutableList.of(),
                 OptionalInt.empty(),
+                OptionalInt.empty(),
                 0,
                 false,
                 TableToPartitionMapping.empty(),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
@@ -221,7 +221,7 @@ public class TestHiveGlueMetastore
                 glueConfig,
                 DefaultAWSCredentialsProviderChain.getInstance(),
                 executor,
-                new DefaultGlueColumnStatisticsProviderFactory(glueConfig, executor, executor),
+                new DefaultGlueColumnStatisticsProviderFactory(executor, executor),
                 Optional.empty(),
                 new DefaultGlueMetastoreTableFilterProvider(
                         new MetastoreConfig()

--- a/plugin/trino-http-event-listener/pom.xml
+++ b/plugin/trino-http-event-listener/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-http-event-listener/pom.xml
+++ b/plugin/trino-http-event-listener/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalogFactory.java
@@ -31,7 +31,6 @@ import javax.inject.Inject;
 
 import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.plugin.hive.metastore.glue.GlueHiveMetastore.createAsyncGlueClient;
 import static java.util.Objects.requireNonNull;
 
@@ -60,7 +59,6 @@ public class TrinoGlueCatalogFactory
         this.tableOperationsProvider = requireNonNull(tableOperationsProvider, "tableOperationsProvider is null");
         this.trinoVersion = requireNonNull(nodeVersion, "nodeVersion is null").toString();
         requireNonNull(glueConfig, "glueConfig is null");
-        checkArgument(glueConfig.getCatalogId().isEmpty(), "catalogId configuration is not supported");
         this.defaultSchemaLocation = glueConfig.getDefaultWarehouseDir();
         requireNonNull(credentialsProvider, "credentialsProvider is null");
         this.glueClient = createAsyncGlueClient(glueConfig, credentialsProvider, Optional.empty(), stats.newRequestMetricsCollector());

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseSharedMetastoreTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseSharedMetastoreTest.java
@@ -52,19 +52,19 @@ public abstract class BaseSharedMetastoreTest
     @Test
     public void testReadInformationSchema()
     {
-        assertThat(query("SELECT table_schema FROM hive.information_schema.tables WHERE table_name = 'region'"))
+        assertThat(query("SELECT table_schema FROM hive.information_schema.tables WHERE table_name = 'region' AND table_schema='" + schema + "'"))
                 .skippingTypesCheck()
                 .containsAll("VALUES '" + schema + "'");
-        assertThat(query("SELECT table_schema FROM iceberg.information_schema.tables WHERE table_name = 'nation'"))
+        assertThat(query("SELECT table_schema FROM iceberg.information_schema.tables WHERE table_name = 'nation' AND table_schema='" + schema + "'"))
                 .skippingTypesCheck()
                 .containsAll("VALUES '" + schema + "'");
-        assertThat(query("SELECT table_schema FROM hive_with_redirections.information_schema.tables WHERE table_name = 'region'"))
+        assertThat(query("SELECT table_schema FROM hive_with_redirections.information_schema.tables WHERE table_name = 'region' AND table_schema='" + schema + "'"))
                 .skippingTypesCheck()
                 .containsAll("VALUES '" + schema + "'");
-        assertThat(query("SELECT table_schema FROM hive_with_redirections.information_schema.tables WHERE table_name = 'nation'"))
+        assertThat(query("SELECT table_schema FROM hive_with_redirections.information_schema.tables WHERE table_name = 'nation' AND table_schema='" + schema + "'"))
                 .skippingTypesCheck()
                 .containsAll("VALUES '" + schema + "'");
-        assertThat(query("SELECT table_schema FROM iceberg_with_redirections.information_schema.tables WHERE table_name = 'region'"))
+        assertThat(query("SELECT table_schema FROM iceberg_with_redirections.information_schema.tables WHERE table_name = 'region' AND table_schema='" + schema + "'"))
                 .skippingTypesCheck()
                 .containsAll("VALUES '" + schema + "'");
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPlugin.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPlugin.java
@@ -86,14 +86,14 @@ public class TestIcebergPlugin
                 new TestingConnectorContext()))
                 .hasMessageContaining("Error: Configuration property 'hive.metastore.uri' was not used");
 
-        assertThatThrownBy(() -> factory.create(
+        factory.create(
                 "test",
                 Map.of(
                         "iceberg.catalog.type", "glue",
                         "hive.metastore.glue.catalogid", "123",
                         "hive.metastore.glue.region", "us-east-1"),
-                new TestingConnectorContext()))
-                .hasMessageContaining("catalogId configuration is not supported");
+                new TestingConnectorContext())
+                .shutdown();
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestSharedGlueMetastore.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestSharedGlueMetastore.java
@@ -108,7 +108,7 @@ public class TestSharedGlueMetastore
                 new GlueHiveMetastoreConfig(),
                 DefaultAWSCredentialsProviderChain.getInstance(),
                 directExecutor(),
-                new DefaultGlueColumnStatisticsProviderFactory(new GlueHiveMetastoreConfig(), directExecutor(), directExecutor()),
+                new DefaultGlueColumnStatisticsProviderFactory(directExecutor(), directExecutor()),
                 Optional.empty(),
                 table -> true);
         queryRunner.installPlugin(new TestingHivePlugin(glueMetastore));

--- a/plugin/trino-jmx/pom.xml
+++ b/plugin/trino-jmx/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-jmx/pom.xml
+++ b/plugin/trino-jmx/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-kafka/pom.xml
+++ b/plugin/trino-kafka/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-kafka/pom.xml
+++ b/plugin/trino-kafka/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-kinesis/pom.xml
+++ b/plugin/trino-kinesis/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-kinesis/pom.xml
+++ b/plugin/trino-kinesis/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-kudu/pom.xml
+++ b/plugin/trino-kudu/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-kudu/pom.xml
+++ b/plugin/trino-kudu/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-local-file/pom.xml
+++ b/plugin/trino-local-file/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-local-file/pom.xml
+++ b/plugin/trino-local-file/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-memory/pom.xml
+++ b/plugin/trino-memory/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-memory/pom.xml
+++ b/plugin/trino-memory/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-ml/pom.xml
+++ b/plugin/trino-ml/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-ml/pom.xml
+++ b/plugin/trino-ml/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-mongodb/pom.xml
+++ b/plugin/trino-mongodb/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-mongodb/pom.xml
+++ b/plugin/trino-mongodb/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-mysql/pom.xml
+++ b/plugin/trino-mysql/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-mysql/pom.xml
+++ b/plugin/trino-mysql/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-oracle/pom.xml
+++ b/plugin/trino-oracle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-oracle/pom.xml
+++ b/plugin/trino-oracle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-password-authenticators/pom.xml
+++ b/plugin/trino-password-authenticators/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-password-authenticators/pom.xml
+++ b/plugin/trino-password-authenticators/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-phoenix/pom.xml
+++ b/plugin/trino-phoenix/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-phoenix/pom.xml
+++ b/plugin/trino-phoenix/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-phoenix5/pom.xml
+++ b/plugin/trino-phoenix5/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-phoenix5/pom.xml
+++ b/plugin/trino-phoenix5/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-pinot/pom.xml
+++ b/plugin/trino-pinot/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>trino-root</artifactId>
         <groupId>io.trino</groupId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-pinot/pom.xml
+++ b/plugin/trino-pinot/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>trino-root</artifactId>
         <groupId>io.trino</groupId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-postgresql/pom.xml
+++ b/plugin/trino-postgresql/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-postgresql/pom.xml
+++ b/plugin/trino-postgresql/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-prometheus/pom.xml
+++ b/plugin/trino-prometheus/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-prometheus/pom.xml
+++ b/plugin/trino-prometheus/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-raptor-legacy/pom.xml
+++ b/plugin/trino-raptor-legacy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-raptor-legacy/pom.xml
+++ b/plugin/trino-raptor-legacy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-redis/pom.xml
+++ b/plugin/trino-redis/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-redis/pom.xml
+++ b/plugin/trino-redis/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-redshift/pom.xml
+++ b/plugin/trino-redshift/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-redshift/pom.xml
+++ b/plugin/trino-redshift/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-resource-group-managers/pom.xml
+++ b/plugin/trino-resource-group-managers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-resource-group-managers/pom.xml
+++ b/plugin/trino-resource-group-managers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-session-property-managers/pom.xml
+++ b/plugin/trino-session-property-managers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-session-property-managers/pom.xml
+++ b/plugin/trino-session-property-managers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-singlestore/pom.xml
+++ b/plugin/trino-singlestore/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-singlestore/pom.xml
+++ b/plugin/trino-singlestore/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-sqlserver/pom.xml
+++ b/plugin/trino-sqlserver/pom.xml
@@ -15,6 +15,14 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+
+        <!--
+          Project's default for air.test.parallel is 'methods'. By design, 'classes' makes TestNG run tests from one class in a single thread.
+          As a side effect, it prevents TestNG from initializing multiple test instances upfront, which happens with 'methods'.
+          A potential downside can be long tail single-threaded execution of a single long test class.
+          TODO (https://github.com/trinodb/trino/issues/11294) remove when we upgrade to surefire with https://issues.apache.org/jira/browse/SUREFIRE-1967
+          -->
+        <air.test.parallel>classes</air.test.parallel>
     </properties>
 
     <dependencies>

--- a/plugin/trino-sqlserver/pom.xml
+++ b/plugin/trino-sqlserver/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-sqlserver/pom.xml
+++ b/plugin/trino-sqlserver/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClientModule.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClientModule.java
@@ -25,6 +25,7 @@ import io.trino.plugin.jdbc.ConnectionFactory;
 import io.trino.plugin.jdbc.DriverConnectionFactory;
 import io.trino.plugin.jdbc.ForBaseJdbc;
 import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.JdbcStatisticsConfig;
 import io.trino.plugin.jdbc.MaxDomainCompactionThreshold;
 import io.trino.plugin.jdbc.credential.CredentialProvider;
 
@@ -40,6 +41,7 @@ public class SqlServerClientModule
     public void configure(Binder binder)
     {
         configBinder(binder).bindConfig(SqlServerConfig.class);
+        configBinder(binder).bindConfig(JdbcStatisticsConfig.class);
         binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class).to(SqlServerClient.class).in(Scopes.SINGLETON);
         bindTablePropertiesProvider(binder, SqlServerTableProperties.class);
         newOptionalBinder(binder, Key.get(int.class, MaxDomainCompactionThreshold.class)).setBinding().toInstance(SQL_SERVER_MAX_LIST_EXPRESSIONS);

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClientModule.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClientModule.java
@@ -15,16 +15,17 @@ package io.trino.plugin.sqlserver;
 
 import com.google.inject.Binder;
 import com.google.inject.Key;
-import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import com.microsoft.sqlserver.jdbc.SQLServerDriver;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.trino.plugin.jdbc.BaseJdbcConfig;
 import io.trino.plugin.jdbc.ConnectionFactory;
 import io.trino.plugin.jdbc.DriverConnectionFactory;
 import io.trino.plugin.jdbc.ForBaseJdbc;
 import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.JdbcJoinPushdownSupportModule;
 import io.trino.plugin.jdbc.JdbcStatisticsConfig;
 import io.trino.plugin.jdbc.MaxDomainCompactionThreshold;
 import io.trino.plugin.jdbc.credential.CredentialProvider;
@@ -35,16 +36,17 @@ import static io.trino.plugin.jdbc.JdbcModule.bindTablePropertiesProvider;
 import static io.trino.plugin.sqlserver.SqlServerClient.SQL_SERVER_MAX_LIST_EXPRESSIONS;
 
 public class SqlServerClientModule
-        implements Module
+        extends AbstractConfigurationAwareModule
 {
     @Override
-    public void configure(Binder binder)
+    protected void setup(Binder binder)
     {
         configBinder(binder).bindConfig(SqlServerConfig.class);
         configBinder(binder).bindConfig(JdbcStatisticsConfig.class);
         binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class).to(SqlServerClient.class).in(Scopes.SINGLETON);
         bindTablePropertiesProvider(binder, SqlServerTableProperties.class);
         newOptionalBinder(binder, Key.get(int.class, MaxDomainCompactionThreshold.class)).setBinding().toInstance(SQL_SERVER_MAX_LIST_EXPRESSIONS);
+        install(new JdbcJoinPushdownSupportModule());
     }
 
     @Provides

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
@@ -539,4 +539,13 @@ public abstract class BaseSqlServerConnectorTest
                 .collect(joining(", "));
         return "orderkey IN (" + longValues + ")";
     }
+
+    @Override
+    protected Session joinPushdownEnabled(Session session)
+    {
+        return Session.builder(super.joinPushdownEnabled(session))
+                // strategy is AUTOMATIC by default and would not work for certain test cases (even if statistics are collected)
+                .setCatalogSessionProperty(session.getCatalog().orElseThrow(), "join_pushdown_strategy", "EAGER")
+                .build();
+    }
 }

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerAutomaticJoinPushdown.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerAutomaticJoinPushdown.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.sqlserver;
+
+import io.trino.plugin.jdbc.BaseAutomaticJoinPushdownTest;
+import io.trino.testing.QueryRunner;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Streams.stream;
+import static io.trino.plugin.sqlserver.SqlServerQueryRunner.createSqlServerQueryRunner;
+import static java.lang.String.format;
+
+public class TestSqlServerAutomaticJoinPushdown
+        extends BaseAutomaticJoinPushdownTest
+{
+    private TestingSqlServer sqlServer;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        sqlServer = closeAfterClass(new TestingSqlServer());
+        return createSqlServerQueryRunner(sqlServer, Map.of(), Map.of(), List.of());
+    }
+
+    @Override
+    protected void gatherStats(String tableName)
+    {
+        List<String> columnNames = stream(computeActual("SHOW COLUMNS FROM " + tableName))
+                .map(row -> (String) row.getField(0))
+                .map(columnName -> "\"" + columnName + "\"")
+                .collect(toImmutableList());
+
+        for (String columnName : columnNames) {
+            sqlServer.execute(format("CREATE STATISTICS %1$s ON %2$s (%1$s)", columnName, tableName));
+        }
+
+        sqlServer.execute("UPDATE STATISTICS " + tableName);
+    }
+}

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerClient.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerClient.java
@@ -19,6 +19,7 @@ import io.trino.plugin.jdbc.DefaultQueryBuilder;
 import io.trino.plugin.jdbc.JdbcClient;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
+import io.trino.plugin.jdbc.JdbcStatisticsConfig;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
 import io.trino.plugin.jdbc.mapping.DefaultIdentifierMapping;
 import io.trino.spi.connector.AggregateFunction;
@@ -59,6 +60,7 @@ public class TestSqlServerClient
     private static final JdbcClient JDBC_CLIENT = new SqlServerClient(
             new BaseJdbcConfig(),
             new SqlServerConfig(),
+            new JdbcStatisticsConfig(),
             session -> {
                 throw new UnsupportedOperationException();
             },

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerTableStatistics.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerTableStatistics.java
@@ -45,9 +45,7 @@ public class TestSqlServerTableStatistics
         return SqlServerQueryRunner.createSqlServerQueryRunner(
                 sqlServer,
                 Map.of(),
-                Map.of(
-                        "case-insensitive-name-matching", "true",
-                        "join-pushdown.enabled", "true"),
+                Map.of("case-insensitive-name-matching", "true"),
                 List.of(ORDERS));
     }
 

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerTableStatistics.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerTableStatistics.java
@@ -1,0 +1,415 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.sqlserver;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.jdbc.BaseJdbcTableStatisticsTest;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.sql.TestTable;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Streams.stream;
+import static io.trino.testing.sql.TestTable.fromColumns;
+import static io.trino.tpch.TpchTable.ORDERS;
+import static java.lang.String.format;
+
+public class TestSqlServerTableStatistics
+        extends BaseJdbcTableStatisticsTest
+{
+    private TestingSqlServer sqlServer;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        sqlServer = closeAfterClass(new TestingSqlServer());
+        return SqlServerQueryRunner.createSqlServerQueryRunner(
+                sqlServer,
+                Map.of(),
+                Map.of(
+                        "case-insensitive-name-matching", "true",
+                        "join-pushdown.enabled", "true"),
+                List.of(ORDERS));
+    }
+
+    @Override
+    @Test
+    public void testNotAnalyzed()
+    {
+        String tableName = "test_stats_not_analyzed";
+        assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        computeActual(format("CREATE TABLE %s AS SELECT * FROM tpch.tiny.orders", tableName));
+        try {
+            assertQuery(
+                    "SHOW STATS FOR " + tableName,
+                    "VALUES " +
+                            "('orderkey', null, null, null, null, null, null)," +
+                            "('custkey', null, null, null, null, null, null)," +
+                            "('orderstatus', null, null, null, null, null, null)," +
+                            "('totalprice', null, null, null, null, null, null)," +
+                            "('orderdate', null, null, null, null, null, null)," +
+                            "('orderpriority', null, null, null, null, null, null)," +
+                            "('clerk', null, null, null, null, null, null)," +
+                            "('shippriority', null, null, null, null, null, null)," +
+                            "('comment', null, null, null, null, null, null)," +
+                            "(null, null, null, null, 15000, null, null)");
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableName);
+        }
+    }
+
+    @Override
+    @Test
+    public void testBasic()
+    {
+        String tableName = "test_stats_orders";
+        assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        computeActual(format("CREATE TABLE %s AS SELECT * FROM tpch.tiny.orders", tableName));
+        try {
+            gatherStats(tableName);
+            assertQuery(
+                    "SHOW STATS FOR " + tableName,
+                    "VALUES " +
+                            "('orderkey', null, 15000, 0, null, null, null)," +
+                            "('custkey', null, 1000, 0, null, null, null)," +
+                            "('orderstatus', 30000, 3, 0, null, null, null)," +
+                            "('totalprice', null, 14996, 0, null, null, null)," +
+                            "('orderdate', null, 2401, 0, null, null, null)," +
+                            "('orderpriority', 252376, 5, 0, null, null, null)," +
+                            "('clerk', 450000, 1000, 0, null, null, null)," +
+                            "('shippriority', null, 1, 0, null, null, null)," +
+                            "('comment', 1454727, 14994, 0, null, null, null)," +
+                            "(null, null, null, null, 15000, null, null)");
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableName);
+        }
+    }
+
+    @Override
+    protected void checkEmptyTableStats(String tableName)
+    {
+        // TODO: Empty tables should have NDV as 0 and nulls fraction as 1
+        assertQuery(
+                "SHOW STATS FOR " + tableName,
+                "VALUES " +
+                        "('orderkey', null, null, null, null, null, null)," +
+                        "('custkey', null, null, null, null, null, null)," +
+                        "('orderpriority', null, null, null, null, null, null)," +
+                        "('comment', null, null, null, null, null, null)," +
+                        "(null, null, null, null, null, null, null)");
+    }
+
+    @Override
+    @Test
+    public void testAllNulls()
+    {
+        String tableName = "test_stats_table_all_nulls";
+        assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        computeActual(format("CREATE TABLE %s AS SELECT orderkey, custkey, orderpriority, comment FROM tpch.tiny.orders WHERE false", tableName));
+        try {
+            computeActual(format("INSERT INTO %s (orderkey) VALUES NULL, NULL, NULL", tableName));
+            gatherStats(tableName);
+            assertQuery(
+                    "SHOW STATS FOR " + tableName,
+                    "VALUES " +
+                            "('orderkey', 0, 0, 1, null, null, null)," +
+                            "('custkey', 0, 0, 1, null, null, null)," +
+                            "('orderpriority', 0, 0, 1, null, null, null)," +
+                            "('comment', 0, 0, 1, null, null, null)," +
+                            "(null, null, null, null, 3, null, null)");
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableName);
+        }
+    }
+
+    @Override
+    @Test
+    public void testNullsFraction()
+    {
+        String tableName = "test_stats_table_with_nulls";
+        assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        assertUpdate("" +
+                        "CREATE TABLE " + tableName + " AS " +
+                        "SELECT " +
+                        "    orderkey, " +
+                        "    if(orderkey % 3 = 0, NULL, custkey) custkey, " +
+                        "    if(orderkey % 5 = 0, NULL, orderpriority) orderpriority " +
+                        "FROM tpch.tiny.orders",
+                15000);
+        try {
+            gatherStats(tableName);
+            assertQuery(
+                    "SHOW STATS FOR " + tableName,
+                    "VALUES " +
+                            "('orderkey', null, 15000, 0, null, null, null)," +
+                            "('custkey', null, 1000, 0.3333333333333333, null, null, null)," +
+                            "('orderpriority', 201914, 5, 0.2, null, null, null)," +
+                            "(null, null, null, null, 15000, null, null)");
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableName);
+        }
+    }
+
+    @Override
+    @Test
+    public void testAverageColumnLength()
+    {
+        String tableName = "test_stats_table_avg_col_len";
+        assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        computeActual("" +
+                "CREATE TABLE " + tableName + " AS SELECT " +
+                "  orderkey, " +
+                "  'abc' v3_in_3, " +
+                "  CAST('abc' AS varchar(42)) v3_in_42, " +
+                "  if(orderkey = 1, '0123456789', NULL) single_10v_value, " +
+                "  if(orderkey % 2 = 0, '0123456789', NULL) half_10v_value, " +
+                "  if(orderkey % 2 = 0, CAST((1000000 - orderkey) * (1000000 - orderkey) AS varchar(20)), NULL) half_distinct_20v_value, " + // 12 chars each
+                "  CAST(NULL AS varchar(10)) all_nulls " +
+                "FROM tpch.tiny.orders " +
+                "ORDER BY orderkey LIMIT 100");
+        try {
+            gatherStats(tableName);
+            assertQuery(
+                    "SHOW STATS FOR " + tableName,
+                    "VALUES " +
+                            "('orderkey', null, 100, 0, null, null, null)," +
+                            "('v3_in_3', 600, 1, 0, null, null, null)," +
+                            "('v3_in_42', 600, 1, 0, null, null, null)," +
+                            "('single_10v_value', 20, 1, 0.99, null, null, null)," +
+                            "('half_10v_value', 1000, 1, 0.5, null, null, null)," +
+                            "('half_distinct_20v_value', 1200, 50, 0.5, null, null, null)," +
+                            "('all_nulls', 0, 0, 1, null, null, null)," +
+                            "(null, null, null, null, 100, null, null)");
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableName);
+        }
+    }
+
+    @Override
+    @Test
+    public void testPartitionedTable()
+    {
+        throw new SkipException("Not implemented"); // TODO
+    }
+
+    @Override
+    @Test
+    public void testView()
+    {
+        String tableName = "test_stats_view";
+        sqlServer.execute("CREATE VIEW " + tableName + " AS SELECT orderkey, custkey, orderpriority, comment FROM orders");
+        try {
+            assertQuery(
+                    "SHOW STATS FOR " + tableName,
+                    "VALUES " +
+                            "('orderkey', null, null, null, null, null, null)," +
+                            "('custkey', null, null, null, null, null, null)," +
+                            "('orderpriority', null, null, null, null, null, null)," +
+                            "('comment', null, null, null, null, null, null)," +
+                            "(null, null, null, null, null, null, null)");
+            // It's not possible to ANALYZE a VIEW in SQL Server
+        }
+        finally {
+            sqlServer.execute("DROP VIEW " + tableName);
+        }
+    }
+
+    @Override
+    public void testMaterializedView()
+    {
+        throw new SkipException("see testIndexedView");
+    }
+
+    @Test
+    public void testIndexedView() // materialized view
+    {
+        String tableName = "test_stats_indexed_view";
+        // indexed views require fixed values for several SET options
+        try (Handle handle = Jdbi.open(sqlServer::createConnection)) {
+            // indexed views require fixed values for several SET options
+            handle.execute("SET NUMERIC_ROUNDABORT OFF");
+            handle.execute("SET ANSI_PADDING, ANSI_WARNINGS, CONCAT_NULL_YIELDS_NULL, ARITHABORT, QUOTED_IDENTIFIER, ANSI_NULLS ON");
+
+            handle.execute("" +
+                    "CREATE VIEW " + tableName + " " +
+                    "WITH SCHEMABINDING " +
+                    "AS SELECT orderkey, custkey, orderpriority, comment FROM dbo.orders");
+            try {
+                handle.execute("CREATE UNIQUE CLUSTERED INDEX idx1 ON " + tableName + " (orderkey, custkey, orderpriority, comment)");
+                gatherStats(tableName);
+                assertQuery(
+                        "SHOW STATS FOR " + tableName,
+                        "VALUES " +
+                                "('orderkey', null, 15000, 0, null, null, null)," +
+                                "('custkey', null, 1000, 0, null, null, null)," +
+                                "('orderpriority', 252376, 5, 0, null, null, null)," +
+                                "('comment', 1454727, 14994, 0, null, null, null)," +
+                                "(null, null, null, null, 15000, null, null)");
+            }
+            finally {
+                handle.execute("DROP VIEW " + tableName);
+            }
+        }
+    }
+
+    @Override
+    @Test(dataProvider = "testCaseColumnNamesDataProvider")
+    public void testCaseColumnNames(String tableName)
+    {
+        sqlServer.execute("" +
+                "SELECT " +
+                "  orderkey CASE_UNQUOTED_UPPER, " +
+                "  custkey case_unquoted_lower, " +
+                "  orderstatus cASe_uNQuoTeD_miXED, " +
+                "  totalprice \"CASE_QUOTED_UPPER\", " +
+                "  orderdate \"case_quoted_lower\", " +
+                "  orderpriority \"CasE_QuoTeD_miXED\" " +
+                "INTO " + tableName + " " +
+                "FROM orders");
+        try {
+            gatherStats(
+                    tableName,
+                    ImmutableList.of(
+                            "CASE_UNQUOTED_UPPER",
+                            "case_unquoted_lower",
+                            "cASe_uNQuoTeD_miXED",
+                            "CASE_QUOTED_UPPER",
+                            "case_quoted_lower",
+                            "CasE_QuoTeD_miXED"));
+            assertQuery(
+                    "SHOW STATS FOR " + tableName,
+                    "VALUES " +
+                            "('case_unquoted_upper', null, 15000, 0, null, null, null)," +
+                            "('case_unquoted_lower', null, 1000, 0, null, null, null)," +
+                            "('case_unquoted_mixed', 30000, 3, 0, null, null, null)," +
+                            "('case_quoted_upper', null, 14996, 0, null, null, null)," +
+                            "('case_quoted_lower', null, 2401, 0, null, null, null)," +
+                            "('case_quoted_mixed', 252376, 5, 0, null, null, null)," +
+                            "(null, null, null, null, 15000, null, null)");
+        }
+        finally {
+            sqlServer.execute("DROP TABLE " + tableName);
+        }
+    }
+
+    @Override
+    @Test
+    public void testNumericCornerCases()
+    {
+        try (TestTable table = fromColumns(
+                getQueryRunner()::execute,
+                "test_numeric_corner_cases_",
+                ImmutableMap.<String, List<String>>builder()
+// TODO infinity and NaNs are not supported by SQLServer
+//                        .put("only_negative_infinity double", List.of("-infinity()", "-infinity()", "-infinity()", "-infinity()"))
+//                        .put("only_positive_infinity double", List.of("infinity()", "infinity()", "infinity()", "infinity()"))
+//                        .put("mixed_infinities double", List.of("-infinity()", "infinity()", "-infinity()", "infinity()"))
+//                        .put("mixed_infinities_and_numbers double", List.of("-infinity()", "infinity()", "-5.0", "7.0"))
+//                        .put("nans_only double", List.of("nan()", "nan()"))
+//                        .put("nans_and_numbers double", List.of("nan()", "nan()", "-5.0", "7.0"))
+                        .put("large_doubles double", List.of("CAST(-50371909150609548946090.0 AS DOUBLE)", "CAST(50371909150609548946090.0 AS DOUBLE)")) // 2^77 DIV 3
+                        .put("short_decimals_big_fraction decimal(16,15)", List.of("-1.234567890123456", "1.234567890123456"))
+                        .put("short_decimals_big_integral decimal(16,1)", List.of("-123456789012345.6", "123456789012345.6"))
+                        .put("long_decimals_big_fraction decimal(38,37)", List.of("-1.2345678901234567890123456789012345678", "1.2345678901234567890123456789012345678"))
+                        .put("long_decimals_middle decimal(38,16)", List.of("-1234567890123456.7890123456789012345678", "1234567890123456.7890123456789012345678"))
+                        .put("long_decimals_big_integral decimal(38,1)", List.of("-1234567890123456789012345678901234567.8", "1234567890123456789012345678901234567.8"))
+                        .buildOrThrow(),
+                "null")) {
+            gatherStats(table.getName());
+            assertQuery(
+                    "SHOW STATS FOR " + table.getName(),
+                    "VALUES " +
+// TODO infinity and NaNs are not supported by SQLServer
+//                            "('only_negative_infinity', null, 1, 0, null, null, null)," +
+//                            "('only_positive_infinity', null, 1, 0, null, null, null)," +
+//                            "('mixed_infinities', null, 2, 0, null, null, null)," +
+//                            "('mixed_infinities_and_numbers', null, 4.0, 0.0, null, null, null)," +
+//                            "('nans_only', null, 1.0, 0.5, null, null, null)," +
+//                            "('nans_and_numbers', null, 3.0, 0.0, null, null, null)," +
+                            "('large_doubles', null, 2.0, 0.0, null, null, null)," +
+                            "('short_decimals_big_fraction', null, 2.0, 0.0, null, null, null)," +
+                            "('short_decimals_big_integral', null, 2.0, 0.0, null, null, null)," +
+                            "('long_decimals_big_fraction', null, 2.0, 0.0, null, null, null)," +
+                            "('long_decimals_middle', null, 2.0, 0.0, null, null, null)," +
+                            "('long_decimals_big_integral', null, 2.0, 0.0, null, null, null)," +
+                            "(null, null, null, null, 2, null, null)");
+        }
+    }
+
+    @Test
+    public void testShowStatsAfterCreateIndex()
+    {
+        String tableName = "test_stats_create_index";
+        assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        computeActual(format("CREATE TABLE %s AS SELECT * FROM tpch.tiny.orders", tableName));
+
+        String expected = "VALUES " +
+                "('orderkey', null, 15000, 0, null, null, null)," +
+                "('custkey', null, 1000, 0, null, null, null)," +
+                "('orderstatus', 30000, 3, 0, null, null, null)," +
+                "('totalprice', null, 14996, 0, null, null, null)," +
+                "('orderdate', null, 2401, 0, null, null, null)," +
+                "('orderpriority', 252376, 5, 0, null, null, null)," +
+                "('clerk', 450000, 1000, 0, null, null, null)," +
+                "('shippriority', null, 1, 0, null, null, null)," +
+                "('comment', 1454727, 14994, 0, null, null, null)," +
+                "(null, null, null, null, 15000, null, null)";
+
+        try {
+            gatherStats(tableName);
+            assertQuery("SHOW STATS FOR " + tableName, expected);
+
+            // CREATE INDEX statement updates sys.partitions table
+            sqlServer.execute(format("CREATE INDEX idx ON %s (orderkey)", tableName));
+            sqlServer.execute(format("CREATE UNIQUE INDEX unique_index ON %s (orderkey)", tableName));
+            sqlServer.execute(format("CREATE CLUSTERED INDEX clustered_index ON %s (orderkey)", tableName));
+            sqlServer.execute(format("CREATE NONCLUSTERED INDEX non_clustered_index ON %s (orderkey)", tableName));
+
+            assertQuery("SHOW STATS FOR " + tableName, expected);
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableName);
+        }
+    }
+
+    @Override
+    protected void gatherStats(String tableName)
+    {
+        List<String> columnNames = stream(computeActual("SHOW COLUMNS FROM " + tableName))
+                .map(row -> (String) row.getField(0))
+                .collect(toImmutableList());
+        gatherStats(tableName, columnNames);
+    }
+
+    private void gatherStats(String tableName, List<String> columnNames)
+    {
+        for (Object columnName : columnNames) {
+            sqlServer.execute(format("CREATE STATISTICS %1$s ON %2$s (%1$s)", columnName, tableName));
+        }
+        sqlServer.execute("UPDATE STATISTICS " + tableName);
+    }
+}

--- a/plugin/trino-teradata-functions/pom.xml
+++ b/plugin/trino-teradata-functions/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-teradata-functions/pom.xml
+++ b/plugin/trino-teradata-functions/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-thrift-api/pom.xml
+++ b/plugin/trino-thrift-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-thrift-api/pom.xml
+++ b/plugin/trino-thrift-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-thrift-testing-server/pom.xml
+++ b/plugin/trino-thrift-testing-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-thrift-testing-server/pom.xml
+++ b/plugin/trino-thrift-testing-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-thrift/pom.xml
+++ b/plugin/trino-thrift/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-thrift/pom.xml
+++ b/plugin/trino-thrift/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-tpcds/pom.xml
+++ b/plugin/trino-tpcds/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-tpcds/pom.xml
+++ b/plugin/trino-tpcds/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-tpch/pom.xml
+++ b/plugin/trino-tpch/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-tpch/pom.xml
+++ b/plugin/trino-tpch/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>io.trino</groupId>
     <artifactId>trino-root</artifactId>
-    <version>376-SNAPSHOT</version>
+    <version>376</version>
 
     <name>trino-root</name>
     <description>Trino</description>
@@ -30,7 +30,7 @@
     <scm>
         <connection>scm:git:git://github.com/trinodb/trino.git</connection>
         <url>https://github.com/trinodb/trino</url>
-        <tag>HEAD</tag>
+        <tag>376</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>io.trino</groupId>
     <artifactId>trino-root</artifactId>
-    <version>376</version>
+    <version>377-SNAPSHOT</version>
 
     <name>trino-root</name>
     <description>Trino</description>
@@ -30,7 +30,7 @@
     <scm>
         <connection>scm:git:git://github.com/trinodb/trino.git</connection>
         <url>https://github.com/trinodb/trino</url>
-        <tag>376</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/service/trino-proxy/pom.xml
+++ b/service/trino-proxy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/service/trino-proxy/pom.xml
+++ b/service/trino-proxy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/service/trino-verifier/pom.xml
+++ b/service/trino-verifier/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/service/trino-verifier/pom.xml
+++ b/service/trino-verifier/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-benchmark/pom.xml
+++ b/testing/trino-benchmark/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-benchmark/pom.xml
+++ b/testing/trino-benchmark/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-benchto-benchmarks/pom.xml
+++ b/testing/trino-benchto-benchmarks/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-benchto-benchmarks/pom.xml
+++ b/testing/trino-benchto-benchmarks/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-product-tests-launcher/pom.xml
+++ b/testing/trino-product-tests-launcher/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-product-tests-launcher/pom.xml
+++ b/testing/trino-product-tests-launcher/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-product-tests/pom.xml
+++ b/testing/trino-product-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-product-tests/pom.xml
+++ b/testing/trino-product-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-server-dev/pom.xml
+++ b/testing/trino-server-dev/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-server-dev/pom.xml
+++ b/testing/trino-server-dev/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-test-jdbc-compatibility-old-driver/pom.xml
+++ b/testing/trino-test-jdbc-compatibility-old-driver/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -14,7 +14,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.presto-jdbc-under-test>376-SNAPSHOT</dep.presto-jdbc-under-test>
+        <dep.presto-jdbc-under-test>376</dep.presto-jdbc-under-test>
     </properties>
 
     <dependencies>

--- a/testing/trino-test-jdbc-compatibility-old-driver/pom.xml
+++ b/testing/trino-test-jdbc-compatibility-old-driver/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -14,7 +14,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.presto-jdbc-under-test>376</dep.presto-jdbc-under-test>
+        <dep.presto-jdbc-under-test>377-SNAPSHOT</dep.presto-jdbc-under-test>
     </properties>
 
     <dependencies>

--- a/testing/trino-test-jdbc-compatibility-old-server/pom.xml
+++ b/testing/trino-test-jdbc-compatibility-old-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-test-jdbc-compatibility-old-server/pom.xml
+++ b/testing/trino-test-jdbc-compatibility-old-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-testing-containers/pom.xml
+++ b/testing/trino-testing-containers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-testing-containers/pom.xml
+++ b/testing/trino-testing-containers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-testing-kafka/pom.xml
+++ b/testing/trino-testing-kafka/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-testing-kafka/pom.xml
+++ b/testing/trino-testing-kafka/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-testing-services/pom.xml
+++ b/testing/trino-testing-services/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-testing-services/pom.xml
+++ b/testing/trino-testing-services/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-testing/pom.xml
+++ b/testing/trino-testing/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-testing/pom.xml
+++ b/testing/trino-testing/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-tests/pom.xml
+++ b/testing/trino-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376</version>
+        <version>377-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-tests/pom.xml
+++ b/testing/trino-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>376-SNAPSHOT</version>
+        <version>376</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Comparable change: prestodb/presto#12429

This change allows executing queries with the following conditions. Currently, these queries will raise an exception.
```
if (tableBucketCount != readBucketCount && bucketFilter.isPresent())
```

A more specific example can be seen in the `testMismatchedBucketWithBucketPredicate()` test.