### PR TITLE
Reset delay counter on task success only if past previous delay period

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/FaultTolerantStageScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/FaultTolerantStageScheduler.java
@@ -599,8 +599,8 @@ public class FaultTolerantStageScheduler
                             partitionToRemoteTaskMap.get(partitionId).forEach(RemoteTask::abort);
                             partitionMemoryEstimator.registerPartitionFinished(session, memoryLimits, taskStatus.getPeakMemoryReservation(), true, Optional.empty());
 
-                            if (delayStopwatch.isRunning()) {
-                                // task completed successfully; reset delay
+                            if (delayStopwatch.isRunning() && delayStopwatch.elapsed().compareTo(delaySchedulingDuration.get()) > 0) {
+                                // we are past delay period and task completed successfully; reset delay
                                 previousDelaySchedulingFuture = delaySchedulingFuture;
                                 delayStopwatch.reset();
                                 delaySchedulingDuration = Optional.empty();


### PR DESCRIPTION

## Description

Reset delay counter on task success only if past previous delay period

> Is this change a fix, improvement, new feature, refactoring, or other?

improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core engine

## Related issues, pull requests, and links

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

