### PR TITLE
Improve redis query performance

### DIFF
--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisRecordCursor.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisRecordCursor.java
@@ -23,15 +23,17 @@ import io.trino.spi.connector.RecordCursor;
 import io.trino.spi.type.Type;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.Pipeline;
 import redis.clients.jedis.params.ScanParams;
 import redis.clients.jedis.resps.ScanResult;
 
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
-import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -39,6 +41,7 @@ import static io.trino.decoder.FieldValueProviders.booleanValueProvider;
 import static io.trino.decoder.FieldValueProviders.bytesValueProvider;
 import static io.trino.decoder.FieldValueProviders.longValueProvider;
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 import static redis.clients.jedis.params.ScanParams.SCAN_POINTER_START;
 
 public class RedisRecordCursor
@@ -57,17 +60,17 @@ public class RedisRecordCursor
     private final ScanParams scanParams;
 
     private ScanResult<String> redisCursor;
-    private Iterator<String> keysIterator;
+    private List<String> keys;
 
     private final AtomicBoolean reported = new AtomicBoolean();
 
-    private String valueString;
-    private Map<String, String> valueMap;
+    private List<String> stringValues;
+    private List<Object> hashValues;
 
     private long totalBytes;
     private long totalValues;
 
-    private final FieldValueProvider[] currentRowValues;
+    private final Queue<FieldValueProvider[]> currentMultipleRows;
 
     RedisRecordCursor(
             RowDecoder keyDecoder,
@@ -83,7 +86,7 @@ public class RedisRecordCursor
         this.redisJedisManager = redisJedisManager;
         this.jedisPool = redisJedisManager.getJedisPool(split.getNodes().get(0));
         this.scanParams = setScanParams();
-        this.currentRowValues = new FieldValueProvider[columnHandles.size()];
+        this.currentMultipleRows = new LinkedList<>();
 
         fetchKeys();
     }
@@ -121,14 +124,20 @@ public class RedisRecordCursor
     @Override
     public boolean advanceNextPosition()
     {
-        while (!keysIterator.hasNext()) {
-            if (!hasUnscannedData()) {
-                return endOfData();
+        // When the row of data is processed, it needs to be removed from the queue
+        currentMultipleRows.poll();
+        if (currentMultipleRows.isEmpty()) {
+            while (keys.isEmpty()) {
+                if (!hasUnscannedData()) {
+                    return endOfData();
+                }
+                fetchKeys();
             }
-            fetchKeys();
+            return nextMultipleRows();
         }
-
-        return nextRow(keysIterator.next());
+        else {
+            return true;
+        }
     }
 
     private boolean endOfData()
@@ -139,63 +148,83 @@ public class RedisRecordCursor
         return false;
     }
 
-    private boolean nextRow(String keyString)
+    private boolean nextMultipleRows()
     {
-        fetchData(keyString);
+        fetchData();
 
-        byte[] keyData = keyString.getBytes(StandardCharsets.UTF_8);
+        for (int i = 0; i < keys.size(); i++) {
+            String keyString = keys.get(i);
+            byte[] keyData = keyString.getBytes(StandardCharsets.UTF_8);
 
-        byte[] valueData = EMPTY_BYTE_ARRAY;
-        if (valueString != null) {
-            valueData = valueString.getBytes(StandardCharsets.UTF_8);
-        }
+            byte[] stringValueData = EMPTY_BYTE_ARRAY;
+            Map<String, String> hashValueMap = new HashMap<>();
+            switch (split.getValueDataType()) {
+                case STRING:
+                    // If the value corresponding to the key does not exist, the valueString is null
+                    String valueString = stringValues.get(i);
+                    if (valueString != null) {
+                        stringValueData = valueString.getBytes(StandardCharsets.UTF_8);
+                        totalBytes += stringValueData.length;
+                    }
+                    else {
+                        log.warn("Redis data modified while query was running, string value at key %s may be deleted", keyString);
+                    }
+                    break;
+                case HASH:
+                    hashValueMap = (Map<String, String>) hashValues.get(i);
+                    break;
+                default:
+                    log.warn("Redis value of type %s is unsupported", split.getValueDataType());
+            }
 
-        totalBytes += valueData.length;
-        totalValues++;
+            totalValues++;
 
-        Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodedKey = keyDecoder.decodeRow(keyData);
-        Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodedValue = valueDecoder.decodeRow(
-                valueData,
-                valueMap);
+            Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodedKey = keyDecoder.decodeRow(keyData);
+            Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodedValue = valueDecoder.decodeRow(
+                    stringValueData,
+                    hashValueMap);
 
-        Map<ColumnHandle, FieldValueProvider> currentRowValuesMap = new HashMap<>();
+            Map<ColumnHandle, FieldValueProvider> currentRowValuesMap = new HashMap<>();
 
-        for (DecoderColumnHandle columnHandle : columnHandles) {
-            if (columnHandle.isInternal()) {
-                RedisInternalFieldDescription fieldDescription = RedisInternalFieldDescription.forColumnName(columnHandle.getName());
-                switch (fieldDescription) {
-                    case KEY_FIELD:
-                        currentRowValuesMap.put(columnHandle, bytesValueProvider(keyData));
-                        break;
-                    case VALUE_FIELD:
-                        currentRowValuesMap.put(columnHandle, bytesValueProvider(valueData));
-                        break;
-                    case KEY_LENGTH_FIELD:
-                        currentRowValuesMap.put(columnHandle, longValueProvider(keyData.length));
-                        break;
-                    case VALUE_LENGTH_FIELD:
-                        currentRowValuesMap.put(columnHandle, longValueProvider(valueData.length));
-                        break;
-                    case KEY_CORRUPT_FIELD:
-                        currentRowValuesMap.put(columnHandle, booleanValueProvider(decodedKey.isEmpty()));
-                        break;
-                    case VALUE_CORRUPT_FIELD:
-                        currentRowValuesMap.put(columnHandle, booleanValueProvider(decodedValue.isEmpty()));
-                        break;
-                    default:
-                        throw new IllegalArgumentException("unknown internal field " + fieldDescription);
+            for (DecoderColumnHandle columnHandle : columnHandles) {
+                if (columnHandle.isInternal()) {
+                    RedisInternalFieldDescription fieldDescription = RedisInternalFieldDescription.forColumnName(columnHandle.getName());
+                    switch (fieldDescription) {
+                        case KEY_FIELD:
+                            currentRowValuesMap.put(columnHandle, bytesValueProvider(keyData));
+                            break;
+                        case VALUE_FIELD:
+                            currentRowValuesMap.put(columnHandle, bytesValueProvider(stringValueData));
+                            break;
+                        case KEY_LENGTH_FIELD:
+                            currentRowValuesMap.put(columnHandle, longValueProvider(keyData.length));
+                            break;
+                        case VALUE_LENGTH_FIELD:
+                            currentRowValuesMap.put(columnHandle, longValueProvider(stringValueData.length));
+                            break;
+                        case KEY_CORRUPT_FIELD:
+                            currentRowValuesMap.put(columnHandle, booleanValueProvider(decodedKey.isEmpty()));
+                            break;
+                        case VALUE_CORRUPT_FIELD:
+                            currentRowValuesMap.put(columnHandle, booleanValueProvider(decodedValue.isEmpty()));
+                            break;
+                        default:
+                            throw new IllegalArgumentException("unknown internal field " + fieldDescription);
+                    }
                 }
             }
+
+            decodedKey.ifPresent(currentRowValuesMap::putAll);
+            decodedValue.ifPresent(currentRowValuesMap::putAll);
+
+            FieldValueProvider[] fieldValues = new FieldValueProvider[columnHandles.size()];
+            for (int j = 0; j < columnHandles.size(); j++) {
+                ColumnHandle columnHandle = columnHandles.get(j);
+                fieldValues[j] = currentRowValuesMap.get(columnHandle);
+            }
+            currentMultipleRows.offer(fieldValues);
         }
-
-        decodedKey.ifPresent(currentRowValuesMap::putAll);
-        decodedValue.ifPresent(currentRowValuesMap::putAll);
-
-        for (int i = 0; i < columnHandles.size(); i++) {
-            ColumnHandle columnHandle = columnHandles.get(i);
-            currentRowValues[i] = currentRowValuesMap.get(columnHandle);
-        }
-
+        keys.clear();
         return true;
     }
 
@@ -227,6 +256,7 @@ public class RedisRecordCursor
     public boolean isNull(int field)
     {
         checkArgument(field < columnHandles.size(), "Invalid field index");
+        FieldValueProvider[] currentRowValues = currentMultipleRows.peek();
         return currentRowValues == null || currentRowValues[field].isNull();
     }
 
@@ -241,7 +271,8 @@ public class RedisRecordCursor
     {
         checkArgument(field < columnHandles.size(), "Invalid field index");
         checkFieldType(field, expectedType);
-        return currentRowValues[field];
+        FieldValueProvider[] currentRowValues = currentMultipleRows.peek();
+        return requireNonNull(currentRowValues)[field];
     }
 
     private void checkFieldType(int field, Class<?> expected)
@@ -300,24 +331,22 @@ public class RedisRecordCursor
                     log.debug("Scanning new Redis keys from cursor %s . %d values read so far", cursor, totalValues);
 
                     redisCursor = jedis.scan(cursor, scanParams);
-                    List<String> keys = redisCursor.getResult();
-                    keysIterator = keys.iterator();
+                    keys = redisCursor.getResult();
                 }
                 break;
                 case ZSET:
-                    List<String> keys = jedis.zrange(split.getKeyName(), split.getStart(), split.getEnd());
-                    keysIterator = keys.iterator();
+                    keys = jedis.zrange(split.getKeyName(), split.getStart(), split.getEnd());
                     break;
                 default:
-                    log.debug("Redis key of type %s is unsupported", split.getKeyDataFormat());
+                    log.warn("Redis key of type %s is unsupported", split.getKeyDataFormat());
             }
         }
     }
 
-    private void fetchData(String keyString)
+    private void fetchData()
     {
-        valueString = null;
-        valueMap = null;
+        stringValues = null;
+        hashValues = null;
         // Redis connector supports two types of Redis
         // values: STRING and HASH
         // HASH types requires hash row decoder to
@@ -326,19 +355,17 @@ public class RedisRecordCursor
         try (Jedis jedis = jedisPool.getResource()) {
             switch (split.getValueDataType()) {
                 case STRING:
-                    valueString = jedis.get(keyString);
-                    if (valueString == null) {
-                        log.warn("Redis data modified while query was running, string value at key %s may be deleted", keyString);
-                    }
+                    stringValues = jedis.mget(keys.toArray(new String[0]));
                     break;
                 case HASH:
-                    valueMap = jedis.hgetAll(keyString);
-                    if (valueMap == null) {
-                        log.warn("Redis data modified while query was running, hash value at key %s may be deleted", keyString);
+                    Pipeline pipeline = jedis.pipelined();
+                    for (String key : keys) {
+                        pipeline.hgetAll(key);
                     }
+                    hashValues = pipeline.syncAndReturnAll();
                     break;
                 default:
-                    log.debug("Redis value of type %s is unsupported", split.getValueDataType());
+                    log.warn("Redis value of type %s is unsupported", split.getValueDataType());
             }
         }
     }


### PR DESCRIPTION
When I use trino to query data from redis, I find it very slow. Some trino users have also given feedback about this problem, so I plan to improve the performance of trino on redis.

An example of performance comparison:
First make sure the environment and sql are the same, the sql is as follows:
```sql
select * from redis_catalog.schema.table limit 100;
```

It took 8 seconds before optimization:
<img width="593" alt="企业微信截图_0dc13516-6f2c-49e9-bc12-fff405114e20" src="https://user-images.githubusercontent.com/29967142/164896526-de2ef5dd-eeab-4a8b-9bf3-99acdd564672.png">

It took 0.8 seconds after optimization:
<img width="564" alt="企业微信截图_bb4ce151-7105-4ce0-b837-40414641f78a" src="https://user-images.githubusercontent.com/29967142/164896542-cf533952-8695-4104-9c5f-40e574a512cb.png">

Note that this is just an example to illustrate the performance difference, the real performance improvement is related to redis service, redis key distribution, sql, etc. In addition, the `redis.scan-count` parameter can be reasonably matched to improve query performance.