### PR TITLE
Fix incorrect predicate precedence involving OR and split predicates

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -412,9 +412,10 @@ public abstract class BaseJdbcClient
         if (constraintExpressions.isEmpty() && splitPredicate.isEmpty()) {
             return Optional.empty();
         }
+
         return Optional.of(
                 Stream.concat(constraintExpressions.stream(), splitPredicate.stream())
-                        .collect(joining(" AND ")));
+                        .collect(joining(") AND (", "(", ")")));
     }
 
     @Override


### PR DESCRIPTION
If constraintExpressions contain translated `OR` expression and there is a split predicate, resulting predicate could be incorrect: `predicate1 OR predicate2 AND splitPredicate`. Instead we need to wrap both sides of OR expression with parens:
`(predicate1 OR predicate2) AND splitPredicate`