### PR TITLE
Allow to disable progress in CLI interactive mode

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
@@ -140,8 +140,8 @@ public class ClientOptions
     @Option(names = "--network-logging", paramLabel = "<level>", defaultValue = "NONE", description = "Network logging level [${COMPLETION-CANDIDATES}] " + DEFAULT_VALUE)
     public HttpLoggingInterceptor.Level networkLogging;
 
-    @Option(names = "--progress", paramLabel = "<progress>", description = "Show query progress in batch mode")
-    public boolean progress;
+    @Option(names = "--progress", paramLabel = "<progress>", description = "Show query progress", negatable = true)
+    public Optional<Boolean> progress;
 
     @Option(names = "--execute", paramLabel = "<execute>", description = "Execute specified statements and exit")
     public String execute;

--- a/client/trino-cli/src/main/java/io/trino/cli/Console.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/Console.java
@@ -188,10 +188,10 @@ public class Console
                         query,
                         clientOptions.outputFormat,
                         clientOptions.ignoreErrors,
-                        clientOptions.progress);
+                        clientOptions.progress.orElse(false));
             }
 
-            runConsole(queryRunner, exiting, clientOptions.editingMode);
+            runConsole(queryRunner, exiting, clientOptions.editingMode, clientOptions.progress.orElse(true));
             return true;
         }
         finally {
@@ -221,7 +221,7 @@ public class Console
         return reader.readLine("Password: ", (char) 0);
     }
 
-    private static void runConsole(QueryRunner queryRunner, AtomicBoolean exiting, ClientOptions.EditingMode editingMode)
+    private static void runConsole(QueryRunner queryRunner, AtomicBoolean exiting, ClientOptions.EditingMode editingMode, boolean progress)
     {
         try (TableNameCompleter tableNameCompleter = new TableNameCompleter(queryRunner);
                 InputReader reader = new InputReader(editingMode, getHistoryFile(), commandCompleter(), tableNameCompleter)) {
@@ -289,7 +289,7 @@ public class Console
                         outputFormat = OutputFormat.VERTICAL;
                     }
 
-                    process(queryRunner, split.statement(), outputFormat, tableNameCompleter::populateCache, true, true, reader.getTerminal(), System.out, System.out);
+                    process(queryRunner, split.statement(), outputFormat, tableNameCompleter::populateCache, true, progress, reader.getTerminal(), System.out, System.out);
                 }
 
                 // replace remaining with trailing partial statement


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->
Allow disabling progress reporting during query executing in the CLI client by specifying `--no-progress`. This makes short queries execute a bit faster since it avoids the delay introduced by waiting for key presses. It doesn't fix the root cause of the issue, but it gives more control to users. It doesn't add a new flag, just a negative variant of the existing one. Queries can still be interrupted with `CTRL+C`. 

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

new feature

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

CLI client

> How would you describe this change to a non-technical end user or system administrator?

Allow disabling progress reporting during query executing in the CLI client by specifying `--no-progress`. 

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->
* Related to #11768 

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# CLI
* Allow disabling progress reporting during query executing in the CLI client by specifying `--no-progress` ({issue}`issuenumber`)
```
