### PR TITLE
Add cleanup mechanism for Iceberg Glue tests

### DIFF
--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -416,6 +416,7 @@
                                 <exclude>**/TestTrinoGlueCatalogTest.java</exclude>
                                 <exclude>**/TestSharedGlueMetastore.java</exclude>
                                 <exclude>**/TestIcebergGlueCatalogAccessOperations.java</exclude>
+                                <exclude>**/TestGlueCleanup.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>
@@ -455,6 +456,7 @@
                                 <include>**/TestTrinoGlueCatalogTest.java</include>
                                 <include>**/TestSharedGlueMetastore.java</include>
                                 <include>**/TestIcebergGlueCatalogAccessOperations.java</include>
+                                <include>**/TestGlueCleanup.java</include>
                             </includes>
                         </configuration>
                     </plugin>

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -70,6 +70,7 @@ import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_DATABASE_LOCATION_ERROR;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
 import static io.trino.plugin.hive.ViewReaderUtil.encodeViewData;
@@ -206,6 +207,8 @@ public class TrinoGlueCatalog
     private DatabaseInput createDatabaseInput(String namespace, Map<String, Object> properties)
     {
         DatabaseInput databaseInput = new DatabaseInput().withName(namespace);
+        databaseInput.setParameters(properties.entrySet().stream()
+                .collect(toImmutableMap(Map.Entry::getKey, entry -> String.valueOf(entry.getValue()))));
         Object location = properties.get(LOCATION_PROPERTY);
         if (location != null) {
             databaseInput.setLocationUri((String) location);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseTrinoCatalogTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseTrinoCatalogTest.java
@@ -54,7 +54,7 @@ public abstract class BaseTrinoCatalogTest
         TrinoCatalog catalog = createTrinoCatalog(false);
 
         String namespace = "test_create_namespace_with_location_" + randomTableSuffix();
-        catalog.createNamespace(SESSION, namespace, ImmutableMap.of(LOCATION_PROPERTY, "/a/path/"), new TrinoPrincipal(PrincipalType.USER, SESSION.getUser()));
+        createNamespace(catalog, namespace, ImmutableMap.of(LOCATION_PROPERTY, "/a/path/"), new TrinoPrincipal(PrincipalType.USER, SESSION.getUser()));
         assertThat(catalog.listNamespaces(SESSION)).contains(namespace);
         assertEquals(catalog.loadNamespaceMetadata(SESSION, namespace), ImmutableMap.of(LOCATION_PROPERTY, "/a/path/"));
         assertEquals(catalog.defaultTableLocation(SESSION, new SchemaTableName(namespace, "table")), "/a/path/table");
@@ -74,7 +74,7 @@ public abstract class BaseTrinoCatalogTest
         String table = "tableName";
         SchemaTableName schemaTableName = new SchemaTableName(namespace, table);
         try {
-            catalog.createNamespace(SESSION, namespace, ImmutableMap.of(), new TrinoPrincipal(PrincipalType.USER, SESSION.getUser()));
+            createNamespace(catalog, namespace, ImmutableMap.of(), new TrinoPrincipal(PrincipalType.USER, SESSION.getUser()));
             catalog.newCreateTableTransaction(
                     SESSION,
                     schemaTableName,
@@ -122,8 +122,8 @@ public abstract class BaseTrinoCatalogTest
         String table = "tableName";
         SchemaTableName sourceSchemaTableName = new SchemaTableName(namespace, table);
         try {
-            catalog.createNamespace(SESSION, namespace, ImmutableMap.of(), new TrinoPrincipal(PrincipalType.USER, SESSION.getUser()));
-            catalog.createNamespace(SESSION, targetNamespace, ImmutableMap.of(), new TrinoPrincipal(PrincipalType.USER, SESSION.getUser()));
+            createNamespace(catalog, namespace, ImmutableMap.of(), new TrinoPrincipal(PrincipalType.USER, SESSION.getUser()));
+            createNamespace(catalog, targetNamespace, ImmutableMap.of(), new TrinoPrincipal(PrincipalType.USER, SESSION.getUser()));
             catalog.newCreateTableTransaction(
                     SESSION,
                     sourceSchemaTableName,
@@ -171,7 +171,7 @@ public abstract class BaseTrinoCatalogTest
         String namespace = "test_unique_table_locations_" + randomTableSuffix();
         String table = "tableName";
         SchemaTableName schemaTableName = new SchemaTableName(namespace, table);
-        catalog.createNamespace(SESSION, namespace, ImmutableMap.of(LOCATION_PROPERTY, tmpDirectory.toString()), new TrinoPrincipal(PrincipalType.USER, SESSION.getUser()));
+        createNamespace(catalog, namespace, ImmutableMap.of(LOCATION_PROPERTY, tmpDirectory.toString()), new TrinoPrincipal(PrincipalType.USER, SESSION.getUser()));
         try {
             String location1 = catalog.defaultTableLocation(SESSION, schemaTableName);
             String location2 = catalog.defaultTableLocation(SESSION, schemaTableName);
@@ -214,7 +214,7 @@ public abstract class BaseTrinoCatalogTest
                 false);
 
         try {
-            catalog.createNamespace(SESSION, namespace, ImmutableMap.of(), new TrinoPrincipal(PrincipalType.USER, SESSION.getUser()));
+            createNamespace(catalog, namespace, ImmutableMap.of(), new TrinoPrincipal(PrincipalType.USER, SESSION.getUser()));
             catalog.createView(SESSION, schemaTableName, viewDefinition, false);
 
             assertThat(catalog.listTables(SESSION, Optional.of(namespace))).contains(schemaTableName);
@@ -246,6 +246,11 @@ public abstract class BaseTrinoCatalogTest
                 LOG.warn("Failed to clean up namespace: " + namespace);
             }
         }
+    }
+
+    protected void createNamespace(TrinoCatalog catalog, String namespace, Map<String, Object> properties, TrinoPrincipal owner)
+    {
+        catalog.createNamespace(SESSION, namespace, properties, owner);
     }
 
     private void assertViewDefinition(ConnectorViewDefinition actualView, ConnectorViewDefinition expectedView)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestGlueCleanup.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestGlueCleanup.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.glue;
+
+import com.amazonaws.services.glue.AWSGlueAsync;
+import com.amazonaws.services.glue.AWSGlueAsyncClientBuilder;
+import com.amazonaws.services.glue.model.Database;
+import com.amazonaws.services.glue.model.DatabaseInput;
+import com.amazonaws.services.glue.model.DeleteDatabaseRequest;
+import com.amazonaws.services.glue.model.GetDatabaseRequest;
+import com.amazonaws.services.glue.model.GetDatabasesRequest;
+import com.amazonaws.services.glue.model.GetDatabasesResult;
+import com.amazonaws.services.glue.model.UpdateDatabaseRequest;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.log.Logger;
+import io.trino.plugin.hive.metastore.glue.GlueMetastoreApiStats;
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Date;
+
+import static io.trino.plugin.hive.metastore.glue.AwsSdkUtil.getPaginatedResults;
+
+/**
+ * Test class with methods to clean up existing Glue tables and schemas from test which were not finished properly.
+ */
+public class TestGlueCleanup
+{
+    // All tests creating Glue schemas should add this key/value pair to the schema properties.
+    public static final String GLUE_SCHEMA_PROPERTY_KEY = "ci_iceberg_integration_test";
+    public static final String GLUE_SCHEMA_PROPERTY_VALUE = "true";
+
+    private static final Logger LOG = Logger.get(TestGlueCleanup.class);
+
+    public static void setSchemaFlag(String schemaName)
+    {
+        AWSGlueAsync glueClient = AWSGlueAsyncClientBuilder.defaultClient();
+        Database database = glueClient.getDatabase(new GetDatabaseRequest().withName(schemaName)).getDatabase();
+        ImmutableMap.Builder<String, String> schemaParameters = ImmutableMap.builder();
+        if (database.getParameters() != null) {
+            schemaParameters.putAll(database.getParameters());
+        }
+        schemaParameters.put(GLUE_SCHEMA_PROPERTY_KEY, GLUE_SCHEMA_PROPERTY_VALUE);
+
+        DatabaseInput databaseInput = new DatabaseInput()
+                .withName(schemaName)
+                .withDescription(database.getDescription())
+                .withLocationUri(database.getLocationUri())
+                .withParameters(schemaParameters.buildOrThrow())
+                .withCreateTableDefaultPermissions(database.getCreateTableDefaultPermissions())
+                .withTargetDatabase(database.getTargetDatabase());
+        glueClient.updateDatabase(new UpdateDatabaseRequest()
+                .withName(schemaName)
+                .withDatabaseInput(databaseInput));
+    }
+
+    @Test
+    public void cleanupOrphanedSchemas()
+    {
+        AWSGlueAsync glueClient = AWSGlueAsyncClientBuilder.defaultClient();
+        long createdAtCutoff = System.currentTimeMillis() - Duration.ofDays(1).toMillis();
+        getPaginatedResults(
+                glueClient::getDatabases,
+                new GetDatabasesRequest(),
+                GetDatabasesRequest::setNextToken,
+                GetDatabasesResult::getNextToken,
+                new GlueMetastoreApiStats())
+                .map(GetDatabasesResult::getDatabaseList)
+                .flatMap(Collection::stream)
+                .filter(database -> database.getParameters() != null && GLUE_SCHEMA_PROPERTY_VALUE.equals(database.getParameters().get(GLUE_SCHEMA_PROPERTY_KEY)))
+                .filter(database -> database.getCreateTime().before(new Date(createdAtCutoff)))
+                .forEach(database -> {
+                    LOG.warn("Deleting old Glue database " + database);
+                    glueClient.deleteDatabase(new DeleteDatabaseRequest().withName(database.getName()));
+                });
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogAccessOperations.java
@@ -109,6 +109,7 @@ public class TestIcebergGlueCatalogAccessOperations
                         "hive.metastore.glue.default-warehouse-dir", tmp.getAbsolutePath()));
 
         queryRunner.execute("CREATE SCHEMA " + testSchema);
+        TestGlueCleanup.setSchemaFlag(testSchema);
 
         glueStats = verifyNotNull(glueStatsReference.get(), "glueStatsReference not set");
         return queryRunner;

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestSharedGlueMetastore.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestSharedGlueMetastore.java
@@ -119,6 +119,7 @@ public class TestSharedGlueMetastore
                 ImmutableMap.of("hive.iceberg-catalog-name", "iceberg"));
 
         queryRunner.execute("CREATE SCHEMA " + schema + " WITH (location = '" + dataDirectory.toString() + "')");
+        TestGlueCleanup.setSchemaFlag(schema);
         copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, icebergSession, ImmutableList.of(TpchTable.NATION));
         copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, hiveSession, ImmutableList.of(TpchTable.REGION));
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

After one day any schemas with the 'ci_iceberg_integration_test' property will be deleted.

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Test infra improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Test only

> How would you describe this change to a non-technical end user or system administrator?

Ensure test cancellation does not result in databases which are never deleted.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:
