### PR TITLE
Never include an empty include section in test matrix

### DIFF
--- a/.github/bin/build-matrix-from-impacted.py
+++ b/.github/bin/build-matrix-from-impacted.py
@@ -86,7 +86,10 @@ def build(matrix_file, impacted_file, output_file):
         item["modules"] = modules
         include.append(item)
     if "include" in matrix:
-        matrix["include"] = include
+        if include:
+            matrix["include"] = include
+        else:
+            del matrix["include"]
 
     json.dump(matrix, output_file)
     output_file.write("\n")


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->
There's a check in the `test` job if matrix is not empty, but it didn't handle the case when an empty matrix also had an empty `include` section. This issue was introduced in #11446

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

ci fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

ci

> How would you describe this change to a non-technical end user or system administrator?

n/a

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

* Fixes #11989

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
