### PR TITLE
Add boundary tests to Cassandra type mapping tests

### DIFF
--- a/plugin/trino-cassandra/pom.xml
+++ b/plugin/trino-cassandra/pom.xml
@@ -192,6 +192,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTypeMapping.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTypeMapping.java
@@ -145,10 +145,10 @@ public class TestMySqlTypeMapping
     {
         try (TestTable table = new TestTable(mySqlServer::execute, "tpch.test_unsupported_tinyint", "(data tinyint)")) {
             assertMySqlQueryFails(
-                    format("INSERT INTO %s VALUES (-129)", table.getName()), // min - 1
+                    "INSERT INTO " + table.getName() + " VALUES (-129)", // min - 1
                     "Data truncation: Out of range value for column 'data' at row 1");
             assertMySqlQueryFails(
-                    format("INSERT INTO %s VALUES (128)", table.getName()), // max + 1
+                    "INSERT INTO " + table.getName() + " VALUES (128)", // max + 1
                     "Data truncation: Out of range value for column 'data' at row 1");
         }
     }
@@ -171,7 +171,7 @@ public class TestMySqlTypeMapping
     {
         try (TestTable table = new TestTable(mySqlServer::execute, "tpch.test_unsupported_smallint", "(data smallint)")) {
             assertMySqlQueryFails(
-                    format("INSERT INTO %s VALUES (-32769)", table.getName()), // min - 1
+                    "INSERT INTO " + table.getName() + " VALUES (-32769)", // min - 1
                     "Data truncation: Out of range value for column 'data' at row 1");
             assertMySqlQueryFails(
                     format("INSERT INTO %s VALUES (32768)", table.getName()), // max + 1
@@ -197,10 +197,10 @@ public class TestMySqlTypeMapping
     {
         try (TestTable table = new TestTable(mySqlServer::execute, "tpch.test_unsupported_integer", "(data integer)")) {
             assertMySqlQueryFails(
-                    format("INSERT INTO %s VALUES (-2147483649)", table.getName()), // min - 1
+                    "INSERT INTO " + table.getName() + " VALUES (-2147483649)", // min - 1
                     "Data truncation: Out of range value for column 'data' at row 1");
             assertMySqlQueryFails(
-                    format("INSERT INTO %s VALUES (2147483648)", table.getName()), // max + 1
+                    "INSERT INTO " + table.getName() + " VALUES (2147483648)", // max + 1
                     "Data truncation: Out of range value for column 'data' at row 1");
         }
     }
@@ -223,10 +223,10 @@ public class TestMySqlTypeMapping
     {
         try (TestTable table = new TestTable(mySqlServer::execute, "tpch.test_unsupported_bigint", "(data bigint)")) {
             assertMySqlQueryFails(
-                    format("INSERT INTO %s VALUES (-9223372036854775809)", table.getName()), // min - 1
+                    "INSERT INTO " + table.getName() + " VALUES (-9223372036854775809)", // min - 1
                     "Data truncation: Out of range value for column 'data' at row 1");
             assertMySqlQueryFails(
-                    format("INSERT INTO %s VALUES (9223372036854775808)", table.getName()), // max + 1
+                    "INSERT INTO " + table.getName() + " VALUES (9223372036854775808)", // max + 1
                     "Data truncation: Out of range value for column 'data' at row 1");
         }
     }

--- a/plugin/trino-phoenix/src/test/java/io/trino/plugin/phoenix/TestPhoenixTypeMapping.java
+++ b/plugin/trino-phoenix/src/test/java/io/trino/plugin/phoenix/TestPhoenixTypeMapping.java
@@ -148,10 +148,10 @@ public class TestPhoenixTypeMapping
     {
         try (TestTable table = new TestTable(new PhoenixSqlExecutor(phoenixServer.getJdbcUrl()), "tpch.test_unsupported_tinyint", "(data tinyint, pk tinyint primary key)")) {
             assertPhoenixQueryFails(
-                    format("INSERT INTO %s VALUES (-129, 1)", table.getName()), // min - 1
+                    "INSERT INTO " + table.getName() + " VALUES (-129, 1)", // min - 1
                     "ERROR 203 (22005): Type mismatch. BIGINT and TINYINT for expression: -129 in column 0.DATA");
             assertPhoenixQueryFails(
-                    format("INSERT INTO %s VALUES (128, 2)", table.getName()), // max + 1
+                    "INSERT INTO " + table.getName() + " VALUES (128, 2)", // max + 1
                     "ERROR 203 (22005): Type mismatch. TINYINT and INTEGER for 128");
         }
     }
@@ -187,10 +187,10 @@ public class TestPhoenixTypeMapping
     {
         try (TestTable table = new TestTable(new PhoenixSqlExecutor(phoenixServer.getJdbcUrl()), "tpch.test_unsupported_smallint", "(data smallint, pk smallint primary key)")) {
             assertPhoenixQueryFails(
-                    format("INSERT INTO %s VALUES (-32769, 1)", table.getName()), // min - 1
+                    "INSERT INTO " + table.getName() + " VALUES (-32769, 1)", // min - 1
                     "ERROR 203 (22005): Type mismatch. BIGINT and SMALLINT for expression: -32769 in column 0.DATA");
             assertPhoenixQueryFails(
-                    format("INSERT INTO %s VALUES (32768, 2)", table.getName()), // max + 1
+                    "INSERT INTO " + table.getName() + " VALUES (32768, 2)", // max + 1
                     "ERROR 203 (22005): Type mismatch. SMALLINT and INTEGER for 32768");
         }
     }
@@ -226,10 +226,10 @@ public class TestPhoenixTypeMapping
     {
         try (TestTable table = new TestTable(new PhoenixSqlExecutor(phoenixServer.getJdbcUrl()), "tpch.test_unsupported_integer", "(data integer, pk integer primary key)")) {
             assertPhoenixQueryFails(
-                    format("INSERT INTO %s VALUES (-2147483649, 1)", table.getName()), // min - 1
+                    "INSERT INTO " + table.getName() + " VALUES (-2147483649, 1)", // min - 1
                     "ERROR 203 (22005): Type mismatch. BIGINT and INTEGER for expression: -2147483649 in column 0.DATA");
             assertPhoenixQueryFails(
-                    format("INSERT INTO %s VALUES (2147483648, 2)", table.getName()), // max + 1
+                    "INSERT INTO " + table.getName() + " VALUES (2147483648, 2)", // max + 1
                     "ERROR 203 (22005): Type mismatch. INTEGER and BIGINT for 2147483648");
         }
     }
@@ -265,7 +265,7 @@ public class TestPhoenixTypeMapping
     {
         try (TestTable table = new TestTable(new PhoenixSqlExecutor(phoenixServer.getJdbcUrl()), "tpch.test_unsupported_bigint", "(data bigint, pk bigint primary key)")) {
             assertPhoenixQueryFails(
-                    format("INSERT INTO %s VALUES (-9223372036854775809, 1)", table.getName()), // min - 1
+                    "INSERT INTO " + table.getName() + " VALUES (-9223372036854775809, 1)", // min - 1
                     "ERROR 203 (22005): Type mismatch. DECIMAL and BIGINT for expression: -9223372036854775809 in column 0.DATA");
 
             // Phoenix JDBC driver throws ArithmeticException instead of SQLException when the value is larger than max of bigint

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixTypeMapping.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixTypeMapping.java
@@ -148,10 +148,10 @@ public class TestPhoenixTypeMapping
     {
         try (TestTable table = new TestTable(new PhoenixSqlExecutor(phoenixServer.getJdbcUrl()), "tpch.test_unsupported_tinyint", "(data tinyint, pk tinyint primary key)")) {
             assertPhoenixQueryFails(
-                    format("INSERT INTO %s VALUES (-129, 1)", table.getName()), // min - 1
+                    "INSERT INTO " + table.getName() + " VALUES (-129, 1)", // min - 1
                     "ERROR 203 (22005): Type mismatch. BIGINT and TINYINT for expression: -129 in column 0.DATA");
             assertPhoenixQueryFails(
-                    format("INSERT INTO %s VALUES (128, 2)", table.getName()), // max + 1
+                    "INSERT INTO " + table.getName() + " VALUES (128, 2)", // max + 1
                     "ERROR 203 (22005): Type mismatch. TINYINT and INTEGER for 128");
         }
     }
@@ -187,10 +187,10 @@ public class TestPhoenixTypeMapping
     {
         try (TestTable table = new TestTable(new PhoenixSqlExecutor(phoenixServer.getJdbcUrl()), "tpch.test_unsupported_smallint", "(data smallint, pk smallint primary key)")) {
             assertPhoenixQueryFails(
-                    format("INSERT INTO %s VALUES (-32769, 1)", table.getName()), // min - 1
+                    "INSERT INTO " + table.getName() + " VALUES (-32769, 1)", // min - 1
                     "ERROR 203 (22005): Type mismatch. BIGINT and SMALLINT for expression: -32769 in column 0.DATA");
             assertPhoenixQueryFails(
-                    format("INSERT INTO %s VALUES (32768, 2)", table.getName()), // max + 1
+                    "INSERT INTO " + table.getName() + " VALUES (32768, 2)", // max + 1
                     "ERROR 203 (22005): Type mismatch. SMALLINT and INTEGER for 32768");
         }
     }
@@ -226,10 +226,10 @@ public class TestPhoenixTypeMapping
     {
         try (TestTable table = new TestTable(new PhoenixSqlExecutor(phoenixServer.getJdbcUrl()), "tpch.test_unsupported_integer", "(data integer, pk integer primary key)")) {
             assertPhoenixQueryFails(
-                    format("INSERT INTO %s VALUES (-2147483649, 1)", table.getName()), // min - 1
+                    "INSERT INTO " + table.getName() + " VALUES (-2147483649, 1)", // min - 1
                     "ERROR 203 (22005): Type mismatch. BIGINT and INTEGER for expression: -2147483649 in column 0.DATA");
             assertPhoenixQueryFails(
-                    format("INSERT INTO %s VALUES (2147483648, 2)", table.getName()), // max + 1
+                    "INSERT INTO " + table.getName() + " VALUES (2147483648, 2)", // max + 1
                     "ERROR 203 (22005): Type mismatch. INTEGER and BIGINT for 2147483648");
         }
     }
@@ -265,7 +265,7 @@ public class TestPhoenixTypeMapping
     {
         try (TestTable table = new TestTable(new PhoenixSqlExecutor(phoenixServer.getJdbcUrl()), "tpch.test_unsupported_bigint", "(data bigint, pk bigint primary key)")) {
             assertPhoenixQueryFails(
-                    format("INSERT INTO %s VALUES (-9223372036854775809, 1)", table.getName()), // min - 1
+                    "INSERT INTO " + table.getName() + " VALUES (-9223372036854775809, 1)", // min - 1
                     "ERROR 203 (22005): Type mismatch. DECIMAL and BIGINT for expression: -9223372036854775809 in column 0.DATA");
 
             // Phoenix JDBC driver throws ArithmeticException instead of SQLException when the value is larger than max of bigint

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -222,10 +222,10 @@ public class TestPostgreSqlTypeMapping
     {
         try (TestTable table = new TestTable(postgreSqlServer::execute, "tpch.test_unsupported_smallint", "(data smallint)")) {
             assertPostgreSqlQueryFails(
-                    format("INSERT INTO %s VALUES (-32769)", table.getName()), // min - 1
+                    "INSERT INTO " + table.getName() + " VALUES (-32769)", // min - 1
                     "ERROR: smallint out of range");
             assertPostgreSqlQueryFails(
-                    format("INSERT INTO %s VALUES (32768)", table.getName()), // max + 1
+                    "INSERT INTO " + table.getName() + " VALUES (32768)", // max + 1
                     "ERROR: smallint out of range");
         }
     }
@@ -260,10 +260,10 @@ public class TestPostgreSqlTypeMapping
     {
         try (TestTable table = new TestTable(postgreSqlServer::execute, "tpch.test_unsupported_integer", "(data integer)")) {
             assertPostgreSqlQueryFails(
-                    format("INSERT INTO %s VALUES (-2147483649)", table.getName()), // min - 1
+                    "INSERT INTO " + table.getName() + " VALUES (-2147483649)", // min - 1
                     "ERROR: integer out of range");
             assertPostgreSqlQueryFails(
-                    format("INSERT INTO %s VALUES (2147483648)", table.getName()), // max + 1
+                    "INSERT INTO " + table.getName() + " VALUES (2147483648)", // max + 1
                     "ERROR: integer out of range");
         }
     }
@@ -298,10 +298,10 @@ public class TestPostgreSqlTypeMapping
     {
         try (TestTable table = new TestTable(postgreSqlServer::execute, "tpch.test_unsupported_bigint", "(data bigint)")) {
             assertPostgreSqlQueryFails(
-                    format("INSERT INTO %s VALUES (-9223372036854775809)", table.getName()), // min - 1
+                    "INSERT INTO " + table.getName() + " VALUES (-9223372036854775809)", // min - 1
                     "ERROR: bigint out of range");
             assertPostgreSqlQueryFails(
-                    format("INSERT INTO %s VALUES (9223372036854775808)", table.getName()), // max + 1
+                    "INSERT INTO " + table.getName() + " VALUES (9223372036854775808)", // max + 1
                     "ERROR: bigint out of range");
         }
     }

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerTypeMapping.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerTypeMapping.java
@@ -136,10 +136,10 @@ public abstract class BaseSqlServerTypeMapping
     {
         try (TestTable table = new TestTable(onRemoteDatabase(), "test_unsupported_tinyint", "(data tinyint)")) {
             assertSqlServerQueryFails(
-                    format("INSERT INTO %s VALUES (-1)", table.getName()), // min - 1
+                    "INSERT INTO " + table.getName() + " VALUES (-1)", // min - 1
                     "Arithmetic overflow error for data type tinyint, value = -1");
             assertSqlServerQueryFails(
-                    format("INSERT INTO %s VALUES (256)", table.getName()), // max + 1
+                    "INSERT INTO " + table.getName() + " VALUES (256)", // max + 1
                     "Arithmetic overflow error for data type tinyint, value = 256.");
         }
     }
@@ -162,10 +162,10 @@ public abstract class BaseSqlServerTypeMapping
     {
         try (TestTable table = new TestTable(onRemoteDatabase(), "test_unsupported_smallint", "(data smallint)")) {
             assertSqlServerQueryFails(
-                    format("INSERT INTO %s VALUES (-32769)", table.getName()), // min - 1
+                    "INSERT INTO " + table.getName() + " VALUES (-32769)", // min - 1
                     "Arithmetic overflow error for data type smallint, value = -32769.");
             assertSqlServerQueryFails(
-                    format("INSERT INTO %s VALUES (32768)", table.getName()), // max + 1
+                    "INSERT INTO " + table.getName() + " VALUES (32768)", // max + 1
                     "Arithmetic overflow error for data type smallint, value = 32768.");
         }
     }
@@ -188,10 +188,10 @@ public abstract class BaseSqlServerTypeMapping
     {
         try (TestTable table = new TestTable(onRemoteDatabase(), "test_unsupported_integer", "(data integer)")) {
             assertSqlServerQueryFails(
-                    format("INSERT INTO %s VALUES (-2147483649)", table.getName()), // min - 1
+                    "INSERT INTO " + table.getName() + " VALUES (-2147483649)", // min - 1
                     "Arithmetic overflow error converting expression to data type int.");
             assertSqlServerQueryFails(
-                    format("INSERT INTO %s VALUES (2147483648)", table.getName()), // max + 1
+                    "INSERT INTO " + table.getName() + " VALUES (2147483648)", // max + 1
                     "Arithmetic overflow error converting expression to data type int.");
         }
     }
@@ -214,10 +214,10 @@ public abstract class BaseSqlServerTypeMapping
     {
         try (TestTable table = new TestTable(onRemoteDatabase(), "test_unsupported_bigint", "(data bigint)")) {
             assertSqlServerQueryFails(
-                    format("INSERT INTO %s VALUES (-9223372036854775809)", table.getName()), // min - 1
+                    "INSERT INTO " + table.getName() + " VALUES (-9223372036854775809)", // min - 1
                     "Arithmetic overflow error converting expression to data type bigint.");
             assertSqlServerQueryFails(
-                    format("INSERT INTO %s VALUES (9223372036854775808)", table.getName()), // max + 1
+                    "INSERT INTO " + table.getName() + " VALUES (9223372036854775808)", // max + 1
                     "Arithmetic overflow error converting expression to data type bigint.");
         }
     }


### PR DESCRIPTION
Cover `min-1`/`max+1` test cases to `tinyint`/`smallint`/`int`/`bigint` types.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Cassandra type mapping tests.

> How would you describe this change to a non-technical end user or system administrator?

N/A.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->
Fixes #12115 
Related #11181 

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
