### PR TITLE
Remove obsolete TODO in getIcebergLiteralValue

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ExpressionConverter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ExpressionConverter.java
@@ -193,7 +193,6 @@ public final class ExpressionConverter
             return (double) trinoNativeValue;
         }
 
-        // TODO: Remove this conversion once we move to next iceberg version
         if (type instanceof DateType) {
             return toIntExact(((Long) trinoNativeValue));
         }


### PR DESCRIPTION
When the code section was added, the method handled selected types and
had implicit fallback. Nowdays, the method must support all types
explicitly, and there is no follback behavior.
