### PR TITLE
Fix Dev Guide references to new locations

### DIFF
--- a/docs/src/main/sphinx/develop/client-protocol.rst
+++ b/docs/src/main/sphinx/develop/client-protocol.rst
@@ -58,9 +58,10 @@ query is finished.
 Important ``QueryResults`` attributes
 -------------------------------------
 
-The most important attributes of the ``QueryResults`` JSON document returned by the REST API
-endpoints are listed in this table.  Refer to the class ``io.trino.client.QueryResults`` in
-module ``trino-client`` for more details.
+The most important attributes of the ``QueryResults`` JSON document returned by
+the REST API endpoints are listed in this table. For more details, refer to the
+class ``io.trino.client.QueryResults`` in module ``trino-client`` in the
+``client`` directory of the Trino source code.
 
 .. list-table:: ``QueryResults attributes``
   :widths: 25, 55
@@ -86,11 +87,10 @@ module ``trino-client`` for more details.
       ``CREATE TABLE`` request, the ``updateType`` is
       "CREATE TABLE"; for ``SET SESSION`` it is "SET SESSION"; etc.
   * - ``error``
-    - If query failed, the ``error`` attribute contains a
-      ``QueryError`` object.  That object contains a ``message``, an
-      ``errorCode`` and other information about the error.  See the
-      ``io.trino.client.QueryError`` class in module ``trino-client``
-      for more details.
+    - If query failed, the ``error`` attribute contains a ``QueryError`` object.
+      That object contains a ``message``, an ``errorCode`` and other information
+      about the error.  See the ``io.trino.client.QueryError`` class in module
+      ``trino-client`` in the ``client`` directory for more details.
 
 
 ``QueryResults`` diagnostic attributes
@@ -262,6 +262,6 @@ subsequent requests to be consistent with the response headers received.
 ``ProtocolHeaders``
 -------------------
 
-Class ``io.trino.client.ProtocolHeaders``, in module ``trino-client``,
-enumerates all the HTTP request and response headers allowed by the
-Trino client REST API.
+Class ``io.trino.client.ProtocolHeaders`` in module ``trino-client`` in the
+``client`` directory of Trino source enumerates all the HTTP request and
+response headers allowed by the Trino client REST API.

--- a/docs/src/main/sphinx/develop/functions.rst
+++ b/docs/src/main/sphinx/develop/functions.rst
@@ -31,9 +31,10 @@ Note that the ``ImmutableSet`` class is a utility class from Guava.
 The ``getFunctions()`` method contains all of the classes for the functions
 that we will implement below in this tutorial.
 
-For a full example in the codebase, see either the ``trino-ml`` module for machine
-learning functions or the ``trino-teradata-functions`` module for Teradata-compatible
-functions, both in the root of the Trino source.
+For a full example in the codebase, see either the ``trino-ml`` module for
+machine learning functions or the ``trino-teradata-functions`` module for
+Teradata-compatible functions, both in the ``plugin`` directory of the Trino
+source.
 
 Scalar function implementation
 ------------------------------

--- a/docs/src/main/sphinx/develop/spi-overview.rst
+++ b/docs/src/main/sphinx/develop/spi-overview.rst
@@ -6,15 +6,15 @@ When you implement a new Trino plugin, you implement interfaces and
 override methods defined by the SPI.
 
 Plugins can provide additional :doc:`connectors`, :doc:`types`,
-:doc:`functions` and :doc:`system-access-control`.
+:doc:`functions`, and :doc:`system-access-control`.
 In particular, connectors are the source of all data for queries in
 Trino: they back each catalog available to Trino.
 
 Code
 ----
 
-The SPI source can be found in the ``trino-spi`` directory in the
-root of the Trino source tree.
+The SPI source can be found in the ``core/trino-spi`` directory in the Trino
+source tree.
 
 Plugin metadata
 ---------------
@@ -77,7 +77,7 @@ to provide isolation and to allow plugins to use a different version
 of a library that Trino uses internally.
 
 For an example ``pom.xml`` file, see the example HTTP connector in the
-``trino-example-http`` directory in the root of the Trino source tree.
+``plugin/trino-example-http`` directory in the Trino source tree.
 
 Deploying a custom plugin
 -------------------------


### PR DESCRIPTION

## Description

The Developer Guide chapter has a few references to sub-projects “at the root of the Trino source tree”. But since the reorganization of that tree, these references are one layer off. Also added one missing Oxford comma.

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Docs only.

> How would you describe this change to a non-technical end user or system administrator?

Doc correction.

## Related issues, pull requests, and links

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

