### PR TITLE
Simplify version logic in plugin/SPI compatibility check

### DIFF
--- a/lib/trino-plugin-toolkit/pom.xml
+++ b/lib/trino-plugin-toolkit/pom.xml
@@ -152,4 +152,23 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>io/trino/plugin/base/trino-spi-compile-time-version.txt</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>io/trino/plugin/base/trino-spi-compile-time-version.txt</exclude>
+                </excludes>
+            </resource>
+        </resources>
+    </build>
 </project>

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/SpiVersionHolder.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/SpiVersionHolder.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base;
+
+import com.google.common.io.Resources;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+// Separate class to isolate static initialization
+final class SpiVersionHolder
+{
+    private SpiVersionHolder() {}
+
+    static final String SPI_COMPILE_TIME_VERSION;
+
+    static {
+        try {
+            String spiVersion = Resources.toString(Resources.getResource(SpiVersionHolder.class, "trino-spi-compile-time-version.txt"), UTF_8);
+            if (spiVersion.isBlank()) {
+                throw new IllegalStateException("Malformed version resource");
+            }
+            SPI_COMPILE_TIME_VERSION = spiVersion.strip();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/resources/io/trino/plugin/base/trino-spi-compile-time-version.txt
+++ b/lib/trino-plugin-toolkit/src/main/resources/io/trino/plugin/base/trino-spi-compile-time-version.txt
@@ -1,0 +1,1 @@
+${project.version}


### PR DESCRIPTION
The check relied on the fact that plugin version and SPI version match
for all plugins maintained within Trino. While this is true, loading
plugin version from jar's manifest isn't exactly same as loading the
version from a maven-filtered resource. This in turn lead to
discrepancies in reported version when a tagged version was rebuilt with
local modifications. (Of course, this remains not a recommended
practice).

This commit replaces the jar's manifest and with explicit maven-filtered
resource on the plugin side. The filtered resource is within
trino-plugin-toolkit, so the check still depends on SPI, Trino plugins
and the plugin toolkit being versioned together and so remains
appropriate only for the plugins maintained within the project.
