### PR TITLE
Make LocalQueryRunner more consistent with production build behaviour

### DIFF
--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -283,6 +283,7 @@ public class LocalQueryRunner
     private final PlanOptimizersProvider planOptimizersProvider;
     private final OperatorFactories operatorFactories;
     private final StatementAnalyzerFactory statementAnalyzerFactory;
+    private final TypeAnalyzer typeAnalyzer;
     private boolean printPlan;
 
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
@@ -386,7 +387,7 @@ public class LocalQueryRunner
                 tablePropertyManager,
                 analyzePropertyManager,
                 tableProceduresPropertyManager);
-        TypeAnalyzer typeAnalyzer = new TypeAnalyzer(plannerContext, statementAnalyzerFactory);
+        this.typeAnalyzer = new TypeAnalyzer(plannerContext, statementAnalyzerFactory);
         this.statsCalculator = createNewStatsCalculator(plannerContext, typeAnalyzer);
         this.scalarStatsCalculator = new ScalarStatsCalculator(plannerContext, typeAnalyzer);
         this.taskCountEstimator = new TaskCountEstimator(() -> nodeCountForStats);
@@ -906,7 +907,7 @@ public class LocalQueryRunner
         tableExecuteContextManager.registerTableExecuteContextForQuery(taskContext.getQueryContext().getQueryId());
         LocalExecutionPlanner executionPlanner = new LocalExecutionPlanner(
                 plannerContext,
-                new TypeAnalyzer(plannerContext, statementAnalyzerFactory),
+                typeAnalyzer,
                 Optional.empty(),
                 pageSourceManager,
                 indexManager,
@@ -1025,7 +1026,7 @@ public class LocalQueryRunner
     {
         return planOptimizersProvider.getPlanOptimizers(
                 plannerContext,
-                new TypeAnalyzer(plannerContext, statementAnalyzerFactory),
+                typeAnalyzer,
                 taskManagerConfig,
                 forceSingleNode,
                 splitManager,
@@ -1066,7 +1067,7 @@ public class LocalQueryRunner
                 new PlanSanityChecker(true),
                 idAllocator,
                 getPlannerContext(),
-                new TypeAnalyzer(plannerContext, statementAnalyzerFactory),
+                typeAnalyzer,
                 statsCalculator,
                 costCalculator,
                 warningCollector);

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
@@ -19,6 +19,7 @@ import com.google.common.collect.MoreCollectors;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.airlift.units.Duration;
 import io.trino.Session;
+import io.trino.execution.QueryIdGenerator;
 import io.trino.execution.QueryState;
 import io.trino.execution.QueryStats;
 import io.trino.execution.warnings.WarningCollector;
@@ -81,6 +82,8 @@ import static org.testng.Assert.fail;
 
 public abstract class AbstractTestQueryFramework
 {
+    private static final QueryIdGenerator queryIdGenerator = new QueryIdGenerator();
+
     private QueryRunner queryRunner;
     private H2QueryRunner h2QueryRunner;
     private SqlParser sqlParser;
@@ -190,7 +193,9 @@ public abstract class AbstractTestQueryFramework
 
     protected Session getSession()
     {
-        return queryRunner.getDefaultSession();
+        return Session.builder(queryRunner.getDefaultSession())
+                .setQueryId(queryIdGenerator.createNextQueryId())
+                .build();
     }
 
     protected final int getNodeCount()


### PR DESCRIPTION
By:

- Passing TypeAnalyzer as singleton (bound in ServerMainModule)
- Generating unique query id instead of reusing a single one