### PR TITLE
Fix wrong entry for Delta Lake in release note 378

### DIFF
--- a/docs/src/main/sphinx/release/release-378.md
+++ b/docs/src/main/sphinx/release/release-378.md
@@ -25,10 +25,10 @@
 * Improve query planning performance. ({issue}`11858`)
 * Fix failure when reading from `information_schema.columns` when metastore
   contains views. ({issue}`11946`)
+* Add support for dropping tables with invalid metadata. ({issue}`11924`)
 
 ## Hive connector
 
-* Add support for dropping tables with invalid metadata. ({issue}`11924`)
 * Improve query planning performance. ({issue}`11858`)
 * Fix query failure when partition column has a `null` value and query has a
   complex predicate on that partition column. ({issue}`12056`)


### PR DESCRIPTION
## Description

The place should be Delta Lake, not Hive.
Relates to https://github.com/trinodb/trino/issues/11947#issuecomment-1104720006

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
