### PR TITLE
Assert no other partitions in assertExpectedPartitions

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -1283,11 +1283,14 @@ public abstract class AbstractTestHive
     {
         Iterable<HivePartition> actualPartitions = ((HiveTableHandle) table).getPartitions().orElseThrow(AssertionError::new);
         Map<String, HivePartition> actualById = uniqueIndex(actualPartitions, HivePartition::getPartitionId);
-        for (HivePartition expectedPartition : expectedPartitions) {
-            HivePartition actualPartition = actualById.get(expectedPartition.getPartitionId());
-            assertEquals(actualPartition, expectedPartition);
-            assertNotNull(actualPartition); // just to keep IDE happy
-            // HivePartition.equals doesn't compare all the fields, so let's check them
+        Map<String, HivePartition> expectedById = uniqueIndex(expectedPartitions, HivePartition::getPartitionId);
+
+        assertThat(actualById).isEqualTo(expectedById);
+
+        // HivePartition.equals doesn't compare all the fields, so let's check them
+        for (Map.Entry<String, HivePartition> expected : expectedById.entrySet()) {
+            HivePartition actualPartition = actualById.get(expected.getKey());
+            HivePartition expectedPartition = expected.getValue();
             assertEquals(actualPartition.getPartitionId(), expectedPartition.getPartitionId());
             assertEquals(actualPartition.getKeys(), expectedPartition.getKeys());
             assertEquals(actualPartition.getTableName(), expectedPartition.getTableName());

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -1286,7 +1286,8 @@ public abstract class AbstractTestHive
         for (HivePartition expectedPartition : expectedPartitions) {
             HivePartition actualPartition = actualById.get(expectedPartition.getPartitionId());
             assertEquals(actualPartition, expectedPartition);
-            assertNotNull(actualPartition, "partition " + expectedPartition.getPartitionId());
+            assertNotNull(actualPartition); // just to keep IDE happy
+            // HivePartition.equals doesn't compare all the fields, so let's check them
             assertEquals(actualPartition.getPartitionId(), expectedPartition.getPartitionId());
             assertEquals(actualPartition.getKeys(), expectedPartition.getKeys());
             assertEquals(actualPartition.getTableName(), expectedPartition.getTableName());

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -1282,16 +1282,10 @@ public abstract class AbstractTestHive
     protected void assertExpectedPartitions(ConnectorTableHandle table, Iterable<HivePartition> expectedPartitions)
     {
         Iterable<HivePartition> actualPartitions = ((HiveTableHandle) table).getPartitions().orElseThrow(AssertionError::new);
-        Map<String, ?> actualById = uniqueIndex(actualPartitions, HivePartition::getPartitionId);
-        for (Object expected : expectedPartitions) {
-            assertInstanceOf(expected, HivePartition.class);
-            HivePartition expectedPartition = (HivePartition) expected;
-
-            Object actual = actualById.get(expectedPartition.getPartitionId());
-            assertEquals(actual, expected);
-            assertInstanceOf(actual, HivePartition.class);
-            HivePartition actualPartition = (HivePartition) actual;
-
+        Map<String, HivePartition> actualById = uniqueIndex(actualPartitions, HivePartition::getPartitionId);
+        for (HivePartition expectedPartition : expectedPartitions) {
+            HivePartition actualPartition = actualById.get(expectedPartition.getPartitionId());
+            assertEquals(actualPartition, expectedPartition);
             assertNotNull(actualPartition, "partition " + expectedPartition.getPartitionId());
             assertEquals(actualPartition.getPartitionId(), expectedPartition.getPartitionId());
             assertEquals(actualPartition.getKeys(), expectedPartition.getKeys());


### PR DESCRIPTION
Previously, `assertExpectedPartitions` checked whether expected
partitions are present. After the change, it still does that, but also
verifies no unexpected partitions are present.

Fixes https://github.com/trinodb/trino/issues/11904 
Note: this PR runs with secrets