### PR TITLE
Support ORC 8-bit field type like tinyint or boolean, which is recognized as numeric type in trino

### DIFF
--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/LongInputStream.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/LongInputStream.java
@@ -32,6 +32,9 @@ public interface LongInputStream
     void next(short[] values, int items)
             throws IOException;
 
+    void next(byte[] values, int items)
+            throws IOException;
+
     default long sum(int items)
             throws IOException
     {

--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/LongInputStreamV1.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/LongInputStreamV1.java
@@ -201,6 +201,44 @@ public class LongInputStreamV1
     }
 
     @Override
+    public void next(byte[] values, int items) throws IOException
+    {
+        int offset = 0;
+        while (items > 0) {
+            if (used == numLiterals) {
+                numLiterals = 0;
+                used = 0;
+                readValues();
+            }
+
+            int chunkSize = min(numLiterals - used, items);
+            if (repeat) {
+                for (int i = 0; i < chunkSize; i++) {
+                    long literal = literals[0] + ((long) (used + i) * delta);
+                    byte value = (byte) literal;
+                    if (literal != value) {
+                        throw new OrcCorruptionException(input.getOrcDataSourceId(), "Decoded value out of range for a 8bit number");
+                    }
+                    values[offset + i] = value;
+                }
+            }
+            else {
+                for (int i = 0; i < chunkSize; i++) {
+                    long literal = literals[used + i];
+                    byte value = (byte) literal;
+                    if (literal != value) {
+                        throw new OrcCorruptionException(input.getOrcDataSourceId(), "Decoded value out of range for a 8bit number");
+                    }
+                    values[offset + i] = value;
+                }
+            }
+            used += chunkSize;
+            offset += chunkSize;
+            items -= chunkSize;
+        }
+    }
+
+    @Override
     public void seekToCheckpoint(LongStreamCheckpoint checkpoint)
             throws IOException
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
It is a improvement.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
The modification of the code is in client library module `trino-orc`.

> How would you describe this change to a non-technical end user or system administrator?
When trino reads the hive orc table of the lower protobuf version, an error is reported when parsing the tinyint/boolean field. 
The field length is 8-bits and considered to be numeric type instead of the original types, but trino do not support parsing 8-bits numeric field.
So I Try to add support for 8-bits numeric field.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->
Fixes #11428 

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

- [x]  No documentation is needed.
- [ ] Sufficient documentation is included in this PR.
- [ ] Documentation PR is available with #prnumber.
- [ ] Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

- [x] No release notes entries required.
- [ ] Release notes entries required with the following suggested text: