### PR TITLE
Ignore views on information_schema.columns queries

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
@@ -62,6 +62,7 @@ import static io.trino.plugin.deltalake.DeltaLakeMetadata.PATH_PROPERTY;
 import static io.trino.plugin.deltalake.DeltaLakeMetadata.createStatisticsPredicate;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.isExtendedStatisticsEnabled;
 import static io.trino.plugin.deltalake.DeltaLakeSplitManager.partitionMatchesPredicate;
+import static io.trino.plugin.hive.ViewReaderUtil.isHiveOrPrestoView;
 import static io.trino.spi.statistics.StatsUtil.toStatsRepresentation;
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
@@ -118,6 +119,10 @@ public class HiveMetastoreBackedDeltaLakeMetastore
     {
         Optional<Table> candidate = delegate.getTable(databaseName, tableName);
         candidate.ifPresent(table -> {
+            if (isHiveOrPrestoView(table)) {
+                // this is a Hive view, hence not a table
+                throw new NotADeltaLakeTableException(databaseName, tableName);
+            }
             if (!TABLE_PROVIDER_VALUE.equalsIgnoreCase(table.getParameters().get(TABLE_PROVIDER_PROPERTY))) {
                 throw new NotADeltaLakeTableException(databaseName, tableName);
             }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

The queries on `delta.information_schema.columns` don't work in the presence of a Hive view in the shared metastore service (HMS/Glue).

On such queries the user receives:
```
NotADeltaLakeTableException: test.v_hivetable is not a Delta Lake table
```

This bugfix uses the same technique employed on the `Iceberg` connnector for throwing a `TableNotFoundException` which is catched on `streamTableColumns()` method on the `DeltaLakeMetadata` so that views can be ignored.

The PR depends on https://github.com/trinodb/trino/pull/11565 for testing

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix 

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Delta Lake connector



## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
