### PR TITLE
Remove redundant skipTestUnlessSupportsDeletes method

### DIFF
--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/AbstractKuduConnectorTest.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/AbstractKuduConnectorTest.java
@@ -341,15 +341,6 @@ public abstract class AbstractKuduConnectorTest
 
     @Test
     @Override
-    public void testDeleteWithLike()
-    {
-        // TODO Support these test once kudu connector can create tables with default partitions
-        assertThatThrownBy(super::testDeleteWithLike)
-                .hasMessage("Table partitioning must be specified using setRangePartitionColumns or addHashPartitions");
-    }
-
-    @Test
-    @Override
     public void testDeleteWithSemiJoin()
     {
         // TODO Support these test once kudu connector can create tables with default partitions

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -632,10 +632,11 @@ public class TestPostgreSqlConnectorTest
     @Test
     public void testDecimalPredicatePushdown()
     {
-        try (TestTable table = new TestTable(onRemoteDatabase(), "test_decimal_pushdown",
-                "(short_decimal decimal(9, 3), long_decimal decimal(30, 10))")) {
-            onRemoteDatabase().execute("INSERT INTO " + table.getName() + " VALUES (123.321, 123456789.987654321)");
-
+        try (TestTable table = new TestTable(
+                onRemoteDatabase(),
+                "test_decimal_pushdown",
+                "(short_decimal decimal(9, 3), long_decimal decimal(30, 10))",
+                List.of("123.321, 123456789.987654321"))) {
             assertThat(query("SELECT * FROM " + table.getName() + " WHERE short_decimal <= 124"))
                     .matches("VALUES (CAST(123.321 AS decimal(9,3)), CAST(123456789.987654321 AS decimal(30, 10)))")
                     .isFullyPushedDown();
@@ -663,12 +664,13 @@ public class TestPostgreSqlConnectorTest
     @Test
     public void testCharPredicatePushdown()
     {
-        try (TestTable table = new TestTable(onRemoteDatabase(), "test_char_pushdown",
-                "(char_1 char(1), char_5 char(5), char_10 char(10))")) {
-            onRemoteDatabase().execute("INSERT INTO " + table.getName() + " VALUES" +
-                    "('0', '0'    , '0'         )," +
-                    "('1', '12345', '1234567890')");
-
+        try (TestTable table = new TestTable(
+                onRemoteDatabase(),
+                "test_char_pushdown",
+                "(char_1 char(1), char_5 char(5), char_10 char(10))",
+                List.of(
+                        "'0', '0', '0'",
+                        "'1', '12345', '1234567890'"))) {
             assertThat(query("SELECT * FROM " + table.getName() + " WHERE char_1 = '0' AND char_5 = '0'"))
                     .matches("VALUES (CHAR'0', CHAR'0    ', CHAR'0         ')")
                     .isFullyPushedDown();

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -2453,7 +2453,7 @@ public abstract class BaseConnectorTest
     @Test
     public void testDelete()
     {
-        skipTestUnlessSupportsDeletes();
+        skipTestUnless(hasBehavior(SUPPORTS_DELETE));
 
         // delete successive parts of the table
         try (TestTable table = new TestTable(getQueryRunner()::execute, "test_delete_", "AS SELECT * FROM orders")) {
@@ -2497,7 +2497,7 @@ public abstract class BaseConnectorTest
     @Test
     public void testDeleteWithLike()
     {
-        skipTestUnlessSupportsDeletes();
+        skipTestUnless(hasBehavior(SUPPORTS_DELETE));
 
         try (TestTable table = new TestTable(getQueryRunner()::execute, "test_with_like_", "AS SELECT * FROM nation")) {
             assertUpdate("DELETE FROM " + table.getName() + " WHERE name LIKE '%a%'", "VALUES 0");
@@ -2508,7 +2508,7 @@ public abstract class BaseConnectorTest
     @Test
     public void testDeleteWithComplexPredicate()
     {
-        skipTestUnlessSupportsDeletes();
+        skipTestUnless(hasBehavior(SUPPORTS_DELETE));
 
         // TODO (https://github.com/trinodb/trino/issues/5901) Use longer table name once Oracle version is updated
         try (TestTable table = new TestTable(getQueryRunner()::execute, "test_delete_complex_", "AS SELECT * FROM orders")) {
@@ -2526,7 +2526,7 @@ public abstract class BaseConnectorTest
     @Test
     public void testDeleteWithSubquery()
     {
-        skipTestUnlessSupportsDeletes();
+        skipTestUnless(hasBehavior(SUPPORTS_DELETE));
 
         // TODO (https://github.com/trinodb/trino/issues/5901) Use longer table name once Oracle version is updated
         try (TestTable table = new TestTable(getQueryRunner()::execute, "test_delete_subquery", "AS SELECT * FROM nation")) {
@@ -2550,7 +2550,7 @@ public abstract class BaseConnectorTest
     @Test
     public void testExplainAnalyzeWithDeleteWithSubquery()
     {
-        skipTestUnlessSupportsDeletes();
+        skipTestUnless(hasBehavior(SUPPORTS_DELETE));
 
         String tableName = "test_delete_" + randomTableSuffix();
 
@@ -2564,7 +2564,7 @@ public abstract class BaseConnectorTest
     @Test
     public void testDeleteWithSemiJoin()
     {
-        skipTestUnlessSupportsDeletes();
+        skipTestUnless(hasBehavior(SUPPORTS_DELETE));
 
         // TODO (https://github.com/trinodb/trino/issues/5901) Use longer table name once Oracle version is updated
         try (TestTable table = new TestTable(getQueryRunner()::execute, "test_delete_semijoin", "AS SELECT * FROM nation")) {
@@ -2599,22 +2599,11 @@ public abstract class BaseConnectorTest
     @Test
     public void testDeleteWithVarcharPredicate()
     {
-        skipTestUnlessSupportsDeletes();
+        skipTestUnless(hasBehavior(SUPPORTS_DELETE));
 
         try (TestTable table = new TestTable(getQueryRunner()::execute, "test_delete_with_varchar_predicate_", "AS SELECT * FROM orders")) {
             assertUpdate("DELETE FROM " + table.getName() + " WHERE orderstatus = 'O'", "SELECT count(*) FROM orders WHERE orderstatus = 'O'");
             assertQuery("SELECT * FROM " + table.getName(), "SELECT * FROM orders WHERE orderstatus <> 'O'");
-        }
-    }
-
-    protected void skipTestUnlessSupportsDeletes()
-    {
-        skipTestUnless(hasBehavior(SUPPORTS_CREATE_TABLE));
-        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_supports_delete", "(col varchar(1))")) {
-            if (!hasBehavior(SUPPORTS_DELETE)) {
-                assertQueryFails("DELETE FROM " + table.getName(), "This connector does not support deletes");
-                throw new SkipException("This connector does not support deletes");
-            }
         }
     }
 


### PR DESCRIPTION
- test skipping can be simply done with
  `skipTestUnless(hasBehavior(SUPPORTS_DELETE));`
- the correctness of SUPPORTS_DELETE declaration is already verified in
  `verifySupportsDeleteDeclaration` and doesn't need to be re-verified
  in other tests
  - a `skip...` method should just do a skip, not assertions, anyway
