### PR TITLE
Support loading of redis table description files by schedule

### DIFF
--- a/docs/src/main/sphinx/connector/redis.rst
+++ b/docs/src/main/sphinx/connector/redis.rst
@@ -61,6 +61,7 @@ Property Name                           Description
 ``redis.key-prefix-schema-table``       Redis keys have schema-name:table-name prefix
 ``redis.key-delimiter``                 Delimiter separating schema_name and table_name if redis.key-prefix-schema-table is used
 ``redis.table-description-dir``         Directory containing table description files
+``redis.table-description-cache-ttl``   The cache time for table description files
 ``redis.hide-internal-columns``         Controls whether internal columns are part of the table schema or not
 ``redis.database-index``                Redis database index
 ``redis.password``                      Redis server password
@@ -77,8 +78,8 @@ For each table defined, a table description file (see below) may
 exist. If no table description file exists, the
 table only contains internal columns (see below).
 
-This property is required; there is no default and at least one table must be
-defined.
+This property is optional; the connector relies on the table description files
+specified in the ``redis.table-description-dir`` property.
 
 ``redis.default-schema``
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -138,7 +139,21 @@ This property is optional; the default is ``:``.
 References a folder within Trino deployment that holds one or more JSON
 files, which must end with ``.json`` and contain table description files.
 
+Note that the table description files will only be used by the Trino coordinator
+node.
+
 This property is optional; the default is ``etc/redis``.
+
+``redis.table-description-cache-ttl``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Redis connector dynamically loads the table description files after waiting
+for the time specified by this property. Therefore, there is no need to update
+the ``redis.table-names`` property and restart the Trino service when adding,
+updating, or deleting a file end with ``.json`` to ``redis.table-description-dir``
+folder.
+
+This property is optional; the default is ``5m``.
 
 ``redis.hide-internal-columns``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/src/main/sphinx/connector/redis.rst
+++ b/docs/src/main/sphinx/connector/redis.rst
@@ -50,21 +50,21 @@ Configuration properties
 
 The following configuration properties are available:
 
-=================================   ==============================================================
-Property Name                       Description
-=================================   ==============================================================
-``redis.table-names``               List of all tables provided by the catalog
-``redis.default-schema``            Default schema name for tables
-``redis.nodes``                     Location of the Redis server
-``redis.scan-count``                Redis parameter for scanning of the keys
-``redis.max-keys-per-fetch``        Get values associated with the specified number of keys in the redis command such as MGET(key...)
-``redis.key-prefix-schema-table``   Redis keys have schema-name:table-name prefix
-``redis.key-delimiter``             Delimiter separating schema_name and table_name if redis.key-prefix-schema-table is used
-``redis.table-description-dir``     Directory containing table description files
-``redis.hide-internal-columns``     Controls whether internal columns are part of the table schema or not
-``redis.database-index``            Redis database index
-``redis.password``                  Redis server password
-=================================   ==============================================================
+======================================  ==============================================================
+Property Name                           Description
+======================================  ==============================================================
+``redis.table-names``                   List of all tables provided by the catalog
+``redis.default-schema``                Default schema name for tables
+``redis.nodes``                         Location of the Redis server
+``redis.scan-count``                    Redis parameter for scanning of the keys
+``redis.max-keys-per-fetch``            Get values associated with the specified number of keys in the redis command such as MGET(key...)
+``redis.key-prefix-schema-table``       Redis keys have schema-name:table-name prefix
+``redis.key-delimiter``                 Delimiter separating schema_name and table_name if redis.key-prefix-schema-table is used
+``redis.table-description-dir``         Directory containing table description files
+``redis.hide-internal-columns``         Controls whether internal columns are part of the table schema or not
+``redis.database-index``                Redis database index
+``redis.password``                      Redis server password
+======================================  ==============================================================
 
 ``redis.table-names``
 ^^^^^^^^^^^^^^^^^^^^^

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisConnectorConfig.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisConnectorConfig.java
@@ -32,6 +32,7 @@ import java.util.stream.StreamSupport;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class RedisConnectorConfig
 {
@@ -47,6 +48,7 @@ public class RedisConnectorConfig
     private String defaultSchema = "default";
     private Set<String> tableNames = ImmutableSet.of();
     private File tableDescriptionDir = new File("etc/redis/");
+    private Duration tableDescriptionCacheDuration = new Duration(5, MINUTES);
     private boolean hideInternalColumns = true;
     private boolean keyPrefixSchemaTable;
 
@@ -61,6 +63,21 @@ public class RedisConnectorConfig
     public RedisConnectorConfig setTableDescriptionDir(File tableDescriptionDir)
     {
         this.tableDescriptionDir = tableDescriptionDir;
+        return this;
+    }
+
+    @NotNull
+    @MinDuration("1s")
+    public Duration getTableDescriptionCacheDuration()
+    {
+        return tableDescriptionCacheDuration;
+    }
+
+    @Config("redis.table-description-cache-ttl")
+    @ConfigDescription("The cache time for redis table description files")
+    public RedisConnectorConfig setTableDescriptionCacheDuration(Duration tableDescriptionCacheDuration)
+    {
+        this.tableDescriptionCacheDuration = tableDescriptionCacheDuration;
         return this;
     }
 

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisMetadata.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisMetadata.java
@@ -42,6 +42,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
  * Manages the Redis connector specific metadata information. The Connector provides an additional set of columns
@@ -67,7 +68,10 @@ public class RedisMetadata
 
         log.debug("Loading redis table definitions from %s", redisConnectorConfig.getTableDescriptionDir().getAbsolutePath());
 
-        this.redisTableDescriptionSupplier = Suppliers.memoize(redisTableDescriptionSupplier::get)::get;
+        this.redisTableDescriptionSupplier = Suppliers.memoizeWithExpiration(
+                redisTableDescriptionSupplier::get,
+                redisConnectorConfig.getTableDescriptionCacheDuration().toMillis(),
+                MILLISECONDS);
     }
 
     @Override

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisTableDescriptionSupplier.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisTableDescriptionSupplier.java
@@ -71,7 +71,6 @@ public class RedisTableDescriptionSupplier
 
             log.debug("Loaded table definitions: %s", tableDefinitions.keySet());
 
-            builder = ImmutableMap.builder();
             for (String definedTable : redisConnectorConfig.getTableNames()) {
                 SchemaTableName tableName;
                 try {
@@ -81,12 +80,7 @@ public class RedisTableDescriptionSupplier
                     tableName = new SchemaTableName(redisConnectorConfig.getDefaultSchema(), definedTable);
                 }
 
-                if (tableDefinitions.containsKey(tableName)) {
-                    RedisTableDescription redisTable = tableDefinitions.get(tableName);
-                    log.debug("Found Table definition for %s: %s", tableName, redisTable);
-                    builder.put(tableName, redisTable);
-                }
-                else {
+                if (!tableDefinitions.containsKey(tableName)) {
                     // A dummy table definition only supports the internal columns.
                     log.debug("Created dummy Table definition for %s", tableName);
                     builder.put(tableName, new RedisTableDescription(tableName.getTableName(),

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisConnectorConfig.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisConnectorConfig.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.redis;
 
 import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -22,6 +23,8 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class TestRedisConnectorConfig
 {
@@ -33,6 +36,7 @@ public class TestRedisConnectorConfig
                 .setDefaultSchema("default")
                 .setTableNames("")
                 .setTableDescriptionDir(new File("etc/redis/"))
+                .setTableDescriptionCacheDuration(new Duration(5, MINUTES))
                 .setKeyPrefixSchemaTable(false)
                 .setRedisKeyDelimiter(":")
                 .setRedisConnectTimeout("2000ms")
@@ -48,6 +52,7 @@ public class TestRedisConnectorConfig
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("redis.table-description-dir", "/var/lib/redis")
+                .put("redis.table-description-cache-ttl", "30s")
                 .put("redis.table-names", "table1, table2, table3")
                 .put("redis.default-schema", "redis")
                 .put("redis.nodes", "localhost:12345,localhost:23456")
@@ -63,6 +68,7 @@ public class TestRedisConnectorConfig
 
         RedisConnectorConfig expected = new RedisConnectorConfig()
                 .setTableDescriptionDir(new File("/var/lib/redis"))
+                .setTableDescriptionCacheDuration(new Duration(30, SECONDS))
                 .setTableNames("table1, table2, table3")
                 .setDefaultSchema("redis")
                 .setNodes("localhost:12345, localhost:23456")


### PR DESCRIPTION
## Description
Support dynamic loading of redis table description files.

## Related issues, pull requests, and links
Fixes https://github.com/trinodb/trino/issues/12240

## Documentation
(x) Sufficient documentation is included in this PR.

## Release notes
```markdown
# Redis
* Support dynamic loading of redis table description files. ({issue}`12240`)
```