### PR TITLE
Remove DeltaLakeGlueMetastoreTableFilterProvider.isDeltaLakeTable

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/glue/DeltaLakeGlueMetastoreTableFilterProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/glue/DeltaLakeGlueMetastoreTableFilterProvider.java
@@ -19,7 +19,6 @@ import io.trino.plugin.hive.metastore.glue.DefaultGlueMetastoreTableFilterProvid
 import javax.inject.Inject;
 import javax.inject.Provider;
 
-import java.util.Map;
 import java.util.function.Predicate;
 
 import static java.util.Objects.requireNonNull;
@@ -40,18 +39,8 @@ public class DeltaLakeGlueMetastoreTableFilterProvider
     public Predicate<Table> get()
     {
         if (hideNonDeltaLakeTables) {
-            return DeltaLakeGlueMetastoreTableFilterProvider::isDeltaLakeTable;
+            return DefaultGlueMetastoreTableFilterProvider::isDeltaLakeTable;
         }
         return table -> true;
-    }
-
-    private static boolean isDeltaLakeTable(Table table)
-    {
-        Map<String, String> parameters = table.getParameters();
-        if (parameters == null) {
-            return false;
-        }
-        // todo; add parameters == null check to DefaultGlueMetastoreTableFilterProvider.isDeltaLakeTable (https://github.com/trinodb/trino/issues/12013)
-        return DefaultGlueMetastoreTableFilterProvider.isDeltaLakeTable(table);
     }
 }


### PR DESCRIPTION
## Description
Replace it with DefaultGlueMetastoreTableFilterProvider.isDeltaLakeTable.

Base on https://github.com/trinodb/trino/commit/b7c07f210c62e63dec4bef157e04d3913abe2b98 tt looks like we don't want to do it anymore. 

fixes: https://github.com/trinodb/trino/issues/12013

## Related issues, pull requests, and links

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
