### PR TITLE
Make the RewriteComparision constructor more explicit

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/RewriteComparison.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/RewriteComparison.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.jdbc.expression;
 
-import com.google.common.collect.ImmutableSet;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
@@ -96,11 +95,6 @@ public class RewriteComparison
     }
 
     private final Pattern<Call> pattern;
-
-    public RewriteComparison(ComparisonOperator... enabledOperators)
-    {
-        this(ImmutableSet.copyOf(enabledOperators));
-    }
 
     public RewriteComparison(Set<ComparisonOperator> enabledOperators)
     {

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -299,7 +299,7 @@ public class PostgreSqlClient
         this.connectorExpressionRewriter = JdbcConnectorExpressionRewriterBuilder.newBuilder()
                 .addStandardRules(this::quoted)
                 // TODO allow all comparison operators for numeric types
-                .add(new RewriteComparison(RewriteComparison.ComparisonOperator.EQUAL, RewriteComparison.ComparisonOperator.NOT_EQUAL))
+                .add(new RewriteComparison(ImmutableSet.of(RewriteComparison.ComparisonOperator.EQUAL, RewriteComparison.ComparisonOperator.NOT_EQUAL)))
                 .withTypeClass("integer_type", ImmutableSet.of("tinyint", "smallint", "integer", "bigint"))
                 .map("$add(left: integer_type, right: integer_type)").to("left + right")
                 .map("$subtract(left: integer_type, right: integer_type)").to("left - right")


### PR DESCRIPTION
A rewrite related class taking two (or more) arguments can be confusing
since it suggests arg1 is rewritten to arg2 which is not the case here.