### PR TITLE
Remove left over comment from MetadataManager

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -2247,10 +2247,6 @@ public final class MetadataManager
     }
 
     //
-    // Blocks
-    //
-
-    //
     // Helpers
     //
 


### PR DESCRIPTION
It used to announce code section with methods like `getBlockEncoding`,
`getBlockEncodingSerde`, which are gone now.
