### PR TITLE
Support dynamic filtering with task retries

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -1286,10 +1286,6 @@ public final class SystemSessionProperties
 
     public static boolean isEnableDynamicFiltering(Session session)
     {
-        if (getRetryPolicy(session) == RetryPolicy.TASK) {
-            // dynamic filtering is not supported with task level failure recovery enabled
-            return false;
-        }
         return session.getSystemProperty(ENABLE_DYNAMIC_FILTERING, Boolean.class);
     }
 

--- a/core/trino-main/src/main/java/io/trino/execution/DynamicFiltersCollector.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DynamicFiltersCollector.java
@@ -75,10 +75,7 @@ public class DynamicFiltersCollector
     {
         acknowledge(callersCurrentVersion);
 
-        return new VersionedDynamicFilterDomains(
-                currentVersion,
-                dynamicFilterDomains.entrySet().stream()
-                        .collect(toImmutableMap(Map.Entry::getKey, entry -> entry.getValue().getDomain())));
+        return getCurrentDynamicFilterDomains();
     }
 
     public synchronized void acknowledge(long callersCurrentVersion)
@@ -86,6 +83,14 @@ public class DynamicFiltersCollector
         // Remove dynamic filter domains that are already received by caller.
         // This assumes there is only one dynamic filters consumer.
         dynamicFilterDomains.values().removeIf(domain -> domain.getVersion() <= callersCurrentVersion);
+    }
+
+    public synchronized VersionedDynamicFilterDomains getCurrentDynamicFilterDomains()
+    {
+        return new VersionedDynamicFilterDomains(
+                currentVersion,
+                dynamicFilterDomains.entrySet().stream()
+                        .collect(toImmutableMap(Map.Entry::getKey, entry -> entry.getValue().getDomain())));
     }
 
     public static class VersionedDynamicFilterDomains

--- a/core/trino-main/src/main/java/io/trino/operator/TaskContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TaskContext.java
@@ -375,6 +375,11 @@ public class TaskContext
         return dynamicFiltersCollector.acknowledgeAndGetNewDomains(callersCurrentVersion);
     }
 
+    public VersionedDynamicFilterDomains getCurrentDynamicFilterDomains()
+    {
+        return dynamicFiltersCollector.getCurrentDynamicFilterDomains();
+    }
+
     public TaskStats getTaskStats()
     {
         // check for end state to avoid callback ordering problems

--- a/core/trino-main/src/main/java/io/trino/server/DynamicFilterService.java
+++ b/core/trino-main/src/main/java/io/trino/server/DynamicFilterService.java
@@ -32,6 +32,7 @@ import io.trino.execution.StageId;
 import io.trino.execution.TaskId;
 import io.trino.metadata.FunctionManager;
 import io.trino.metadata.Metadata;
+import io.trino.operator.RetryPolicy;
 import io.trino.operator.join.JoinUtils;
 import io.trino.spi.QueryId;
 import io.trino.spi.connector.ColumnHandle;
@@ -48,6 +49,7 @@ import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.TypeProvider;
 import io.trino.sql.planner.optimizations.PlanNodeSearcher;
 import io.trino.sql.planner.plan.DynamicFilterId;
+import io.trino.sql.planner.plan.DynamicFilterSourceNode;
 import io.trino.sql.planner.plan.JoinNode;
 import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.SemiJoinNode;
@@ -89,6 +91,7 @@ import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.concurrent.MoreFutures.toCompletableFuture;
 import static io.airlift.concurrent.MoreFutures.unmodifiableFuture;
 import static io.airlift.concurrent.MoreFutures.whenAnyComplete;
+import static io.trino.SystemSessionProperties.getRetryPolicy;
 import static io.trino.SystemSessionProperties.isEnableLargeDynamicFilters;
 import static io.trino.spi.connector.DynamicFilter.EMPTY;
 import static io.trino.spi.predicate.Domain.union;
@@ -216,7 +219,7 @@ public class DynamicFilterService
     }
 
     /**
-     * Dynamic filters are collected in same stage as the join operator. This can result in deadlock
+     * Dynamic filters are collected in same stage as the join operator in pipelined execution. This can result in deadlock
      * for source stage joins and connectors that wait for dynamic filters before generating splits
      * (probe splits might be blocked on dynamic filters which require at least one probe task in order to be collected).
      * To overcome this issue an initial task is created for source stages running broadcast join operator.
@@ -260,6 +263,7 @@ public class DynamicFilterService
             // or a newer attempt has already been triggered
             return;
         }
+        checkState(!context.isTaskRetriesEnabled(), "unblockStageDynamicFilters is not required for task retry mode");
         checkState(
                 attemptId == context.getAttemptId(),
                 "Query %s retry attempt %s has not been registered with dynamic filter service",
@@ -369,7 +373,7 @@ public class DynamicFilterService
             return;
         }
         checkState(
-                attemptId == context.getAttemptId(),
+                context.isTaskRetriesEnabled() || attemptId == context.getAttemptId(),
                 "Query %s retry attempt %s has not been registered with dynamic filter service",
                 queryId,
                 attemptId);
@@ -385,9 +389,9 @@ public class DynamicFilterService
             return;
         }
         checkState(
-                taskAttemptId == context.getAttemptId(),
-                "Task %s retry attempt %s has not been registered with dynamic filter service",
-                taskId,
+                context.isTaskRetriesEnabled() || taskAttemptId == context.getAttemptId(),
+                "Query %s retry attempt %s has not been registered with dynamic filter service",
+                taskId.getQueryId(),
                 taskAttemptId);
         context.addTaskDynamicFilters(taskId, newDynamicFilters);
     }
@@ -486,7 +490,7 @@ public class DynamicFilterService
     private static Set<DynamicFilterId> getProducedDynamicFilters(PlanNode planNode)
     {
         return PlanNodeSearcher.searchFrom(planNode)
-                .whereIsInstanceOfAny(JoinNode.class, SemiJoinNode.class)
+                .whereIsInstanceOfAny(JoinNode.class, SemiJoinNode.class, DynamicFilterSourceNode.class)
                 .findAll().stream()
                 .flatMap(node -> getDynamicFiltersProducedInPlanNode(node).stream())
                 .collect(toImmutableSet());
@@ -499,6 +503,9 @@ public class DynamicFilterService
         }
         if (planNode instanceof SemiJoinNode) {
             return ((SemiJoinNode) planNode).getDynamicFilterId().map(ImmutableSet::of).orElse(ImmutableSet.of());
+        }
+        if (planNode instanceof DynamicFilterSourceNode) {
+            return ((DynamicFilterSourceNode) planNode).getDynamicFilters().keySet();
         }
         throw new IllegalStateException("getDynamicFiltersProducedInPlanNode called with neither JoinNode nor SemiJoinNode");
     }
@@ -1016,6 +1023,11 @@ public class DynamicFilterService
         private int getAttemptId()
         {
             return attemptId;
+        }
+
+        private boolean isTaskRetriesEnabled()
+        {
+            return getRetryPolicy(session) == RetryPolicy.TASK;
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/server/remotetask/ContinuousTaskStatusFetcher.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/ContinuousTaskStatusFetcher.java
@@ -242,7 +242,7 @@ class ContinuousTaskStatusFetcher
             onFail.accept(new TrinoException(REMOTE_TASK_MISMATCH, format("%s (%s)", REMOTE_TASK_MISMATCH_ERROR, HostAddress.fromUri(getTaskStatus().getSelf()))));
         }
 
-        dynamicFiltersFetcher.updateDynamicFiltersVersion(newValue.getDynamicFiltersVersion());
+        dynamicFiltersFetcher.updateDynamicFiltersVersionAndFetchIfNecessary(newValue.getDynamicFiltersVersion());
     }
 
     /**

--- a/core/trino-main/src/main/java/io/trino/server/remotetask/DynamicFiltersFetcher.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/DynamicFiltersFetcher.java
@@ -103,16 +103,7 @@ class DynamicFiltersFetcher
         fetchDynamicFiltersIfNecessary();
     }
 
-    public synchronized void stop()
-    {
-        running = false;
-        if (future != null) {
-            future.cancel(true);
-            future = null;
-        }
-    }
-
-    public synchronized void updateDynamicFiltersVersion(long newDynamicFiltersVersion)
+    public synchronized void updateDynamicFiltersVersionAndFetchIfNecessary(long newDynamicFiltersVersion)
     {
         if (dynamicFiltersVersion >= newDynamicFiltersVersion) {
             return;
@@ -218,7 +209,9 @@ class DynamicFiltersFetcher
             }
 
             localDynamicFiltersVersion = newDynamicFilterDomains.getVersion();
-            updateDynamicFiltersVersion(localDynamicFiltersVersion);
+            if (dynamicFiltersVersion < localDynamicFiltersVersion) {
+                dynamicFiltersVersion = localDynamicFiltersVersion;
+            }
         }
 
         // Subsequent DF versions can be narrowing down only. Therefore order in which they are intersected

--- a/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
@@ -701,7 +701,6 @@ public final class HttpRemoteTask
         }
 
         taskStatusFetcher.stop();
-        dynamicFiltersFetcher.stop();
 
         // The remote task is likely to get a delete from the PageBufferClient first.
         // We send an additional delete anyway to get the final TaskInfo

--- a/core/trino-main/src/main/java/io/trino/sql/planner/DynamicFilterSourceConsumer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DynamicFilterSourceConsumer.java
@@ -21,4 +21,6 @@ public interface DynamicFilterSourceConsumer
     void addPartition(TupleDomain<DynamicFilterId> tupleDomain);
 
     void setPartitionCount(int partitionCount);
+
+    boolean isDomainCollectionComplete();
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalDynamicFilterConsumer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalDynamicFilterConsumer.java
@@ -163,7 +163,7 @@ public class LocalDynamicFilterConsumer
                 return;
             }
             if (partitionCount == 0) {
-                result = TupleDomain.all();
+                result = TupleDomain.none();
             }
             else {
                 // run final compaction as previous concurrent compactions may have left more than a single domain
@@ -206,6 +206,12 @@ public class LocalDynamicFilterConsumer
         long currentSize = summaryDomainsRetainedSizeInBytes.get();
         verify(currentSize >= 0, "currentSize is expected to be greater than or equal to zero: %s", currentSize);
         summaryDomains.add(union);
+    }
+
+    @Override
+    public synchronized boolean isDomainCollectionComplete()
+    {
+        return collected;
     }
 
     private void clearSummaryDomains()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanCopier.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanCopier.java
@@ -18,6 +18,7 @@ import io.trino.sql.planner.optimizations.UnaliasSymbolReferences;
 import io.trino.sql.planner.plan.AggregationNode;
 import io.trino.sql.planner.plan.ApplyNode;
 import io.trino.sql.planner.plan.CorrelatedJoinNode;
+import io.trino.sql.planner.plan.DynamicFilterSourceNode;
 import io.trino.sql.planner.plan.EnforceSingleRowNode;
 import io.trino.sql.planner.plan.ExceptNode;
 import io.trino.sql.planner.plan.FilterNode;
@@ -160,6 +161,12 @@ public final class PlanCopier
                     node.isSpillable(),
                     node.getDynamicFilters(),
                     node.getReorderJoinStatsAndCost());
+        }
+
+        @Override
+        public PlanNode visitDynamicFilterSource(DynamicFilterSourceNode node, RewriteContext<Void> context)
+        {
+            return new DynamicFilterSourceNode(idAllocator.getNextId(), node.getSource(), node.getDynamicFilters());
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/SplitSourceFactory.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/SplitSourceFactory.java
@@ -30,6 +30,7 @@ import io.trino.sql.planner.plan.AggregationNode;
 import io.trino.sql.planner.plan.AssignUniqueId;
 import io.trino.sql.planner.plan.DeleteNode;
 import io.trino.sql.planner.plan.DistinctLimitNode;
+import io.trino.sql.planner.plan.DynamicFilterSourceNode;
 import io.trino.sql.planner.plan.EnforceSingleRowNode;
 import io.trino.sql.planner.plan.ExchangeNode;
 import io.trino.sql.planner.plan.ExplainAnalyzeNode;
@@ -222,6 +223,12 @@ public class SplitSourceFactory
         public Map<PlanNodeId, SplitSource> visitIndexJoin(IndexJoinNode node, Void context)
         {
             return node.getProbeSource().accept(this, context);
+        }
+
+        @Override
+        public Map<PlanNodeId, SplitSource> visitDynamicFilterSource(DynamicFilterSourceNode node, Void context)
+        {
+            return node.getSource().accept(this, context);
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/AddDynamicFilterSource.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/AddDynamicFilterSource.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.trino.Session;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.operator.RetryPolicy;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.plan.DynamicFilterSourceNode;
+import io.trino.sql.planner.plan.ExchangeNode;
+import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.ProjectNode;
+import io.trino.sql.planner.plan.SemiJoinNode;
+
+import java.util.Collection;
+import java.util.Set;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.SystemSessionProperties.getRetryPolicy;
+import static io.trino.matching.Pattern.typeOf;
+import static io.trino.sql.planner.plan.ExchangeNode.Scope.REMOTE;
+import static io.trino.sql.planner.plan.Patterns.Join.right;
+import static io.trino.sql.planner.plan.Patterns.SemiJoin.getFilteringSource;
+import static io.trino.sql.planner.plan.Patterns.dynamicFilterSource;
+import static io.trino.sql.planner.plan.Patterns.join;
+import static io.trino.sql.planner.plan.Patterns.semiJoin;
+import static io.trino.sql.planner.plan.Patterns.source;
+
+/**
+ * For task retry mode, dynamic filters are removed from the JoinNode/SemiJoinNode
+ * and rewritten into a DynamicFilterSourceNode below the remote exchange on the
+ * build side of the join.
+ */
+public final class AddDynamicFilterSource
+{
+    private AddDynamicFilterSource() {}
+
+    public static Set<Rule<?>> rules()
+    {
+        return ImmutableSet.of(
+                new RewriteJoinDynamicFilter(),
+                new RewriteSemiJoinDynamicFilter(),
+                new PushOrRemoveDynamicFilterSource());
+    }
+
+    private static class RewriteJoinDynamicFilter
+            implements Rule<JoinNode>
+    {
+        private static final Capture<PlanNode> BUILD_SIDE_NODE = Capture.newCapture();
+        private static final Pattern<JoinNode> PATTERN = join()
+                .matching(node -> !node.getDynamicFilters().isEmpty())
+                .with(right().capturedAs(BUILD_SIDE_NODE));
+
+        @Override
+        public Pattern<JoinNode> getPattern()
+        {
+            return PATTERN;
+        }
+
+        @Override
+        public boolean isEnabled(Session session)
+        {
+            return getRetryPolicy(session) == RetryPolicy.TASK;
+        }
+
+        @Override
+        public Result apply(JoinNode joinNode, Captures captures, Context context)
+        {
+            PlanNode buildSource = captures.get(BUILD_SIDE_NODE);
+            // We try to push down or remove DynamicFilterSourceNode below right child of join here so that
+            // PushOrRemoveDynamicFilterSource can just handle cases of DynamicFilterSourceNode below a plan node with single source
+            if (!canAddDynamicFilterSource(buildSource, joinNode.getDynamicFilters().values())) {
+                return Result.ofPlanNode(joinNode.withoutDynamicFilters());
+            }
+            return Result.ofPlanNode(
+                    joinNode.withoutDynamicFilters().replaceChildren(ImmutableList.of(
+                            joinNode.getLeft(),
+                            buildSource.replaceChildren(ImmutableList.of(
+                                    new DynamicFilterSourceNode(
+                                            context.getIdAllocator().getNextId(),
+                                            getOnlyElement(buildSource.getSources()),
+                                            joinNode.getDynamicFilters()))))));
+        }
+    }
+
+    private static class RewriteSemiJoinDynamicFilter
+            implements Rule<SemiJoinNode>
+    {
+        private static final Capture<PlanNode> FILTERING_SOURCE_NODE = Capture.newCapture();
+        private static final Pattern<SemiJoinNode> PATTERN = semiJoin()
+                .matching(node -> node.getDynamicFilterId().isPresent())
+                .with(getFilteringSource().capturedAs(FILTERING_SOURCE_NODE));
+
+        @Override
+        public Pattern<SemiJoinNode> getPattern()
+        {
+            return PATTERN;
+        }
+
+        @Override
+        public boolean isEnabled(Session session)
+        {
+            return getRetryPolicy(session) == RetryPolicy.TASK;
+        }
+
+        @Override
+        public Result apply(SemiJoinNode semiJoinNode, Captures captures, Context context)
+        {
+            PlanNode filteringSource = captures.get(FILTERING_SOURCE_NODE);
+            // We try to push down or remove DynamicFilterSourceNode below right child of join here so that
+            // PushOrRemoveDynamicFilterSource can just handle cases of DynamicFilterSourceNode below a plan node with single source
+            if (!canAddDynamicFilterSource(filteringSource, ImmutableList.of(semiJoinNode.getFilteringSourceJoinSymbol()))) {
+                return Result.ofPlanNode(semiJoinNode.withoutDynamicFilter());
+            }
+            return Result.ofPlanNode(
+                    semiJoinNode.withoutDynamicFilter().replaceChildren(ImmutableList.of(
+                            semiJoinNode.getSource(),
+                            filteringSource.replaceChildren(ImmutableList.of(
+                                    new DynamicFilterSourceNode(
+                                            context.getIdAllocator().getNextId(),
+                                            getOnlyElement(filteringSource.getSources()),
+                                            ImmutableMap.of(
+                                                    semiJoinNode.getDynamicFilterId().orElseThrow(),
+                                                    semiJoinNode.getFilteringSourceJoinSymbol())))))));
+        }
+    }
+
+    private static class PushOrRemoveDynamicFilterSource
+            implements Rule<PlanNode>
+    {
+        private static final Capture<DynamicFilterSourceNode> DYNAMIC_FILTER_SOURCE = Capture.newCapture();
+        private static final Pattern<PlanNode> PATTERN = typeOf(PlanNode.class)
+                .with(source().matching(dynamicFilterSource().capturedAs(DYNAMIC_FILTER_SOURCE)));
+
+        @Override
+        public Pattern<PlanNode> getPattern()
+        {
+            return PATTERN;
+        }
+
+        @Override
+        public boolean isEnabled(Session session)
+        {
+            return getRetryPolicy(session) == RetryPolicy.TASK;
+        }
+
+        @Override
+        public Result apply(PlanNode node, Captures captures, Context context)
+        {
+            if (isRemoteExchange(node)) {
+                // If DynamicFilterSourceNode is already below a remote exchange, don't change the plan
+                return Result.empty();
+            }
+            DynamicFilterSourceNode dynamicFilterSourceNode = captures.get(DYNAMIC_FILTER_SOURCE);
+            PlanNode dynamicFilterChildNode = context.getLookup().resolve(dynamicFilterSourceNode.getSource());
+            if (!canAddDynamicFilterSource(dynamicFilterChildNode, dynamicFilterSourceNode.getDynamicFilters().values())) {
+                // DynamicFilterSourceNode is not below a remote exchange and can't be pushed further, so remove it from the plan
+                return Result.ofPlanNode(node.replaceChildren(ImmutableList.of(dynamicFilterChildNode)));
+            }
+            PlanNode dynamicFilterSourceRewritten = dynamicFilterSourceNode.replaceChildren(dynamicFilterChildNode.getSources());
+            return Result.ofPlanNode(node.replaceChildren(ImmutableList.of(
+                    dynamicFilterChildNode.replaceChildren(ImmutableList.of(dynamicFilterSourceRewritten)))));
+        }
+    }
+
+    private static boolean canAddDynamicFilterSource(PlanNode node, Collection<Symbol> dynamicFilterSymbols)
+    {
+        boolean isIdentityProjection = (node instanceof ProjectNode) &&
+                dynamicFilterSymbols.stream().allMatch(symbol -> ((ProjectNode) node).getAssignments().isIdentity(symbol));
+        // TODO: Add support for cases where the build side has multiple sources, e.g., a UNION ALL for a join
+        return isIdentityProjection || (node instanceof ExchangeNode && node.getSources().size() == 1);
+    }
+
+    private static boolean isRemoteExchange(PlanNode node)
+    {
+        if (!(node instanceof ExchangeNode)) {
+            return false;
+        }
+
+        return ((ExchangeNode) node).getScope() == REMOTE;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
@@ -44,6 +44,7 @@ import io.trino.sql.planner.plan.AssignUniqueId;
 import io.trino.sql.planner.plan.CorrelatedJoinNode;
 import io.trino.sql.planner.plan.DeleteNode;
 import io.trino.sql.planner.plan.DistinctLimitNode;
+import io.trino.sql.planner.plan.DynamicFilterSourceNode;
 import io.trino.sql.planner.plan.EnforceSingleRowNode;
 import io.trino.sql.planner.plan.ExchangeNode;
 import io.trino.sql.planner.plan.ExplainAnalyzeNode;
@@ -595,6 +596,12 @@ public final class PropertyDerivations
                             .build();
             }
             throw new UnsupportedOperationException("Unsupported join type: " + node.getType());
+        }
+
+        @Override
+        public ActualProperties visitDynamicFilterSource(DynamicFilterSourceNode node, List<ActualProperties> inputProperties)
+        {
+            return Iterables.getOnlyElement(inputProperties);
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/StreamPropertyDerivations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/StreamPropertyDerivations.java
@@ -35,6 +35,7 @@ import io.trino.sql.planner.plan.AssignUniqueId;
 import io.trino.sql.planner.plan.CorrelatedJoinNode;
 import io.trino.sql.planner.plan.DeleteNode;
 import io.trino.sql.planner.plan.DistinctLimitNode;
+import io.trino.sql.planner.plan.DynamicFilterSourceNode;
 import io.trino.sql.planner.plan.EnforceSingleRowNode;
 import io.trino.sql.planner.plan.ExchangeNode;
 import io.trino.sql.planner.plan.ExplainAnalyzeNode;
@@ -261,6 +262,12 @@ public final class StreamPropertyDerivations
                     return probeProperties.withUnspecifiedPartitioning();
             }
             throw new UnsupportedOperationException("Unsupported join type: " + node.getType());
+        }
+
+        @Override
+        public StreamProperties visitDynamicFilterSource(DynamicFilterSourceNode node, List<StreamProperties> inputProperties)
+        {
+            return Iterables.getOnlyElement(inputProperties);
         }
 
         //

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/DynamicFilterSourceNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/DynamicFilterSourceNode.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.plan;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.trino.sql.planner.Symbol;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class DynamicFilterSourceNode
+        extends PlanNode
+{
+    private final PlanNode source;
+    private final Map<DynamicFilterId, Symbol> dynamicFilters;
+
+    @JsonCreator
+    public DynamicFilterSourceNode(
+            @JsonProperty("id") PlanNodeId id,
+            @JsonProperty("source") PlanNode source,
+            @JsonProperty("dynamicFilters") Map<DynamicFilterId, Symbol> dynamicFilters)
+    {
+        super(id);
+        this.source = requireNonNull(source, "source is null");
+        this.dynamicFilters = ImmutableMap.copyOf(requireNonNull(dynamicFilters, "dynamicFilters is null"));
+        Set<Symbol> outputSymbols = ImmutableSet.copyOf(source.getOutputSymbols());
+        checkArgument(!outputSymbols.isEmpty(), "outputSymbols is empty");
+        checkArgument(outputSymbols.containsAll(dynamicFilters.values()), "Dynamic filter symbols need to be part of the output symbols");
+    }
+
+    @Override
+    @JsonProperty
+    public List<Symbol> getOutputSymbols()
+    {
+        return source.getOutputSymbols();
+    }
+
+    @JsonProperty
+    public Map<DynamicFilterId, Symbol> getDynamicFilters()
+    {
+        return dynamicFilters;
+    }
+
+    @JsonProperty
+    public PlanNode getSource()
+    {
+        return source;
+    }
+
+    @Override
+    public List<PlanNode> getSources()
+    {
+        return ImmutableList.of(source);
+    }
+
+    @Override
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitDynamicFilterSource(this, context);
+    }
+
+    @Override
+    public PlanNode replaceChildren(List<PlanNode> newChildren)
+    {
+        checkArgument(newChildren.size() == 1, "expected newChildren to contain 1 node");
+        return new DynamicFilterSourceNode(getId(), newChildren.get(0), dynamicFilters);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/JoinNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/JoinNode.java
@@ -355,6 +355,11 @@ public class JoinNode
         return new JoinNode(getId(), type, left, right, criteria, leftOutputSymbols, rightOutputSymbols, maySkipOutputDuplicates, filter, leftHashSymbol, rightHashSymbol, distributionType, spillable, dynamicFilters, Optional.of(statsAndCost));
     }
 
+    public JoinNode withoutDynamicFilters()
+    {
+        return new JoinNode(getId(), type, left, right, criteria, leftOutputSymbols, rightOutputSymbols, maySkipOutputDuplicates, filter, leftHashSymbol, rightHashSymbol, distributionType, spillable, ImmutableMap.of(), reorderJoinStatsAndCost);
+    }
+
     public boolean isCrossJoin()
     {
         return criteria.isEmpty() && filter.isEmpty() && type == INNER;

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/Patterns.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/Patterns.java
@@ -105,6 +105,11 @@ public final class Patterns
         return typeOf(JoinNode.class);
     }
 
+    public static Pattern<DynamicFilterSourceNode> dynamicFilterSource()
+    {
+        return typeOf(DynamicFilterSourceNode.class);
+    }
+
     public static Pattern<SpatialJoinNode> spatialJoin()
     {
         return typeOf(SpatialJoinNode.class);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/PlanNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/PlanNode.java
@@ -43,6 +43,7 @@ import static java.util.Objects.requireNonNull;
         @JsonSubTypes.Type(value = SortNode.class, name = "sort"),
         @JsonSubTypes.Type(value = RemoteSourceNode.class, name = "remoteSource"),
         @JsonSubTypes.Type(value = JoinNode.class, name = "join"),
+        @JsonSubTypes.Type(value = DynamicFilterSourceNode.class, name = "dynamicFilterSource"),
         @JsonSubTypes.Type(value = SemiJoinNode.class, name = "semijoin"),
         @JsonSubTypes.Type(value = SpatialJoinNode.class, name = "spatialjoin"),
         @JsonSubTypes.Type(value = IndexJoinNode.class, name = "indexjoin"),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/PlanVisitor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/PlanVisitor.java
@@ -89,6 +89,11 @@ public abstract class PlanVisitor<R, C>
         return visitPlan(node, context);
     }
 
+    public R visitDynamicFilterSource(DynamicFilterSourceNode node, C context)
+    {
+        return visitPlan(node, context);
+    }
+
     public R visitJoin(JoinNode node, C context)
     {
         return visitPlan(node, context);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/SemiJoinNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/SemiJoinNode.java
@@ -179,4 +179,19 @@ public class SemiJoinNode
                 Optional.of(distributionType),
                 dynamicFilterId);
     }
+
+    public SemiJoinNode withoutDynamicFilter()
+    {
+        return new SemiJoinNode(
+                getId(),
+                source,
+                filteringSource,
+                sourceJoinSymbol,
+                filteringSourceJoinSymbol,
+                semiJoinOutput,
+                sourceHashSymbol,
+                filteringSourceHashSymbol,
+                distributionType,
+                Optional.empty());
+    }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/GraphvizPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/GraphvizPrinter.java
@@ -26,6 +26,7 @@ import io.trino.sql.planner.plan.ApplyNode;
 import io.trino.sql.planner.plan.AssignUniqueId;
 import io.trino.sql.planner.plan.CorrelatedJoinNode;
 import io.trino.sql.planner.plan.DistinctLimitNode;
+import io.trino.sql.planner.plan.DynamicFilterSourceNode;
 import io.trino.sql.planner.plan.EnforceSingleRowNode;
 import io.trino.sql.planner.plan.ExchangeNode;
 import io.trino.sql.planner.plan.FilterNode;
@@ -101,6 +102,7 @@ public final class GraphvizPrinter
         INDEX_SOURCE,
         UNNEST,
         ANALYZE_FINISH,
+        DYNAMIC_FILTER_SOURCE
     }
 
     private static final Map<NodeType, String> NODE_COLORS = immutableEnumMap(ImmutableMap.<NodeType, String>builder()
@@ -125,6 +127,7 @@ public final class GraphvizPrinter
             .put(NodeType.UNNEST, "crimson")
             .put(NodeType.SAMPLE, "goldenrod4")
             .put(NodeType.ANALYZE_FINISH, "plum")
+            .put(NodeType.DYNAMIC_FILTER_SOURCE, "magenta")
             .buildOrThrow());
 
     static {
@@ -584,6 +587,13 @@ public final class GraphvizPrinter
             node.getIndexSource().accept(this, context);
 
             return null;
+        }
+
+        @Override
+        public Void visitDynamicFilterSource(DynamicFilterSourceNode node, Void context)
+        {
+            printNode(node, "DynamicFilterSource", NODE_COLORS.get(NodeType.DYNAMIC_FILTER_SOURCE));
+            return node.getSource().accept(this, context);
         }
 
         private void printNode(PlanNode node, String label, String color)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
@@ -60,6 +60,7 @@ import io.trino.sql.planner.plan.CorrelatedJoinNode;
 import io.trino.sql.planner.plan.DeleteNode;
 import io.trino.sql.planner.plan.DistinctLimitNode;
 import io.trino.sql.planner.plan.DynamicFilterId;
+import io.trino.sql.planner.plan.DynamicFilterSourceNode;
 import io.trino.sql.planner.plan.EnforceSingleRowNode;
 import io.trino.sql.planner.plan.ExceptNode;
 import io.trino.sql.planner.plan.ExchangeNode;
@@ -535,6 +536,17 @@ public class PlanPrinter
             node.getSource().accept(this, context);
             node.getFilteringSource().accept(this, context);
 
+            return null;
+        }
+
+        @Override
+        public Void visitDynamicFilterSource(DynamicFilterSourceNode node, Void context)
+        {
+            addNode(
+                    node,
+                    "DynamicFilterSource",
+                    ImmutableMap.of("dynamicFilterAssignments", printDynamicFilterAssignments(node.getDynamicFilters())));
+            node.getSource().accept(this, context);
             return null;
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/sanity/DynamicFiltersChecker.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/sanity/DynamicFiltersChecker.java
@@ -18,12 +18,14 @@ import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
 import io.trino.cost.StatsAndCosts;
 import io.trino.execution.warnings.WarningCollector;
+import io.trino.operator.RetryPolicy;
 import io.trino.sql.DynamicFilters;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.planner.SubExpressionExtractor;
 import io.trino.sql.planner.TypeAnalyzer;
 import io.trino.sql.planner.TypeProvider;
 import io.trino.sql.planner.plan.DynamicFilterId;
+import io.trino.sql.planner.plan.DynamicFilterSourceNode;
 import io.trino.sql.planner.plan.FilterNode;
 import io.trino.sql.planner.plan.JoinNode;
 import io.trino.sql.planner.plan.OutputNode;
@@ -44,6 +46,9 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Sets.difference;
 import static com.google.common.collect.Sets.intersection;
+import static io.trino.SystemSessionProperties.getRetryPolicy;
+import static io.trino.operator.join.JoinUtils.getJoinDynamicFilters;
+import static io.trino.operator.join.JoinUtils.getSemiJoinDynamicFilterId;
 import static io.trino.sql.planner.planprinter.PlanPrinter.textLogicalPlan;
 
 /**
@@ -62,7 +67,7 @@ public class DynamicFiltersChecker
             WarningCollector warningCollector)
     {
         try {
-            validate(plan);
+            validate(plan, session);
         }
         catch (RuntimeException e) {
             try {
@@ -85,8 +90,9 @@ public class DynamicFiltersChecker
         }
     }
 
-    private void validate(PlanNode plan)
+    private void validate(PlanNode plan, Session session)
     {
+        RetryPolicy retryPolicy = getRetryPolicy(session);
         plan.accept(new PlanVisitor<Set<DynamicFilterId>, Void>()
         {
             @Override
@@ -110,7 +116,11 @@ public class DynamicFiltersChecker
             @Override
             public Set<DynamicFilterId> visitJoin(JoinNode node, Void context)
             {
-                Set<DynamicFilterId> currentJoinDynamicFilters = node.getDynamicFilters().keySet();
+                boolean taskRetriesEnabled = retryPolicy == RetryPolicy.TASK;
+                verify(
+                        !taskRetriesEnabled || node.getDynamicFilters().isEmpty(),
+                        "Dynamic filters %s present in a join in task retry mode", node.getDynamicFilters());
+                Set<DynamicFilterId> currentJoinDynamicFilters = getJoinDynamicFilters(node).keySet();
                 Set<DynamicFilterId> consumedProbeSide = node.getLeft().accept(this, context);
                 Set<DynamicFilterId> unconsumedByProbeSide = difference(currentJoinDynamicFilters, consumedProbeSide);
                 verify(unconsumedByProbeSide.isEmpty(),
@@ -137,14 +147,19 @@ public class DynamicFiltersChecker
             @Override
             public Set<DynamicFilterId> visitSemiJoin(SemiJoinNode node, Void context)
             {
+                boolean taskRetriesEnabled = retryPolicy == RetryPolicy.TASK;
+                verify(
+                        !taskRetriesEnabled || node.getDynamicFilterId().isEmpty(),
+                        "Dynamic filters %s present in a semi-join in task retry mode", node.getDynamicFilterId());
                 Set<DynamicFilterId> consumedSourceSide = node.getSource().accept(this, context);
                 Set<DynamicFilterId> consumedFilteringSourceSide = node.getFilteringSource().accept(this, context);
 
                 Set<DynamicFilterId> unmatched = new HashSet<>(consumedSourceSide);
                 unmatched.addAll(consumedFilteringSourceSide);
 
-                if (node.getDynamicFilterId().isPresent()) {
-                    DynamicFilterId dynamicFilterId = node.getDynamicFilterId().get();
+                Optional<DynamicFilterId> currentSemiJoinDynamicFilter = getSemiJoinDynamicFilterId(node);
+                if (currentSemiJoinDynamicFilter.isPresent()) {
+                    DynamicFilterId dynamicFilterId = currentSemiJoinDynamicFilter.get();
                     verify(consumedSourceSide.contains(dynamicFilterId),
                             "The dynamic filter %s present in semi-join was not consumed by it's source side.", dynamicFilterId);
                     verify(!consumedFilteringSourceSide.contains(dynamicFilterId),
@@ -169,6 +184,17 @@ public class DynamicFiltersChecker
                 });
                 consumed.addAll(node.getSource().accept(this, context));
                 return consumed.build();
+            }
+
+            @Override
+            public Set<DynamicFilterId> visitDynamicFilterSource(DynamicFilterSourceNode node, Void context)
+            {
+                verify(
+                        retryPolicy == RetryPolicy.TASK,
+                        "Found DynamicFilterSourceNode %s with retry policy %s",
+                        node,
+                        retryPolicy);
+                return node.getSource().accept(this, context);
             }
         }, null);
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -29,6 +29,7 @@ import io.trino.sql.planner.plan.AssignUniqueId;
 import io.trino.sql.planner.plan.CorrelatedJoinNode;
 import io.trino.sql.planner.plan.DeleteNode;
 import io.trino.sql.planner.plan.DistinctLimitNode;
+import io.trino.sql.planner.plan.DynamicFilterSourceNode;
 import io.trino.sql.planner.plan.EnforceSingleRowNode;
 import io.trino.sql.planner.plan.ExceptNode;
 import io.trino.sql.planner.plan.ExchangeNode;
@@ -550,6 +551,15 @@ public final class ValidateDependenciesChecker
         {
             checkDependencies(node.getOutputSymbols(), node.getLookupSymbols(), "Lookup symbols must be part of output symbols");
             checkDependencies(node.getAssignments().keySet(), node.getOutputSymbols(), "Assignments must contain mappings for output symbols");
+
+            return null;
+        }
+
+        @Override
+        public Void visitDynamicFilterSource(DynamicFilterSourceNode node, Set<Symbol> boundSymbols)
+        {
+            node.getSource().accept(this, boundSymbols); // visit child
+            checkDependencies(node.getOutputSymbols(), node.getDynamicFilters().values(), "Dynamic filter symbols must be part of output symbols");
 
             return null;
         }

--- a/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
@@ -49,6 +49,8 @@ import io.trino.sql.planner.Partitioning;
 import io.trino.sql.planner.PartitioningScheme;
 import io.trino.sql.planner.PlanFragment;
 import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.plan.DynamicFilterId;
+import io.trino.sql.planner.plan.DynamicFilterSourceNode;
 import io.trino.sql.planner.plan.PlanFragmentId;
 import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.sql.planner.plan.TableScanNode;
@@ -92,6 +94,28 @@ public final class TaskTestUtils
                     ImmutableMap.of(SYMBOL, new TestingColumnHandle("column", 0, BIGINT)),
                     false,
                     Optional.empty()),
+            ImmutableMap.of(SYMBOL, VARCHAR),
+            SOURCE_DISTRIBUTION,
+            ImmutableList.of(TABLE_SCAN_NODE_ID),
+            new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), ImmutableList.of(SYMBOL))
+                    .withBucketToPartition(Optional.of(new int[1])),
+            StatsAndCosts.empty(),
+            Optional.empty());
+
+    public static final DynamicFilterId DYNAMIC_FILTER_SOURCE_ID = new DynamicFilterId("filter");
+
+    public static final PlanFragment PLAN_FRAGMENT_WITH_DYNAMIC_FILTER_SOURCE = new PlanFragment(
+            new PlanFragmentId("fragment"),
+            new DynamicFilterSourceNode(
+                    new PlanNodeId("dynamicFilterSource"),
+                    TableScanNode.newInstance(
+                            TABLE_SCAN_NODE_ID,
+                            TEST_TABLE_HANDLE,
+                            ImmutableList.of(SYMBOL),
+                            ImmutableMap.of(SYMBOL, new TestingColumnHandle("column", 0, BIGINT)),
+                            false,
+                            Optional.empty()),
+                    ImmutableMap.of(DYNAMIC_FILTER_SOURCE_ID, SYMBOL)),
             ImmutableMap.of(SYMBOL, VARCHAR),
             SOURCE_DISTRIBUTION,
             ImmutableList.of(TABLE_SCAN_NODE_ID),

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkDynamicFilterSourceOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkDynamicFilterSourceOperator.java
@@ -100,7 +100,16 @@ public class BenchmarkDynamicFilterSourceOperator
                         public void addPartition(TupleDomain<DynamicFilterId> tupleDomain) {}
 
                         @Override
-                        public void setPartitionCount(int partitionCount) {}
+                        public void setPartitionCount(int partitionCount)
+                        {
+                            throw new UnsupportedOperationException();
+                        }
+
+                        @Override
+                        public boolean isDomainCollectionComplete()
+                        {
+                            return false;
+                        }
                     },
                     ImmutableList.of(new DynamicFilterSourceOperator.Channel(new DynamicFilterId("0"), BIGINT, 0)),
                     maxDistinctValuesCount,

--- a/core/trino-main/src/test/java/io/trino/operator/TestDynamicFilterSourceOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestDynamicFilterSourceOperator.java
@@ -142,6 +142,12 @@ public class TestDynamicFilterSourceOperator
 
                     @Override
                     public void setPartitionCount(int partitionCount) {}
+
+                    @Override
+                    public boolean isDomainCollectionComplete()
+                    {
+                        return false;
+                    }
                 },
                 ImmutableList.copyOf(buildChannels),
                 maxFilterDistinctValues,

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestAddDynamicFilterSource.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestAddDynamicFilterSource.java
@@ -1,0 +1,291 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.trino.Session;
+import io.trino.cost.StatsProvider;
+import io.trino.metadata.Metadata;
+import io.trino.operator.RetryPolicy;
+import io.trino.sql.DynamicFilters;
+import io.trino.sql.planner.OptimizerConfig.JoinDistributionType;
+import io.trino.sql.planner.OptimizerConfig.JoinReorderingStrategy;
+import io.trino.sql.planner.assertions.BasePlanTest;
+import io.trino.sql.planner.assertions.MatchResult;
+import io.trino.sql.planner.assertions.Matcher;
+import io.trino.sql.planner.assertions.SymbolAliases;
+import io.trino.sql.planner.plan.DynamicFilterSourceNode;
+import io.trino.sql.planner.plan.FilterNode;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.SemiJoinNode;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.trino.SystemSessionProperties.ENABLE_DYNAMIC_FILTERING;
+import static io.trino.SystemSessionProperties.FILTERING_SEMI_JOIN_TO_INNER;
+import static io.trino.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
+import static io.trino.SystemSessionProperties.JOIN_REORDERING_STRATEGY;
+import static io.trino.SystemSessionProperties.RETRY_POLICY;
+import static io.trino.sql.planner.OptimizerConfig.JoinDistributionType.BROADCAST;
+import static io.trino.sql.planner.OptimizerConfig.JoinDistributionType.PARTITIONED;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.DynamicFilterPattern;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.exchange;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.semiJoin;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static io.trino.sql.planner.plan.ExchangeNode.Scope.LOCAL;
+import static io.trino.sql.planner.plan.ExchangeNode.Scope.REMOTE;
+import static io.trino.sql.planner.plan.ExchangeNode.Type.REPARTITION;
+import static io.trino.sql.planner.plan.ExchangeNode.Type.REPLICATE;
+import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
+import static io.trino.sql.tree.BooleanLiteral.TRUE_LITERAL;
+import static io.trino.sql.tree.ComparisonExpression.Operator.GREATER_THAN_OR_EQUAL;
+import static io.trino.sql.tree.ComparisonExpression.Operator.LESS_THAN_OR_EQUAL;
+
+public class TestAddDynamicFilterSource
+        extends BasePlanTest
+{
+    public TestAddDynamicFilterSource()
+    {
+        super(ImmutableMap.of(
+                RETRY_POLICY, RetryPolicy.TASK.name(),
+                ENABLE_DYNAMIC_FILTERING, "true",
+                JOIN_REORDERING_STRATEGY, JoinReorderingStrategy.NONE.name()));
+    }
+
+    @Test(dataProvider = "joinDistributionTypes")
+    public void testInnerJoin(JoinDistributionType joinDistributionType)
+    {
+        assertDistributedPlan(
+                "SELECT l.suppkey FROM lineitem l, supplier s WHERE l.suppkey = s.suppkey",
+                withJoinDistributionType(joinDistributionType),
+                anyTree(
+                        join(
+                                INNER,
+                                ImmutableList.of(equiJoinClause("LINEITEM_SK", "SUPPLIER_SK")),
+                                ImmutableMap.of("LINEITEM_SK", "SUPPLIER_SK"),
+                                anyTree(
+                                        node(
+                                                FilterNode.class,
+                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_SK", "suppkey")))
+                                                .with(numberOfDynamicFilters(1))),
+                                exchange(
+                                        LOCAL,
+                                        exchange(
+                                                REMOTE,
+                                                joinDistributionType == PARTITIONED ? REPARTITION : REPLICATE,
+                                                node(
+                                                        DynamicFilterSourceNode.class,
+                                                        project(
+                                                                tableScan("supplier", ImmutableMap.of("SUPPLIER_SK", "suppkey")))))))));
+    }
+
+    @Test(dataProvider = "joinDistributionTypes")
+    public void testSemiJoin(JoinDistributionType joinDistributionType)
+    {
+        SemiJoinNode.DistributionType semiJoinDistributionType = joinDistributionType == PARTITIONED
+                ? SemiJoinNode.DistributionType.PARTITIONED
+                : SemiJoinNode.DistributionType.REPLICATED;
+        assertDistributedPlan(
+                "SELECT * FROM orders WHERE orderkey IN (SELECT orderkey FROM lineitem WHERE linenumber % 4 = 0)",
+                noSemiJoinRewrite(joinDistributionType),
+                anyTree(
+                        filter("S",
+                                project(
+                                        semiJoin("X", "Y", "S", Optional.of(semiJoinDistributionType), Optional.of(true),
+                                                anyTree(
+                                                        node(
+                                                                FilterNode.class,
+                                                                tableScan("orders", ImmutableMap.of("X", "orderkey")))
+                                                                        .with(numberOfDynamicFilters(1))),
+                                                        exchange(
+                                                                LOCAL,
+                                                                exchange(
+                                                                        REMOTE,
+                                                                        joinDistributionType == PARTITIONED ? REPARTITION : REPLICATE,
+                                                                        node(
+                                                                                DynamicFilterSourceNode.class,
+                                                                                project(
+                                                                                        filter(
+                                                                                                "Z % 4 = 0",
+                                                                                        tableScan("lineitem", ImmutableMap.of("Y", "orderkey", "Z", "linenumber"))))))))))));
+    }
+
+    @Test
+    public void testInnerJoinWithUnionAllOnBuild()
+    {
+        assertDistributedPlan(
+                "SELECT l.suppkey FROM lineitem l JOIN (SELECT suppkey FROM supplier UNION ALL SELECT suppkey FROM supplier) s ON l.suppkey = s.suppkey",
+                withJoinDistributionType(BROADCAST),
+                anyTree(
+                        join(
+                                INNER,
+                                ImmutableList.of(equiJoinClause("LINEITEM_SK", "SUPPLIER_SK")),
+                                ImmutableMap.of("LINEITEM_SK", "SUPPLIER_SK"),
+                                anyTree(
+                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_SK", "suppkey"))),
+                                exchange(
+                                        LOCAL,
+                                        exchange(
+                                                REMOTE,
+                                                REPLICATE,
+                                                node(
+                                                        DynamicFilterSourceNode.class,
+                                                        exchange(
+                                                                REMOTE,
+                                                                Optional.empty(),
+                                                                ImmutableList.of(),
+                                                                ImmutableSet.of(),
+                                                                Optional.empty(),
+                                                                ImmutableList.of("SUPPLIER_SK"),
+                                                                project(tableScan("supplier", ImmutableMap.of("SUPPLIER_SK_1", "suppkey"))),
+                                                                project(tableScan("supplier", ImmutableMap.of("SUPPLIER_SK_2", "suppkey"))))))))));
+
+        // TODO: Add support for cases where the build side has multiple sources
+        assertDistributedPlan(
+                "SELECT l.suppkey FROM lineitem l JOIN (SELECT suppkey FROM supplier UNION ALL SELECT suppkey FROM supplier) s ON l.suppkey = s.suppkey",
+                withJoinDistributionType(PARTITIONED),
+                anyTree(
+                        join(
+                                INNER,
+                                ImmutableList.of(equiJoinClause("LINEITEM_SK", "SUPPLIER_SK")),
+                                ImmutableMap.of(),
+                                anyTree(
+                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_SK", "suppkey"))),
+                                exchange(
+                                        LOCAL,
+                                        Optional.empty(),
+                                        ImmutableList.of(),
+                                        ImmutableSet.of(),
+                                        Optional.empty(),
+                                        ImmutableList.of("SUPPLIER_SK"),
+                                        exchange(project(tableScan("supplier", ImmutableMap.of("SUPPLIER_SK_1", "suppkey")))),
+                                        exchange(project(tableScan("supplier", ImmutableMap.of("SUPPLIER_SK_2", "suppkey"))))))));
+    }
+
+    @Test
+    public void testCrossJoinInequality()
+    {
+        assertDistributedPlan(
+                "SELECT o.orderkey FROM orders o, lineitem l WHERE o.orderkey BETWEEN l.orderkey AND l.partkey",
+                anyTree(
+                        filter("O_ORDERKEY BETWEEN L_ORDERKEY AND L_PARTKEY",
+                                join(
+                                        INNER,
+                                        ImmutableList.of(),
+                                        ImmutableList.of(
+                                                new DynamicFilterPattern("O_ORDERKEY", GREATER_THAN_OR_EQUAL, "L_ORDERKEY"),
+                                                new DynamicFilterPattern("O_ORDERKEY", LESS_THAN_OR_EQUAL, "L_PARTKEY")),
+                                        filter(
+                                                TRUE_LITERAL,
+                                                tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey"))),
+                                        exchange(
+                                                LOCAL,
+                                                exchange(
+                                                        REMOTE,
+                                                        node(
+                                                                DynamicFilterSourceNode.class,
+                                                                tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey", "L_PARTKEY", "partkey")))))))));
+
+        // TODO: Add support for dynamic filters in the below case
+        assertDistributedPlan(
+                "SELECT o.orderkey FROM orders o, lineitem l WHERE o.orderkey >= l.orderkey AND o.orderkey <= l.partkey - 1",
+                anyTree(
+                        filter("O_ORDERKEY >= L_ORDERKEY AND O_ORDERKEY <= expr",
+                                join(
+                                        INNER,
+                                        ImmutableList.of(),
+                                        ImmutableList.of(),
+                                        tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey")),
+                                        exchange(
+                                                LOCAL,
+                                                project(
+                                                        ImmutableMap.of("expr", expression("L_PARTKEY - BIGINT '1'")),
+                                                        exchange(
+                                                                REMOTE,
+                                                                tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey", "L_PARTKEY", "partkey")))))))));
+    }
+
+    @Test
+    public void testJoinWithPrePartitionedBuild()
+    {
+        // TODO: Add support for dynamic filters in the below case
+        assertDistributedPlan(
+                "SELECT * FROM lineitem JOIN (SELECT suppkey FROM supplier GROUP BY 1) s ON lineitem.suppkey = s.suppkey",
+                withJoinDistributionType(PARTITIONED),
+                anyTree(
+                        join(
+                                INNER,
+                                ImmutableList.of(equiJoinClause("LINEITEM_SK", "SUPPLIER_SK")),
+                                ImmutableMap.of(),
+                                exchange(
+                                        REMOTE,
+                                        REPARTITION,
+                                        project(
+                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_SK", "suppkey")))),
+                                anyTree(
+                                        tableScan("supplier", ImmutableMap.of("SUPPLIER_SK", "suppkey"))))));
+    }
+
+    private Matcher numberOfDynamicFilters(int numberOfDynamicFilters)
+    {
+        return new Matcher()
+        {
+            @Override
+            public boolean shapeMatches(PlanNode node)
+            {
+                return node instanceof FilterNode;
+            }
+
+            @Override
+            public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+            {
+                FilterNode filterNode = (FilterNode) node;
+                return new MatchResult(DynamicFilters.extractDynamicFilters(filterNode.getPredicate()).getDynamicConjuncts().size() == numberOfDynamicFilters);
+            }
+        };
+    }
+
+    @DataProvider
+    public Object[][] joinDistributionTypes()
+    {
+        return new Object[][] {{BROADCAST}, {PARTITIONED}};
+    }
+
+    private Session noSemiJoinRewrite(JoinDistributionType distributionType)
+    {
+        return Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty(FILTERING_SEMI_JOIN_TO_INNER, "false")
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, distributionType.name())
+                .build();
+    }
+
+    private Session withJoinDistributionType(JoinDistributionType distributionType)
+    {
+        return Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty(JOIN_REORDERING_STRATEGY, JoinReorderingStrategy.NONE.name())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, distributionType.name())
+                .build();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/SemiJoinMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/SemiJoinMatcher.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.operator.join.JoinUtils.getSemiJoinDynamicFilterId;
 import static io.trino.sql.DynamicFilters.extractDynamicFilters;
 import static io.trino.sql.planner.ExpressionExtractor.extractExpressions;
 import static io.trino.sql.planner.assertions.MatchResult.NO_MATCH;
@@ -81,11 +82,12 @@ final class SemiJoinMatcher
         }
 
         if (hasDynamicFilter.isPresent()) {
+            Optional<DynamicFilterId> semiJoinDynamicFilterId = getSemiJoinDynamicFilterId(semiJoinNode);
             if (hasDynamicFilter.get()) {
-                if (semiJoinNode.getDynamicFilterId().isEmpty()) {
+                if (semiJoinDynamicFilterId.isEmpty()) {
                     return NO_MATCH;
                 }
-                DynamicFilterId dynamicFilterId = semiJoinNode.getDynamicFilterId().get();
+                DynamicFilterId dynamicFilterId = semiJoinDynamicFilterId.get();
                 List<DynamicFilters.Descriptor> matchingDescriptors = searchFrom(semiJoinNode.getSource())
                         .where(FilterNode.class::isInstance)
                         .findAll()
@@ -102,7 +104,7 @@ final class SemiJoinMatcher
                 }
                 return NO_MATCH;
             }
-            if (semiJoinNode.getDynamicFilterId().isPresent()) {
+            if (semiJoinDynamicFilterId.isPresent()) {
                 return NO_MATCH;
             }
         }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveDistributedJoinQueries.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveDistributedJoinQueries.java
@@ -29,7 +29,7 @@ import static io.trino.sql.planner.OptimizerConfig.JoinDistributionType.BROADCAS
 import static org.testng.Assert.assertEquals;
 
 /**
- * @see TestHiveDistributedJoinQueriesWithoutDynamicFiltering for tests with dynamic filtering enabled
+ * @see TestHiveDistributedJoinQueriesWithoutDynamicFiltering for tests with dynamic filtering disabled
  */
 public class TestHiveDistributedJoinQueries
         extends AbstractTestJoinQueries
@@ -40,6 +40,8 @@ public class TestHiveDistributedJoinQueries
     {
         verify(new DynamicFilterConfig().isEnableDynamicFiltering(), "this class assumes dynamic filtering is enabled by default");
         return HiveQueryRunner.builder()
+                .addExtraProperty("retry-policy", "NONE") // See TestHiveFaultTolerantExecutionJoinQueries for tests with task retries enabled
+                .addHiveProperty("hive.dynamic-filtering.wait-timeout", "1h")
                 .setInitialTables(REQUIRED_TPCH_TABLES)
                 .build();
     }

--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchConnectorFactory.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchConnectorFactory.java
@@ -45,11 +45,11 @@ public class TpchConnectorFactory
     public static final String TPCH_TABLE_SCAN_REDIRECTION_CATALOG = "tpch.table-scan-redirection-catalog";
     public static final String TPCH_TABLE_SCAN_REDIRECTION_SCHEMA = "tpch.table-scan-redirection-schema";
     public static final String TPCH_SPLITS_PER_NODE = "tpch.splits-per-node";
+    public static final String TPCH_PARTITIONING_ENABLED = "tpch.partitioning-enabled";
     private static final int DEFAULT_MAX_ROWS_PER_PAGE = 1_000_000;
 
     private final int defaultSplitsPerNode;
     private final boolean predicatePushdownEnabled;
-    private final boolean partitioningEnabled;
 
     public TpchConnectorFactory()
     {
@@ -58,14 +58,13 @@ public class TpchConnectorFactory
 
     public TpchConnectorFactory(int defaultSplitsPerNode)
     {
-        this(defaultSplitsPerNode, true, true);
+        this(defaultSplitsPerNode, true);
     }
 
-    public TpchConnectorFactory(int defaultSplitsPerNode, boolean predicatePushdownEnabled, boolean partitioningEnabled)
+    public TpchConnectorFactory(int defaultSplitsPerNode, boolean predicatePushdownEnabled)
     {
         this.defaultSplitsPerNode = defaultSplitsPerNode;
         this.predicatePushdownEnabled = predicatePushdownEnabled;
-        this.partitioningEnabled = partitioningEnabled;
     }
 
     @Override
@@ -82,6 +81,7 @@ public class TpchConnectorFactory
         int splitsPerNode = getSplitsPerNode(properties);
         ColumnNaming columnNaming = ColumnNaming.valueOf(properties.getOrDefault(TPCH_COLUMN_NAMING_PROPERTY, ColumnNaming.SIMPLIFIED.name()).toUpperCase(ENGLISH));
         DecimalTypeMapping decimalTypeMapping = DecimalTypeMapping.valueOf(properties.getOrDefault(TPCH_DOUBLE_TYPE_MAPPING_PROPERTY, DecimalTypeMapping.DOUBLE.name()).toUpperCase(ENGLISH));
+        boolean partitioningEnabled = Boolean.parseBoolean(properties.getOrDefault(TPCH_PARTITIONING_ENABLED, "true"));
         NodeManager nodeManager = context.getNodeManager();
 
         return new Connector()

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/delta/TestDeltaTaskFailureRecoveryTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/delta/TestDeltaTaskFailureRecoveryTest.java
@@ -30,7 +30,6 @@ import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.createS3DeltaLakeQu
 import static io.trino.plugin.exchange.filesystem.containers.MinioStorage.getExchangeManagerProperties;
 import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestDeltaTaskFailureRecoveryTest
         extends BaseDeltaFailureRecoveryTest
@@ -71,12 +70,5 @@ public class TestDeltaTaskFailureRecoveryTest
         requiredTpchTables.forEach(table -> queryRunner.execute(format("CREATE TABLE %s AS SELECT * FROM tpch.tiny.%1$s", table.getTableName())));
 
         return queryRunner;
-    }
-
-    @Override
-    public void testJoinDynamicFilteringEnabled()
-    {
-        assertThatThrownBy(super::testJoinDynamicFilteringEnabled)
-                .hasMessageContaining("Dynamic filter is missing");
     }
 }

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/hive/TestHiveTaskFailureRecoveryTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/hive/TestHiveTaskFailureRecoveryTest.java
@@ -28,7 +28,6 @@ import java.util.Map;
 
 import static io.trino.plugin.exchange.filesystem.containers.MinioStorage.getExchangeManagerProperties;
 import static io.trino.testing.sql.TestTable.randomTableSuffix;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestHiveTaskFailureRecoveryTest
         extends BaseHiveFailureRecoveryTest
@@ -70,13 +69,6 @@ public class TestHiveTaskFailureRecoveryTest
                         .put("hive.s3.streaming.enabled", "false")
                         .buildOrThrow())
                 .build();
-    }
-
-    @Override
-    public void testJoinDynamicFilteringEnabled()
-    {
-        assertThatThrownBy(super::testJoinDynamicFilteringEnabled)
-                .hasMessageContaining("Dynamic filter is missing");
     }
 
     @AfterClass(alwaysRun = true)

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/iceberg/TestIcebergTaskFailureRecoveryTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/iceberg/TestIcebergTaskFailureRecoveryTest.java
@@ -26,7 +26,6 @@ import java.util.Map;
 
 import static io.trino.plugin.exchange.filesystem.containers.MinioStorage.getExchangeManagerProperties;
 import static io.trino.testing.sql.TestTable.randomTableSuffix;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestIcebergTaskFailureRecoveryTest
         extends BaseIcebergFailureRecoveryTest
@@ -57,13 +56,6 @@ public class TestIcebergTaskFailureRecoveryTest
                     runner.loadExchangeManager("filesystem", getExchangeManagerProperties(minioStorage));
                 })
                 .build();
-    }
-
-    @Override
-    public void testJoinDynamicFilteringEnabled()
-    {
-        assertThatThrownBy(super::testJoinDynamicFilteringEnabled)
-                .hasMessageContaining("Dynamic filter is missing");
     }
 
     @AfterClass(alwaysRun = true)

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractDistributedEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractDistributedEngineOnlyQueries.java
@@ -30,6 +30,7 @@ import java.util.regex.Pattern;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.SystemSessionProperties.ENABLE_DYNAMIC_FILTERING;
+import static io.trino.SystemSessionProperties.ENABLE_LARGE_DYNAMIC_FILTERS;
 import static io.trino.execution.QueryState.RUNNING;
 import static io.trino.sql.planner.OptimizerConfig.JoinDistributionType.BROADCAST;
 import static io.trino.testing.assertions.Assert.assertEventually;
@@ -207,6 +208,9 @@ public abstract class AbstractDistributedEngineOnlyQueries
     {
         // ExplainAnalyzeOperator may finish before dynamic filter stats are reported to QueryInfo
         assertEventually(() -> assertExplainAnalyze(
+                Session.builder(getSession())
+                        .setSystemProperty(ENABLE_LARGE_DYNAMIC_FILTERS, "true")
+                        .build(),
                 "EXPLAIN ANALYZE SELECT * FROM nation a, nation b WHERE a.nationkey = b.nationkey",
                 "Dynamic filters: \n.*ranges=25, \\{\\[0], ..., \\[24]}.* collection time=\\d+.*"));
     }

--- a/testing/trino-tests/src/test/java/io/trino/execution/AbstractTestCoordinatorDynamicFiltering.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/AbstractTestCoordinatorDynamicFiltering.java
@@ -67,6 +67,7 @@ import static io.trino.SystemSessionProperties.TASK_CONCURRENCY;
 import static io.trino.SystemSessionProperties.getJoinDistributionType;
 import static io.trino.SystemSessionProperties.isEnableCoordinatorDynamicFiltersDistribution;
 import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_PARTITIONING_ENABLED;
+import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_SPLITS_PER_NODE;
 import static io.trino.spi.predicate.Domain.multipleValues;
 import static io.trino.spi.predicate.Domain.singleValue;
 import static io.trino.spi.predicate.Range.range;
@@ -105,7 +106,10 @@ public abstract class AbstractTestCoordinatorDynamicFiltering
         getQueryRunner().installPlugin(new TpcdsPlugin());
         getQueryRunner().installPlugin(new MemoryPlugin());
         getQueryRunner().createCatalog("test", "test", ImmutableMap.of());
-        getQueryRunner().createCatalog("tpch", "tpch", ImmutableMap.of(TPCH_PARTITIONING_ENABLED, "false"));
+        getQueryRunner().createCatalog(
+                "tpch",
+                "tpch",
+                ImmutableMap.of(TPCH_PARTITIONING_ENABLED, "false", TPCH_SPLITS_PER_NODE, "16"));
         getQueryRunner().createCatalog("tpcds", "tpcds", ImmutableMap.of());
         getQueryRunner().createCatalog("memory", "memory", ImmutableMap.of());
         computeActual("CREATE TABLE lineitem AS SELECT * FROM tpch.tiny.lineitem");

--- a/testing/trino-tests/src/test/java/io/trino/execution/AbstractTestCoordinatorDynamicFiltering.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/AbstractTestCoordinatorDynamicFiltering.java
@@ -66,6 +66,7 @@ import static io.trino.SystemSessionProperties.JOIN_REORDERING_STRATEGY;
 import static io.trino.SystemSessionProperties.TASK_CONCURRENCY;
 import static io.trino.SystemSessionProperties.getJoinDistributionType;
 import static io.trino.SystemSessionProperties.isEnableCoordinatorDynamicFiltersDistribution;
+import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_PARTITIONING_ENABLED;
 import static io.trino.spi.predicate.Domain.multipleValues;
 import static io.trino.spi.predicate.Domain.singleValue;
 import static io.trino.spi.predicate.Range.range;
@@ -104,7 +105,7 @@ public abstract class AbstractTestCoordinatorDynamicFiltering
         getQueryRunner().installPlugin(new TpcdsPlugin());
         getQueryRunner().installPlugin(new MemoryPlugin());
         getQueryRunner().createCatalog("test", "test", ImmutableMap.of());
-        getQueryRunner().createCatalog("tpch", "tpch", ImmutableMap.of());
+        getQueryRunner().createCatalog("tpch", "tpch", ImmutableMap.of(TPCH_PARTITIONING_ENABLED, "false"));
         getQueryRunner().createCatalog("tpcds", "tpcds", ImmutableMap.of());
         getQueryRunner().createCatalog("memory", "memory", ImmutableMap.of());
         computeActual("CREATE TABLE lineitem AS SELECT * FROM tpch.tiny.lineitem");

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestCoordinatorDynamicFiltering.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestCoordinatorDynamicFiltering.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.operator.RetryPolicy;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.testng.annotations.Test;
+
+@Test(singleThreaded = true)
+public class TestCoordinatorDynamicFiltering
+        extends AbstractTestCoordinatorDynamicFiltering
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return DistributedQueryRunner.builder(getDefaultSession())
+                .setExtraProperties(ImmutableMap.of(
+                        "retry-policy", RetryPolicy.NONE.name(),
+                        // keep limits lower to test edge cases
+                        "dynamic-filtering.small-partitioned.max-distinct-values-per-driver", "10",
+                        "dynamic-filtering.small-broadcast.max-distinct-values-per-driver", "10"))
+                .build();
+    }
+}

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestCoordinatorDynamicFiltering.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestCoordinatorDynamicFiltering.java
@@ -19,6 +19,8 @@ import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
 import org.testng.annotations.Test;
 
+import static io.trino.operator.RetryPolicy.NONE;
+
 @Test(singleThreaded = true)
 public class TestCoordinatorDynamicFiltering
         extends AbstractTestCoordinatorDynamicFiltering
@@ -29,10 +31,16 @@ public class TestCoordinatorDynamicFiltering
     {
         return DistributedQueryRunner.builder(getDefaultSession())
                 .setExtraProperties(ImmutableMap.of(
-                        "retry-policy", RetryPolicy.NONE.name(),
+                        "retry-policy", getRetryPolicy().name(),
                         // keep limits lower to test edge cases
                         "dynamic-filtering.small-partitioned.max-distinct-values-per-driver", "10",
                         "dynamic-filtering.small-broadcast.max-distinct-values-per-driver", "10"))
                 .build();
+    }
+
+    @Override
+    protected RetryPolicy getRetryPolicy()
+    {
+        return NONE;
     }
 }

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestFaultTolerantExecutionDynamicFiltering.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestFaultTolerantExecutionDynamicFiltering.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.operator.RetryPolicy;
+import io.trino.plugin.exchange.filesystem.FileSystemExchangePlugin;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.FaultTolerantExecutionConnectorTestHelper;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.TestingMetadata;
+import org.testng.annotations.Test;
+
+import java.util.Set;
+
+import static io.trino.operator.RetryPolicy.TASK;
+import static io.trino.spi.predicate.Range.range;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.planner.OptimizerConfig.JoinDistributionType;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Test(singleThreaded = true)
+public class TestFaultTolerantExecutionDynamicFiltering
+        extends AbstractTestCoordinatorDynamicFiltering
+{
+    private static final TestingMetadata.TestingColumnHandle PART_KEY_HANDLE = new TestingMetadata.TestingColumnHandle("partkey", 1, BIGINT);
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        ImmutableMap<String, String> exchangeManagerProperties = ImmutableMap.<String, String>builder()
+                .put("exchange.base-directories", System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager")
+                .buildOrThrow();
+
+        return DistributedQueryRunner.builder(getDefaultSession())
+                .setAdditionalSetup(runner -> {
+                    runner.installPlugin(new FileSystemExchangePlugin());
+                    runner.loadExchangeManager("filesystem", exchangeManagerProperties);
+                })
+                .setExtraProperties(FaultTolerantExecutionConnectorTestHelper.getExtraProperties())
+                // keep limits lower to test edge cases
+                .addExtraProperty("dynamic-filtering.small-partitioned.max-distinct-values-per-driver", "10")
+                .addExtraProperty("dynamic-filtering.small-broadcast.max-distinct-values-per-driver", "10")
+                .build();
+    }
+
+    @Override
+    protected RetryPolicy getRetryPolicy()
+    {
+        return TASK;
+    }
+
+    // Tests with non-selective build side are overridden because moving dynamic filter collection to the build source side in task retry mode
+    // results in each instance of DynamicFilterSourceOperator receiving fewer input rows. Therefore, testing max-distinct-values-per-driver
+    // requires larger build side and the assertions on the collected domain are adjusted for multiple ranges instead of single range.
+    @Override
+    @Test(timeOut = 30_000, dataProvider = "testJoinDistributionType")
+    public void testSemiJoinWithNonSelectiveBuildSide(JoinDistributionType joinDistributionType, boolean coordinatorDynamicFiltersDistribution)
+    {
+        assertQueryDynamicFilters(
+                noJoinReordering(joinDistributionType, coordinatorDynamicFiltersDistribution),
+                "SELECT * FROM lineitem WHERE lineitem.partkey IN (SELECT part.partkey FROM tpch.tiny.part)",
+                Set.of(PART_KEY_HANDLE),
+                collectedDomain -> {
+                    TupleDomain<ColumnHandle> expectedRange = TupleDomain.withColumnDomains(ImmutableMap.of(
+                            PART_KEY_HANDLE,
+                            Domain.create(ValueSet.ofRanges(range(BIGINT, 1L, true, 2000L, true)), false)));
+                    // Collected domain is {[1,41], [42,82], [83,123], [124,164], ..., [1928,2000]}
+                    assertThat(collectedDomain.simplify(2)).isEqualTo(expectedRange);
+                    collectedDomain.getDomains().orElseThrow().values().forEach(domain -> assertThat(domain.isNullableDiscreteSet()).isFalse());
+                    assertThat(collectedDomain.intersect(expectedRange)).isEqualTo(collectedDomain);
+                });
+    }
+
+    @Override
+    @Test(timeOut = 30_000, dataProvider = "testJoinDistributionType")
+    public void testJoinWithNonSelectiveBuildSide(JoinDistributionType joinDistributionType, boolean coordinatorDynamicFiltersDistribution)
+    {
+        assertQueryDynamicFilters(
+                noJoinReordering(joinDistributionType, coordinatorDynamicFiltersDistribution),
+                "SELECT * FROM lineitem l JOIN tpch.tiny.part p ON l.partkey = p.partkey",
+                Set.of(PART_KEY_HANDLE),
+                collectedDomain -> {
+                    TupleDomain<ColumnHandle> expectedRange = TupleDomain.withColumnDomains(ImmutableMap.of(
+                            PART_KEY_HANDLE,
+                            Domain.create(ValueSet.ofRanges(range(BIGINT, 1L, true, 2000L, true)), false)));
+                    // Collected domain is {[1,41], [42,82], [83,123], [124,164], ..., [1928,2000]}
+                    assertThat(collectedDomain.simplify(2)).isEqualTo(expectedRange);
+                    collectedDomain.getDomains().orElseThrow().values().forEach(domain -> assertThat(domain.isNullableDiscreteSet()).isFalse());
+                    assertThat(collectedDomain.intersect(expectedRange)).isEqualTo(collectedDomain);
+                });
+    }
+
+    @Override
+    @Test(timeOut = 30_000)
+    public void testRightJoinWithNonSelectiveBuildSide()
+    {
+        assertQueryDynamicFilters(
+                noJoinReordering(),
+                "SELECT * FROM lineitem l RIGHT JOIN tpch.tiny.part p ON l.partkey = p.partkey",
+                Set.of(PART_KEY_HANDLE),
+                collectedDomain -> {
+                    TupleDomain<ColumnHandle> expectedRange = TupleDomain.withColumnDomains(ImmutableMap.of(
+                            PART_KEY_HANDLE,
+                            Domain.create(ValueSet.ofRanges(range(BIGINT, 1L, true, 2000L, true)), false)));
+                    // Collected domain is {[1,41], [42,82], [83,123], [124,164], ..., [1928,2000]}
+                    assertThat(collectedDomain.simplify(2)).isEqualTo(expectedRange);
+                    collectedDomain.getDomains().orElseThrow().values().forEach(domain -> assertThat(domain.isNullableDiscreteSet()).isFalse());
+                    assertThat(collectedDomain.intersect(expectedRange)).isEqualTo(collectedDomain);
+                });
+    }
+}

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestDistributedFaultTolerantEngineOnlyQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestDistributedFaultTolerantEngineOnlyQueries.java
@@ -25,7 +25,6 @@ import io.trino.testing.QueryRunner;
 import io.trino.tpch.TpchTable;
 
 import static io.airlift.testing.Closeables.closeAllSuppress;
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestDistributedFaultTolerantEngineOnlyQueries
         extends AbstractDistributedEngineOnlyQueries
@@ -58,13 +57,5 @@ public class TestDistributedFaultTolerantEngineOnlyQueries
             throw closeAllSuppress(e, queryRunner);
         }
         return queryRunner;
-    }
-
-    @Override
-    public void testExplainAnalyzeDynamicFilterInfo()
-    {
-        // dynamic filters are disabled
-        String result = (String) computeActual("EXPLAIN ANALYZE SELECT * FROM nation a, nation b WHERE a.nationkey = b.nationkey").getOnlyValue();
-        assertThat(result).doesNotContainPattern("Dynamic filters:.*");
     }
 }


### PR DESCRIPTION
## Description

High level changes:
Add a new plan node DynamicFilterSourceNode for DF collection in build source stage.
Add a new optimizer rule AddDynamicFilterSource near the end in PlanOptimizers which matches for a join with DFs with remote exchange as right child and adds new plan node below the exchange.
Changes to LocalExecutionPlanner to add DynamicFilterSourceOperator based on DynamicFilterSourceNode.
Change to DynamicFilterSourceOperator to short-circuit dynamic filter collection in source stage for subsequent splits if the initial splits already exceeded collection thresholds.
Changes to dynamic filter collection on worker node to keep "final" dynamic filter for collection after successful completion of task.
Changes to DynamicFiltersCollector to track whether the current version of dynamic filter collected is the "final" one. This allows HttpRemoteTask on the coordinator to figure out whether DynamicFiltersFetcher needs to the fetch the collected DF from the worker after task completion.
Changes to DynamicFilterService to make it aware about task retry mode.
All the changes implement DF collection for task level retry mode while keeping existing pipelined mode execution as-is.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

new feature
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core query engine
> How would you describe this change to a non-technical end user or system administrator?

Implements support for dynamic filtering in task retry mode of execution
## Related issues, pull requests, and links

fixes #9935

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# General
* Support dynamic filtering with task retries. ({issue}`9935`)
```
