### PR TITLE
Allow users to configure retry mode for S3

### DIFF
--- a/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/s3/ExchangeS3Config.java
+++ b/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/s3/ExchangeS3Config.java
@@ -19,6 +19,7 @@ import io.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.units.DataSize;
 import io.airlift.units.MaxDataSize;
 import io.airlift.units.MinDataSize;
+import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.model.StorageClass;
 
@@ -29,7 +30,6 @@ import java.util.Optional;
 
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.Locale.ENGLISH;
-import static software.amazon.awssdk.services.s3.model.StorageClass.STANDARD;
 
 public class ExchangeS3Config
 {
@@ -41,7 +41,8 @@ public class ExchangeS3Config
     private int s3MaxErrorRetries = 3;
     // Default to S3 multi-part upload minimum size to avoid excessive memory consumption from buffering
     private DataSize s3UploadPartSize = DataSize.of(5, MEGABYTE);
-    private StorageClass storageClass = STANDARD;
+    private StorageClass storageClass = StorageClass.STANDARD;
+    private RetryMode retryMode = RetryMode.ADAPTIVE;
     private int asyncClientConcurrency = 500;
 
     public String getS3AwsAccessKey()
@@ -147,6 +148,19 @@ public class ExchangeS3Config
     public ExchangeS3Config setStorageClass(StorageClass storageClass)
     {
         this.storageClass = storageClass;
+        return this;
+    }
+
+    @NotNull
+    public RetryMode getRetryMode()
+    {
+        return retryMode;
+    }
+
+    @Config("exchange.s3.retry-mode")
+    public ExchangeS3Config setRetryMode(RetryMode retryMode)
+    {
+        this.retryMode = retryMode;
         return this;
     }
 

--- a/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/s3/S3FileSystemExchangeStorage.java
+++ b/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/s3/S3FileSystemExchangeStorage.java
@@ -125,7 +125,7 @@ public class S3FileSystemExchangeStorage
         this.storageClass = config.getStorageClass();
 
         AwsCredentialsProvider credentialsProvider = createAwsCredentialsProvider(config);
-        RetryPolicy retryPolicy = RetryPolicy.builder()
+        RetryPolicy retryPolicy = RetryPolicy.builder(config.getRetryMode())
                 .numRetries(config.getS3MaxErrorRetries())
                 .build();
         ClientOverrideConfiguration overrideConfig = ClientOverrideConfiguration.builder()

--- a/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/s3/TestExchangeS3Config.java
+++ b/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/s3/TestExchangeS3Config.java
@@ -16,6 +16,8 @@ package io.trino.plugin.exchange.s3;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 import org.testng.annotations.Test;
+import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.services.s3.model.StorageClass;
 
 import java.util.Map;
 
@@ -23,8 +25,6 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertFullMappin
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
-import static software.amazon.awssdk.services.s3.model.StorageClass.REDUCED_REDUNDANCY;
-import static software.amazon.awssdk.services.s3.model.StorageClass.STANDARD;
 
 public class TestExchangeS3Config
 {
@@ -39,7 +39,8 @@ public class TestExchangeS3Config
                 .setS3UseWebIdentityTokenCredentials(false)
                 .setS3MaxErrorRetries(3)
                 .setS3UploadPartSize(DataSize.of(5, MEGABYTE))
-                .setStorageClass(STANDARD)
+                .setStorageClass(StorageClass.STANDARD)
+                .setRetryMode(RetryMode.ADAPTIVE)
                 .setAsyncClientConcurrency(500));
     }
 
@@ -55,6 +56,7 @@ public class TestExchangeS3Config
                 .put("exchange.s3.max-error-retries", "8")
                 .put("exchange.s3.upload.part-size", "10MB")
                 .put("exchange.s3.storage-class", "REDUCED_REDUNDANCY")
+                .put("exchange.s3.retry-mode", "STANDARD")
                 .put("exchange.s3.async-client-concurrency", "202")
                 .buildOrThrow();
 
@@ -66,7 +68,8 @@ public class TestExchangeS3Config
                 .setS3UseWebIdentityTokenCredentials(true)
                 .setS3MaxErrorRetries(8)
                 .setS3UploadPartSize(DataSize.of(10, MEGABYTE))
-                .setStorageClass(REDUCED_REDUNDANCY)
+                .setStorageClass(StorageClass.REDUCED_REDUNDANCY)
+                .setRetryMode(RetryMode.STANDARD)
                 .setAsyncClientConcurrency(202);
 
         assertFullMapping(properties, expected);


### PR DESCRIPTION
Allow users to specify retry policy for S3.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

trino-exchange

> How would you describe this change to a non-technical end user or system administrator?

This will allow users to select the retry mode for S3 requests.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
