### PR TITLE
Improve connector logo placement and layout

### DIFF
--- a/docs/src/main/sphinx/connector/accumulo.rst
+++ b/docs/src/main/sphinx/connector/accumulo.rst
@@ -5,9 +5,6 @@ Accumulo connector
 
   <img src="../_static/img/accumulo.png" class="connector-logo">
 
-Overview
---------
-
 The Accumulo connector supports reading and writing data from
 `Apache Accumulo <https://accumulo.apache.org/>`_.
 Please read this page thoroughly to understand the capabilities and features of the connector.

--- a/docs/src/main/sphinx/connector/elasticsearch.rst
+++ b/docs/src/main/sphinx/connector/elasticsearch.rst
@@ -2,9 +2,6 @@
 Elasticsearch connector
 =======================
 
-Overview
---------
-
 .. raw:: html
 
   <img src="../_static/img/elasticsearch.png" class="connector-logo">

--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -17,9 +17,6 @@ Hive connector
     Storage Caching <hive-caching>
     Alluxio <hive-alluxio>
 
-Overview
---------
-
 The Hive connector allows querying data stored in an
 `Apache Hive <https://hive.apache.org/>`_
 data warehouse. Hive is a combination of three components:
@@ -1041,8 +1038,8 @@ Table properties supply or set metadata for the underlying tables. This
 is key for :doc:`/sql/create-table-as` statements. Table properties are passed
 to the connector using a :doc:`WITH </sql/create-table-as>` clause::
 
-  CREATE TABLE tablename 
-  WITH (format='CSV', 
+  CREATE TABLE tablename
+  WITH (format='CSV',
         csv_escape = '"')
 
 See the :ref:`hive_examples` for more information.
@@ -1055,7 +1052,7 @@ See the :ref:`hive_examples` for more information.
     - Description
     - Default
   * - ``auto_purge``
-    - Indicates to the configured metastore to perform a purge when a table or 
+    - Indicates to the configured metastore to perform a purge when a table or
       partition is deleted instead of a soft deletion using the trash.
     -
   * - ``avro_schema_url``
@@ -1066,11 +1063,11 @@ See the :ref:`hive_examples` for more information.
       ``bucketed_by``.
     - 0
   * - ``bucketed_by``
-    - The bucketing column for the storage table. Only valid if used with 
+    - The bucketing column for the storage table. Only valid if used with
       ``bucket_count``.
     - ``[]``
   * - ``bucketing_version``
-    - Specifies which Hive bucketing version to use. Valid values are ``1`` 
+    - Specifies which Hive bucketing version to use. Valid values are ``1``
       or ``2``.
     -
   * - ``csv_escape``
@@ -1087,51 +1084,51 @@ See the :ref:`hive_examples` for more information.
       :ref:`hive_examples` for more information.
     -
   * - ``format``
-    - The table file format. Valid values include ``ORC``, ``PARQUET``, ``AVRO``, 
-      ``RCBINARY``, ``RCTEXT``, ``SEQUENCEFILE``, ``JSON``, ``TEXTFILE``, and 
-      ``CSV``. The catalog property ``hive.storage-format`` sets the default 
+    - The table file format. Valid values include ``ORC``, ``PARQUET``, ``AVRO``,
+      ``RCBINARY``, ``RCTEXT``, ``SEQUENCEFILE``, ``JSON``, ``TEXTFILE``, and
+      ``CSV``. The catalog property ``hive.storage-format`` sets the default
       value and can change it to a different default.
-    - 
+    -
   * - ``null_format``
-    - The serialization format for ``NULL`` value. Requires TextFile, RCText, 
+    - The serialization format for ``NULL`` value. Requires TextFile, RCText,
       or SequenceFile format.
     -
   * - ``orc_bloom_filter_columns``
-    - Comma separated list of columns to use for ORC bloom filter. It improves 
-      the performance of queries using range predicates when reading ORC files. 
+    - Comma separated list of columns to use for ORC bloom filter. It improves
+      the performance of queries using range predicates when reading ORC files.
       Requires ORC format.
     - ``[]``
   * - ``orc_bloom_filter_fpp``
     - The ORC bloom filters false positive probability. Requires ORC format.
     - 0.05
   * - ``partitioned_by``
-    - The partitioning column for the storage table. The columns listed in the 
-      ``partitioned_by`` clause must be the last columns as defined in the DDL. 
+    - The partitioning column for the storage table. The columns listed in the
+      ``partitioned_by`` clause must be the last columns as defined in the DDL.
     - ``[]``
   * - ``skip_footer_line_count``
-    - The number of footer lines to ignore when parsing the file for data.  
+    - The number of footer lines to ignore when parsing the file for data.
       Requires TextFile or CSV format tables.
-    - 
+    -
   * - ``skip_header_line_count``
-    - The number of header lines to ignore when parsing the file for data. 
+    - The number of header lines to ignore when parsing the file for data.
       Requires TextFile or CSV format tables.
     -
   * - ``sorted_by``
-    - The column to sort by to determine bucketing for row. Only valid if 
+    - The column to sort by to determine bucketing for row. Only valid if
       ``bucketed_by`` and ``bucket_count`` are specified as well.
     - ``[]``
   * - ``textfile_field_separator``
-    - Allows the use of custom field separators, such as '|', for TextFile 
+    - Allows the use of custom field separators, such as '|', for TextFile
       formatted tables.
-    - 
+    -
   * - ``textfile_field_separator_escape``
     - Allows the use of a custom escape character for TextFile formatted tables.
-    - 
+    -
   * - ``transactional``
-    - Set this property to ``true`` to create an ORC ACID transactional table. 
-      Requires ORC format. This property may be shown as true for insert-only 
+    - Set this property to ``true`` to create an ORC ACID transactional table.
+      Requires ORC format. This property may be shown as true for insert-only
       tables created using older versions of Hive.
-    - 
+    -
 
 .. _hive_special_columns:
 

--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -6,9 +6,6 @@ Iceberg connector
 
   <img src="../_static/img/iceberg.png" class="connector-logo">
 
-Overview
---------
-
 Apache Iceberg is an open table format for huge analytic datasets.
 The Iceberg connector allows querying data stored in
 files written in Iceberg format, as defined in the

--- a/docs/src/main/sphinx/connector/kafka.rst
+++ b/docs/src/main/sphinx/connector/kafka.rst
@@ -12,9 +12,6 @@ Kafka connector
 
     Tutorial <kafka-tutorial>
 
-Overview
---------
-
 This connector allows the use of `Apache Kafka <https://kafka.apache.org/>`_
 topics as tables in Trino. Each message is presented as a row in Trino.
 

--- a/docs/src/main/sphinx/static/trino.css
+++ b/docs/src/main/sphinx/static/trino.css
@@ -80,4 +80,6 @@ pre.literal-block {
 
 .connector-logo {
     float: right;
+    position: relative;
+    top: -5.5rem;
 }


### PR DESCRIPTION
## Description

Remove redundant titles and shift connector logos up beside title. The logo is still floating left of the paragraph and then just shifted up .. thats why the first paragraph wraps and looks to have a gap for the image. 

I tried leaving the image lower and adding padding on the left .. that works okay as well but having the logo higher up with the title looks better .. at least @electrum and myself think so.. I am not sure how we can get rid of the whitespace beside the paragraph .. any ideas @dedep or @aliloney ?

Also fyi @Jessie212 .. 

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Connector documentation. 

> How would you describe this change to a non-technical end user or system administrator?

Improve the look of the connector docs.

## Related issues, pull requests, and links

Fixes #12058 

Some examples:

<img width="1093" alt="Screen Shot 2022-04-20 at 09 53 24" src="https://user-images.githubusercontent.com/145658/164286168-6ef0d9b4-1c48-4574-aeb5-236231a177cf.png">

<img width="1401" alt="Screen Shot 2022-04-20 at 10 13 36" src="https://user-images.githubusercontent.com/145658/164286212-81be2f7b-ff38-4324-8910-4bff7c808b75.png">



## Documentation

( ) No documentation is needed.
(✅) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(✅ ) No release notes entries required.
( ) Release notes entries required with the following suggested text:
