### PR TITLE
Fix running TestTableScanNodePartitioning test on single CPU nodes

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestTableScanNodePartitioning.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestTableScanNodePartitioning.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.ToIntFunction;
 
+import static io.trino.SystemSessionProperties.TASK_CONCURRENCY;
 import static io.trino.SystemSessionProperties.USE_TABLE_SCAN_NODE_PARTITIONING;
 import static io.trino.spi.connector.ConnectorBucketNodeMap.createBucketNodeMap;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -78,11 +79,13 @@ public class TestTableScanNodePartitioning
             .setCatalog(MOCK_CATALOG)
             .setSchema(TEST_SCHEMA)
             .setSystemProperty(USE_TABLE_SCAN_NODE_PARTITIONING, "true")
+            .setSystemProperty(TASK_CONCURRENCY, "2") // force parallel plan even on test nodes with single CPU
             .build();
     public static final Session DISABLE_PLAN_WITH_TABLE_NODE_PARTITIONING = testSessionBuilder()
             .setCatalog(MOCK_CATALOG)
             .setSchema(TEST_SCHEMA)
             .setSystemProperty(USE_TABLE_SCAN_NODE_PARTITIONING, "false")
+            .setSystemProperty(TASK_CONCURRENCY, "2") // force parallel plan even on test nodes with single CPU
             .build();
 
     public static final int BUCKET_COUNT = 10;
@@ -121,7 +124,8 @@ public class TestTableScanNodePartitioning
     {
         Session.SessionBuilder sessionBuilder = testSessionBuilder()
                 .setCatalog(MOCK_CATALOG)
-                .setSchema(TEST_SCHEMA);
+                .setSchema(TEST_SCHEMA)
+                .setSystemProperty(TASK_CONCURRENCY, "2"); // force parallel plan even on test nodes with single CPU
 
         LocalQueryRunner queryRunner = LocalQueryRunner.builder(sessionBuilder.build())
                 .withNodeCountForStats(10)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
