### PR TITLE
Disable handling of OVERRIDES_DIR / /overrides in product tests

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop/apply-config-overrides.sh
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop/apply-config-overrides.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 
-OVERRIDES_DIR=${OVERRIDES_DIR:-/overrides}
-IFS=':' read -r -a HADOOP_OVERRIDES_DIRS <<< "${OVERRIDES_DIR}"
+# test whether OVERRIDES_DIR is set
+if [[ -n "${OVERRIDES_DIR+x}" ]]; then
+    echo "The OVERRIDES_DIR (${OVERRIDES_DIR}) support is disabled as it was deemed unused." >&2
+    echo "It is being removed." >&2
+    exit 16
+fi
 
-for overrides_dir in "${HADOOP_OVERRIDES_DIRS[@]}"
-do
-    if test -d "${overrides_dir}"; then
-        echo "Applying Hadoop conf overrides from dir ${overrides_dir}"
-        /usr/local/bin/apply-all-site-xml-overrides "${overrides_dir}"
-    else
-      echo "Hadoop conf overrides dir ${overrides_dir} does not exist"
-    fi
-done
+if test -e /overrides; then
+    find /overrides >&2
+    echo "The /overrides handling is disabled as it was deemed unused." >&2
+    echo "It is being removed." >&2
+    exit 17
+fi


### PR DESCRIPTION
This seems unused in product tests.

Moreover, `apply-all-site-xml-overrides /overrides` is done as part of
Docker images build process (see `docker-images` repo), so it seems we
would be applying same overrides twice.