### PR TITLE
Document catalog property for orc bloom filters

### DIFF
--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -426,6 +426,9 @@ with ORC files performed by the Hive connector.
         accessed by their ordinal position in the Hive table definition. The
         equivalent catalog session property is ``orc_use_column_names``.
       - ``false``
+    * - ``hive.orc.bloom-filters.enabled``
+      - Enable bloom filters for predicate pushdown.
+      - ``false``
 
 Parquet format configuration properties
 ---------------------------------------


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

The `hive.orc.bloom-filters.enabled` ORC format configuration property was only documented in the release notes for release-0.153. The bloom filter table properties are documented in hive.rst, but not the configuration property that enables them.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->
Added a single table row to ORC format configuration properties.

> Is this change a fix, improvement, new feature, refactoring, or other?
Fix. (Missing from documentation.)

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
This is a simple documentation change.

> How would you describe this change to a non-technical end user or system administrator?
N/A.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
