### PR TITLE
Increase timeout in container test

### DIFF
--- a/core/docker/container-test.sh
+++ b/core/docker/container-test.sh
@@ -8,7 +8,7 @@ function cleanup {
 
 function test_trino_starts {
     local QUERY_PERIOD=10
-    local QUERY_RETRIES=60
+    local QUERY_RETRIES=90
 
     CONTAINER_ID=
     trap cleanup EXIT


### PR DESCRIPTION
On arm64 using emulation we are now occasionally hitting 10m timeout for starting Trino container, 
so I increased timeout to 15 minutes.