### PR TITLE
Adjust connection pool parameters for S3 based exchange

### DIFF
--- a/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/s3/ExchangeS3Config.java
+++ b/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/s3/ExchangeS3Config.java
@@ -45,7 +45,7 @@ public class ExchangeS3Config
     private DataSize s3UploadPartSize = DataSize.of(5, MEGABYTE);
     private StorageClass storageClass = StorageClass.STANDARD;
     private RetryMode retryMode = RetryMode.ADAPTIVE;
-    private int asyncClientConcurrency = 500;
+    private int asyncClientConcurrency = 100;
     private int asyncClientMaxPendingConnectionAcquires = 10000;
     private Duration connectionAcquisitionTimeout = new Duration(1, MINUTES);
 

--- a/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/s3/ExchangeS3Config.java
+++ b/plugin/trino-exchange/src/main/java/io/trino/plugin/exchange/s3/ExchangeS3Config.java
@@ -17,6 +17,7 @@ import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
 import io.airlift.units.MaxDataSize;
 import io.airlift.units.MinDataSize;
 import software.amazon.awssdk.core.retry.RetryMode;
@@ -30,6 +31,7 @@ import java.util.Optional;
 
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.Locale.ENGLISH;
+import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class ExchangeS3Config
 {
@@ -44,6 +46,8 @@ public class ExchangeS3Config
     private StorageClass storageClass = StorageClass.STANDARD;
     private RetryMode retryMode = RetryMode.ADAPTIVE;
     private int asyncClientConcurrency = 500;
+    private int asyncClientMaxPendingConnectionAcquires = 10000;
+    private Duration connectionAcquisitionTimeout = new Duration(1, MINUTES);
 
     public String getS3AwsAccessKey()
     {
@@ -174,6 +178,31 @@ public class ExchangeS3Config
     public ExchangeS3Config setAsyncClientConcurrency(int asyncClientConcurrency)
     {
         this.asyncClientConcurrency = asyncClientConcurrency;
+        return this;
+    }
+
+    @Min(1)
+    public int getAsyncClientMaxPendingConnectionAcquires()
+    {
+        return asyncClientMaxPendingConnectionAcquires;
+    }
+
+    @Config("exchange.s3.async-client-max-pending-connection-acquires")
+    public ExchangeS3Config setAsyncClientMaxPendingConnectionAcquires(int asyncClientMaxPendingConnectionAcquires)
+    {
+        this.asyncClientMaxPendingConnectionAcquires = asyncClientMaxPendingConnectionAcquires;
+        return this;
+    }
+
+    public Duration getConnectionAcquisitionTimeout()
+    {
+        return connectionAcquisitionTimeout;
+    }
+
+    @Config("exchange.s3.async-client-connection-acquisition-timeout")
+    public ExchangeS3Config setConnectionAcquisitionTimeout(Duration connectionAcquisitionTimeout)
+    {
+        this.connectionAcquisitionTimeout = connectionAcquisitionTimeout;
         return this;
     }
 }

--- a/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/s3/TestExchangeS3Config.java
+++ b/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/s3/TestExchangeS3Config.java
@@ -15,6 +15,7 @@ package io.trino.plugin.exchange.s3;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
 import org.testng.annotations.Test;
 import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.services.s3.model.StorageClass;
@@ -25,6 +26,7 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertFullMappin
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class TestExchangeS3Config
 {
@@ -41,7 +43,9 @@ public class TestExchangeS3Config
                 .setS3UploadPartSize(DataSize.of(5, MEGABYTE))
                 .setStorageClass(StorageClass.STANDARD)
                 .setRetryMode(RetryMode.ADAPTIVE)
-                .setAsyncClientConcurrency(500));
+                .setAsyncClientConcurrency(500)
+                .setAsyncClientMaxPendingConnectionAcquires(10000)
+                .setConnectionAcquisitionTimeout(new Duration(1, MINUTES)));
     }
 
     @Test
@@ -58,6 +62,8 @@ public class TestExchangeS3Config
                 .put("exchange.s3.storage-class", "REDUCED_REDUNDANCY")
                 .put("exchange.s3.retry-mode", "STANDARD")
                 .put("exchange.s3.async-client-concurrency", "202")
+                .put("exchange.s3.async-client-max-pending-connection-acquires", "999")
+                .put("exchange.s3.async-client-connection-acquisition-timeout", "5m")
                 .buildOrThrow();
 
         ExchangeS3Config expected = new ExchangeS3Config()
@@ -70,7 +76,9 @@ public class TestExchangeS3Config
                 .setS3UploadPartSize(DataSize.of(10, MEGABYTE))
                 .setStorageClass(StorageClass.REDUCED_REDUNDANCY)
                 .setRetryMode(RetryMode.STANDARD)
-                .setAsyncClientConcurrency(202);
+                .setAsyncClientConcurrency(202)
+                .setAsyncClientMaxPendingConnectionAcquires(999)
+                .setConnectionAcquisitionTimeout(new Duration(5, MINUTES));
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/s3/TestExchangeS3Config.java
+++ b/plugin/trino-exchange/src/test/java/io/trino/plugin/exchange/s3/TestExchangeS3Config.java
@@ -43,7 +43,7 @@ public class TestExchangeS3Config
                 .setS3UploadPartSize(DataSize.of(5, MEGABYTE))
                 .setStorageClass(StorageClass.STANDARD)
                 .setRetryMode(RetryMode.ADAPTIVE)
-                .setAsyncClientConcurrency(500)
+                .setAsyncClientConcurrency(100)
                 .setAsyncClientMaxPendingConnectionAcquires(10000)
                 .setConnectionAcquisitionTimeout(new Duration(1, MINUTES)));
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

Reduce maximum number of concurrent requests and increase timeout for obtaining a connection from a pool.

Generally only ~15 connections should be enough to utilize 10Gbit / s NIC in one direction. 100 connections should be more than necessary. Allowing to many connections is likely to create unnecessary contention.

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Exchange

> How would you describe this change to a non-technical end user or system administrator?

`-`

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

`-`

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
