### PR TITLE
Produce RunLengthEncodedBlock in VariableWidthBlockBuilder when all values are null

### DIFF
--- a/core/trino-main/src/test/java/io/trino/execution/buffer/TestPagesSerde.java
+++ b/core/trino-main/src/test/java/io/trino/execution/buffer/TestPagesSerde.java
@@ -92,10 +92,11 @@ public class TestPagesSerde
         // empty page
         Page page = new Page(builder.build());
         int pageSize = serializedSize(ImmutableList.of(VARCHAR), page);
-        assertEquals(pageSize, 44); // page overhead
+        assertEquals(pageSize, 60); // page overhead ideally 44 but since a 0 sized block will be a RLEBlock we have an overhead of 16
 
         // page with one value
         VARCHAR.writeString(builder, "alice");
+        pageSize = 44; // Now we have moved to the normal block implementation so the page size overhead is 44
         page = new Page(builder.build());
         int firstValueSize = serializedSize(ImmutableList.of(VARCHAR), page) - pageSize;
         assertEquals(firstValueSize, 4 + 5); // length + "alice"

--- a/core/trino-spi/src/test/java/io/trino/spi/block/TestVariableWidthBlockBuilder.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/TestVariableWidthBlockBuilder.java
@@ -69,4 +69,36 @@ public class TestVariableWidthBlockBuilder
         assertEquals(blockBuilder.getPositionCount(), EXPECTED_ENTRY_COUNT);
         assertEquals(pageBuilderStatus.isFull(), true);
     }
+
+    @Test
+    public void testBuilderProducesNullRleForNullRows()
+    {
+        // empty block
+        assertIsNullRle(blockBuilder().build(), 0);
+
+        // single null
+        assertIsNullRle(blockBuilder().appendNull().build(), 1);
+
+        // multiple nulls
+        assertIsNullRle(blockBuilder().appendNull().appendNull().build(), 2);
+
+        BlockBuilder blockBuilder = blockBuilder().appendNull().appendNull();
+        assertIsNullRle(blockBuilder.copyPositions(new int[] {0}, 0, 1), 1);
+        assertIsNullRle(blockBuilder.getRegion(0, 1), 1);
+        assertIsNullRle(blockBuilder.copyRegion(0, 1), 1);
+    }
+
+    private static BlockBuilder blockBuilder()
+    {
+        return new VariableWidthBlockBuilder(null, 10, 0);
+    }
+
+    private void assertIsNullRle(Block block, int expectedPositionCount)
+    {
+        assertEquals(block.getPositionCount(), expectedPositionCount);
+        assertEquals(block.getClass(), RunLengthEncodedBlock.class);
+        if (expectedPositionCount > 0) {
+            assertTrue(block.isNull(0));
+        }
+    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Add support in VariableWidthBlockBuilder for producing RunLengthEncodedBlock if all positions are null.

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

improvement
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

only VariableWidthBlockBuilder class
> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
