### PR TITLE
Support json value constructors

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
@@ -314,6 +314,8 @@ import static io.trino.operator.scalar.RowToRowCast.ROW_TO_ROW_CAST;
 import static io.trino.operator.scalar.TryCastFunction.TRY_CAST;
 import static io.trino.operator.scalar.ZipFunction.ZIP_FUNCTIONS;
 import static io.trino.operator.scalar.ZipWithFunction.ZIP_WITH_FUNCTION;
+import static io.trino.operator.scalar.json.JsonArrayFunction.JSON_ARRAY_FUNCTION;
+import static io.trino.operator.scalar.json.JsonObjectFunction.JSON_OBJECT_FUNCTION;
 import static io.trino.type.DecimalCasts.BIGINT_TO_DECIMAL_CAST;
 import static io.trino.type.DecimalCasts.BOOLEAN_TO_DECIMAL_CAST;
 import static io.trino.type.DecimalCasts.DECIMAL_TO_BIGINT_CAST;
@@ -441,6 +443,7 @@ public final class SystemFunctionBundle
                 .scalars(JsonFunctions.class)
                 .scalars(JsonInputFunctions.class)
                 .scalars(JsonOutputFunctions.class)
+                .functions(JSON_OBJECT_FUNCTION, JSON_ARRAY_FUNCTION)
                 .scalars(ColorFunctions.class)
                 .scalars(HyperLogLogFunctions.class)
                 .scalars(QuantileDigestFunctions.class)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonArrayFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonArrayFunction.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.google.common.collect.ImmutableList;
+import io.trino.annotation.UsedByGeneratedCode;
+import io.trino.json.ir.TypedValue;
+import io.trino.metadata.BoundSignature;
+import io.trino.metadata.FunctionMetadata;
+import io.trino.metadata.Signature;
+import io.trino.metadata.SqlScalarFunction;
+import io.trino.operator.scalar.ChoicesScalarFunctionImplementation;
+import io.trino.operator.scalar.ScalarFunctionImplementation;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.Block;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeSignature;
+import io.trino.type.Json2016Type;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.trino.json.JsonInputErrorNode.JSON_ERROR;
+import static io.trino.json.ir.SqlJsonLiteralConverter.getJsonNode;
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BOXED_NULLABLE;
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.type.StandardTypes.BOOLEAN;
+import static io.trino.spi.type.StandardTypes.JSON_2016;
+import static io.trino.spi.type.TypeUtils.readNativeValue;
+import static io.trino.sql.analyzer.ExpressionAnalyzer.JSON_NO_PARAMETERS_ROW_TYPE;
+import static io.trino.util.Reflection.methodHandle;
+
+public class JsonArrayFunction
+        extends SqlScalarFunction
+{
+    public static final JsonArrayFunction JSON_ARRAY_FUNCTION = new JsonArrayFunction();
+    public static final String JSON_ARRAY_FUNCTION_NAME = "$json_array";
+    private static final MethodHandle METHOD_HANDLE = methodHandle(JsonArrayFunction.class, "jsonArray", RowType.class, Block.class, boolean.class);
+    private static final JsonNode EMPTY_ARRAY = new ArrayNode(JsonNodeFactory.instance);
+
+    private JsonArrayFunction()
+    {
+        super(FunctionMetadata.scalarBuilder()
+                .signature(Signature.builder()
+                        .name(JSON_ARRAY_FUNCTION_NAME)
+                        .typeVariable("E")
+                        .returnType(new TypeSignature(JSON_2016))
+                        .argumentTypes(ImmutableList.of(new TypeSignature("E"), new TypeSignature(BOOLEAN)))
+                        .build())
+                .argumentNullability(true, false)
+                .hidden()
+                .description("Creates a JSON array from elements")
+                .build());
+    }
+
+    @Override
+    protected ScalarFunctionImplementation specialize(BoundSignature boundSignature)
+    {
+        RowType elementsRowType = (RowType) boundSignature.getArgumentType(0);
+        MethodHandle methodHandle = METHOD_HANDLE
+                .bindTo(elementsRowType);
+        return new ChoicesScalarFunctionImplementation(
+                boundSignature,
+                FAIL_ON_NULL,
+                ImmutableList.of(BOXED_NULLABLE, NEVER_NULL),
+                methodHandle);
+    }
+
+    @UsedByGeneratedCode
+    public static JsonNode jsonArray(RowType elementsRowType, Block elementsRow, boolean nullOnNull)
+    {
+        if (JSON_NO_PARAMETERS_ROW_TYPE.equals(elementsRowType)) {
+            return EMPTY_ARRAY;
+        }
+
+        List<Block> elements = elementsRow.getChildren();
+        ImmutableList.Builder<JsonNode> arrayElements = ImmutableList.builder();
+
+        for (int i = 0; i < elementsRowType.getFields().size(); i++) {
+            Type elementType = elementsRowType.getFields().get(i).getType();
+            Object element = readNativeValue(elementType, elements.get(i), 0);
+            checkState(!JSON_ERROR.equals(element), "malformed JSON error suppressed in the input function");
+
+            JsonNode elementNode;
+            if (element == null) {
+                if (nullOnNull) {
+                    elementNode = NullNode.getInstance();
+                }
+                else { // absent on null
+                    continue;
+                }
+            }
+            else if (elementType.equals(Json2016Type.JSON_2016)) {
+                elementNode = (JsonNode) element;
+            }
+            else {
+                elementNode = getJsonNode(TypedValue.fromValueAsObject(elementType, element))
+                        .orElseThrow(() -> new TrinoException(INVALID_FUNCTION_ARGUMENT, "value passed to JSON_ARRAY function cannot be converted to JSON"));
+            }
+
+            arrayElements.add(elementNode);
+        }
+
+        return new ArrayNode(JsonNodeFactory.instance, arrayElements.build());
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonInputFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonInputFunctions.java
@@ -43,6 +43,10 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * Otherwise, the parse error is suppressed, and a marker value JSON_ERROR
  * is returned, so that the enclosing function can handle the error accordingly
  * to its error handling strategy (e.g. return a default value).
+ * <p>
+ * A duplicate key in a JSON object does not cause error.
+ * The resulting object has one entry with that key, chosen arbitrarily.
+ * This behavior fulfills the 'WITHOUT UNIQUE KEYS' option. (SQL standard p. 692)
  */
 public final class JsonInputFunctions
 {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonObjectFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonObjectFunction.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.trino.annotation.UsedByGeneratedCode;
+import io.trino.json.ir.TypedValue;
+import io.trino.metadata.BoundSignature;
+import io.trino.metadata.FunctionMetadata;
+import io.trino.metadata.Signature;
+import io.trino.metadata.SqlScalarFunction;
+import io.trino.operator.scalar.ChoicesScalarFunctionImplementation;
+import io.trino.operator.scalar.ScalarFunctionImplementation;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.Block;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeSignature;
+import io.trino.type.Json2016Type;
+
+import java.lang.invoke.MethodHandle;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static io.trino.json.JsonInputErrorNode.JSON_ERROR;
+import static io.trino.json.ir.SqlJsonLiteralConverter.getJsonNode;
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BOXED_NULLABLE;
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.type.StandardTypes.BOOLEAN;
+import static io.trino.spi.type.StandardTypes.JSON_2016;
+import static io.trino.spi.type.TypeUtils.readNativeValue;
+import static io.trino.sql.analyzer.ExpressionAnalyzer.JSON_NO_PARAMETERS_ROW_TYPE;
+import static io.trino.util.Reflection.methodHandle;
+
+public class JsonObjectFunction
+        extends SqlScalarFunction
+{
+    public static final JsonObjectFunction JSON_OBJECT_FUNCTION = new JsonObjectFunction();
+    public static final String JSON_OBJECT_FUNCTION_NAME = "$json_object";
+    private static final MethodHandle METHOD_HANDLE = methodHandle(JsonObjectFunction.class, "jsonObject", RowType.class, RowType.class, Block.class, Block.class, boolean.class, boolean.class);
+    private static final JsonNode EMPTY_OBJECT = new ObjectNode(JsonNodeFactory.instance);
+
+    private JsonObjectFunction()
+    {
+        super(FunctionMetadata.scalarBuilder()
+                .signature(Signature.builder()
+                        .name(JSON_OBJECT_FUNCTION_NAME)
+                        .typeVariable("K")
+                        .typeVariable("V")
+                        .returnType(new TypeSignature(JSON_2016))
+                        .argumentTypes(ImmutableList.of(new TypeSignature("K"), new TypeSignature("V"), new TypeSignature(BOOLEAN), new TypeSignature(BOOLEAN)))
+                        .build())
+                .argumentNullability(true, true, false, false)
+                .hidden()
+                .description("Creates a JSON object from key-value pairs")
+                .build());
+    }
+
+    @Override
+    protected ScalarFunctionImplementation specialize(BoundSignature boundSignature)
+    {
+        RowType keysRowType = (RowType) boundSignature.getArgumentType(0);
+        RowType valuesRowType = (RowType) boundSignature.getArgumentType(1);
+        checkArgument(keysRowType.getFields().size() == valuesRowType.getFields().size(), "keys and values do not match");
+        MethodHandle methodHandle = METHOD_HANDLE
+                .bindTo(keysRowType)
+                .bindTo(valuesRowType);
+        return new ChoicesScalarFunctionImplementation(
+                boundSignature,
+                FAIL_ON_NULL,
+                ImmutableList.of(BOXED_NULLABLE, BOXED_NULLABLE, NEVER_NULL, NEVER_NULL),
+                methodHandle);
+    }
+
+    @UsedByGeneratedCode
+    public static JsonNode jsonObject(RowType keysRowType, RowType valuesRowType, Block keysRow, Block valuesRow, boolean nullOnNull, boolean uniqueKeys)
+    {
+        if (JSON_NO_PARAMETERS_ROW_TYPE.equals(keysRowType)) {
+            return EMPTY_OBJECT;
+        }
+
+        Map<String, JsonNode> members = new HashMap<>();
+        List<Block> keys = keysRow.getChildren();
+        List<Block> values = valuesRow.getChildren();
+
+        for (int i = 0; i < keysRowType.getFields().size(); i++) {
+            Type keyType = keysRowType.getFields().get(i).getType();
+            Object key = readNativeValue(keyType, keys.get(i), 0);
+            if (key == null) {
+                throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "null value passed for JSON object key to JSON_OBJECT function");
+            }
+            String keyName = ((Slice) key).toStringUtf8();
+
+            Type valueType = valuesRowType.getFields().get(i).getType();
+            Object value = readNativeValue(valueType, values.get(i), 0);
+            checkState(!JSON_ERROR.equals(value), "malformed JSON error suppressed in the input function");
+
+            JsonNode valueNode;
+            if (value == null) {
+                if (nullOnNull) {
+                    valueNode = NullNode.getInstance();
+                }
+                else { // absent on null
+                    continue;
+                }
+            }
+            else if (valueType.equals(Json2016Type.JSON_2016)) {
+                valueNode = (JsonNode) value;
+            }
+            else {
+                valueNode = getJsonNode(TypedValue.fromValueAsObject(valueType, value))
+                        .orElseThrow(() -> new TrinoException(INVALID_FUNCTION_ARGUMENT, "value passed to JSON_OBJECT function cannot be converted to JSON"));
+            }
+
+            if (members.put(keyName, valueNode) != null) {
+                if (uniqueKeys) {
+                    // failure is the expected behavior when a duplicate key is found in the WITH UNIQUE KEYS option
+                    throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "duplicate key passed to JSON_OBJECT function");
+                }
+                // in the WITHOUT UNIQUE KEYS option, if a duplicate key is found, both entries should be present in the resulting JSON object (per SQL standard p. 359-360).
+                // the chosen library does not support JSON objects with duplicate keys.
+                // we try to support the WITHOUT UNIQUE KEYS option, which is the default, but we have to fail if a duplicate key appears.
+                throw new TrinoException(NOT_SUPPORTED, "cannot construct a JSON object with duplicate key");
+            }
+        }
+
+        return new ObjectNode(JsonNodeFactory.instance, members);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/AggregationAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/AggregationAnalyzer.java
@@ -43,7 +43,9 @@ import io.trino.sql.tree.InListExpression;
 import io.trino.sql.tree.InPredicate;
 import io.trino.sql.tree.IsNotNullPredicate;
 import io.trino.sql.tree.IsNullPredicate;
+import io.trino.sql.tree.JsonArray;
 import io.trino.sql.tree.JsonExists;
+import io.trino.sql.tree.JsonObject;
 import io.trino.sql.tree.JsonPathInvocation;
 import io.trino.sql.tree.JsonPathParameter;
 import io.trino.sql.tree.JsonQuery;
@@ -747,6 +749,20 @@ class AggregationAnalyzer
                     node.getPathParameters().stream()
                             .map(JsonPathParameter::getParameter)
                             .allMatch(expression -> process(expression, context));
+        }
+
+        @Override
+        protected Boolean visitJsonObject(JsonObject node, Void context)
+        {
+            return node.getMembers().stream()
+                    .allMatch(member -> process(member.getKey(), context) && process(member.getValue(), context));
+        }
+
+        @Override
+        protected Boolean visitJsonArray(JsonArray node, Void context)
+        {
+            return node.getElements().stream()
+                    .allMatch(element -> process(element.getValue(), context));
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -97,7 +97,9 @@ import io.trino.sql.tree.InPredicate;
 import io.trino.sql.tree.IntervalLiteral;
 import io.trino.sql.tree.IsNotNullPredicate;
 import io.trino.sql.tree.IsNullPredicate;
+import io.trino.sql.tree.JsonArray;
 import io.trino.sql.tree.JsonExists;
+import io.trino.sql.tree.JsonObject;
 import io.trino.sql.tree.JsonPathInvocation;
 import io.trino.sql.tree.JsonPathParameter;
 import io.trino.sql.tree.JsonPathParameter.JsonFormat;
@@ -2907,6 +2909,18 @@ public class ExpressionAnalyzer
             catch (TrinoException e) {
                 throw new TrinoException(TYPE_MISMATCH, extractLocation(node), format("Cannot output JSON value as %s using formatting %s", type, format), e);
             }
+        }
+
+        @Override
+        protected Type visitJsonObject(JsonObject node, StackableAstVisitorContext<Context> context)
+        {
+            throw new TrinoException(NOT_SUPPORTED, "JSON_OBJECT function is not yet supported");
+        }
+
+        @Override
+        protected Type visitJsonArray(JsonArray node, StackableAstVisitorContext<Context> context)
+        {
+            throw new TrinoException(NOT_SUPPORTED, "JSON_ARRAY function is not yet supported");
         }
 
         private Type getOperator(StackableAstVisitorContext<Context> context, Expression node, OperatorType operatorType, Expression... arguments)

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -98,8 +98,10 @@ import io.trino.sql.tree.IntervalLiteral;
 import io.trino.sql.tree.IsNotNullPredicate;
 import io.trino.sql.tree.IsNullPredicate;
 import io.trino.sql.tree.JsonArray;
+import io.trino.sql.tree.JsonArrayElement;
 import io.trino.sql.tree.JsonExists;
 import io.trino.sql.tree.JsonObject;
+import io.trino.sql.tree.JsonObjectMember;
 import io.trino.sql.tree.JsonPathInvocation;
 import io.trino.sql.tree.JsonPathParameter;
 import io.trino.sql.tree.JsonPathParameter.JsonFormat;
@@ -169,12 +171,14 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.collect.cache.CacheUtils.uncheckedCacheGet;
 import static io.trino.collect.cache.SafeCaches.buildNonEvictableCache;
+import static io.trino.operator.scalar.json.JsonArrayFunction.JSON_ARRAY_FUNCTION_NAME;
 import static io.trino.operator.scalar.json.JsonExistsFunction.JSON_EXISTS_FUNCTION_NAME;
 import static io.trino.operator.scalar.json.JsonInputFunctions.VARBINARY_TO_JSON;
 import static io.trino.operator.scalar.json.JsonInputFunctions.VARBINARY_UTF16_TO_JSON;
 import static io.trino.operator.scalar.json.JsonInputFunctions.VARBINARY_UTF32_TO_JSON;
 import static io.trino.operator.scalar.json.JsonInputFunctions.VARBINARY_UTF8_TO_JSON;
 import static io.trino.operator.scalar.json.JsonInputFunctions.VARCHAR_TO_JSON;
+import static io.trino.operator.scalar.json.JsonObjectFunction.JSON_OBJECT_FUNCTION_NAME;
 import static io.trino.operator.scalar.json.JsonOutputFunctions.JSON_TO_VARBINARY;
 import static io.trino.operator.scalar.json.JsonOutputFunctions.JSON_TO_VARBINARY_UTF16;
 import static io.trino.operator.scalar.json.JsonOutputFunctions.JSON_TO_VARBINARY_UTF32;
@@ -2769,7 +2773,9 @@ public class ExpressionAnalyzer
                 }
                 // if the input expression is a JSON-returning function, there should be an explicit or implicit input format (spec p.817)
                 // JSON-returning functions are: JSON_OBJECT, JSON_OBJECTAGG, JSON_ARRAY, JSON_ARRAYAGG and JSON_QUERY
-                if (parameter instanceof JsonQuery && // TODO add JSON_OBJECT, JSON_OBJECTAGG, JSON_ARRAY, JSON_ARRAYAGG when supported
+                if ((parameter instanceof JsonQuery ||
+                        parameter instanceof JsonObject ||
+                        parameter instanceof JsonArray) && // TODO add JSON_OBJECTAGG, JSON_ARRAYAGG when supported
                         parameterFormat.isEmpty()) {
                     parameterFormat = Optional.of(JsonFormat.JSON);
                 }
@@ -2914,13 +2920,239 @@ public class ExpressionAnalyzer
         @Override
         protected Type visitJsonObject(JsonObject node, StackableAstVisitorContext<Context> context)
         {
-            throw new TrinoException(NOT_SUPPORTED, "JSON_OBJECT function is not yet supported");
+            // TODO verify parameter count? Is there a limit on Row size?
+
+            ImmutableList.Builder<RowType.Field> keyFields = ImmutableList.builder();
+            ImmutableList.Builder<RowType.Field> valueFields = ImmutableList.builder();
+
+            for (JsonObjectMember member : node.getMembers()) {
+                Expression key = member.getKey();
+                Expression value = member.getValue();
+                Optional<JsonFormat> format = member.getFormat();
+
+                Type keyType = process(key, context);
+                if (!isCharacterStringType(keyType)) {
+                    throw semanticException(INVALID_FUNCTION_ARGUMENT, key, "Invalid type of JSON object key: %s", keyType.getDisplayName());
+                }
+                keyFields.add(new RowType.Field(Optional.empty(), keyType));
+
+                if (value instanceof LambdaExpression || value instanceof BindExpression) {
+                    throw semanticException(NOT_SUPPORTED, value, "%s is not supported as JSON object value", value.getClass().getSimpleName());
+                }
+
+                // types accepted for values of a JSON object:
+                // - values of types numeric, string, and boolean are passed as-is
+                // - values with explicit or implicit FORMAT, are converted to JSON (type JSON_2016)
+                // - all other values are cast to VARCHAR
+
+                // if the value expression is a JSON-returning function, there should be an explicit or implicit input format (spec p.817)
+                // JSON-returning functions are: JSON_OBJECT, JSON_OBJECTAGG, JSON_ARRAY, JSON_ARRAYAGG and JSON_QUERY
+                if ((value instanceof JsonQuery ||
+                        value instanceof JsonObject ||
+                        value instanceof JsonArray) && // TODO add JSON_OBJECTAGG, JSON_ARRAYAGG when supported
+                        format.isEmpty()) {
+                    format = Optional.of(JsonFormat.JSON);
+                }
+
+                Type valueType = process(value, context);
+
+                if (format.isPresent()) {
+                    // in case when there is an input expression with FORMAT option, the only supported behavior
+                    // for the JSON_OBJECT function is WITHOUT UNIQUE KEYS. This is because the functions used for
+                    // converting input to JSON only support this option.
+                    if (node.isUniqueKeys()) {
+                        throw semanticException(NOT_SUPPORTED, node, "WITH UNIQUE KEYS behavior is not supported for JSON_OBJECT function when input expression has FORMAT");
+                    }
+                    // resolve function to read the value as JSON
+                    ResolvedFunction inputFunction = getInputFunction(valueType, format.get(), value);
+                    Type expectedValueType = inputFunction.getSignature().getArgumentType(0);
+                    coerceType(value, valueType, expectedValueType, "value passed to JSON_OBJECT function");
+                    jsonInputFunctions.put(NodeRef.of(value), inputFunction);
+                    valueType = JSON_2016;
+                }
+                else {
+                    if (isStringType(valueType)) {
+                        if (!isCharacterStringType(valueType)) {
+                            throw semanticException(NOT_SUPPORTED, value, "Unsupported type of value passed to JSON_OBJECT function: %s", valueType.getDisplayName());
+                        }
+                    }
+
+                    if (!isStringType(valueType) && !isNumericType(valueType) && !valueType.equals(BOOLEAN)) {
+                        try {
+                            plannerContext.getMetadata().getCoercion(session, valueType, VARCHAR);
+                        }
+                        catch (OperatorNotFoundException e) {
+                            throw semanticException(NOT_SUPPORTED, node, "Unsupported type of value passed to JSON_OBJECT function: %s", valueType.getDisplayName());
+                        }
+                        addOrReplaceExpressionCoercion(value, valueType, VARCHAR);
+                        valueType = VARCHAR;
+                    }
+                }
+
+                valueFields.add(new RowType.Field(Optional.empty(), valueType));
+            }
+
+            RowType keysRowType = JSON_NO_PARAMETERS_ROW_TYPE;
+            RowType valuesRowType = JSON_NO_PARAMETERS_ROW_TYPE;
+            if (!node.getMembers().isEmpty()) {
+                keysRowType = RowType.from(keyFields.build());
+                valuesRowType = RowType.from(valueFields.build());
+            }
+
+            // resolve function
+            List<Type> argumentTypes = ImmutableList.of(keysRowType, valuesRowType, BOOLEAN, BOOLEAN);
+            ResolvedFunction function;
+            try {
+                function = plannerContext.getMetadata().resolveFunction(session, QualifiedName.of(JSON_OBJECT_FUNCTION_NAME), fromTypes(argumentTypes));
+            }
+            catch (TrinoException e) {
+                if (e.getLocation().isPresent()) {
+                    throw e;
+                }
+                throw new TrinoException(e::getErrorCode, extractLocation(node), e.getMessage(), e);
+            }
+            accessControl.checkCanExecuteFunction(SecurityContext.of(session), JSON_OBJECT_FUNCTION_NAME);
+            resolvedFunctions.put(NodeRef.of(node), function);
+
+            // analyze returned type and format
+            Type returnedType = VARCHAR; // default
+            if (node.getReturnedType().isPresent()) {
+                try {
+                    returnedType = plannerContext.getTypeManager().getType(toTypeSignature(node.getReturnedType().get()));
+                }
+                catch (TypeNotFoundException e) {
+                    throw semanticException(TYPE_MISMATCH, node, "Unknown type: %s", node.getReturnedType().get());
+                }
+            }
+            JsonFormat outputFormat = node.getOutputFormat().orElse(JsonFormat.JSON); // default
+
+            // resolve function to format output
+            ResolvedFunction outputFunction = getOutputFunction(returnedType, outputFormat, node);
+            jsonOutputFunctions.put(NodeRef.of(node), outputFunction);
+
+            // cast the output value to the declared returned type if necessary
+            Type outputType = outputFunction.getSignature().getReturnType();
+            if (!outputType.equals(returnedType)) {
+                try {
+                    plannerContext.getMetadata().getCoercion(session, outputType, returnedType);
+                }
+                catch (OperatorNotFoundException e) {
+                    throw semanticException(TYPE_MISMATCH, node, "Cannot return type %s from JSON_OBJECT function", returnedType);
+                }
+            }
+
+            return setExpressionType(node, returnedType);
         }
 
         @Override
         protected Type visitJsonArray(JsonArray node, StackableAstVisitorContext<Context> context)
         {
-            throw new TrinoException(NOT_SUPPORTED, "JSON_ARRAY function is not yet supported");
+            // TODO verify parameter count? Is there a limit on Row size?
+
+            ImmutableList.Builder<RowType.Field> elementFields = ImmutableList.builder();
+
+            for (JsonArrayElement arrayElement : node.getElements()) {
+                Expression element = arrayElement.getValue();
+                Optional<JsonFormat> format = arrayElement.getFormat();
+
+                if (element instanceof LambdaExpression || element instanceof BindExpression) {
+                    throw semanticException(NOT_SUPPORTED, element, "%s is not supported as JSON array element", element.getClass().getSimpleName());
+                }
+
+                // types accepted for elements of a JSON array:
+                // - values of types numeric, string, and boolean are passed as-is
+                // - values with explicit or implicit FORMAT, are converted to JSON (type JSON_2016)
+                // - all other values are cast to VARCHAR
+
+                // if the value expression is a JSON-returning function, there should be an explicit or implicit input format (spec p.817)
+                // JSON-returning functions are: JSON_OBJECT, JSON_OBJECTAGG, JSON_ARRAY, JSON_ARRAYAGG and JSON_QUERY
+                if ((element instanceof JsonQuery ||
+                        element instanceof JsonObject ||
+                        element instanceof JsonArray) && // TODO add JSON_OBJECTAGG, JSON_ARRAYAGG when supported
+                        format.isEmpty()) {
+                    format = Optional.of(JsonFormat.JSON);
+                }
+
+                Type elementType = process(element, context);
+
+                if (format.isPresent()) {
+                    // resolve function to read the value as JSON
+                    ResolvedFunction inputFunction = getInputFunction(elementType, format.get(), element);
+                    Type expectedElementType = inputFunction.getSignature().getArgumentType(0);
+                    coerceType(element, elementType, expectedElementType, "value passed to JSON_ARRAY function");
+                    jsonInputFunctions.put(NodeRef.of(element), inputFunction);
+                    elementType = JSON_2016;
+                }
+                else {
+                    if (isStringType(elementType)) {
+                        if (!isCharacterStringType(elementType)) {
+                            throw semanticException(NOT_SUPPORTED, element, "Unsupported type of value passed to JSON_ARRAY function: %s", elementType.getDisplayName());
+                        }
+                    }
+
+                    if (!isStringType(elementType) && !isNumericType(elementType) && !elementType.equals(BOOLEAN)) {
+                        try {
+                            plannerContext.getMetadata().getCoercion(session, elementType, VARCHAR);
+                        }
+                        catch (OperatorNotFoundException e) {
+                            throw semanticException(NOT_SUPPORTED, node, "Unsupported type of value passed to JSON_ARRAY function: %s", elementType.getDisplayName());
+                        }
+                        addOrReplaceExpressionCoercion(element, elementType, VARCHAR);
+                        elementType = VARCHAR;
+                    }
+                }
+
+                elementFields.add(new RowType.Field(Optional.empty(), elementType));
+            }
+
+            RowType elementsRowType = JSON_NO_PARAMETERS_ROW_TYPE;
+            if (!node.getElements().isEmpty()) {
+                elementsRowType = RowType.from(elementFields.build());
+            }
+
+            // resolve function
+            List<Type> argumentTypes = ImmutableList.of(elementsRowType, BOOLEAN);
+            ResolvedFunction function;
+            try {
+                function = plannerContext.getMetadata().resolveFunction(session, QualifiedName.of(JSON_ARRAY_FUNCTION_NAME), fromTypes(argumentTypes));
+            }
+            catch (TrinoException e) {
+                if (e.getLocation().isPresent()) {
+                    throw e;
+                }
+                throw new TrinoException(e::getErrorCode, extractLocation(node), e.getMessage(), e);
+            }
+            accessControl.checkCanExecuteFunction(SecurityContext.of(session), JSON_ARRAY_FUNCTION_NAME);
+            resolvedFunctions.put(NodeRef.of(node), function);
+
+            // analyze returned type and format
+            Type returnedType = VARCHAR; // default
+            if (node.getReturnedType().isPresent()) {
+                try {
+                    returnedType = plannerContext.getTypeManager().getType(toTypeSignature(node.getReturnedType().get()));
+                }
+                catch (TypeNotFoundException e) {
+                    throw semanticException(TYPE_MISMATCH, node, "Unknown type: %s", node.getReturnedType().get());
+                }
+            }
+            JsonFormat outputFormat = node.getOutputFormat().orElse(JsonFormat.JSON); // default
+
+            // resolve function to format output
+            ResolvedFunction outputFunction = getOutputFunction(returnedType, outputFormat, node);
+            jsonOutputFunctions.put(NodeRef.of(node), outputFunction);
+
+            // cast the output value to the declared returned type if necessary
+            Type outputType = outputFunction.getSignature().getReturnType();
+            if (!outputType.equals(returnedType)) {
+                try {
+                    plannerContext.getMetadata().getCoercion(session, outputType, returnedType);
+                }
+                catch (OperatorNotFoundException e) {
+                    throw semanticException(TYPE_MISMATCH, node, "Cannot return type %s from JSON_ARRAY function", returnedType);
+                }
+            }
+
+            return setExpressionType(node, returnedType);
         }
 
         private Type getOperator(StackableAstVisitorContext<Context> context, Expression node, OperatorType operatorType, Expression... arguments)

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/AbstractTestFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/AbstractTestFunctions.java
@@ -31,6 +31,7 @@ import org.testng.annotations.BeforeClass;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static io.airlift.testing.Closeables.closeAllRuntimeException;
 import static io.trino.SessionTestUtils.TEST_SESSION;
@@ -100,6 +101,11 @@ public abstract class AbstractTestFunctions
                 statement,
                 createDecimalType(expectedResult.getPrecision(), expectedResult.getScale()),
                 expectedResult);
+    }
+
+    protected void assertAmbiguousFunction(@Language("SQL") String projection, Type expectedType, Set<Object> expected)
+    {
+        functionAssertions.assertAmbiguousFunction(projection, expectedType, expected);
     }
 
     protected void assertInvalidFunction(@Language("SQL") String projection, ErrorCodeSupplier errorCode, String message)

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestJsonInputFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestJsonInputFunctions.java
@@ -17,10 +17,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
 import java.nio.charset.Charset;
@@ -225,5 +227,18 @@ public class TestJsonInputFunctions
                 "\"$varchar_to_json\"(null, true)",
                 JSON_2016,
                 null);
+    }
+
+    @Test
+    public void testDuplicateObjectKeys()
+    {
+        // A duplicate key does not cause error. The resulting object has one member with that key, chosen arbitrarily from the input entries.
+        // According to the SQL standard, this behavior is a correct implementation of the 'WITHOUT UNIQUE KEYS' option.
+        assertAmbiguousFunction(
+                "\"$varchar_to_json\"('{\"key\" : 1, \"key\" : 2}', true)",
+                JSON_2016,
+                ImmutableSet.of(
+                        new ObjectNode(JsonNodeFactory.instance, ImmutableMap.of("key", IntNode.valueOf(1))),
+                        new ObjectNode(JsonNodeFactory.instance, ImmutableMap.of("key", IntNode.valueOf(2)))));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJsonArrayFunction.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJsonArrayFunction.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.nio.charset.Charset;
+
+import static com.google.common.io.BaseEncoding.base16;
+import static io.trino.spi.StandardErrorCode.JSON_INPUT_CONVERSION_ERROR;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
+import static java.nio.charset.StandardCharsets.UTF_16LE;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+public class TestJsonArrayFunction
+{
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testCreateEmptyArray()
+    {
+        assertThat(assertions.query(
+                "SELECT json_array()"))
+                .matches("VALUES VARCHAR '[]'");
+    }
+
+    @Test
+    public void testMultipleElements()
+    {
+        assertThat(assertions.query(
+                "SELECT json_array(1, true)"))
+                .matches("VALUES VARCHAR '[1,true]'");
+    }
+
+    @Test
+    public void testNullElement()
+    {
+        // ABSENT ON NULL is the default option
+        assertThat(assertions.query(
+                "SELECT json_array(null)"))
+                .matches("VALUES VARCHAR '[]'");
+
+        assertThat(assertions.query(
+                "SELECT json_array(null ABSENT ON NULL)"))
+                .matches("VALUES VARCHAR '[]'");
+
+        assertThat(assertions.query(
+                "SELECT json_array(null NULL ON NULL)"))
+                .matches("VALUES VARCHAR '[null]'");
+    }
+
+    @Test
+    public void testDuplicateElement()
+    {
+        assertThat(assertions.query(
+                "SELECT json_array(1, 1)"))
+                .matches("VALUES VARCHAR '[1,1]'");
+    }
+
+    @Test
+    public void testElementWithFormat()
+    {
+        // character string to be read as JSON
+        assertThat(assertions.query(
+                "SELECT json_array('{\"a\" : 1}' FORMAT JSON)"))
+                .matches("VALUES VARCHAR '[{\"a\":1}]'");
+
+        // binary string to be read as JSON
+        byte[] bytes = "{\"a\" : 1}".getBytes(UTF_16LE);
+        String varbinaryLiteral = "X'" + base16().encode(bytes) + "'";
+        assertThat(assertions.query(
+                "SELECT json_array(" + varbinaryLiteral + " FORMAT JSON ENCODING UTF16)"))
+                .matches("VALUES VARCHAR '[{\"a\":1}]'");
+
+        // malformed string to be read as JSON
+        assertTrinoExceptionThrownBy(() -> assertions.query(
+                "SELECT json_array('[...' FORMAT JSON)"))
+                .hasErrorCode(JSON_INPUT_CONVERSION_ERROR);
+
+        // duplicate key inside the formatted element: only one entry is retained
+        assertThat(assertions.query(
+                "SELECT json_array('{\"a\" : 1, \"a\" : 1}' FORMAT JSON)"))
+                .matches("VALUES VARCHAR '[{\"a\":1}]'");
+    }
+
+    @Test
+    public void testElementTypes()
+    {
+        assertThat(assertions.query(
+                "SELECT json_array(1e0)"))
+                .matches("VALUES VARCHAR '[1.0]'");
+
+        // uuid can be cast to varchar
+        assertThat(assertions.query(
+                "SELECT json_array(UUID '12151fd2-7586-11e9-8f9e-2a86e4085a59')"))
+                .matches("VALUES VARCHAR '[\"12151fd2-7586-11e9-8f9e-2a86e4085a59\"]'");
+
+        // date can be cast to varchar
+        assertThat(assertions.query(
+                "SELECT json_array(DATE '2001-01-31')"))
+                .matches("VALUES VARCHAR '[\"2001-01-31\"]'");
+
+        // HyperLogLog cannot be cast to varchar
+        assertTrinoExceptionThrownBy(() -> assertions.query(
+                "SELECT json_array(approx_set(1))"))
+                .hasErrorCode(NOT_SUPPORTED);
+    }
+
+    @Test
+    public void testJsonReturningFunctionAsElement()
+    {
+        assertThat(assertions.query(
+                "SELECT json_array(json_array(1))"))
+                .matches("VALUES VARCHAR '[[1]]'");
+    }
+
+    @Test
+    public void testSubqueries()
+    {
+        assertThat(assertions.query(
+                "SELECT json_array((SELECT 1))"))
+                .matches("VALUES VARCHAR '[1]'");
+    }
+
+    @Test
+    public void testOutputFormat()
+    {
+        assertThat(assertions.query(
+                "SELECT json_array(true)"))
+                .matches("VALUES VARCHAR '[true]'");
+
+        // default returned type
+        assertThat(assertions.query(
+                "SELECT json_array(true RETURNING varchar)"))
+                .matches("VALUES VARCHAR '[true]'");
+
+        // default returned format
+        assertThat(assertions.query(
+                "SELECT json_array(true RETURNING varchar FORMAT JSON)"))
+                .matches("VALUES VARCHAR '[true]'");
+
+        assertThat(assertions.query(
+                "SELECT json_array(true RETURNING varchar(100))"))
+                .matches("VALUES CAST('[true]' AS varchar(100))");
+
+        // varbinary output
+        String output = "[true]";
+
+        byte[] bytes = output.getBytes(UTF_8);
+        String varbinaryLiteral = "X'" + base16().encode(bytes) + "'";
+        assertThat(assertions.query(
+                "SELECT json_array(true RETURNING varbinary FORMAT JSON ENCODING UTF8)"))
+                .matches("VALUES " + varbinaryLiteral);
+
+        bytes = output.getBytes(UTF_16LE);
+        varbinaryLiteral = "X'" + base16().encode(bytes) + "'";
+        assertThat(assertions.query(
+                "SELECT json_array(true RETURNING varbinary FORMAT JSON ENCODING UTF16)"))
+                .matches("VALUES " + varbinaryLiteral);
+
+        bytes = output.getBytes(Charset.forName("UTF_32LE"));
+        varbinaryLiteral = "X'" + base16().encode(bytes) + "'";
+        assertThat(assertions.query(
+                "SELECT json_array(true RETURNING varbinary FORMAT JSON ENCODING UTF32)"))
+                .matches("VALUES " + varbinaryLiteral);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJsonObjectFunction.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJsonObjectFunction.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.nio.charset.Charset;
+
+import static com.google.common.io.BaseEncoding.base16;
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.StandardErrorCode.JSON_INPUT_CONVERSION_ERROR;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
+import static java.nio.charset.StandardCharsets.UTF_16LE;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+public class TestJsonObjectFunction
+{
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testCreateEmptyObject()
+    {
+        assertThat(assertions.query(
+                "SELECT json_object()"))
+                .matches("VALUES VARCHAR '{}'");
+    }
+
+    @Test
+    public void testArgumentPassingConventions()
+    {
+        assertThat(assertions.query(
+                "SELECT json_object('X' : 'Y')"))
+                .matches("VALUES VARCHAR '{\"X\":\"Y\"}'");
+
+        assertThat(assertions.query(
+                "SELECT json_object(KEY 'X' VALUE 'Y')"))
+                .matches("VALUES VARCHAR '{\"X\":\"Y\"}'");
+
+        assertThat(assertions.query(
+                "SELECT json_object('X' VALUE 'Y')"))
+                .matches("VALUES VARCHAR '{\"X\":\"Y\"}'");
+    }
+
+    @Test
+    public void testMultipleMembers()
+    {
+        // the order of members in the result JSON object is arbitrary
+        assertThat(assertions.query(
+                "SELECT json_object('key_1' : 1, 'key_2' : 2)"))
+                .matches("VALUES VARCHAR '{\"key_2\":2,\"key_1\":1}'");
+    }
+
+    @Test
+    public void testNullKey()
+    {
+        assertTrinoExceptionThrownBy(() -> assertions.query(
+                "SELECT json_object(CAST(null AS varchar) : 1)"))
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessage("null value passed for JSON object key to JSON_OBJECT function");
+    }
+
+    @Test
+    public void testNullValue()
+    {
+        // null value becomes JSON null
+        assertThat(assertions.query(
+                "SELECT json_object('key' : null NULL ON NULL)"))
+                .matches("VALUES VARCHAR '{\"key\":null}'");
+
+        // NULL ON NULL is the default option
+        assertThat(assertions.query(
+                "SELECT json_object('key' : null)"))
+                .matches("VALUES VARCHAR '{\"key\":null}'");
+
+        // member with null value is omitted
+        assertThat(assertions.query(
+                "SELECT json_object('key' : null ABSENT ON NULL)"))
+                .matches("VALUES VARCHAR '{}'");
+    }
+
+    @Test
+    public void testDuplicateKey()
+    {
+        // we don't support it because it requires creating a JSON object with duplicate key
+        assertTrinoExceptionThrownBy(() -> assertions.query(
+                "SELECT json_object('key' : 1, 'key' : 2 WITHOUT UNIQUE KEYS)"))
+                .hasErrorCode(NOT_SUPPORTED)
+                .hasMessage("cannot construct a JSON object with duplicate key");
+
+        // WITHOUT UNIQUE KEYS is the default option
+        assertTrinoExceptionThrownBy(() -> assertions.query(
+                "SELECT json_object('key' : 1, 'key' : 2)"))
+                .hasErrorCode(NOT_SUPPORTED)
+                .hasMessage("cannot construct a JSON object with duplicate key");
+
+        assertTrinoExceptionThrownBy(() -> assertions.query(
+                "SELECT json_object('key' : 1, 'key' : 2 WITH UNIQUE KEYS)"))
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessage("duplicate key passed to JSON_OBJECT function");
+    }
+
+    @Test
+    public void testValueWithFormat()
+    {
+        // character string to be read as JSON
+        assertThat(assertions.query(
+                "SELECT json_object('key' : '[ 1, true, \"a\", null ]' FORMAT JSON)"))
+                .matches("VALUES VARCHAR '{\"key\":[1,true,\"a\",null]}'");
+
+        // binary string to be read as JSON
+        byte[] bytes = "{\"a\" : 1}".getBytes(UTF_16LE);
+        String varbinaryLiteral = "X'" + base16().encode(bytes) + "'";
+        assertThat(assertions.query(
+                "SELECT json_object('key' : " + varbinaryLiteral + " FORMAT JSON ENCODING UTF16)"))
+                .matches("VALUES VARCHAR '{\"key\":{\"a\":1}}'");
+
+        // malformed string to be read as JSON
+        assertTrinoExceptionThrownBy(() -> assertions.query(
+                "SELECT json_object('key' : '[...' FORMAT JSON)"))
+                .hasErrorCode(JSON_INPUT_CONVERSION_ERROR);
+
+        // duplicate key inside the formatted value: only one entry is retained
+        assertThat(assertions.query(
+                "SELECT json_object('key' : '{\"a\" : 1, \"a\" : 1}' FORMAT JSON)"))
+                .matches("VALUES VARCHAR '{\"key\":{\"a\":1}}'");
+
+        assertThat(assertions.query(
+                "SELECT json_object('key' : '{\"a\" : 1, \"a\" : 1}' FORMAT JSON WITHOUT UNIQUE KEYS)"))
+                .matches("VALUES VARCHAR '{\"key\":{\"a\":1}}'");
+
+        // in presence of input value with FORMAT, the option WITH UNIQUE KEYS is not supported, because the input function does not support this semantics
+        assertTrinoExceptionThrownBy(() -> assertions.query(
+                "SELECT json_object('key' : '{\"a\" : 1, \"a\" : 1}' FORMAT JSON WITH UNIQUE KEYS)"))
+                .hasErrorCode(NOT_SUPPORTED)
+                .hasMessage("line 1:8: WITH UNIQUE KEYS behavior is not supported for JSON_OBJECT function when input expression has FORMAT");
+    }
+
+    @Test
+    public void testValueTypes()
+    {
+        assertThat(assertions.query(
+                "SELECT json_object('key' : 1e0)"))
+                .matches("VALUES VARCHAR '{\"key\":1.0}'");
+
+        // uuid can be cast to varchar
+        assertThat(assertions.query(
+                "SELECT json_object('key' : UUID '12151fd2-7586-11e9-8f9e-2a86e4085a59')"))
+                .matches("VALUES VARCHAR '{\"key\":\"12151fd2-7586-11e9-8f9e-2a86e4085a59\"}'");
+
+        // date can be cast to varchar
+        assertThat(assertions.query(
+                "SELECT json_object('key' : DATE '2001-01-31')"))
+                .matches("VALUES VARCHAR '{\"key\":\"2001-01-31\"}'");
+
+        // HyperLogLog cannot be cast to varchar
+        assertTrinoExceptionThrownBy(() -> assertions.query(
+                "SELECT json_object('key' : (approx_set(1)))"))
+                .hasErrorCode(NOT_SUPPORTED);
+    }
+
+    @Test
+    public void testJsonReturningFunctionAsValue()
+    {
+        assertThat(assertions.query(
+                "SELECT json_object('key' : json_object('a' : 1))"))
+                .matches("VALUES VARCHAR '{\"key\":{\"a\":1}}'");
+    }
+
+    @Test
+    public void testSubqueries()
+    {
+        assertThat(assertions.query(
+                "SELECT json_object((SELECT 'key') : (SELECT 1))"))
+                .matches("VALUES VARCHAR '{\"key\":1}'");
+    }
+
+    @Test
+    public void testOutputFormat()
+    {
+        assertThat(assertions.query(
+                "SELECT json_object('key' : 1)"))
+                .matches("VALUES VARCHAR '{\"key\":1}'");
+
+        // default returned type
+        assertThat(assertions.query(
+                "SELECT json_object('key' : 1 RETURNING varchar)"))
+                .matches("VALUES VARCHAR '{\"key\":1}'");
+
+        // default returned format
+        assertThat(assertions.query(
+                "SELECT json_object('key' : 1 RETURNING varchar FORMAT JSON)"))
+                .matches("VALUES VARCHAR '{\"key\":1}'");
+
+        assertThat(assertions.query(
+                "SELECT json_object('key' : 1 RETURNING varchar(100))"))
+                .matches("VALUES CAST('{\"key\":1}' AS varchar(100))");
+
+        // varbinary output
+        String output = "{\"key\":1}";
+
+        byte[] bytes = output.getBytes(UTF_8);
+        String varbinaryLiteral = "X'" + base16().encode(bytes) + "'";
+        assertThat(assertions.query(
+                "SELECT json_object('key' : 1 RETURNING varbinary FORMAT JSON ENCODING UTF8)"))
+                .matches("VALUES " + varbinaryLiteral);
+
+        bytes = output.getBytes(UTF_16LE);
+        varbinaryLiteral = "X'" + base16().encode(bytes) + "'";
+        assertThat(assertions.query(
+                "SELECT json_object('key' : 1 RETURNING varbinary FORMAT JSON ENCODING UTF16)"))
+                .matches("VALUES " + varbinaryLiteral);
+
+        bytes = output.getBytes(Charset.forName("UTF_32LE"));
+        varbinaryLiteral = "X'" + base16().encode(bytes) + "'";
+        assertThat(assertions.query(
+                "SELECT json_object('key' : 1 RETURNING varbinary FORMAT JSON ENCODING UTF32)"))
+                .matches("VALUES " + varbinaryLiteral);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestListagg.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestListagg.java
@@ -176,52 +176,52 @@ public class TestListagg
     {
         // missing WITHIN GROUP (ORDER BY ...)
         assertThatThrownBy(() -> assertions.query(
-                "SELECT listagg(value, ',') " +
-                        "FROM (VALUES 'a') t(value)"))
+                "SELECT listagg(v, ',') " +
+                        "FROM (VALUES 'a') t(v)"))
                 .isInstanceOf(ParsingException.class)
-                .hasMessage("line 1:28: mismatched input 'FROM'. Expecting: 'WITHIN'");
+                .hasMessage("line 1:24: mismatched input 'FROM'. Expecting: 'WITHIN'");
 
         // missing WITHIN GROUP (ORDER BY ...)
         assertThatThrownBy(() -> assertions.query(
-                "SELECT listagg(value) " +
-                        "FROM (VALUES 'a') t(value)"))
+                "SELECT listagg(v) " +
+                        "FROM (VALUES 'a') t(v)"))
                 .isInstanceOf(ParsingException.class)
-                .hasMessage("line 1:23: mismatched input 'FROM'. Expecting: 'WITHIN'");
+                .hasMessage("line 1:19: mismatched input 'FROM'. Expecting: 'WITHIN'");
 
         // too many arguments
         assertThatThrownBy(() -> assertions.query(
-                "SELECT listagg(value, ',', '...') WITHIN GROUP (ORDER BY value)" +
-                        "FROM (VALUES 'a') t(value)"))
+                "SELECT listagg(v, ',', '...') WITHIN GROUP (ORDER BY v)" +
+                        "FROM (VALUES 'a') t(v)"))
                 .isInstanceOf(ParsingException.class)
-                .hasMessage("line 1:26: mismatched input ','. Expecting: ')', 'ON'");
+                .hasMessage("line 1:22: mismatched input ','. Expecting: ')', 'ON'");
 
         // window frames are not supported
         assertThatThrownBy(() -> assertions.query(
-                "SELECT listagg(value, ',') WITHIN GROUP (ORDER BY value) OVER (PARTITION BY id)" +
-                        "FROM (VALUES (1, 'a')) t(id, value)"))
+                "SELECT listagg(v, ',') WITHIN GROUP (ORDER BY v) OVER (PARTITION BY id)" +
+                        "FROM (VALUES (1, 'a')) t(id, v)"))
                 .isInstanceOf(ParsingException.class)
-                .hasMessage("line 1:63: mismatched input '('. Expecting: ',', 'EXCEPT', 'FETCH', 'FROM', 'GROUP', 'HAVING', 'INTERSECT', 'LIMIT', 'OFFSET', 'ORDER', 'UNION', 'WHERE', 'WINDOW', <EOF>");
+                .hasMessage("line 1:55: mismatched input '('. Expecting: ',', 'EXCEPT', 'FETCH', 'FROM', 'GROUP', 'HAVING', 'INTERSECT', 'LIMIT', 'OFFSET', 'ORDER', 'UNION', 'WHERE', 'WINDOW', <EOF>");
 
         // invalid argument for ON OVERFLOW clause
         assertThatThrownBy(() -> assertions.query(
-                "SELECT listagg(value, ',' ON OVERFLOW COLLAPSE) WITHIN GROUP (ORDER BY value)" +
-                        "FROM (VALUES 'a') t(value)"))
+                "SELECT listagg(v, ',' ON OVERFLOW COLLAPSE) WITHIN GROUP (ORDER BY v)" +
+                        "FROM (VALUES 'a') t(v)"))
                 .isInstanceOf(ParsingException.class)
-                .hasMessage("line 1:39: mismatched input 'COLLAPSE'. Expecting: 'ERROR', 'TRUNCATE'");
+                .hasMessage("line 1:35: mismatched input 'COLLAPSE'. Expecting: 'ERROR', 'TRUNCATE'");
 
         // invalid separator type (integer instead of varchar)
         assertThatThrownBy(() -> assertions.query(
-                "SELECT LISTAGG(value, 123) WITHIN GROUP (ORDER BY value) " +
-                        "FROM (VALUES 'Trino', 'SQL', 'everything') t(value) "))
+                "SELECT LISTAGG(v, 123) WITHIN GROUP (ORDER BY v) " +
+                        "FROM (VALUES 'Trino', 'SQL', 'everything') t(v) "))
                 .isInstanceOf(ParsingException.class)
-                .hasMessage("line 1:23: mismatched input '123'. Expecting: <string>");
+                .hasMessage("line 1:19: mismatched input '123'. Expecting: <string>");
 
         // invalid truncation filler type (integer instead of varchar)
         assertThatThrownBy(() -> assertions.query(
-                "SELECT LISTAGG(value, ',' ON OVERFLOW TRUNCATE 1234567890 WITHOUT COUNT) WITHIN GROUP (ORDER BY value) " +
-                        "FROM (VALUES 'Trino', 'SQL', 'everything') t(value) "))
+                "SELECT LISTAGG(v, ',' ON OVERFLOW TRUNCATE 1234567890 WITHOUT COUNT) WITHIN GROUP (ORDER BY v) " +
+                        "FROM (VALUES 'Trino', 'SQL', 'everything') t(v) "))
                 .isInstanceOf(ParsingException.class)
-                .hasMessage("line 1:48: mismatched input '1234567890'. Expecting: 'WITH', 'WITHOUT', <string>");
+                .hasMessage("line 1:44: mismatched input '1234567890'. Expecting: 'WITH', 'WITHOUT', <string>");
     }
 
     @Test

--- a/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4
+++ b/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4
@@ -541,6 +541,21 @@ primaryExpression
         (emptyBehavior=jsonQueryBehavior ON EMPTY)?
         (errorBehavior=jsonQueryBehavior ON ERROR)?
       ')'                                                                                 #jsonQuery
+    | JSON_OBJECT '('
+        (
+          jsonObjectMember (',' jsonObjectMember)*
+          (NULL ON NULL | ABSENT ON NULL)?
+          (WITH UNIQUE KEYS? | WITHOUT UNIQUE KEYS?)?
+        )?
+        (RETURNING type (FORMAT jsonRepresentation)?)?
+      ')'                                                                                 #jsonObject
+    | JSON_ARRAY '('
+        (
+          jsonValueExpression (',' jsonValueExpression)*
+          (NULL ON NULL | ABSENT ON NULL)?
+        )?
+        (RETURNING type (FORMAT jsonRepresentation)?)?
+     ')'                                                                                  #jsonArray
     ;
 
 jsonPathInvocation
@@ -583,6 +598,11 @@ jsonQueryBehavior
     | NULL
     | EMPTY ARRAY
     | EMPTY OBJECT
+    ;
+
+jsonObjectMember
+    : KEY? expression VALUE jsonValueExpression
+    | expression ':' jsonValueExpression
     ;
 
 processingMode
@@ -807,7 +827,7 @@ number
 
 nonReserved
     // IMPORTANT: this rule must only contain tokens. Nested rules are not supported. See SqlParser.exitNonReserved
-    : ADD | ADMIN | AFTER | ALL | ANALYZE | ANY | ARRAY | ASC | AT | AUTHORIZATION
+    : ABSENT | ADD | ADMIN | AFTER | ALL | ANALYZE | ANY | ARRAY | ASC | AT | AUTHORIZATION
     | BERNOULLI | BOTH
     | CALL | CASCADE | CATALOGS | COLUMN | COLUMNS | COMMENT | COMMIT | COMMITTED | CONDITIONAL | COPARTITION | COUNT | CURRENT
     | DATA | DATE | DAY | DEFAULT | DEFINE | DEFINER | DESC | DESCRIPTOR | DISTRIBUTED | DOUBLE
@@ -817,7 +837,7 @@ nonReserved
     | HOUR
     | IF | IGNORE | INCLUDING | INITIAL | INPUT | INTERVAL | INVOKER | IO | ISOLATION
     | JSON
-    | KEEP
+    | KEEP | KEY | KEYS
     | LAST | LATERAL | LEADING | LEVEL | LIMIT | LOCAL | LOGICAL
     | MAP | MATCH | MATCHED | MATCHES | MATCH_RECOGNIZE | MATERIALIZED | MEASURES | MERGE | MINUTE | MONTH
     | NEXT | NFC | NFD | NFKC | NFKD | NO | NONE | NULLIF | NULLS
@@ -828,13 +848,14 @@ nonReserved
     | SCALAR | SCHEMA | SCHEMAS | SECOND | SECURITY | SEEK | SERIALIZABLE | SESSION | SET | SETS
     | SHOW | SOME | START | STATS | SUBSET | SUBSTRING | SYSTEM
     | TABLES | TABLESAMPLE | TEXT | TEXT_STRING | TIES | TIME | TIMESTAMP | TO | TRAILING | TRANSACTION | TRUNCATE | TRY_CAST | TYPE
-    | UNBOUNDED | UNCOMMITTED | UNCONDITIONAL | UNKNOWN | UNMATCHED | UPDATE | USE | USER | UTF16 | UTF32 | UTF8
-    | VALIDATE | VERBOSE | VERSION | VIEW
+    | UNBOUNDED | UNCOMMITTED | UNCONDITIONAL | UNIQUE | UNKNOWN | UNMATCHED | UPDATE | USE | USER | UTF16 | UTF32 | UTF8
+    | VALIDATE | VALUE | VERBOSE | VERSION | VIEW
     | WINDOW | WITHIN | WITHOUT | WORK | WRAPPER | WRITE
     | YEAR
     | ZONE
     ;
 
+ABSENT: 'ABSENT';
 ADD: 'ADD';
 ADMIN: 'ADMIN';
 AFTER: 'AFTER';
@@ -943,10 +964,14 @@ IS: 'IS';
 ISOLATION: 'ISOLATION';
 JOIN: 'JOIN';
 JSON: 'JSON';
+JSON_ARRAY: 'JSON_ARRAY';
 JSON_EXISTS: 'JSON_EXISTS';
+JSON_OBJECT: 'JSON_OBJECT';
 JSON_QUERY: 'JSON_QUERY';
 JSON_VALUE: 'JSON_VALUE';
 KEEP: 'KEEP';
+KEY: 'KEY';
+KEYS: 'KEYS';
 LAST: 'LAST';
 LATERAL: 'LATERAL';
 LEADING: 'LEADING';
@@ -1073,6 +1098,7 @@ UNBOUNDED: 'UNBOUNDED';
 UNCOMMITTED: 'UNCOMMITTED';
 UNCONDITIONAL: 'UNCONDITIONAL';
 UNION: 'UNION';
+UNIQUE: 'UNIQUE';
 UNKNOWN: 'UNKNOWN';
 UNMATCHED: 'UNMATCHED';
 UNNEST: 'UNNEST';
@@ -1084,6 +1110,7 @@ UTF16: 'UTF16';
 UTF32: 'UTF32';
 UTF8: 'UTF8';
 VALIDATE: 'VALIDATE';
+VALUE: 'VALUE';
 VALUES: 'VALUES';
 VERBOSE: 'VERBOSE';
 VERSION: 'VERSION';

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
@@ -1136,4 +1136,14 @@ public abstract class AstVisitor<R, C>
     {
         return visitNode(node, context);
     }
+
+    protected R visitJsonObject(JsonObject node, C context)
+    {
+        return visitExpression(node, context);
+    }
+
+    protected R visitJsonArray(JsonArray node, C context)
+    {
+        return visitExpression(node, context);
+    }
 }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
@@ -957,4 +957,24 @@ public abstract class DefaultTraversalVisitor<C>
 
         return null;
     }
+
+    @Override
+    protected Void visitJsonObject(JsonObject node, C context)
+    {
+        for (JsonObjectMember member : node.getMembers()) {
+            process(member, context);
+        }
+
+        return null;
+    }
+
+    @Override
+    protected Void visitJsonArray(JsonArray node, C context)
+    {
+        for (JsonArrayElement element : node.getElements()) {
+            process(element, context);
+        }
+
+        return null;
+    }
 }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionRewriter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionRewriter.java
@@ -284,4 +284,14 @@ public class ExpressionRewriter<C>
     {
         return rewriteExpression(node, context, treeRewriter);
     }
+
+    public Expression rewriteJsonObject(JsonObject node, C context, ExpressionTreeRewriter<C> treeRewriter)
+    {
+        return rewriteExpression(node, context, treeRewriter);
+    }
+
+    public Expression rewriteJsonArray(JsonArray node, C context, ExpressionTreeRewriter<C> treeRewriter)
+    {
+        return rewriteExpression(node, context, treeRewriter);
+    }
 }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/JsonArray.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/JsonArray.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.sql.tree.JsonPathParameter.JsonFormat;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class JsonArray
+        extends Expression
+{
+    private final List<JsonArrayElement> elements;
+    private final boolean nullOnNull;
+    private final Optional<DataType> returnedType;
+    private final Optional<JsonFormat> outputFormat;
+
+    public JsonArray(Optional<NodeLocation> location, List<JsonArrayElement> elements, boolean nullOnNull, Optional<DataType> returnedType, Optional<JsonFormat> outputFormat)
+    {
+        super(location);
+
+        requireNonNull(elements, "elements is null");
+        requireNonNull(returnedType, "returnedType is null");
+        requireNonNull(outputFormat, "outputFormat is null");
+
+        this.elements = ImmutableList.copyOf(elements);
+        this.nullOnNull = nullOnNull;
+        this.returnedType = returnedType;
+        this.outputFormat = outputFormat;
+    }
+
+    public List<JsonArrayElement> getElements()
+    {
+        return elements;
+    }
+
+    public boolean isNullOnNull()
+    {
+        return nullOnNull;
+    }
+
+    public Optional<DataType> getReturnedType()
+    {
+        return returnedType;
+    }
+
+    public Optional<JsonFormat> getOutputFormat()
+    {
+        return outputFormat;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitJsonArray(this, context);
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        return elements;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        JsonArray that = (JsonArray) o;
+        return Objects.equals(elements, that.elements) &&
+                nullOnNull == that.nullOnNull &&
+                Objects.equals(returnedType, that.returnedType) &&
+                Objects.equals(outputFormat, that.outputFormat);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(elements, nullOnNull, returnedType, outputFormat);
+    }
+
+    @Override
+    public boolean shallowEquals(Node other)
+    {
+        if (!sameClass(this, other)) {
+            return false;
+        }
+
+        JsonArray that = (JsonArray) other;
+        return nullOnNull == that.nullOnNull &&
+                Objects.equals(returnedType, that.returnedType) &&
+                Objects.equals(outputFormat, that.outputFormat);
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/JsonArrayElement.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/JsonArrayElement.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.sql.tree.JsonPathParameter.JsonFormat;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class JsonArrayElement
+        extends Node
+{
+    private final Expression value;
+    private final Optional<JsonFormat> format;
+
+    public JsonArrayElement(NodeLocation location, Expression value, Optional<JsonFormat> format)
+    {
+        this(Optional.of(location), value, format);
+    }
+
+    public JsonArrayElement(Expression value, Optional<JsonFormat> format)
+    {
+        this(Optional.empty(), value, format);
+    }
+
+    public JsonArrayElement(Optional<NodeLocation> location, Expression value, Optional<JsonFormat> format)
+    {
+        super(location);
+
+        requireNonNull(value, "value is null");
+        requireNonNull(format, "format is null");
+
+        this.value = value;
+        this.format = format;
+    }
+
+    public Expression getValue()
+    {
+        return value;
+    }
+
+    public Optional<JsonFormat> getFormat()
+    {
+        return format;
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        return ImmutableList.of(value);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        JsonArrayElement that = (JsonArrayElement) o;
+        return Objects.equals(value, that.value) &&
+                Objects.equals(format, that.format);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(value, format);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("value", value)
+                .add("format", format)
+                .omitNullValues()
+                .toString();
+    }
+
+    @Override
+    public boolean shallowEquals(Node other)
+    {
+        if (!sameClass(this, other)) {
+            return false;
+        }
+
+        return format.equals(((JsonArrayElement) other).format);
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/JsonObject.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/JsonObject.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.sql.tree.JsonPathParameter.JsonFormat;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class JsonObject
+        extends Expression
+{
+    private final List<JsonObjectMember> members;
+    private final boolean nullOnNull;
+    private final boolean uniqueKeys;
+    private final Optional<DataType> returnedType;
+    private final Optional<JsonFormat> outputFormat;
+
+    public JsonObject(Optional<NodeLocation> location, List<JsonObjectMember> members, boolean nullOnNull, boolean uniqueKeys, Optional<DataType> returnedType, Optional<JsonFormat> outputFormat)
+    {
+        super(location);
+
+        requireNonNull(members, "members is null");
+        requireNonNull(returnedType, "returnedType is null");
+        requireNonNull(outputFormat, "outputFormat is null");
+
+        this.members = ImmutableList.copyOf(members);
+        this.nullOnNull = nullOnNull;
+        this.uniqueKeys = uniqueKeys;
+        this.returnedType = returnedType;
+        this.outputFormat = outputFormat;
+    }
+
+    public List<JsonObjectMember> getMembers()
+    {
+        return members;
+    }
+
+    public boolean isNullOnNull()
+    {
+        return nullOnNull;
+    }
+
+    public boolean isUniqueKeys()
+    {
+        return uniqueKeys;
+    }
+
+    public Optional<DataType> getReturnedType()
+    {
+        return returnedType;
+    }
+
+    public Optional<JsonFormat> getOutputFormat()
+    {
+        return outputFormat;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitJsonObject(this, context);
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        return members;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        JsonObject that = (JsonObject) o;
+        return Objects.equals(members, that.members) &&
+                nullOnNull == that.nullOnNull &&
+                uniqueKeys == that.uniqueKeys &&
+                Objects.equals(returnedType, that.returnedType) &&
+                Objects.equals(outputFormat, that.outputFormat);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(members, nullOnNull, uniqueKeys, returnedType, outputFormat);
+    }
+
+    @Override
+    public boolean shallowEquals(Node other)
+    {
+        if (!sameClass(this, other)) {
+            return false;
+        }
+
+        JsonObject that = (JsonObject) other;
+        return nullOnNull == that.nullOnNull &&
+                uniqueKeys == that.uniqueKeys &&
+                Objects.equals(returnedType, that.returnedType) &&
+                Objects.equals(outputFormat, that.outputFormat);
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/JsonObjectMember.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/JsonObjectMember.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.sql.tree.JsonPathParameter.JsonFormat;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class JsonObjectMember
+        extends Node
+{
+    private final Expression key;
+    private final Expression value;
+    private final Optional<JsonFormat> format;
+
+    public JsonObjectMember(NodeLocation location, Expression key, Expression value, Optional<JsonFormat> format)
+    {
+        this(Optional.of(location), key, value, format);
+    }
+
+    public JsonObjectMember(Expression key, Expression value, Optional<JsonFormat> format)
+    {
+        this(Optional.empty(), key, value, format);
+    }
+
+    private JsonObjectMember(Optional<NodeLocation> location, Expression key, Expression value, Optional<JsonFormat> format)
+    {
+        super(location);
+
+        requireNonNull(key, "key is null");
+        requireNonNull(value, "value is null");
+        requireNonNull(format, "format is null");
+
+        this.key = key;
+        this.value = value;
+        this.format = format;
+    }
+
+    public Expression getKey()
+    {
+        return key;
+    }
+
+    public Expression getValue()
+    {
+        return value;
+    }
+
+    public Optional<JsonFormat> getFormat()
+    {
+        return format;
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        return ImmutableList.of(key, value);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        JsonObjectMember that = (JsonObjectMember) o;
+        return Objects.equals(key, that.key) &&
+                Objects.equals(value, that.value) &&
+                Objects.equals(format, that.format);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(key, value, format);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("key", key)
+                .add("value", value)
+                .add("format", format)
+                .omitNullValues()
+                .toString();
+    }
+
+    @Override
+    public boolean shallowEquals(Node other)
+    {
+        if (!sameClass(this, other)) {
+            return false;
+        }
+
+        return format.equals(((JsonObjectMember) other).format);
+    }
+}

--- a/docs/src/main/sphinx/language/reserved.rst
+++ b/docs/src/main/sphinx/language/reserved.rst
@@ -1,4 +1,3 @@
-
 =================
 Reserved keywords
 =================
@@ -55,7 +54,9 @@ Keyword                        SQL:2016      SQL-92
 ``INTO``                       reserved      reserved
 ``IS``                         reserved      reserved
 ``JOIN``                       reserved      reserved
+``JSON_ARRAY``                 reserved
 ``JSON_EXISTS``                reserved
+``JSON_OBJECT``                reserved
 ``JSON_QUERY``                 reserved
 ``JSON_VALUE``                 reserved
 ``LEFT``                       reserved      reserved

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -6474,6 +6474,62 @@ public abstract class AbstractTestEngineOnlyQueries
                 .matches("VALUES VARCHAR '0', '1', '2', 'x', 'x'");
     }
 
+    @Test
+    public void testJsonObjectFunction()
+    {
+        assertThat(query("SELECT json_object(name : regionkey) result " +
+                "              FROM region"))
+                .matches("VALUES (VARCHAR '{\"AFRICA\":0}'), ('{\"AMERICA\":1}'), ('{\"ASIA\":2}'), ('{\"EUROPE\":3}'), ('{\"MIDDLE EAST\":4}')");
+
+        assertThat(query("SELECT json_object(name : IF(regionkey < 3, regionkey, null) NULL ON NULL) result " +
+                "              FROM region"))
+                .matches("VALUES (VARCHAR '{\"AFRICA\":0}'), ('{\"AMERICA\":1}'), ('{\"ASIA\":2}'), ('{\"EUROPE\":null}'), ('{\"MIDDLE EAST\":null}')");
+
+        assertThat(query("SELECT json_object(name : IF(regionkey < 3, regionkey, null) ABSENT ON NULL) result " +
+                "              FROM region"))
+                .matches("VALUES (VARCHAR '{\"AFRICA\":0}'), ('{\"AMERICA\":1}'), ('{\"ASIA\":2}'), ('{}'), ('{}')");
+
+        assertThat(query("SELECT json_object((SELECT name) : (SELECT regionkey)) result " +
+                "              FROM region"))
+                .matches("VALUES (VARCHAR '{\"AFRICA\":0}'), ('{\"AMERICA\":1}'), ('{\"ASIA\":2}'), ('{\"EUROPE\":3}'), ('{\"MIDDLE EAST\":4}')");
+
+        assertThat(query("SELECT json_object(name : format('\"%s\"', lower(name)) FORMAT JSON) result " +
+                "              FROM region"))
+                .matches("VALUES (VARCHAR '{\"AFRICA\":\"africa\"}'), ('{\"AMERICA\":\"america\"}'), ('{\"ASIA\":\"asia\"}'), ('{\"EUROPE\":\"europe\"}'), ('{\"MIDDLE EAST\":\"middle east\"}')");
+
+        assertThat(query("SELECT json_object(name : regionkey RETURNING varchar(100) FORMAT JSON) result " +
+                "              FROM region"))
+                .matches("VALUES (CAST('{\"AFRICA\":0}' AS varchar(100))), ('{\"AMERICA\":1}'), ('{\"ASIA\":2}'), ('{\"EUROPE\":3}'), ('{\"MIDDLE EAST\":4}')");
+    }
+
+    @Test
+    public void testJsonArrayFunction()
+    {
+        assertThat(query("SELECT json_array(name, regionkey) result " +
+                "              FROM region"))
+                .matches("VALUES (VARCHAR '[\"AFRICA\",0]'), ('[\"AMERICA\",1]'), ('[\"ASIA\",2]'), ('[\"EUROPE\",3]'), ('[\"MIDDLE EAST\",4]')");
+
+        assertThat(query("SELECT json_array(name, IF(regionkey < 3, regionkey, null) NULL ON NULL) result " +
+                "              FROM region"))
+                .matches("VALUES (VARCHAR '[\"AFRICA\",0]'), ('[\"AMERICA\",1]'), ('[\"ASIA\",2]'), ('[\"EUROPE\",null]'), ('[\"MIDDLE EAST\",null]')");
+
+        assertThat(query("SELECT json_array(name, IF(regionkey < 3, regionkey, null) ABSENT ON NULL) result " +
+                "              FROM region"))
+                .matches("VALUES (VARCHAR '[\"AFRICA\",0]'), ('[\"AMERICA\",1]'), ('[\"ASIA\",2]'), ('[\"EUROPE\"]'), ('[\"MIDDLE EAST\"]')");
+
+        assertThat(query("SELECT json_array((SELECT name), (SELECT regionkey)) result " +
+                "              FROM region"))
+                .matches("VALUES (VARCHAR '[\"AFRICA\",0]'), ('[\"AMERICA\",1]'), ('[\"ASIA\",2]'), ('[\"EUROPE\",3]'), ('[\"MIDDLE EAST\",4]')");
+
+        assertThat(query("SELECT json_array(name, format('\"%s\"', lower(name)) FORMAT JSON) result " +
+                "              FROM region"))
+                .matches("VALUES (VARCHAR '[\"AFRICA\",\"africa\"]'), ('[\"AMERICA\",\"america\"]'), ('[\"ASIA\",\"asia\"]'), ('[\"EUROPE\",\"europe\"]'), ('[\"MIDDLE EAST\",\"middle east\"]')");
+
+        assertThat(query("SELECT json_array(name, regionkey RETURNING varchar(100) FORMAT JSON) result " +
+                "              FROM region"))
+                .matches("VALUES (CAST('[\"AFRICA\",0]' AS varchar(100))), ('[\"AMERICA\",1]'), ('[\"ASIA\",2]'), ('[\"EUROPE\",3]'), ('[\"MIDDLE EAST\",4]')");
+    }
+
     private static ZonedDateTime zonedDateTime(String value)
     {
         return ZONED_DATE_TIME_FORMAT.parse(value, ZonedDateTime::from);


### PR DESCRIPTION
Support `json_object()` and `json_array()` functions, as specified by the SQL standard.

Documentation https://github.com/trinodb/trino/pull/12677