### PR TITLE
Cache ExpressionInterpreter optimizations

### DIFF
--- a/core/trino-main/src/main/java/io/trino/cost/FilterStatsCalculator.java
+++ b/core/trino-main/src/main/java/io/trino/cost/FilterStatsCalculator.java
@@ -119,8 +119,9 @@ public class FilterStatsCalculator
         // TODO reuse io.trino.sql.planner.iterative.rule.SimplifyExpressions.rewrite
 
         Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypes(plannerContext, session, predicate, types);
-        ExpressionInterpreter interpreter = new ExpressionInterpreter(predicate, plannerContext, session, expressionTypes);
-        Object value = interpreter.optimize(NoOpSymbolResolver.INSTANCE);
+        // TODO - Use the same instance of ExpressionInterpreter create per planning once StatsRule has context
+        ExpressionInterpreter interpreter = new ExpressionInterpreter(plannerContext, session);
+        Object value = interpreter.optimize(predicate, expressionTypes, NoOpSymbolResolver.INSTANCE);
 
         if (value == null) {
             // Expression evaluates to SQL null, which in Filter is equivalent to false. This assumes the expression is a top-level expression (eg. not in NOT).

--- a/core/trino-main/src/main/java/io/trino/cost/ScalarStatsCalculator.java
+++ b/core/trino-main/src/main/java/io/trino/cost/ScalarStatsCalculator.java
@@ -136,8 +136,9 @@ public class ScalarStatsCalculator
         protected SymbolStatsEstimate visitFunctionCall(FunctionCall node, Void context)
         {
             Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypes(plannerContext, session, node, types);
-            ExpressionInterpreter interpreter = new ExpressionInterpreter(node, plannerContext, session, expressionTypes);
-            Object value = interpreter.optimize(NoOpSymbolResolver.INSTANCE);
+            // TODO - Use the same instance of ExpressionInterpreter create per planning once StatsRule has context
+            ExpressionInterpreter interpreter = new ExpressionInterpreter(plannerContext, session);
+            Object value = interpreter.optimize(node, expressionTypes, NoOpSymbolResolver.INSTANCE);
 
             if (value == null || value instanceof NullLiteral) {
                 return nullStatsEstimate();

--- a/core/trino-main/src/main/java/io/trino/sql/ExpressionUtils.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ExpressionUtils.java
@@ -304,8 +304,8 @@ public final class ExpressionUtils
     private static boolean constantExpressionEvaluatesSuccessfully(PlannerContext plannerContext, Session session, Expression constantExpression)
     {
         Map<NodeRef<Expression>, Type> types = getExpressionTypes(plannerContext, session, constantExpression, TypeProvider.empty());
-        ExpressionInterpreter interpreter = new ExpressionInterpreter(constantExpression, plannerContext, session, types);
-        Object literalValue = interpreter.optimize(NoOpSymbolResolver.INSTANCE);
+        ExpressionInterpreter interpreter = new ExpressionInterpreter(plannerContext, session);
+        Object literalValue = interpreter.optimize(constantExpression, types, NoOpSymbolResolver.INSTANCE);
         return !(literalValue instanceof Expression);
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -2094,9 +2094,9 @@ class StatementAnalyzer
                 throw semanticException(TYPE_MISMATCH, samplePercentage, "Sample percentage should be a numeric expression");
             }
 
-            ExpressionInterpreter samplePercentageEval = new ExpressionInterpreter(samplePercentage, plannerContext, session, expressionTypes);
+            ExpressionInterpreter samplePercentageEval = new ExpressionInterpreter(plannerContext, session);
 
-            Object samplePercentageObject = samplePercentageEval.optimize(symbol -> {
+            Object samplePercentageObject = samplePercentageEval.optimize(samplePercentage, expressionTypes, symbol -> {
                 throw semanticException(EXPRESSION_NOT_CONSTANT, samplePercentage, "Sample percentage cannot contain column references");
             });
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionInterpreter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionInterpreter.java
@@ -693,7 +693,24 @@ public class ExpressionInterpreter
                     return new ComparisonExpression(ComparisonExpression.Operator.EQUAL, toExpression(value, type), simplifiedExpressionValues.get(0));
                 }
 
-                return new InPredicate(toExpression(value, type), new InListExpression(simplifiedExpressionValues));
+                Expression simplifiedValue = toExpression(value, type);
+                if (simplifiedValue.equals(node.getValue())) {
+                    simplifiedValue = node.getValue();
+                }
+
+                Expression simplifiedValueList = new InListExpression(simplifiedExpressionValues);
+                if (simplifiedValueList.equals(node.getValueList())) {
+                    simplifiedValueList = node.getValueList();
+                }
+
+                if (simplifiedValue == node.getValue() && simplifiedValueList == node.getValueList()) {
+                    // Do not create a new instance of InPredicate expression if it would be same as original expression.
+                    // Creating a new instance of InPredicate would cause inListCache cache miss, which is using node
+                    // reference as a cache key.
+                    return node;
+                }
+
+                return new InPredicate(simplifiedValue, simplifiedValueList);
             }
             if (hasNullValue) {
                 return null;

--- a/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionInterpreter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionInterpreter.java
@@ -261,7 +261,7 @@ public class ExpressionInterpreter
         requireNonNull(expression, "expression is null");
         verify((expressionTypes.containsKey(NodeRef.of(expression))));
 
-        Object result = new Visitor(expressionTypes, false).processWithExceptionHandling(expression, new NoPagePositionContext());
+        Object result = new Visitor(expressionTypes, false).processWithExceptionHandling(expression, NoOpSymbolResolver.INSTANCE);
         verify(!(result instanceof Expression), "Expression interpreter returned an unresolved expression");
         return result;
     }
@@ -285,7 +285,7 @@ public class ExpressionInterpreter
     }
 
     private class Visitor
-            extends AstVisitor<Object, Object>
+            extends AstVisitor<Object, SymbolResolver>
     {
         private final boolean optimize;
         private final Map<NodeRef<Expression>, Type> expressionTypes;
@@ -296,14 +296,14 @@ public class ExpressionInterpreter
             this.optimize = optimize;
         }
 
-        private Object processWithExceptionHandling(Expression expression, Object context)
+        private Object processWithExceptionHandling(Expression expression, SymbolResolver resolver)
         {
             if (expression == null) {
                 return null;
             }
 
             try {
-                return process(expression, context);
+                return process(expression, resolver);
             }
             catch (TrinoException e) {
                 if (optimize) {
@@ -319,13 +319,13 @@ public class ExpressionInterpreter
         }
 
         @Override
-        public Object visitFieldReference(FieldReference node, Object context)
+        public Object visitFieldReference(FieldReference node, SymbolResolver resolver)
         {
             throw new UnsupportedOperationException("Field references not supported in interpreter");
         }
 
         @Override
-        protected Object visitDereferenceExpression(DereferenceExpression node, Object context)
+        protected Object visitDereferenceExpression(DereferenceExpression node, SymbolResolver resolver)
         {
             checkArgument(!isQualifiedAllFieldsReference(node), "unexpected expression: all fields labeled reference " + node);
             Identifier fieldIdentifier = node.getField().orElseThrow();
@@ -337,7 +337,7 @@ public class ExpressionInterpreter
             }
 
             // Row dereference: process dereference base eagerly, and only then pick the expected field
-            Object base = processWithExceptionHandling(node.getBase(), context);
+            Object base = processWithExceptionHandling(node.getBase(), resolver);
             // if the base part is evaluated to be null, the dereference expression should also be null
             if (base == null) {
                 return null;
@@ -366,37 +366,37 @@ public class ExpressionInterpreter
         }
 
         @Override
-        protected Object visitIdentifier(Identifier node, Object context)
+        protected Object visitIdentifier(Identifier node, SymbolResolver resolver)
         {
             // Identifier only exists before planning.
             // ExpressionInterpreter should only be invoked after planning.
             // As a result, this method should be unreachable.
             // However, RelationPlanner.visitUnnest and visitValues invokes evaluateConstantExpression.
-            return ((SymbolResolver) context).getValue(new Symbol(node.getValue()));
+            return resolver.getValue(new Symbol(node.getValue()));
         }
 
         @Override
-        protected Object visitParameter(Parameter node, Object context)
+        protected Object visitParameter(Parameter node, SymbolResolver resolver)
         {
             return node;
         }
 
         @Override
-        protected Object visitSymbolReference(SymbolReference node, Object context)
+        protected Object visitSymbolReference(SymbolReference node, SymbolResolver resolver)
         {
-            return ((SymbolResolver) context).getValue(Symbol.from(node));
+            return resolver.getValue(Symbol.from(node));
         }
 
         @Override
-        protected Object visitLiteral(Literal node, Object context)
+        protected Object visitLiteral(Literal node, SymbolResolver resolver)
         {
             return literalInterpreter.evaluate(node, type(node));
         }
 
         @Override
-        protected Object visitIsNullPredicate(IsNullPredicate node, Object context)
+        protected Object visitIsNullPredicate(IsNullPredicate node, SymbolResolver resolver)
         {
-            Object value = processWithExceptionHandling(node.getValue(), context);
+            Object value = processWithExceptionHandling(node.getValue(), resolver);
 
             if (value instanceof Expression) {
                 return new IsNullPredicate(toExpression(value, type(node.getValue())));
@@ -406,9 +406,9 @@ public class ExpressionInterpreter
         }
 
         @Override
-        protected Object visitIsNotNullPredicate(IsNotNullPredicate node, Object context)
+        protected Object visitIsNotNullPredicate(IsNotNullPredicate node, SymbolResolver resolver)
         {
-            Object value = processWithExceptionHandling(node.getValue(), context);
+            Object value = processWithExceptionHandling(node.getValue(), resolver);
 
             if (value instanceof Expression) {
                 return new IsNotNullPredicate(toExpression(value, type(node.getValue())));
@@ -418,25 +418,25 @@ public class ExpressionInterpreter
         }
 
         @Override
-        protected Object visitSearchedCaseExpression(SearchedCaseExpression node, Object context)
+        protected Object visitSearchedCaseExpression(SearchedCaseExpression node, SymbolResolver resolver)
         {
             Object newDefault = null;
             boolean foundNewDefault = false;
 
             List<WhenClause> whenClauses = new ArrayList<>();
             for (WhenClause whenClause : node.getWhenClauses()) {
-                Object whenOperand = processWithExceptionHandling(whenClause.getOperand(), context);
+                Object whenOperand = processWithExceptionHandling(whenClause.getOperand(), resolver);
 
                 if (whenOperand instanceof Expression) {
                     // cannot fully evaluate, add updated whenClause
                     whenClauses.add(new WhenClause(
                             toExpression(whenOperand, type(whenClause.getOperand())),
-                            toExpression(processWithExceptionHandling(whenClause.getResult(), context), type(whenClause.getResult()))));
+                            toExpression(processWithExceptionHandling(whenClause.getResult(), resolver), type(whenClause.getResult()))));
                 }
                 else if (Boolean.TRUE.equals(whenOperand)) {
                     // condition is true, use this as default
                     foundNewDefault = true;
-                    newDefault = processWithExceptionHandling(whenClause.getResult(), context);
+                    newDefault = processWithExceptionHandling(whenClause.getResult(), resolver);
                     break;
                 }
             }
@@ -446,7 +446,7 @@ public class ExpressionInterpreter
                 defaultResult = newDefault;
             }
             else {
-                defaultResult = processWithExceptionHandling(node.getDefaultValue().orElse(null), context);
+                defaultResult = processWithExceptionHandling(node.getDefaultValue().orElse(null), resolver);
             }
 
             if (whenClauses.isEmpty()) {
@@ -458,33 +458,33 @@ public class ExpressionInterpreter
         }
 
         @Override
-        protected Object visitIfExpression(IfExpression node, Object context)
+        protected Object visitIfExpression(IfExpression node, SymbolResolver resolver)
         {
-            Object condition = processWithExceptionHandling(node.getCondition(), context);
+            Object condition = processWithExceptionHandling(node.getCondition(), resolver);
 
             if (condition instanceof Expression) {
-                Object trueValue = processWithExceptionHandling(node.getTrueValue(), context);
-                Object falseValue = processWithExceptionHandling(node.getFalseValue().orElse(null), context);
+                Object trueValue = processWithExceptionHandling(node.getTrueValue(), resolver);
+                Object falseValue = processWithExceptionHandling(node.getFalseValue().orElse(null), resolver);
                 return new IfExpression(
                         toExpression(condition, type(node.getCondition())),
                         toExpression(trueValue, type(node.getTrueValue())),
                         (falseValue == null) ? null : toExpression(falseValue, type(node.getFalseValue().get())));
             }
             if (Boolean.TRUE.equals(condition)) {
-                return processWithExceptionHandling(node.getTrueValue(), context);
+                return processWithExceptionHandling(node.getTrueValue(), resolver);
             }
-            return processWithExceptionHandling(node.getFalseValue().orElse(null), context);
+            return processWithExceptionHandling(node.getFalseValue().orElse(null), resolver);
         }
 
         @Override
-        protected Object visitSimpleCaseExpression(SimpleCaseExpression node, Object context)
+        protected Object visitSimpleCaseExpression(SimpleCaseExpression node, SymbolResolver resolver)
         {
-            Object operand = processWithExceptionHandling(node.getOperand(), context);
+            Object operand = processWithExceptionHandling(node.getOperand(), resolver);
             Type operandType = type(node.getOperand());
 
             // if operand is null, return defaultValue
             if (operand == null) {
-                return processWithExceptionHandling(node.getDefaultValue().orElse(null), context);
+                return processWithExceptionHandling(node.getDefaultValue().orElse(null), resolver);
             }
 
             Object newDefault = null;
@@ -492,18 +492,18 @@ public class ExpressionInterpreter
 
             List<WhenClause> whenClauses = new ArrayList<>();
             for (WhenClause whenClause : node.getWhenClauses()) {
-                Object whenOperand = processWithExceptionHandling(whenClause.getOperand(), context);
+                Object whenOperand = processWithExceptionHandling(whenClause.getOperand(), resolver);
 
                 if (whenOperand instanceof Expression || operand instanceof Expression) {
                     // cannot fully evaluate, add updated whenClause
                     whenClauses.add(new WhenClause(
                             toExpression(whenOperand, type(whenClause.getOperand())),
-                            toExpression(processWithExceptionHandling(whenClause.getResult(), context), type(whenClause.getResult()))));
+                            toExpression(processWithExceptionHandling(whenClause.getResult(), resolver), type(whenClause.getResult()))));
                 }
                 else if (whenOperand != null && isEqual(operand, operandType, whenOperand, type(whenClause.getOperand()))) {
                     // condition is true, use this as default
                     foundNewDefault = true;
-                    newDefault = processWithExceptionHandling(whenClause.getResult(), context);
+                    newDefault = processWithExceptionHandling(whenClause.getResult(), resolver);
                     break;
                 }
             }
@@ -513,7 +513,7 @@ public class ExpressionInterpreter
                 defaultResult = newDefault;
             }
             else {
-                defaultResult = processWithExceptionHandling(node.getDefaultValue().orElse(null), context);
+                defaultResult = processWithExceptionHandling(node.getDefaultValue().orElse(null), resolver);
             }
 
             if (whenClauses.isEmpty()) {
@@ -535,9 +535,9 @@ public class ExpressionInterpreter
         }
 
         @Override
-        protected Object visitCoalesceExpression(CoalesceExpression node, Object context)
+        protected Object visitCoalesceExpression(CoalesceExpression node, SymbolResolver resolver)
         {
-            List<Object> newOperands = processOperands(node, context);
+            List<Object> newOperands = processOperands(node, resolver);
             if (newOperands.isEmpty()) {
                 return null;
             }
@@ -549,12 +549,12 @@ public class ExpressionInterpreter
                     .collect(toImmutableList()));
         }
 
-        private List<Object> processOperands(CoalesceExpression node, Object context)
+        private List<Object> processOperands(CoalesceExpression node, SymbolResolver resolver)
         {
             List<Object> newOperands = new ArrayList<>();
             Set<Expression> uniqueNewOperands = new HashSet<>();
             for (Expression operand : node.getOperands()) {
-                Object value = processWithExceptionHandling(operand, context);
+                Object value = processWithExceptionHandling(operand, resolver);
                 if (value instanceof CoalesceExpression) {
                     // The nested CoalesceExpression was recursively processed. It does not contain null.
                     for (Expression nestedOperand : ((CoalesceExpression) value).getOperands()) {
@@ -589,9 +589,9 @@ public class ExpressionInterpreter
         }
 
         @Override
-        protected Object visitInPredicate(InPredicate node, Object context)
+        protected Object visitInPredicate(InPredicate node, SymbolResolver resolver)
         {
-            Object value = processWithExceptionHandling(node.getValue(), context);
+            Object value = processWithExceptionHandling(node.getValue(), resolver);
 
             Expression valueListExpression = node.getValueList();
             if (!(valueListExpression instanceof InListExpression)) {
@@ -615,7 +615,7 @@ public class ExpressionInterpreter
                 if (!inListCache.containsKey(valueList)) {
                     if (valueList.getValues().stream().allMatch(Literal.class::isInstance) &&
                             valueList.getValues().stream().noneMatch(NullLiteral.class::isInstance)) {
-                        Set<Object> objectSet = valueList.getValues().stream().map(expression -> processWithExceptionHandling(expression, context)).collect(Collectors.toSet());
+                        Set<Object> objectSet = valueList.getValues().stream().map(expression -> processWithExceptionHandling(expression, resolver)).collect(Collectors.toSet());
                         Type type = type(node.getValue());
                         set = FastutilSetHelper.toFastutilHashSet(
                                 objectSet,
@@ -652,7 +652,7 @@ public class ExpressionInterpreter
                 // but fail the whole in-predicate evaluation.
                 // According to in-predicate semantics, all in-list items must be successfully evaluated
                 // before a check for the match is performed.
-                Object inValue = process(expression, context);
+                Object inValue = process(expression, resolver);
                 if (value instanceof Expression || inValue instanceof Expression) {
                     hasUnresolvedValue = true;
                     values.add(inValue);
@@ -702,7 +702,7 @@ public class ExpressionInterpreter
         }
 
         @Override
-        protected Object visitExists(ExistsPredicate node, Object context)
+        protected Object visitExists(ExistsPredicate node, SymbolResolver resolver)
         {
             if (!optimize) {
                 throw new UnsupportedOperationException("Exists subquery not yet implemented");
@@ -711,7 +711,7 @@ public class ExpressionInterpreter
         }
 
         @Override
-        protected Object visitSubqueryExpression(SubqueryExpression node, Object context)
+        protected Object visitSubqueryExpression(SubqueryExpression node, SymbolResolver resolver)
         {
             if (!optimize) {
                 throw new UnsupportedOperationException("Subquery not yet implemented");
@@ -720,9 +720,9 @@ public class ExpressionInterpreter
         }
 
         @Override
-        protected Object visitArithmeticUnary(ArithmeticUnaryExpression node, Object context)
+        protected Object visitArithmeticUnary(ArithmeticUnaryExpression node, SymbolResolver resolver)
         {
-            Object value = processWithExceptionHandling(node.getValue(), context);
+            Object value = processWithExceptionHandling(node.getValue(), resolver);
             if (value == null) {
                 return null;
             }
@@ -766,13 +766,13 @@ public class ExpressionInterpreter
         }
 
         @Override
-        protected Object visitArithmeticBinary(ArithmeticBinaryExpression node, Object context)
+        protected Object visitArithmeticBinary(ArithmeticBinaryExpression node, SymbolResolver resolver)
         {
-            Object left = processWithExceptionHandling(node.getLeft(), context);
+            Object left = processWithExceptionHandling(node.getLeft(), resolver);
             if (left == null) {
                 return null;
             }
-            Object right = processWithExceptionHandling(node.getRight(), context);
+            Object right = processWithExceptionHandling(node.getRight(), resolver);
             if (right == null) {
                 return null;
             }
@@ -785,20 +785,20 @@ public class ExpressionInterpreter
         }
 
         @Override
-        protected Object visitComparisonExpression(ComparisonExpression node, Object context)
+        protected Object visitComparisonExpression(ComparisonExpression node, SymbolResolver resolver)
         {
             ComparisonExpression.Operator operator = node.getOperator();
             Expression left = node.getLeft();
             Expression right = node.getRight();
 
             if (operator == Operator.IS_DISTINCT_FROM) {
-                return processIsDistinctFrom(context, left, right);
+                return processIsDistinctFrom(resolver, left, right);
             }
             // Execution engine does not have not equal and greater than operators, so interpret with
             // equal or less than, but do not flip operator in result, as many optimizers depend on
             // operators not flipping
             if (node.getOperator() == Operator.NOT_EQUAL) {
-                Object result = visitComparisonExpression(flipComparison(node), context);
+                Object result = visitComparisonExpression(flipComparison(node), resolver);
                 if (result == null) {
                     return null;
                 }
@@ -808,20 +808,20 @@ public class ExpressionInterpreter
                 return !(Boolean) result;
             }
             if (node.getOperator() == Operator.GREATER_THAN || node.getOperator() == Operator.GREATER_THAN_OR_EQUAL) {
-                Object result = visitComparisonExpression(flipComparison(node), context);
+                Object result = visitComparisonExpression(flipComparison(node), resolver);
                 if (result instanceof ComparisonExpression) {
                     return flipComparison((ComparisonExpression) result);
                 }
                 return result;
             }
 
-            return processComparisonExpression(context, operator, left, right);
+            return processComparisonExpression(resolver, operator, left, right);
         }
 
-        private Object processIsDistinctFrom(Object context, Expression leftExpression, Expression rightExpression)
+        private Object processIsDistinctFrom(SymbolResolver resolver, Expression leftExpression, Expression rightExpression)
         {
-            Object left = processWithExceptionHandling(leftExpression, context);
-            Object right = processWithExceptionHandling(rightExpression, context);
+            Object left = processWithExceptionHandling(leftExpression, resolver);
+            Object right = processWithExceptionHandling(rightExpression, resolver);
 
             if (left == null && right instanceof Expression) {
                 return new IsNotNullPredicate((Expression) right);
@@ -838,14 +838,14 @@ public class ExpressionInterpreter
             return invokeOperator(OperatorType.valueOf(Operator.IS_DISTINCT_FROM.name()), types(leftExpression, rightExpression), Arrays.asList(left, right));
         }
 
-        private Object processComparisonExpression(Object context, Operator operator, Expression leftExpression, Expression rightExpression)
+        private Object processComparisonExpression(SymbolResolver resolver, Operator operator, Expression leftExpression, Expression rightExpression)
         {
-            Object left = processWithExceptionHandling(leftExpression, context);
+            Object left = processWithExceptionHandling(leftExpression, resolver);
             if (left == null) {
                 return null;
             }
 
-            Object right = processWithExceptionHandling(rightExpression, context);
+            Object right = processWithExceptionHandling(rightExpression, resolver);
             if (right == null) {
                 return null;
             }
@@ -880,14 +880,14 @@ public class ExpressionInterpreter
         }
 
         @Override
-        protected Object visitBetweenPredicate(BetweenPredicate node, Object context)
+        protected Object visitBetweenPredicate(BetweenPredicate node, SymbolResolver resolver)
         {
-            Object value = processWithExceptionHandling(node.getValue(), context);
+            Object value = processWithExceptionHandling(node.getValue(), resolver);
             if (value == null) {
                 return null;
             }
-            Object min = processWithExceptionHandling(node.getMin(), context);
-            Object max = processWithExceptionHandling(node.getMax(), context);
+            Object min = processWithExceptionHandling(node.getMin(), resolver);
+            Object max = processWithExceptionHandling(node.getMax(), resolver);
 
             if (value instanceof Expression || min instanceof Expression || max instanceof Expression) {
                 return new BetweenPredicate(
@@ -915,13 +915,13 @@ public class ExpressionInterpreter
         }
 
         @Override
-        protected Object visitNullIfExpression(NullIfExpression node, Object context)
+        protected Object visitNullIfExpression(NullIfExpression node, SymbolResolver resolver)
         {
-            Object first = processWithExceptionHandling(node.getFirst(), context);
+            Object first = processWithExceptionHandling(node.getFirst(), resolver);
             if (first == null) {
                 return null;
             }
-            Object second = processWithExceptionHandling(node.getSecond(), context);
+            Object second = processWithExceptionHandling(node.getSecond(), resolver);
             if (second == null) {
                 return first;
             }
@@ -953,9 +953,9 @@ public class ExpressionInterpreter
         }
 
         @Override
-        protected Object visitNotExpression(NotExpression node, Object context)
+        protected Object visitNotExpression(NotExpression node, SymbolResolver resolver)
         {
-            Object value = processWithExceptionHandling(node.getValue(), context);
+            Object value = processWithExceptionHandling(node.getValue(), resolver);
             if (value == null) {
                 return null;
             }
@@ -968,13 +968,13 @@ public class ExpressionInterpreter
         }
 
         @Override
-        protected Object visitLogicalExpression(LogicalExpression node, Object context)
+        protected Object visitLogicalExpression(LogicalExpression node, SymbolResolver resolver)
         {
             List<Object> terms = new ArrayList<>();
             List<Type> types = new ArrayList<>();
 
             for (Expression term : node.getTerms()) {
-                Object processed = processWithExceptionHandling(term, context);
+                Object processed = processWithExceptionHandling(term, resolver);
 
                 switch (node.getOperator()) {
                     case AND:
@@ -1028,18 +1028,18 @@ public class ExpressionInterpreter
         }
 
         @Override
-        protected Object visitBooleanLiteral(BooleanLiteral node, Object context)
+        protected Object visitBooleanLiteral(BooleanLiteral node, SymbolResolver resolver)
         {
             return node.equals(BooleanLiteral.TRUE_LITERAL);
         }
 
         @Override
-        protected Object visitFunctionCall(FunctionCall node, Object context)
+        protected Object visitFunctionCall(FunctionCall node, SymbolResolver resolver)
         {
             List<Type> argumentTypes = new ArrayList<>();
             List<Object> argumentValues = new ArrayList<>();
             for (Expression expression : node.getArguments()) {
-                Object value = processWithExceptionHandling(expression, context);
+                Object value = processWithExceptionHandling(expression, resolver);
                 Type type = type(expression);
                 argumentValues.add(value);
                 argumentTypes.add(type);
@@ -1072,7 +1072,7 @@ public class ExpressionInterpreter
         }
 
         @Override
-        protected Object visitLambdaExpression(LambdaExpression node, Object context)
+        protected Object visitLambdaExpression(LambdaExpression node, SymbolResolver resolver)
         {
             if (optimize) {
                 // TODO: enable optimization related to lambda expression
@@ -1099,12 +1099,12 @@ public class ExpressionInterpreter
         }
 
         @Override
-        protected Object visitBindExpression(BindExpression node, Object context)
+        protected Object visitBindExpression(BindExpression node, SymbolResolver resolver)
         {
             List<Object> values = node.getValues().stream()
-                    .map(value -> processWithExceptionHandling(value, context))
+                    .map(value -> processWithExceptionHandling(value, resolver))
                     .collect(toList()); // values are nullable
-            Object function = processWithExceptionHandling(node.getFunction(), context);
+            Object function = processWithExceptionHandling(node.getFunction(), resolver);
 
             if (hasUnresolvedValue(values) || hasUnresolvedValue(function)) {
                 ImmutableList.Builder<Expression> builder = ImmutableList.builder();
@@ -1121,9 +1121,9 @@ public class ExpressionInterpreter
         }
 
         @Override
-        protected Object visitLikePredicate(LikePredicate node, Object context)
+        protected Object visitLikePredicate(LikePredicate node, SymbolResolver resolver)
         {
-            Object value = processWithExceptionHandling(node.getValue(), context);
+            Object value = processWithExceptionHandling(node.getValue(), resolver);
 
             if (value == null) {
                 return null;
@@ -1136,7 +1136,7 @@ public class ExpressionInterpreter
                 return evaluateLikePredicate(node, (Slice) value, getConstantPattern(node));
             }
 
-            Object pattern = processWithExceptionHandling(node.getPattern(), context);
+            Object pattern = processWithExceptionHandling(node.getPattern(), resolver);
 
             if (pattern == null) {
                 return null;
@@ -1144,7 +1144,7 @@ public class ExpressionInterpreter
 
             Object escape = null;
             if (node.getEscape().isPresent()) {
-                escape = processWithExceptionHandling(node.getEscape().get(), context);
+                escape = processWithExceptionHandling(node.getEscape().get(), resolver);
 
                 if (escape == null) {
                     return null;
@@ -1239,9 +1239,9 @@ public class ExpressionInterpreter
         }
 
         @Override
-        public Object visitCast(Cast node, Object context)
+        public Object visitCast(Cast node, SymbolResolver resolver)
         {
-            Object value = processWithExceptionHandling(node.getExpression(), context);
+            Object value = processWithExceptionHandling(node.getExpression(), resolver);
             Type targetType = plannerContext.getTypeManager().getType(toTypeSignature(node.getType()));
             Type sourceType = type(node.getExpression());
             if (value instanceof Expression) {
@@ -1274,13 +1274,13 @@ public class ExpressionInterpreter
         }
 
         @Override
-        protected Object visitArrayConstructor(ArrayConstructor node, Object context)
+        protected Object visitArrayConstructor(ArrayConstructor node, SymbolResolver resolver)
         {
             Type elementType = ((ArrayType) type(node)).getElementType();
             BlockBuilder arrayBlockBuilder = elementType.createBlockBuilder(null, node.getValues().size());
 
             for (Expression expression : node.getValues()) {
-                Object value = processWithExceptionHandling(expression, context);
+                Object value = processWithExceptionHandling(expression, resolver);
                 if (value instanceof Expression) {
                     checkCondition(node.getValues().size() <= 254, NOT_SUPPORTED, "Too many arguments for array constructor");
                     return visitFunctionCall(
@@ -1288,7 +1288,7 @@ public class ExpressionInterpreter
                                     .setName(QualifiedName.of(ArrayConstructor.ARRAY_CONSTRUCTOR))
                                     .setArguments(types(node.getValues()), node.getValues())
                                     .build(),
-                            context);
+                            resolver);
                 }
                 writeNativeValue(elementType, arrayBlockBuilder, value);
             }
@@ -1297,31 +1297,31 @@ public class ExpressionInterpreter
         }
 
         @Override
-        protected Object visitCurrentCatalog(CurrentCatalog node, Object context)
+        protected Object visitCurrentCatalog(CurrentCatalog node, SymbolResolver resolver)
         {
-            return visitFunctionCall(desugarCurrentCatalog(session, node, metadata), context);
+            return visitFunctionCall(desugarCurrentCatalog(session, node, metadata), resolver);
         }
 
         @Override
-        protected Object visitCurrentSchema(CurrentSchema node, Object context)
+        protected Object visitCurrentSchema(CurrentSchema node, SymbolResolver resolver)
         {
-            return visitFunctionCall(desugarCurrentSchema(session, node, metadata), context);
+            return visitFunctionCall(desugarCurrentSchema(session, node, metadata), resolver);
         }
 
         @Override
-        protected Object visitCurrentUser(CurrentUser node, Object context)
+        protected Object visitCurrentUser(CurrentUser node, SymbolResolver resolver)
         {
-            return visitFunctionCall(DesugarCurrentUser.getCall(node, metadata, session), context);
+            return visitFunctionCall(DesugarCurrentUser.getCall(node, metadata, session), resolver);
         }
 
         @Override
-        protected Object visitCurrentPath(CurrentPath node, Object context)
+        protected Object visitCurrentPath(CurrentPath node, SymbolResolver resolver)
         {
-            return visitFunctionCall(DesugarCurrentPath.getCall(node, metadata, session), context);
+            return visitFunctionCall(DesugarCurrentPath.getCall(node, metadata, session), resolver);
         }
 
         @Override
-        protected Object visitRow(Row node, Object context)
+        protected Object visitRow(Row node, SymbolResolver resolver)
         {
             RowType rowType = (RowType) type(node);
             List<Type> parameterTypes = rowType.getTypeParameters();
@@ -1330,7 +1330,7 @@ public class ExpressionInterpreter
             int cardinality = arguments.size();
             List<Object> values = new ArrayList<>(cardinality);
             for (Expression argument : arguments) {
-                values.add(processWithExceptionHandling(argument, context));
+                values.add(processWithExceptionHandling(argument, resolver));
             }
             if (hasUnresolvedValue(values)) {
                 return new Row(toExpressions(values, parameterTypes));
@@ -1345,13 +1345,13 @@ public class ExpressionInterpreter
         }
 
         @Override
-        protected Object visitSubscriptExpression(SubscriptExpression node, Object context)
+        protected Object visitSubscriptExpression(SubscriptExpression node, SymbolResolver resolver)
         {
-            Object base = processWithExceptionHandling(node.getBase(), context);
+            Object base = processWithExceptionHandling(node.getBase(), resolver);
             if (base == null) {
                 return null;
             }
-            Object index = processWithExceptionHandling(node.getIndex(), context);
+            Object index = processWithExceptionHandling(node.getIndex(), resolver);
             if (index == null) {
                 return null;
             }
@@ -1379,7 +1379,7 @@ public class ExpressionInterpreter
         }
 
         @Override
-        protected Object visitQuantifiedComparisonExpression(QuantifiedComparisonExpression node, Object context)
+        protected Object visitQuantifiedComparisonExpression(QuantifiedComparisonExpression node, SymbolResolver resolver)
         {
             if (!optimize) {
                 throw new UnsupportedOperationException("QuantifiedComparison not yet implemented");
@@ -1388,13 +1388,13 @@ public class ExpressionInterpreter
         }
 
         @Override
-        protected Object visitExpression(Expression node, Object context)
+        protected Object visitExpression(Expression node, SymbolResolver resolver)
         {
             throw new TrinoException(NOT_SUPPORTED, "not yet implemented: " + node.getClass().getName());
         }
 
         @Override
-        protected Object visitNode(Node node, Object context)
+        protected Object visitNode(Node node, SymbolResolver resolver)
         {
             throw new UnsupportedOperationException("Evaluator visitor can only handle Expression nodes");
         }
@@ -1439,29 +1439,6 @@ public class ExpressionInterpreter
         private List<Expression> toExpressions(List<Object> values, List<Type> types)
         {
             return literalEncoder.toExpressions(session, values, types);
-        }
-    }
-
-    private interface PagePositionContext
-    {
-        Block getBlock(int channel);
-
-        int getPosition(int channel);
-    }
-
-    private static class NoPagePositionContext
-            implements PagePositionContext
-    {
-        @Override
-        public Block getBlock(int channel)
-        {
-            throw new IllegalArgumentException("Context does not contain any blocks");
-        }
-
-        @Override
-        public int getPosition(int channel)
-        {
-            throw new IllegalArgumentException("Context does not have a position");
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -2059,7 +2059,7 @@ public class LocalExecutionPlanner
                     Map<NodeRef<Expression>, Type> types = typeAnalyzer.getTypes(session, TypeProvider.empty(), row);
                     checkState(types.get(NodeRef.of(row)) instanceof RowType, "unexpected type of Values row: %s", types);
                     // evaluate the literal value
-                    Object result = new ExpressionInterpreter(row, plannerContext, session, types).evaluate();
+                    Object result = new ExpressionInterpreter(plannerContext, session).evaluate(row, types);
                     for (int j = 0; j < outputTypes.size(); j++) {
                         // divide row into fields
                         writeNativeValue(outputTypes.get(j), pageBuilder.getBlockBuilder(j), readNativeValue(outputTypes.get(j), (SingleRowBlock) result, j));

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
@@ -235,7 +235,7 @@ public class LogicalPlanner
         planSanityChecker.validateIntermediatePlan(root, session, plannerContext, typeAnalyzer, symbolAllocator.getTypes(), warningCollector);
 
         if (stage.ordinal() >= OPTIMIZED.ordinal()) {
-            PlanOptimizer.Context context = createOptimizerContext();
+            PlanOptimizer.Context context = createOptimizerContext(new ExpressionInterpreter(plannerContext, session));
             for (PlanOptimizer optimizer : planOptimizers) {
                 root = optimizer.optimize(root, context);
                 requireNonNull(root, format("%s returned a null plan", optimizer.getClass().getName()));
@@ -270,7 +270,7 @@ public class LogicalPlanner
         return new Plan(root, types, statsAndCosts);
     }
 
-    private PlanOptimizer.Context createOptimizerContext()
+    private PlanOptimizer.Context createOptimizerContext(ExpressionInterpreter interpreter)
     {
         return new PlanOptimizer.Context()
         {
@@ -296,6 +296,12 @@ public class LogicalPlanner
             public WarningCollector getWarningCollector()
             {
                 return warningCollector;
+            }
+
+            @Override
+            public ExpressionInterpreter getExpressionInterpreter()
+            {
+                return interpreter;
             }
         };
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
@@ -235,8 +235,9 @@ public class LogicalPlanner
         planSanityChecker.validateIntermediatePlan(root, session, plannerContext, typeAnalyzer, symbolAllocator.getTypes(), warningCollector);
 
         if (stage.ordinal() >= OPTIMIZED.ordinal()) {
+            PlanOptimizer.Context context = createOptimizerContext();
             for (PlanOptimizer optimizer : planOptimizers) {
-                root = optimizer.optimize(root, session, symbolAllocator.getTypes(), symbolAllocator, idAllocator, warningCollector);
+                root = optimizer.optimize(root, context);
                 requireNonNull(root, format("%s returned a null plan", optimizer.getClass().getName()));
 
                 if (LOG.isDebugEnabled()) {
@@ -267,6 +268,36 @@ public class LogicalPlanner
             statsAndCosts = StatsAndCosts.create(root, statsProvider, costProvider);
         }
         return new Plan(root, types, statsAndCosts);
+    }
+
+    private PlanOptimizer.Context createOptimizerContext()
+    {
+        return new PlanOptimizer.Context()
+        {
+            @Override
+            public Session getSession()
+            {
+                return session;
+            }
+
+            @Override
+            public SymbolAllocator getSymbolAllocator()
+            {
+                return symbolAllocator;
+            }
+
+            @Override
+            public PlanNodeIdAllocator getIdAllocator()
+            {
+                return idAllocator;
+            }
+
+            @Override
+            public WarningCollector getWarningCollector()
+            {
+                return warningCollector;
+            }
+        };
     }
 
     public PlanNode planStatement(Analysis analysis, Statement statement)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/IterativeOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/IterativeOptimizer.java
@@ -31,6 +31,7 @@ import io.trino.matching.Match;
 import io.trino.matching.Pattern;
 import io.trino.spi.TrinoException;
 import io.trino.sql.PlannerContext;
+import io.trino.sql.planner.ExpressionInterpreter;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.RuleStatsRecorder;
 import io.trino.sql.planner.SymbolAllocator;
@@ -120,7 +121,8 @@ public class IterativeOptimizer
                 nanoTime(),
                 timeout.toMillis(),
                 optimizerContext.getSession(),
-                optimizerContext.getWarningCollector());
+                optimizerContext.getWarningCollector(),
+                optimizerContext.getExpressionInterpreter());
         exploreGroup(memo.getRootGroup(), context);
 
         return memo.extract();
@@ -317,6 +319,12 @@ public class IterativeOptimizer
             {
                 return context.warningCollector;
             }
+
+            @Override
+            public ExpressionInterpreter getExpressionInterpreter()
+            {
+                return context.expressionInterpreter;
+            }
         };
     }
 
@@ -330,6 +338,7 @@ public class IterativeOptimizer
         private final long timeoutInMilliseconds;
         private final Session session;
         private final WarningCollector warningCollector;
+        private final ExpressionInterpreter expressionInterpreter;
 
         private final Map<Rule<?>, RuleInvocationStats> ruleStats = new HashMap<>();
 
@@ -341,7 +350,8 @@ public class IterativeOptimizer
                 long startTimeInNanos,
                 long timeoutInMilliseconds,
                 Session session,
-                WarningCollector warningCollector)
+                WarningCollector warningCollector,
+                ExpressionInterpreter expressionInterpreter)
         {
             checkArgument(timeoutInMilliseconds >= 0, "Timeout has to be a non-negative number [milliseconds]");
 
@@ -353,6 +363,7 @@ public class IterativeOptimizer
             this.timeoutInMilliseconds = timeoutInMilliseconds;
             this.session = session;
             this.warningCollector = warningCollector;
+            this.expressionInterpreter = expressionInterpreter;
         }
 
         public void checkTimeoutNotExhausted()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/Rule.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/Rule.java
@@ -19,6 +19,7 @@ import io.trino.cost.StatsProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
+import io.trino.sql.planner.ExpressionInterpreter;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.SymbolAllocator;
 import io.trino.sql.planner.plan.PlanNode;
@@ -58,6 +59,8 @@ public interface Rule<T>
         void checkTimeoutNotExhausted();
 
         WarningCollector getWarningCollector();
+
+        ExpressionInterpreter getExpressionInterpreter();
     }
 
     final class Result

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/AddExchangesBelowPartialAggregationOverGroupIdRuleSet.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/AddExchangesBelowPartialAggregationOverGroupIdRuleSet.java
@@ -342,7 +342,14 @@ public class AddExchangesBelowPartialAggregationOverGroupIdRuleSet
             List<StreamProperties> inputProperties = resolvedPlanNode.getSources().stream()
                     .map(source -> derivePropertiesRecursively(source, context))
                     .collect(toImmutableList());
-            return deriveProperties(resolvedPlanNode, inputProperties, plannerContext, context.getSession(), context.getSymbolAllocator().getTypes(), typeAnalyzer);
+            return deriveProperties(
+                    resolvedPlanNode,
+                    inputProperties,
+                    plannerContext,
+                    context.getSession(),
+                    context.getSymbolAllocator().getTypes(),
+                    typeAnalyzer,
+                    context.getExpressionInterpreter());
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushAggregationIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushAggregationIntoTableScan.java
@@ -33,7 +33,6 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.Type;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.planner.ConnectorExpressionTranslator;
-import io.trino.sql.planner.ExpressionInterpreter;
 import io.trino.sql.planner.LiteralEncoder;
 import io.trino.sql.planner.NoOpSymbolResolver;
 import io.trino.sql.planner.OrderingScheme;
@@ -197,8 +196,7 @@ public class PushAggregationIntoTableScan
                     Map<NodeRef<Expression>, Type> translatedExpressionTypes = typeAnalyzer.getTypes(session, context.getSymbolAllocator().getTypes(), translated);
                     translated = literalEncoder.toExpression(
                             session,
-                            new ExpressionInterpreter(translated, plannerContext, session, translatedExpressionTypes)
-                                    .optimize(NoOpSymbolResolver.INSTANCE),
+                            context.getExpressionInterpreter().optimize(translated, translatedExpressionTypes, NoOpSymbolResolver.INSTANCE),
                             translatedExpressionTypes.get(NodeRef.of(translated)));
                     return translated;
                 })

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushFilterThroughCountAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushFilterThroughCountAggregation.java
@@ -180,7 +180,12 @@ public class PushFilterThroughCountAggregation
         Symbol countSymbol = getOnlyElement(aggregationNode.getAggregations().keySet());
         Aggregation aggregation = getOnlyElement(aggregationNode.getAggregations().values());
 
-        DomainTranslator.ExtractionResult extractionResult = getExtractionResult(plannerContext, context.getSession(), filterNode.getPredicate(), context.getSymbolAllocator().getTypes());
+        DomainTranslator.ExtractionResult extractionResult = getExtractionResult(
+                plannerContext,
+                context.getSession(),
+                filterNode.getPredicate(),
+                context.getSymbolAllocator().getTypes(),
+                context.getExpressionInterpreter());
         TupleDomain<Symbol> tupleDomain = extractionResult.getTupleDomain();
 
         if (tupleDomain.isNone()) {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPredicateThroughProjectIntoRowNumber.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPredicateThroughProjectIntoRowNumber.java
@@ -108,7 +108,8 @@ public class PushPredicateThroughProjectIntoRowNumber
                 plannerContext,
                 context.getSession(),
                 filter.getPredicate(),
-                context.getSymbolAllocator().getTypes());
+                context.getSymbolAllocator().getTypes(),
+                context.getExpressionInterpreter());
         TupleDomain<Symbol> tupleDomain = extractionResult.getTupleDomain();
         OptionalInt upperBound = extractUpperBound(tupleDomain, rowNumberSymbol);
         if (upperBound.isEmpty()) {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPredicateThroughProjectIntoWindow.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPredicateThroughProjectIntoWindow.java
@@ -120,7 +120,8 @@ public class PushPredicateThroughProjectIntoWindow
                 plannerContext,
                 context.getSession(),
                 filter.getPredicate(),
-                context.getSymbolAllocator().getTypes());
+                context.getSymbolAllocator().getTypes(),
+                context.getExpressionInterpreter());
         TupleDomain<Symbol> tupleDomain = extractionResult.getTupleDomain();
         OptionalInt upperBound = extractUpperBound(tupleDomain, rankingSymbol);
         if (upperBound.isEmpty()) {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushProjectionIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushProjectionIntoTableScan.java
@@ -33,7 +33,6 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.Type;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.planner.ConnectorExpressionTranslator;
-import io.trino.sql.planner.ExpressionInterpreter;
 import io.trino.sql.planner.LiteralEncoder;
 import io.trino.sql.planner.NoOpSymbolResolver;
 import io.trino.sql.planner.Symbol;
@@ -158,8 +157,7 @@ public class PushProjectionIntoTableScan
                     Map<NodeRef<Expression>, Type> translatedExpressionTypes = typeAnalyzer.getTypes(session, context.getSymbolAllocator().getTypes(), translated);
                     translated = literalEncoder.toExpression(
                             session,
-                            new ExpressionInterpreter(translated, plannerContext, session, translatedExpressionTypes)
-                                    .optimize(NoOpSymbolResolver.INSTANCE),
+                            context.getExpressionInterpreter().optimize(translated, translatedExpressionTypes, NoOpSymbolResolver.INSTANCE),
                             translatedExpressionTypes.get(NodeRef.of(translated)));
                     return translated;
                 })

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushdownFilterIntoRowNumber.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushdownFilterIntoRowNumber.java
@@ -72,7 +72,12 @@ public class PushdownFilterIntoRowNumber
         Session session = context.getSession();
         TypeProvider types = context.getSymbolAllocator().getTypes();
 
-        DomainTranslator.ExtractionResult extractionResult = DomainTranslator.getExtractionResult(plannerContext, session, node.getPredicate(), types);
+        DomainTranslator.ExtractionResult extractionResult = DomainTranslator.getExtractionResult(
+                plannerContext,
+                session,
+                node.getPredicate(),
+                types,
+                context.getExpressionInterpreter());
         TupleDomain<Symbol> tupleDomain = extractionResult.getTupleDomain();
 
         RowNumberNode source = captures.get(CHILD);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushdownFilterIntoWindow.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushdownFilterIntoWindow.java
@@ -90,7 +90,12 @@ public class PushdownFilterIntoWindow
 
         WindowNode windowNode = captures.get(childCapture);
 
-        DomainTranslator.ExtractionResult extractionResult = DomainTranslator.getExtractionResult(plannerContext, session, node.getPredicate(), types);
+        DomainTranslator.ExtractionResult extractionResult = DomainTranslator.getExtractionResult(
+                plannerContext,
+                session,
+                node.getPredicate(),
+                types,
+                context.getExpressionInterpreter());
         TupleDomain<Symbol> tupleDomain = extractionResult.getTupleDomain();
 
         Optional<RankingType> rankingType = toTopNRankingType(windowNode);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveUnsupportedDynamicFilters.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveUnsupportedDynamicFilters.java
@@ -16,7 +16,6 @@ package io.trino.sql.planner.iterative.rule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
-import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.AnalyzePropertyManager;
 import io.trino.metadata.OperatorNotFoundException;
 import io.trino.metadata.SessionPropertyManager;
@@ -29,9 +28,7 @@ import io.trino.sql.DynamicFilters;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.analyzer.StatementAnalyzerFactory;
 import io.trino.sql.parser.SqlParser;
-import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.Symbol;
-import io.trino.sql.planner.SymbolAllocator;
 import io.trino.sql.planner.TypeAnalyzer;
 import io.trino.sql.planner.TypeProvider;
 import io.trino.sql.planner.optimizations.PlanOptimizer;
@@ -104,9 +101,11 @@ public class RemoveUnsupportedDynamicFilters
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanNode optimize(PlanNode plan, Context context)
     {
-        PlanWithConsumedDynamicFilters result = plan.accept(new RemoveUnsupportedDynamicFilters.Rewriter(session, types), ImmutableSet.of());
+        PlanWithConsumedDynamicFilters result = plan.accept(
+                new RemoveUnsupportedDynamicFilters.Rewriter(context.getSession(), context.getSymbolAllocator().getTypes()),
+                ImmutableSet.of());
         return result.getNode();
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapTimestampToDateCastInComparison.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapTimestampToDateCastInComparison.java
@@ -111,8 +111,8 @@ public class UnwrapTimestampToDateCastInComparison
                 return expression;
             }
 
-            Object right = new ExpressionInterpreter(expression.getRight(), plannerContext, session, typeAnalyzer.getTypes(session, types, expression.getRight()))
-                    .optimize(NoOpSymbolResolver.INSTANCE);
+            Object right = new ExpressionInterpreter(plannerContext, session)
+                    .optimize(expression.getRight(), typeAnalyzer.getTypes(session, types, expression.getRight()), NoOpSymbolResolver.INSTANCE);
 
             Cast cast = (Cast) expression.getLeft();
             ComparisonExpression.Operator operator = expression.getOperator();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
@@ -24,7 +24,6 @@ import io.trino.SystemSessionProperties;
 import io.trino.cost.CachingStatsProvider;
 import io.trino.cost.StatsCalculator;
 import io.trino.cost.StatsProvider;
-import io.trino.execution.warnings.WarningCollector;
 import io.trino.spi.connector.GroupingProperty;
 import io.trino.spi.connector.LocalProperty;
 import io.trino.sql.PlannerContext;
@@ -133,9 +132,11 @@ public class AddExchanges
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanNode optimize(PlanNode plan, Context context)
     {
-        PlanWithProperties result = plan.accept(new Rewriter(idAllocator, symbolAllocator, session), PreferredProperties.any());
+        PlanWithProperties result = plan.accept(
+                new Rewriter(context.getIdAllocator(), context.getSymbolAllocator(), context.getSession()),
+                PreferredProperties.any());
         return result.getNode();
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
@@ -28,6 +28,7 @@ import io.trino.spi.connector.GroupingProperty;
 import io.trino.spi.connector.LocalProperty;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.planner.DomainTranslator;
+import io.trino.sql.planner.ExpressionInterpreter;
 import io.trino.sql.planner.Partitioning;
 import io.trino.sql.planner.PartitioningScheme;
 import io.trino.sql.planner.PlanNodeIdAllocator;
@@ -135,7 +136,11 @@ public class AddExchanges
     public PlanNode optimize(PlanNode plan, Context context)
     {
         PlanWithProperties result = plan.accept(
-                new Rewriter(context.getIdAllocator(), context.getSymbolAllocator(), context.getSession()),
+                new Rewriter(
+                        context.getIdAllocator(),
+                        context.getSymbolAllocator(),
+                        context.getSession(),
+                        context.getExpressionInterpreter()),
                 PreferredProperties.any());
         return result.getNode();
     }
@@ -148,19 +153,25 @@ public class AddExchanges
         private final TypeProvider types;
         private final StatsProvider statsProvider;
         private final Session session;
+        private final ExpressionInterpreter expressionInterpreter;
         private final DomainTranslator domainTranslator;
         private final boolean distributedIndexJoins;
         private final boolean preferStreamingOperators;
         private final boolean redistributeWrites;
         private final boolean scaleWriters;
 
-        public Rewriter(PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
+        public Rewriter(
+                PlanNodeIdAllocator idAllocator,
+                SymbolAllocator symbolAllocator,
+                Session session,
+                ExpressionInterpreter expressionInterpreter)
         {
             this.idAllocator = idAllocator;
             this.symbolAllocator = symbolAllocator;
             this.types = symbolAllocator.getTypes();
             this.statsProvider = new CachingStatsProvider(statsCalculator, session, types);
             this.session = session;
+            this.expressionInterpreter = expressionInterpreter;
             this.domainTranslator = new DomainTranslator(plannerContext);
             this.distributedIndexJoins = SystemSessionProperties.isDistributedIndexJoinEnabled(session);
             this.redistributeWrites = SystemSessionProperties.isRedistributeWrites(session);
@@ -569,7 +580,8 @@ public class AddExchanges
                         plannerContext,
                         typeAnalyzer,
                         statsProvider,
-                        domainTranslator);
+                        domainTranslator,
+                        expressionInterpreter);
                 if (plan.isPresent()) {
                     return new PlanWithProperties(plan.get(), derivePropertiesRecursively(plan.get()));
                 }
@@ -1309,7 +1321,14 @@ public class AddExchanges
         private ActualProperties deriveProperties(PlanNode result, List<ActualProperties> inputProperties)
         {
             // TODO: move this logic to PlanSanityChecker once PropertyDerivations.deriveProperties fully supports local exchanges
-            ActualProperties outputProperties = PropertyDerivations.deriveProperties(result, inputProperties, plannerContext, session, types, typeAnalyzer);
+            ActualProperties outputProperties = PropertyDerivations.deriveProperties(
+                    result,
+                    inputProperties,
+                    plannerContext,
+                    session,
+                    types,
+                    typeAnalyzer,
+                    expressionInterpreter);
             verify(result instanceof SemiJoinNode || inputProperties.stream().noneMatch(ActualProperties::isNullsAndAnyReplicated) || outputProperties.isNullsAndAnyReplicated(),
                     "SemiJoinNode is the only node that can strip null replication");
             return outputProperties;
@@ -1317,7 +1336,13 @@ public class AddExchanges
 
         private ActualProperties derivePropertiesRecursively(PlanNode result)
         {
-            return PropertyDerivations.derivePropertiesRecursively(result, plannerContext, session, types, typeAnalyzer);
+            return PropertyDerivations.derivePropertiesRecursively(
+                    result,
+                    plannerContext,
+                    session,
+                    types,
+                    typeAnalyzer,
+                    expressionInterpreter);
         }
 
         private PreferredProperties computePreference(PreferredProperties preferredProperties, PreferredProperties parentPreferredProperties)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddLocalExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddLocalExchanges.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import io.trino.Session;
-import io.trino.execution.warnings.WarningCollector;
 import io.trino.spi.connector.ConstantProperty;
 import io.trino.spi.connector.GroupingProperty;
 import io.trino.spi.connector.LocalProperty;
@@ -113,9 +112,11 @@ public class AddLocalExchanges
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanNode optimize(PlanNode plan, Context context)
     {
-        PlanWithProperties result = plan.accept(new Rewriter(symbolAllocator, idAllocator, session), any());
+        PlanWithProperties result = plan.accept(
+                new Rewriter(context.getSymbolAllocator(), context.getIdAllocator(), context.getSession()),
+                any());
         return result.getNode();
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/CheckSubqueryNodesAreRewritten.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/CheckSubqueryNodesAreRewritten.java
@@ -14,13 +14,8 @@
 
 package io.trino.sql.planner.optimizations;
 
-import io.trino.Session;
-import io.trino.execution.warnings.WarningCollector;
 import io.trino.spi.TrinoException;
-import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.Symbol;
-import io.trino.sql.planner.SymbolAllocator;
-import io.trino.sql.planner.TypeProvider;
 import io.trino.sql.planner.plan.ApplyNode;
 import io.trino.sql.planner.plan.CorrelatedJoinNode;
 import io.trino.sql.planner.plan.PlanNode;
@@ -37,7 +32,7 @@ public class CheckSubqueryNodesAreRewritten
         implements PlanOptimizer
 {
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanNode optimize(PlanNode plan, Context context)
     {
         searchFrom(plan).where(ApplyNode.class::isInstance)
                 .findFirst()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -25,7 +25,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import io.trino.Session;
 import io.trino.SystemSessionProperties;
-import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
 import io.trino.spi.function.OperatorType;
 import io.trino.spi.type.StandardTypes;
@@ -106,15 +105,17 @@ public class HashGenerationOptimizer
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanNode optimize(PlanNode plan, Context context)
     {
-        requireNonNull(plan, "plan is null");
-        requireNonNull(session, "session is null");
-        requireNonNull(types, "types is null");
-        requireNonNull(symbolAllocator, "symbolAllocator is null");
-        requireNonNull(idAllocator, "idAllocator is null");
-        if (SystemSessionProperties.isOptimizeHashGenerationEnabled(session)) {
-            PlanWithProperties result = plan.accept(new Rewriter(session, metadata, idAllocator, symbolAllocator, types), new HashComputationSet());
+        if (SystemSessionProperties.isOptimizeHashGenerationEnabled(context.getSession())) {
+            PlanWithProperties result = plan.accept(
+                    new Rewriter(
+                            context.getSession(),
+                            metadata,
+                            context.getIdAllocator(),
+                            context.getSymbolAllocator(),
+                            context.getSymbolAllocator().getTypes()),
+                    new HashComputationSet());
             return result.getNode();
         }
         return plan;

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/IndexJoinOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/IndexJoinOptimizer.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import io.trino.Session;
-import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.BoundSignature;
 import io.trino.metadata.ResolvedFunction;
 import io.trino.metadata.ResolvedIndex;
@@ -32,7 +31,6 @@ import io.trino.sql.planner.DomainTranslator;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.SymbolAllocator;
-import io.trino.sql.planner.TypeProvider;
 import io.trino.sql.planner.plan.AggregationNode;
 import io.trino.sql.planner.plan.Assignments;
 import io.trino.sql.planner.plan.FilterNode;
@@ -80,14 +78,12 @@ public class IndexJoinOptimizer
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider type, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanNode optimize(PlanNode plan, Context context)
     {
-        requireNonNull(plan, "plan is null");
-        requireNonNull(session, "session is null");
-        requireNonNull(symbolAllocator, "symbolAllocator is null");
-        requireNonNull(idAllocator, "idAllocator is null");
-
-        return SimplePlanRewriter.rewriteWith(new Rewriter(symbolAllocator, idAllocator, plannerContext, session), plan, null);
+        return SimplePlanRewriter.rewriteWith(
+                new Rewriter(context.getSymbolAllocator(), context.getIdAllocator(), plannerContext, context.getSession()),
+                plan,
+                null);
     }
 
     private static class Rewriter

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/LimitPushDown.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/LimitPushDown.java
@@ -14,11 +14,7 @@
 package io.trino.sql.planner.optimizations;
 
 import com.google.common.collect.ImmutableList;
-import io.trino.Session;
-import io.trino.execution.warnings.WarningCollector;
 import io.trino.sql.planner.PlanNodeIdAllocator;
-import io.trino.sql.planner.SymbolAllocator;
-import io.trino.sql.planner.TypeProvider;
 import io.trino.sql.planner.plan.AggregationNode;
 import io.trino.sql.planner.plan.DistinctLimitNode;
 import io.trino.sql.planner.plan.LimitNode;
@@ -43,15 +39,10 @@ public class LimitPushDown
         implements PlanOptimizer
 {
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanNode optimize(PlanNode plan, Context context)
     {
         requireNonNull(plan, "plan is null");
-        requireNonNull(session, "session is null");
-        requireNonNull(types, "types is null");
-        requireNonNull(symbolAllocator, "symbolAllocator is null");
-        requireNonNull(idAllocator, "idAllocator is null");
-
-        return SimplePlanRewriter.rewriteWith(new Rewriter(idAllocator), plan, null);
+        return SimplePlanRewriter.rewriteWith(new Rewriter(context.getIdAllocator()), plan, null);
     }
 
     private static class LimitContext

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/MetadataQueryOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/MetadataQueryOptimizer.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import io.trino.Session;
 import io.trino.SystemSessionProperties;
-import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.TableProperties;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
@@ -31,8 +30,6 @@ import io.trino.sql.PlannerContext;
 import io.trino.sql.planner.LiteralEncoder;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.Symbol;
-import io.trino.sql.planner.SymbolAllocator;
-import io.trino.sql.planner.TypeProvider;
 import io.trino.sql.planner.plan.AggregationNode;
 import io.trino.sql.planner.plan.AggregationNode.Aggregation;
 import io.trino.sql.planner.plan.FilterNode;
@@ -73,12 +70,15 @@ public class MetadataQueryOptimizer
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanNode optimize(PlanNode plan, Context context)
     {
-        if (!SystemSessionProperties.isOptimizeMetadataQueries(session)) {
+        if (!SystemSessionProperties.isOptimizeMetadataQueries(context.getSession())) {
             return plan;
         }
-        return SimplePlanRewriter.rewriteWith(new Optimizer(session, plannerContext, idAllocator), plan, null);
+        return SimplePlanRewriter.rewriteWith(
+                new Optimizer(context.getSession(), plannerContext, context.getIdAllocator()),
+                plan,
+                null);
     }
 
     private static class Optimizer

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
@@ -18,13 +18,11 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import io.trino.Session;
-import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
 import io.trino.spi.type.Type;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.SymbolAllocator;
-import io.trino.sql.planner.TypeProvider;
 import io.trino.sql.planner.plan.AggregationNode;
 import io.trino.sql.planner.plan.AggregationNode.Aggregation;
 import io.trino.sql.planner.plan.Assignments;
@@ -83,10 +81,13 @@ public class OptimizeMixedDistinctAggregations
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanNode optimize(PlanNode plan, Context context)
     {
-        if (isOptimizeDistinctAggregationEnabled(session)) {
-            return SimplePlanRewriter.rewriteWith(new Optimizer(session, idAllocator, symbolAllocator, metadata), plan, Optional.empty());
+        if (isOptimizeDistinctAggregationEnabled(context.getSession())) {
+            return SimplePlanRewriter.rewriteWith(
+                    new Optimizer(context.getSession(), context.getIdAllocator(), context.getSymbolAllocator(), metadata),
+                    plan,
+                    Optional.empty());
         }
 
         return plan;

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PlanOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PlanOptimizer.java
@@ -15,6 +15,7 @@ package io.trino.sql.planner.optimizations;
 
 import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
+import io.trino.sql.planner.ExpressionInterpreter;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.SymbolAllocator;
 import io.trino.sql.planner.plan.PlanNode;
@@ -32,5 +33,7 @@ public interface PlanOptimizer
         PlanNodeIdAllocator getIdAllocator();
 
         WarningCollector getWarningCollector();
+
+        ExpressionInterpreter getExpressionInterpreter();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PlanOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PlanOptimizer.java
@@ -17,16 +17,20 @@ import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.SymbolAllocator;
-import io.trino.sql.planner.TypeProvider;
 import io.trino.sql.planner.plan.PlanNode;
 
 public interface PlanOptimizer
 {
-    PlanNode optimize(
-            PlanNode plan,
-            Session session,
-            TypeProvider types,
-            SymbolAllocator symbolAllocator,
-            PlanNodeIdAllocator idAllocator,
-            WarningCollector warningCollector);
+    PlanNode optimize(PlanNode plan, Context context);
+
+    interface Context
+    {
+        Session getSession();
+
+        SymbolAllocator getSymbolAllocator();
+
+        PlanNodeIdAllocator getIdAllocator();
+
+        WarningCollector getWarningCollector();
+    }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import io.trino.Session;
-import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
 import io.trino.spi.type.Type;
 import io.trino.sql.PlannerContext;
@@ -143,15 +142,20 @@ public class PredicatePushDown
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanNode optimize(PlanNode plan, Context context)
     {
         requireNonNull(plan, "plan is null");
-        requireNonNull(session, "session is null");
-        requireNonNull(types, "types is null");
-        requireNonNull(idAllocator, "idAllocator is null");
 
         return SimplePlanRewriter.rewriteWith(
-                new Rewriter(symbolAllocator, idAllocator, plannerContext, typeAnalyzer, session, types, useTableProperties, dynamicFiltering),
+                new Rewriter(
+                        context.getSymbolAllocator(),
+                        context.getIdAllocator(),
+                        plannerContext,
+                        typeAnalyzer,
+                        context.getSession(),
+                        context.getSymbolAllocator().getTypes(),
+                        useTableProperties,
+                        dynamicFiltering),
                 plan,
                 TRUE_LITERAL);
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
@@ -154,6 +154,7 @@ public class PredicatePushDown
                         typeAnalyzer,
                         context.getSession(),
                         context.getSymbolAllocator().getTypes(),
+                        context.getExpressionInterpreter(),
                         useTableProperties,
                         dynamicFiltering),
                 plan,
@@ -170,6 +171,7 @@ public class PredicatePushDown
         private final TypeAnalyzer typeAnalyzer;
         private final Session session;
         private final TypeProvider types;
+        private final ExpressionInterpreter expressionInterpreter;
         private final ExpressionEquivalence expressionEquivalence;
         private final boolean dynamicFiltering;
         private final LiteralEncoder literalEncoder;
@@ -182,6 +184,7 @@ public class PredicatePushDown
                 TypeAnalyzer typeAnalyzer,
                 Session session,
                 TypeProvider types,
+                ExpressionInterpreter expressionInterpreter,
                 boolean useTableProperties,
                 boolean dynamicFiltering)
         {
@@ -192,6 +195,7 @@ public class PredicatePushDown
             this.typeAnalyzer = requireNonNull(typeAnalyzer, "typeAnalyzer is null");
             this.session = requireNonNull(session, "session is null");
             this.types = requireNonNull(types, "types is null");
+            this.expressionInterpreter = requireNonNull(expressionInterpreter, "expressionInterpreter is null");
             this.expressionEquivalence = new ExpressionEquivalence(plannerContext.getMetadata(), plannerContext.getFunctionManager(), typeAnalyzer);
             this.dynamicFiltering = dynamicFiltering;
 
@@ -300,7 +304,7 @@ public class PredicatePushDown
             List<Expression> inlinedDeterministicConjuncts = inlineConjuncts.get(true).stream()
                     .map(entry -> inlineSymbols(node.getAssignments().getMap(), entry))
                     .map(conjunct -> canonicalizeExpression(conjunct, typeAnalyzer.getTypes(session, types, conjunct), plannerContext, session)) // normalize expressions to a form that unwrapCasts understands
-                    .map(conjunct -> unwrapCasts(session, plannerContext, typeAnalyzer, types, conjunct))
+                    .map(conjunct -> unwrapCasts(session, plannerContext, typeAnalyzer, types, conjunct, expressionInterpreter))
                     .collect(Collectors.toList());
 
             PlanNode rewrittenNode = context.defaultRewrite(node, combineConjuncts(metadata, inlinedDeterministicConjuncts));
@@ -430,8 +434,18 @@ public class PredicatePushDown
             // See if we can rewrite outer joins in terms of a plain inner join
             node = tryNormalizeToOuterToInnerJoin(node, inheritedPredicate);
 
-            Expression leftEffectivePredicate = effectivePredicateExtractor.extract(session, node.getLeft(), types, typeAnalyzer);
-            Expression rightEffectivePredicate = effectivePredicateExtractor.extract(session, node.getRight(), types, typeAnalyzer);
+            Expression leftEffectivePredicate = effectivePredicateExtractor.extract(
+                    session,
+                    node.getLeft(),
+                    types,
+                    typeAnalyzer,
+                    expressionInterpreter);
+            Expression rightEffectivePredicate = effectivePredicateExtractor.extract(
+                    session,
+                    node.getRight(),
+                    types,
+                    typeAnalyzer,
+                    expressionInterpreter);
             Expression joinPredicate = extractJoinPredicate(node);
 
             Expression leftPredicate;
@@ -752,8 +766,18 @@ public class PredicatePushDown
                 node = new SpatialJoinNode(node.getId(), SpatialJoinNode.Type.INNER, node.getLeft(), node.getRight(), node.getOutputSymbols(), node.getFilter(), node.getLeftPartitionSymbol(), node.getRightPartitionSymbol(), node.getKdbTree());
             }
 
-            Expression leftEffectivePredicate = effectivePredicateExtractor.extract(session, node.getLeft(), types, typeAnalyzer);
-            Expression rightEffectivePredicate = effectivePredicateExtractor.extract(session, node.getRight(), types, typeAnalyzer);
+            Expression leftEffectivePredicate = effectivePredicateExtractor.extract(
+                    session,
+                    node.getLeft(),
+                    types,
+                    typeAnalyzer,
+                    expressionInterpreter);
+            Expression rightEffectivePredicate = effectivePredicateExtractor.extract(
+                    session,
+                    node.getRight(),
+                    types,
+                    typeAnalyzer,
+                    expressionInterpreter);
             Expression joinPredicate = node.getFilter();
 
             Expression leftPredicate;
@@ -1225,8 +1249,10 @@ public class PredicatePushDown
         private Expression simplifyExpression(Expression expression)
         {
             Map<NodeRef<Expression>, Type> expressionTypes = typeAnalyzer.getTypes(session, symbolAllocator.getTypes(), expression);
-            ExpressionInterpreter optimizer = new ExpressionInterpreter(expression, plannerContext, session, expressionTypes);
-            return literalEncoder.toExpression(session, optimizer.optimize(NoOpSymbolResolver.INSTANCE), expressionTypes.get(NodeRef.of(expression)));
+            return literalEncoder.toExpression(
+                    session,
+                    expressionInterpreter.optimize(expression, expressionTypes, NoOpSymbolResolver.INSTANCE),
+                    expressionTypes.get(NodeRef.of(expression)));
         }
 
         private boolean areExpressionsEquivalent(Expression leftExpression, Expression rightExpression)
@@ -1240,8 +1266,8 @@ public class PredicatePushDown
         private Object nullInputEvaluator(Collection<Symbol> nullSymbols, Expression expression)
         {
             Map<NodeRef<Expression>, Type> expressionTypes = typeAnalyzer.getTypes(session, symbolAllocator.getTypes(), expression);
-            return new ExpressionInterpreter(expression, plannerContext, session, expressionTypes)
-                    .optimize(symbol -> nullSymbols.contains(symbol) ? null : symbol.toSymbolReference());
+            return expressionInterpreter
+                    .optimize(expression, expressionTypes, symbol -> nullSymbols.contains(symbol) ? null : symbol.toSymbolReference());
         }
 
         private boolean joinEqualityExpression(Expression expression, Collection<Symbol> leftSymbols, Collection<Symbol> rightSymbols)
@@ -1363,8 +1389,12 @@ public class PredicatePushDown
         {
             Expression inheritedPredicate = context.get();
             Expression deterministicInheritedPredicate = filterDeterministicConjuncts(metadata, inheritedPredicate);
-            Expression sourceEffectivePredicate = filterDeterministicConjuncts(metadata, effectivePredicateExtractor.extract(session, node.getSource(), types, typeAnalyzer));
-            Expression filteringSourceEffectivePredicate = filterDeterministicConjuncts(metadata, effectivePredicateExtractor.extract(session, node.getFilteringSource(), types, typeAnalyzer));
+            Expression sourceEffectivePredicate = filterDeterministicConjuncts(
+                    metadata,
+                    effectivePredicateExtractor.extract(session, node.getSource(), types, typeAnalyzer, expressionInterpreter));
+            Expression filteringSourceEffectivePredicate = filterDeterministicConjuncts(
+                    metadata,
+                    effectivePredicateExtractor.extract(session, node.getFilteringSource(), types, typeAnalyzer, expressionInterpreter));
             Expression joinExpression = new ComparisonExpression(
                     EQUAL,
                     node.getSourceJoinSymbol().toSymbolReference(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/ReplicateSemiJoinInDelete.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/ReplicateSemiJoinInDelete.java
@@ -13,11 +13,6 @@
  */
 package io.trino.sql.planner.optimizations;
 
-import io.trino.Session;
-import io.trino.execution.warnings.WarningCollector;
-import io.trino.sql.planner.PlanNodeIdAllocator;
-import io.trino.sql.planner.SymbolAllocator;
-import io.trino.sql.planner.TypeProvider;
 import io.trino.sql.planner.plan.DeleteNode;
 import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.SemiJoinNode;
@@ -30,7 +25,7 @@ public class ReplicateSemiJoinInDelete
         implements PlanOptimizer
 {
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanNode optimize(PlanNode plan, Context context)
     {
         requireNonNull(plan, "plan is null");
         return SimplePlanRewriter.rewriteWith(new Rewriter(), plan);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/StatsRecordingPlanOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/StatsRecordingPlanOptimizer.java
@@ -13,12 +13,7 @@
  */
 package io.trino.sql.planner.optimizations;
 
-import io.trino.Session;
-import io.trino.execution.warnings.WarningCollector;
 import io.trino.sql.planner.OptimizerStatsRecorder;
-import io.trino.sql.planner.PlanNodeIdAllocator;
-import io.trino.sql.planner.SymbolAllocator;
-import io.trino.sql.planner.TypeProvider;
 import io.trino.sql.planner.plan.PlanNode;
 
 import static java.util.Objects.requireNonNull;
@@ -37,19 +32,13 @@ public final class StatsRecordingPlanOptimizer
     }
 
     @Override
-    public PlanNode optimize(
-            PlanNode plan,
-            Session session,
-            TypeProvider types,
-            SymbolAllocator symbolAllocator,
-            PlanNodeIdAllocator idAllocator,
-            WarningCollector warningCollector)
+    public PlanNode optimize(PlanNode plan, Context context)
     {
         PlanNode result;
         long duration;
         try {
             long start = System.nanoTime();
-            result = delegate.optimize(plan, session, types, symbolAllocator, idAllocator, warningCollector);
+            result = delegate.optimize(plan, context);
             duration = System.nanoTime() - start;
         }
         catch (RuntimeException e) {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/TransformQuantifiedComparisonApplyToCorrelatedJoin.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/TransformQuantifiedComparisonApplyToCorrelatedJoin.java
@@ -16,7 +16,6 @@ package io.trino.sql.planner.optimizations;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
-import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
 import io.trino.spi.type.BigintType;
 import io.trino.spi.type.Type;
@@ -81,9 +80,17 @@ public class TransformQuantifiedComparisonApplyToCorrelatedJoin
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanNode optimize(PlanNode plan, Context context)
     {
-        return rewriteWith(new Rewriter(idAllocator, types, symbolAllocator, metadata, session), plan, null);
+        return rewriteWith(
+                new Rewriter(
+                        context.getIdAllocator(),
+                        context.getSymbolAllocator().getTypes(),
+                        context.getSymbolAllocator(),
+                        metadata,
+                        context.getSession()),
+                plan,
+                null);
     }
 
     private static class Rewriter

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -19,9 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Sets;
-import io.trino.Session;
 import io.trino.cost.PlanNodeStatsEstimate;
-import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.sql.DynamicFilters;
@@ -29,10 +27,8 @@ import io.trino.sql.planner.DeterminismEvaluator;
 import io.trino.sql.planner.NodeAndMappings;
 import io.trino.sql.planner.OrderingScheme;
 import io.trino.sql.planner.PartitioningScheme;
-import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.SymbolAllocator;
-import io.trino.sql.planner.TypeProvider;
 import io.trino.sql.planner.plan.AggregationNode;
 import io.trino.sql.planner.plan.ApplyNode;
 import io.trino.sql.planner.plan.AssignUniqueId;
@@ -134,13 +130,9 @@ public class UnaliasSymbolReferences
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanNode optimize(PlanNode plan, Context context)
     {
         requireNonNull(plan, "plan is null");
-        requireNonNull(session, "session is null");
-        requireNonNull(types, "types is null");
-        requireNonNull(symbolAllocator, "symbolAllocator is null");
-        requireNonNull(idAllocator, "idAllocator is null");
 
         Visitor visitor = new Visitor(metadata, SymbolMapper::symbolMapper);
         PlanAndMappings result = plan.accept(visitor, UnaliasContext.empty());

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/WindowFilterPushDown.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/WindowFilterPushDown.java
@@ -15,7 +15,6 @@ package io.trino.sql.planner.optimizations;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.Session;
-import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.FunctionId;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.Range;
@@ -26,7 +25,6 @@ import io.trino.sql.PlannerContext;
 import io.trino.sql.planner.DomainTranslator;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.Symbol;
-import io.trino.sql.planner.SymbolAllocator;
 import io.trino.sql.planner.TypeProvider;
 import io.trino.sql.planner.plan.FilterNode;
 import io.trino.sql.planner.plan.LimitNode;
@@ -67,15 +65,13 @@ public class WindowFilterPushDown
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanNode optimize(PlanNode plan, Context context)
     {
         requireNonNull(plan, "plan is null");
-        requireNonNull(session, "session is null");
-        requireNonNull(types, "types is null");
-        requireNonNull(symbolAllocator, "symbolAllocator is null");
-        requireNonNull(idAllocator, "idAllocator is null");
-
-        return SimplePlanRewriter.rewriteWith(new Rewriter(idAllocator, plannerContext, session, types), plan, null);
+        return SimplePlanRewriter.rewriteWith(
+                new Rewriter(context.getIdAllocator(), plannerContext, context.getSession(), context.getSymbolAllocator().getTypes()),
+                plan,
+                null);
     }
 
     private static class Rewriter

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/IoPlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/IoPlanPrinter.java
@@ -31,6 +31,7 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.Type;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.planner.DomainTranslator;
+import io.trino.sql.planner.ExpressionInterpreter;
 import io.trino.sql.planner.Plan;
 import io.trino.sql.planner.plan.FilterNode;
 import io.trino.sql.planner.plan.PlanNode;
@@ -619,7 +620,8 @@ public class IoPlanPrinter
                         plannerContext,
                         session,
                         node.getPredicate(),
-                        plan.getTypes());
+                        plan.getTypes(),
+                        new ExpressionInterpreter(plannerContext, session));
                 TupleDomain<ColumnHandle> filterDomain = decomposedPredicate.getTupleDomain()
                         .transformKeys(tableScanNode.getAssignments()::get);
                 addInputTableConstraints(filterDomain, tableScanNode, context);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/sanity/ValidateLimitWithPresortedInput.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/sanity/ValidateLimitWithPresortedInput.java
@@ -21,6 +21,7 @@ import io.trino.spi.connector.ConstantProperty;
 import io.trino.spi.connector.LocalProperty;
 import io.trino.spi.connector.SortingProperty;
 import io.trino.sql.PlannerContext;
+import io.trino.sql.planner.ExpressionInterpreter;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.TypeAnalyzer;
 import io.trino.sql.planner.TypeProvider;
@@ -62,6 +63,7 @@ public class ValidateLimitWithPresortedInput
         private final PlannerContext plannerContext;
         private final TypeAnalyzer typeAnalyzer;
         private final TypeProvider types;
+        private final ExpressionInterpreter expressionInterpreter;
 
         private Visitor(Session session,
                 PlannerContext plannerContext,
@@ -72,6 +74,7 @@ public class ValidateLimitWithPresortedInput
             this.plannerContext = plannerContext;
             this.typeAnalyzer = typeAnalyzer;
             this.types = types;
+            this.expressionInterpreter = new ExpressionInterpreter(plannerContext, session);
         }
 
         @Override
@@ -91,7 +94,13 @@ public class ValidateLimitWithPresortedInput
                 return null;
             }
 
-            StreamProperties properties = derivePropertiesRecursively(node.getSource(), plannerContext, session, types, typeAnalyzer);
+            StreamProperties properties = derivePropertiesRecursively(
+                    node.getSource(),
+                    plannerContext,
+                    session,
+                    types,
+                    typeAnalyzer,
+                    expressionInterpreter);
 
             PeekingIterator<LocalProperty<Symbol>> actuals = peekingIterator(normalizeAndPrune(properties.getLocalProperties()).iterator());
 

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/FunctionAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/FunctionAssertions.java
@@ -762,9 +762,9 @@ public final class FunctionAssertions
     private Object interpret(Expression expression, Type expectedType, Session session)
     {
         Map<NodeRef<Expression>, Type> expressionTypes = getTypes(session, getPlannerContext(), INPUT_TYPES, expression);
-        ExpressionInterpreter evaluator = new ExpressionInterpreter(expression, runner.getPlannerContext(), session, expressionTypes);
+        ExpressionInterpreter evaluator = new ExpressionInterpreter(runner.getPlannerContext(), session);
 
-        Object result = evaluator.evaluate(symbol -> {
+        Object result = evaluator.evaluate(expression, expressionTypes, symbol -> {
             int position = 0;
             int channel = INPUT_MAPPING.get(symbol);
             Type type = INPUT_TYPES.get(symbol);

--- a/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
@@ -1926,8 +1926,8 @@ public class TestExpressionInterpreter
     static Object optimize(Expression parsedExpression)
     {
         Map<NodeRef<Expression>, Type> expressionTypes = getTypes(TEST_SESSION, PLANNER_CONTEXT, SYMBOL_TYPES, parsedExpression);
-        ExpressionInterpreter interpreter = new ExpressionInterpreter(parsedExpression, PLANNER_CONTEXT, TEST_SESSION, expressionTypes);
-        return interpreter.optimize(INPUTS);
+        ExpressionInterpreter interpreter = new ExpressionInterpreter(PLANNER_CONTEXT, TEST_SESSION);
+        return interpreter.optimize(parsedExpression, expressionTypes, INPUTS);
     }
 
     // TODO replace that method with io.trino.sql.ExpressionTestUtils.planExpression
@@ -1974,8 +1974,8 @@ public class TestExpressionInterpreter
     private static Object evaluate(Expression expression)
     {
         Map<NodeRef<Expression>, Type> expressionTypes = getTypes(TEST_SESSION, PLANNER_CONTEXT, SYMBOL_TYPES, expression);
-        ExpressionInterpreter interpreter = new ExpressionInterpreter(expression, PLANNER_CONTEXT, TEST_SESSION, expressionTypes);
+        ExpressionInterpreter interpreter = new ExpressionInterpreter(PLANNER_CONTEXT, TEST_SESSION);
 
-        return interpreter.evaluate(INPUTS);
+        return interpreter.evaluate(expression, expressionTypes, INPUTS);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
@@ -14,6 +14,7 @@
 package io.trino.sql;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
@@ -30,8 +31,12 @@ import io.trino.sql.planner.SymbolResolver;
 import io.trino.sql.planner.TypeProvider;
 import io.trino.sql.planner.assertions.SymbolAliases;
 import io.trino.sql.planner.iterative.rule.CanonicalizeExpressionRewriter;
+import io.trino.sql.tree.Cast;
 import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.InListExpression;
+import io.trino.sql.tree.InPredicate;
 import io.trino.sql.tree.LikePredicate;
+import io.trino.sql.tree.LongLiteral;
 import io.trino.sql.tree.NodeRef;
 import io.trino.sql.tree.StringLiteral;
 import io.trino.sql.tree.SymbolReference;
@@ -71,6 +76,7 @@ import static io.trino.sql.ExpressionTestUtils.getTypes;
 import static io.trino.sql.ExpressionTestUtils.resolveFunctionCalls;
 import static io.trino.sql.ExpressionUtils.rewriteIdentifiersToSymbolReferences;
 import static io.trino.sql.ParsingUtil.createParsingOptions;
+import static io.trino.sql.analyzer.TypeSignatureTranslator.toSqlType;
 import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
 import static io.trino.sql.planner.TypeAnalyzer.createTestingTypeAnalyzer;
 import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
@@ -81,6 +87,8 @@ import static java.util.Locale.ENGLISH;
 import static java.util.function.Function.identity;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
 public class TestExpressionInterpreter
@@ -518,6 +526,50 @@ public class TestExpressionInterpreter
         assertOptimizedEquals("0 / 0 in (2, 4, 2, 4)", "0 / 0 in (2, 4)");
         assertOptimizedEquals("0 / 0 in (rand(), 2, 4)", "0 / 0 in (2, 4, rand())");
         assertOptimizedEquals("0 / 0 in (2, 2)", "0 / 0 = 2");
+    }
+
+    @Test
+    public void testDoesNotOptimizeInPredicateWithLiteralsInList()
+    {
+        // should not create a new instance of InPredicate when IN list consists of literals only
+        InListExpression inList = new InListExpression(ImmutableList.of(new LongLiteral("42"), new LongLiteral("43")));
+        InPredicate inPredicate = new InPredicate(new SymbolReference("unbound_integer"), inList);
+        assertSame(optimize(inPredicate), inPredicate);
+    }
+
+    @Test
+    public void testDoesNotOptimizeUnboundedInPredicate()
+    {
+        // should not create a new instance of InPredicate when it contains unbounded expressions that cannot be simplified
+        InListExpression inList = new InListExpression(ImmutableList.of(
+                new SymbolReference("unbound_integer"),
+                new Cast(new SymbolReference("unbound_long"), toSqlType(INTEGER))));
+        InPredicate inPredicate = new InPredicate(new SymbolReference("unbound_integer"), inList);
+        assertSame(optimize(inPredicate), inPredicate);
+    }
+
+    @Test
+    public void testDoesNotOptimizeInListExpression()
+    {
+        // should not create a new instance of InListExpression since only value changed
+        InListExpression inList = new InListExpression(ImmutableList.of(new LongLiteral("42"), new LongLiteral("43")));
+        InPredicate inPredicate = new InPredicate(planExpression("3 * 2 * unbound_integer"), inList);
+        InPredicate optimizedInPredicate = (InPredicate) optimize(inPredicate);
+        assertNotSame(inPredicate, optimizedInPredicate);
+        assertSame(inPredicate.getValueList(), inList);
+    }
+
+    @Test
+    public void testDoesNotOptimizeInPredicateValueExpression()
+    {
+        // should not create a new instance of value since only InListExpression changed
+        Expression value = new SymbolReference("unbound_integer");
+        InPredicate inPredicate = new InPredicate(value, new InListExpression(ImmutableList.of(
+                new LongLiteral("42"),
+                planExpression("2 * 3"))));
+        InPredicate optimizedInPredicate = (InPredicate) optimize(inPredicate);
+        assertNotSame(inPredicate, optimizedInPredicate);
+        assertSame(optimizedInPredicate.getValue(), value);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/TestSqlToRowExpressionTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/TestSqlToRowExpressionTranslator.java
@@ -100,8 +100,8 @@ public class TestSqlToRowExpressionTranslator
         // Testing simplified expressions is important, since simplification may create CASTs or function calls that cannot be simplified by the ExpressionOptimizer
 
         Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypes(expression);
-        ExpressionInterpreter interpreter = new ExpressionInterpreter(expression, PLANNER_CONTEXT, TEST_SESSION, expressionTypes);
-        Object value = interpreter.optimize(NoOpSymbolResolver.INSTANCE);
+        ExpressionInterpreter interpreter = new ExpressionInterpreter(PLANNER_CONTEXT, TEST_SESSION);
+        Object value = interpreter.optimize(expression, expressionTypes, NoOpSymbolResolver.INSTANCE);
         return literalEncoder.toExpression(TEST_SESSION, value, expressionTypes.get(NodeRef.of(expression)));
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainTranslator.java
@@ -1929,7 +1929,12 @@ public class TestDomainTranslator
         return transaction(new TestingTransactionManager(), new AllowAllAccessControl())
                 .singleStatement()
                 .execute(TEST_SESSION, transactionSession -> {
-                    return DomainTranslator.getExtractionResult(functionResolution.getPlannerContext(), transactionSession, originalPredicate, TYPES);
+                    return DomainTranslator.getExtractionResult(
+                            functionResolution.getPlannerContext(),
+                            transactionSession,
+                            originalPredicate,
+                            TYPES,
+                            new ExpressionInterpreter(functionResolution.getPlannerContext(), transactionSession));
                 });
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestEffectivePredicateExtractor.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestEffectivePredicateExtractor.java
@@ -174,6 +174,7 @@ public class TestEffectivePredicateExtractor
     private final PlannerContext plannerContext = plannerContextBuilder().withMetadata(metadata).build();
 
     private final TypeAnalyzer typeAnalyzer = createTestingTypeAnalyzer(plannerContext);
+    private final ExpressionInterpreter expressionInterpreter = new ExpressionInterpreter(plannerContext, SESSION);
     private final EffectivePredicateExtractor effectivePredicateExtractor = new EffectivePredicateExtractor(new DomainTranslator(plannerContext), plannerContext, true);
     private final EffectivePredicateExtractor effectivePredicateExtractorWithoutTableProperties = new EffectivePredicateExtractor(new DomainTranslator(plannerContext), plannerContext, false);
 
@@ -242,7 +243,12 @@ public class TestEffectivePredicateExtractor
                 Optional.empty(),
                 Optional.empty());
 
-        Expression effectivePredicate = effectivePredicateExtractor.extract(SESSION, node, TypeProvider.empty(), typeAnalyzer);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(
+                SESSION,
+                node,
+                TypeProvider.empty(),
+                typeAnalyzer,
+                expressionInterpreter);
 
         // Rewrite in terms of group by symbols
         assertEquals(
@@ -267,7 +273,12 @@ public class TestEffectivePredicateExtractor
                 Optional.empty(),
                 Optional.empty());
 
-        Expression effectivePredicate = effectivePredicateExtractor.extract(SESSION, node, TypeProvider.empty(), typeAnalyzer);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(
+                SESSION,
+                node,
+                TypeProvider.empty(),
+                typeAnalyzer,
+                expressionInterpreter);
 
         assertEquals(effectivePredicate, TRUE_LITERAL);
     }
@@ -285,7 +296,12 @@ public class TestEffectivePredicateExtractor
                                         .build()),
                         lessThan(BE, bigintLiteral(10))));
 
-        Expression effectivePredicate = effectivePredicateExtractor.extract(SESSION, node, TypeProvider.empty(), typeAnalyzer);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(
+                SESSION,
+                node,
+                TypeProvider.empty(),
+                typeAnalyzer,
+                expressionInterpreter);
 
         // Non-deterministic functions should be purged
         assertEquals(
@@ -306,7 +322,12 @@ public class TestEffectivePredicateExtractor
                                 lessThan(CE, bigintLiteral(10)))),
                 Assignments.of(D, AE, E, CE));
 
-        Expression effectivePredicate = effectivePredicateExtractor.extract(SESSION, node, TypeProvider.empty(), typeAnalyzer);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(
+                SESSION,
+                node,
+                TypeProvider.empty(),
+                typeAnalyzer,
+                expressionInterpreter);
 
         // Rewrite in terms of project output symbols
         assertEquals(
@@ -331,7 +352,12 @@ public class TestEffectivePredicateExtractor
                                 lessThan(CE, bigintLiteral(10)))),
                 Assignments.of(D, AE, B, CE));
 
-        Expression effectivePredicateWhenBReused = effectivePredicateExtractor.extract(SESSION, projectReusingB, TypeProvider.empty(), typeAnalyzer);
+        Expression effectivePredicateWhenBReused = effectivePredicateExtractor.extract(
+                SESSION,
+                projectReusingB,
+                TypeProvider.empty(),
+                typeAnalyzer,
+                expressionInterpreter);
 
         assertEquals(
                 normalizeConjuncts(effectivePredicateWhenBReused),
@@ -354,7 +380,12 @@ public class TestEffectivePredicateExtractor
                         .put(F, BE)
                         .build());
 
-        Expression effectivePredicateWhenCReused = effectivePredicateExtractor.extract(SESSION, projectReusingC, TypeProvider.empty(), typeAnalyzer);
+        Expression effectivePredicateWhenCReused = effectivePredicateExtractor.extract(
+                SESSION,
+                projectReusingC,
+                TypeProvider.empty(),
+                typeAnalyzer,
+                expressionInterpreter);
 
         assertEquals(
                 normalizeConjuncts(effectivePredicateWhenCReused),
@@ -375,7 +406,12 @@ public class TestEffectivePredicateExtractor
                 1,
                 new OrderingScheme(ImmutableList.of(A), ImmutableMap.of(A, SortOrder.ASC_NULLS_LAST)), TopNNode.Step.PARTIAL);
 
-        Expression effectivePredicate = effectivePredicateExtractor.extract(SESSION, node, TypeProvider.empty(), typeAnalyzer);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(
+                SESSION,
+                node,
+                TypeProvider.empty(),
+                typeAnalyzer,
+                expressionInterpreter);
 
         // Pass through
         assertEquals(
@@ -400,7 +436,12 @@ public class TestEffectivePredicateExtractor
                 1,
                 false);
 
-        Expression effectivePredicate = effectivePredicateExtractor.extract(SESSION, node, TypeProvider.empty(), typeAnalyzer);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(
+                SESSION,
+                node,
+                TypeProvider.empty(),
+                typeAnalyzer,
+                expressionInterpreter);
 
         // Pass through
         assertEquals(
@@ -425,7 +466,12 @@ public class TestEffectivePredicateExtractor
                 new OrderingScheme(ImmutableList.of(A), ImmutableMap.of(A, SortOrder.ASC_NULLS_LAST)),
                 false);
 
-        Expression effectivePredicate = effectivePredicateExtractor.extract(SESSION, node, TypeProvider.empty(), typeAnalyzer);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(
+                SESSION,
+                node,
+                TypeProvider.empty(),
+                typeAnalyzer,
+                expressionInterpreter);
 
         // Pass through
         assertEquals(
@@ -457,7 +503,12 @@ public class TestEffectivePredicateExtractor
                 ImmutableSet.of(),
                 0);
 
-        Expression effectivePredicate = effectivePredicateExtractor.extract(SESSION, node, TypeProvider.empty(), typeAnalyzer);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(
+                SESSION,
+                node,
+                TypeProvider.empty(),
+                typeAnalyzer,
+                expressionInterpreter);
 
         // Pass through
         assertEquals(
@@ -480,7 +531,12 @@ public class TestEffectivePredicateExtractor
                 assignments,
                 false,
                 Optional.empty());
-        Expression effectivePredicate = effectivePredicateExtractor.extract(SESSION, node, TypeProvider.empty(), typeAnalyzer);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(
+                SESSION,
+                node,
+                TypeProvider.empty(),
+                typeAnalyzer,
+                expressionInterpreter);
         assertEquals(effectivePredicate, BooleanLiteral.TRUE_LITERAL);
 
         node = new TableScanNode(
@@ -492,7 +548,12 @@ public class TestEffectivePredicateExtractor
                 Optional.empty(),
                 false,
                 Optional.empty());
-        effectivePredicate = effectivePredicateExtractor.extract(SESSION, node, TypeProvider.empty(), typeAnalyzer);
+        effectivePredicate = effectivePredicateExtractor.extract(
+                SESSION,
+                node,
+                TypeProvider.empty(),
+                typeAnalyzer,
+                expressionInterpreter);
         assertEquals(effectivePredicate, FALSE_LITERAL);
 
         TupleDomain<ColumnHandle> predicate = TupleDomain.withColumnDomains(ImmutableMap.of(scanAssignments.get(A), Domain.singleValue(BIGINT, 1L)));
@@ -505,7 +566,12 @@ public class TestEffectivePredicateExtractor
                 Optional.empty(),
                 false,
                 Optional.empty());
-        effectivePredicate = effectivePredicateExtractor.extract(SESSION, node, TypeProvider.empty(), typeAnalyzer);
+        effectivePredicate = effectivePredicateExtractor.extract(
+                SESSION,
+                node,
+                TypeProvider.empty(),
+                typeAnalyzer,
+                expressionInterpreter);
         assertEquals(normalizeConjuncts(effectivePredicate), normalizeConjuncts(equals(bigintLiteral(1L), AE)));
 
         predicate = TupleDomain.withColumnDomains(ImmutableMap.of(
@@ -520,7 +586,12 @@ public class TestEffectivePredicateExtractor
                 Optional.empty(),
                 false,
                 Optional.empty());
-        effectivePredicate = effectivePredicateExtractorWithoutTableProperties.extract(SESSION, node, TypeProvider.empty(), typeAnalyzer);
+        effectivePredicate = effectivePredicateExtractorWithoutTableProperties.extract(
+                SESSION,
+                node,
+                TypeProvider.empty(),
+                typeAnalyzer,
+                expressionInterpreter);
         assertEquals(normalizeConjuncts(effectivePredicate), normalizeConjuncts(equals(bigintLiteral(2L), BE), equals(bigintLiteral(1L), AE)));
 
         node = new TableScanNode(
@@ -532,7 +603,12 @@ public class TestEffectivePredicateExtractor
                 Optional.empty(),
                 false,
                 Optional.empty());
-        effectivePredicate = effectivePredicateExtractor.extract(SESSION, node, TypeProvider.empty(), typeAnalyzer);
+        effectivePredicate = effectivePredicateExtractor.extract(
+                SESSION,
+                node,
+                TypeProvider.empty(),
+                typeAnalyzer,
+                expressionInterpreter);
         assertEquals(effectivePredicate, and(equals(AE, bigintLiteral(1)), equals(BE, bigintLiteral(2))));
 
         node = new TableScanNode(
@@ -546,7 +622,12 @@ public class TestEffectivePredicateExtractor
                 Optional.empty(),
                 false,
                 Optional.empty());
-        effectivePredicate = effectivePredicateExtractor.extract(SESSION, node, TypeProvider.empty(), typeAnalyzer);
+        effectivePredicate = effectivePredicateExtractor.extract(
+                SESSION,
+                node,
+                TypeProvider.empty(),
+                typeAnalyzer,
+                expressionInterpreter);
         assertEquals(normalizeConjuncts(effectivePredicate), normalizeConjuncts(equals(bigintLiteral(2L), BE), equals(bigintLiteral(1L), AE)));
 
         node = new TableScanNode(
@@ -558,7 +639,12 @@ public class TestEffectivePredicateExtractor
                 Optional.empty(),
                 false,
                 Optional.empty());
-        effectivePredicate = effectivePredicateExtractor.extract(SESSION, node, TypeProvider.empty(), typeAnalyzer);
+        effectivePredicate = effectivePredicateExtractor.extract(
+                SESSION,
+                node,
+                TypeProvider.empty(),
+                typeAnalyzer,
+                expressionInterpreter);
         assertEquals(effectivePredicate, BooleanLiteral.TRUE_LITERAL);
     }
 
@@ -583,7 +669,8 @@ public class TestEffectivePredicateExtractor
                                         new Row(ImmutableList.of(bigintLiteral(1))),
                                         new Row(ImmutableList.of(bigintLiteral(2))))),
                         types,
-                        typeAnalyzer),
+                        typeAnalyzer,
+                        expressionInterpreter),
                 new InPredicate(AE, new InListExpression(ImmutableList.of(bigintLiteral(1), bigintLiteral(2)))));
 
         // one column with null
@@ -598,7 +685,8 @@ public class TestEffectivePredicateExtractor
                                         new Row(ImmutableList.of(bigintLiteral(2))),
                                         new Row(ImmutableList.of(new Cast(new NullLiteral(), toSqlType(BIGINT)))))),
                         types,
-                        typeAnalyzer),
+                        typeAnalyzer,
+                        expressionInterpreter),
                 or(
                         new InPredicate(AE, new InListExpression(ImmutableList.of(bigintLiteral(1), bigintLiteral(2)))),
                         new IsNullPredicate(AE)));
@@ -612,7 +700,8 @@ public class TestEffectivePredicateExtractor
                                 ImmutableList.of(A),
                                 ImmutableList.of(new Row(ImmutableList.of(new Cast(new NullLiteral(), toSqlType(BIGINT)))))),
                         types,
-                        typeAnalyzer),
+                        typeAnalyzer,
+                        expressionInterpreter),
                 new IsNullPredicate(AE));
 
         // nested row
@@ -624,7 +713,8 @@ public class TestEffectivePredicateExtractor
                                 ImmutableList.of(R),
                                 ImmutableList.of(new Row(ImmutableList.of(new Row(ImmutableList.of(bigintLiteral(1), new NullLiteral())))))),
                         types,
-                        typeAnalyzer),
+                        typeAnalyzer,
+                        expressionInterpreter),
                 TRUE_LITERAL);
 
         // many rows
@@ -641,7 +731,8 @@ public class TestEffectivePredicateExtractor
                                 ImmutableList.of(A),
                                 rows),
                         types,
-                        typeAnalyzer),
+                        typeAnalyzer,
+                        expressionInterpreter),
                 new BetweenPredicate(AE, bigintLiteral(0), bigintLiteral(499)));
 
         // NaN
@@ -653,7 +744,8 @@ public class TestEffectivePredicateExtractor
                                 ImmutableList.of(D),
                                 ImmutableList.of(new Row(ImmutableList.of(doubleLiteral(Double.NaN))))),
                         types,
-                        typeAnalyzer),
+                        typeAnalyzer,
+                        expressionInterpreter),
                 new NotExpression(new IsNullPredicate(DE)));
 
         // NaN and NULL
@@ -667,7 +759,8 @@ public class TestEffectivePredicateExtractor
                                         new Row(ImmutableList.of(new Cast(new NullLiteral(), toSqlType(DOUBLE)))),
                                         new Row(ImmutableList.of(doubleLiteral(Double.NaN))))),
                         types,
-                        typeAnalyzer),
+                        typeAnalyzer,
+                        expressionInterpreter),
                 TRUE_LITERAL);
 
         // NaN and value
@@ -681,7 +774,8 @@ public class TestEffectivePredicateExtractor
                                         new Row(ImmutableList.of(doubleLiteral(42.))),
                                         new Row(ImmutableList.of(doubleLiteral(Double.NaN))))),
                         types,
-                        typeAnalyzer),
+                        typeAnalyzer,
+                        expressionInterpreter),
                 new NotExpression(new IsNullPredicate(DE)));
 
         // Real NaN
@@ -693,7 +787,8 @@ public class TestEffectivePredicateExtractor
                                 ImmutableList.of(D),
                                 ImmutableList.of(new Row(ImmutableList.of(new Cast(doubleLiteral(Double.NaN), toSqlType(REAL)))))),
                         TypeProvider.copyOf(ImmutableMap.of(D, REAL)),
-                        typeAnalyzer),
+                        typeAnalyzer,
+                        expressionInterpreter),
                 new NotExpression(new IsNullPredicate(DE)));
 
         // multiple columns
@@ -707,7 +802,8 @@ public class TestEffectivePredicateExtractor
                                         new Row(ImmutableList.of(bigintLiteral(1), bigintLiteral(100))),
                                         new Row(ImmutableList.of(bigintLiteral(2), bigintLiteral(200))))),
                         types,
-                        typeAnalyzer),
+                        typeAnalyzer,
+                        expressionInterpreter),
                 and(
                         new InPredicate(AE, new InListExpression(ImmutableList.of(bigintLiteral(1), bigintLiteral(2)))),
                         new InPredicate(BE, new InListExpression(ImmutableList.of(bigintLiteral(100), bigintLiteral(200))))));
@@ -723,7 +819,8 @@ public class TestEffectivePredicateExtractor
                                         new Row(ImmutableList.of(bigintLiteral(1), new Cast(new NullLiteral(), toSqlType(BIGINT)))),
                                         new Row(ImmutableList.of(new Cast(new NullLiteral(), toSqlType(BIGINT)), bigintLiteral(200))))),
                         types,
-                        typeAnalyzer),
+                        typeAnalyzer,
+                        expressionInterpreter),
                 and(
                         or(new ComparisonExpression(EQUAL, AE, bigintLiteral(1)), new IsNullPredicate(AE)),
                         or(new ComparisonExpression(EQUAL, BE, bigintLiteral(200)), new IsNullPredicate(BE))));
@@ -747,7 +844,8 @@ public class TestEffectivePredicateExtractor
                                         new Row(ImmutableList.of(bigintLiteral(1))),
                                         new Row(ImmutableList.of(BE)))),
                         types,
-                        typeAnalyzer),
+                        typeAnalyzer,
+                        expressionInterpreter),
                 TRUE_LITERAL);
     }
 
@@ -756,7 +854,12 @@ public class TestEffectivePredicateExtractor
         return transaction(new TestingTransactionManager(), new AllowAllAccessControl())
                 .singleStatement()
                 .execute(SESSION, transactionSession -> {
-                    return effectivePredicateExtractor.extract(transactionSession, node, types, typeAnalyzer);
+                    return effectivePredicateExtractor.extract(
+                            transactionSession,
+                            node,
+                            types,
+                            typeAnalyzer,
+                            expressionInterpreter);
                 });
     }
 
@@ -773,7 +876,12 @@ public class TestEffectivePredicateExtractor
                 symbolMapping,
                 ImmutableList.copyOf(symbolMapping.keySet()));
 
-        Expression effectivePredicate = effectivePredicateExtractor.extract(SESSION, node, TypeProvider.empty(), typeAnalyzer);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(
+                SESSION,
+                node,
+                TypeProvider.empty(),
+                typeAnalyzer,
+                expressionInterpreter);
 
         // Only the common conjuncts can be inferred through a Union
         assertEquals(
@@ -824,7 +932,12 @@ public class TestEffectivePredicateExtractor
                 ImmutableMap.of(),
                 Optional.empty());
 
-        Expression effectivePredicate = effectivePredicateExtractor.extract(SESSION, node, TypeProvider.empty(), typeAnalyzer);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(
+                SESSION,
+                node,
+                TypeProvider.empty(),
+                typeAnalyzer,
+                expressionInterpreter);
 
         // All predicates having output symbol should be carried through
         assertEquals(
@@ -868,7 +981,12 @@ public class TestEffectivePredicateExtractor
                 ImmutableMap.of(),
                 Optional.empty());
 
-        Expression effectivePredicate = effectivePredicateExtractor.extract(SESSION, node, TypeProvider.empty(), typeAnalyzer);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(
+                SESSION,
+                node,
+                TypeProvider.empty(),
+                typeAnalyzer,
+                expressionInterpreter);
 
         assertEquals(
                 normalizeConjuncts(effectivePredicate),
@@ -901,7 +1019,12 @@ public class TestEffectivePredicateExtractor
                 ImmutableMap.of(),
                 Optional.empty());
 
-        Expression effectivePredicate = effectivePredicateExtractor.extract(SESSION, node, TypeProvider.empty(), typeAnalyzer);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(
+                SESSION,
+                node,
+                TypeProvider.empty(),
+                typeAnalyzer,
+                expressionInterpreter);
 
         assertEquals(effectivePredicate, FALSE_LITERAL);
     }
@@ -948,7 +1071,12 @@ public class TestEffectivePredicateExtractor
                 ImmutableMap.of(),
                 Optional.empty());
 
-        Expression effectivePredicate = effectivePredicateExtractor.extract(SESSION, node, TypeProvider.empty(), typeAnalyzer);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(
+                SESSION,
+                node,
+                TypeProvider.empty(),
+                typeAnalyzer,
+                expressionInterpreter);
 
         // All right side symbols having output symbols should be checked against NULL
         assertEquals(
@@ -997,7 +1125,12 @@ public class TestEffectivePredicateExtractor
                 ImmutableMap.of(),
                 Optional.empty());
 
-        Expression effectivePredicate = effectivePredicateExtractor.extract(SESSION, node, TypeProvider.empty(), typeAnalyzer);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(
+                SESSION,
+                node,
+                TypeProvider.empty(),
+                typeAnalyzer,
+                expressionInterpreter);
 
         // False literal on the right side should be ignored
         assertEquals(
@@ -1050,7 +1183,12 @@ public class TestEffectivePredicateExtractor
                 ImmutableMap.of(),
                 Optional.empty());
 
-        Expression effectivePredicate = effectivePredicateExtractor.extract(SESSION, node, TypeProvider.empty(), typeAnalyzer);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(
+                SESSION,
+                node,
+                TypeProvider.empty(),
+                typeAnalyzer,
+                expressionInterpreter);
 
         // All left side symbols should be checked against NULL
         assertEquals(
@@ -1098,7 +1236,12 @@ public class TestEffectivePredicateExtractor
                 ImmutableMap.of(),
                 Optional.empty());
 
-        Expression effectivePredicate = effectivePredicateExtractor.extract(SESSION, node, TypeProvider.empty(), typeAnalyzer);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(
+                SESSION,
+                node,
+                TypeProvider.empty(),
+                typeAnalyzer,
+                expressionInterpreter);
 
         // False literal on the left side should be ignored
         assertEquals(
@@ -1122,7 +1265,12 @@ public class TestEffectivePredicateExtractor
                 Optional.empty(),
                 Optional.empty());
 
-        Expression effectivePredicate = effectivePredicateExtractor.extract(SESSION, node, TypeProvider.empty(), typeAnalyzer);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(
+                SESSION,
+                node,
+                TypeProvider.empty(),
+                typeAnalyzer,
+                expressionInterpreter);
 
         // Currently, only pull predicates through the source plan
         assertEquals(

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLiteralEncoder.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLiteralEncoder.java
@@ -289,7 +289,8 @@ public class TestLiteralEncoder
 
     private Object getExpressionValue(Expression expression)
     {
-        return new ExpressionInterpreter(expression, PLANNER_CONTEXT, TEST_SESSION, getExpressionTypes(expression)).evaluate();
+        return new ExpressionInterpreter(PLANNER_CONTEXT, TEST_SESSION)
+                .evaluate(expression, getExpressionTypes(expression));
     }
 
     private Type getExpressionType(Expression expression)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/BasePlanTest.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/BasePlanTest.java
@@ -22,8 +22,10 @@ import io.trino.execution.warnings.WarningCollector;
 import io.trino.plugin.tpch.TpchConnectorFactory;
 import io.trino.sql.planner.LogicalPlanner;
 import io.trino.sql.planner.Plan;
+import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.RuleStatsRecorder;
 import io.trino.sql.planner.SubPlan;
+import io.trino.sql.planner.SymbolAllocator;
 import io.trino.sql.planner.iterative.IterativeOptimizer;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.iterative.rule.RemoveRedundantIdentityProjections;
@@ -225,5 +227,38 @@ public class BasePlanTest
         catch (RuntimeException e) {
             throw new AssertionError("Planning failed for SQL: " + sql, e);
         }
+    }
+
+    protected PlanOptimizer.Context createOptimizerContext(
+            Session session,
+            SymbolAllocator symbolAllocator,
+            PlanNodeIdAllocator idAllocator)
+    {
+        return new PlanOptimizer.Context()
+        {
+            @Override
+            public Session getSession()
+            {
+                return session;
+            }
+
+            @Override
+            public SymbolAllocator getSymbolAllocator()
+            {
+                return symbolAllocator;
+            }
+
+            @Override
+            public PlanNodeIdAllocator getIdAllocator()
+            {
+                return idAllocator;
+            }
+
+            @Override
+            public WarningCollector getWarningCollector()
+            {
+                return WarningCollector.NOOP;
+            }
+        };
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/BasePlanTest.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/BasePlanTest.java
@@ -20,6 +20,7 @@ import io.trino.Session;
 import io.trino.connector.CatalogName;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.plugin.tpch.TpchConnectorFactory;
+import io.trino.sql.planner.ExpressionInterpreter;
 import io.trino.sql.planner.LogicalPlanner;
 import io.trino.sql.planner.Plan;
 import io.trino.sql.planner.PlanNodeIdAllocator;
@@ -232,7 +233,8 @@ public class BasePlanTest
     protected PlanOptimizer.Context createOptimizerContext(
             Session session,
             SymbolAllocator symbolAllocator,
-            PlanNodeIdAllocator idAllocator)
+            PlanNodeIdAllocator idAllocator,
+            ExpressionInterpreter interpreter)
     {
         return new PlanOptimizer.Context()
         {
@@ -258,6 +260,12 @@ public class BasePlanTest
             public WarningCollector getWarningCollector()
             {
                 return WarningCollector.NOOP;
+            }
+
+            @Override
+            public ExpressionInterpreter getExpressionInterpreter()
+            {
+                return interpreter;
             }
         };
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestJoinEnumerator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestJoinEnumerator.java
@@ -24,6 +24,7 @@ import io.trino.cost.CostProvider;
 import io.trino.cost.PlanCostEstimate;
 import io.trino.cost.StatsProvider;
 import io.trino.execution.warnings.WarningCollector;
+import io.trino.sql.planner.ExpressionInterpreter;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.SymbolAllocator;
@@ -124,6 +125,9 @@ public class TestJoinEnumerator
                 Optional.empty(),
                 queryRunner.getDefaultSession(),
                 symbolAllocator.getTypes());
+        ExpressionInterpreter expressionInterpreter = new ExpressionInterpreter(
+                queryRunner.getPlannerContext(),
+                queryRunner.getDefaultSession());
 
         return new Rule.Context()
         {
@@ -170,6 +174,12 @@ public class TestJoinEnumerator
             public WarningCollector getWarningCollector()
             {
                 return WarningCollector.NOOP;
+            }
+
+            @Override
+            public ExpressionInterpreter getExpressionInterpreter()
+            {
+                return expressionInterpreter;
             }
         };
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyExpressions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyExpressions.java
@@ -16,6 +16,7 @@ package io.trino.sql.planner.iterative.rule;
 import io.trino.spi.type.Type;
 import io.trino.sql.parser.ParsingOptions;
 import io.trino.sql.parser.SqlParser;
+import io.trino.sql.planner.ExpressionInterpreter;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.SymbolAllocator;
 import io.trino.sql.planner.SymbolsExtractor;
@@ -266,7 +267,13 @@ public class TestSimplifyExpressions
     private static Expression simplify(@Language("SQL") String expression)
     {
         Expression actualExpression = rewriteIdentifiersToSymbolReferences(SQL_PARSER.createExpression(expression, new ParsingOptions()));
-        return normalize(rewrite(actualExpression, TEST_SESSION, new SymbolAllocator(booleanSymbolTypeMapFor(actualExpression)), PLANNER_CONTEXT, createTestingTypeAnalyzer(PLANNER_CONTEXT)));
+        return normalize(rewrite(
+                actualExpression,
+                TEST_SESSION,
+                new SymbolAllocator(booleanSymbolTypeMapFor(actualExpression)),
+                PLANNER_CONTEXT,
+                createTestingTypeAnalyzer(PLANNER_CONTEXT),
+                new ExpressionInterpreter(PLANNER_CONTEXT, TEST_SESSION)));
     }
 
     private static Map<Symbol, Type> booleanSymbolTypeMapFor(Expression expression)
@@ -342,7 +349,13 @@ public class TestSimplifyExpressions
         ParsingOptions parsingOptions = new ParsingOptions();
         Expression actualExpression = rewriteIdentifiersToSymbolReferences(SQL_PARSER.createExpression(expression, parsingOptions));
         Expression expectedExpression = rewriteIdentifiersToSymbolReferences(SQL_PARSER.createExpression(expected, parsingOptions));
-        Expression rewritten = rewrite(actualExpression, TEST_SESSION, new SymbolAllocator(numericAndBooleanSymbolTypeMapFor(actualExpression)), PLANNER_CONTEXT, createTestingTypeAnalyzer(PLANNER_CONTEXT));
+        Expression rewritten = rewrite(
+                actualExpression,
+                TEST_SESSION,
+                new SymbolAllocator(numericAndBooleanSymbolTypeMapFor(actualExpression)),
+                PLANNER_CONTEXT,
+                createTestingTypeAnalyzer(PLANNER_CONTEXT),
+                new ExpressionInterpreter(PLANNER_CONTEXT, TEST_SESSION));
         assertEquals(
                 normalize(rewritten),
                 normalize(expectedExpression));

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/RuleTester.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/RuleTester.java
@@ -102,7 +102,7 @@ public class RuleTester
 
     public RuleAssert assertThat(Rule<?> rule)
     {
-        return new RuleAssert(metadata, functionManager, queryRunner.getStatsCalculator(), queryRunner.getEstimatedExchangesCostCalculator(), session, rule, transactionManager, accessControl);
+        return new RuleAssert(queryRunner.getPlannerContext(), queryRunner.getStatsCalculator(), queryRunner.getEstimatedExchangesCostCalculator(), session, rule, transactionManager, accessControl);
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestBeginTableWrite.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestBeginTableWrite.java
@@ -22,6 +22,7 @@ import io.trino.metadata.TableHandle;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.type.BigintType;
+import io.trino.sql.planner.ExpressionInterpreter;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.SymbolAllocator;
 import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
@@ -32,6 +33,7 @@ import java.util.List;
 import java.util.function.Function;
 
 import static io.trino.metadata.FunctionManager.createTestingFunctionManager;
+import static io.trino.sql.planner.TestingPlannerContext.plannerContextBuilder;
 import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -134,6 +136,7 @@ public class TestBeginTableWrite
         Session session = testSessionBuilder().build();
         SymbolAllocator symbolAllocator = new SymbolAllocator();
         PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+        ExpressionInterpreter interpreter = new ExpressionInterpreter(plannerContextBuilder().withMetadata(metadata).build(), session);
 
         new BeginTableWrite(metadata, createTestingFunctionManager()).optimize(
                 planProvider.apply(new PlanBuilder(new PlanNodeIdAllocator(), metadata, testSessionBuilder().build())),
@@ -161,6 +164,12 @@ public class TestBeginTableWrite
                     public WarningCollector getWarningCollector()
                     {
                         return WarningCollector.NOOP;
+                    }
+
+                    @Override
+                    public ExpressionInterpreter getExpressionInterpreter()
+                    {
+                        return interpreter;
                     }
                 });
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestRemoveUnsupportedDynamicFilters.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestRemoveUnsupportedDynamicFilters.java
@@ -477,7 +477,9 @@ public class TestRemoveUnsupportedDynamicFilters
         return getQueryRunner().inTransaction(session -> {
             // metadata.getCatalogHandle() registers the catalog for the transaction
             session.getCatalog().ifPresent(catalog -> metadata.getCatalogHandle(session, catalog));
-            PlanNode rewrittenPlan = new RemoveUnsupportedDynamicFilters(plannerContext).optimize(root, session, builder.getTypes(), new SymbolAllocator(), new PlanNodeIdAllocator(), WarningCollector.NOOP);
+            PlanNode rewrittenPlan = new RemoveUnsupportedDynamicFilters(plannerContext).optimize(
+                    root,
+                    createOptimizerContext(session, new SymbolAllocator(builder.getTypes().allTypes()), new PlanNodeIdAllocator()));
             new DynamicFiltersChecker().validate(rewrittenPlan,
                     session,
                     plannerContext, createTestingTypeAnalyzer(plannerContext),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestRemoveUnsupportedDynamicFilters.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestRemoveUnsupportedDynamicFilters.java
@@ -23,6 +23,7 @@ import io.trino.metadata.TableHandle;
 import io.trino.plugin.tpch.TpchColumnHandle;
 import io.trino.plugin.tpch.TpchTableHandle;
 import io.trino.sql.PlannerContext;
+import io.trino.sql.planner.ExpressionInterpreter;
 import io.trino.sql.planner.Plan;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.Symbol;
@@ -479,7 +480,11 @@ public class TestRemoveUnsupportedDynamicFilters
             session.getCatalog().ifPresent(catalog -> metadata.getCatalogHandle(session, catalog));
             PlanNode rewrittenPlan = new RemoveUnsupportedDynamicFilters(plannerContext).optimize(
                     root,
-                    createOptimizerContext(session, new SymbolAllocator(builder.getTypes().allTypes()), new PlanNodeIdAllocator()));
+                    createOptimizerContext(
+                            session,
+                            new SymbolAllocator(builder.getTypes().allTypes()),
+                            new PlanNodeIdAllocator(),
+                            new ExpressionInterpreter(plannerContext, session)));
             new DynamicFiltersChecker().validate(rewrittenPlan,
                     session,
                     plannerContext, createTestingTypeAnalyzer(plannerContext),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestUnaliasSymbolReferences.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestUnaliasSymbolReferences.java
@@ -25,6 +25,7 @@ import io.trino.plugin.tpch.TpchTableHandle;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.type.BigintType;
 import io.trino.sql.ExpressionUtils;
+import io.trino.sql.planner.ExpressionInterpreter;
 import io.trino.sql.planner.Plan;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.Symbol;
@@ -126,7 +127,11 @@ public class TestUnaliasSymbolReferences
             PlanNode plan = planCreator.create(planBuilder, session, metadata);
             PlanNode optimized = optimizer.optimize(
                     plan,
-                    createOptimizerContext(session, symbolAllocator, idAllocator));
+                    createOptimizerContext(
+                            session,
+                            symbolAllocator,
+                            idAllocator,
+                            new ExpressionInterpreter(queryRunner.getPlannerContext(), session)));
 
             Plan actual = new Plan(optimized, planBuilder.getTypes(), StatsAndCosts.empty());
             PlanAssert.assertPlan(session, queryRunner.getMetadata(), queryRunner.getFunctionManager(), queryRunner.getStatsCalculator(), actual, pattern);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core query engine

> How would you describe this change to a non-technical end user or system administrator?

**Problem**: ExpressionInterpreter is called multiple times during planning. Hence its optimization results should be cached (especially for long IN lists)


This PR introduces the following things
- The first two commits introduce a way to utilize the same instance of ExpressionInterpreter for a query. This way query level expression caching is possible without maintaining a global cache. This is based on Karol's comment: https://github.com/trinodb/trino/pull/12016#discussion_r853931832
- Caching optimization results in ExpressionInterpreter whose instance is unique at query level.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
