### PR TITLE
Remove duplicate exception class

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
@@ -597,13 +597,4 @@ public class TrinoHiveCatalog
         }
         return Optional.empty();
     }
-
-    private static class MaterializedViewMayBeBeingRemovedException
-            extends RuntimeException
-    {
-        public MaterializedViewMayBeBeingRemovedException(Throwable cause)
-        {
-            super(requireNonNull(cause, "cause is null"));
-        }
-    }
 }


### PR DESCRIPTION
The class has been copied to `AbstractTrinoCatalog` and so should have
been removed from `TrinoHiveCatalog`.

This may or may not fix a concurrency-related bug.
`AbstractTrinoCatalog` has some generic handling for
`MaterializedViewMayBeBeingRemovedException`, but since the HMS-related
subclass had a copy of the exception, the handling would not kick in.