### PR TITLE
Only fail query if whole node was used on task out-of-memory error

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/BinPackingNodeAllocatorService.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/BinPackingNodeAllocatorService.java
@@ -71,8 +71,7 @@ import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.SystemSessionProperties.getFaultTolerantExecutionTaskMemoryEstimationQuantile;
 import static io.trino.SystemSessionProperties.getFaultTolerantExecutionTaskMemoryGrowthFactor;
-import static io.trino.spi.StandardErrorCode.CLUSTER_OUT_OF_MEMORY;
-import static io.trino.spi.StandardErrorCode.EXCEEDED_LOCAL_MEMORY_LIMIT;
+import static io.trino.execution.scheduler.ErrorCodes.isOutOfMemoryError;
 import static io.trino.spi.StandardErrorCode.NO_NODES_AVAILABLE;
 import static java.lang.Math.max;
 import static java.lang.Thread.currentThread;
@@ -627,12 +626,6 @@ public class BinPackingNodeAllocatorService
                 return memory;
             }
             return Ordering.natural().min(memory, currentMaxNodePoolSize.get());
-        }
-
-        private boolean isOutOfMemoryError(ErrorCode errorCode)
-        {
-            return EXCEEDED_LOCAL_MEMORY_LIMIT.toErrorCode().equals(errorCode) // too many tasks from single query on a node
-                    || CLUSTER_OUT_OF_MEMORY.toErrorCode().equals(errorCode); // too many tasks in general on a node
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/ErrorCodes.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/ErrorCodes.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.scheduler;
+
+import io.trino.spi.ErrorCode;
+
+import static io.trino.spi.StandardErrorCode.CLUSTER_OUT_OF_MEMORY;
+import static io.trino.spi.StandardErrorCode.EXCEEDED_LOCAL_MEMORY_LIMIT;
+
+public final class ErrorCodes
+{
+    private ErrorCodes() {}
+
+    public static boolean isOutOfMemoryError(ErrorCode errorCode)
+    {
+        return EXCEEDED_LOCAL_MEMORY_LIMIT.toErrorCode().equals(errorCode) // too many tasks from single query on a node
+                || CLUSTER_OUT_OF_MEMORY.toErrorCode().equals(errorCode); // too many tasks in general on a node
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/ErrorCodes.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/ErrorCodes.java
@@ -16,6 +16,7 @@ package io.trino.execution.scheduler;
 import io.trino.spi.ErrorCode;
 
 import static io.trino.spi.StandardErrorCode.CLUSTER_OUT_OF_MEMORY;
+import static io.trino.spi.StandardErrorCode.EXCEEDED_GLOBAL_MEMORY_LIMIT;
 import static io.trino.spi.StandardErrorCode.EXCEEDED_LOCAL_MEMORY_LIMIT;
 
 public final class ErrorCodes
@@ -24,7 +25,8 @@ public final class ErrorCodes
 
     public static boolean isOutOfMemoryError(ErrorCode errorCode)
     {
-        return EXCEEDED_LOCAL_MEMORY_LIMIT.toErrorCode().equals(errorCode) // too many tasks from single query on a node
-                || CLUSTER_OUT_OF_MEMORY.toErrorCode().equals(errorCode); // too many tasks in general on a node
+        return EXCEEDED_LOCAL_MEMORY_LIMIT.toErrorCode().equals(errorCode)
+                || EXCEEDED_GLOBAL_MEMORY_LIMIT.toErrorCode().equals(errorCode)
+                || CLUSTER_OUT_OF_MEMORY.toErrorCode().equals(errorCode);
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Only fail query if whole node was used on task out-of-memory error. On other types of errors still try to retry a task.

> Is this change a fix, improvement, new feature, refactoring, or other?

bugfix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

engine

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

