### PR TITLE
Move testDropSchemaExternalFiles to base class in Delta Lake

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeAwsConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeAwsConnectorSmokeTest.java
@@ -71,4 +71,10 @@ public abstract class BaseDeltaLakeAwsConnectorSmokeTest
                 .map(path -> format("s3://%s/%s", bucketName, path))
                 .collect(toImmutableList());
     }
+
+    @Override
+    protected String bucketUrl()
+    {
+        return format("s3://%s/", bucketName);
+    }
 }


### PR DESCRIPTION
## Description

Move testDropSchemaExternalFiles to base class in Delta Lake
Fixes #12009

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
