### PR TITLE
Enable TestDeltaLakeAnalyze

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAnalyze.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAnalyze.java
@@ -39,10 +39,8 @@ import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 
-// TODO (https://github.com/trinodb/trino/issues/11325): hadoop container sometimes fails during the test (e.g. testAnalyzeWithFilesModifiedAfter)
-//   enable the class by making it non-abstract
 // smoke test which covers ANALYZE compatibility with different filesystems is part of AbstractTestDeltaLakeIntegrationSmokeTest
-public abstract class TestDeltaLakeAnalyze
+public class TestDeltaLakeAnalyze
         extends AbstractTestQueryFramework
 {
     private static final String SCHEMA = "default";


### PR DESCRIPTION
## Description

Enable TestDeltaLakeAnalyze
Relates to #11325

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.

## Note
* 30/30 passed https://github.com/trinodb/trino/actions/runs/2159316250
* 30/30 passed https://github.com/trinodb/trino/actions/runs/2159711028
* 30/30 passed https://github.com/trinodb/trino/actions/runs/2160160810