### PR TITLE
Expose JMX metrics for TrinoFileSystemCache

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveModule.java
@@ -22,6 +22,8 @@ import com.google.inject.multibindings.Multibinder;
 import io.airlift.event.client.EventClient;
 import io.trino.plugin.base.CatalogName;
 import io.trino.plugin.hive.fs.CachingDirectoryLister;
+import io.trino.plugin.hive.fs.TrinoFileSystemCache;
+import io.trino.plugin.hive.fs.TrinoFileSystemCacheStats;
 import io.trino.plugin.hive.metastore.HiveMetastoreConfig;
 import io.trino.plugin.hive.metastore.thrift.TranslateHiveViews;
 import io.trino.plugin.hive.orc.OrcFileWriterFactory;
@@ -100,6 +102,10 @@ public class HiveModule
 
         binder.bind(FileFormatDataSourceStats.class).in(Scopes.SINGLETON);
         newExporter(binder).export(FileFormatDataSourceStats.class).withGeneratedName();
+
+        binder.bind(TrinoFileSystemCacheStats.class).toInstance(TrinoFileSystemCache.INSTANCE.getFileSystemCacheStats());
+        newExporter(binder).export(TrinoFileSystemCacheStats.class)
+                .as(generator -> generator.generatedNameOf(TrinoFileSystemCache.class));
 
         Multibinder<HivePageSourceFactory> pageSourceFactoryBinder = newSetBinder(binder, HivePageSourceFactory.class);
         pageSourceFactoryBinder.addBinding().to(OrcPageSourceFactory.class).in(Scopes.SINGLETON);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/TrinoFileSystemCacheStats.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/TrinoFileSystemCacheStats.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.fs;
+
+import io.airlift.stats.CounterStat;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
+
+import java.util.function.LongSupplier;
+
+import static java.util.Objects.requireNonNull;
+
+public class TrinoFileSystemCacheStats
+{
+    private final CounterStat getCalls = new CounterStat();
+    private final CounterStat getUniqueCalls = new CounterStat();
+    private final CounterStat getCallsFailed = new CounterStat();
+    private final CounterStat removeCalls = new CounterStat();
+    private final LongSupplier cacheSize;
+
+    TrinoFileSystemCacheStats(LongSupplier cacheSize)
+    {
+        this.cacheSize = requireNonNull(cacheSize, "cacheSize is null");
+    }
+
+    @Managed
+    public long getCacheSize()
+    {
+        return cacheSize.getAsLong();
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getGetCalls()
+    {
+        return getCalls;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getGetCallsFailed()
+    {
+        return getCallsFailed;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getGetUniqueCalls()
+    {
+        return getUniqueCalls;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getRemoveCalls()
+    {
+        return removeCalls;
+    }
+
+    public void newGetCall()
+    {
+        getCalls.update(1);
+    }
+
+    public void newGetUniqueCall()
+    {
+        getUniqueCalls.update(1);
+    }
+
+    public void newGetCallFailed()
+    {
+        getCallsFailed.update(1);
+    }
+
+    public void newRemoveCall()
+    {
+        removeCalls.update(1);
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/TestTrinoFileSystemCacheStats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/TestTrinoFileSystemCacheStats.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.fs;
+
+import io.trino.plugin.hive.s3.TrinoS3FileSystem;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testng.Assert.assertEquals;
+
+public class TestTrinoFileSystemCacheStats
+{
+    @Test
+    public void testCacheSizeIsCorrect()
+            throws Exception
+    {
+        TrinoFileSystemCache trinoFileSystemCache = new TrinoFileSystemCache();
+        TrinoFileSystemCacheStats trinoFileSystemCacheStats = trinoFileSystemCache.getFileSystemCacheStats();
+        assertEquals(trinoFileSystemCacheStats.getCacheSize(), 0);
+        assertEquals(trinoFileSystemCache.getCacheSize(), 0);
+
+        Configuration configuration = new Configuration(true);
+        configuration.set("fs.s3.impl", TrinoS3FileSystem.class.getName());
+        trinoFileSystemCache.get(new URI("s3://bucket/path/"), configuration);
+        assertEquals(trinoFileSystemCacheStats.getGetCalls().getTotalCount(), 1);
+        assertEquals(trinoFileSystemCacheStats.getCacheSize(), 1);
+        assertEquals(trinoFileSystemCache.getCacheSize(), 1);
+
+        trinoFileSystemCache.get(new URI("s3://bucket/path1/"), configuration);
+        assertEquals(trinoFileSystemCacheStats.getGetCalls().getTotalCount(), 2);
+        assertEquals(trinoFileSystemCacheStats.getCacheSize(), 1);
+        assertEquals(trinoFileSystemCache.getCacheSize(), 1);
+
+        // use getUnique to ensure cache size is increased
+        FileSystem fileSystem = trinoFileSystemCache.getUnique(new URI("s3://bucket/path2/"), configuration);
+        assertEquals(trinoFileSystemCacheStats.getGetCalls().getTotalCount(), 2);
+        assertEquals(trinoFileSystemCacheStats.getGetUniqueCalls().getTotalCount(), 1);
+        assertEquals(trinoFileSystemCacheStats.getCacheSize(), 2);
+        assertEquals(trinoFileSystemCache.getCacheSize(), 2);
+
+        trinoFileSystemCache.remove(fileSystem);
+        assertEquals(trinoFileSystemCacheStats.getRemoveCalls().getTotalCount(), 1);
+        assertEquals(trinoFileSystemCacheStats.getCacheSize(), 1);
+        assertEquals(trinoFileSystemCache.getCacheSize(), 1);
+
+        trinoFileSystemCache.closeAll();
+        assertEquals(trinoFileSystemCacheStats.getCacheSize(), 0);
+        assertEquals(trinoFileSystemCache.getCacheSize(), 0);
+    }
+
+    @Test
+    public void testFailedCallsCountIsCorrect()
+    {
+        TrinoFileSystemCache trinoFileSystemCache = new TrinoFileSystemCache();
+        TrinoFileSystemCacheStats trinoFileSystemCacheStats = trinoFileSystemCache.getFileSystemCacheStats();
+        Configuration configuration = new Configuration(false);
+        configuration.setInt("fs.cache.max-size", 0);
+        assertThatThrownBy(() -> trinoFileSystemCache.get(new URI("s3://bucket/path/"), configuration))
+                .hasMessageMatching("FileSystem max cache size has been reached: 0");
+        assertEquals(trinoFileSystemCacheStats.getGetCallsFailed().getTotalCount(), 1);
+        assertEquals(trinoFileSystemCacheStats.getGetCalls().getTotalCount(), 1);
+        assertEquals(trinoFileSystemCacheStats.getCacheSize(), 0);
+        assertEquals(trinoFileSystemCache.getCacheSize(), 0);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

The Hive connector in Trino has it's own implementation of Hadoop's `FileSystemCache`. The size of this cache defaults to 1000 but there is no way to see what the current size of the cache is.

In deployments where HDFS impersonation is enabled with many distinct users connecting to Trino, this cache can get large.

This PR exposes some statistics on the cache via JMX to help Trino admins know if the cache is getting close to capacity.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

New JMX statistics for `TrinoFileSystemCache`.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Update to the Hive connector.

> How would you describe this change to a non-technical end user or system administrator?

This change exposes new JMX stats which will be available at `trino.plugin.hive.fs:name=<catalog_name>,type=trinofilesystemcache`.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(X ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( X) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
