### PR TITLE
Check Connector version in SPI compatibility check

### DIFF
--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloConnectorFactory.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloConnectorFactory.java
@@ -43,7 +43,7 @@ public class AccumuloConnectorFactory
         requireNonNull(catalogName, "catalogName is null");
         requireNonNull(config, "config is null");
         requireNonNull(context, "context is null");
-        checkSpiVersion(context, this);
+        checkSpiVersion(context, CONNECTOR_NAME, AccumuloConnector.class);
 
         Bootstrap app = new Bootstrap(
                 new JsonModule(),

--- a/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopConnectorFactory.java
+++ b/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopConnectorFactory.java
@@ -53,7 +53,7 @@ public class AtopConnectorFactory
     public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
     {
         requireNonNull(requiredConfig, "requiredConfig is null");
-        checkSpiVersion(context, this);
+        checkSpiVersion(context, getName(), AtopConnector.class);
 
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             Bootstrap app = new Bootstrap(

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcConnectorFactory.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcConnectorFactory.java
@@ -63,7 +63,7 @@ public class JdbcConnectorFactory
     public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
     {
         requireNonNull(requiredConfig, "requiredConfig is null");
-        checkSpiVersion(context, this);
+        checkSpiVersion(context, name, JdbcConnector.class);
 
         Bootstrap app = new Bootstrap(
                 binder -> binder.bind(TypeManager.class).toInstance(context.getTypeManager()),

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorFactory.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorFactory.java
@@ -41,7 +41,7 @@ public class BigQueryConnectorFactory
     {
         requireNonNull(catalogName, "catalogName is null");
         requireNonNull(config, "config is null");
-        checkSpiVersion(context, this);
+        checkSpiVersion(context, getName(), BigQueryConnector.class);
 
         Bootstrap app = new Bootstrap(
                 new JsonModule(),

--- a/plugin/trino-blackhole/src/main/java/io/trino/plugin/blackhole/BlackHoleConnectorFactory.java
+++ b/plugin/trino-blackhole/src/main/java/io/trino/plugin/blackhole/BlackHoleConnectorFactory.java
@@ -37,7 +37,7 @@ public class BlackHoleConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
     {
-        checkSpiVersion(context, this);
+        checkSpiVersion(context, getName(), BlackHoleConnector.class);
 
         ListeningScheduledExecutorService executorService = listeningDecorator(newSingleThreadScheduledExecutor(daemonThreadsNamed("blackhole")));
         return new BlackHoleConnector(

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraConnectorFactory.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraConnectorFactory.java
@@ -40,7 +40,7 @@ public class CassandraConnectorFactory
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
         requireNonNull(config, "config is null");
-        checkSpiVersion(context, this);
+        checkSpiVersion(context, getName(), CassandraConnector.class);
 
         Bootstrap app = new Bootstrap(
                 new MBeanModule(),

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConnectorFactory.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConnectorFactory.java
@@ -46,7 +46,7 @@ public class DeltaLakeConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
-        checkSpiVersion(context, this);
+        checkSpiVersion(context, getName(), DeltaLakeConnector.class);
 
         ClassLoader classLoader = context.duplicatePluginClassLoader();
         try {

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchConnectorFactory.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchConnectorFactory.java
@@ -46,7 +46,7 @@ public class ElasticsearchConnectorFactory
     {
         requireNonNull(catalogName, "catalogName is null");
         requireNonNull(config, "config is null");
-        checkSpiVersion(context, this);
+        checkSpiVersion(context, getName(), ElasticsearchConnector.class);
 
         Bootstrap app = new Bootstrap(
                 new MBeanModule(),

--- a/plugin/trino-example-http/src/main/java/io/trino/plugin/example/ExampleConnectorFactory.java
+++ b/plugin/trino-example-http/src/main/java/io/trino/plugin/example/ExampleConnectorFactory.java
@@ -39,7 +39,7 @@ public class ExampleConnectorFactory
     public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
     {
         requireNonNull(requiredConfig, "requiredConfig is null");
-        checkSpiVersion(context, this);
+        checkSpiVersion(context, getName(), ExampleConnector.class);
 
         // A plugin is not required to use Guice; it is just very convenient
         Bootstrap app = new Bootstrap(

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsConnectorFactory.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsConnectorFactory.java
@@ -39,7 +39,7 @@ public class SheetsConnectorFactory
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
         requireNonNull(config, "config is null");
-        checkSpiVersion(context, this);
+        checkSpiVersion(context, getName(), SheetsConnector.class);
 
         Bootstrap app = new Bootstrap(
                 new JsonModule(),

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConnectorFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConnectorFactory.java
@@ -55,7 +55,7 @@ public class HiveConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
-        checkSpiVersion(context, this);
+        checkSpiVersion(context, getName(), HiveConnector.class);
 
         ClassLoader classLoader = context.duplicatePluginClassLoader();
         try {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConnectorFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConnectorFactory.java
@@ -51,7 +51,7 @@ public class IcebergConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
-        checkSpiVersion(context, this);
+        checkSpiVersion(context, getName(), IcebergConnector.class);
 
         ClassLoader classLoader = context.duplicatePluginClassLoader();
         try {

--- a/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxConnectorFactory.java
+++ b/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxConnectorFactory.java
@@ -39,7 +39,7 @@ public class JmxConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
-        checkSpiVersion(context, this);
+        checkSpiVersion(context, getName(), JmxConnector.class);
 
         Bootstrap app = new Bootstrap(
                 new MBeanServerModule(),

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConnectorFactory.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConnectorFactory.java
@@ -51,7 +51,7 @@ public class KafkaConnectorFactory
     {
         requireNonNull(catalogName, "catalogName is null");
         requireNonNull(config, "config is null");
-        checkSpiVersion(context, this);
+        checkSpiVersion(context, getName(), KafkaConnector.class);
 
         Bootstrap app = new Bootstrap(
                 new CatalogNameModule(catalogName),

--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisConnectorFactory.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisConnectorFactory.java
@@ -46,7 +46,7 @@ public class KinesisConnectorFactory
     {
         requireNonNull(catalogName, "catalogName is null");
         requireNonNull(config, "config is null");
-        checkSpiVersion(context, this);
+        checkSpiVersion(context, getName(), KinesisConnector.class);
 
         try {
             Bootstrap app = new Bootstrap(

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduConnectorFactory.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduConnectorFactory.java
@@ -42,7 +42,7 @@ public class KuduConnectorFactory
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
         requireNonNull(config, "config is null");
-        checkSpiVersion(context, this);
+        checkSpiVersion(context, getName(), KuduConnector.class);
 
         Bootstrap app = new Bootstrap(
                 new JsonModule(),

--- a/plugin/trino-local-file/src/main/java/io/trino/plugin/localfile/LocalFileConnectorFactory.java
+++ b/plugin/trino-local-file/src/main/java/io/trino/plugin/localfile/LocalFileConnectorFactory.java
@@ -38,7 +38,7 @@ public class LocalFileConnectorFactory
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
         requireNonNull(config, "config is null");
-        checkSpiVersion(context, this);
+        checkSpiVersion(context, getName(), LocalFileConnector.class);
 
         Bootstrap app = new Bootstrap(
                 binder -> binder.bind(NodeManager.class).toInstance(context.getNodeManager()),

--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryConnectorFactory.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryConnectorFactory.java
@@ -38,7 +38,7 @@ public class MemoryConnectorFactory
     public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
     {
         requireNonNull(requiredConfig, "requiredConfig is null");
-        checkSpiVersion(context, this);
+        checkSpiVersion(context, getName(), MemoryConnector.class);
 
         // A plugin is not required to use Guice; it is just very convenient
         Bootstrap app = new Bootstrap(

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoConnectorFactory.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoConnectorFactory.java
@@ -49,7 +49,7 @@ public class MongoConnectorFactory
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
         requireNonNull(config, "config is null");
-        checkSpiVersion(context, this);
+        checkSpiVersion(context, getName(), MongoConnector.class);
 
         Bootstrap app = new Bootstrap(
                 new JsonModule(),

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixConnectorFactory.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixConnectorFactory.java
@@ -48,7 +48,7 @@ public class PhoenixConnectorFactory
     public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
     {
         requireNonNull(requiredConfig, "requiredConfig is null");
-        checkSpiVersion(context, this);
+        checkSpiVersion(context, getName(), PhoenixConnector.class);
 
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             Bootstrap app = new Bootstrap(

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixConnectorFactory.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixConnectorFactory.java
@@ -48,7 +48,7 @@ public class PhoenixConnectorFactory
     public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
     {
         requireNonNull(requiredConfig, "requiredConfig is null");
-        checkSpiVersion(context, this);
+        checkSpiVersion(context, getName(), PhoenixConnector.class);
 
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             Bootstrap app = new Bootstrap(

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotConnectorFactory.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotConnectorFactory.java
@@ -52,7 +52,7 @@ public class PinotConnectorFactory
     {
         requireNonNull(catalogName, "catalogName is null");
         requireNonNull(config, "config is null");
-        checkSpiVersion(context, this);
+        checkSpiVersion(context, getName(), PinotConnector.class);
 
         ImmutableList.Builder<Module> modulesBuilder = ImmutableList.<Module>builder()
                 .add(new JsonModule())

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusConnectorFactory.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusConnectorFactory.java
@@ -40,7 +40,7 @@ public class PrometheusConnectorFactory
     public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
     {
         requireNonNull(requiredConfig, "requiredConfig is null");
-        checkSpiVersion(context, this);
+        checkSpiVersion(context, getName(), PrometheusConnector.class);
 
         try {
             // A plugin is not required to use Guice; it is just very convenient

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorConnectorFactory.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorConnectorFactory.java
@@ -63,7 +63,7 @@ public class RaptorConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
-        checkSpiVersion(context, this);
+        checkSpiVersion(context, getName(), RaptorConnector.class);
 
         Bootstrap app = new Bootstrap(
                 new CatalogNameModule(catalogName),

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisConnectorFactory.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisConnectorFactory.java
@@ -53,7 +53,7 @@ public class RedisConnectorFactory
     {
         requireNonNull(catalogName, "catalogName is null");
         requireNonNull(config, "config is null");
-        checkSpiVersion(context, this);
+        checkSpiVersion(context, getName(), RedisConnector.class);
 
         Bootstrap app = new Bootstrap(
                 new JsonModule(),

--- a/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftConnectorFactory.java
+++ b/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftConnectorFactory.java
@@ -51,7 +51,7 @@ public class ThriftConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
-        checkSpiVersion(context, this);
+        checkSpiVersion(context, getName(), ThriftConnector.class);
 
         Bootstrap app = new Bootstrap(
                 new MBeanModule(),

--- a/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsConnectorFactory.java
+++ b/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsConnectorFactory.java
@@ -59,7 +59,7 @@ public class TpcdsConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
-        checkSpiVersion(context, this);
+        checkSpiVersion(context, getName(), TpcdsConnector.class);
         return new TpcdsConnector(config, context);
     }
 

--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchConnectorFactory.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchConnectorFactory.java
@@ -78,7 +78,7 @@ public class TpchConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> properties, ConnectorContext context)
     {
-        checkSpiVersion(context, this);
+        checkSpiVersion(context, getName(), TpchConnector.class);
         return new TpchConnector(properties, context);
     }
 

--- a/testing/trino-testing/src/main/java/io/trino/testing/tpch/IndexedTpchConnectorFactory.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/tpch/IndexedTpchConnectorFactory.java
@@ -61,7 +61,7 @@ public class IndexedTpchConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> properties, ConnectorContext context)
     {
-        checkSpiVersion(context, this);
+        checkSpiVersion(context, getName(), IndexedTpchConnector.class);
         return new IndexedTpchConnector(properties, context);
     }
 


### PR DESCRIPTION
Instead of checking `ConnectorFactory` version, check the actual
`Connector` implementation class's version. The `Connector`
implementation is the thing which fulfills SPI contract, so it is a more
appropriate thing to test.

Follow up to https://github.com/trinodb/trino/pull/11774 