### PR TITLE
Fix Delta Lake queries with predicates not expressible by tuple domain

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
@@ -184,7 +184,7 @@ public class DeltaLakeSplitManager
                                 .filter(column -> partitionValues.containsKey(((DeltaLakeColumnHandle) column).getName()))
                                 .collect(toImmutableMap(identity(), column -> {
                                     DeltaLakeColumnHandle deltaLakeColumn = (DeltaLakeColumnHandle) column;
-                                    return NullableValue.of(
+                                    return new NullableValue(
                                             deltaLakeColumn.getType(),
                                             deserializePartitionValue(deltaLakeColumn, addAction.getCanonicalPartitionValues().get(deltaLakeColumn.getName())));
                                 }));

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeMinioConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeMinioConnectorTest.java
@@ -205,6 +205,18 @@ public abstract class BaseDeltaLakeMinioConnectorTest
                         ")");
     }
 
+    // not pushdownable means not convertible to a tuple domain
+    @Test
+    public void testQueryNullPartitionWithNotPushdownablePredicate()
+    {
+        String tableName = "test_null_partitions_" + randomTableSuffix();
+        assertUpdate("" +
+                        "CREATE TABLE " + tableName + " (a, b, c) WITH (location = '" + format("s3://%s/%s", bucketName, tableName) + "', partitioned_by = ARRAY['c']) " +
+                        "AS VALUES (1, 1, 1), (2, 2, 2), (3, 3, 3), (null, null, null), (4, 4, 4)",
+                "VALUES 5");
+        assertQuery("SELECT a FROM " + tableName + " WHERE c % 5 = 1", "VALUES (1)");
+    }
+
     @Override
     public void testShowCreateSchema()
     {


### PR DESCRIPTION
It didn't work when table was partitioned by column that contained null values
and predicate was applied to it
## Description
## Related issues, pull requests, and links

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
