### PR TITLE
Improve Iceberg commit to Glue

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergTableOperations.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.iceberg.catalog.glue;
 
 import com.amazonaws.services.glue.AWSGlueAsync;
+import com.amazonaws.services.glue.model.ConcurrentModificationException;
 import com.amazonaws.services.glue.model.CreateTableRequest;
 import com.amazonaws.services.glue.model.EntityNotFoundException;
 import com.amazonaws.services.glue.model.GetTableRequest;
@@ -31,9 +32,10 @@ import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.io.FileIO;
 
+import javax.annotation.Nullable;
+
 import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static io.trino.plugin.hive.ViewReaderUtil.isHiveOrPrestoView;
 import static io.trino.plugin.hive.ViewReaderUtil.isPrestoView;
@@ -52,6 +54,9 @@ public class GlueIcebergTableOperations
 {
     private final AWSGlueAsync glueClient;
     private final GlueMetastoreStats stats;
+
+    @Nullable
+    private String glueVersionId;
 
     protected GlueIcebergTableOperations(
             AWSGlueAsync glueClient,
@@ -72,6 +77,7 @@ public class GlueIcebergTableOperations
     protected String getRefreshedLocation(boolean invalidateCaches)
     {
         Table table = getTable();
+        glueVersionId = table.getVersionId();
 
         if (isPrestoView(table.getParameters()) && isHiveOrPrestoView(table.getTableType())) {
             // this is a Presto Hive view, hence not a table
@@ -115,19 +121,17 @@ public class GlueIcebergTableOperations
                 .put(PREVIOUS_METADATA_LOCATION_PROP, currentMetadataLocation)
                 .buildOrThrow());
 
-        Table table = getTable();
-
-        checkState(currentMetadataLocation != null, "No current metadata location for existing table");
-        String metadataLocation = table.getParameters().get(METADATA_LOCATION_PROP);
-        if (!currentMetadataLocation.equals(metadataLocation)) {
-            throw new CommitFailedException("Metadata location [%s] is not same as table metadata location [%s] for %s",
-                    currentMetadataLocation, metadataLocation, getSchemaTableName());
-        }
-
         UpdateTableRequest updateTableRequest = new UpdateTableRequest()
                 .withDatabaseName(database)
-                .withTableInput(tableInput);
-        stats.getUpdateTable().call(() -> glueClient.updateTable(updateTableRequest));
+                .withTableInput(tableInput)
+                .withVersionId(glueVersionId);
+        try {
+            stats.getUpdateTable().call(() -> glueClient.updateTable(updateTableRequest));
+        }
+        catch (ConcurrentModificationException e) {
+            // CommitFailedException is handled as a special case in the Iceberg library. This commit will automatically retry
+            throw new CommitFailedException(e, "Failed to commit to Glue table due to concurrent updates: %s.%s", database, tableName);
+        }
         shouldRefresh = true;
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
@@ -20,9 +20,20 @@ import io.trino.testing.sql.TestTable;
 import org.apache.iceberg.FileFormat;
 import org.testng.annotations.Test;
 
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.stream.IntStream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newFixedThreadPool;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertTrue;
 
 public abstract class BaseIcebergConnectorSmokeTest
         extends BaseConnectorSmokeTest
@@ -83,6 +94,48 @@ public abstract class BaseIcebergConnectorSmokeTest
 
             // Check whether the "$path" hidden column is correctly evaluated in the filter expression
             assertQuery(format("SELECT a FROM %s WHERE \"$path\" = '%s'", table.getName(), filePath), "VALUES 1");
+        }
+    }
+
+    // Repeat test with invocationCount for better test coverage, since the tested aspect is inherently non-deterministic.
+    @Test(timeOut = 60_000, invocationCount = 4)
+    public void testDeleteRowsConcurrently()
+            throws Exception
+    {
+        int threads = 4;
+        CyclicBarrier barrier = new CyclicBarrier(threads);
+        ExecutorService executor = newFixedThreadPool(threads);
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "test_concurrent_delete",
+                "(col0 INTEGER, col1 INTEGER, col2 INTEGER, col3 INTEGER)")) {
+            String tableName = table.getName();
+            assertUpdate("INSERT INTO " + tableName + " VALUES (0, 0, 0, 0)", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 0, 0, 0)", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (0, 1, 0, 0)", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (0, 0, 1, 0)", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (0, 0, 0, 1)", 1);
+
+            List<Future<Boolean>> futures = IntStream.range(0, threads)
+                    .mapToObj(threadNumber -> executor.submit(() -> {
+                        barrier.await(10, SECONDS);
+                        try {
+                            String columnName = "col" + threadNumber;
+                            getQueryRunner().execute(format("DELETE FROM %s WHERE %s = 1", tableName, columnName));
+                            return true;
+                        }
+                        catch (Exception e) {
+                            return false;
+                        }
+                    }))
+                    .collect(toImmutableList());
+
+            futures.forEach(future -> assertTrue(getFutureValue(future)));
+            assertThat(query("SELECT max(col0), max(col1), max(col2), max(col3) FROM " + tableName)).matches("VALUES (0, 0, 0, 0)");
+        }
+        finally {
+            executor.shutdownNow();
+            executor.awaitTermination(10, SECONDS);
         }
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMinioConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMinioConnectorSmokeTest.java
@@ -16,28 +16,16 @@ package io.trino.plugin.iceberg;
 import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.hive.containers.HiveMinioDataLake;
 import io.trino.testing.QueryRunner;
-import io.trino.testing.sql.TestTable;
 import org.apache.iceberg.FileFormat;
 import org.testng.annotations.Test;
 
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-import java.util.stream.IntStream;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.trino.plugin.hive.containers.HiveMinioDataLake.ACCESS_KEY;
 import static io.trino.plugin.hive.containers.HiveMinioDataLake.SECRET_KEY;
 import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
-import static java.util.concurrent.Executors.newFixedThreadPool;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.Assert.assertTrue;
 
 public abstract class BaseIcebergMinioConnectorSmokeTest
         extends BaseIcebergConnectorSmokeTest
@@ -95,48 +83,5 @@ public abstract class BaseIcebergMinioConnectorSmokeTest
         assertQueryFails(
                 format("ALTER SCHEMA %s RENAME TO %s", schemaName, schemaName + randomTableSuffix()),
                 "Hive metastore does not support renaming schemas");
-    }
-
-    // TODO: https://github.com/trinodb/trino/issues/11713 Run this test against Glue
-    // Repeat test with invocationCount for better test coverage, since the tested aspect is inherently non-deterministic.
-    @Test(timeOut = 60_000, invocationCount = 4)
-    public void testDeleteRowsConcurrently()
-            throws Exception
-    {
-        int threads = 4;
-        CyclicBarrier barrier = new CyclicBarrier(threads);
-        ExecutorService executor = newFixedThreadPool(threads);
-        try (TestTable table = new TestTable(
-                getQueryRunner()::execute,
-                "test_concurrent_delete",
-                "(col0 INTEGER, col1 INTEGER, col2 INTEGER, col3 INTEGER)")) {
-            String tableName = table.getName();
-            assertUpdate("INSERT INTO " + tableName + " VALUES (0, 0, 0, 0)", 1);
-            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 0, 0, 0)", 1);
-            assertUpdate("INSERT INTO " + tableName + " VALUES (0, 1, 0, 0)", 1);
-            assertUpdate("INSERT INTO " + tableName + " VALUES (0, 0, 1, 0)", 1);
-            assertUpdate("INSERT INTO " + tableName + " VALUES (0, 0, 0, 1)", 1);
-
-            List<Future<Boolean>> futures = IntStream.range(0, threads)
-                    .mapToObj(threadNumber -> executor.submit(() -> {
-                        barrier.await(10, SECONDS);
-                        try {
-                            String columnName = "col" + threadNumber;
-                            getQueryRunner().execute(format("DELETE FROM %s WHERE %s = 1", tableName, columnName));
-                            return true;
-                        }
-                        catch (Exception e) {
-                            return false;
-                        }
-                    }))
-                    .collect(toImmutableList());
-
-            futures.forEach(future -> assertTrue(getFutureValue(future)));
-            assertThat(query("SELECT max(col0), max(col1), max(col2), max(col3) FROM " + tableName)).matches("VALUES (0, 0, 0, 0)");
-        }
-        finally {
-            executor.shutdownNow();
-            executor.awaitTermination(10, SECONDS);
-        }
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConnectorSmokeTest.java
@@ -14,6 +14,8 @@
 package io.trino.plugin.iceberg;
 
 import io.trino.testing.QueryRunner;
+import org.testng.SkipException;
+import org.testng.annotations.Test;
 
 import static org.apache.iceberg.FileFormat.ORC;
 
@@ -34,5 +36,12 @@ public class TestIcebergConnectorSmokeTest
         return IcebergQueryRunner.builder()
                 .setInitialTables(REQUIRED_TPCH_TABLES)
                 .build();
+    }
+
+    @Test
+    @Override
+    public void testDeleteRowsConcurrently()
+    {
+        throw new SkipException("The File Hive Metastore does not have strong concurrency guarantees");
     }
 }


### PR DESCRIPTION
## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

Glue uses an optional versionId during updates to make
sure there are no conflicts. If the given version has
already been updated, the Iceberg commit will retry.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix to Iceberg commit protocol for Glue

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Iceberg connector with Glue catalog

> How would you describe this change to a non-technical end user or system administrator?

Ensure updates made at the same time do not conflict

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

Fixes https://github.com/trinodb/trino/issues/11713

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Iceberg
* Use Glue version ids to ensure concurrent Iceberg commits do not cause conflicts. ({issue}`#11713`)
```
