### PR TITLE
Should limit the output length if valuesNode exist in Explain

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -168,6 +168,7 @@ public final class SystemSessionProperties
     public static final String ADAPTIVE_PARTIAL_AGGREGATION_ENABLED = "adaptive_partial_aggregation_enabled";
     public static final String ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS = "adaptive_partial_aggregation_min_rows";
     public static final String ADAPTIVE_PARTIAL_AGGREGATION_UNIQUE_ROWS_RATIO_THRESHOLD = "adaptive_partial_aggregation_unique_rows_ratio_threshold";
+    public static final String EXPLAIN_VALUES_LIMIT = "explain_values_limit";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -817,7 +818,14 @@ public final class SystemSessionProperties
                         ADAPTIVE_PARTIAL_AGGREGATION_UNIQUE_ROWS_RATIO_THRESHOLD,
                         "Ratio between aggregation output and input rows above which partial aggregation might be adaptively turned off",
                         optimizerConfig.getAdaptivePartialAggregationUniqueRowsRatioThreshold(),
-                        false));
+                        false),
+                integerProperty(
+                        EXPLAIN_VALUES_LIMIT,
+                        "The length of the limit when values exist in Explain",
+                        optimizerConfig.getExplainValuesLimit(),
+                        false
+
+                ));
     }
 
     @Override
@@ -1468,5 +1476,10 @@ public final class SystemSessionProperties
     public static double getAdaptivePartialAggregationUniqueRowsRatioThreshold(Session session)
     {
         return session.getSystemProperty(ADAPTIVE_PARTIAL_AGGREGATION_UNIQUE_ROWS_RATIO_THRESHOLD, Double.class);
+    }
+
+    public static int getExplainValuesLimit(Session session)
+    {
+        return session.getSystemProperty(EXPLAIN_VALUES_LIMIT, Integer.class);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/OptimizerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/OptimizerConfig.java
@@ -86,6 +86,8 @@ public class OptimizerConfig
     private long adaptivePartialAggregationMinRows = 100_000;
     private double adaptivePartialAggregationUniqueRowsRatioThreshold = 0.8;
 
+    private int explainValuesLimit = 5;
+
     public enum JoinReorderingStrategy
     {
         NONE,
@@ -711,6 +713,20 @@ public class OptimizerConfig
     public OptimizerConfig setAdaptivePartialAggregationUniqueRowsRatioThreshold(double adaptivePartialAggregationUniqueRowsRatioThreshold)
     {
         this.adaptivePartialAggregationUniqueRowsRatioThreshold = adaptivePartialAggregationUniqueRowsRatioThreshold;
+        return this;
+    }
+
+    @Min(1)
+    public int getExplainValuesLimit()
+    {
+        return explainValuesLimit;
+    }
+
+    @Config("explain.values-limit")
+    @ConfigDescription("The length of the limit when values exist in Explain")
+    public OptimizerConfig setExplainValuesLimit(int explainValuesLimit)
+    {
+        this.explainValuesLimit = explainValuesLimit;
         return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/ValuePrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/ValuePrinter.java
@@ -59,4 +59,8 @@ public final class ValuePrinter
         Slice coerced = (Slice) new InterpretedFunctionInvoker(functionManager).invoke(coercion, session.toConnectorSession(), value);
         return coerced.toStringUtf8();
     }
+
+    public Session getSession() {
+        return this.session;
+    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
`Explain` is used to show logical/distributed execution plans for SQL, but when there is a ValueNode in Explain, Trino will output unlimited length. This output is sometimes confusing, such as' Explain show function ', the current behavior is(Only part of the screenshot is shown):
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/51110188/164018032-7f3eecc1-ce9a-46f6-bd92-7de29f7fa908.png">

This pr aims to change this behavior:
- Limit explain's out length if `ValueNode` exist in `Explain`
- Add a config to control the length of `Explain`

After this pr, `explain show functions`'s behavior as follows:
<img width="1328" alt="image" src="https://user-images.githubusercontent.com/51110188/164018822-bc0c34c2-8ccc-40d9-ac40-64f1727f5bf4.png">


## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
