### PR TITLE
Require internal shared secret is set when authentication is enabled

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
+++ b/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
@@ -236,7 +236,8 @@ public class TestingTrinoServer
                 .put("coordinator", String.valueOf(coordinator))
                 .put("task.concurrency", "4")
                 .put("task.max-worker-threads", "4")
-                .put("exchange.client-threads", "4");
+                .put("exchange.client-threads", "4")
+                .put("internal-communication.shared-secret", "internal-shared-secret");
 
         if (coordinator) {
             // TODO: enable failure detector

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-oauth2-http-proxy/config.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-oauth2-http-proxy/config.properties
@@ -23,3 +23,5 @@ http-server.authentication.oauth2.user-mapping.pattern=(.*)(@.*)?
 http-server.authentication.oauth2.groups-field=groups
 oauth2-jwk.http-client.trust-store-path=/docker/presto-product-tests/conf/presto/etc/hydra.pem
 oauth2-jwk.http-client.http-proxy=proxy:8888
+
+internal-communication.shared-secret=internal-shared-secret

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-oauth2-https-proxy/config.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-oauth2-https-proxy/config.properties
@@ -25,3 +25,5 @@ oauth2-jwk.http-client.trust-store-path=/docker/presto-product-tests/conf/presto
 oauth2-jwk.http-client.trust-store-password=123456
 oauth2-jwk.http-client.http-proxy=proxy:8888
 oauth2-jwk.http-client.http-proxy.secure=true
+
+internal-communication.shared-secret=internal-shared-secret

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-oauth2/config.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-oauth2/config.properties
@@ -22,3 +22,5 @@ http-server.authentication.oauth2.client-secret=trinodb_client_secret
 http-server.authentication.oauth2.user-mapping.pattern=(.*)(@.*)?
 http-server.authentication.oauth2.groups-field=groups
 oauth2-jwk.http-client.trust-store-path=/docker/presto-product-tests/conf/presto/etc/hydra.pem
+
+internal-communication.shared-secret=internal-shared-secret

--- a/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
@@ -229,7 +229,6 @@ public class DistributedQueryRunner
     {
         long start = System.nanoTime();
         ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.<String, String>builder()
-                .put("internal-communication.shared-secret", "test-secret")
                 .put("query.client.timeout", "10m")
                 // Use few threads in tests to preserve resources on CI
                 .put("discovery.http-client.min-threads", "1") // default 8


### PR DESCRIPTION
## Description
Require internal shared secret is set when authentication is enabled.  This prevents configuration errors where the client to server interface is secured, but the server to server interface is not.

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
(X) Documentation issue #issuenumber is filed, and can be handled later.

The existing security documentation will need to be updated to note that the secret is required when configuring authentication.  There are many pages with instructions for setting up authentication and it is not clear where this note should go.

## Release notes

( ) No release notes entries required.
(X) Release notes entries required with the following suggested text:

```markdown
# General
* The ``internal-communication.shared-secret`` must now be set when authentication installed. ({issue}`11944`)
```
