### PR TITLE
Task retries related Web UI improvements

### DIFF
--- a/core/trino-main/src/main/java/io/trino/dispatcher/FailedDispatchQuery.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/FailedDispatchQuery.java
@@ -25,6 +25,7 @@ import io.trino.execution.QueryInfo;
 import io.trino.execution.QueryState;
 import io.trino.execution.QueryStats;
 import io.trino.execution.StateMachine.StateChangeListener;
+import io.trino.operator.RetryPolicy;
 import io.trino.server.BasicQueryInfo;
 import io.trino.spi.ErrorCode;
 import io.trino.spi.QueryId;
@@ -240,7 +241,8 @@ public class FailedDispatchQuery
                 ImmutableList.of(),
                 true,
                 resourceGroupId,
-                Optional.empty());
+                Optional.empty(),
+                RetryPolicy.NONE);
 
         return queryInfo;
     }

--- a/core/trino-main/src/main/java/io/trino/execution/BasicStageStats.java
+++ b/core/trino-main/src/main/java/io/trino/execution/BasicStageStats.java
@@ -33,6 +33,8 @@ public class BasicStageStats
             false,
 
             0,
+
+            0,
             0,
             0,
             0,
@@ -63,6 +65,7 @@ public class BasicStageStats
             OptionalDouble.empty());
 
     private final boolean isScheduled;
+    private final int failedTasks;
     private final int totalDrivers;
     private final int queuedDrivers;
     private final int runningDrivers;
@@ -88,6 +91,8 @@ public class BasicStageStats
 
     public BasicStageStats(
             boolean isScheduled,
+
+            int failedTasks,
 
             int totalDrivers,
             int queuedDrivers,
@@ -120,6 +125,7 @@ public class BasicStageStats
             OptionalDouble progressPercentage)
     {
         this.isScheduled = isScheduled;
+        this.failedTasks = failedTasks;
         this.totalDrivers = totalDrivers;
         this.queuedDrivers = queuedDrivers;
         this.runningDrivers = runningDrivers;
@@ -147,6 +153,11 @@ public class BasicStageStats
     public boolean isScheduled()
     {
         return isScheduled;
+    }
+
+    public int getFailedTasks()
+    {
+        return failedTasks;
     }
 
     public int getTotalDrivers()
@@ -261,6 +272,8 @@ public class BasicStageStats
 
     public static BasicStageStats aggregateBasicStageStats(Iterable<BasicStageStats> stages)
     {
+        int failedTasks = 0;
+
         int totalDrivers = 0;
         int queuedDrivers = 0;
         int runningDrivers = 0;
@@ -292,6 +305,8 @@ public class BasicStageStats
         Set<BlockedReason> blockedReasons = new HashSet<>();
 
         for (BasicStageStats stageStats : stages) {
+            failedTasks += stageStats.getFailedTasks();
+
             totalDrivers += stageStats.getTotalDrivers();
             queuedDrivers += stageStats.getQueuedDrivers();
             runningDrivers += stageStats.getRunningDrivers();
@@ -330,6 +345,8 @@ public class BasicStageStats
 
         return new BasicStageStats(
                 isScheduled,
+
+                failedTasks,
 
                 totalDrivers,
                 queuedDrivers,

--- a/core/trino-main/src/main/java/io/trino/execution/MemoryTrackingRemoteTaskFactory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/MemoryTrackingRemoteTaskFactory.java
@@ -14,6 +14,7 @@
 package io.trino.execution;
 
 import com.google.common.collect.Multimap;
+import io.airlift.units.DataSize;
 import io.trino.Session;
 import io.trino.execution.NodeTaskMap.PartitionedSplitCountTracker;
 import io.trino.execution.StateMachine.StateChangeListener;
@@ -24,6 +25,7 @@ import io.trino.sql.planner.PlanFragment;
 import io.trino.sql.planner.plan.DynamicFilterId;
 import io.trino.sql.planner.plan.PlanNodeId;
 
+import java.util.Optional;
 import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
@@ -50,6 +52,7 @@ public class MemoryTrackingRemoteTaskFactory
             OutputBuffers outputBuffers,
             PartitionedSplitCountTracker partitionedSplitCountTracker,
             Set<DynamicFilterId> outboundDynamicFilterIds,
+            Optional<DataSize> estimatedMemory,
             boolean summarizeTaskInfo)
     {
         RemoteTask task = remoteTaskFactory.createRemoteTask(session,
@@ -60,6 +63,7 @@ public class MemoryTrackingRemoteTaskFactory
                 outputBuffers,
                 partitionedSplitCountTracker,
                 outboundDynamicFilterIds,
+                estimatedMemory,
                 summarizeTaskInfo);
 
         task.addStateChangeListener(new UpdatePeakMemory(stateMachine));

--- a/core/trino-main/src/main/java/io/trino/execution/QueryInfo.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryInfo.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.SessionRepresentation;
+import io.trino.operator.RetryPolicy;
 import io.trino.spi.ErrorCode;
 import io.trino.spi.ErrorType;
 import io.trino.spi.QueryId;
@@ -79,6 +80,7 @@ public class QueryInfo
     private final boolean completeInfo;
     private final Optional<ResourceGroupId> resourceGroupId;
     private final Optional<QueryType> queryType;
+    private final RetryPolicy retryPolicy;
 
     @JsonCreator
     public QueryInfo(
@@ -112,7 +114,8 @@ public class QueryInfo
             @JsonProperty("routines") List<RoutineInfo> routines,
             @JsonProperty("completeInfo") boolean completeInfo,
             @JsonProperty("resourceGroupId") Optional<ResourceGroupId> resourceGroupId,
-            @JsonProperty("queryType") Optional<QueryType> queryType)
+            @JsonProperty("queryType") Optional<QueryType> queryType,
+            @JsonProperty("retryPolicy") RetryPolicy retryPolicy)
     {
         requireNonNull(queryId, "queryId is null");
         requireNonNull(session, "session is null");
@@ -138,6 +141,7 @@ public class QueryInfo
         requireNonNull(resourceGroupId, "resourceGroupId is null");
         requireNonNull(warnings, "warnings is null");
         requireNonNull(queryType, "queryType is null");
+        requireNonNull(retryPolicy, "retryPolicy is null");
 
         this.queryId = queryId;
         this.session = session;
@@ -171,6 +175,7 @@ public class QueryInfo
         this.completeInfo = completeInfo;
         this.resourceGroupId = resourceGroupId;
         this.queryType = queryType;
+        this.retryPolicy = retryPolicy;
     }
 
     @JsonProperty
@@ -367,6 +372,12 @@ public class QueryInfo
     public Optional<QueryType> getQueryType()
     {
         return queryType;
+    }
+
+    @JsonProperty
+    public RetryPolicy getRetryPolicy()
+    {
+        return retryPolicy;
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
@@ -25,6 +25,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
 import io.trino.Session;
+import io.trino.SystemSessionProperties;
 import io.trino.execution.QueryExecution.QueryOutputInfo;
 import io.trino.execution.StateMachine.StateChangeListener;
 import io.trino.execution.warnings.WarningCollector;
@@ -466,7 +467,8 @@ public class QueryStateMachine
                 routines.get(),
                 completeInfo,
                 Optional.of(resourceGroup),
-                queryType);
+                queryType,
+                SystemSessionProperties.getRetryPolicy(session));
     }
 
     private QueryStats getQueryStats(Optional<StageInfo> rootStage)
@@ -1186,7 +1188,8 @@ public class QueryStateMachine
                 queryInfo.getRoutines(),
                 queryInfo.isCompleteInfo(),
                 queryInfo.getResourceGroupId(),
-                queryInfo.getQueryType());
+                queryInfo.getQueryType(),
+                queryInfo.getRetryPolicy());
         finalQueryInfo.compareAndSet(finalInfo, Optional.of(prunedQueryInfo));
     }
 

--- a/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
@@ -25,7 +25,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
 import io.trino.Session;
-import io.trino.SystemSessionProperties;
 import io.trino.execution.QueryExecution.QueryOutputInfo;
 import io.trino.execution.StateMachine.StateChangeListener;
 import io.trino.execution.warnings.WarningCollector;
@@ -77,6 +76,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.units.DataSize.succinctBytes;
+import static io.trino.SystemSessionProperties.getRetryPolicy;
 import static io.trino.execution.BasicStageStats.EMPTY_STAGE_STATS;
 import static io.trino.execution.QueryState.DISPATCHING;
 import static io.trino.execution.QueryState.FAILED;
@@ -374,6 +374,8 @@ public class QueryStateMachine
                 queryStateTimer.getElapsedTime(),
                 queryStateTimer.getExecutionTime(),
 
+                stageStats.getFailedTasks(),
+
                 stageStats.getTotalDrivers(),
                 stageStats.getQueuedDrivers(),
                 stageStats.getRunningDrivers(),
@@ -412,7 +414,8 @@ public class QueryStateMachine
                 queryStats,
                 errorCode == null ? null : errorCode.getType(),
                 errorCode,
-                queryType);
+                queryType,
+                getRetryPolicy(session));
     }
 
     @VisibleForTesting
@@ -468,7 +471,7 @@ public class QueryStateMachine
                 completeInfo,
                 Optional.of(resourceGroup),
                 queryType,
-                SystemSessionProperties.getRetryPolicy(session));
+                getRetryPolicy(session));
     }
 
     private QueryStats getQueryStats(Optional<StageInfo> rootStage)

--- a/core/trino-main/src/main/java/io/trino/execution/RemoteTaskFactory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RemoteTaskFactory.java
@@ -14,6 +14,7 @@
 package io.trino.execution;
 
 import com.google.common.collect.Multimap;
+import io.airlift.units.DataSize;
 import io.trino.Session;
 import io.trino.execution.NodeTaskMap.PartitionedSplitCountTracker;
 import io.trino.execution.buffer.OutputBuffers;
@@ -23,6 +24,7 @@ import io.trino.sql.planner.PlanFragment;
 import io.trino.sql.planner.plan.DynamicFilterId;
 import io.trino.sql.planner.plan.PlanNodeId;
 
+import java.util.Optional;
 import java.util.Set;
 
 public interface RemoteTaskFactory
@@ -36,5 +38,6 @@ public interface RemoteTaskFactory
             OutputBuffers outputBuffers,
             PartitionedSplitCountTracker partitionedSplitCountTracker,
             Set<DynamicFilterId> outboundDynamicFilterIds,
+            Optional<DataSize> estimatedMemory,
             boolean summarizeTaskInfo);
 }

--- a/core/trino-main/src/main/java/io/trino/execution/SqlStage.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlStage.java
@@ -15,6 +15,7 @@ package io.trino.execution;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
+import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.Session;
 import io.trino.execution.StateMachine.StateChangeListener;
@@ -213,7 +214,8 @@ public final class SqlStage
             OutputBuffers outputBuffers,
             Multimap<PlanNodeId, Split> splits,
             Multimap<PlanNodeId, Lifespan> noMoreSplitsForLifespan,
-            Set<PlanNodeId> noMoreSplits)
+            Set<PlanNodeId> noMoreSplits,
+            Optional<DataSize> estimatedMemory)
     {
         if (stateMachine.getState().isDone()) {
             return Optional.empty();
@@ -232,6 +234,7 @@ public final class SqlStage
                 outputBuffers,
                 nodeTaskMap.createPartitionedSplitCountTracker(node, taskId),
                 outboundDynamicFilterIds,
+                estimatedMemory,
                 summarizeTaskInfo);
 
         noMoreSplitsForLifespan.forEach(task::noMoreSplits);

--- a/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
@@ -394,6 +394,7 @@ public class SqlTask
                 outputBuffer.getInfo(),
                 noMoreSplits,
                 taskStats,
+                Optional.empty(),
                 needsPlan.get());
     }
 

--- a/core/trino-main/src/main/java/io/trino/execution/StageStateMachine.java
+++ b/core/trino-main/src/main/java/io/trino/execution/StageStateMachine.java
@@ -236,6 +236,8 @@ public class StageStateMachine
 
         List<TaskInfo> taskInfos = ImmutableList.copyOf(taskInfosSupplier.get());
 
+        int failedTasks = 0;
+
         int totalDrivers = 0;
         int queuedDrivers = 0;
         int runningDrivers = 0;
@@ -267,6 +269,10 @@ public class StageStateMachine
         for (TaskInfo taskInfo : taskInfos) {
             TaskState taskState = taskInfo.getTaskStatus().getState();
             TaskStats taskStats = taskInfo.getStats();
+
+            if (taskState == TaskState.FAILED) {
+                failedTasks++;
+            }
 
             totalDrivers += taskStats.getTotalDrivers();
             queuedDrivers += taskStats.getQueuedDrivers();
@@ -314,6 +320,8 @@ public class StageStateMachine
 
         return new BasicStageStats(
                 isScheduled,
+
+                failedTasks,
 
                 totalDrivers,
                 queuedDrivers,

--- a/core/trino-main/src/main/java/io/trino/execution/StageStats.java
+++ b/core/trino-main/src/main/java/io/trino/execution/StageStats.java
@@ -623,6 +623,7 @@ public class StageStats
 
         return new BasicStageStats(
                 isScheduled,
+                failedTasks,
                 totalDrivers,
                 queuedDrivers,
                 runningDrivers,

--- a/core/trino-main/src/main/java/io/trino/execution/TaskInfo.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TaskInfo.java
@@ -16,6 +16,7 @@ package io.trino.execution;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableSet;
+import io.airlift.units.DataSize;
 import io.trino.execution.buffer.BufferInfo;
 import io.trino.execution.buffer.OutputBufferInfo;
 import io.trino.operator.TaskStats;
@@ -26,6 +27,7 @@ import javax.annotation.concurrent.Immutable;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -41,6 +43,7 @@ public class TaskInfo
     private final OutputBufferInfo outputBuffers;
     private final Set<PlanNodeId> noMoreSplits;
     private final TaskStats stats;
+    private final Optional<DataSize> estimatedMemory; // filled in on coordinator
 
     private final boolean needsPlan;
 
@@ -50,6 +53,7 @@ public class TaskInfo
             @JsonProperty("outputBuffers") OutputBufferInfo outputBuffers,
             @JsonProperty("noMoreSplits") Set<PlanNodeId> noMoreSplits,
             @JsonProperty("stats") TaskStats stats,
+            @JsonProperty("estimatedMemory") Optional<DataSize> estimatedMemory,
             @JsonProperty("needsPlan") boolean needsPlan)
     {
         this.taskStatus = requireNonNull(taskStatus, "taskStatus is null");
@@ -57,6 +61,7 @@ public class TaskInfo
         this.outputBuffers = requireNonNull(outputBuffers, "outputBuffers is null");
         this.noMoreSplits = requireNonNull(noMoreSplits, "noMoreSplits is null");
         this.stats = requireNonNull(stats, "stats is null");
+        this.estimatedMemory = requireNonNull(estimatedMemory, "estimatedMemory is null");
 
         this.needsPlan = needsPlan;
     }
@@ -92,6 +97,12 @@ public class TaskInfo
     }
 
     @JsonProperty
+    public Optional<DataSize> getEstimatedMemory()
+    {
+        return estimatedMemory;
+    }
+
+    @JsonProperty
     public boolean isNeedsPlan()
     {
         return needsPlan;
@@ -100,9 +111,9 @@ public class TaskInfo
     public TaskInfo summarize()
     {
         if (taskStatus.getState().isDone()) {
-            return new TaskInfo(taskStatus, lastHeartbeat, outputBuffers.summarize(), noMoreSplits, stats.summarizeFinal(), needsPlan);
+            return new TaskInfo(taskStatus, lastHeartbeat, outputBuffers.summarize(), noMoreSplits, stats.summarizeFinal(), estimatedMemory, needsPlan);
         }
-        return new TaskInfo(taskStatus, lastHeartbeat, outputBuffers.summarize(), noMoreSplits, stats.summarize(), needsPlan);
+        return new TaskInfo(taskStatus, lastHeartbeat, outputBuffers.summarize(), noMoreSplits, stats.summarize(), estimatedMemory, needsPlan);
     }
 
     @Override
@@ -122,11 +133,17 @@ public class TaskInfo
                 new OutputBufferInfo("UNINITIALIZED", OPEN, true, true, 0, 0, 0, 0, bufferStates),
                 ImmutableSet.of(),
                 taskStats,
+                Optional.empty(),
                 true);
     }
 
     public TaskInfo withTaskStatus(TaskStatus newTaskStatus)
     {
-        return new TaskInfo(newTaskStatus, lastHeartbeat, outputBuffers, noMoreSplits, stats, needsPlan);
+        return new TaskInfo(newTaskStatus, lastHeartbeat, outputBuffers, noMoreSplits, stats, estimatedMemory, needsPlan);
+    }
+
+    public TaskInfo withEstimatedMemory(DataSize estimatedMemory)
+    {
+        return new TaskInfo(taskStatus, lastHeartbeat, outputBuffers, noMoreSplits, stats, Optional.of(estimatedMemory), needsPlan);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedStageExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedStageExecution.java
@@ -329,7 +329,8 @@ public class PipelinedStageExecution
                 outputBuffers,
                 initialSplits,
                 ImmutableMultimap.of(),
-                ImmutableSet.of());
+                ImmutableSet.of(),
+                Optional.empty());
 
         if (optionalTask.isEmpty()) {
             return Optional.empty();

--- a/core/trino-main/src/main/java/io/trino/server/BasicQueryInfo.java
+++ b/core/trino-main/src/main/java/io/trino/server/BasicQueryInfo.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.SessionRepresentation;
 import io.trino.execution.QueryInfo;
 import io.trino.execution.QueryState;
+import io.trino.operator.RetryPolicy;
 import io.trino.spi.ErrorCode;
 import io.trino.spi.ErrorType;
 import io.trino.spi.QueryId;
@@ -53,6 +54,7 @@ public class BasicQueryInfo
     private final ErrorType errorType;
     private final ErrorCode errorCode;
     private final Optional<QueryType> queryType;
+    private final RetryPolicy retryPolicy;
 
     @JsonCreator
     public BasicQueryInfo(
@@ -68,7 +70,8 @@ public class BasicQueryInfo
             @JsonProperty("queryStats") BasicQueryStats queryStats,
             @JsonProperty("errorType") ErrorType errorType,
             @JsonProperty("errorCode") ErrorCode errorCode,
-            @JsonProperty("queryType") Optional<QueryType> queryType)
+            @JsonProperty("queryType") Optional<QueryType> queryType,
+            @JsonProperty("retryPolicy") RetryPolicy retryPolicy)
     {
         this.queryId = requireNonNull(queryId, "queryId is null");
         this.session = requireNonNull(session, "session is null");
@@ -83,6 +86,7 @@ public class BasicQueryInfo
         this.preparedQuery = requireNonNull(preparedQuery, "preparedQuery is null");
         this.queryStats = requireNonNull(queryStats, "queryStats is null");
         this.queryType = requireNonNull(queryType, "queryType is null");
+        this.retryPolicy = requireNonNull(retryPolicy, "retryPolicy is null");
     }
 
     public BasicQueryInfo(QueryInfo queryInfo)
@@ -99,7 +103,8 @@ public class BasicQueryInfo
                 new BasicQueryStats(queryInfo.getQueryStats()),
                 queryInfo.getErrorType(),
                 queryInfo.getErrorCode(),
-                queryInfo.getQueryType());
+                queryInfo.getQueryType(),
+                queryInfo.getRetryPolicy());
     }
 
     @JsonProperty
@@ -180,6 +185,12 @@ public class BasicQueryInfo
     public Optional<QueryType> getQueryType()
     {
         return queryType;
+    }
+
+    @JsonProperty
+    public RetryPolicy getRetryPolicy()
+    {
+        return retryPolicy;
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/server/BasicQueryStats.java
+++ b/core/trino-main/src/main/java/io/trino/server/BasicQueryStats.java
@@ -45,6 +45,8 @@ public class BasicQueryStats
     private final Duration elapsedTime;
     private final Duration executionTime;
 
+    private final int failedTasks;
+
     private final int totalDrivers;
     private final int queuedDrivers;
     private final int runningDrivers;
@@ -77,6 +79,7 @@ public class BasicQueryStats
             @JsonProperty("queuedTime") Duration queuedTime,
             @JsonProperty("elapsedTime") Duration elapsedTime,
             @JsonProperty("executionTime") Duration executionTime,
+            @JsonProperty("failedTasks") int failedTasks,
             @JsonProperty("totalDrivers") int totalDrivers,
             @JsonProperty("queuedDrivers") int queuedDrivers,
             @JsonProperty("runningDrivers") int runningDrivers,
@@ -104,6 +107,9 @@ public class BasicQueryStats
         this.queuedTime = requireNonNull(queuedTime, "queuedTime is null");
         this.elapsedTime = requireNonNull(elapsedTime, "elapsedTime is null");
         this.executionTime = requireNonNull(executionTime, "executionTime is null");
+
+        checkArgument(failedTasks >= 0, "failedTasks is negative");
+        this.failedTasks = failedTasks;
 
         checkArgument(totalDrivers >= 0, "totalDrivers is negative");
         this.totalDrivers = totalDrivers;
@@ -142,6 +148,7 @@ public class BasicQueryStats
                 queryStats.getQueuedTime(),
                 queryStats.getElapsedTime(),
                 queryStats.getExecutionTime(),
+                queryStats.getFailedTasks(),
                 queryStats.getTotalDrivers(),
                 queryStats.getQueuedDrivers(),
                 queryStats.getRunningDrivers(),
@@ -173,6 +180,7 @@ public class BasicQueryStats
                 new Duration(0, MILLISECONDS),
                 new Duration(0, MILLISECONDS),
                 new Duration(0, MILLISECONDS),
+                0,
                 0,
                 0,
                 0,
@@ -223,6 +231,12 @@ public class BasicQueryStats
     public Duration getExecutionTime()
     {
         return executionTime;
+    }
+
+    @JsonProperty
+    public int getFailedTasks()
+    {
+        return failedTasks;
     }
 
     @JsonProperty

--- a/core/trino-main/src/main/java/io/trino/server/HttpRemoteTaskFactory.java
+++ b/core/trino-main/src/main/java/io/trino/server/HttpRemoteTaskFactory.java
@@ -18,6 +18,7 @@ import io.airlift.concurrent.BoundedExecutor;
 import io.airlift.concurrent.ThreadPoolExecutorMBean;
 import io.airlift.http.client.HttpClient;
 import io.airlift.json.JsonCodec;
+import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.Session;
 import io.trino.execution.DynamicFiltersCollector.VersionedDynamicFilterDomains;
@@ -45,6 +46,7 @@ import org.weakref.jmx.Nested;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -136,6 +138,7 @@ public class HttpRemoteTaskFactory
             OutputBuffers outputBuffers,
             PartitionedSplitCountTracker partitionedSplitCountTracker,
             Set<DynamicFilterId> outboundDynamicFilterIds,
+            Optional<DataSize> estimatedMemory,
             boolean summarizeTaskInfo)
     {
         return new HttpRemoteTask(session,
@@ -161,6 +164,7 @@ public class HttpRemoteTaskFactory
                 partitionedSplitCountTracker,
                 stats,
                 dynamicFilterService,
-                outboundDynamicFilterIds);
+                outboundDynamicFilterIds,
+                estimatedMemory);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
@@ -30,6 +30,7 @@ import io.airlift.http.client.HttpUriBuilder;
 import io.airlift.http.client.Request;
 import io.airlift.json.JsonCodec;
 import io.airlift.log.Logger;
+import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.Session;
 import io.trino.execution.DynamicFiltersCollector;
@@ -200,7 +201,8 @@ public final class HttpRemoteTask
             PartitionedSplitCountTracker partitionedSplitCountTracker,
             RemoteTaskStats stats,
             DynamicFilterService dynamicFilterService,
-            Set<DynamicFilterId> outboundDynamicFilterIds)
+            Set<DynamicFilterId> outboundDynamicFilterIds,
+            Optional<DataSize> estimatedMemory)
     {
         requireNonNull(session, "session is null");
         requireNonNull(taskId, "taskId is null");
@@ -216,6 +218,7 @@ public final class HttpRemoteTask
         requireNonNull(partitionedSplitCountTracker, "partitionedSplitCountTracker is null");
         requireNonNull(stats, "stats is null");
         requireNonNull(outboundDynamicFilterIds, "outboundDynamicFilterIds is null");
+        requireNonNull(estimatedMemory, "estimatedMemory is null");
 
         try (SetThreadName ignored = new SetThreadName("HttpRemoteTask-%s", taskId)) {
             this.taskId = taskId;
@@ -297,7 +300,8 @@ public final class HttpRemoteTask
                     executor,
                     updateScheduledExecutor,
                     errorScheduledExecutor,
-                    stats);
+                    stats,
+                    estimatedMemory);
 
             taskStatusFetcher.addStateChangeListener(newStatus -> {
                 TaskState state = newStatus.getState();

--- a/core/trino-main/src/main/java/io/trino/server/ui/TrimmedBasicQueryInfo.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/TrimmedBasicQueryInfo.java
@@ -15,6 +15,7 @@ package io.trino.server.ui;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.execution.QueryState;
+import io.trino.operator.RetryPolicy;
 import io.trino.server.BasicQueryInfo;
 import io.trino.server.BasicQueryStats;
 import io.trino.spi.ErrorCode;
@@ -51,6 +52,7 @@ public class TrimmedBasicQueryInfo
     private final Optional<ErrorType> errorType;
     private final Optional<ErrorCode> errorCode;
     private final Optional<QueryType> queryType;
+    private final RetryPolicy retryPolicy;
 
     public TrimmedBasicQueryInfo(BasicQueryInfo queryInfo)
     {
@@ -75,6 +77,7 @@ public class TrimmedBasicQueryInfo
         this.preparedQuery = requireNonNull(queryInfo.getPreparedQuery(), "preparedQuery is null");
         this.queryStats = requireNonNull(queryInfo.getQueryStats(), "queryStats is null");
         this.queryType = requireNonNull(queryInfo.getQueryType(), "queryType is null");
+        this.retryPolicy = requireNonNull(queryInfo.getRetryPolicy(), " is null");
     }
 
     @JsonProperty
@@ -165,6 +168,12 @@ public class TrimmedBasicQueryInfo
     public Optional<QueryType> getQueryType()
     {
         return queryType;
+    }
+
+    @JsonProperty
+    public RetryPolicy getRetryPolicy()
+    {
+        return retryPolicy;
     }
 
     @Override

--- a/core/trino-main/src/main/resources/webapp/assets/trino.css
+++ b/core/trino-main/src/main/resources/webapp/assets/trino.css
@@ -556,6 +556,10 @@ pre {
     color: #fff;
 }
 
+.info-failed {
+    color: #aaa;
+}
+
 .table > tbody > tr > .info-sparkline-text {
     color: #fff;
     border-top: none;

--- a/core/trino-main/src/main/resources/webapp/assets/trino.css
+++ b/core/trino-main/src/main/resources/webapp/assets/trino.css
@@ -404,7 +404,7 @@ pre {
 
 .tinystat {
     display: inline-block;
-    width: 100px;
+    width: 94px;
 }
 
 .stat-row {

--- a/core/trino-main/src/main/resources/webapp/assets/trino.css
+++ b/core/trino-main/src/main/resources/webapp/assets/trino.css
@@ -584,6 +584,10 @@ pre {
     text-align: right;
 }
 
+#stage-list #tasks {
+    text-align: left;
+}
+
 .stage-id {
     font-size: 90px;
     color: #b5b5b5;

--- a/core/trino-main/src/main/resources/webapp/src/components/QueryDetail.jsx
+++ b/core/trino-main/src/main/resources/webapp/src/components/QueryDetail.jsx
@@ -410,7 +410,6 @@ class StageSummary extends React.Component {
                                             {stage.stageStats.failedCpuTime}
                                         </td>
                                     </tr>
-
                                     </tbody>
                                 </table>
                             </td>
@@ -1171,7 +1170,6 @@ export class QueryDetail extends React.Component {
 
     render() {
         const query = this.state.query;
-
         if (query === null || this.state.initialized === false) {
             let label = (<div className="loader">Loading...</div>);
             if (this.state.initialized) {
@@ -1183,6 +1181,8 @@ export class QueryDetail extends React.Component {
                 </div>
             );
         }
+
+        const taskRetriesEnabled = query.retryPolicy == "TASK";
 
         return (
             <div>
@@ -1368,9 +1368,11 @@ export class QueryDetail extends React.Component {
                                         <td className="info-text">
                                             {query.queryStats.totalCpuTime}
                                         </td>
+                                        {taskRetriesEnabled &&
                                         <td className="info-failed">
                                             {query.queryStats.failedCpuTime}
                                         </td>
+                                        }
                                     </tr>
                                     <tr>
                                         <td className="info-title">
@@ -1379,9 +1381,11 @@ export class QueryDetail extends React.Component {
                                         <td className="info-text">
                                             {query.queryStats.totalScheduledTime}
                                         </td>
+                                        {taskRetriesEnabled &&
                                         <td className="info-failed">
                                             {query.queryStats.failedScheduledTime}
                                         </td>
+                                        }
                                     </tr>
                                     <tr>
                                         <td className="info-title">
@@ -1390,9 +1394,11 @@ export class QueryDetail extends React.Component {
                                         <td className="info-text">
                                             {formatCount(query.queryStats.processedInputPositions)}
                                         </td>
+                                        {taskRetriesEnabled &&
                                         <td className="info-failed">
                                             {query.queryStats.failedProcessedInputPositions}
                                         </td>
+                                        }
                                     </tr>
                                     <tr>
                                         <td className="info-title">
@@ -1401,9 +1407,11 @@ export class QueryDetail extends React.Component {
                                         <td className="info-text">
                                             {parseAndFormatDataSize(query.queryStats.processedInputDataSize)}
                                         </td>
+                                        {taskRetriesEnabled &&
                                         <td className="info-failed">
                                             {query.queryStats.failedProcessedInputDataSize}
                                         </td>
+                                        }
                                     </tr>
                                     <tr>
                                         <td className="info-title">
@@ -1412,9 +1420,11 @@ export class QueryDetail extends React.Component {
                                         <td className="info-text">
                                             {formatCount(query.queryStats.physicalInputPositions)}
                                         </td>
+                                        {taskRetriesEnabled &&
                                         <td className="info-failed">
                                             {formatCount(query.queryStats.failedPhysicalInputPositions)}
                                         </td>
+                                        }
                                     </tr>
                                     <tr>
                                         <td className="info-title">
@@ -1423,9 +1433,11 @@ export class QueryDetail extends React.Component {
                                         <td className="info-text">
                                             {parseAndFormatDataSize(query.queryStats.physicalInputDataSize)}
                                         </td>
+                                        {taskRetriesEnabled &&
                                         <td className="info-failed">
                                             {parseAndFormatDataSize(query.queryStats.failedPhysicalInputDataSize)}
                                         </td>
+                                        }
                                     </tr>
                                     <tr>
                                         <td className="info-title">
@@ -1434,9 +1446,11 @@ export class QueryDetail extends React.Component {
                                         <td className="info-text">
                                             {query.queryStats.physicalInputReadTime}
                                         </td>
+                                        {taskRetriesEnabled &&
                                         <td className="info-failed">
                                             {query.queryStats.failedPhysicalInputReadTime}
                                         </td>
+                                        }
                                     </tr>
                                     <tr>
                                         <td className="info-title">
@@ -1445,9 +1459,11 @@ export class QueryDetail extends React.Component {
                                         <td className="info-text">
                                             {formatCount(query.queryStats.internalNetworkInputPositions)}
                                         </td>
+                                        {taskRetriesEnabled &&
                                         <td className="info-failed">
                                             {formatCount(query.queryStats.failedInternalNetworkInputPositions)}
                                         </td>
+                                        }
                                     </tr>
                                     <tr>
                                         <td className="info-title">
@@ -1456,9 +1472,11 @@ export class QueryDetail extends React.Component {
                                         <td className="info-text">
                                             {parseAndFormatDataSize(query.queryStats.internalNetworkInputDataSize)}
                                         </td>
+                                        {taskRetriesEnabled &&
                                         <td className="info-failed">
                                             {parseAndFormatDataSize(query.queryStats.failedInternalNetworkInputDataSize)}
                                         </td>
+                                        }
                                     </tr>
                                     <tr>
                                         <td className="info-title">
@@ -1493,9 +1511,11 @@ export class QueryDetail extends React.Component {
                                         <td className="info-text">
                                             {formatDataSizeBytes(query.queryStats.cumulativeUserMemory / 1000.0) + " seconds"}
                                         </td>
+                                        {taskRetriesEnabled &&
                                         <td className="info-failed">
                                             {formatDataSizeBytes(query.queryStats.failedCumulativeUserMemory / 1000.0) + " seconds"}
                                         </td>
+                                        }
                                     </tr>
                                     <tr>
                                         <td className="info-title">
@@ -1504,9 +1524,11 @@ export class QueryDetail extends React.Component {
                                         <td className="info-text">
                                             {formatCount(query.queryStats.outputPositions)}
                                         </td>
+                                        {taskRetriesEnabled &&
                                         <td className="info-failed">
                                             {formatCount(query.queryStats.failedOutputPositions)}
                                         </td>
+                                        }
                                     </tr>
                                     <tr>
                                         <td className="info-title">
@@ -1515,9 +1537,11 @@ export class QueryDetail extends React.Component {
                                         <td className="info-text">
                                             {parseAndFormatDataSize(query.queryStats.outputDataSize)}
                                         </td>
+                                        {taskRetriesEnabled &&
                                         <td className="info-failed">
                                             {parseAndFormatDataSize(query.queryStats.failedOutputDataSize)}
                                         </td>
+                                        }
                                     </tr>
                                     <tr>
                                         <td className="info-title">
@@ -1542,9 +1566,11 @@ export class QueryDetail extends React.Component {
                                         <td className="info-text">
                                             {parseAndFormatDataSize(query.queryStats.physicalWrittenDataSize)}
                                         </td>
+                                        {taskRetriesEnabled &&
                                         <td className="info-failed">
                                             {parseAndFormatDataSize(query.queryStats.failedPhysicalWrittenDataSize)}
                                         </td>
+                                        }
                                     </tr>
                                     {parseDataSize(query.queryStats.spilledDataSize) > 0 &&
                                     <tr>

--- a/core/trino-main/src/main/resources/webapp/src/components/QueryDetail.jsx
+++ b/core/trino-main/src/main/resources/webapp/src/components/QueryDetail.jsx
@@ -394,6 +394,23 @@ class StageSummary extends React.Component {
                                             {stage.stageStats.totalCpuTime}
                                         </td>
                                     </tr>
+                                    <tr>
+                                        <td className="stage-table-stat-title">
+                                            Failed
+                                        </td>
+                                        <td className="stage-table-stat-text">
+                                            {stage.stageStats.failedScheduledTime}
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td className="stage-table-stat-title">
+                                            CPU Failed
+                                        </td>
+                                        <td className="stage-table-stat-text">
+                                            {stage.stageStats.failedCpuTime}
+                                        </td>
+                                    </tr>
+
                                     </tbody>
                                 </table>
                             </td>
@@ -440,6 +457,14 @@ class StageSummary extends React.Component {
                                             {parseAndFormatDataSize(stage.stageStats.peakUserMemoryReservation)}
                                         </td>
                                     </tr>
+                                    <tr>
+                                        <td className="stage-table-stat-title">
+                                            Failed
+                                        </td>
+                                        <td className="stage-table-stat-text">
+                                            {formatDataSizeBytes(stage.stageStats.failedCumulativeUserMemory / 1000)}
+                                        </td>
+                                    </tr>
                                     </tbody>
                                 </table>
                             </td>
@@ -476,6 +501,14 @@ class StageSummary extends React.Component {
                                         </td>
                                         <td className="stage-table-stat-text">
                                             {stage.tasks.filter(task => task.stats.fullyBlocked).length}
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td className="stage-table-stat-title">
+                                            Failed
+                                        </td>
+                                        <td className="stage-table-stat-text">
+                                            {stage.tasks.filter(task => task.taskStatus.state === "FAILED").length}
                                         </td>
                                     </tr>
                                     <tr>

--- a/core/trino-main/src/main/resources/webapp/src/components/QueryDetail.jsx
+++ b/core/trino-main/src/main/resources/webapp/src/components/QueryDetail.jsx
@@ -1368,12 +1368,7 @@ export class QueryDetail extends React.Component {
                                         <td className="info-text">
                                             {query.queryStats.totalCpuTime}
                                         </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="info-title">
-                                            CPU Time (failed tasks)
-                                        </td>
-                                        <td className="info-text">
+                                        <td className="info-failed">
                                             {query.queryStats.failedCpuTime}
                                         </td>
                                     </tr>
@@ -1384,12 +1379,7 @@ export class QueryDetail extends React.Component {
                                         <td className="info-text">
                                             {query.queryStats.totalScheduledTime}
                                         </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="info-title">
-                                            Scheduled Time (failed tasks)
-                                        </td>
-                                        <td className="info-text">
+                                        <td className="info-failed">
                                             {query.queryStats.failedScheduledTime}
                                         </td>
                                     </tr>
@@ -1400,6 +1390,9 @@ export class QueryDetail extends React.Component {
                                         <td className="info-text">
                                             {formatCount(query.queryStats.processedInputPositions)}
                                         </td>
+                                        <td className="info-failed">
+                                            {query.queryStats.failedProcessedInputPositions}
+                                        </td>
                                     </tr>
                                     <tr>
                                         <td className="info-title">
@@ -1407,6 +1400,9 @@ export class QueryDetail extends React.Component {
                                         </td>
                                         <td className="info-text">
                                             {parseAndFormatDataSize(query.queryStats.processedInputDataSize)}
+                                        </td>
+                                        <td className="info-failed">
+                                            {query.queryStats.failedProcessedInputDataSize}
                                         </td>
                                     </tr>
                                     <tr>
@@ -1416,6 +1412,9 @@ export class QueryDetail extends React.Component {
                                         <td className="info-text">
                                             {formatCount(query.queryStats.physicalInputPositions)}
                                         </td>
+                                        <td className="info-failed">
+                                            {formatCount(query.queryStats.failedPhysicalInputPositions)}
+                                        </td>
                                     </tr>
                                     <tr>
                                         <td className="info-title">
@@ -1423,6 +1422,9 @@ export class QueryDetail extends React.Component {
                                         </td>
                                         <td className="info-text">
                                             {parseAndFormatDataSize(query.queryStats.physicalInputDataSize)}
+                                        </td>
+                                        <td className="info-failed">
+                                            {parseAndFormatDataSize(query.queryStats.failedPhysicalInputDataSize)}
                                         </td>
                                     </tr>
                                     <tr>
@@ -1432,6 +1434,9 @@ export class QueryDetail extends React.Component {
                                         <td className="info-text">
                                             {query.queryStats.physicalInputReadTime}
                                         </td>
+                                        <td className="info-failed">
+                                            {query.queryStats.failedPhysicalInputReadTime}
+                                        </td>
                                     </tr>
                                     <tr>
                                         <td className="info-title">
@@ -1440,6 +1445,9 @@ export class QueryDetail extends React.Component {
                                         <td className="info-text">
                                             {formatCount(query.queryStats.internalNetworkInputPositions)}
                                         </td>
+                                        <td className="info-failed">
+                                            {formatCount(query.queryStats.failedInternalNetworkInputPositions)}
+                                        </td>
                                     </tr>
                                     <tr>
                                         <td className="info-title">
@@ -1447,6 +1455,9 @@ export class QueryDetail extends React.Component {
                                         </td>
                                         <td className="info-text">
                                             {parseAndFormatDataSize(query.queryStats.internalNetworkInputDataSize)}
+                                        </td>
+                                        <td className="info-failed">
+                                            {parseAndFormatDataSize(query.queryStats.failedInternalNetworkInputDataSize)}
                                         </td>
                                     </tr>
                                     <tr>
@@ -1482,12 +1493,7 @@ export class QueryDetail extends React.Component {
                                         <td className="info-text">
                                             {formatDataSizeBytes(query.queryStats.cumulativeUserMemory / 1000.0) + " seconds"}
                                         </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="info-title">
-                                            Cumulative User Memory (failed tasks)
-                                        </td>
-                                        <td className="info-text">
+                                        <td className="info-failed">
                                             {formatDataSizeBytes(query.queryStats.failedCumulativeUserMemory / 1000.0) + " seconds"}
                                         </td>
                                     </tr>
@@ -1498,6 +1504,9 @@ export class QueryDetail extends React.Component {
                                         <td className="info-text">
                                             {formatCount(query.queryStats.outputPositions)}
                                         </td>
+                                        <td className="info-failed">
+                                            {formatCount(query.queryStats.failedOutputPositions)}
+                                        </td>
                                     </tr>
                                     <tr>
                                         <td className="info-title">
@@ -1505,6 +1514,9 @@ export class QueryDetail extends React.Component {
                                         </td>
                                         <td className="info-text">
                                             {parseAndFormatDataSize(query.queryStats.outputDataSize)}
+                                        </td>
+                                        <td className="info-failed">
+                                            {parseAndFormatDataSize(query.queryStats.failedOutputDataSize)}
                                         </td>
                                     </tr>
                                     <tr>
@@ -1529,6 +1541,9 @@ export class QueryDetail extends React.Component {
                                         </td>
                                         <td className="info-text">
                                             {parseAndFormatDataSize(query.queryStats.physicalWrittenDataSize)}
+                                        </td>
+                                        <td className="info-failed">
+                                            {parseAndFormatDataSize(query.queryStats.failedPhysicalWrittenDataSize)}
                                         </td>
                                     </tr>
                                     {parseDataSize(query.queryStats.spilledDataSize) > 0 &&

--- a/core/trino-main/src/main/resources/webapp/src/components/QueryDetail.jsx
+++ b/core/trino-main/src/main/resources/webapp/src/components/QueryDetail.jsx
@@ -99,6 +99,7 @@ class TaskList extends React.Component {
 
     render() {
         const tasks = this.props.tasks;
+        const taskRetriesEnabled = this.props.taskRetriesEnabled;
 
         if (tasks === undefined || tasks.length === 0) {
             return (
@@ -163,6 +164,17 @@ class TaskList extends React.Component {
                     <Td column="bufferedBytes" value={task.outputBuffers.totalBufferedBytes}>
                         {formatDataSizeBytes(task.outputBuffers.totalBufferedBytes)}
                     </Td>
+                    <Td column="memory" value={parseDataSize(task.stats.userMemoryReservation)}>
+                        {parseAndFormatDataSize(task.stats.userMemoryReservation)}
+                    </Td>
+                    <Td column="peakMemory" value={parseDataSize(task.stats.peakUserMemoryReservation)}>
+                        {parseAndFormatDataSize(task.stats.peakUserMemoryReservation)}
+                    </Td>
+                    {taskRetriesEnabled &&
+                    <Td column="estimatedMemory" value={parseDataSize(task.estimatedMemory)}>
+                        {parseAndFormatDataSize(task.estimatedMemory)}
+                    </Td>
+                    }
                 </Tr>
             );
         });
@@ -187,6 +199,9 @@ class TaskList extends React.Component {
                     'elapsedTime',
                     'cpuTime',
                     'bufferedBytes',
+                    'memory',
+                    'peakMemory',
+                    'estimatedMemory',
                 ]}
                    defaultSort={{column: 'id', direction: 'asc'}}>
                 <Thead>
@@ -207,7 +222,11 @@ class TaskList extends React.Component {
                 <Th column="bytesSec">Bytes/s</Th>
                 <Th column="elapsedTime">Elapsed</Th>
                 <Th column="cpuTime">CPU Time</Th>
-                <Th column="bufferedBytes">Buffered</Th>
+                <Th column="memory">Mem</Th>
+                <Th column="peakMemory">Peak Mem</Th>
+                {taskRetriesEnabled &&
+                <Th column="estimatedMemory">Est Mem</Th>
+                }
                 </Thead>
                 {renderedTasks}
             </Table>
@@ -938,7 +957,7 @@ export class QueryDetail extends React.Component {
         new window.ClipboardJS('.copy-button');
     }
 
-    renderTasks() {
+    renderTasks(taskRetriesEnabled) {
         if (this.state.lastSnapshotTasks === null) {
             return;
         }
@@ -978,7 +997,7 @@ export class QueryDetail extends React.Component {
                 </div>
                 <div className="row">
                     <div className="col-xs-12">
-                        <TaskList key={this.state.query.queryId} tasks={tasks}/>
+                        <TaskList key={this.state.query.queryId} tasks={tasks} taskRetriesEnabled={taskRetriesEnabled}/>
                     </div>
                 </div>
             </div>
@@ -1705,7 +1724,7 @@ export class QueryDetail extends React.Component {
                     {this.renderPreparedQuery()}
                 </div>
                 {this.renderStages()}
-                {this.renderTasks()}
+                {this.renderTasks(taskRetriesEnabled)}
             </div>
         );
     }

--- a/core/trino-main/src/main/resources/webapp/src/components/QueryList.jsx
+++ b/core/trino-main/src/main/resources/webapp/src/components/QueryList.jsx
@@ -88,6 +88,12 @@ export class QueryListItem extends React.Component {
                     <span className="glyphicon glyphicon-pause" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
                     {(query.state === "FINISHED" || query.state === "FAILED") ? 0 : query.queryStats.queuedDrivers}
                     </span>
+                {query.retryPolicy === "TASK" &&
+                        <span className="tinystat" data-toggle="tooltip" data-placement="top" title="Failed tasks">
+                    <span className="glyphicon glyphicon-remove-circle" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
+                            {query.queryStats.failedTasks}
+                    </span>
+                }
             </div>);
 
         const timingDetails = (

--- a/core/trino-main/src/test/java/io/trino/execution/MockManagedQueryExecution.java
+++ b/core/trino-main/src/test/java/io/trino/execution/MockManagedQueryExecution.java
@@ -20,6 +20,7 @@ import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.Session;
 import io.trino.execution.StateMachine.StateChangeListener;
+import io.trino.operator.RetryPolicy;
 import io.trino.server.BasicQueryInfo;
 import io.trino.server.BasicQueryStats;
 import io.trino.spi.ErrorCode;
@@ -267,7 +268,8 @@ public class MockManagedQueryExecution
                 ImmutableList.of(),
                 state.isDone(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                RetryPolicy.NONE);
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/execution/MockManagedQueryExecution.java
+++ b/core/trino-main/src/test/java/io/trino/execution/MockManagedQueryExecution.java
@@ -124,6 +124,7 @@ public class MockManagedQueryExecution
                         new Duration(3, NANOSECONDS),
                         new Duration(4, NANOSECONDS),
                         new Duration(5, NANOSECONDS),
+                        99,
                         6,
                         7,
                         8,
@@ -146,7 +147,8 @@ public class MockManagedQueryExecution
                         OptionalDouble.empty()),
                 null,
                 null,
-                Optional.empty());
+                Optional.empty(),
+                RetryPolicy.NONE);
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/execution/MockRemoteTaskFactory.java
+++ b/core/trino-main/src/test/java/io/trino/execution/MockRemoteTaskFactory.java
@@ -129,7 +129,7 @@ public class MockRemoteTaskFactory
         for (Split sourceSplit : splits) {
             initialSplits.put(sourceId, sourceSplit);
         }
-        return createRemoteTask(TEST_SESSION, taskId, newNode, testFragment, initialSplits.build(), createInitialEmptyOutputBuffers(BROADCAST), partitionedSplitCountTracker, ImmutableSet.of(), true);
+        return createRemoteTask(TEST_SESSION, taskId, newNode, testFragment, initialSplits.build(), createInitialEmptyOutputBuffers(BROADCAST), partitionedSplitCountTracker, ImmutableSet.of(), Optional.empty(), true);
     }
 
     @Override
@@ -142,6 +142,7 @@ public class MockRemoteTaskFactory
             OutputBuffers outputBuffers,
             PartitionedSplitCountTracker partitionedSplitCountTracker,
             Set<DynamicFilterId> outboundDynamicFilterIds,
+            Optional<DataSize> estimatedMemory,
             boolean summarizeTaskInfo)
     {
         return new MockRemoteTask(taskId, fragment, node.getNodeIdentifier(), executor, scheduledExecutor, initialSplits, partitionedSplitCountTracker);
@@ -271,6 +272,7 @@ public class MockRemoteTaskFactory
                     outputBuffer.getInfo(),
                     ImmutableSet.of(),
                     taskContext.getTaskStats(),
+                    Optional.empty(),
                     true);
         }
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlStage.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlStage.java
@@ -136,7 +136,8 @@ public class TestSqlStage
                             createInitialEmptyOutputBuffers(ARBITRARY),
                             ImmutableMultimap.of(),
                             ImmutableMultimap.of(),
-                            ImmutableSet.of());
+                            ImmutableSet.of(),
+                            Optional.empty());
                     latch.countDown();
                 }
             }

--- a/core/trino-main/src/test/java/io/trino/execution/TestingRemoteTaskFactory.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestingRemoteTaskFactory.java
@@ -42,6 +42,7 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -73,6 +74,7 @@ public class TestingRemoteTaskFactory
             OutputBuffers outputBuffers,
             PartitionedSplitCountTracker partitionedSplitCountTracker,
             Set<DynamicFilterId> outboundDynamicFilterIds,
+            Optional<DataSize> estimatedMemory,
             boolean summarizeTaskInfo)
     {
         TestingRemoteTask task = new TestingRemoteTask(taskId, node.getNodeIdentifier(), fragment);
@@ -147,6 +149,7 @@ public class TestingRemoteTaskFactory
                             ImmutableList.of()),
                     ImmutableSet.copyOf(noMoreSplits),
                     new TaskStats(DateTime.now(), null),
+                    Optional.empty(),
                     false);
         }
 

--- a/core/trino-main/src/test/java/io/trino/server/TestBasicQueryInfo.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestBasicQueryInfo.java
@@ -21,6 +21,7 @@ import io.airlift.units.Duration;
 import io.trino.execution.QueryInfo;
 import io.trino.execution.QueryStats;
 import io.trino.operator.BlockedReason;
+import io.trino.operator.RetryPolicy;
 import io.trino.spi.QueryId;
 import io.trino.spi.StandardErrorCode;
 import io.trino.spi.eventlistener.StageGcStatistics;
@@ -154,7 +155,8 @@ public class TestBasicQueryInfo
                         ImmutableList.of(),
                         false,
                         Optional.empty(),
-                        Optional.of(QueryType.SELECT)));
+                        Optional.of(QueryType.SELECT),
+                        RetryPolicy.NONE));
 
         assertEquals(basicInfo.getQueryId().getId(), "0");
         assertEquals(basicInfo.getState(), RUNNING);

--- a/core/trino-main/src/test/java/io/trino/server/TestQueryStateInfo.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestQueryStateInfo.java
@@ -22,6 +22,7 @@ import io.trino.execution.QueryInfo;
 import io.trino.execution.QueryState;
 import io.trino.execution.QueryStats;
 import io.trino.execution.resourcegroups.InternalResourceGroup;
+import io.trino.operator.RetryPolicy;
 import io.trino.spi.QueryId;
 import io.trino.spi.resourcegroups.QueryType;
 import org.joda.time.DateTime;
@@ -198,6 +199,7 @@ public class TestQueryStateInfo
                 ImmutableList.of(),
                 false,
                 Optional.empty(),
-                Optional.of(QueryType.SELECT));
+                Optional.of(QueryType.SELECT),
+                RetryPolicy.NONE);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/server/remotetask/TestHttpRemoteTask.java
+++ b/core/trino-main/src/test/java/io/trino/server/remotetask/TestHttpRemoteTask.java
@@ -431,6 +431,7 @@ public class TestHttpRemoteTask
                 createInitialEmptyOutputBuffers(OutputBuffers.BufferType.BROADCAST),
                 new NodeTaskMap.PartitionedSplitCountTracker(i -> {}),
                 outboundDynamicFilterIds,
+                Optional.empty(),
                 true);
     }
 
@@ -739,6 +740,7 @@ public class TestHttpRemoteTask
                     initialTaskInfo.getOutputBuffers(),
                     initialTaskInfo.getNoMoreSplits(),
                     initialTaskInfo.getStats(),
+                    initialTaskInfo.getEstimatedMemory(),
                     initialTaskInfo.isNeedsPlan());
         }
 

--- a/testing/trino-tests/src/test/java/io/trino/memory/TestClusterMemoryLeakDetector.java
+++ b/testing/trino-tests/src/test/java/io/trino/memory/TestClusterMemoryLeakDetector.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.execution.QueryState;
+import io.trino.operator.RetryPolicy;
 import io.trino.server.BasicQueryInfo;
 import io.trino.server.BasicQueryStats;
 import io.trino.spi.QueryId;
@@ -83,6 +84,7 @@ public class TestClusterMemoryLeakDetector
                         new Duration(8, MINUTES),
                         new Duration(7, MINUTES),
                         new Duration(34, MINUTES),
+                        99,
                         13,
                         14,
                         15,
@@ -105,6 +107,7 @@ public class TestClusterMemoryLeakDetector
                         OptionalDouble.of(20)),
                 null,
                 null,
-                Optional.empty());
+                Optional.empty(),
+                RetryPolicy.NONE);
     }
 }


### PR DESCRIPTION
## Description

Render task failures related info per stage in web UI
> Is this change a fix, improvement, new feature, refactoring, or other?

improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Web UI

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:


```markdown
# Web UI
* Group information about tasks in by stage. ({issue}`12099`)
* Show aggregated statistics for failed tasks, for queries that are executed with `retry-policy` set to `TASK`. ({issue}`12099`)
```
