### PR TITLE
Delay checking for user input in CLI client

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/StatusPrinter.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/StatusPrinter.java
@@ -95,6 +95,7 @@ Spilled: 20GB
     public void printInitialStatusUpdates(Terminal terminal)
     {
         Attributes originalAttributes = terminal.enterRawMode();
+        long start = System.nanoTime();
         long lastPrint = System.nanoTime();
         try {
             WarningsPrinter warningsPrinter = new ConsoleWarningsPrinter(console);
@@ -108,7 +109,8 @@ Spilled: 20GB
                     // check if time to update screen
                     boolean update = nanosSince(lastPrint).getValue(SECONDS) >= 0.5;
 
-                    if (checkInput) {
+                    // start checking for input after 300ms to avoid delaying short queries
+                    if (checkInput && nanosSince(start).getValue(SECONDS) >= 0.3) {
                         // check for keyboard input
                         int key = readKey(terminal);
                         if (key == CTRL_P) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->
Avoid adding about 200ms of delay to very short queries by not checking user input in the first 300ms of query execution. Queries can still be canceled, as `CTRL+C` signal handling is setup earlier in `Query.renderOutput`.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

cli client

> How would you describe this change to a non-technical end user or system administrator?

Avoid adding about 200ms of delay to very short queries.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

* Fixes #11768

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# CLI client
* Avoid adding about 200ms of delay to very short queries. ({issue}`issuenumber`)
```
