### PR TITLE
Eliminate useless build warning

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -27,6 +27,7 @@
                             <exclude>**/*.conf</exclude>
                             <exclude>**/*.css</exclude>
                             <exclude>**/*.js</exclude>
+                            <exclude>**/*.fragment</exclude>
                         </excludes>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
This pr aims to eliminate useless build warning

Before pr, The following Licenses check warning will appear：
<img width="978" alt="image" src="https://user-images.githubusercontent.com/51110188/164589699-99f3e9bd-89e1-4bde-815d-851dc6aa8b69.png">

Licenses check warning no longer appears after this change

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
