### PR TITLE
[MINOR] Fix useless final modifier in QueryId

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/QueryId.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/QueryId.java
@@ -74,7 +74,7 @@ public final class QueryId
     //
 
     // Check if the string matches [_a-z0-9]+ , but without the overhead of regex
-    private static final boolean isValidId(String id)
+    private static boolean isValidId(String id)
     {
         if (id.length() == 0) {
             return false;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
This pr aims to fix a minor issue, The final modifier of method `QueryId.isValidId` is useless, This is because
- QueryId had been modified by `final`
- Method `isValidId` is a private a method

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
