### PR TITLE
Disable spark caching for singlenode-spark-iceberg image

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg/spark-defaults.conf
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg/spark-defaults.conf
@@ -8,6 +8,8 @@ spark.sql.catalog.spark_catalog.type = hive
 spark.sql.catalog.iceberg_test=org.apache.iceberg.spark.SparkCatalog
 spark.sql.catalog.iceberg_test.type=hive
 spark.sql.catalog.iceberg_test.uri=thrift://hadoop-master:9083
+; disabling caching allows us to run spark queries interchangeably with trino's
+spark.sql.catalog.iceberg_test.cache-enabled=false
 spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions
 
 spark.hadoop.fs.defaultFS=hdfs://hadoop-master:9000


### PR DESCRIPTION
## Description
When the cache was enabled spark didn't see updates made by trino
on iceberg tables and thus made it hard to test compatibility

## Related issues, pull requests, and links

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
