### PR TITLE
Cache type and operator resolution for GenericLiteral

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -252,6 +252,7 @@ public class ExpressionAnalyzer
     private final PlannerContext plannerContext;
     private final AccessControl accessControl;
     private final BiFunction<Node, CorrelationSupport, StatementAnalyzer> statementAnalyzerFactory;
+    private final LiteralInterpreter literalInterpreter;
     private final TypeProvider symbolTypes;
     private final boolean isDescribe;
 
@@ -345,6 +346,7 @@ public class ExpressionAnalyzer
         this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.statementAnalyzerFactory = requireNonNull(statementAnalyzerFactory, "statementAnalyzerFactory is null");
+        this.literalInterpreter = new LiteralInterpreter(plannerContext, session);
         this.session = requireNonNull(session, "session is null");
         this.symbolTypes = requireNonNull(symbolTypes, "symbolTypes is null");
         this.parameters = requireNonNull(parameters, "parameters is null");
@@ -1058,7 +1060,7 @@ public class ExpressionAnalyzer
                 return resolvedType;
             });
             try {
-                LiteralInterpreter.evaluate(plannerContext, session, ImmutableMap.of(NodeRef.of(node), type), node);
+                literalInterpreter.evaluate(ImmutableMap.of(NodeRef.of(node), type), node);
             }
             catch (RuntimeException e) {
                 throw semanticException(INVALID_LITERAL, node, e, "'%s' is not a valid %s literal", node.getValue(), type.getDisplayName());
@@ -1130,7 +1132,7 @@ public class ExpressionAnalyzer
                 type = INTERVAL_DAY_TIME;
             }
             try {
-                LiteralInterpreter.evaluate(plannerContext, session, ImmutableMap.of(NodeRef.of(node), type), node);
+                literalInterpreter.evaluate(ImmutableMap.of(NodeRef.of(node), type), node);
             }
             catch (RuntimeException e) {
                 throw semanticException(INVALID_LITERAL, node, e, "'%s' is not a valid interval literal", node.getValue());

--- a/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionInterpreter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionInterpreter.java
@@ -161,6 +161,7 @@ public class ExpressionInterpreter
     private final Expression expression;
     private final PlannerContext plannerContext;
     private final Metadata metadata;
+    private final LiteralInterpreter literalInterpreter;
     private final LiteralEncoder literalEncoder;
     private final Session session;
     private final ConnectorSession connectorSession;
@@ -177,6 +178,7 @@ public class ExpressionInterpreter
         this.expression = requireNonNull(expression, "expression is null");
         this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
         this.metadata = plannerContext.getMetadata();
+        this.literalInterpreter = new LiteralInterpreter(plannerContext, session);
         this.literalEncoder = new LiteralEncoder(plannerContext);
         this.session = requireNonNull(session, "session is null");
         this.connectorSession = session.toConnectorSession();
@@ -387,7 +389,7 @@ public class ExpressionInterpreter
         @Override
         protected Object visitLiteral(Literal node, Object context)
         {
-            return LiteralInterpreter.evaluate(plannerContext, session, expressionTypes, node);
+            return literalInterpreter.evaluate(expressionTypes, node);
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LiteralInterpreter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LiteralInterpreter.java
@@ -65,31 +65,34 @@ import static java.util.Objects.requireNonNull;
 
 public final class LiteralInterpreter
 {
-    private LiteralInterpreter() {}
+    private final PlannerContext plannerContext;
+    private final Session session;
+    private final ConnectorSession connectorSession;
+    private final InterpretedFunctionInvoker functionInvoker;
 
-    public static Object evaluate(PlannerContext plannerContext, Session session, Map<NodeRef<Expression>, Type> types, Expression node)
+    public LiteralInterpreter(PlannerContext plannerContext, Session session)
+    {
+        this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
+        this.session = requireNonNull(session, "session is null");
+        this.connectorSession = session.toConnectorSession();
+        this.functionInvoker = new InterpretedFunctionInvoker(plannerContext.getFunctionManager());
+    }
+
+    public Object evaluate(Map<NodeRef<Expression>, Type> types, Expression node)
     {
         if (!(node instanceof Literal)) {
             throw new IllegalArgumentException("node must be a Literal");
         }
-        return new LiteralVisitor(session, plannerContext, types).process(node, null);
+        return new LiteralVisitor(types).process(node, null);
     }
 
-    private static class LiteralVisitor
+    private class LiteralVisitor
             extends AstVisitor<Object, Void>
     {
-        private final Session session;
-        private final ConnectorSession connectorSession;
-        private final PlannerContext plannerContext;
-        private final InterpretedFunctionInvoker functionInvoker;
         private final Map<NodeRef<Expression>, Type> types;
 
-        private LiteralVisitor(Session session, PlannerContext plannerContext, Map<NodeRef<Expression>, Type> types)
+        private LiteralVisitor(Map<NodeRef<Expression>, Type> types)
         {
-            this.session = requireNonNull(session, "session is null");
-            this.connectorSession = session.toConnectorSession();
-            this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
-            this.functionInvoker = new InterpretedFunctionInvoker(plannerContext.getFunctionManager());
             this.types = requireNonNull(types, "types is null");
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LiteralInterpreter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LiteralInterpreter.java
@@ -13,10 +13,13 @@
  */
 package io.trino.sql.planner;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.trino.Session;
+import io.trino.collect.cache.CacheUtils;
 import io.trino.metadata.ResolvedFunction;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.type.Decimals;
@@ -47,8 +50,10 @@ import io.trino.sql.tree.TimeLiteral;
 import io.trino.sql.tree.TimestampLiteral;
 
 import java.util.Map;
+import java.util.function.Function;
 
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.collect.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.spi.StandardErrorCode.INVALID_LITERAL;
 import static io.trino.spi.StandardErrorCode.TYPE_NOT_FOUND;
 import static io.trino.spi.type.VarcharType.VARCHAR;
@@ -69,6 +74,8 @@ public final class LiteralInterpreter
     private final Session session;
     private final ConnectorSession connectorSession;
     private final InterpretedFunctionInvoker functionInvoker;
+
+    private final Cache<String, Function<GenericLiteral, Object>> genericLiteralEvaluatorCache = buildNonEvictableCache(CacheBuilder.newBuilder().maximumSize(1000));
 
     public LiteralInterpreter(PlannerContext plannerContext, Session session)
     {
@@ -147,26 +154,36 @@ public final class LiteralInterpreter
         @Override
         protected Object visitGenericLiteral(GenericLiteral node, Void context)
         {
-            Type type;
-            try {
-                type = plannerContext.getTypeManager().fromSqlType(node.getType());
-            }
-            catch (TypeNotFoundException e) {
-                throw semanticException(TYPE_NOT_FOUND, node, "Unknown type: %s", node.getType());
-            }
-
-            if (JSON.equals(type)) {
-                ResolvedFunction resolvedFunction = plannerContext.getMetadata().resolveFunction(session, QualifiedName.of("json_parse"), fromTypes(VARCHAR));
-                return functionInvoker.invoke(resolvedFunction, connectorSession, ImmutableList.of(utf8Slice(node.getValue())));
-            }
-
-            try {
-                ResolvedFunction resolvedFunction = plannerContext.getMetadata().getCoercion(session, VARCHAR, type);
-                return functionInvoker.invoke(resolvedFunction, connectorSession, ImmutableList.of(utf8Slice(node.getValue())));
-            }
-            catch (IllegalArgumentException e) {
-                throw semanticException(INVALID_LITERAL, node, "No literal form for type %s", type);
-            }
+            Function<GenericLiteral, Object> evaluator = CacheUtils.uncheckedCacheGet(genericLiteralEvaluatorCache, node.getType(), () -> {
+                Type type;
+                try {
+                    type = plannerContext.getTypeManager().fromSqlType(node.getType());
+                }
+                catch (TypeNotFoundException e) {
+                    throw semanticException(TYPE_NOT_FOUND, node, "Unknown type: %s", node.getType());
+                }
+                boolean isJson = JSON.equals(type);
+                ResolvedFunction resolvedFunction;
+                if (isJson) {
+                    resolvedFunction = plannerContext.getMetadata().resolveFunction(session, QualifiedName.of("json_parse"), fromTypes(VARCHAR));
+                }
+                else {
+                    resolvedFunction = plannerContext.getMetadata().getCoercion(session, VARCHAR, type);
+                }
+                return evaluatedNode -> {
+                    try {
+                        return functionInvoker.invoke(resolvedFunction, connectorSession, ImmutableList.of(utf8Slice(evaluatedNode.getValue())));
+                    }
+                    catch (IllegalArgumentException e) {
+                        if (isJson) {
+                            // TODO it may be not correct to propagate this exceptiion as-is in JSON case
+                            throw e;
+                        }
+                        throw semanticException(INVALID_LITERAL, evaluatedNode, "No literal form for type %s", type);
+                    }
+                };
+            });
+            return evaluator.apply(node);
         }
 
         @Override


### PR DESCRIPTION
Improve planning performance for long IN value lists GenericLiteral (e.g. `bigint`, unbounded `varchar`).