### PR TITLE
Rename big_query group to large_query in product tests

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/Suite1.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/Suite1.java
@@ -31,7 +31,7 @@ public class Suite1
     {
         return ImmutableList.of(
                 testOnEnvironment(EnvMultinode.class)
-                        .withExcludedGroups("big_query", "storage_formats", "storage_formats_detailed", "profile_specific_tests", "tpcds", "hive_compression")
+                        .withExcludedGroups("large_query", "storage_formats", "storage_formats_detailed", "profile_specific_tests", "tpcds", "hive_compression")
                         .build());
     }
 }

--- a/testing/trino-product-tests/README.md
+++ b/testing/trino-product-tests/README.md
@@ -52,7 +52,7 @@ The Trino product tests must be run explicitly because they do not run
 as part of the Maven build like the unit tests do. Note that the product
 tests cannot be run in parallel. This means that only one instance of a
 test can be run at once in a given environment. To run all product
-tests and exclude the `quarantine`, `big_query` and `profile_specific_tests`
+tests and exclude the `quarantine`, `large_query` and `profile_specific_tests`
 groups run the following command:
 
 ```

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestGroups.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestGroups.java
@@ -62,7 +62,7 @@ public final class TestGroups
     public static final String TLS = "tls";
     public static final String ROLES = "roles";
     public static final String CANCEL_QUERY = "cancel_query";
-    public static final String BIG_QUERY = "big_query";
+    public static final String LARGE_QUERY = "large_query";
     public static final String KAFKA = "kafka";
     public static final String TWO_HIVES = "two_hives";
     public static final String ICEBERG = "iceberg";

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveBucketedTables.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveBucketedTables.java
@@ -44,7 +44,7 @@ import static io.trino.tempto.fulfillment.table.MutableTablesState.mutableTables
 import static io.trino.tempto.fulfillment.table.TableRequirements.immutableTable;
 import static io.trino.tempto.fulfillment.table.hive.tpch.TpchTableDefinitions.NATION;
 import static io.trino.tempto.query.QueryExecutor.param;
-import static io.trino.tests.product.TestGroups.BIG_QUERY;
+import static io.trino.tests.product.TestGroups.LARGE_QUERY;
 import static io.trino.tests.product.TpchTableResults.PRESTO_NATION_RESULT;
 import static io.trino.tests.product.hive.BucketingType.BUCKETED_DEFAULT;
 import static io.trino.tests.product.hive.BucketingType.BUCKETED_V1;
@@ -115,7 +115,7 @@ public class TestHiveBucketedTables
         assertThat(onTrino().executeQuery("SELECT * FROM " + tableName)).matches(PRESTO_NATION_RESULT);
     }
 
-    @Test(groups = BIG_QUERY)
+    @Test(groups = LARGE_QUERY)
     @Flaky(issue = ERROR_COMMITTING_WRITE_TO_HIVE_ISSUE, match = ERROR_COMMITTING_WRITE_TO_HIVE_MATCH)
     public void testIgnorePartitionBucketingIfNotBucketed()
     {
@@ -133,7 +133,7 @@ public class TestHiveBucketedTables
                 .containsExactlyInOrder(row(2));
     }
 
-    @Test(groups = BIG_QUERY)
+    @Test(groups = LARGE_QUERY)
     @Flaky(issue = ERROR_COMMITTING_WRITE_TO_HIVE_ISSUE, match = ERROR_COMMITTING_WRITE_TO_HIVE_MATCH)
     public void testAllowMultipleFilesPerBucket()
     {

--- a/testing/trino-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q09.sql
+++ b/testing/trino-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q09.sql
@@ -1,4 +1,4 @@
--- database: presto; groups: tpch, big_query; tables: part,supplier,lineitem,partsupp,orders,nation
+-- database: presto; groups: tpch, large_query; tables: part,supplier,lineitem,partsupp,orders,nation
 SELECT
   nation,
   o_year,

--- a/testing/trino-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q19.sql
+++ b/testing/trino-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q19.sql
@@ -1,4 +1,4 @@
--- database: presto;  groups: tpch, big_query; tables: lineitem,part
+-- database: presto;  groups: tpch, large_query; tables: lineitem,part
 SELECT sum(l_extendedprice * (1 - l_discount)) AS revenue
 FROM
   lineitem,

--- a/testing/trino-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q21.sql
+++ b/testing/trino-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q21.sql
@@ -1,4 +1,4 @@
--- database: presto; groups: tpch,big_query; tables: supplier,lineitem,orders,nation
+-- database: presto; groups: tpch,large_query; tables: supplier,lineitem,orders,nation
 SELECT
   s_name,
   count(*) AS numwait


### PR DESCRIPTION
## Description

Rename `big_query` group to `large_query` in product tests. The previous name is confusing because we have BigQuery connector now. 

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
