### PR TITLE
Support row level deletes in the Iceberg connector

### DIFF
--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -205,6 +205,12 @@
         <!-- used by tests but also needed transitively -->
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>concurrent</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>log-manager</artifactId>
             <scope>runtime</scope>
         </dependency>

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/CommitTaskData.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/CommitTaskData.java
@@ -15,6 +15,7 @@ package io.trino.plugin.iceberg;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.iceberg.FileContent;
 
 import java.util.Optional;
 
@@ -24,21 +25,33 @@ import static java.util.Objects.requireNonNull;
 public class CommitTaskData
 {
     private final String path;
+    private final IcebergFileFormat fileFormat;
     private final long fileSizeInBytes;
     private final MetricsWrapper metrics;
+    private final String partitionSpecJson;
     private final Optional<String> partitionDataJson;
+    private final FileContent content;
+    private final Optional<String> referencedDataFile;
 
     @JsonCreator
     public CommitTaskData(
             @JsonProperty("path") String path,
+            @JsonProperty("fileFormat") IcebergFileFormat fileFormat,
             @JsonProperty("fileSizeInBytes") long fileSizeInBytes,
             @JsonProperty("metrics") MetricsWrapper metrics,
-            @JsonProperty("partitionDataJson") Optional<String> partitionDataJson)
+            @JsonProperty("partitionSpecJson") String partitionSpecJson,
+            @JsonProperty("partitionDataJson") Optional<String> partitionDataJson,
+            @JsonProperty("content") FileContent content,
+            @JsonProperty("referencedDataFile") Optional<String> referencedDataFile)
     {
         this.path = requireNonNull(path, "path is null");
+        this.fileFormat = requireNonNull(fileFormat, "fileFormat is null");
         this.fileSizeInBytes = fileSizeInBytes;
         this.metrics = requireNonNull(metrics, "metrics is null");
+        this.partitionSpecJson = requireNonNull(partitionSpecJson, "partitionSpecJson is null");
         this.partitionDataJson = requireNonNull(partitionDataJson, "partitionDataJson is null");
+        this.content = requireNonNull(content, "content is null");
+        this.referencedDataFile = requireNonNull(referencedDataFile, "referencedDataFile is null");
         checkArgument(fileSizeInBytes >= 0, "fileSizeInBytes is negative");
     }
 
@@ -46,6 +59,12 @@ public class CommitTaskData
     public String getPath()
     {
         return path;
+    }
+
+    @JsonProperty
+    public IcebergFileFormat getFileFormat()
+    {
+        return fileFormat;
     }
 
     @JsonProperty
@@ -61,8 +80,26 @@ public class CommitTaskData
     }
 
     @JsonProperty
+    public String getPartitionSpecJson()
+    {
+        return partitionSpecJson;
+    }
+
+    @JsonProperty
     public Optional<String> getPartitionDataJson()
     {
         return partitionDataJson;
+    }
+
+    @JsonProperty
+    public FileContent getContent()
+    {
+        return content;
+    }
+
+    @JsonProperty
+    public Optional<String> getReferencedDataFile()
+    {
+        return referencedDataFile;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -47,7 +47,7 @@ public class IcebergConfig
     private boolean tableStatisticsEnabled = true;
     private boolean projectionPushdownEnabled = true;
     private Optional<String> hiveCatalogName = Optional.empty();
-    private int formatVersion = FORMAT_VERSION_SUPPORT_MIN;
+    private int formatVersion = FORMAT_VERSION_SUPPORT_MAX;
     private Duration expireSnapshotsMinRetention = new Duration(7, DAYS);
     private Duration deleteOrphanFilesMinRetention = new Duration(7, DAYS);
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
@@ -71,10 +71,13 @@ import static io.trino.plugin.iceberg.TypeConverter.toTrinoType;
 import static io.trino.plugin.iceberg.util.PrimitiveTypeMapBuilder.makeTypeMap;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.util.Objects.requireNonNull;
+import static org.apache.iceberg.TableProperties.DEFAULT_WRITE_METRICS_MODE;
 import static org.apache.iceberg.parquet.ParquetSchemaUtil.convert;
 
 public class IcebergFileWriterFactory
 {
+    private static final MetricsConfig FULL_METRICS_CONFIG = MetricsConfig.fromProperties(ImmutableMap.of(DEFAULT_WRITE_METRICS_MODE, "full"));
+
     private final HdfsEnvironment hdfsEnvironment;
     private final TypeManager typeManager;
     private final NodeVersion nodeVersion;
@@ -104,7 +107,7 @@ public class IcebergFileWriterFactory
         return orcWriterStats;
     }
 
-    public IcebergFileWriter createFileWriter(
+    public IcebergFileWriter createDataFileWriter(
             Path outputPath,
             Schema icebergSchema,
             JobConf jobConf,
@@ -120,7 +123,25 @@ public class IcebergFileWriterFactory
             case ORC:
                 return createOrcWriter(metricsConfig, outputPath, icebergSchema, jobConf, session);
             default:
-                throw new TrinoException(NOT_SUPPORTED, "File format not supported for Iceberg: " + fileFormat);
+                throw new TrinoException(NOT_SUPPORTED, "File format not supported: " + fileFormat);
+        }
+    }
+
+    public IcebergFileWriter createPositionDeleteWriter(
+            Path outputPath,
+            Schema icebergSchema,
+            JobConf jobConf,
+            ConnectorSession session,
+            HdfsContext hdfsContext,
+            IcebergFileFormat fileFormat)
+    {
+        switch (fileFormat) {
+            case PARQUET:
+                return createParquetWriter(outputPath, icebergSchema, jobConf, session, hdfsContext);
+            case ORC:
+                return createOrcWriter(FULL_METRICS_CONFIG, outputPath, icebergSchema, jobConf, session);
+            default:
+                throw new TrinoException(NOT_SUPPORTED, "File format not supported: " + fileFormat);
         }
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
@@ -45,6 +45,7 @@ import org.apache.hadoop.mapred.JobConf;
 import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.transforms.Transform;
@@ -79,6 +80,7 @@ import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.apache.iceberg.FileContent.DATA;
 
 public class IcebergPageSink
         implements ConnectorPageSink
@@ -312,9 +314,13 @@ public class IcebergPageSink
 
         CommitTaskData task = new CommitTaskData(
                 writeContext.getPath().toString(),
+                fileFormat,
                 writeContext.getWriter().getWrittenBytes(),
                 new MetricsWrapper(writeContext.getWriter().getMetrics()),
-                writeContext.getPartitionData().map(PartitionData::toJson));
+                PartitionSpecParser.toJson(partitionSpec),
+                writeContext.getPartitionData().map(PartitionData::toJson),
+                DATA,
+                Optional.empty());
 
         commitTasks.add(wrappedBuffer(jsonCodec.toJsonBytes(task)));
 
@@ -329,7 +335,7 @@ public class IcebergPageSink
         Path outputPath = partitionData.map(partition -> new Path(locationProvider.newDataLocation(partitionSpec, partition, fileName)))
                 .orElse(new Path(locationProvider.newDataLocation(fileName)));
 
-        IcebergFileWriter writer = fileWriterFactory.createFileWriter(
+        IcebergFileWriter writer = fileWriterFactory.createDataFileWriter(
                 outputPath,
                 outputSchema,
                 jobConf,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplit.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplit.java
@@ -17,19 +17,15 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.airlift.slice.SizeOf;
 import io.trino.plugin.iceberg.delete.TrinoDeleteFile;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
-import static io.airlift.slice.SizeOf.sizeOf;
 import static java.util.Objects.requireNonNull;
 
 public class IcebergSplit
@@ -43,7 +39,8 @@ public class IcebergSplit
     private final long fileSize;
     private final IcebergFileFormat fileFormat;
     private final List<HostAddress> addresses;
-    private final Map<Integer, Optional<String>> partitionKeys;
+    private final String partitionSpecJson;
+    private final String partitionDataJson;
     private final List<TrinoDeleteFile> deletes;
 
     @JsonCreator
@@ -54,7 +51,8 @@ public class IcebergSplit
             @JsonProperty("fileSize") long fileSize,
             @JsonProperty("fileFormat") IcebergFileFormat fileFormat,
             @JsonProperty("addresses") List<HostAddress> addresses,
-            @JsonProperty("partitionKeys") Map<Integer, Optional<String>> partitionKeys,
+            @JsonProperty("partitionSpecJson") String partitionSpecJson,
+            @JsonProperty("partitionDataJson") String partitionDataJson,
             @JsonProperty("deletes") List<TrinoDeleteFile> deletes)
     {
         this.path = requireNonNull(path, "path is null");
@@ -63,7 +61,8 @@ public class IcebergSplit
         this.fileSize = fileSize;
         this.fileFormat = requireNonNull(fileFormat, "fileFormat is null");
         this.addresses = ImmutableList.copyOf(requireNonNull(addresses, "addresses is null"));
-        this.partitionKeys = ImmutableMap.copyOf(requireNonNull(partitionKeys, "partitionKeys is null"));
+        this.partitionSpecJson = requireNonNull(partitionSpecJson, "partitionSpecJson is null");
+        this.partitionDataJson = requireNonNull(partitionDataJson, "partitionDataJson is null");
         this.deletes = ImmutableList.copyOf(requireNonNull(deletes, "deletes is null"));
     }
 
@@ -111,9 +110,15 @@ public class IcebergSplit
     }
 
     @JsonProperty
-    public Map<Integer, Optional<String>> getPartitionKeys()
+    public String getPartitionSpecJson()
     {
-        return partitionKeys;
+        return partitionSpecJson;
+    }
+
+    @JsonProperty
+    public String getPartitionDataJson()
+    {
+        return partitionDataJson;
     }
 
     @JsonProperty
@@ -138,7 +143,8 @@ public class IcebergSplit
         return INSTANCE_SIZE
                 + estimatedSizeOf(path)
                 + estimatedSizeOf(addresses, HostAddress::getRetainedSizeInBytes)
-                + estimatedSizeOf(partitionKeys, SizeOf::sizeOf, valueOptional -> sizeOf(valueOptional, SizeOf::estimatedSizeOf))
+                + estimatedSizeOf(partitionSpecJson)
+                + estimatedSizeOf(partitionDataJson)
                 + estimatedSizeOf(deletes, TrinoDeleteFile::getRetainedSizeInBytes);
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableHandle.java
@@ -16,13 +16,16 @@ package io.trino.plugin.iceberg;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
 import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.RetryMode;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.TupleDomain;
 
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -37,6 +40,10 @@ public class IcebergTableHandle
     private final TableType tableType;
     private final Optional<Long> snapshotId;
     private final String tableSchemaJson;
+    private final int formatVersion;
+    private final String tableLocation;
+    private final Map<String, String> storageProperties;
+    private final RetryMode retryMode;
 
     // Filter used during split generation and table scan, but not required to be strictly enforced by Iceberg Connector
     private final TupleDomain<IcebergColumnHandle> unenforcedPredicate;
@@ -58,10 +65,14 @@ public class IcebergTableHandle
             @JsonProperty("tableType") TableType tableType,
             @JsonProperty("snapshotId") Optional<Long> snapshotId,
             @JsonProperty("tableSchemaJson") String tableSchemaJson,
+            @JsonProperty("formatVersion") int formatVersion,
             @JsonProperty("unenforcedPredicate") TupleDomain<IcebergColumnHandle> unenforcedPredicate,
             @JsonProperty("enforcedPredicate") TupleDomain<IcebergColumnHandle> enforcedPredicate,
             @JsonProperty("projectedColumns") Set<IcebergColumnHandle> projectedColumns,
-            @JsonProperty("nameMappingJson") Optional<String> nameMappingJson)
+            @JsonProperty("nameMappingJson") Optional<String> nameMappingJson,
+            @JsonProperty("tableLocation") String tableLocation,
+            @JsonProperty("storageProperties") Map<String, String> storageProperties,
+            @JsonProperty("retryMode") RetryMode retryMode)
     {
         this(
                 schemaName,
@@ -69,10 +80,14 @@ public class IcebergTableHandle
                 tableType,
                 snapshotId,
                 tableSchemaJson,
+                formatVersion,
                 unenforcedPredicate,
                 enforcedPredicate,
                 projectedColumns,
                 nameMappingJson,
+                tableLocation,
+                storageProperties,
+                retryMode,
                 false,
                 Optional.empty());
     }
@@ -83,10 +98,14 @@ public class IcebergTableHandle
             TableType tableType,
             Optional<Long> snapshotId,
             String tableSchemaJson,
+            int formatVersion,
             TupleDomain<IcebergColumnHandle> unenforcedPredicate,
             TupleDomain<IcebergColumnHandle> enforcedPredicate,
             Set<IcebergColumnHandle> projectedColumns,
             Optional<String> nameMappingJson,
+            String tableLocation,
+            Map<String, String> storageProperties,
+            RetryMode retryMode,
             boolean recordScannedFiles,
             Optional<DataSize> maxScannedFileSize)
     {
@@ -95,10 +114,14 @@ public class IcebergTableHandle
         this.tableType = requireNonNull(tableType, "tableType is null");
         this.snapshotId = requireNonNull(snapshotId, "snapshotId is null");
         this.tableSchemaJson = requireNonNull(tableSchemaJson, "schemaJson is null");
+        this.formatVersion = formatVersion;
         this.unenforcedPredicate = requireNonNull(unenforcedPredicate, "unenforcedPredicate is null");
         this.enforcedPredicate = requireNonNull(enforcedPredicate, "enforcedPredicate is null");
         this.projectedColumns = ImmutableSet.copyOf(requireNonNull(projectedColumns, "projectedColumns is null"));
         this.nameMappingJson = requireNonNull(nameMappingJson, "nameMappingJson is null");
+        this.tableLocation = requireNonNull(tableLocation, "tableLocation is null");
+        this.storageProperties = ImmutableMap.copyOf(requireNonNull(storageProperties, "storageProperties is null"));
+        this.retryMode = requireNonNull(retryMode, "retryMode is null");
         this.recordScannedFiles = recordScannedFiles;
         this.maxScannedFileSize = requireNonNull(maxScannedFileSize, "maxScannedFileSize is null");
     }
@@ -134,6 +157,12 @@ public class IcebergTableHandle
     }
 
     @JsonProperty
+    public int getFormatVersion()
+    {
+        return formatVersion;
+    }
+
+    @JsonProperty
     public TupleDomain<IcebergColumnHandle> getUnenforcedPredicate()
     {
         return unenforcedPredicate;
@@ -155,6 +184,24 @@ public class IcebergTableHandle
     public Optional<String> getNameMappingJson()
     {
         return nameMappingJson;
+    }
+
+    @JsonProperty
+    public String getTableLocation()
+    {
+        return tableLocation;
+    }
+
+    @JsonProperty
+    public Map<String, String> getStorageProperties()
+    {
+        return storageProperties;
+    }
+
+    @JsonProperty
+    public RetryMode getRetryMode()
+    {
+        return retryMode;
     }
 
     @JsonIgnore
@@ -187,10 +234,34 @@ public class IcebergTableHandle
                 tableType,
                 snapshotId,
                 tableSchemaJson,
+                formatVersion,
                 unenforcedPredicate,
                 enforcedPredicate,
                 projectedColumns,
                 nameMappingJson,
+                tableLocation,
+                storageProperties,
+                retryMode,
+                recordScannedFiles,
+                maxScannedFileSize);
+    }
+
+    public IcebergTableHandle withRetryMode(RetryMode retryMode)
+    {
+        return new IcebergTableHandle(
+                schemaName,
+                tableName,
+                tableType,
+                snapshotId,
+                tableSchemaJson,
+                formatVersion,
+                unenforcedPredicate,
+                enforcedPredicate,
+                projectedColumns,
+                nameMappingJson,
+                tableLocation,
+                storageProperties,
+                retryMode,
                 recordScannedFiles,
                 maxScannedFileSize);
     }
@@ -203,10 +274,14 @@ public class IcebergTableHandle
                 tableType,
                 snapshotId,
                 tableSchemaJson,
+                formatVersion,
                 unenforcedPredicate,
                 enforcedPredicate,
                 projectedColumns,
                 nameMappingJson,
+                tableLocation,
+                storageProperties,
+                retryMode,
                 recordScannedFiles,
                 Optional.of(maxScannedFileSize));
     }
@@ -228,17 +303,22 @@ public class IcebergTableHandle
                 tableType == that.tableType &&
                 Objects.equals(snapshotId, that.snapshotId) &&
                 Objects.equals(tableSchemaJson, that.tableSchemaJson) &&
+                formatVersion == that.formatVersion &&
                 Objects.equals(unenforcedPredicate, that.unenforcedPredicate) &&
                 Objects.equals(enforcedPredicate, that.enforcedPredicate) &&
                 Objects.equals(projectedColumns, that.projectedColumns) &&
                 Objects.equals(nameMappingJson, that.nameMappingJson) &&
+                Objects.equals(tableLocation, that.tableLocation) &&
+                Objects.equals(retryMode, that.retryMode) &&
+                Objects.equals(storageProperties, that.storageProperties) &&
                 Objects.equals(maxScannedFileSize, that.maxScannedFileSize);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(schemaName, tableName, tableType, snapshotId, tableSchemaJson, unenforcedPredicate, enforcedPredicate, projectedColumns, nameMappingJson, recordScannedFiles, maxScannedFileSize);
+        return Objects.hash(schemaName, tableName, tableType, snapshotId, tableSchemaJson, formatVersion, unenforcedPredicate, enforcedPredicate,
+                projectedColumns, nameMappingJson, tableLocation, storageProperties, retryMode, recordScannedFiles, maxScannedFileSize);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionData.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionData.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.UUID;
 
 import static io.trino.spi.type.DecimalType.createDecimalType;
@@ -77,15 +76,15 @@ public class PartitionData
         partitionValues[pos] = value;
     }
 
-    public String toJson()
+    public static String toJson(StructLike structLike)
     {
         try {
             StringWriter writer = new StringWriter();
             JsonGenerator generator = FACTORY.createGenerator(writer);
             generator.writeStartObject();
             generator.writeArrayFieldStart(PARTITION_VALUES_FIELD);
-            for (Object value : partitionValues) {
-                generator.writeObject(value);
+            for (int i = 0; i < structLike.size(); i++) {
+                generator.writeObject(structLike.get(i, Object.class));
             }
             generator.writeEndArray();
             generator.writeEndObject();
@@ -93,7 +92,7 @@ public class PartitionData
             return writer.toString();
         }
         catch (IOException e) {
-            throw new UncheckedIOException("JSON conversion failed for PartitionData: " + Arrays.toString(partitionValues), e);
+            throw new UncheckedIOException("JSON conversion failed for: " + structLike, e);
         }
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractIcebergTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractIcebergTableOperations.java
@@ -107,7 +107,7 @@ public abstract class AbstractIcebergTableOperations
     public TableMetadata current()
     {
         if (shouldRefresh) {
-            return refresh();
+            return refresh(false);
         }
         return currentMetadata;
     }
@@ -115,11 +115,16 @@ public abstract class AbstractIcebergTableOperations
     @Override
     public TableMetadata refresh()
     {
+        return refresh(true);
+    }
+
+    public TableMetadata refresh(boolean invalidateCaches)
+    {
         if (location.isPresent()) {
             refreshFromMetadataLocation(null);
             return currentMetadata;
         }
-        refreshFromMetadataLocation(getRefreshedLocation());
+        refreshFromMetadataLocation(getRefreshedLocation(invalidateCaches));
         return currentMetadata;
     }
 
@@ -148,7 +153,7 @@ public abstract class AbstractIcebergTableOperations
         shouldRefresh = true;
     }
 
-    protected abstract String getRefreshedLocation();
+    protected abstract String getRefreshedLocation(boolean invalidateCaches);
 
     protected abstract void commitNewTable(TableMetadata metadata);
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/file/FileMetastoreTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/file/FileMetastoreTableOperations.java
@@ -13,10 +13,10 @@
  */
 package io.trino.plugin.iceberg.catalog.file;
 
-import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.MetastoreUtil;
 import io.trino.plugin.hive.metastore.PrincipalPrivileges;
 import io.trino.plugin.hive.metastore.Table;
+import io.trino.plugin.hive.metastore.cache.CachingHiveMetastore;
 import io.trino.plugin.iceberg.catalog.hms.AbstractMetastoreTableOperations;
 import io.trino.spi.connector.ConnectorSession;
 import org.apache.iceberg.TableMetadata;
@@ -38,7 +38,7 @@ public class FileMetastoreTableOperations
 {
     public FileMetastoreTableOperations(
             FileIO fileIo,
-            HiveMetastore metastore,
+            CachingHiveMetastore metastore,
             ConnectorSession session,
             String database,
             String table,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergTableOperations.java
@@ -69,7 +69,7 @@ public class GlueIcebergTableOperations
     }
 
     @Override
-    protected String getRefreshedLocation()
+    protected String getRefreshedLocation(boolean invalidateCaches)
     {
         Table table = getTable();
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/HiveMetastoreTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/HiveMetastoreTableOperations.java
@@ -15,12 +15,11 @@ package io.trino.plugin.iceberg.catalog.hms;
 
 import io.trino.plugin.hive.authentication.HiveIdentity;
 import io.trino.plugin.hive.metastore.AcidTransactionOwner;
-import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.MetastoreUtil;
 import io.trino.plugin.hive.metastore.PrincipalPrivileges;
 import io.trino.plugin.hive.metastore.Table;
+import io.trino.plugin.hive.metastore.cache.CachingHiveMetastore;
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastore;
-import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.TableNotFoundException;
 import org.apache.iceberg.TableMetadata;
@@ -34,8 +33,6 @@ import java.util.Optional;
 import static com.google.common.base.Preconditions.checkState;
 import static io.trino.plugin.hive.metastore.PrincipalPrivileges.NO_PRIVILEGES;
 import static io.trino.plugin.hive.metastore.thrift.ThriftMetastoreUtil.fromMetastoreApiTable;
-import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_COMMIT_ERROR;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.BaseMetastoreTableOperations.METADATA_LOCATION_PROP;
 import static org.apache.iceberg.BaseMetastoreTableOperations.PREVIOUS_METADATA_LOCATION_PROP;
@@ -48,7 +45,7 @@ public class HiveMetastoreTableOperations
 
     public HiveMetastoreTableOperations(
             FileIO fileIo,
-            HiveMetastore metastore,
+            CachingHiveMetastore metastore,
             ThriftMetastore thriftMetastore,
             ConnectorSession session,
             String database,
@@ -99,7 +96,8 @@ public class HiveMetastoreTableOperations
                 catch (RuntimeException ex) {
                     e.addSuppressed(ex);
                 }
-                throw new TrinoException(ICEBERG_COMMIT_ERROR, format("Failed to commit to table %s.%s", database, tableName), e);
+                // CommitFailedException is handled as a special case in the Iceberg library. This commit will automatically retry
+                throw new CommitFailedException(e, "Failed to commit to table %s.%s", database, tableName);
             }
 
             // todo privileges should not be replaced for an alter

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
@@ -24,7 +24,6 @@ import io.trino.plugin.hive.TableAlreadyExistsException;
 import io.trino.plugin.hive.ViewAlreadyExistsException;
 import io.trino.plugin.hive.metastore.Column;
 import io.trino.plugin.hive.metastore.Database;
-import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.HivePrincipal;
 import io.trino.plugin.hive.metastore.PrincipalPrivileges;
 import io.trino.plugin.hive.metastore.cache.CachingHiveMetastore;
@@ -126,7 +125,7 @@ public class TrinoHiveCatalog
         this.deleteSchemaLocationsFallback = deleteSchemaLocationsFallback;
     }
 
-    public HiveMetastore getMetastore()
+    public CachingHiveMetastore getMetastore()
     {
         return metastore;
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/IcebergPositionDeletePageSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/IcebergPositionDeletePageSink.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.delete;
+
+import io.airlift.json.JsonCodec;
+import io.airlift.slice.Slice;
+import io.trino.plugin.hive.HdfsEnvironment;
+import io.trino.plugin.hive.HdfsEnvironment.HdfsContext;
+import io.trino.plugin.iceberg.CommitTaskData;
+import io.trino.plugin.iceberg.IcebergFileFormat;
+import io.trino.plugin.iceberg.IcebergFileWriter;
+import io.trino.plugin.iceberg.IcebergFileWriterFactory;
+import io.trino.plugin.iceberg.MetricsWrapper;
+import io.trino.plugin.iceberg.PartitionData;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.spi.connector.ConnectorPageSink;
+import io.trino.spi.connector.ConnectorSession;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.PartitionSpecParser;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.io.LocationProvider;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static io.trino.plugin.hive.util.ConfigurationUtils.toJobConf;
+import static io.trino.spi.predicate.Utils.nativeValueToBlock;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.util.Objects.requireNonNull;
+import static java.util.UUID.randomUUID;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.apache.iceberg.io.DeleteSchemaUtil.pathPosSchema;
+
+public class IcebergPositionDeletePageSink
+        implements ConnectorPageSink
+{
+    private static final Schema POSITION_DELETE_SCHEMA = pathPosSchema();
+
+    private final String dataFilePath;
+    private final PartitionSpec partitionSpec;
+    private final Optional<PartitionData> partition;
+    private final String outputPath;
+    private final JsonCodec<CommitTaskData> jsonCodec;
+    private final IcebergFileWriter writer;
+    private final IcebergFileFormat fileFormat;
+
+    private long validationCpuNanos;
+    private boolean writtenData;
+
+    public IcebergPositionDeletePageSink(
+            String dataFilePath,
+            PartitionSpec partitionSpec,
+            Optional<PartitionData> partition,
+            LocationProvider locationProvider,
+            IcebergFileWriterFactory fileWriterFactory,
+            HdfsEnvironment hdfsEnvironment,
+            HdfsContext hdfsContext,
+            JsonCodec<CommitTaskData> jsonCodec,
+            ConnectorSession session,
+            IcebergFileFormat fileFormat)
+    {
+        this.dataFilePath = requireNonNull(dataFilePath, "dataFilePath is null");
+        this.jsonCodec = requireNonNull(jsonCodec, "jsonCodec is null");
+        this.partitionSpec = requireNonNull(partitionSpec, "partitionSpec is null");
+        this.partition = requireNonNull(partition, "partition is null");
+        this.fileFormat = requireNonNull(fileFormat, "fileFormat is null");
+        // prepend query id to a file name so we can determine which files were written by which query. This is needed for opportunistic cleanup of extra files
+        // which may be present for successfully completing query in presence of failure recovery mechanisms.
+        String fileName = fileFormat.toIceberg().addExtension(session.getQueryId() + "-" + randomUUID());
+        this.outputPath = partition
+                .map(partitionData -> locationProvider.newDataLocation(partitionSpec, partitionData, fileName))
+                .orElseGet(() -> locationProvider.newDataLocation(fileName));
+        JobConf jobConf = toJobConf(hdfsEnvironment.getConfiguration(hdfsContext, new Path(outputPath)));
+        this.writer = fileWriterFactory.createPositionDeleteWriter(new Path(outputPath), POSITION_DELETE_SCHEMA, jobConf, session, hdfsContext, fileFormat);
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return writer.getWrittenBytes();
+    }
+
+    @Override
+    public long getMemoryUsage()
+    {
+        return writer.getMemoryUsage();
+    }
+
+    @Override
+    public long getValidationCpuNanos()
+    {
+        return validationCpuNanos;
+    }
+
+    @Override
+    public CompletableFuture<?> appendPage(Page page)
+    {
+        checkArgument(page.getChannelCount() == 1, "IcebergPositionDeletePageSink expected a Page with only one channel, but got " + page.getChannelCount());
+
+        Block[] blocks = new Block[2];
+        blocks[0] = new RunLengthEncodedBlock(nativeValueToBlock(VARCHAR, utf8Slice(dataFilePath)), page.getPositionCount());
+        blocks[1] = page.getBlock(0);
+        writer.appendRows(new Page(blocks));
+
+        writtenData = true;
+        return NOT_BLOCKED;
+    }
+
+    @Override
+    public CompletableFuture<Collection<Slice>> finish()
+    {
+        Collection<Slice> commitTasks = new ArrayList<>();
+        if (writtenData) {
+            writer.commit();
+            CommitTaskData task = new CommitTaskData(
+                    outputPath,
+                    fileFormat,
+                    writer.getWrittenBytes(),
+                    new MetricsWrapper(writer.getMetrics()),
+                    PartitionSpecParser.toJson(partitionSpec),
+                    partition.map(PartitionData::toJson),
+                    FileContent.POSITION_DELETES,
+                    Optional.of(dataFilePath));
+            Long recordCount = task.getMetrics().recordCount();
+            if (recordCount != null && recordCount > 0) {
+                commitTasks.add(wrappedBuffer(jsonCodec.toJsonBytes(task)));
+            }
+            validationCpuNanos = writer.getValidationCpuNanos();
+        }
+        else {
+            // clean up the empty delete file
+            writer.rollback();
+        }
+        return completedFuture(commitTasks);
+    }
+
+    @Override
+    public void abort()
+    {
+        writer.rollback();
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
@@ -78,7 +78,7 @@ public abstract class BaseIcebergConnectorSmokeTest
                         "\\)\n" +
                         "WITH \\(\n" +
                         "   format = '" + format.name() + "',\n" +
-                        "   format_version = 1,\n" +
+                        "   format_version = 2,\n" +
                         format("   location = '.*/" + schemaName + "/region'\n") +
                         "\\)");
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
@@ -23,7 +23,6 @@ import org.testng.annotations.Test;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public abstract class BaseIcebergConnectorSmokeTest
         extends BaseConnectorSmokeTest
@@ -53,15 +52,6 @@ public abstract class BaseIcebergConnectorSmokeTest
             default:
                 return super.hasBehavior(connectorBehavior);
         }
-    }
-
-    @Test
-    @Override
-    public void testRowLevelDelete()
-    {
-        // Deletes are covered AbstractTestIcebergConnectorTest
-        assertThatThrownBy(super::testRowLevelDelete)
-                .hasStackTraceContaining("This connector only supports delete where one or more identity-transformed partitions are deleted entirely");
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -283,7 +283,7 @@ public abstract class BaseIcebergConnectorTest
                         ")\n" +
                         "WITH (\n" +
                         "   format = '" + format.name() + "',\n" +
-                        "   format_version = 1,\n" +
+                        "   format_version = 2,\n" +
                         "   location = '" + tempDir + "/iceberg_data/tpch/orders'\n" +
                         ")");
     }
@@ -918,7 +918,7 @@ public abstract class BaseIcebergConnectorTest
                 "COMMENT '%s'\n" +
                 "WITH (\n" +
                 format("   format = '%s',\n", format) +
-                "   format_version = 1,\n" +
+                "   format_version = 2,\n" +
                 format("   location = '%s'\n", tempDirPath) +
                 ")";
         String createTableWithoutComment = "" +
@@ -927,7 +927,7 @@ public abstract class BaseIcebergConnectorTest
                 ")\n" +
                 "WITH (\n" +
                 "   format = '" + format + "',\n" +
-                "   format_version = 1,\n" +
+                "   format_version = 2,\n" +
                 "   location = '" + tempDirPath + "'\n" +
                 ")";
         String createTableSql = format(createTableTemplate, "test table comment", format);
@@ -1080,7 +1080,7 @@ public abstract class BaseIcebergConnectorTest
         assertUpdate(format("CREATE TABLE test_create_table_like_original (col1 INTEGER, aDate DATE) WITH(format = '%s', location = '%s', partitioning = ARRAY['aDate'])", format, tempDirPath));
         assertEquals(getTablePropertiesString("test_create_table_like_original"), "WITH (\n" +
                 format("   format = '%s',\n", format) +
-                "   format_version = 1,\n" +
+                "   format_version = 2,\n" +
                 format("   location = '%s',\n", tempDirPath) +
                 "   partitioning = ARRAY['adate']\n" +
                 ")");
@@ -1091,17 +1091,17 @@ public abstract class BaseIcebergConnectorTest
 
         assertUpdate("CREATE TABLE test_create_table_like_copy1 (LIKE test_create_table_like_original)");
         assertEquals(getTablePropertiesString("test_create_table_like_copy1"), "WITH (\n" +
-                format("   format = '%s',\n   format_version = 1,\n   location = '%s'\n)", format, tempDir + "/iceberg_data/tpch/test_create_table_like_copy1"));
+                format("   format = '%s',\n   format_version = 2,\n   location = '%s'\n)", format, tempDir + "/iceberg_data/tpch/test_create_table_like_copy1"));
 
         assertUpdate("CREATE TABLE test_create_table_like_copy2 (LIKE test_create_table_like_original EXCLUDING PROPERTIES)");
         assertEquals(getTablePropertiesString("test_create_table_like_copy2"), "WITH (\n" +
-                format("   format = '%s',\n   format_version = 1,\n   location = '%s'\n)", format, tempDir + "/iceberg_data/tpch/test_create_table_like_copy2"));
+                format("   format = '%s',\n   format_version = 2,\n   location = '%s'\n)", format, tempDir + "/iceberg_data/tpch/test_create_table_like_copy2"));
         dropTable("test_create_table_like_copy2");
 
         assertUpdate("CREATE TABLE test_create_table_like_copy3 (LIKE test_create_table_like_original INCLUDING PROPERTIES)");
         assertEquals(getTablePropertiesString("test_create_table_like_copy3"), "WITH (\n" +
                 format("   format = '%s',\n", format) +
-                "   format_version = 1,\n" +
+                "   format_version = 2,\n" +
                 format("   location = '%s',\n", tempDirPath) +
                 "   partitioning = ARRAY['adate']\n" +
                 ")");
@@ -1109,7 +1109,7 @@ public abstract class BaseIcebergConnectorTest
         assertUpdate(format("CREATE TABLE test_create_table_like_copy4 (LIKE test_create_table_like_original INCLUDING PROPERTIES) WITH (format = '%s')", otherFormat));
         assertEquals(getTablePropertiesString("test_create_table_like_copy4"), "WITH (\n" +
                 format("   format = '%s',\n", otherFormat) +
-                "   format_version = 1,\n" +
+                "   format_version = 2,\n" +
                 format("   location = '%s',\n", tempDirPath) +
                 "   partitioning = ARRAY['adate']\n" +
                 ")");
@@ -3083,7 +3083,7 @@ public abstract class BaseIcebergConnectorTest
             throws Exception
     {
         String tableName = "test_optimize_" + randomTableSuffix();
-        assertUpdate("CREATE TABLE " + tableName + " (key integer, value varchar)");
+        assertUpdate("CREATE TABLE " + tableName + " (key integer, value varchar) WITH (format_version = 1)");
 
         // DistributedQueryRunner sets node-scheduler.include-coordinator by default, so include coordinator
         int workerCount = getQueryRunner().getNodeCount();
@@ -3145,7 +3145,7 @@ public abstract class BaseIcebergConnectorTest
                 .setSystemProperty("preferred_write_partitioning_min_number_of_partitions", "100")
                 .build();
         String tableName = "test_repartitiong_during_optimize_" + randomTableSuffix();
-        assertUpdate(session, "CREATE TABLE " + tableName + " (key varchar, value integer) WITH (partitioning = ARRAY['key'])");
+        assertUpdate(session, "CREATE TABLE " + tableName + " (key varchar, value integer) WITH (format_version = 1, partitioning = ARRAY['key'])");
         // optimize an empty table
         assertQuerySucceeds(session, "ALTER TABLE " + tableName + " EXECUTE OPTIMIZE");
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergFailureRecoveryTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergFailureRecoveryTest.java
@@ -15,12 +15,19 @@ package io.trino.plugin.iceberg;
 
 import io.trino.Session;
 import io.trino.operator.RetryPolicy;
+import io.trino.spi.ErrorType;
 import io.trino.testing.BaseFailureRecoveryTest;
 import org.testng.annotations.Test;
 
 import java.util.List;
 import java.util.Optional;
 
+import static io.trino.execution.FailureInjector.FAILURE_INJECTION_MESSAGE;
+import static io.trino.execution.FailureInjector.InjectedFailureType.TASK_FAILURE;
+import static io.trino.execution.FailureInjector.InjectedFailureType.TASK_GET_RESULTS_REQUEST_FAILURE;
+import static io.trino.execution.FailureInjector.InjectedFailureType.TASK_GET_RESULTS_REQUEST_TIMEOUT;
+import static io.trino.execution.FailureInjector.InjectedFailureType.TASK_MANAGEMENT_REQUEST_FAILURE;
+import static io.trino.execution.FailureInjector.InjectedFailureType.TASK_MANAGEMENT_REQUEST_TIMEOUT;
 import static java.lang.String.format;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
@@ -46,20 +53,6 @@ public abstract class BaseIcebergFailureRecoveryTest
     }
 
     @Override
-    public void testDelete()
-    {
-        assertThatThrownBy(super::testDelete)
-                .hasMessageContaining("This connector only supports delete where one or more identity-transformed partitions are deleted entirely");
-    }
-
-    @Override
-    public void testDeleteWithSubquery()
-    {
-        assertThatThrownBy(super::testDelete)
-                .hasMessageContaining("This connector only supports delete where one or more identity-transformed partitions are deleted entirely");
-    }
-
-    @Override
     protected void createPartitionedLineitemTable(String tableName, List<String> columns, String partitionColumn)
     {
         String sql = format(
@@ -68,6 +61,91 @@ public abstract class BaseIcebergFailureRecoveryTest
                 partitionColumn,
                 String.join(",", columns));
         getQueryRunner().execute(sql);
+    }
+
+    // Copied from BaseDeltaFailureRecoveryTest
+    @Override
+    public void testDelete()
+    {
+        // Test method is overriden because method from superclass assumes more complex plan for `DELETE` query.
+        // Assertions do not play well if plan consists of just two fragments.
+
+        Optional<String> setupQuery = Optional.of("CREATE TABLE <table> AS SELECT * FROM orders");
+        Optional<String> cleanupQuery = Optional.of("DROP TABLE <table>");
+        String deleteQuery = "DELETE FROM <table> WHERE orderkey = 1";
+
+        assertThatQuery(deleteQuery)
+                .withSetupQuery(setupQuery)
+                .withCleanupQuery(cleanupQuery)
+                .experiencing(TASK_FAILURE, Optional.of(ErrorType.INTERNAL_ERROR))
+                .at(boundaryCoordinatorStage())
+                .failsAlways(failure -> failure.hasMessageContaining(FAILURE_INJECTION_MESSAGE));
+
+        assertThatQuery(deleteQuery)
+                .withSetupQuery(setupQuery)
+                .withCleanupQuery(cleanupQuery)
+                .experiencing(TASK_FAILURE, Optional.of(ErrorType.INTERNAL_ERROR))
+                .at(rootStage())
+                .failsAlways(failure -> failure.hasMessageContaining(FAILURE_INJECTION_MESSAGE));
+
+        assertThatQuery(deleteQuery)
+                .withSetupQuery(setupQuery)
+                .withCleanupQuery(cleanupQuery)
+                .experiencing(TASK_FAILURE, Optional.of(ErrorType.INTERNAL_ERROR))
+                .at(leafStage())
+                .failsWithoutRetries(failure -> failure.hasMessageContaining(FAILURE_INJECTION_MESSAGE))
+                .finishesSuccessfully();
+
+        // note: this is effectively same as test with `leafStage`. Should it be dropped?
+        assertThatQuery(deleteQuery)
+                .withSetupQuery(setupQuery)
+                .withCleanupQuery(cleanupQuery)
+                .experiencing(TASK_FAILURE, Optional.of(ErrorType.INTERNAL_ERROR))
+                .at(boundaryDistributedStage())
+                .failsWithoutRetries(failure -> failure.hasMessageContaining(FAILURE_INJECTION_MESSAGE))
+                .finishesSuccessfully();
+
+        // DELETE plan is too simplistic for testing with `intermediateDistributedStage`
+        assertThatThrownBy(() ->
+                assertThatQuery(deleteQuery)
+                        .withSetupQuery(setupQuery)
+                        .withCleanupQuery(cleanupQuery)
+                        .experiencing(TASK_FAILURE, Optional.of(ErrorType.INTERNAL_ERROR))
+                        .at(intermediateDistributedStage())
+                        .failsWithoutRetries(failure -> failure.hasMessageContaining(FAILURE_INJECTION_MESSAGE)))
+                .hasMessageContaining("stage not found");
+
+        assertThatQuery(deleteQuery)
+                .withSetupQuery(setupQuery)
+                .withCleanupQuery(cleanupQuery)
+                .experiencing(TASK_MANAGEMENT_REQUEST_FAILURE)
+                .at(boundaryDistributedStage())
+                .failsWithoutRetries(failure -> failure.hasMessageFindingMatch("Error 500 Internal Server Error|Error closing remote buffer, expected 204 got 500"))
+                .finishesSuccessfully();
+
+        assertThatQuery(deleteQuery)
+                .withSetupQuery(setupQuery)
+                .withCleanupQuery(cleanupQuery)
+                .experiencing(TASK_GET_RESULTS_REQUEST_FAILURE)
+                .at(boundaryDistributedStage())
+                .failsWithoutRetries(failure -> failure.hasMessageFindingMatch("Error 500 Internal Server Error|Error closing remote buffer, expected 204 got 500"))
+                .finishesSuccessfully();
+
+        assertThatQuery(deleteQuery)
+                .withSetupQuery(setupQuery)
+                .withCleanupQuery(cleanupQuery)
+                .experiencing(TASK_MANAGEMENT_REQUEST_TIMEOUT)
+                .at(boundaryDistributedStage())
+                .failsWithoutRetries(failure -> failure.hasMessageContaining("Encountered too many errors talking to a worker node"))
+                .finishesSuccessfully();
+
+        assertThatQuery(deleteQuery)
+                .withSetupQuery(setupQuery)
+                .withCleanupQuery(cleanupQuery)
+                .experiencing(TASK_GET_RESULTS_REQUEST_TIMEOUT)
+                .at(boundaryDistributedStage())
+                .failsWithoutRetries(failure -> failure.hasMessageContaining("Encountered too many errors talking to a worker node"))
+                .finishesSuccessfully();
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMinioConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMinioConnectorSmokeTest.java
@@ -16,16 +16,28 @@ package io.trino.plugin.iceberg;
 import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.hive.containers.HiveMinioDataLake;
 import io.trino.testing.QueryRunner;
+import io.trino.testing.sql.TestTable;
 import org.apache.iceberg.FileFormat;
 import org.testng.annotations.Test;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.stream.IntStream;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.trino.plugin.hive.containers.HiveMinioDataLake.ACCESS_KEY;
 import static io.trino.plugin.hive.containers.HiveMinioDataLake.SECRET_KEY;
 import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
+import static java.util.concurrent.Executors.newFixedThreadPool;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertTrue;
 
 public abstract class BaseIcebergMinioConnectorSmokeTest
         extends BaseIcebergConnectorSmokeTest
@@ -83,5 +95,48 @@ public abstract class BaseIcebergMinioConnectorSmokeTest
         assertQueryFails(
                 format("ALTER SCHEMA %s RENAME TO %s", schemaName, schemaName + randomTableSuffix()),
                 "Hive metastore does not support renaming schemas");
+    }
+
+    // TODO: https://github.com/trinodb/trino/issues/11713 Run this test against Glue
+    // Repeat test with invocationCount for better test coverage, since the tested aspect is inherently non-deterministic.
+    @Test(timeOut = 60_000, invocationCount = 4)
+    public void testDeleteRowsConcurrently()
+            throws Exception
+    {
+        int threads = 4;
+        CyclicBarrier barrier = new CyclicBarrier(threads);
+        ExecutorService executor = newFixedThreadPool(threads);
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "test_concurrent_delete",
+                "(col0 INTEGER, col1 INTEGER, col2 INTEGER, col3 INTEGER)")) {
+            String tableName = table.getName();
+            assertUpdate("INSERT INTO " + tableName + " VALUES (0, 0, 0, 0)", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 0, 0, 0)", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (0, 1, 0, 0)", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (0, 0, 1, 0)", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (0, 0, 0, 1)", 1);
+
+            List<Future<Boolean>> futures = IntStream.range(0, threads)
+                    .mapToObj(threadNumber -> executor.submit(() -> {
+                        barrier.await(10, SECONDS);
+                        try {
+                            String columnName = "col" + threadNumber;
+                            getQueryRunner().execute(format("DELETE FROM %s WHERE %s = 1", tableName, columnName));
+                            return true;
+                        }
+                        catch (Exception e) {
+                            return false;
+                        }
+                    }))
+                    .collect(toImmutableList());
+
+            futures.forEach(future -> assertTrue(getFutureValue(future)));
+            assertThat(query("SELECT max(col0), max(col1), max(col2), max(col3) FROM " + tableName)).matches("VALUES (0, 0, 0, 0)");
+        }
+        finally {
+            executor.shutdownNow();
+            executor.awaitTermination(10, SECONDS);
+        }
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
@@ -48,7 +48,7 @@ public class TestIcebergConfig
                 .setTableStatisticsEnabled(true)
                 .setProjectionPushdownEnabled(true)
                 .setHiveCatalogName(null)
-                .setFormatVersion(1)
+                .setFormatVersion(2)
                 .setExpireSnapshotsMinRetention(new Duration(7, DAYS))
                 .setDeleteOrphanFilesMinRetention(new Duration(7, DAYS)));
     }
@@ -67,7 +67,7 @@ public class TestIcebergConfig
                 .put("iceberg.table-statistics-enabled", "false")
                 .put("iceberg.projection-pushdown-enabled", "false")
                 .put("iceberg.hive-catalog-name", "hive")
-                .put("iceberg.format-version", "2")
+                .put("iceberg.format-version", "1")
                 .put("iceberg.expire_snapshots.min-retention", "13h")
                 .put("iceberg.delete_orphan_files.min-retention", "14h")
                 .buildOrThrow();
@@ -83,7 +83,7 @@ public class TestIcebergConfig
                 .setTableStatisticsEnabled(false)
                 .setProjectionPushdownEnabled(false)
                 .setHiveCatalogName("hive")
-                .setFormatVersion(2)
+                .setFormatVersion(1)
                 .setExpireSnapshotsMinRetention(new Duration(13, HOURS))
                 .setDeleteOrphanFilesMinRetention(new Duration(14, HOURS));
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
@@ -194,7 +194,7 @@ public class TestIcebergMetastoreAccessOperations
 
         assertMetastoreInvocations("REFRESH MATERIALIZED VIEW test_refresh_mview_view",
                 ImmutableMultiset.builder()
-                        .addCopies(GET_TABLE, 5)
+                        .addCopies(GET_TABLE, 9)
                         .addCopies(REPLACE_TABLE, 2)
                         .build());
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
@@ -63,6 +63,7 @@ import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.trino.plugin.hive.metastore.cache.CachingHiveMetastore.memoizeMetastore;
 import static io.trino.plugin.hive.metastore.file.FileHiveMetastore.createTestingFileHiveMetastore;
 import static io.trino.spi.connector.Constraint.alwaysTrue;
+import static io.trino.spi.connector.RetryMode.NO_RETRIES;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.testing.TestingConnectorSession.SESSION;
 import static io.trino.tpch.TpchTable.NATION;
@@ -126,10 +127,14 @@ public class TestIcebergSplitSource
                 TableType.DATA,
                 Optional.empty(),
                 SchemaParser.toJson(nationTable.schema()),
+                1,
                 TupleDomain.all(),
                 TupleDomain.all(),
                 ImmutableSet.of(),
-                Optional.empty());
+                Optional.empty(),
+                nationTable.location(),
+                nationTable.properties(),
+                NO_RETRIES);
 
         IcebergSplitSource splitSource = new IcebergSplitSource(
                 tableHandle,

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
@@ -116,7 +116,7 @@ public class TestIcebergV2
     {
         String tableName = "test_default_format_version_" + randomTableSuffix();
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM tpch.tiny.nation", 25);
-        assertThat(loadTable(tableName).operations().current().formatVersion()).isEqualTo(1);
+        assertThat(loadTable(tableName).operations().current().formatVersion()).isEqualTo(2);
         assertUpdate("DROP TABLE " + tableName);
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogConnectorSmokeTest.java
@@ -118,7 +118,7 @@ public class TestIcebergGlueCatalogConnectorSmokeTest
                                 ")\n" +
                                 "WITH (\n" +
                                 "   format = 'ORC',\n" +
-                                "   format_version = 1,\n" +
+                                "   format_version = 2,\n" +
                                 "   location = '%2$s/%1$s.db/region'\n" +
                                 ")",
                         schemaName,

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/optimizer/TestConnectorPushdownRulesWithIceberg.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/optimizer/TestConnectorPushdownRulesWithIceberg.java
@@ -72,6 +72,7 @@ import static io.trino.plugin.hive.metastore.file.FileHiveMetastore.createTestin
 import static io.trino.plugin.iceberg.ColumnIdentity.TypeCategory.STRUCT;
 import static io.trino.plugin.iceberg.ColumnIdentity.primitiveColumnIdentity;
 import static io.trino.plugin.iceberg.TableType.DATA;
+import static io.trino.spi.connector.RetryMode.NO_RETRIES;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RowType.field;
@@ -164,7 +165,7 @@ public class TestConnectorPushdownRulesWithIceberg
                 BIGINT,
                 Optional.empty());
 
-        IcebergTableHandle icebergTable = new IcebergTableHandle(SCHEMA_NAME, tableName, DATA, Optional.of(1L), "", TupleDomain.all(), TupleDomain.all(), ImmutableSet.of(), Optional.empty());
+        IcebergTableHandle icebergTable = new IcebergTableHandle(SCHEMA_NAME, tableName, DATA, Optional.of(1L), "", 1, TupleDomain.all(), TupleDomain.all(), ImmutableSet.of(), Optional.empty(), "", ImmutableMap.of(), NO_RETRIES);
         TableHandle table = new TableHandle(new CatalogName(ICEBERG_CATALOG_NAME), icebergTable, new HiveTransactionHandle(false));
 
         IcebergColumnHandle fullColumn = partialColumn.getBaseColumn();
@@ -228,7 +229,7 @@ public class TestConnectorPushdownRulesWithIceberg
 
         PushPredicateIntoTableScan pushPredicateIntoTableScan = new PushPredicateIntoTableScan(tester().getPlannerContext(), tester().getTypeAnalyzer());
 
-        IcebergTableHandle icebergTable = new IcebergTableHandle(SCHEMA_NAME, tableName, DATA, Optional.of(1L), "", TupleDomain.all(), TupleDomain.all(), ImmutableSet.of(), Optional.empty());
+        IcebergTableHandle icebergTable = new IcebergTableHandle(SCHEMA_NAME, tableName, DATA, Optional.of(1L), "", 1, TupleDomain.all(), TupleDomain.all(), ImmutableSet.of(), Optional.empty(), "", ImmutableMap.of(), NO_RETRIES);
         TableHandle table = new TableHandle(new CatalogName(ICEBERG_CATALOG_NAME), icebergTable, new HiveTransactionHandle(false));
 
         IcebergColumnHandle column = new IcebergColumnHandle(primitiveColumnIdentity(1, "a"), INTEGER, ImmutableList.of(), INTEGER, Optional.empty());
@@ -260,7 +261,7 @@ public class TestConnectorPushdownRulesWithIceberg
 
         PruneTableScanColumns pruneTableScanColumns = new PruneTableScanColumns(tester().getMetadata());
 
-        IcebergTableHandle icebergTable = new IcebergTableHandle(SCHEMA_NAME, tableName, DATA, Optional.empty(), "", TupleDomain.all(), TupleDomain.all(), ImmutableSet.of(), Optional.empty());
+        IcebergTableHandle icebergTable = new IcebergTableHandle(SCHEMA_NAME, tableName, DATA, Optional.empty(), "", 1, TupleDomain.all(), TupleDomain.all(), ImmutableSet.of(), Optional.empty(), "", ImmutableMap.of(), NO_RETRIES);
         TableHandle table = new TableHandle(new CatalogName(ICEBERG_CATALOG_NAME), icebergTable, new HiveTransactionHandle(false));
 
         IcebergColumnHandle columnA = new IcebergColumnHandle(primitiveColumnIdentity(0, "a"), INTEGER, ImmutableList.of(), INTEGER, Optional.empty());
@@ -303,7 +304,7 @@ public class TestConnectorPushdownRulesWithIceberg
                 tester().getTypeAnalyzer(),
                 new ScalarStatsCalculator(tester().getPlannerContext(), tester().getTypeAnalyzer()));
 
-        IcebergTableHandle icebergTable = new IcebergTableHandle(SCHEMA_NAME, tableName, DATA, Optional.of(1L), "", TupleDomain.all(), TupleDomain.all(), ImmutableSet.of(), Optional.empty());
+        IcebergTableHandle icebergTable = new IcebergTableHandle(SCHEMA_NAME, tableName, DATA, Optional.of(1L), "", 1, TupleDomain.all(), TupleDomain.all(), ImmutableSet.of(), Optional.empty(), "", ImmutableMap.of(), NO_RETRIES);
         TableHandle table = new TableHandle(new CatalogName(ICEBERG_CATALOG_NAME), icebergTable, new HiveTransactionHandle(false));
 
         IcebergColumnHandle bigintColumn = new IcebergColumnHandle(primitiveColumnIdentity(1, "just_bigint"), BIGINT, ImmutableList.of(), BIGINT, Optional.empty());

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveRedirectionToIceberg.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveRedirectionToIceberg.java
@@ -269,7 +269,7 @@ public class TestHiveRedirectionToIceberg
                         ")\n" +
                         "WITH (\n" +
                         "   format = 'ORC',\n" +
-                        "   format_version = 1,\n" +
+                        "   format_version = 2,\n" +
                         format("   location = 'hdfs://hadoop-master:9000/user/hive/warehouse/%s',\n", tableName) +
                         "   partitioning = ARRAY['regionkey']\n" + // 'partitioning' comes from Iceberg
                         ")"));

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergPartitionEvolution.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergPartitionEvolution.java
@@ -32,7 +32,7 @@ public class TestIcebergPartitionEvolution
     {
         onTrino().executeQuery("USE iceberg.default");
         onTrino().executeQuery("DROP TABLE IF EXISTS test_dropped_partition_field");
-        onTrino().executeQuery("CREATE TABLE test_dropped_partition_field(a varchar, b varchar, c varchar) WITH (partitioning = ARRAY['a','b'])");
+        onTrino().executeQuery("CREATE TABLE test_dropped_partition_field(a varchar, b varchar, c varchar) WITH (format_version = 1, partitioning = ARRAY['a','b'])");
         onTrino().executeQuery("INSERT INTO test_dropped_partition_field VALUES " +
                 "('one', 'small', 'snake')," +
                 "('one', 'small', 'rabbit')," +

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
@@ -1434,6 +1434,12 @@ public class TestIcebergSparkCompatibility
         assertThat(onTrino().executeQuery("SELECT * FROM " + trinoTableName)).containsOnly(expected);
         assertThat(onSpark().executeQuery("SELECT * FROM " + sparkTableName)).containsOnly(expected);
 
+        // Delete to a file that already has deleted rows
+        onSpark().executeQuery("DELETE FROM " + sparkTableName + " WHERE a = 12");
+        expected = ImmutableList.of(row(11, 12));
+        assertThat(onTrino().executeQuery("SELECT * FROM " + trinoTableName)).containsOnly(expected);
+        assertThat(onSpark().executeQuery("SELECT * FROM " + sparkTableName)).containsOnly(expected);
+
         onSpark().executeQuery("DROP TABLE " + sparkTableName);
     }
 
@@ -1458,6 +1464,105 @@ public class TestIcebergSparkCompatibility
         List<Row> expected = ImmutableList.of(row(1, 2), row(1, 6), row(2, 2));
         assertThat(onTrino().executeQuery("SELECT part_key, row_t.b FROM " + trinoTableName)).containsOnly(expected);
         assertThat(onSpark().executeQuery("SELECT part_key, row_t.b FROM " + sparkTableName)).containsOnly(expected);
+
+        onSpark().executeQuery("DROP TABLE " + sparkTableName);
+    }
+
+    @Test(groups = {ICEBERG, PROFILE_SPECIFIC_TESTS}, dataProvider = "storageFormats")
+    public void testSparkReadsTrinoRowLevelDeletes(StorageFormat storageFormat)
+    {
+        String tableName = format("test_spark_reads_trino_row_level_deletes_%s_%s", storageFormat.name(), randomTableSuffix());
+        String sparkTableName = sparkTableName(tableName);
+        String trinoTableName = trinoTableName(tableName);
+
+        onTrino().executeQuery("CREATE TABLE " + trinoTableName + "(a INT, b INT) WITH(partitioning = ARRAY['b'], format_version = 2, format = '" + storageFormat.name() + "')");
+        onTrino().executeQuery("INSERT INTO " + trinoTableName + " VALUES (1, 2), (2, 2), (3, 2), (11, 12), (12, 12), (13, 12)");
+        // Delete one row in a file
+        onTrino().executeQuery("DELETE FROM " + trinoTableName + " WHERE a = 13");
+        // Delete an entire partition
+        onTrino().executeQuery("DELETE FROM " + trinoTableName + " WHERE b = 2");
+
+        List<Row> expected = ImmutableList.of(row(11, 12), row(12, 12));
+        assertThat(onTrino().executeQuery("SELECT * FROM " + trinoTableName)).containsOnly(expected);
+        assertThat(onSpark().executeQuery("SELECT * FROM " + sparkTableName)).containsOnly(expected);
+
+        // Delete to a file that already has deleted rows
+        onTrino().executeQuery("DELETE FROM " + trinoTableName + " WHERE a = 12");
+        expected = ImmutableList.of(row(11, 12));
+        assertThat(onTrino().executeQuery("SELECT * FROM " + trinoTableName)).containsOnly(expected);
+        assertThat(onSpark().executeQuery("SELECT * FROM " + sparkTableName)).containsOnly(expected);
+
+        onSpark().executeQuery("DROP TABLE " + sparkTableName);
+    }
+
+    @Test(groups = {ICEBERG, PROFILE_SPECIFIC_TESTS}, dataProvider = "storageFormats")
+    public void testSparkReadsTrinoRowLevelDeletesWithRowTypes(StorageFormat storageFormat)
+    {
+        String tableName = format("test_spark_reads_trino_row_level_deletes_row_types_%s_%s", storageFormat.name(), randomTableSuffix());
+        String sparkTableName = sparkTableName(tableName);
+        String trinoTableName = trinoTableName(tableName);
+
+        onTrino().executeQuery("CREATE TABLE " + trinoTableName + "(part_key INT, int_t INT, row_t ROW(a INT, b INT)) " +
+                "WITH(partitioning = ARRAY['part_key'], format_version = 2, format = '" + storageFormat.name() + "') ");
+        onTrino().executeQuery("INSERT INTO " + trinoTableName + " VALUES (1, 1, row(1, 2)), (1, 2, row(3, 4)), (1, 3, row(5, 6)), (2, 4, row(1, 2))");
+        onTrino().executeQuery("DELETE FROM " + trinoTableName + " WHERE int_t = 2");
+
+        List<Row> expected = ImmutableList.of(row(1, 2), row(1, 6), row(2, 2));
+        assertThat(onTrino().executeQuery("SELECT part_key, row_t.b FROM " + trinoTableName)).containsOnly(expected);
+        assertThat(onSpark().executeQuery("SELECT part_key, row_t.b FROM " + sparkTableName)).containsOnly(expected);
+
+        onSpark().executeQuery("DROP TABLE " + sparkTableName);
+    }
+
+    @Test(groups = {ICEBERG, PROFILE_SPECIFIC_TESTS}, dataProvider = "storageFormats")
+    public void testDeleteAfterPartitionEvolution(StorageFormat storageFormat)
+    {
+        String baseTableName = "test_delete_after_partition_evolution_" + storageFormat + randomTableSuffix();
+        String trinoTableName = trinoTableName(baseTableName);
+        String sparkTableName = sparkTableName(baseTableName);
+
+        onSpark().executeQuery("DROP TABLE IF EXISTS " + sparkTableName);
+        onSpark().executeQuery(format(
+                "CREATE TABLE %s (" +
+                        "col0 BIGINT, " +
+                        "col1 BIGINT, " +
+                        "col2 BIGINT) "
+                        + " USING ICEBERG"
+                        + " TBLPROPERTIES ('write.format.default' = '%s', 'format-version' = 2, 'write.delete.mode' = 'merge-on-read')",
+                sparkTableName,
+                storageFormat));
+        onSpark().executeQuery("INSERT INTO " + sparkTableName + " VALUES (1, 11, 21)");
+
+        onSpark().executeQuery("ALTER TABLE " + sparkTableName + " ADD PARTITION FIELD bucket(3, col0)");
+        onSpark().executeQuery("INSERT INTO " + sparkTableName + " VALUES (2, 12, 22)");
+
+        onSpark().executeQuery("ALTER TABLE " + sparkTableName + " ADD PARTITION FIELD col1");
+        onSpark().executeQuery("INSERT INTO " + sparkTableName + " VALUES (3, 13, 23)");
+
+        onSpark().executeQuery("ALTER TABLE " + sparkTableName + " DROP PARTITION FIELD col1");
+        onSpark().executeQuery("ALTER TABLE " + sparkTableName + " ADD PARTITION FIELD col2");
+        onSpark().executeQuery("INSERT INTO " + sparkTableName + " VALUES (4, 14, 24)");
+
+        onSpark().executeQuery("ALTER TABLE " + sparkTableName + " DROP PARTITION FIELD bucket(3, col0)");
+        onSpark().executeQuery("ALTER TABLE " + sparkTableName + " DROP PARTITION FIELD col2");
+        onSpark().executeQuery("ALTER TABLE " + sparkTableName + " ADD PARTITION FIELD col0");
+        onSpark().executeQuery("INSERT INTO " + sparkTableName + " VALUES (5, 15, 25)");
+
+        List<Row> expected = new ArrayList<>();
+        expected.add(row(1, 11, 21));
+        expected.add(row(2, 12, 22));
+        expected.add(row(3, 13, 23));
+        expected.add(row(4, 14, 24));
+        expected.add(row(5, 15, 25));
+        assertThat(onTrino().executeQuery("SELECT * FROM " + trinoTableName)).containsOnly(expected);
+
+        for (int columnValue = 1; columnValue <= 5; columnValue++) {
+            onTrino().executeQuery("DELETE FROM " + trinoTableName + " WHERE col0 = " + columnValue);
+            // Rows are in order so removing the first one always matches columnValue
+            expected.remove(0);
+            assertThat(onTrino().executeQuery("SELECT * FROM " + trinoTableName)).containsOnly(expected);
+            assertThat(onSpark().executeQuery("SELECT * FROM " + sparkTableName)).containsOnly(expected);
+        }
 
         onSpark().executeQuery("DROP TABLE " + sparkTableName);
     }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
@@ -1640,7 +1640,7 @@ public class TestIcebergSparkCompatibility
         String sparkTableName = sparkTableName(baseTableName);
         onTrino().executeQuery("DROP TABLE IF EXISTS " + trinoTableName);
 
-        onTrino().executeQuery(format("CREATE TABLE %s (_string VARCHAR, _bigint BIGINT) WITH (partitioning = ARRAY['_string'], format = '%s')", trinoTableName, storageFormat));
+        onTrino().executeQuery(format("CREATE TABLE %s (_string VARCHAR, _bigint BIGINT) WITH (partitioning = ARRAY['_string'], format = '%s', format_version = 1)", trinoTableName, storageFormat));
         // separate inserts give us snapshot per insert
         onTrino().executeQuery(format("INSERT INTO %s VALUES ('a', 1001)", trinoTableName));
         onTrino().executeQuery(format("INSERT INTO %s VALUES ('a', 1002)", trinoTableName));
@@ -1684,7 +1684,7 @@ public class TestIcebergSparkCompatibility
         String sparkTableName = sparkTableName(baseTableName);
         onTrino().executeQuery("DROP TABLE IF EXISTS " + trinoTableName);
 
-        onTrino().executeQuery(format("CREATE TABLE %s (_string VARCHAR, _bigint BIGINT) WITH (partitioning = ARRAY['_string'], format = '%s')", trinoTableName, storageFormat));
+        onTrino().executeQuery(format("CREATE TABLE %s (_string VARCHAR, _bigint BIGINT) WITH (partitioning = ARRAY['_string'], format = '%s', format_version = 1)", trinoTableName, storageFormat));
         // separate inserts give us snapshot per insert
         onTrino().executeQuery(format("INSERT INTO %s VALUES ('a', 1001)", trinoTableName));
         onTrino().executeQuery(format("INSERT INTO %s VALUES ('a', 1002)", trinoTableName));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Support removing individual rows by writing positional delete files
compatible with v2 of the Iceberg specification.

> Is this change a fix, improvement, new feature, refactoring, or other?

New feature

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Iceberg connector

> How would you describe this change to a non-technical end user or system administrator?

Allow deleting individual rows from an Iceberg table

## Related issues, pull requests, and links

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
(x) Documentation PR is available with https://github.com/trinodb/trino/pull/12061
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Iceberg
* Support row level deletes following the Iceberg v2 specification for merge-on-read.
```
