### PR TITLE
Produce RunLengthEncodedBlock in RowBlockBuilder when all values are null

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/block/AbstractRowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/AbstractRowBlock.java
@@ -72,7 +72,7 @@ public abstract class AbstractRowBlock
     }
 
     @Override
-    public final Block copyPositions(int[] positions, int offset, int length)
+    public Block copyPositions(int[] positions, int offset, int length)
     {
         checkArrayRange(positions, offset, length);
 

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlockBuilder.java
@@ -25,6 +25,8 @@ import java.util.function.ObjLongConsumer;
 
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.calculateBlockResetSize;
+import static io.trino.spi.block.BlockUtil.checkArrayRange;
+import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.RowBlock.createRowBlockInternal;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -46,6 +48,7 @@ public class RowBlockBuilder
 
     private boolean currentEntryOpened;
     private boolean hasNullRow;
+    private boolean hasNonNullRow;
 
     public RowBlockBuilder(List<Type> fieldTypes, BlockBuilderStatus blockBuilderStatus, int expectedEntries)
     {
@@ -201,6 +204,7 @@ public class RowBlockBuilder
         }
         rowIsNull[positionCount] = isNull;
         hasNullRow |= isNull;
+        hasNonNullRow |= !isNull;
         positionCount++;
 
         for (int i = 0; i < numFields; i++) {
@@ -219,6 +223,9 @@ public class RowBlockBuilder
     {
         if (currentEntryOpened) {
             throw new IllegalStateException("Current entry must be closed before the block can be built");
+        }
+        if (!hasNonNullRow) {
+            return nullRle(positionCount);
         }
         Block[] fieldBlocks = new Block[numFields];
         for (int i = 0; i < numFields; i++) {
@@ -242,5 +249,51 @@ public class RowBlockBuilder
             newBlockBuilders[i] = fieldBlockBuilders[i].newBlockBuilderLike(blockBuilderStatus);
         }
         return new RowBlockBuilder(blockBuilderStatus, newBlockBuilders, new int[newSize + 1], new boolean[newSize]);
+    }
+
+    @Override
+    public Block copyPositions(int[] positions, int offset, int length)
+    {
+        checkArrayRange(positions, offset, length);
+
+        if (!hasNonNullRow) {
+            return nullRle(length);
+        }
+        return super.copyPositions(positions, offset, length);
+    }
+
+    @Override
+    public Block getRegion(int position, int length)
+    {
+        int positionCount = getPositionCount();
+        checkValidRegion(positionCount, position, length);
+
+        if (!hasNonNullRow) {
+            return nullRle(length);
+        }
+        return super.getRegion(position, length);
+    }
+
+    @Override
+    public Block copyRegion(int position, int length)
+    {
+        int positionCount = getPositionCount();
+        checkValidRegion(positionCount, position, length);
+
+        if (!hasNonNullRow) {
+            return nullRle(length);
+        }
+        return super.copyRegion(position, length);
+    }
+
+    private RunLengthEncodedBlock nullRle(int length)
+    {
+        Block[] fieldBlocks = new Block[numFields];
+        for (int i = 0; i < numFields; i++) {
+            fieldBlocks[i] = fieldBlockBuilders[i].newBlockBuilderLike(null).build();
+        }
+
+        RowBlock nullRowBlock = createRowBlockInternal(0, 1, new boolean[] {true}, new int[] {0, 0}, fieldBlocks);
+        return new RunLengthEncodedBlock(nullRowBlock, length);
     }
 }

--- a/core/trino-spi/src/test/java/io/trino/spi/block/TestRowBlockBuilder.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/TestRowBlockBuilder.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.block;
+
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestRowBlockBuilder
+{
+    @Test
+    public void testBuilderProducesNullRleForNullRows()
+    {
+        // empty block
+        assertIsNullRle(blockBuilder().build(), 0);
+
+        // single null
+        assertIsNullRle(blockBuilder().appendNull().build(), 1);
+
+        // multiple nulls
+        assertIsNullRle(blockBuilder().appendNull().appendNull().build(), 2);
+
+        BlockBuilder blockBuilder = blockBuilder().appendNull().appendNull();
+        assertIsNullRle(blockBuilder.copyPositions(new int[] {0}, 0, 1), 1);
+        assertIsNullRle(blockBuilder.getRegion(0, 1), 1);
+        assertIsNullRle(blockBuilder.copyRegion(0, 1), 1);
+    }
+
+    private static BlockBuilder blockBuilder()
+    {
+        return new RowBlockBuilder(ImmutableList.of(BIGINT), null, 10);
+    }
+
+    private void assertIsNullRle(Block block, int expectedPositionCount)
+    {
+        assertEquals(block.getPositionCount(), expectedPositionCount);
+        assertEquals(block.getClass(), RunLengthEncodedBlock.class);
+        if (expectedPositionCount > 0) {
+            assertTrue(block.isNull(0));
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Add support in RowBlockBuilder for producing RunLengthEncodedBlock if all positions are null.

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

improvement
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

changes only in RowBlockBuilder, AbstractRowBlock classes in the trino-spi, not affecting API.

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

Similar to https://github.com/trinodb/trino/pull/12043

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
