### PR TITLE
Catch exception at joinCompiler lookup source

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/PagesIndex.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PagesIndex.java
@@ -515,16 +515,21 @@ public class PagesIndex
             // This code path will trigger only for OUTER joins. To fix that we need to add support for
             //        OUTER joins into NestedLoopsJoin and remove "type == INNER" condition in LocalExecutionPlanner.visitJoin()
 
-            LookupSourceSupplierFactory lookupSourceFactory = joinCompiler.compileLookupSourceFactory(types, joinChannels, sortChannel, outputChannels);
-            return lookupSourceFactory.createLookupSourceSupplier(
-                    session,
-                    valueAddresses,
-                    channels,
-                    hashChannel,
-                    filterFunctionFactory,
-                    sortChannel,
-                    searchFunctionFactories,
-                    hashArraySizeSupplier);
+            try {
+                LookupSourceSupplierFactory lookupSourceFactory = joinCompiler.compileLookupSourceFactory(types, joinChannels, sortChannel, outputChannels);
+                return lookupSourceFactory.createLookupSourceSupplier(
+                        session,
+                        valueAddresses,
+                        channels,
+                        hashChannel,
+                        filterFunctionFactory,
+                        sortChannel,
+                        searchFunctionFactories,
+                        hashArraySizeSupplier);
+            }
+            catch (Exception e) {
+                log.error(e, "Lookup source compile failed for types=%s error=%s", types, e);
+            }
         }
 
         PagesHashStrategy hashStrategy = new SimplePagesHashStrategy(


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

This could fix when a join query failed to compile byte codes at Join query and use interpreter at the compilation failure by various reasons ex, too many involved columns. 

We got the following error when hundreds of columns are used at the output columns in a JOIN query in presto 350. 
```
com.google.common.util.concurrent.UncheckedExecutionException: io.airlift.bytecode.CompilationException: Error compiling class: io/prestosql/$gen/PagesHashStrategy_20220421_050326_462152
    at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2051)
    at com.google.common.cache.LocalCache.get(LocalCache.java:3951)
    at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3974)
    at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4958)
    at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:4964)
    at io.prestosql.sql.gen.JoinCompiler.compileLookupSourceFactory(JoinCompiler.java:131)
    at io.prestosql.operator.PagesIndex.createLookupSourceSupplier(PagesIndex.java:504)
    at io.prestosql.operator.HashBuilderOperator.buildLookupSource(HashBuilderOperator.java:589)
    at io.prestosql.operator.HashBuilderOperator.finishInput(HashBuilderOperator.java:486)
    at io.prestosql.operator.HashBuilderOperator.finish(HashBuilderOperator.java:442)
    at io.prestosql.operator.Driver.processInternal(Driver.java:397)
    at io.prestosql.operator.Driver.lambda$processFor$8(Driver.java:283)
    at io.prestosql.operator.Driver.tryWithLock(Driver.java:675)
    at io.prestosql.operator.Driver.processFor(Driver.java:276)
    at io.prestosql.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:1076)
    at io.prestosql.execution.executor.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:163)
    at io.prestosql.execution.executor.TaskExecutor$TaskRunner.run(TaskExecutor.java:484)
    at io.prestosql.$gen.Presto_350____20220418_042654_2.run(Unknown Source)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: io.airlift.bytecode.CompilationException: Error compiling class: io/prestosql/$gen/PagesHashStrategy_20220421_050326_462152
    at io.airlift.bytecode.ClassGenerator.defineClasses(ClassGenerator.java:143)
    at io.airlift.bytecode.ClassGenerator.defineClass(ClassGenerator.java:117)
    at io.prestosql.util.CompilerUtils.defineClass(CompilerUtils.java:63)
    at io.prestosql.util.CompilerUtils.defineClass(CompilerUtils.java:57)
    at io.prestosql.sql.gen.JoinCompiler.internalCompileHashStrategy(JoinCompiler.java:234)
    at io.prestosql.sql.gen.JoinCompiler.internalCompileLookupSourceFactory(JoinCompiler.java:165)
    at io.prestosql.sql.gen.JoinCompiler.lambda$new$0(JoinCompiler.java:101)
    at com.google.common.cache.CacheLoader$FunctionToCacheLoader.load(CacheLoader.java:165)
    at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3529)
    at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2278)
    at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2155)
    at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2045)
    ... 20 more
Caused by: org.objectweb.asm.MethodTooLargeException: Method too large: io/prestosql/$gen/PagesHashStrategy_20220421_050326_462152.<init> (Ljava/util/List;Ljava/util/OptionalInt;)V
    at org.objectweb.asm.MethodWriter.computeMethodInfoSize(MethodWriter.java:2080)
    at org.objectweb.asm.ClassWriter.toByteArray(ClassWriter.java:459)
    at io.airlift.bytecode.ClassGenerator.defineClasses(ClassGenerator.java:140)
```

`PagesIndex.createPagesHashStrategy` catches compilation error at `joinCompiler.compilePagesHashStrategyFactory` and uses interpreter's one but not for `joinCompiler.compileLookupSourceFactory`

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
