### PR TITLE
Hide JsonType constructor

### DIFF
--- a/core/trino-main/src/main/java/io/trino/type/JsonType.java
+++ b/core/trino-main/src/main/java/io/trino/type/JsonType.java
@@ -43,7 +43,7 @@ public class JsonType
 
     public static final JsonType JSON = new JsonType();
 
-    public JsonType()
+    private JsonType()
     {
         super(new TypeSignature(StandardTypes.JSON), Slice.class);
     }


### PR DESCRIPTION
The type should be accessed via a defined constant.
