### PR TITLE
Use proper SQL identifier semantics for object or action properties

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/PropertyUtil.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/PropertyUtil.java
@@ -36,7 +36,6 @@ import java.util.Optional;
 import static io.trino.spi.type.TypeUtils.writeNativeValue;
 import static io.trino.sql.planner.ExpressionInterpreter.evaluateConstantExpression;
 import static java.lang.String.format;
-import static java.util.Locale.ENGLISH;
 
 public final class PropertyUtil
 {
@@ -57,8 +56,7 @@ public final class PropertyUtil
 
         // Fill in user-specified properties
         for (Property property : setProperties) {
-            // property names are case-insensitive and normalized to lower case
-            String propertyName = property.getName().getValue().toLowerCase(ENGLISH);
+            String propertyName = property.getName().getCanonicalValue();
             PropertyMetadata<?> propertyMetadata = metadata.get(propertyName);
             if (propertyMetadata == null) {
                 throw new TrinoException(errorCode, format("%s '%s' does not exist", capitalize(propertyTypeDescription), propertyName));

--- a/core/trino-main/src/main/java/io/trino/metadata/TableProceduresPropertyManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/TableProceduresPropertyManager.java
@@ -74,7 +74,7 @@ public class TableProceduresPropertyManager
     public Map<String, Object> getProperties(
             CatalogName catalog,
             String procedureName,
-            Map<String, Expression> sqlPropertyValues,
+            Map<Identifier, Expression> sqlPropertyValues,
             Session session,
             PlannerContext plannerContext,
             AccessControl accessControl,
@@ -87,7 +87,7 @@ public class TableProceduresPropertyManager
 
         Map<String, Optional<Object>> propertyValues = evaluateProperties(
                 sqlPropertyValues.entrySet().stream()
-                        .map(entry -> new Property(new Identifier(entry.getKey()), entry.getValue()))
+                        .map(entry -> new Property(entry.getKey(), entry.getValue()))
                         .collect(toImmutableList()),
                 session,
                 plannerContext,

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -1078,7 +1078,7 @@ class StatementAnalyzer
 
             // analyze arguments
 
-            Map<String, Expression> propertiesMap = processTableExecuteArguments(node, procedureMetadata, scope);
+            Map<Identifier, Expression> propertiesMap = processTableExecuteArguments(node, procedureMetadata, scope);
             Map<String, Object> tableProperties = tableProceduresPropertyManager.getProperties(
                     catalogName,
                     procedureName,
@@ -1105,7 +1105,7 @@ class StatementAnalyzer
             return createAndAssignScope(node, scope, Field.newUnqualified("rows", BIGINT));
         }
 
-        private Map<String, Expression> processTableExecuteArguments(TableExecute node, TableProcedureMetadata procedureMetadata, Optional<Scope> scope)
+        private Map<Identifier, Expression> processTableExecuteArguments(TableExecute node, TableProcedureMetadata procedureMetadata, Optional<Scope> scope)
         {
             List<CallArgument> arguments = node.getArguments();
             Predicate<CallArgument> hasName = argument -> argument.getName().isPresent();
@@ -1123,12 +1123,12 @@ class StatementAnalyzer
                 process(argument, scope);
             }
 
-            Map<String, Expression> argumentsMap = new HashMap<>();
+            Map<Identifier, Expression> argumentsMap = new HashMap<>();
 
             if (anyNamed) {
                 // all properties named
                 for (CallArgument argument : arguments) {
-                    if (argumentsMap.put(argument.getName().get().getCanonicalValue(), argument.getValue()) != null) {
+                    if (argumentsMap.put(argument.getName().get(), argument.getValue()) != null) {
                         throw semanticException(DUPLICATE_PROPERTY, argument, "Duplicate named argument: %s", argument.getName());
                     }
                 }
@@ -1137,7 +1137,7 @@ class StatementAnalyzer
                 // all properties unnamed
                 int pos = 0;
                 for (CallArgument argument : arguments) {
-                    argumentsMap.put(procedureMetadata.getProperties().get(pos).getName(), argument.getValue());
+                    argumentsMap.put(new Identifier(procedureMetadata.getProperties().get(pos).getName()), argument.getValue());
                     pos++;
                 }
             }

--- a/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
+++ b/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
@@ -86,10 +86,10 @@ public abstract class BaseDataDefinitionTaskTest
     protected static final String CATALOG_NAME = "catalog";
     public static final String SCHEMA = "schema";
 
-    protected static final String MATERIALIZED_VIEW_PROPERTY_1_NAME = "property1";
+    protected static final String MATERIALIZED_VIEW_PROPERTY_1_NAME = "PROPERTY1";
     protected static final Long MATERIALIZED_VIEW_PROPERTY_1_DEFAULT_VALUE = null;
 
-    protected static final String MATERIALIZED_VIEW_PROPERTY_2_NAME = "property2";
+    protected static final String MATERIALIZED_VIEW_PROPERTY_2_NAME = "PROPERTY2";
     protected static final String MATERIALIZED_VIEW_PROPERTY_2_DEFAULT_VALUE = "defaultProperty2Value";
 
     private LocalQueryRunner queryRunner;

--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateMaterializedViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateMaterializedViewTask.java
@@ -128,8 +128,8 @@ public class TestCreateMaterializedViewTask
                 CATALOG_NAME,
                 MockConnectorFactory.builder()
                         .withGetMaterializedViewProperties(() -> ImmutableList.<PropertyMetadata<?>>builder()
-                                .add(stringProperty("foo", "test materialized view property", DEFAULT_MATERIALIZED_VIEW_FOO_PROPERTY_VALUE, false))
-                                .add(integerProperty("bar", "test materialized view property", DEFAULT_MATERIALIZED_VIEW_BAR_PROPERTY_VALUE, false))
+                                .add(stringProperty("FOO", "test materialized view property", DEFAULT_MATERIALIZED_VIEW_FOO_PROPERTY_VALUE, false))
+                                .add(integerProperty("BAR", "test materialized view property", DEFAULT_MATERIALIZED_VIEW_BAR_PROPERTY_VALUE, false))
                                 .build())
                         .build(),
                 ImmutableMap.of());
@@ -204,7 +204,7 @@ public class TestCreateMaterializedViewTask
         assertTrinoExceptionThrownBy(() -> getFutureValue(new CreateMaterializedViewTask(plannerContext, new AllowAllAccessControl(), parser, analyzerFactory, materializedViewPropertyManager, new FeaturesConfig())
                 .execute(statement, queryStateMachine, ImmutableList.of(), WarningCollector.NOOP)))
                 .hasErrorCode(INVALID_MATERIALIZED_VIEW_PROPERTY)
-                .hasMessage("Catalog 'catalog' materialized view property 'baz' does not exist");
+                .hasMessage("Catalog 'catalog' materialized view property 'BAZ' does not exist");
 
         assertEquals(metadata.getCreateMaterializedViewCallCount(), 0);
     }
@@ -230,8 +230,8 @@ public class TestCreateMaterializedViewTask
                 metadata.getMaterializedView(testSession, QualifiedObjectName.valueOf(materializedViewName.toString()));
         assertThat(definitionOptional).isPresent();
         Map<String, Object> properties = definitionOptional.get().getProperties();
-        assertThat(properties.get("foo")).isEqualTo(DEFAULT_MATERIALIZED_VIEW_FOO_PROPERTY_VALUE);
-        assertThat(properties.get("bar")).isEqualTo(DEFAULT_MATERIALIZED_VIEW_BAR_PROPERTY_VALUE);
+        assertThat(properties.get("FOO")).isEqualTo(DEFAULT_MATERIALIZED_VIEW_FOO_PROPERTY_VALUE);
+        assertThat(properties.get("BAR")).isEqualTo(DEFAULT_MATERIALIZED_VIEW_BAR_PROPERTY_VALUE);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateTableTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateTableTask.java
@@ -98,7 +98,7 @@ public class TestCreateTableTask
     private static final ConnectorTableMetadata PARENT_TABLE = new ConnectorTableMetadata(
             new SchemaTableName("schema", "parent_table"),
             List.of(new ColumnMetadata("a", SMALLINT), new ColumnMetadata("b", BIGINT)),
-            Map.of("baz", "property_value"));
+            Map.of("BAZ", "property_value"));
 
     private LocalQueryRunner queryRunner;
     private Session testSession;
@@ -116,7 +116,7 @@ public class TestCreateTableTask
         queryRunner.createCatalog(
                 CATALOG_NAME,
                 MockConnectorFactory.builder()
-                        .withTableProperties(() -> ImmutableList.of(stringProperty("baz", "test property", null, false)))
+                        .withTableProperties(() -> ImmutableList.of(stringProperty("BAZ", "test property", null, false)))
                         .build(),
                 ImmutableMap.of());
 
@@ -180,7 +180,7 @@ public class TestCreateTableTask
         CreateTableTask createTableTask = new CreateTableTask(plannerContext, new AllowAllAccessControl(), columnPropertyManager, tablePropertyManager);
         assertTrinoExceptionThrownBy(() -> getFutureValue(createTableTask.internalExecute(statement, testSession, emptyList(), output -> {})))
                 .hasErrorCode(INVALID_TABLE_PROPERTY)
-                .hasMessage("Catalog 'catalog' table property 'foo' does not exist");
+                .hasMessage("Catalog 'catalog' table property 'FOO' does not exist");
 
         assertEquals(metadata.getCreateTableCallCount(), 0);
     }

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -5728,8 +5728,8 @@ public class TestAnalyzer
         public List<PropertyMetadata<?>> getAnalyzeProperties()
         {
             return ImmutableList.of(
-                    stringProperty("p1", "test string property", "", false),
-                    integerProperty("p2", "test integer property", 0, false));
+                    stringProperty("P1", "test string property", "", false),
+                    integerProperty("P2", "test integer property", 0, false));
         }
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/session/PropertyMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/session/PropertyMetadata.java
@@ -58,9 +58,6 @@ public final class PropertyMetadata<T>
         requireNonNull(decoder, "decoder is null");
         requireNonNull(encoder, "encoder is null");
 
-        if (name.isEmpty() || !name.trim().toLowerCase(ENGLISH).equals(name)) {
-            throw new IllegalArgumentException(format("Invalid property name '%s'", name));
-        }
         if (description.isEmpty() || !description.trim().equals(description)) {
             throw new IllegalArgumentException(format("Invalid property description '%s'", description));
         }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveAnalyzeProperties.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveAnalyzeProperties.java
@@ -36,8 +36,8 @@ import static java.lang.String.format;
 
 public class HiveAnalyzeProperties
 {
-    public static final String PARTITIONS_PROPERTY = "partitions";
-    public static final String COLUMNS_PROPERTY = "columns";
+    public static final String PARTITIONS_PROPERTY = "PARTITIONS";
+    public static final String COLUMNS_PROPERTY = "COLUMNS";
 
     private final List<PropertyMetadata<?>> analyzeProperties;
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -259,6 +259,7 @@ import static io.trino.plugin.hive.metastore.PrincipalPrivileges.fromHivePrivile
 import static io.trino.plugin.hive.metastore.SemiTransactionalHiveMetastore.cleanExtraOutputFiles;
 import static io.trino.plugin.hive.metastore.StorageFormat.VIEW_STORAGE_FORMAT;
 import static io.trino.plugin.hive.metastore.StorageFormat.fromHiveStorageFormat;
+import static io.trino.plugin.hive.procedure.OptimizeTableProcedure.FILE_SIZE_THRESHOLD;
 import static io.trino.plugin.hive.util.CompressionConfigUtil.configureCompression;
 import static io.trino.plugin.hive.util.ConfigurationUtils.toJobConf;
 import static io.trino.plugin.hive.util.HiveBucketing.getHiveBucketHandle;
@@ -320,7 +321,7 @@ public class HiveMetadata
     public static final String PRESTO_VERSION_NAME = "presto_version";
     public static final String TRINO_CREATED_BY = "trino_created_by";
     public static final String PRESTO_QUERY_ID_NAME = "presto_query_id";
-    public static final String BUCKETING_VERSION = "bucketing_version";
+    public static final String BUCKETING_VERSION = "BUCKETING_VERSION";
     public static final String TABLE_COMMENT = "comment";
     public static final String STORAGE_TABLE = "storage_table";
     private static final String TRANSACTIONAL = "transactional";
@@ -2106,7 +2107,7 @@ public class HiveMetadata
         }
         LocationHandle locationHandle = locationService.forOptimize(metastore, session, table);
 
-        DataSize fileSizeThreshold = (DataSize) executeProperties.get("file_size_threshold");
+        DataSize fileSizeThreshold = (DataSize) executeProperties.get(FILE_SIZE_THRESHOLD);
 
         return Optional.of(new HiveTableExecuteHandle(
                 OptimizeTableProcedure.NAME,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSchemaProperties.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSchemaProperties.java
@@ -26,7 +26,7 @@ import static io.trino.spi.session.PropertyMetadata.stringProperty;
 
 public final class HiveSchemaProperties
 {
-    public static final String LOCATION_PROPERTY = "location";
+    public static final String LOCATION_PROPERTY = "LOCATION";
 
     public static final List<PropertyMetadata<?>> SCHEMA_PROPERTIES = ImmutableList.of(
             stringProperty(

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableProperties.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableProperties.java
@@ -44,31 +44,31 @@ import static java.util.Locale.ENGLISH;
 
 public class HiveTableProperties
 {
-    public static final String EXTERNAL_LOCATION_PROPERTY = "external_location";
-    public static final String STORAGE_FORMAT_PROPERTY = "format";
-    public static final String PARTITIONED_BY_PROPERTY = "partitioned_by";
-    public static final String BUCKETED_BY_PROPERTY = "bucketed_by";
-    public static final String BUCKETING_VERSION = "bucketing_version";
-    public static final String BUCKET_COUNT_PROPERTY = "bucket_count";
-    public static final String SORTED_BY_PROPERTY = "sorted_by";
+    public static final String EXTERNAL_LOCATION_PROPERTY = "EXTERNAL_LOCATION";
+    public static final String STORAGE_FORMAT_PROPERTY = "FORMAT";
+    public static final String PARTITIONED_BY_PROPERTY = "PARTITIONED_BY";
+    public static final String BUCKETED_BY_PROPERTY = "BUCKETED_BY";
+    public static final String BUCKETING_VERSION = "BUCKETING_VERSION";
+    public static final String BUCKET_COUNT_PROPERTY = "BUCKET_COUNT";
+    public static final String SORTED_BY_PROPERTY = "SORTED_BY";
     // TODO: This property represents the subset of columns to be analyzed. This exists mainly because there is no way
     //       to pass the column names to ConnectorMetadata#getStatisticsCollectionMetadata; we should consider passing
     //       ConnectorTableHandle instead of ConnectorTableMetadata as an argument since it makes more information
     //       available (including the names of the columns to be analyzed)
-    public static final String ANALYZE_COLUMNS_PROPERTY = "presto.analyze_columns";
-    public static final String ORC_BLOOM_FILTER_COLUMNS = "orc_bloom_filter_columns";
-    public static final String ORC_BLOOM_FILTER_FPP = "orc_bloom_filter_fpp";
-    public static final String AVRO_SCHEMA_URL = "avro_schema_url";
-    public static final String TEXTFILE_FIELD_SEPARATOR = "textfile_field_separator";
-    public static final String TEXTFILE_FIELD_SEPARATOR_ESCAPE = "textfile_field_separator_escape";
-    public static final String NULL_FORMAT_PROPERTY = "null_format";
-    public static final String SKIP_HEADER_LINE_COUNT = "skip_header_line_count";
-    public static final String SKIP_FOOTER_LINE_COUNT = "skip_footer_line_count";
-    public static final String CSV_SEPARATOR = "csv_separator";
-    public static final String CSV_QUOTE = "csv_quote";
-    public static final String CSV_ESCAPE = "csv_escape";
-    public static final String TRANSACTIONAL = "transactional";
-    public static final String AUTO_PURGE = "auto_purge";
+    public static final String ANALYZE_COLUMNS_PROPERTY = "PRESTO.ANALYZE_COLUMNS";
+    public static final String ORC_BLOOM_FILTER_COLUMNS = "ORC_BLOOM_FILTER_COLUMNS";
+    public static final String ORC_BLOOM_FILTER_FPP = "ORC_BLOOM_FILTER_FPP";
+    public static final String AVRO_SCHEMA_URL = "AVRO_SCHEMA_URL";
+    public static final String TEXTFILE_FIELD_SEPARATOR = "TEXTFILE_FIELD_SEPARATOR";
+    public static final String TEXTFILE_FIELD_SEPARATOR_ESCAPE = "TEXTFILE_FIELD_SEPARATOR_ESCAPE";
+    public static final String NULL_FORMAT_PROPERTY = "NULL_FORMAT";
+    public static final String SKIP_HEADER_LINE_COUNT = "SKIP_HEADER_LINE_COUNT";
+    public static final String SKIP_FOOTER_LINE_COUNT = "SKIP_FOOTER_LINE_COUNT";
+    public static final String CSV_SEPARATOR = "CSV_SEPARATOR";
+    public static final String CSV_QUOTE = "CSV_QUOTE";
+    public static final String CSV_ESCAPE = "CSV_ESCAPE";
+    public static final String TRANSACTIONAL = "TRANSACTIONAL";
+    public static final String AUTO_PURGE = "AUTO_PURGE";
 
     private final List<PropertyMetadata<?>> tableProperties;
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/OptimizeTableProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/OptimizeTableProcedure.java
@@ -26,6 +26,7 @@ public class OptimizeTableProcedure
         implements Provider<TableProcedureMetadata>
 {
     public static final String NAME = "OPTIMIZE";
+    public static final String FILE_SIZE_THRESHOLD = "FILE_SIZE_THRESHOLD";
 
     @Override
     public TableProcedureMetadata get()
@@ -35,7 +36,7 @@ public class OptimizeTableProcedure
                 distributedWithFilteringAndRepartitioning(),
                 ImmutableList.of(
                         dataSizeProperty(
-                                "file_size_threshold",
+                                FILE_SIZE_THRESHOLD,
                                 "Only compact files smaller than given threshold in bytes",
                                 DataSize.of(100, DataSize.Unit.MEGABYTE),
                                 false)));

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -971,7 +971,7 @@ public abstract class BaseHiveConnectorTest
                         "CREATE SCHEMA %s.test_show_create_schema\n" +
                         "AUTHORIZATION USER hive\n" +
                         "WITH \\(\n" +
-                        "   location = '.*test_show_create_schema'\n" +
+                        "   LOCATION = '.*test_show_create_schema'\n" +
                         "\\)",
                 getSession().getCatalog().get());
 
@@ -986,7 +986,7 @@ public abstract class BaseHiveConnectorTest
                         "CREATE SCHEMA %s.test_show_create_schema\n" +
                         "AUTHORIZATION ROLE test_show_create_schema_role\n" +
                         "WITH \\(\n" +
-                        "   location = '.*test_show_create_schema'\n" +
+                        "   LOCATION = '.*test_show_create_schema'\n" +
                         "\\)",
                 getSession().getCatalog().get());
 
@@ -3764,7 +3764,7 @@ public abstract class BaseHiveConnectorTest
                         "   comment varchar(79)\n" +
                         ")\n" +
                         "WITH (\n" +
-                        "   format = 'ORC'\n" +
+                        "   FORMAT = 'ORC'\n" +
                         ")");
 
         String createTableSql = format("" +
@@ -3776,7 +3776,7 @@ public abstract class BaseHiveConnectorTest
                         "   c5 map(bigint, varchar)\n" +
                         ")\n" +
                         "WITH (\n" +
-                        "   format = 'RCBINARY'\n" +
+                        "   FORMAT = 'RCBINARY'\n" +
                         ")",
                 getSession().getCatalog().get(),
                 getSession().getSchema().get(),
@@ -3795,15 +3795,15 @@ public abstract class BaseHiveConnectorTest
                         "   c5 double COMMENT ''\n)\n" +
                         "COMMENT 'test'\n" +
                         "WITH (\n" +
-                        "   bucket_count = 5,\n" +
-                        "   bucketed_by = ARRAY['c1','c 2'],\n" +
-                        "   bucketing_version = 1,\n" +
-                        "   format = 'ORC',\n" +
-                        "   orc_bloom_filter_columns = ARRAY['c1','c2'],\n" +
-                        "   orc_bloom_filter_fpp = 7E-1,\n" +
-                        "   partitioned_by = ARRAY['c5'],\n" +
-                        "   sorted_by = ARRAY['c1','c 2 DESC'],\n" +
-                        "   transactional = true\n" +
+                        "   BUCKETED_BY = ARRAY['c1','c 2'],\n" +
+                        "   BUCKETING_VERSION = 1,\n" +
+                        "   BUCKET_COUNT = 5,\n" +
+                        "   FORMAT = 'ORC',\n" +
+                        "   ORC_BLOOM_FILTER_COLUMNS = ARRAY['c1','c2'],\n" +
+                        "   ORC_BLOOM_FILTER_FPP = 7E-1,\n" +
+                        "   PARTITIONED_BY = ARRAY['c5'],\n" +
+                        "   SORTED_BY = ARRAY['c1','c 2 DESC'],\n" +
+                        "   TRANSACTIONAL = true\n" +
                         ")",
                 getSession().getCatalog().get(),
                 getSession().getSchema().get(),
@@ -3816,7 +3816,7 @@ public abstract class BaseHiveConnectorTest
                         "CREATE TABLE %s.%s.%s (\n" +
                         "   c1 ROW(\"$a\" bigint, \"$b\" varchar)\n)\n" +
                         "WITH (\n" +
-                        "   format = 'ORC'\n" +
+                        "   FORMAT = 'ORC'\n" +
                         ")",
                 getSession().getCatalog().get(),
                 getSession().getSchema().get(),
@@ -3840,8 +3840,8 @@ public abstract class BaseHiveConnectorTest
         // Table properties
         StringJoiner propertiesSql = new StringJoiner(",\n   ");
         propertiesSql.add(
-                format("external_location = '%s'", new Path(tempDir.toUri().toASCIIString())));
-        propertiesSql.add("format = 'TEXTFILE'");
+                format("EXTERNAL_LOCATION = '%s'", new Path(tempDir.toUri().toASCIIString())));
+        propertiesSql.add("FORMAT = 'TEXTFILE'");
         tableProperties.forEach(propertiesSql::add);
 
         @Language("SQL") String createTableSql = format("" +
@@ -3886,7 +3886,7 @@ public abstract class BaseHiveConnectorTest
                 "test_create_external_with_field_separator",
                 "helloXworld\nbyeXworld",
                 "VALUES ('hello', 'world'), ('bye', 'world')",
-                ImmutableList.of("textfile_field_separator = 'X'"));
+                ImmutableList.of("TEXTFILE_FIELD_SEPARATOR = 'X'"));
     }
 
     @Test
@@ -3897,7 +3897,7 @@ public abstract class BaseHiveConnectorTest
                 "test_create_external_with_field_separator_unescaped",
                 "heXlloXworld\nbyeXworld", // the first line contains an unescaped separator character which leads to inconsistent reading of its content
                 "VALUES ('he', 'llo'), ('bye', 'world')",
-                ImmutableList.of("textfile_field_separator = 'X'"));
+                ImmutableList.of("TEXTFILE_FIELD_SEPARATOR = 'X'"));
     }
 
     @Test
@@ -3909,8 +3909,8 @@ public abstract class BaseHiveConnectorTest
                 "HelloEFFWorld\nByeEFFWorld",
                 "VALUES ('HelloF', 'World'), ('ByeF', 'World')",
                 ImmutableList.of(
-                        "textfile_field_separator = 'F'",
-                        "textfile_field_separator_escape = 'E'"));
+                        "TEXTFILE_FIELD_SEPARATOR = 'F'",
+                        "TEXTFILE_FIELD_SEPARATOR_ESCAPE = 'E'"));
     }
 
     @Test
@@ -3921,7 +3921,7 @@ public abstract class BaseHiveConnectorTest
                 "test_create_external_textfile_with_null_format",
                 "hello\u0001NULL_VALUE\nNULL_VALUE\u0001123\n\\N\u0001456",
                 "VALUES ('hello', NULL), (NULL, 123), ('\\N', 456)",
-                ImmutableList.of("null_format = 'NULL_VALUE'"));
+                ImmutableList.of("NULL_FORMAT = 'NULL_VALUE'"));
     }
 
     @Test
@@ -3951,8 +3951,8 @@ public abstract class BaseHiveConnectorTest
                         "   name varchar\n" +
                         ")\n" +
                         "WITH (\n" +
-                        "   format = '%s',\n" +
-                        "   skip_header_line_count = 1\n" +
+                        "   FORMAT = '%s',\n" +
+                        "   SKIP_HEADER_LINE_COUNT = 1\n" +
                         ")",
                 catalog, schema, name, format);
 
@@ -3967,8 +3967,8 @@ public abstract class BaseHiveConnectorTest
                         "   name varchar\n" +
                         ")\n" +
                         "WITH (\n" +
-                        "   format = '%s',\n" +
-                        "   skip_footer_line_count = 1\n" +
+                        "   FORMAT = '%s',\n" +
+                        "   SKIP_HEADER_LINE_COUNT = 1\n" +
                         ")",
                 catalog, schema, name, format);
 
@@ -3983,9 +3983,9 @@ public abstract class BaseHiveConnectorTest
                         "   name varchar\n" +
                         ")\n" +
                         "WITH (\n" +
-                        "   format = '%s',\n" +
-                        "   skip_footer_line_count = 1,\n" +
-                        "   skip_header_line_count = 1\n" +
+                        "   FORMAT = '%s',\n" +
+                        "   SKIP_FOOTER_LINE_COUNT = 1,\n" +
+                        "   SKIP_HEADER_LINE_COUNT = 1\n" +
                         ")",
                 catalog, schema, name, format);
 
@@ -4097,33 +4097,33 @@ public abstract class BaseHiveConnectorTest
     {
         // ORC
         assertThatThrownBy(() -> assertUpdate("CREATE TABLE invalid_table (col1 bigint) WITH (format = 'TEXTFILE', orc_bloom_filter_columns = ARRAY['col1'])"))
-                .hasMessageMatching("Cannot specify orc_bloom_filter_columns table property for storage format: TEXTFILE");
+                .hasMessageMatching("Cannot specify ORC_BLOOM_FILTER_COLUMNS table property for storage format: TEXTFILE");
 
         // TEXTFILE
         assertThatThrownBy(() -> assertUpdate("CREATE TABLE test_orc_skip_header (col1 bigint) WITH (format = 'ORC', skip_header_line_count = 1)"))
-                .hasMessageMatching("Cannot specify skip_header_line_count table property for storage format: ORC");
+                .hasMessageMatching("Cannot specify SKIP_HEADER_LINE_COUNT table property for storage format: ORC");
         assertThatThrownBy(() -> assertUpdate("CREATE TABLE test_orc_skip_footer (col1 bigint) WITH (format = 'ORC', skip_footer_line_count = 1)"))
-                .hasMessageMatching("Cannot specify skip_footer_line_count table property for storage format: ORC");
+                .hasMessageMatching("Cannot specify SKIP_FOOTER_LINE_COUNT table property for storage format: ORC");
         assertThatThrownBy(() -> assertUpdate("CREATE TABLE test_orc_skip_footer (col1 bigint) WITH (format = 'ORC', null_format = 'ERROR')"))
-                .hasMessageMatching("Cannot specify null_format table property for storage format: ORC");
+                .hasMessageMatching("Cannot specify NULL_FORMAT table property for storage format: ORC");
         assertThatThrownBy(() -> assertUpdate("CREATE TABLE test_invalid_skip_header (col1 bigint) WITH (format = 'TEXTFILE', skip_header_line_count = -1)"))
-                .hasMessageMatching("Invalid value for skip_header_line_count property: -1");
+                .hasMessageMatching("Invalid value for SKIP_HEADER_LINE_COUNT property: -1");
         assertThatThrownBy(() -> assertUpdate("CREATE TABLE test_invalid_skip_footer (col1 bigint) WITH (format = 'TEXTFILE', skip_footer_line_count = -1)"))
-                .hasMessageMatching("Invalid value for skip_footer_line_count property: -1");
+                .hasMessageMatching("Invalid value for SKIP_FOOTER_LINE_COUNT property: -1");
 
         // CSV
         assertThatThrownBy(() -> assertUpdate("CREATE TABLE invalid_table (col1 bigint) WITH (format = 'ORC', csv_separator = 'S')"))
-                .hasMessageMatching("Cannot specify csv_separator table property for storage format: ORC");
+                .hasMessageMatching("Cannot specify CSV_SEPARATOR table property for storage format: ORC");
         assertThatThrownBy(() -> assertUpdate("CREATE TABLE invalid_table (col1 varchar) WITH (format = 'CSV', csv_separator = 'SS')"))
-                .hasMessageMatching("csv_separator must be a single character string, but was: 'SS'");
+                .hasMessageMatching("CSV_SEPARATOR must be a single character string, but was: 'SS'");
         assertThatThrownBy(() -> assertUpdate("CREATE TABLE invalid_table (col1 bigint) WITH (format = 'ORC', csv_quote = 'Q')"))
-                .hasMessageMatching("Cannot specify csv_quote table property for storage format: ORC");
+                .hasMessageMatching("Cannot specify CSV_QUOTE table property for storage format: ORC");
         assertThatThrownBy(() -> assertUpdate("CREATE TABLE invalid_table (col1 varchar) WITH (format = 'CSV', csv_quote = 'QQ')"))
-                .hasMessageMatching("csv_quote must be a single character string, but was: 'QQ'");
+                .hasMessageMatching("CSV_QUOTE must be a single character string, but was: 'QQ'");
         assertThatThrownBy(() -> assertUpdate("CREATE TABLE invalid_table (col1 varchar) WITH (format = 'ORC', csv_escape = 'E')"))
-                .hasMessageMatching("Cannot specify csv_escape table property for storage format: ORC");
+                .hasMessageMatching("Cannot specify CSV_ESCAPE table property for storage format: ORC");
         assertThatThrownBy(() -> assertUpdate("CREATE TABLE invalid_table (col1 varchar) WITH (format = 'CSV', csv_escape = 'EE')"))
-                .hasMessageMatching("csv_escape must be a single character string, but was: 'EE'");
+                .hasMessageMatching("CSV_ESCAPE must be a single character string, but was: 'EE'");
     }
 
     @Test
@@ -6418,8 +6418,8 @@ public abstract class BaseHiveConnectorTest
         assertQuery(
                 "SELECT * FROM system.metadata.analyze_properties WHERE catalog_name = 'hive'",
                 "SELECT * FROM VALUES " +
-                        "('hive', 'partitions', '', 'array(array(varchar))', 'Partitions to be analyzed'), " +
-                        "('hive', 'columns', '', 'array(varchar)', 'Columns to be analyzed')");
+                        "('hive', 'PARTITIONS', '', 'array(array(varchar))', 'Partitions to be analyzed'), " +
+                        "('hive', 'COLUMNS', '', 'array(varchar)', 'Columns to be analyzed')");
     }
 
     @Test
@@ -6441,9 +6441,9 @@ public abstract class BaseHiveConnectorTest
         createPartitionedTableForAnalyzeTest(tableName);
 
         // Test invalid property
-        assertQueryFails(format("ANALYZE %s WITH (error = 1)", tableName), ".*'hive' analyze property 'error' does not exist.*");
-        assertQueryFails(format("ANALYZE %s WITH (partitions = 1)", tableName), "\\QInvalid value for catalog 'hive' analyze property 'partitions': Cannot convert [1] to array(array(varchar))\\E");
-        assertQueryFails(format("ANALYZE %s WITH (partitions = NULL)", tableName), "\\QInvalid null value for catalog 'hive' analyze property 'partitions' from [null]\\E");
+        assertQueryFails(format("ANALYZE %s WITH (error = 1)", tableName), ".*'hive' analyze property 'ERROR' does not exist.*");
+        assertQueryFails(format("ANALYZE %s WITH (partitions = 1)", tableName), "\\QInvalid value for catalog 'hive' analyze property 'PARTITIONS': Cannot convert [1] to array(array(varchar))\\E");
+        assertQueryFails(format("ANALYZE %s WITH (partitions = NULL)", tableName), "\\QInvalid null value for catalog 'hive' analyze property 'PARTITIONS' from [null]\\E");
         assertQueryFails(format("ANALYZE %s WITH (partitions = ARRAY[NULL])", tableName), ".*Invalid null value in analyze partitions property.*");
 
         // Test non-existed partition
@@ -6956,7 +6956,7 @@ public abstract class BaseHiveConnectorTest
         // Column names must be strings
         assertQueryFails(
                 "ANALYZE " + tableName + " WITH (columns = ARRAY[42])",
-                "\\QInvalid value for catalog 'hive' analyze property 'columns': Cannot convert [ARRAY[42]] to array(varchar)\\E");
+                "\\QInvalid value for catalog 'hive' analyze property 'COLUMNS': Cannot convert [ARRAY[42]] to array(varchar)\\E");
 
         assertUpdate("DROP TABLE " + tableName);
     }
@@ -7521,8 +7521,8 @@ public abstract class BaseHiveConnectorTest
                         "   another_dummy_col varchar\n" +
                         ")\n" +
                         "WITH (\n" +
-                        "   avro_schema_url = '%s',\n" +
-                        "   format = 'AVRO'\n" +
+                        "   AVRO_SCHEMA_URL = '%s',\n" +
+                        "   FORMAT = 'AVRO'\n" +
                         ")",
                 getSession().getCatalog().get(),
                 getSession().getSchema().get(),
@@ -7559,7 +7559,7 @@ public abstract class BaseHiveConnectorTest
                 getSession().getCatalog().get(),
                 getSession().getSchema().get());
 
-        assertQueryFails(createTableSql, "Cannot specify avro_schema_url table property for storage format: ORC");
+        assertQueryFails(createTableSql, "Cannot specify AVRO_SCHEMA_URL table property for storage format: ORC");
     }
 
     @Test
@@ -7910,7 +7910,8 @@ public abstract class BaseHiveConnectorTest
         assertQueryFails(optimizeEnabledSession, "ALTER TABLE " + tableName + " EXECUTE \"optimize\"", "Procedure optimize not registered for catalog hive");
         assertUpdate(optimizeEnabledSession, "ALTER TABLE " + tableName + " EXECUTE \"OPTIMIZE\"");
         // optimize with delimited parameter name (and procedure name)
-        assertUpdate(optimizeEnabledSession, "ALTER TABLE " + tableName + " EXECUTE \"OPTIMIZE\" (\"file_size_threshold\" => '10B')"); // TODO (https://github.com/trinodb/trino/issues/11326) this should fail
+        assertQueryFails(optimizeEnabledSession, "ALTER TABLE " + tableName + " EXECUTE \"OPTIMIZE\" (\"file_size_threshold\" => '10B')",
+                ".*'OPTIMIZE' property 'file_size_threshold' does not exist.*");
         assertUpdate(optimizeEnabledSession, "ALTER TABLE " + tableName + " EXECUTE \"OPTIMIZE\" (\"FILE_SIZE_THRESHOLD\" => '10B')");
 
         assertUpdate("DROP TABLE " + tableName);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConnectorSmokeTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConnectorSmokeTest.java
@@ -85,7 +85,7 @@ public class TestHiveConnectorSmokeTest
                         "   comment varchar(152)\n" +
                         ")\n" +
                         "WITH (\n" +
-                        "   format = 'ORC'\n" +
+                        "   FORMAT = 'ORC'\n" +
                         ")");
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcWriterOptions.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcWriterOptions.java
@@ -94,7 +94,7 @@ public class TestOrcWriterOptions
         tableProperties.setProperty(ORC_BLOOM_FILTER_COLUMNS_KEY, "column_with_bloom_filter");
         tableProperties.setProperty(ORC_BLOOM_FILTER_FPP_KEY, "abc");
         assertThatThrownBy(() -> getOrcWriterOptions(tableProperties, new OrcWriterOptions()))
-                .hasMessage("Invalid value for orc_bloom_filter_fpp property: abc");
+                .hasMessage("Invalid value for ORC_BLOOM_FILTER_FPP property: abc");
     }
 
     @Test(dataProvider = "invalidBloomFilterFpp")


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Identifiers of object/action properties are currently always converted to lowercase. This is not according the SQL spec.

According the SQL spec delimited identifiers should be matched as is, taking into account the given case or any special characters specified by the user.

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Change to core query engine and impact on all connectors

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

* Fixes #11326

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
