### PR TITLE
Modify `RowDecoder` and add `RedisRowDecoder`

### DIFF
--- a/lib/trino-record-decoder/pom.xml
+++ b/lib/trino-record-decoder/pom.xml
@@ -34,12 +34,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/avro/GenericRecordRowDecoder.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/avro/GenericRecordRowDecoder.java
@@ -44,7 +44,7 @@ class GenericRecordRowDecoder
     }
 
     @Override
-    public Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodeRow(byte[] data, Map<String, String> dataMap)
+    public Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodeRow(byte[] data)
     {
         GenericRecord avroRecord = deserializer.deserialize(data);
         return Optional.of(columnDecoders.stream()

--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/avro/SingleValueRowDecoder.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/avro/SingleValueRowDecoder.java
@@ -36,7 +36,7 @@ class SingleValueRowDecoder
     }
 
     @Override
-    public Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodeRow(byte[] data, Map<String, String> dataMap)
+    public Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodeRow(byte[] data)
     {
         Object avroValue = deserializer.deserialize(data);
         return Optional.of(ImmutableMap.of(column, new AvroColumnDecoder.ObjectValueProvider(avroValue, column.getType(), column.getName())));

--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/csv/CsvRowDecoder.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/csv/CsvRowDecoder.java
@@ -51,7 +51,7 @@ public class CsvRowDecoder
     }
 
     @Override
-    public Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodeRow(byte[] data, Map<String, String> dataMap)
+    public Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodeRow(byte[] data)
     {
         String[] tokens;
         try {

--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/dummy/DummyRowDecoder.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/dummy/DummyRowDecoder.java
@@ -39,8 +39,7 @@ public class DummyRowDecoder
     private static final Optional<Map<DecoderColumnHandle, FieldValueProvider>> ALL_NULLS = Optional.of(ImmutableMap.of());
 
     @Override
-    public Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodeRow(byte[] data,
-            Map<String, String> dataMap)
+    public Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodeRow(byte[] data)
     {
         return ALL_NULLS;
     }

--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/json/JsonRowDecoder.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/json/JsonRowDecoder.java
@@ -47,8 +47,7 @@ public class JsonRowDecoder
     }
 
     @Override
-    public Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodeRow(byte[] data,
-            Map<String, String> dataMap)
+    public Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodeRow(byte[] data)
     {
         JsonNode tree;
         try {

--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/raw/RawRowDecoder.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/raw/RawRowDecoder.java
@@ -48,7 +48,7 @@ public class RawRowDecoder
     }
 
     @Override
-    public Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodeRow(byte[] data, Map<String, String> dataMap)
+    public Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodeRow(byte[] data)
     {
         return Optional.of(columnDecoders.entrySet().stream()
                 .collect(toImmutableMap(

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestAvroConfluentRowDecoder.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestAvroConfluentRowDecoder.java
@@ -120,14 +120,14 @@ public class TestAvroConfluentRowDecoder
     private static void testRow(RowDecoder rowDecoder, GenericRecord record, int schemaId)
     {
         byte[] serializedRecord = serializeRecord(record, record.getSchema(), schemaId);
-        Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodedRow = rowDecoder.decodeRow(serializedRecord, null);
+        Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodedRow = rowDecoder.decodeRow(serializedRecord);
         assertRowsAreEqual(decodedRow, record);
     }
 
     private static void testSingleValueRow(RowDecoder rowDecoder, Object value, Schema schema, int schemaId)
     {
         byte[] serializedRecord = serializeRecord(value, schema, schemaId);
-        Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodedRow = rowDecoder.decodeRow(serializedRecord, null);
+        Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodedRow = rowDecoder.decodeRow(serializedRecord);
         checkState(decodedRow.isPresent(), "decodedRow is not present");
         Map.Entry<DecoderColumnHandle, FieldValueProvider> entry = getOnlyElement(decodedRow.get().entrySet());
         assertValuesAreEqual(entry.getValue(), value, schema);

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/decoder/RedisRowDecoder.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/decoder/RedisRowDecoder.java
@@ -11,21 +11,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.decoder;
+package io.trino.plugin.redis.decoder;
+
+import io.trino.decoder.DecoderColumnHandle;
+import io.trino.decoder.FieldValueProvider;
+import io.trino.decoder.RowDecoder;
+
+import javax.annotation.Nullable;
 
 import java.util.Map;
 import java.util.Optional;
 
 /**
- * Implementations decode a row from bytes and add field value providers for all decodable columns.
+ * Implementations decode a row from map and add field value providers for all decodable columns.
  */
-public interface RowDecoder
+public interface RedisRowDecoder
+        extends RowDecoder
 {
     /**
-     * Decodes a given sequence of bytes into field values.
+     * Decodes a given map into field values.
      *
-     * @param data The row data to decode.
+     * @param dataMap The row data as fields map
      * @return Returns mapping from column handle to decoded value. Unmapped columns will be reported as null. Optional.empty() signals decoding error.
      */
-    Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodeRow(byte[] data);
+    Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodeRow(@Nullable Map<String, String> dataMap);
 }

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/decoder/hash/HashRedisRowDecoder.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/decoder/hash/HashRedisRowDecoder.java
@@ -16,8 +16,8 @@ package io.trino.plugin.redis.decoder.hash;
 import com.google.common.collect.ImmutableMap;
 import io.trino.decoder.DecoderColumnHandle;
 import io.trino.decoder.FieldValueProvider;
-import io.trino.decoder.RowDecoder;
 import io.trino.plugin.redis.RedisFieldDecoder;
+import io.trino.plugin.redis.decoder.RedisRowDecoder;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,7 +30,7 @@ import static java.util.Collections.emptyMap;
  * The row decoder for the Redis values that are stored in Hash format.
  */
 public class HashRedisRowDecoder
-        implements RowDecoder
+        implements RedisRowDecoder
 {
     public static final String NAME = "hash";
 
@@ -42,7 +42,7 @@ public class HashRedisRowDecoder
     }
 
     @Override
-    public Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodeRow(byte[] data, Map<String, String> dataMap)
+    public Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodeRow(Map<String, String> dataMap)
     {
         if (dataMap == null) {
             return Optional.of(emptyMap());
@@ -61,5 +61,11 @@ public class HashRedisRowDecoder
             decodedRow.put(columnHandle, decoder.decode(valueField, columnHandle));
         }
         return Optional.of(decodedRow);
+    }
+
+    @Override
+    public Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodeRow(byte[] data)
+    {
+        throw new UnsupportedOperationException();
     }
 }

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/decoder/hash/HashRedisRowDecoderFactory.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/decoder/hash/HashRedisRowDecoderFactory.java
@@ -14,9 +14,9 @@
 package io.trino.plugin.redis.decoder.hash;
 
 import io.trino.decoder.DecoderColumnHandle;
-import io.trino.decoder.RowDecoder;
 import io.trino.decoder.RowDecoderFactory;
 import io.trino.plugin.redis.RedisFieldDecoder;
+import io.trino.plugin.redis.decoder.RedisRowDecoder;
 
 import java.util.Map;
 import java.util.Set;
@@ -31,7 +31,7 @@ public class HashRedisRowDecoderFactory
         implements RowDecoderFactory
 {
     @Override
-    public RowDecoder create(Map<String, String> decoderParams, Set<DecoderColumnHandle> columns)
+    public RedisRowDecoder create(Map<String, String> decoderParams, Set<DecoderColumnHandle> columns)
     {
         requireNonNull(columns, "columns is null");
         return new HashRedisRowDecoder(chooseFieldDecoders(columns));

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/decoder/zset/ZsetRedisRowDecoder.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/decoder/zset/ZsetRedisRowDecoder.java
@@ -15,7 +15,7 @@ package io.trino.plugin.redis.decoder.zset;
 
 import io.trino.decoder.DecoderColumnHandle;
 import io.trino.decoder.FieldValueProvider;
-import io.trino.decoder.RowDecoder;
+import io.trino.plugin.redis.decoder.RedisRowDecoder;
 
 import java.util.Map;
 import java.util.Optional;
@@ -26,14 +26,18 @@ import static java.util.Collections.emptyMap;
  * The row decoder for the 'zset' format. Zset's can contain redis keys for tables
  */
 public class ZsetRedisRowDecoder
-        implements RowDecoder
+        implements RedisRowDecoder
 {
     public static final String NAME = "zset";
 
     @Override
-    public Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodeRow(
-            byte[] data,
-            Map<String, String> dataMap)
+    public Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodeRow(Map<String, String> dataMap)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodeRow(byte[] data)
     {
         return Optional.of(emptyMap());
     }

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/decoder/zset/ZsetRedisRowDecoderFactory.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/decoder/zset/ZsetRedisRowDecoderFactory.java
@@ -14,8 +14,8 @@
 package io.trino.plugin.redis.decoder.zset;
 
 import io.trino.decoder.DecoderColumnHandle;
-import io.trino.decoder.RowDecoder;
 import io.trino.decoder.RowDecoderFactory;
+import io.trino.plugin.redis.decoder.RedisRowDecoder;
 
 import java.util.Map;
 import java.util.Set;
@@ -26,10 +26,10 @@ import static java.util.Objects.requireNonNull;
 public class ZsetRedisRowDecoderFactory
         implements RowDecoderFactory
 {
-    private static final RowDecoder DECODER_INSTANCE = new ZsetRedisRowDecoder();
+    private static final RedisRowDecoder DECODER_INSTANCE = new ZsetRedisRowDecoder();
 
     @Override
-    public RowDecoder create(Map<String, String> decoderParams, Set<DecoderColumnHandle> columns)
+    public RedisRowDecoder create(Map<String, String> decoderParams, Set<DecoderColumnHandle> columns)
     {
         requireNonNull(columns, "columns is null");
         checkArgument(columns.stream().noneMatch(DecoderColumnHandle::isInternal), "unexpected internal column");


### PR DESCRIPTION
## Description
I remove the `decodeRow(byte[] data, @Nullable Map<String, String> dataMap)` function to redis module because it is Redis-specific:
<img width="1175" alt="image" src="https://user-images.githubusercontent.com/29967142/165468618-cbfd45aa-3a46-4b1f-871f-eb61e969c878.png">

I remove the `com.google.code.findbugs` dependency in pom.xml of `trino-record-decoder` because it is unused:
![wecom-temp-b29fd0c9ca120ed14c8bc6504b166012](https://user-images.githubusercontent.com/29967142/165468781-59a0bca1-dabb-4bc2-abb4-48fcdb614876.png)

## Documentation
(x) No documentation is needed.

## Release notes
(x) No release notes entries required.