### PR TITLE
Correct release notes entry in 377

### DIFF
--- a/docs/src/main/sphinx/release/release-377.md
+++ b/docs/src/main/sphinx/release/release-377.md
@@ -7,9 +7,10 @@
 
 ## Hive connector
 
-* Add support for partition names that include special characters. ({issue}`11719`)
 * Add support for `date` type partition names with timestamp formatting. ({issue}`11873`)
 * Improve performance of queries that use Glue metadata. ({issue}`11869`)
+* Fix `sync_partition_metadata` procedure when partition names differ from
+  partition paths on the file system. ({issue}`11864`)
 
 ## Iceberg connector
 


### PR DESCRIPTION
## Description

Correct a release notes entry for Trino 377 for the Hive connector where @martint and myself misread the comments and linked tickets.

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix. 

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Docs

> How would you describe this change to a non-technical end user or system administrator?

Fix a minor detail in the release notes.

## Related issues, pull requests, and links

na.

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:
