### PR TITLE
Support reading Iceberg S3 paths with double slashes

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/TrinoS3FileSystem.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/TrinoS3FileSystem.java
@@ -858,7 +858,10 @@ public class TrinoS3FileSystem
     public static String keyFromPath(Path path)
     {
         checkArgument(path.isAbsolute(), "Path is not absolute: %s", path);
-        String key = nullToEmpty(path.toUri().getPath());
+        // hack to use path from fragment -- see IcebergSplitSource#hadoopPath()
+        String key = Optional.ofNullable(path.toUri().getFragment())
+                .or(() -> Optional.ofNullable(path.toUri().getPath()))
+                .orElse("");
         if (key.startsWith(PATH_SEPARATOR)) {
             key = key.substring(PATH_SEPARATOR.length());
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Allow reading Iceberg tables written by Glue that have locations containing double slashes. This type of path is not possible to represent by the Hadoop `Path` object since it normalizes paths, so we can hide the original path in the URI fragment.

## Related issues, pull requests, and links

Fixes #11964

## Documentation

(x) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# Iceberg connector
* Allow reading Iceberg tables written by Glue that have locations containing double slashes. ({issue}`11964`)
```
