### PR TITLE
Use property to specify trino version

### DIFF
--- a/client/trino-jdbc/src/main/resources/io/trino/jdbc/driver.properties
+++ b/client/trino-jdbc/src/main/resources/io/trino/jdbc/driver.properties
@@ -1,2 +1,2 @@
 driverName=Trino JDBC Driver
-driverVersion=${project.version}
+driverVersion=${dep.trino.version}

--- a/core/trino-server-rpm/pom.xml
+++ b/core/trino-server-rpm/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
 
-        <server.tar.package>trino-server-${project.version}</server.tar.package>
+        <server.tar.package>trino-server-${dep.trino.version}</server.tar.package>
     </properties>
 
     <dependencies>
@@ -146,8 +146,8 @@
                     <packages>
                         <package>
                             <name>trino-server-rpm</name>
-                            <nameOverride>trino-server-rpm-${project.version}.noarch.rpm</nameOverride>
-                            <version>${project.version}</version>
+                            <nameOverride>trino-server-rpm-${dep.trino.version}.noarch.rpm</nameOverride>
+                            <version>${dep.trino.version}</version>
                             <release>1</release>
 
                             <group>Applications/Databases</group>

--- a/core/trino-server-rpm/src/main/provisio/presto.xml
+++ b/core/trino-server-rpm/src/main/provisio/presto.xml
@@ -2,7 +2,7 @@
 
     <!-- Bring server tar.gz over for the RPM -->
     <artifactSet to="/">
-        <artifact id="${project.groupId}:trino-server:tar.gz:${project.version}">
+        <artifact id="${project.groupId}:trino-server:tar.gz:${dep.trino.version}">
             <unpack useRoot="true" />
         </artifact>
     </artifactSet>

--- a/core/trino-server/pom.xml
+++ b/core/trino-server/pom.xml
@@ -37,7 +37,7 @@
                             <!-- Maven Central has a 1GB limit -->
                             <maxsize>1073741824</maxsize>
                             <files>
-                                <file>${project.build.directory}/${project.artifactId}-${project.version}.tar.gz</file>
+                                <file>${project.build.directory}/${project.artifactId}-${dep.trino.version}.tar.gz</file>
                             </files>
                         </requireFilesSize>
                     </rules>

--- a/core/trino-server/src/main/provisio/trino.xml
+++ b/core/trino-server/src/main/provisio/trino.xml
@@ -1,6 +1,6 @@
 <runtime>
     <!-- Target -->
-    <archive name="${project.artifactId}-${project.version}.tar.gz" hardLinkIncludes="**/*.jar" />
+    <archive name="${project.artifactId}-${dep.trino.version}.tar.gz" hardLinkIncludes="**/*.jar" />
 
     <!-- Notices -->
     <fileSet to="/">
@@ -22,263 +22,263 @@
 
     <!-- Server -->
     <artifactSet to="lib">
-        <artifact id="${project.groupId}:trino-server-main:${project.version}" />
+        <artifact id="${project.groupId}:trino-server-main:${dep.trino.version}" />
     </artifactSet>
 
     <!-- Plugins -->
     <artifactSet to="plugin/resource-group-managers">
-        <artifact id="${project.groupId}:trino-resource-group-managers:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-resource-group-managers:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/password-authenticators">
-        <artifact id="${project.groupId}:trino-password-authenticators:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-password-authenticators:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/session-property-managers">
-        <artifact id="${project.groupId}:trino-session-property-managers:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-session-property-managers:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/jmx">
-        <artifact id="${project.groupId}:trino-jmx:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-jmx:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/cassandra">
-        <artifact id="${project.groupId}:trino-cassandra:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-cassandra:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/clickhouse">
-        <artifact id="${project.groupId}:trino-clickhouse:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-clickhouse:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/example-http">
-        <artifact id="${project.groupId}:trino-example-http:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-example-http:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/hive">
-        <artifact id="${project.groupId}:trino-hive-hadoop2:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-hive-hadoop2:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/iceberg">
-        <artifact id="${project.groupId}:trino-iceberg:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-iceberg:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/memory">
-        <artifact id="${project.groupId}:trino-memory:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-memory:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/blackhole">
-        <artifact id="${project.groupId}:trino-blackhole:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-blackhole:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/kafka">
-        <artifact id="${project.groupId}:trino-kafka:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-kafka:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/kudu">
-        <artifact id="${project.groupId}:trino-kudu:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-kudu:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/atop">
-        <artifact id="${project.groupId}:trino-atop:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-atop:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/ml">
-        <artifact id="${project.groupId}:trino-ml:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-ml:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/geospatial">
-        <artifact id="${project.groupId}:trino-geospatial:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-geospatial:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/singlestore">
-        <artifact id="${project.groupId}:trino-singlestore:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-singlestore:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/mysql">
-        <artifact id="${project.groupId}:trino-mysql:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-mysql:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/oracle">
-        <artifact id="${project.groupId}:trino-oracle:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-oracle:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/phoenix">
-        <artifact id="${project.groupId}:trino-phoenix:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-phoenix:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/phoenix5">
-        <artifact id="${project.groupId}:trino-phoenix5:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-phoenix5:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/postgresql">
-        <artifact id="${project.groupId}:trino-postgresql:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-postgresql:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/prometheus">
-        <artifact id="${project.groupId}:trino-prometheus:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-prometheus:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/http-event-listener">
-        <artifact id="${project.groupId}:trino-http-event-listener:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-http-event-listener:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/redshift">
-        <artifact id="${project.groupId}:trino-redshift:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-redshift:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/sqlserver">
-        <artifact id="${project.groupId}:trino-sqlserver:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-sqlserver:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/raptor-legacy">
-        <artifact id="${project.groupId}:trino-raptor-legacy:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-raptor-legacy:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/redis">
-        <artifact id="${project.groupId}:trino-redis:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-redis:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/tpch">
-        <artifact id="${project.groupId}:trino-tpch:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-tpch:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/tpcds">
-        <artifact id="${project.groupId}:trino-tpcds:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-tpcds:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/teradata-functions">
-        <artifact id="${project.groupId}:trino-teradata-functions:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-teradata-functions:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/mongodb">
-        <artifact id="${project.groupId}:trino-mongodb:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-mongodb:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/local-file">
-        <artifact id="${project.groupId}:trino-local-file:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-local-file:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/accumulo">
-        <artifact id="${project.groupId}:trino-accumulo:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-accumulo:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/thrift">
-        <artifact id="${project.groupId}:trino-thrift:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-thrift:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/elasticsearch">
-        <artifact id="${project.groupId}:trino-elasticsearch:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-elasticsearch:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/google-sheets">
-        <artifact id="${project.groupId}:trino-google-sheets:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-google-sheets:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/kinesis">
-        <artifact id="${project.groupId}:trino-kinesis:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-kinesis:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/bigquery">
-        <artifact id="${project.groupId}:trino-bigquery:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-bigquery:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
     <artifactSet to="plugin/pinot">
-        <artifact id="${project.groupId}:trino-pinot:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-pinot:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/druid">
-        <artifact id="${project.groupId}:trino-druid:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-druid:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/delta-lake">
-        <artifact id="${project.groupId}:trino-delta-lake:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-delta-lake:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
     <artifactSet to="plugin/exchange">
-        <artifact id="${project.groupId}:trino-exchange:zip:${project.version}">
+        <artifact id="${project.groupId}:trino-exchange:zip:${dep.trino.version}">
             <unpack />
         </artifact>
     </artifactSet>

--- a/core/trino-spi/src/main/resources/io/trino/spi/trino-spi-version.txt
+++ b/core/trino-spi/src/main/resources/io/trino/spi/trino-spi-version.txt
@@ -1,1 +1,1 @@
-${project.version}
+${dep.trino.version}

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -56,7 +56,7 @@
                     <dependency>
                         <groupId>io.trino</groupId>
                         <artifactId>trino-thrift-api</artifactId>
-                        <version>${project.version}</version>
+                        <version>${dep.trino.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>
@@ -114,7 +114,7 @@
                     <dependency>
                         <groupId>io.trino</groupId>
                         <artifactId>trino-parser</artifactId>
-                        <version>${project.version}</version>
+                        <version>${dep.trino.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/plugin/trino-accumulo/pom.xml
+++ b/plugin/trino-accumulo/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-accumulo-iterators</artifactId>
-            <version>${project.version}</version>
+            <version>${dep.trino.version}</version>
         </dependency>
 
         <dependency>
@@ -337,7 +337,7 @@
                                 <artifactItem>
                                     <groupId>io.trino</groupId>
                                     <artifactId>trino-accumulo-iterators</artifactId>
-                                    <version>${project.version}</version>
+                                    <version>${dep.trino.version}</version>
                                     <type>jar</type>
                                 </artifactItem>
                             </artifactItems>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
 
         <air.release.preparation-goals>clean verify -DskipTests</air.release.preparation-goals>
 
+        <dep.trino.version>378-SNAPSHOT</dep.trino.version>
         <dep.accumulo.version>1.7.4</dep.accumulo.version>
         <dep.accumulo-hadoop.version>2.7.7-1</dep.accumulo-hadoop.version>
         <dep.antlr.version>4.9.3</dep.antlr.version>
@@ -177,406 +178,406 @@
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-array</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-base-jdbc</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-base-jdbc</artifactId>
                 <type>test-jar</type>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-benchmark</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-benchto-benchmarks</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-blackhole</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-cli</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-client</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-collect</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-collect</artifactId>
                 <type>test-jar</type>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-delta-lake</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-delta-lake</artifactId>
                 <type>test-jar</type>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-elasticsearch</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-example-http</artifactId>
                 <type>zip</type>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-exchange</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-exchange</artifactId>
                 <type>test-jar</type>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-geospatial</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-geospatial-toolkit</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-hive</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-hive</artifactId>
                 <type>test-jar</type>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-hive-hadoop2</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-iceberg</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-jdbc</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-jmx</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-local-file</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-main</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-main</artifactId>
                 <type>test-jar</type>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-matching</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-memory</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-memory</artifactId>
                 <type>test-jar</type>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-memory-context</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-mongodb</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-mysql</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-orc</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-parquet</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-parser</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-parser</artifactId>
                 <type>test-jar</type>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-password-authenticators</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-pinot</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-plugin-toolkit</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-plugin-toolkit</artifactId>
                 <type>test-jar</type>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-product-tests</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-raptor-legacy</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-rcfile</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-record-decoder</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-resource-group-managers</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-resource-group-managers</artifactId>
                 <type>test-jar</type>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-server</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-server-rpm</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-session-property-managers</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-session-property-managers</artifactId>
                 <type>test-jar</type>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-spi</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-spi</artifactId>
                 <type>test-jar</type>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-sqlserver</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-testing</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-testing-containers</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-testing-kafka</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-testing-services</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-tests</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-thrift</artifactId>
                 <type>zip</type>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-thrift-api</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-thrift-api</artifactId>
                 <type>test-jar</type>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-thrift-testing-server</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-tpcds</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-tpch</artifactId>
-                <version>${project.version}</version>
+                <version>${dep.trino.version}</version>
             </dependency>
 
             <!-- Trino external -->

--- a/testing/trino-benchto-benchmarks/pom.xml
+++ b/testing/trino-benchto-benchmarks/pom.xml
@@ -107,7 +107,7 @@
                     <descriptors>
                         <descriptor>src/assembly/benchmarks.xml</descriptor>
                     </descriptors>
-                    <finalName>presto-benchto-benchmarks-package-${project.version}</finalName>
+                    <finalName>presto-benchto-benchmarks-package-${dep.trino.version}</finalName>
                     <appendAssemblyId>false</appendAssemblyId>
                 </configuration>
                 <executions>

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/SuiteDescribe.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/SuiteDescribe.java
@@ -91,7 +91,7 @@ public class SuiteDescribe
         @Option(names = "--suite", paramLabel = "<suite>", description = "Name of the suite to describe", required = true)
         public String suite;
 
-        @Option(names = "--test-jar", paramLabel = "<jar>", description = "Path to test JAR " + DEFAULT_VALUE, defaultValue = "${product-tests.module}/target/${product-tests.name}-${project.version}-executable.jar")
+        @Option(names = "--test-jar", paramLabel = "<jar>", description = "Path to test JAR " + DEFAULT_VALUE, defaultValue = "${product-tests.module}/target/${product-tests.name}-${dep.trino.version}-executable.jar")
         public File testJar;
 
         public Module toModule()

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/SuiteRun.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/SuiteRun.java
@@ -120,7 +120,7 @@ public class SuiteRun
         @Option(names = "--suite", paramLabel = "<suite>", description = "Name of the suite(s) to run (comma separated)", required = true, split = ",")
         public List<String> suites;
 
-        @Option(names = "--test-jar", paramLabel = "<jar>", description = "Path to test JAR " + DEFAULT_VALUE, defaultValue = "${product-tests.module}/target/${product-tests.name}-${project.version}-executable.jar")
+        @Option(names = "--test-jar", paramLabel = "<jar>", description = "Path to test JAR " + DEFAULT_VALUE, defaultValue = "${product-tests.module}/target/${product-tests.name}-${dep.trino.version}-executable.jar")
         public File testJar;
 
         @Option(names = "--cli-executable", paramLabel = "<jar>", description = "Path to CLI executable " + DEFAULT_VALUE, defaultValue = "${cli.bin}")

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/TestRun.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/TestRun.java
@@ -114,7 +114,7 @@ public final class TestRun
     {
         private static final String DEFAULT_VALUE = "(default: ${DEFAULT-VALUE})";
 
-        @Option(names = "--test-jar", paramLabel = "<jar>", description = "Path to test JAR " + DEFAULT_VALUE, defaultValue = "${product-tests.module}/target/${product-tests.name}-${project.version}-executable.jar")
+        @Option(names = "--test-jar", paramLabel = "<jar>", description = "Path to test JAR " + DEFAULT_VALUE, defaultValue = "${product-tests.module}/target/${product-tests.name}-${dep.trino.version}-executable.jar")
         public File testJar;
 
         @Option(names = "--cli-executable", paramLabel = "<jar>", description = "Path to CLI executable " + DEFAULT_VALUE, defaultValue = "${cli.bin}")

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/EnvironmentOptions.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/EnvironmentOptions.java
@@ -36,7 +36,7 @@ public final class EnvironmentOptions
     @Option(names = "--config", paramLabel = "<config>", description = "Environment config to use")
     public String config = "config-default";
 
-    @Option(names = "--server-package", paramLabel = "<package>", description = "Path to Trino server package " + DEFAULT_VALUE, defaultValue = "${server.module}/target/${server.name}-${project.version}.tar.gz")
+    @Option(names = "--server-package", paramLabel = "<package>", description = "Path to Trino server package " + DEFAULT_VALUE, defaultValue = "${server.module}/target/${server.name}-${dep.trino.version}.tar.gz")
     public File serverPackage;
 
     @Option(names = "--without-trino", description = "Do not start " + COORDINATOR)

--- a/testing/trino-test-jdbc-compatibility-old-server/pom.xml
+++ b/testing/trino-test-jdbc-compatibility-old-server/pom.xml
@@ -27,7 +27,7 @@
             <groupId>io.trino</groupId>
             <artifactId>trino-jdbc</artifactId>
             <type>test-jar</type>
-            <version>${project.version}</version>
+            <version>${dep.trino.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/testing/trino-test-jdbc-compatibility-old-server/src/main/resources/trino-test-jdbc-compatibility-old-server-version.txt
+++ b/testing/trino-test-jdbc-compatibility-old-server/src/main/resources/trino-test-jdbc-compatibility-old-server-version.txt
@@ -1,1 +1,1 @@
-${project.version}
+${dep.trino.version}

--- a/testing/trino-testing-services/src/main/resources/trino-testing.properties
+++ b/testing/trino-testing-services/src/main/resources/trino-testing.properties
@@ -1,2 +1,2 @@
-project.version=${project.version}
+project.version=${dep.trino.version}
 docker.images.version=${dep.docker.images.version}


### PR DESCRIPTION
Proprietary plugins which have `trino` as a maven parent could have
their own release schedule, version or even versioning schema. Once
<version> property is specified within such plugin it overrides one from
the `trino` (which is maven parent for this plugin). Such override makes
pom unresolvable because parent pom has references to inexistent
versions of dependencies. This commit mitigates that.