### PR TITLE
Remove redundant test override

### DIFF
--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConnectorTest.java
@@ -82,33 +82,6 @@ public class TestBigQueryConnectorTest
 
     @Test
     @Override
-    public void testCreateSchema()
-    {
-        String schemaName = "test_schema_create_" + randomTableSuffix();
-        assertThat(computeActual("SHOW SCHEMAS").getOnlyColumnAsSet()).doesNotContain(schemaName);
-        assertUpdate("CREATE SCHEMA " + schemaName);
-        assertUpdate("CREATE SCHEMA IF NOT EXISTS " + schemaName);
-
-        // verify listing of new schema
-        assertThat(computeActual("SHOW SCHEMAS").getOnlyColumnAsSet()).contains(schemaName);
-
-        // verify SHOW CREATE SCHEMA works
-        assertThat((String) computeScalar("SHOW CREATE SCHEMA " + schemaName))
-                .startsWith(format("CREATE SCHEMA %s.%s", getSession().getCatalog().orElseThrow(), schemaName));
-
-        // try to create duplicate schema
-        assertQueryFails("CREATE SCHEMA " + schemaName, format("line 1:1: Schema '.*\\.%s' already exists", schemaName));
-
-        // cleanup
-        assertUpdate("DROP SCHEMA " + schemaName);
-
-        // verify DROP SCHEMA for non-existing schema
-        assertQueryFails("DROP SCHEMA " + schemaName, format("line 1:1: Schema '.*\\.%s' does not exist", schemaName));
-        assertUpdate("DROP SCHEMA IF EXISTS " + schemaName);
-    }
-
-    @Test
-    @Override
     public void testShowColumns()
     {
         // shippriority column is bigint (not integer) in BigQuery connector


### PR DESCRIPTION
The version of the test in BaseConnectorTest works for BigQuery already
and the override is redundant.

(submitted directly to get BigQuery CI to run)