### PR TITLE
Evenly distribute exchange spooling data across different shards

### DIFF
--- a/core/trino-main/src/test/java/io/trino/operator/TestDeduplicatingDirectExchangeBuffer.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestDeduplicatingDirectExchangeBuffer.java
@@ -67,7 +67,7 @@ public class TestDeduplicatingDirectExchangeBuffer
         exchangeManagerRegistry = new ExchangeManagerRegistry(new ExchangeHandleResolver());
         exchangeManagerRegistry.addExchangeManagerFactory(new FileSystemExchangeManagerFactory());
         exchangeManagerRegistry.loadExchangeManager("filesystem", ImmutableMap.of(
-                "exchange.base-directory", System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager"));
+                "exchange.base-directories", System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager"));
     }
 
     @AfterClass(alwaysRun = true)

--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
@@ -293,7 +293,7 @@ for your storage solution.
    * - Property name
      - Description
      - Default value
-   * - ``exchange.base-directory``
+   * - ``exchange.base-directories``
      - The base directory URI location that the exchange manager uses to store
        spooling data. Only supports S3 and local filesystems.
      -
@@ -346,7 +346,7 @@ does not have to be in AWS, but can be any S3-compatible storage system.
 .. code-block:: properties
 
     exchange-manager.name=filesystem
-    exchange.base-directory=s3n://trino-exchange-manager
+    exchange.base-directories=s3n://trino-exchange-manager
     exchange.encryption-enabled=true
     exchange.s3.region=us-west-1
     exchange.s3.aws-access-key=example-access-key
@@ -366,4 +366,4 @@ destination.
 .. code-block:: properties
 
     exchange-manager.name=filesystem
-    exchange.base-directory=/tmp/trino-exchange-manager
+    exchange.base-directories=/tmp/trino-exchange-manager

--- a/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/FileSystemExchangeManager.java
+++ b/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/FileSystemExchangeManager.java
@@ -89,9 +89,7 @@ public class FileSystemExchangeManager
                 throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to generate new secret key: " + e.getMessage(), e);
             }
         }
-        FileSystemExchange exchange = new FileSystemExchange(baseDirectories, exchangeStorage, context, outputPartitionCount, secretKey, executor);
-        exchange.initialize();
-        return exchange;
+        return new FileSystemExchange(baseDirectories, exchangeStorage, context, outputPartitionCount, secretKey, executor);
     }
 
     @Override

--- a/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/TestFileSystemExchangeConfig.java
+++ b/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/TestFileSystemExchangeConfig.java
@@ -31,7 +31,7 @@ public class TestFileSystemExchangeConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(FileSystemExchangeConfig.class)
-                .setBaseDirectory(null)
+                .setBaseDirectories(null)
                 .setExchangeEncryptionEnabled(true)
                 .setMaxPageStorageSize(DataSize.of(16, MEGABYTE))
                 .setExchangeSinkBufferPoolMinSize(10)
@@ -44,7 +44,7 @@ public class TestFileSystemExchangeConfig
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
-                .put("exchange.base-directory", "s3n://exchange-spooling-test/")
+                .put("exchange.base-directories", "s3n://exchange-spooling-test/")
                 .put("exchange.encryption-enabled", "false")
                 .put("exchange.max-page-storage-size", "32MB")
                 .put("exchange.sink-buffer-pool-min-size", "20")
@@ -54,7 +54,7 @@ public class TestFileSystemExchangeConfig
                 .buildOrThrow();
 
         FileSystemExchangeConfig expected = new FileSystemExchangeConfig()
-                .setBaseDirectory("s3n://exchange-spooling-test/")
+                .setBaseDirectories("s3n://exchange-spooling-test/")
                 .setExchangeEncryptionEnabled(false)
                 .setMaxPageStorageSize(DataSize.of(32, MEGABYTE))
                 .setExchangeSinkBufferPoolMinSize(20)

--- a/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/containers/MinioStorage.java
+++ b/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/containers/MinioStorage.java
@@ -86,7 +86,7 @@ public class MinioStorage
     public static Map<String, String> getExchangeManagerProperties(MinioStorage minioStorage)
     {
         return ImmutableMap.<String, String>builder()
-                .put("exchange.base-directory", "s3n://" + minioStorage.getBucketName())
+                .put("exchange.base-directories", "s3n://" + minioStorage.getBucketName())
                 // TODO: enable exchange encryption after https is supported for Trino MinIO
                 .put("exchange.encryption-enabled", "false")
                 // to trigger file split in some tests

--- a/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/local/TestLocalFileSystemExchangeManager.java
+++ b/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/local/TestLocalFileSystemExchangeManager.java
@@ -27,7 +27,7 @@ public class TestLocalFileSystemExchangeManager
         String baseDirectory1 = System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager-1";
         String baseDirectory2 = System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager-2";
         return new FileSystemExchangeManagerFactory().create(ImmutableMap.of(
-                "exchange.base-directory", baseDirectory1 + "," + baseDirectory2,
+                "exchange.base-directories", baseDirectory1 + "," + baseDirectory2,
                 // to trigger file split in some tests
                 "exchange.sink-max-file-size", "16MB"));
     }

--- a/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/local/TestLocalFileSystemExchangeManager.java
+++ b/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/local/TestLocalFileSystemExchangeManager.java
@@ -24,8 +24,10 @@ public class TestLocalFileSystemExchangeManager
     @Override
     protected ExchangeManager createExchangeManager()
     {
+        String baseDirectory1 = System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager-1";
+        String baseDirectory2 = System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager-2";
         return new FileSystemExchangeManagerFactory().create(ImmutableMap.of(
-                "exchange.base-directory", System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager",
+                "exchange.base-directory", baseDirectory1 + "," + baseDirectory2,
                 // to trigger file split in some tests
                 "exchange.sink-max-file-size", "16MB"));
     }

--- a/testing/trino-server-dev/etc/exchange-manager.properties
+++ b/testing/trino-server-dev/etc/exchange-manager.properties
@@ -1,2 +1,2 @@
 exchange-manager.name=filesystem
-exchange.base-directory=/tmp/trino-local-file-system-exchange-manager
+exchange.base-directories=/tmp/trino-local-file-system-exchange-manager

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestDistributedFaultTolerantEngineOnlyQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestDistributedFaultTolerantEngineOnlyQueries.java
@@ -35,7 +35,7 @@ public class TestDistributedFaultTolerantEngineOnlyQueries
             throws Exception
     {
         ImmutableMap<String, String> exchangeManagerProperties = ImmutableMap.<String, String>builder()
-                .put("exchange.base-directory", System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager")
+                .put("exchange.base-directories", System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager")
                 .buildOrThrow();
 
         DistributedQueryRunner queryRunner = MemoryQueryRunner.builder()


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

trino-exchange

> How would you describe this change to a non-technical end user or system administrator?

Sometimes we run into cases where we get throttled by S3. 

1. Supporting multiple buckets as exchange spooling destinations will distribute the requests to get around the throttling limits. Currently, data of different taskPartitions gets assigned to these buckets in a round-robin fashion.
2. Adding a random prefix to sink output path. Data output file path format: {randomizedPrefix}.{queryId}.{stageId}.{sinkPartitionId}/{attemptId}/{sourcePartitionId}_{splitId}.data

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

() No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
