### PR TITLE
Fix race condition in BinPackingNodeAllocator

### DIFF
--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestBinPackingNodeAllocator.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestBinPackingNodeAllocator.java
@@ -580,6 +580,20 @@ public class TestBinPackingNodeAllocator
         }
     }
 
+    @Test
+    public void testStressAcquireRelease()
+    {
+        InMemoryNodeManager nodeManager = testingNodeManager(basicNodesMap(NODE_1));
+        setupNodeAllocatorService(nodeManager, DataSize.of(4, GIGABYTE));
+
+        try (NodeAllocator nodeAllocator = nodeAllocatorService.getNodeAllocator(SESSION)) {
+            for (int i = 0; i < 10_000_000; ++i) {
+                NodeAllocator.NodeLease lease = nodeAllocator.acquire(REQ_32);
+                lease.release();
+            }
+        }
+    }
+
     private TaskId taskId(int partition)
     {
         return new TaskId(new StageId("test_query", 0), partition, 0);


### PR DESCRIPTION
Fix race condition in BinPackingNodeAllocator where
BinPackingNodeLease.release() could subtract from entry in
allocatedMemory map before processPendingAcquires added to this entry.

With changed allocation/deallocation protocol it is no longer possible.


> Is this change a fix, improvement, new feature, refactoring, or other?

fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core engine

## Related issues, pull requests, and links

fixes #11876

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

