### PR TITLE
Remove wrong note about Java 17

### DIFF
--- a/docs/src/main/sphinx/security/internal-communication.rst
+++ b/docs/src/main/sphinx/security/internal-communication.rst
@@ -58,8 +58,7 @@ configuration identical on all cluster nodes.
 
    Note that using hostnames or fully qualified domain names for the URI is
    not supported. The automatic certificate creation for internal TLS only
-   supports IP addresses. Java 17 is known to be incompatible with this feature
-   and can not be used as a runtime for Trino with this feature enabled.
+   supports IP addresses.
 
 4. Enable the HTTPS endpoint on all workers.
 


### PR DESCRIPTION
## Description

Internal communication works with Java 17 as well. This was fixed quite a while ago.

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Documentation only.

> How would you describe this change to a non-technical end user or system administrator?

Correct documentation about internal communication. 

## Related issues, pull requests, and links

NA

## Documentation

( ) No documentation is needed.
(✅ ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(✅ ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

