### PR TITLE
Support query docvalue field in Elasticsearch

### DIFF
--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchQueryBuilder.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchQueryBuilder.java
@@ -65,7 +65,7 @@ public final class ElasticsearchQueryBuilder
 
                 checkArgument(!domain.isNone(), "Unexpected NONE domain for %s", column.getName());
                 if (!domain.isAll()) {
-                    queryBuilder.filter(new BoolQueryBuilder().must(buildPredicate(column.getName(), domain, column.getType())));
+                    queryBuilder.filter(new BoolQueryBuilder().must(buildPredicate(column.getPredicateName(), domain, column.getType())));
                 }
             }
         }

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/IndexMetadata.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/IndexMetadata.java
@@ -15,6 +15,7 @@ package io.trino.plugin.elasticsearch.client;
 
 import com.google.common.collect.ImmutableList;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -42,7 +43,15 @@ public class IndexMetadata
         private final String name;
         private final Type type;
 
+        // support multi-field, see https://github.com/trinodb/trino/issues/8358
+        private final List<Field> multiFields;
+
         public Field(boolean asRawJson, boolean isArray, String name, Type type)
+        {
+            this(asRawJson, isArray, name, type, new ArrayList<>());
+        }
+
+        public Field(boolean asRawJson, boolean isArray, String name, Type type, List<Field> multiFields)
         {
             checkArgument(!asRawJson || !isArray,
                     format("A column, (%s) cannot be declared as a Trino array and also be rendered as json.", name));
@@ -50,6 +59,7 @@ public class IndexMetadata
             this.isArray = isArray;
             this.name = requireNonNull(name, "name is null");
             this.type = requireNonNull(type, "type is null");
+            this.multiFields = requireNonNull(multiFields, "multi-fields is null");
         }
 
         public boolean asRawJson()
@@ -70,6 +80,11 @@ public class IndexMetadata
         public Type getType()
         {
             return type;
+        }
+
+        public List<Field> getMultiFields()
+        {
+            return multiFields;
         }
     }
 

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
@@ -1710,6 +1710,37 @@ public abstract class BaseElasticsearchConnectorTest
     }
 
     @Test
+    public void testMultiFields()
+            throws IOException
+    {
+        String indexName = "multi_fields";
+        @Language("JSON")
+        String properties = "" +
+                "{" +
+                "  \"properties\":{" +
+                "    \"textField\":   { " +
+                "        \"type\": \"text\"," +
+                "        \"fields\": {" +
+                "            \"raw\": { \"type\": \"keyword\" }" +
+                "        } " +
+                "    }" +
+                "  }" +
+                "}";
+        createIndex(indexName, properties);
+        index(indexName, ImmutableMap.<String, Object>builder()
+                .put("textField", "xxx")
+                .buildOrThrow());
+
+        assertQuery(
+                "SELECT textField FROM multi_fields",
+                "VALUES \'xxx\'");
+        assertQuery(
+                "SELECT textField FROM multi_fields WHERE textField=\'xxx\'",
+                "VALUES \'xxx\'");
+        assertThat(query("SELECT textField FROM multi_fields WHERE textField=\'xxx\'")).isFullyPushedDown();
+    }
+
+    @Test
     public void testQueryStringError()
     {
         assertQueryFails("SELECT orderkey FROM \"orders: ++foo AND\"", "\\QFailed to parse query [ ++foo and]\\E");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

<!-- Is this change a fix, improvement, new feature, refactoring, or other? -->

This is an enhancement of ElasticSearch Connector. 

Support query docvalue fields which is more efficient than source fields.

<!-- > Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)-->

<!-- > How would you describe this change to a non-technical end user or system administrator?-->

## Related issues, pull requests, and links
Solve #8358 

With elasicsearch multi-field mapping 
```json    
    "mappings": {
        "properties": {
            "textField": {
                "type": "text",
                "fields": {
                    "raw": {
                        "type": "keyword"
                    }
                }
            }
        }
    }
```
for trino sql
```sql
select * from "test-index"
```
we can query textField from source field (current way)
```json
{
  "size" : 1000,
  "query" : {
    "match_all" : {
      "boost" : 1.0
    }
  },
  "_source" : {
    "includes" : [
      "textField"
    ],
    "excludes" : [ ]
  },
  "sort" : [
    {
      "_doc" : {
        "order" : "asc"
      }
    }
  ]
}
```
or from docvalue field
```json
{
  "size" : 1000,
  "query" : {
    "match_all" : {
      "boost" : 1.0
    }
  },
  "_source" : false,
  "docvalue_fields" : [
    "textField.raw"
  ],
  "sort" : [
    {
      "_doc" : {
        "order" : "asc"
      }
    }
  ]
}
```
technically, query docvalue is 2 or 3 times faster than query source field.

this pull request support:

- query docvalue field if possible
- support text field pushdown if the field has keyword multi-field

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

<!--
## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
-->
