### PR TITLE
Use "union" in partial aggregation output

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/HashAggregationOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/HashAggregationOperator.java
@@ -23,6 +23,7 @@ import io.trino.operator.aggregation.builder.HashAggregationBuilder;
 import io.trino.operator.aggregation.builder.InMemoryHashAggregationBuilder;
 import io.trino.operator.aggregation.builder.SpillableHashAggregationBuilder;
 import io.trino.operator.aggregation.partial.PartialAggregationController;
+import io.trino.operator.aggregation.partial.PartialAggregationOutputProcessor;
 import io.trino.operator.aggregation.partial.SkipAggregationBuilder;
 import io.trino.operator.scalar.CombineHashFunction;
 import io.trino.spi.Page;
@@ -62,6 +63,7 @@ public class HashAggregationOperator
         private final Step step;
         private final boolean produceDefaultOutput;
         private final List<AggregatorFactory> aggregatorFactories;
+        private final Optional<PartialAggregationOutputProcessor> partialAggregationOutputProcessor;
         private final Optional<Integer> hashChannel;
         private final Optional<Integer> groupIdChannel;
 
@@ -83,6 +85,7 @@ public class HashAggregationOperator
                 PlanNodeId planNodeId,
                 List<? extends Type> groupByTypes,
                 List<Integer> groupByChannels,
+                Optional<PartialAggregationOutputProcessor> partialAggregationOutputProcessor,
                 List<Integer> globalAggregationGroupIds,
                 Step step,
                 List<AggregatorFactory> aggregatorFactories,
@@ -98,6 +101,7 @@ public class HashAggregationOperator
                     planNodeId,
                     groupByTypes,
                     groupByChannels,
+                    partialAggregationOutputProcessor,
                     globalAggregationGroupIds,
                     step,
                     false,
@@ -122,6 +126,7 @@ public class HashAggregationOperator
                 PlanNodeId planNodeId,
                 List<? extends Type> groupByTypes,
                 List<Integer> groupByChannels,
+                Optional<PartialAggregationOutputProcessor> partialAggregationOutputProcessor,
                 List<Integer> globalAggregationGroupIds,
                 Step step,
                 boolean produceDefaultOutput,
@@ -141,6 +146,7 @@ public class HashAggregationOperator
                     planNodeId,
                     groupByTypes,
                     groupByChannels,
+                    partialAggregationOutputProcessor,
                     globalAggregationGroupIds,
                     step,
                     produceDefaultOutput,
@@ -164,6 +170,7 @@ public class HashAggregationOperator
                 PlanNodeId planNodeId,
                 List<? extends Type> groupByTypes,
                 List<Integer> groupByChannels,
+                Optional<PartialAggregationOutputProcessor> partialAggregationOutputProcessor,
                 List<Integer> globalAggregationGroupIds,
                 Step step,
                 boolean produceDefaultOutput,
@@ -186,6 +193,10 @@ public class HashAggregationOperator
             this.groupIdChannel = requireNonNull(groupIdChannel, "groupIdChannel is null");
             this.groupByTypes = ImmutableList.copyOf(groupByTypes);
             this.groupByChannels = ImmutableList.copyOf(groupByChannels);
+            if (step.isOutputPartial() && partialAggregationController.isPresent()) {
+                checkArgument(partialAggregationOutputProcessor.isPresent(), "partialAggregationOutputProcessor must be present in the partial step");
+            }
+            this.partialAggregationOutputProcessor = requireNonNull(partialAggregationOutputProcessor, "partialAggregationOutputProcessor is null");
             this.globalAggregationGroupIds = ImmutableList.copyOf(globalAggregationGroupIds);
             this.step = step;
             this.produceDefaultOutput = produceDefaultOutput;
@@ -211,6 +222,7 @@ public class HashAggregationOperator
                     operatorContext,
                     groupByTypes,
                     groupByChannels,
+                    partialAggregationOutputProcessor,
                     globalAggregationGroupIds,
                     step,
                     produceDefaultOutput,
@@ -243,6 +255,7 @@ public class HashAggregationOperator
                     planNodeId,
                     groupByTypes,
                     groupByChannels,
+                    partialAggregationOutputProcessor,
                     globalAggregationGroupIds,
                     step,
                     produceDefaultOutput,
@@ -265,6 +278,7 @@ public class HashAggregationOperator
     private final Optional<PartialAggregationController> partialAggregationController;
     private final List<Type> groupByTypes;
     private final List<Integer> groupByChannels;
+    private final Optional<PartialAggregationOutputProcessor> partialAggregationOutputProcessor;
     private final List<Integer> globalAggregationGroupIds;
     private final Step step;
     private final boolean produceDefaultOutput;
@@ -299,6 +313,7 @@ public class HashAggregationOperator
             OperatorContext operatorContext,
             List<Type> groupByTypes,
             List<Integer> groupByChannels,
+            Optional<PartialAggregationOutputProcessor> partialAggregationOutputProcessor,
             List<Integer> globalAggregationGroupIds,
             Step step,
             boolean produceDefaultOutput,
@@ -321,9 +336,12 @@ public class HashAggregationOperator
         requireNonNull(aggregatorFactories, "aggregatorFactories is null");
         requireNonNull(operatorContext, "operatorContext is null");
         checkArgument(partialAggregationController.isEmpty() || step.isOutputPartial(), "partialAggregationController should be present only for partial aggregation");
-
+        if (step.isOutputPartial() && partialAggregationController.isPresent()) {
+            checkArgument(partialAggregationOutputProcessor.isPresent(), "partialAggregationOutputProcessor must be present in the partial step");
+        }
         this.groupByTypes = ImmutableList.copyOf(groupByTypes);
         this.groupByChannels = ImmutableList.copyOf(groupByChannels);
+        this.partialAggregationOutputProcessor = requireNonNull(partialAggregationOutputProcessor, "partialAggregationOutputProcessor is null");
         this.globalAggregationGroupIds = ImmutableList.copyOf(globalAggregationGroupIds);
         this.aggregatorFactories = ImmutableList.copyOf(aggregatorFactories);
         this.hashChannel = requireNonNull(hashChannel, "hashChannel is null");
@@ -390,7 +408,7 @@ public class HashAggregationOperator
                     .map(PartialAggregationController::isPartialAggregationDisabled)
                     .orElse(false);
             if (step.isOutputPartial() && partialAggregationDisabled) {
-                aggregationBuilder = new SkipAggregationBuilder(groupByChannels, hashChannel, aggregatorFactories, memoryContext);
+                aggregationBuilder = new SkipAggregationBuilder(partialAggregationOutputProcessor.get(), memoryContext);
             }
             else if (step.isOutputPartial() || !spillEnabled || !isSpillable()) {
                 // TODO: We ignore spillEnabled here if any aggregate has ORDER BY clause or DISTINCT because they are not yet implemented for spilling.
@@ -400,6 +418,7 @@ public class HashAggregationOperator
                         expectedGroups,
                         groupByTypes,
                         groupByChannels,
+                        partialAggregationOutputProcessor,
                         hashChannel,
                         operatorContext,
                         maxPartialMemory,
@@ -421,6 +440,7 @@ public class HashAggregationOperator
                         expectedGroups,
                         groupByTypes,
                         groupByChannels,
+                        partialAggregationOutputProcessor,
                         hashChannel,
                         operatorContext,
                         memoryLimitForMerge,
@@ -584,7 +604,12 @@ public class HashAggregationOperator
         if (output.isEmpty()) {
             return null;
         }
-        return output.build();
+
+        Page page = output.build();
+
+        return partialAggregationOutputProcessor
+                .map(outputProcessor -> outputProcessor.processAggregatedPage(page))
+                .orElse(page);
     }
 
     private static long calculateDefaultOutputHash(List<Type> groupByChannels, int groupIdChannel, int groupId)

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/AbstractAggregator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/AbstractAggregator.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation;
+
+import com.google.common.primitives.Ints;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.ByteArrayBlock;
+import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.spi.type.Type;
+import io.trino.sql.planner.plan.AggregationNode;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public abstract class AbstractAggregator
+{
+    private AggregationNode.Step step;
+    private final Type intermediateType;
+    private final Type finalType;
+    private final int[] aggregationRawInputChannels;
+    private final OptionalInt intermediateStateChannel;
+    private final OptionalInt rawInputMaskChannel;
+    private final OptionalInt maskChannel;
+
+    AbstractAggregator(
+            AggregationNode.Step step,
+            Type intermediateType,
+            Type finalType,
+            List<Integer> aggregationRawInputChannels,
+            OptionalInt intermediateStateChannel,
+            OptionalInt rawInputMaskChannel,
+            OptionalInt maskChannel)
+    {
+        this.step = requireNonNull(step, "step is null");
+        this.intermediateType = requireNonNull(intermediateType, "intermediateType is null");
+        this.finalType = requireNonNull(finalType, "finalType is null");
+        this.aggregationRawInputChannels = Ints.toArray(requireNonNull(aggregationRawInputChannels, "aggregationRawInputChannels is null"));
+        this.intermediateStateChannel = requireNonNull(intermediateStateChannel, "intermediateStateChannel is null");
+        this.rawInputMaskChannel = requireNonNull(rawInputMaskChannel, "rawInputMaskChannel is null");
+        this.maskChannel = requireNonNull(maskChannel, "maskChannel is null");
+        checkArgument(step.isInputRaw() || intermediateStateChannel.isPresent(), "expected intermediateStateChannel for intermediate aggregation but got %s ", intermediateStateChannel);
+    }
+
+    protected void processPage(Page page, AccumulatorWrapper accumulator)
+    {
+        if (step.isInputRaw()) {
+            accumulator.addInput(page.getColumns(aggregationRawInputChannels), getMaskBlock(page));
+            return;
+        }
+
+        if (rawInputMaskChannel.isEmpty()) {
+            // process partially aggregated data
+            accumulator.addIntermediate(page.getBlock(intermediateStateChannel.getAsInt()));
+            return;
+        }
+        Block rawInputMaskBlock = page.getBlock(rawInputMaskChannel.getAsInt());
+        if (rawInputMaskBlock instanceof RunLengthEncodedBlock) {
+            if (rawInputMaskBlock.isNull(0)) {
+                // process partially aggregated data
+                accumulator.addIntermediate(page.getBlock(intermediateStateChannel.getAsInt()));
+            }
+            else {
+                // process raw data=
+                accumulator.addInput(page.getColumns(aggregationRawInputChannels), getMaskBlock(page));
+            }
+            return;
+        }
+
+        // rawInputMaskBlock has potentially mixed partially aggregated and raw data
+        Block maskBlock = getMaskBlock(page)
+                .map(mask -> andMasks(mask, rawInputMaskBlock))
+                .orElse(rawInputMaskBlock);
+
+        accumulator.addInput(page.getColumns(aggregationRawInputChannels), Optional.of(maskBlock));
+
+        accumulator.addIntermediate(filterByNull(rawInputMaskBlock), page.getBlock(intermediateStateChannel.getAsInt()));
+    }
+
+    public Type getType()
+    {
+        if (step.isOutputPartial()) {
+            return intermediateType;
+        }
+        else {
+            return finalType;
+        }
+    }
+
+    // todo this should return a new GroupedAggregator instead of modifying the existing object
+    public void setSpillOutput()
+    {
+        step = AggregationNode.Step.partialOutput(step);
+    }
+
+    public Type getSpillType()
+    {
+        return intermediateType;
+    }
+
+    protected boolean isOutputPartial()
+    {
+        return step.isOutputPartial();
+    }
+
+    private Optional<Block> getMaskBlock(Page page)
+    {
+        if (maskChannel.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(page.getBlock(maskChannel.getAsInt()));
+    }
+
+    private static Block andMasks(Block mask1, Block mask2)
+    {
+        int positionCount = mask1.getPositionCount();
+        byte[] mask = new byte[positionCount];
+        for (int i = 0; i < positionCount; i++) {
+            mask[i] = (byte) ((!mask1.isNull(i) && mask1.getByte(i, 0) == 1 && !mask2.isNull(i) && mask2.getByte(i, 0) == 1) ? 1 : 0);
+        }
+        return new ByteArrayBlock(positionCount, Optional.empty(), mask);
+    }
+
+    private static IntArrayList filterByNull(Block mask)
+    {
+        int positions = mask.getPositionCount();
+
+        IntArrayList ids = new IntArrayList(positions);
+        for (int i = 0; i < positions; ++i) {
+            if (mask.isNull(i)) {
+                ids.add(i);
+            }
+        }
+
+        return ids;
+    }
+
+    public interface AccumulatorWrapper
+    {
+        void addInput(Page page, Optional<Block> maskBlock);
+
+        void addIntermediate(Block block);
+
+        void addIntermediate(IntArrayList positions, Block block);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/Aggregator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/Aggregator.java
@@ -13,71 +13,70 @@
  */
 package io.trino.operator.aggregation;
 
-import com.google.common.primitives.Ints;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.Type;
 import io.trino.sql.planner.plan.AggregationNode.Step;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public class Aggregator
+        extends AbstractAggregator
 {
     private final Accumulator accumulator;
-    private final Step step;
-    private final Type intermediateType;
-    private final Type finalType;
-    private final int[] inputChannels;
-    private final OptionalInt maskChannel;
 
-    public Aggregator(Accumulator accumulator, Step step, Type intermediateType, Type finalType, List<Integer> inputChannels, OptionalInt maskChannel)
+    public Aggregator(
+            Accumulator accumulator,
+            Step step,
+            Type intermediateType,
+            Type finalType,
+            List<Integer> aggregationRawInputChannels,
+            OptionalInt intermediateStateChannel,
+            OptionalInt rawInputMaskChannel,
+            OptionalInt maskChannel)
     {
+        super(step, intermediateType, finalType, aggregationRawInputChannels, intermediateStateChannel, rawInputMaskChannel, maskChannel);
         this.accumulator = requireNonNull(accumulator, "accumulator is null");
-        this.step = requireNonNull(step, "step is null");
-        this.intermediateType = requireNonNull(intermediateType, "intermediateType is null");
-        this.finalType = requireNonNull(finalType, "finalType is null");
-        this.inputChannels = Ints.toArray(requireNonNull(inputChannels, "inputChannels is null"));
-        this.maskChannel = requireNonNull(maskChannel, "maskChannel is null");
-        checkArgument(step.isInputRaw() || inputChannels.size() == 1, "expected 1 input channel for intermediate aggregation");
-    }
-
-    public Type getType()
-    {
-        if (step.isOutputPartial()) {
-            return intermediateType;
-        }
-        else {
-            return finalType;
-        }
     }
 
     public void processPage(Page page)
     {
-        if (step.isInputRaw()) {
-            accumulator.addInput(page.getColumns(inputChannels), getMaskBlock(page));
-        }
-        else {
-            accumulator.addIntermediate(page.getBlock(inputChannels[0]));
-        }
-    }
+        processPage(page, new AccumulatorWrapper()
+        {
+            @Override
+            public void addInput(Page page, Optional<Block> maskBlock)
+            {
+                accumulator.addInput(page, maskBlock);
+            }
 
-    private Optional<Block> getMaskBlock(Page page)
-    {
-        if (maskChannel.isEmpty()) {
-            return Optional.empty();
-        }
-        return Optional.of(page.getBlock(maskChannel.getAsInt()));
+            @Override
+            public void addIntermediate(Block block)
+            {
+                accumulator.addIntermediate(block);
+            }
+
+            @Override
+            public void addIntermediate(IntArrayList positions, Block intermediateStateBlock)
+            {
+                if (positions.size() != intermediateStateBlock.getPositionCount()) {
+                    // some rows were eliminated by the filter
+                    intermediateStateBlock = intermediateStateBlock.getPositions(positions.elements(), 0, positions.size());
+                }
+
+                accumulator.addIntermediate(intermediateStateBlock);
+            }
+        });
     }
 
     public void evaluate(BlockBuilder blockBuilder)
     {
-        if (step.isOutputPartial()) {
+        if (isOutputPartial()) {
             accumulator.evaluateIntermediate(blockBuilder);
         }
         else {

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/builder/MergingHashAggregationBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/builder/MergingHashAggregationBuilder.java
@@ -22,6 +22,7 @@ import io.trino.operator.WorkProcessor;
 import io.trino.operator.WorkProcessor.Transformation;
 import io.trino.operator.WorkProcessor.TransformationState;
 import io.trino.operator.aggregation.AggregatorFactory;
+import io.trino.operator.aggregation.partial.PartialAggregationOutputProcessor;
 import io.trino.spi.Page;
 import io.trino.spi.type.Type;
 import io.trino.sql.gen.JoinCompiler;
@@ -46,6 +47,7 @@ public class MergingHashAggregationBuilder
     private final WorkProcessor<Page> sortedPages;
     private InMemoryHashAggregationBuilder hashAggregationBuilder;
     private final List<Type> groupByTypes;
+    private final Optional<PartialAggregationOutputProcessor> partialAggregationOutputProcessor;
     private final LocalMemoryContext memoryContext;
     private final long memoryLimitForMerge;
     private final int overwriteIntermediateChannelOffset;
@@ -57,6 +59,7 @@ public class MergingHashAggregationBuilder
             AggregationNode.Step step,
             int expectedGroups,
             List<Type> groupByTypes,
+            Optional<PartialAggregationOutputProcessor> partialAggregationOutputProcessor,
             Optional<Integer> hashChannel,
             OperatorContext operatorContext,
             WorkProcessor<Page> sortedPages,
@@ -79,6 +82,7 @@ public class MergingHashAggregationBuilder
         this.operatorContext = operatorContext;
         this.sortedPages = sortedPages;
         this.groupByTypes = groupByTypes;
+        this.partialAggregationOutputProcessor = partialAggregationOutputProcessor;
         this.memoryContext = aggregatedMemoryContext.newLocalMemoryContext(MergingHashAggregationBuilder.class.getSimpleName());
         this.memoryLimitForMerge = memoryLimitForMerge;
         this.overwriteIntermediateChannelOffset = overwriteIntermediateChannelOffset;
@@ -149,6 +153,7 @@ public class MergingHashAggregationBuilder
                 expectedGroups,
                 groupByTypes,
                 groupByPartialChannels,
+                partialAggregationOutputProcessor,
                 hashChannel,
                 operatorContext,
                 Optional.of(DataSize.succinctBytes(0)),

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/builder/SpillableHashAggregationBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/builder/SpillableHashAggregationBuilder.java
@@ -24,6 +24,7 @@ import io.trino.operator.OperatorContext;
 import io.trino.operator.Work;
 import io.trino.operator.WorkProcessor;
 import io.trino.operator.aggregation.AggregatorFactory;
+import io.trino.operator.aggregation.partial.PartialAggregationOutputProcessor;
 import io.trino.spi.Page;
 import io.trino.spi.type.Type;
 import io.trino.spiller.Spiller;
@@ -54,6 +55,7 @@ public class SpillableHashAggregationBuilder
     private final int expectedGroups;
     private final List<Type> groupByTypes;
     private final List<Integer> groupByChannels;
+    private final Optional<PartialAggregationOutputProcessor> partialAggregationOutputProcessor;
     private final Optional<Integer> hashChannel;
     private final OperatorContext operatorContext;
     private final LocalMemoryContext localUserMemoryContext;
@@ -80,6 +82,7 @@ public class SpillableHashAggregationBuilder
             int expectedGroups,
             List<Type> groupByTypes,
             List<Integer> groupByChannels,
+            Optional<PartialAggregationOutputProcessor> partialAggregationOutputProcessor,
             Optional<Integer> hashChannel,
             OperatorContext operatorContext,
             DataSize memoryLimitForMerge,
@@ -93,6 +96,7 @@ public class SpillableHashAggregationBuilder
         this.expectedGroups = expectedGroups;
         this.groupByTypes = groupByTypes;
         this.groupByChannels = groupByChannels;
+        this.partialAggregationOutputProcessor = partialAggregationOutputProcessor;
         this.hashChannel = hashChannel;
         this.operatorContext = operatorContext;
         this.localUserMemoryContext = operatorContext.localUserMemoryContext();
@@ -310,6 +314,7 @@ public class SpillableHashAggregationBuilder
                 step,
                 expectedGroups,
                 groupByTypes,
+                partialAggregationOutputProcessor,
                 hashChannel,
                 operatorContext,
                 sortedPages,
@@ -336,6 +341,7 @@ public class SpillableHashAggregationBuilder
                 expectedGroups,
                 groupByTypes,
                 groupByChannels,
+                partialAggregationOutputProcessor,
                 hashChannel,
                 operatorContext,
                 Optional.of(DataSize.succinctBytes(0)),

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/partial/PartialAggregationOutputProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/partial/PartialAggregationOutputProcessor.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation.partial;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Ints;
+import io.trino.operator.aggregation.AggregatorFactory;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.spi.type.Type;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Creates final output of the partial aggregation step based on either aggregated or raw input.
+ * <p>
+ * Partial aggregation step output has additional channels used to send
+ * raw input data when the partial aggregation is disabled.
+ * Those channels need to be present in the output, albeit empty, even if the
+ * partial aggregation is enabled.
+ * <p>
+ * The additional channels are:
+ * - mask channels used by any aggregation
+ * - every aggregation input channels that are not already in hash channels
+ * - a boolean rawInputMask channel that contains decision which input, aggregated or raw, should be used for a given position.
+ */
+public class PartialAggregationOutputProcessor
+{
+    private final List<Type> aggregatorIntermediateOutputTypes;
+    private final List<Type> aggregationRawInputTypes;
+    private final int[] hashChannels;
+    private final int[] aggregationRawInputChannels;
+    private final int[] maskChannels;
+    private final int finalBlockCount;
+
+    public PartialAggregationOutputProcessor(
+            List<Integer> groupByChannels,
+            Optional<Integer> inputHashChannel,
+            List<AggregatorFactory> aggregatorFactories,
+            List<? extends Type> aggregationRawInputTypes,
+            List<Integer> aggregationRawInputChannels)
+    {
+        this.aggregationRawInputTypes = ImmutableList.copyOf(aggregationRawInputTypes);
+
+        this.aggregatorIntermediateOutputTypes = requireNonNull(aggregatorFactories, "aggregatorFactories is null")
+                .stream()
+                .map(AggregatorFactory::getIntermediateType)
+                .collect(toImmutableList());
+        this.aggregationRawInputChannels = Ints.toArray(aggregationRawInputChannels);
+        this.maskChannels = Ints.toArray(aggregatorFactories
+                .stream()
+                .map(AggregatorFactory::getMaskChannel)
+                .flatMapToInt(OptionalInt::stream)
+                .boxed()
+                .distinct()
+                .collect(toImmutableList()));
+        this.hashChannels = new int[groupByChannels.size() + (inputHashChannel.isPresent() ? 1 : 0)];
+        for (int i = 0; i < groupByChannels.size(); i++) {
+            hashChannels[i] = groupByChannels.get(i);
+        }
+        inputHashChannel.ifPresent(channelIndex -> hashChannels[groupByChannels.size()] = channelIndex);
+        finalBlockCount = hashChannels.length + aggregatorIntermediateOutputTypes.size() + maskChannels.length + aggregationRawInputChannels.size() + 1;
+    }
+
+    public Page processAggregatedPage(Page page)
+    {
+        Block[] finalPage = new Block[finalBlockCount];
+        int blockOffset = 0;
+        for (int i = 0; i < page.getChannelCount(); i++, blockOffset++) {
+            finalPage[blockOffset] = page.getBlock(i);
+        }
+        int positionCount = page.getPositionCount();
+
+        // mask channels
+        for (int i = 0; i < maskChannels.length; i++, blockOffset++) {
+            finalPage[blockOffset] = RunLengthEncodedBlock.create(BOOLEAN, null, positionCount);
+        }
+        // aggregation raw inputs
+        for (int i = 0; i < aggregationRawInputTypes.size(); i++, blockOffset++) {
+            finalPage[blockOffset] = RunLengthEncodedBlock.create(aggregationRawInputTypes.get(i), null, positionCount);
+        }
+
+        // use raw input mask channel
+        finalPage[blockOffset] = RunLengthEncodedBlock.create(BOOLEAN, null, positionCount);
+        return new Page(positionCount, finalPage);
+    }
+
+    public Page processRawInputPage(Page page)
+    {
+        Block[] finalPage = new Block[finalBlockCount];
+        int blockOffset = 0;
+        // raw input hash channels
+        for (int i = 0; i < hashChannels.length; i++, blockOffset++) {
+            finalPage[blockOffset] = page.getBlock(hashChannels[i]);
+        }
+        // aggregator state channels
+        for (int i = 0; i < aggregatorIntermediateOutputTypes.size(); i++, blockOffset++) {
+            finalPage[blockOffset] = RunLengthEncodedBlock.create(aggregatorIntermediateOutputTypes.get(i), null, page.getPositionCount());
+        }
+        // mask channels
+        for (int i = 0; i < maskChannels.length; i++, blockOffset++) {
+            finalPage[blockOffset] = page.getBlock(maskChannels[i]);
+        }
+        // aggregation raw inputs
+        for (int i = 0; i < aggregationRawInputChannels.length; i++, blockOffset++) {
+            finalPage[blockOffset] = page.getBlock(aggregationRawInputChannels[i]);
+        }
+        // use raw input mask channel
+        finalPage[blockOffset] = RunLengthEncodedBlock.create(BOOLEAN, true, page.getPositionCount());
+        return new Page(page.getPositionCount(), finalPage);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/partial/SkipAggregationBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/partial/SkipAggregationBuilder.java
@@ -16,25 +16,15 @@ package io.trino.operator.aggregation.partial;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.trino.memory.context.LocalMemoryContext;
 import io.trino.operator.CompletedWork;
-import io.trino.operator.GroupByIdBlock;
 import io.trino.operator.HashCollisionsCounter;
 import io.trino.operator.Work;
 import io.trino.operator.WorkProcessor;
-import io.trino.operator.aggregation.AggregatorFactory;
-import io.trino.operator.aggregation.GroupedAggregator;
 import io.trino.operator.aggregation.builder.HashAggregationBuilder;
 import io.trino.spi.Page;
-import io.trino.spi.block.Block;
-import io.trino.spi.block.BlockBuilder;
-import io.trino.spi.block.LongArrayBlock;
 
 import javax.annotation.Nullable;
 
-import java.util.List;
-import java.util.Optional;
-
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -45,28 +35,17 @@ import static java.util.Objects.requireNonNull;
 public class SkipAggregationBuilder
         implements HashAggregationBuilder
 {
+    private final PartialAggregationOutputProcessor partialAggregationOutputProcessor;
     private final LocalMemoryContext memoryContext;
-    private final List<GroupedAggregator> groupedAggregators;
     @Nullable
     private Page currentPage;
-    private final int[] hashChannels;
 
     public SkipAggregationBuilder(
-            List<Integer> groupByChannels,
-            Optional<Integer> inputHashChannel,
-            List<AggregatorFactory> aggregatorFactories,
+            PartialAggregationOutputProcessor partialAggregationOutputProcessor,
             LocalMemoryContext memoryContext)
     {
+        this.partialAggregationOutputProcessor = requireNonNull(partialAggregationOutputProcessor, "partialAggregationOutputProcessor is null");
         this.memoryContext = requireNonNull(memoryContext, "memoryContext is null");
-        this.groupedAggregators = requireNonNull(aggregatorFactories, "aggregatorFactories is null")
-                .stream()
-                .map(AggregatorFactory::createGroupedAggregator)
-                .collect(toImmutableList());
-        this.hashChannels = new int[groupByChannels.size() + (inputHashChannel.isPresent() ? 1 : 0)];
-        for (int i = 0; i < groupByChannels.size(); i++) {
-            hashChannels[i] = groupByChannels.get(i);
-        }
-        inputHashChannel.ifPresent(channelIndex -> hashChannels[groupByChannels.size()] = channelIndex);
     }
 
     @Override
@@ -84,7 +63,7 @@ public class SkipAggregationBuilder
             return WorkProcessor.of();
         }
 
-        Page result = buildOutputPage(currentPage);
+        Page result = partialAggregationOutputProcessor.processRawInputPage(currentPage);
         currentPage = null;
         return WorkProcessor.of(result);
     }
@@ -124,67 +103,5 @@ public class SkipAggregationBuilder
     public void finishMemoryRevoke()
     {
         throw new UnsupportedOperationException("finishMemoryRevoke not supported for SkipAggregationBuilder");
-    }
-
-    private Page buildOutputPage(Page page)
-    {
-        populateInitialAccumulatorState(page);
-
-        BlockBuilder[] outputBuilders = serializeAccumulatorState(page.getPositionCount());
-
-        return constructOutputPage(page, outputBuilders);
-    }
-
-    private void populateInitialAccumulatorState(Page page)
-    {
-        GroupByIdBlock groupByIdBlock = getGroupByIdBlock(page.getPositionCount());
-        for (GroupedAggregator groupedAggregator : groupedAggregators) {
-            groupedAggregator.processPage(groupByIdBlock, page);
-        }
-    }
-
-    private GroupByIdBlock getGroupByIdBlock(int positionCount)
-    {
-        return new GroupByIdBlock(
-                positionCount,
-                new LongArrayBlock(positionCount, Optional.empty(), consecutive(positionCount)));
-    }
-
-    private BlockBuilder[] serializeAccumulatorState(int positionCount)
-    {
-        BlockBuilder[] outputBuilders = new BlockBuilder[groupedAggregators.size()];
-        for (int i = 0; i < outputBuilders.length; i++) {
-            outputBuilders[i] = groupedAggregators.get(i).getType().createBlockBuilder(null, positionCount);
-        }
-
-        for (int position = 0; position < positionCount; position++) {
-            for (int i = 0; i < groupedAggregators.size(); i++) {
-                GroupedAggregator groupedAggregator = groupedAggregators.get(i);
-                BlockBuilder output = outputBuilders[i];
-                groupedAggregator.evaluate(position, output);
-            }
-        }
-        return outputBuilders;
-    }
-
-    private Page constructOutputPage(Page page, BlockBuilder[] outputBuilders)
-    {
-        Block[] outputBlocks = new Block[hashChannels.length + outputBuilders.length];
-        for (int i = 0; i < hashChannels.length; i++) {
-            outputBlocks[i] = page.getBlock(hashChannels[i]);
-        }
-        for (int i = 0; i < outputBuilders.length; i++) {
-            outputBlocks[hashChannels.length + i] = outputBuilders[i].build();
-        }
-        return new Page(page.getPositionCount(), outputBlocks);
-    }
-
-    private static long[] consecutive(int positionCount)
-    {
-        long[] longs = new long[positionCount];
-        for (int i = 0; i < positionCount; i++) {
-            longs[i] = i;
-        }
-        return longs;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
@@ -1185,7 +1185,8 @@ class QueryPlanner
                 ImmutableList.of(),
                 AggregationNode.Step.SINGLE,
                 Optional.empty(),
-                groupIdSymbol);
+                groupIdSymbol,
+                Optional.empty());
 
         return new PlanBuilder(
                 subPlan.getTranslations()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/AggregationDecorrelation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/AggregationDecorrelation.java
@@ -75,6 +75,7 @@ class AggregationDecorrelation
                 ImmutableList.of(),
                 distinct.getStep(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                distinct.getRawInputMaskSymbol());
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PreAggregateCaseAggregations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PreAggregateCaseAggregations.java
@@ -185,24 +185,20 @@ public class PreAggregateCaseAggregations
             AggregationNode aggregationNode,
             Map<CaseAggregation, Symbol> newProjectionSymbols)
     {
-        return new AggregationNode(
-                aggregationNode.getId(),
-                source,
-                newProjectionSymbols.entrySet().stream()
-                        .collect(toImmutableMap(
-                                entry -> entry.getKey().getAggregationSymbol(),
-                                entry -> new Aggregation(
-                                        entry.getKey().getCumulativeFunction(),
-                                        ImmutableList.of(entry.getValue().toSymbolReference()),
-                                        false,
-                                        Optional.empty(),
-                                        Optional.empty(),
-                                        Optional.empty()))),
-                aggregationNode.getGroupingSets(),
-                aggregationNode.getPreGroupedSymbols(),
-                aggregationNode.getStep(),
-                aggregationNode.getHashSymbol(),
-                aggregationNode.getGroupIdSymbol());
+        return AggregationNode.builderFrom(aggregationNode)
+                .setSource(source)
+                .setAggregations(
+                        newProjectionSymbols.entrySet().stream()
+                                .collect(toImmutableMap(
+                                        entry -> entry.getKey().getAggregationSymbol(),
+                                        entry -> new Aggregation(
+                                                entry.getKey().getCumulativeFunction(),
+                                                ImmutableList.of(entry.getValue().toSymbolReference()),
+                                                false,
+                                                Optional.empty(),
+                                                Optional.empty(),
+                                                Optional.empty()))))
+                .build();
     }
 
     private ProjectNode createNewProjection(
@@ -240,7 +236,7 @@ public class PreAggregateCaseAggregations
             Map<PreAggregationKey, PreAggregation> preAggregations,
             Context context)
     {
-        return new AggregationNode(
+        return AggregationNode.singleAggregation(
                 context.getIdAllocator().getNextId(),
                 source,
                 preAggregations.entrySet().stream()
@@ -253,11 +249,7 @@ public class PreAggregateCaseAggregations
                                         Optional.empty(),
                                         Optional.empty(),
                                         Optional.empty()))),
-                singleGroupingSet(groupingKeys),
-                ImmutableList.of(),
-                SINGLE,
-                Optional.empty(),
-                Optional.empty());
+                singleGroupingSet(groupingKeys));
     }
 
     private ProjectNode createPreProjection(

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveRedundantDistinctLimit.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveRedundantDistinctLimit.java
@@ -67,6 +67,7 @@ public class RemoveRedundantDistinctLimit
                     ImmutableList.of(),
                     SINGLE,
                     node.getHashSymbol(),
+                    Optional.empty(),
                     Optional.empty()));
         }
         return Result.empty();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformCorrelatedDistinctAggregationWithProjection.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformCorrelatedDistinctAggregationWithProjection.java
@@ -150,7 +150,8 @@ public class TransformCorrelatedDistinctAggregationWithProjection
                 ImmutableList.of(),
                 aggregation.getStep(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                aggregation.getRawInputMaskSymbol());
 
         // restrict outputs and apply projection
         Set<Symbol> outputSymbols = new HashSet<>(correlatedJoinNode.getOutputSymbols());

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformCorrelatedGlobalAggregationWithProjection.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformCorrelatedGlobalAggregationWithProjection.java
@@ -268,7 +268,8 @@ public class TransformCorrelatedGlobalAggregationWithProjection
                 ImmutableList.of(),
                 globalAggregation.getStep(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                globalAggregation.getRawInputMaskSymbol());
 
         // restrict outputs and apply projection
         Set<Symbol> outputSymbols = new HashSet<>(correlatedJoinNode.getOutputSymbols());

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformCorrelatedGlobalAggregationWithoutProjection.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformCorrelatedGlobalAggregationWithoutProjection.java
@@ -260,7 +260,8 @@ public class TransformCorrelatedGlobalAggregationWithoutProjection
                 ImmutableList.of(),
                 globalAggregation.getStep(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                globalAggregation.getRawInputMaskSymbol());
 
         // restrict outputs
         Optional<PlanNode> project = restrictOutputs(context.getIdAllocator(), globalAggregation, ImmutableSet.copyOf(correlatedJoinNode.getOutputSymbols()));

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
@@ -200,7 +200,8 @@ public class OptimizeMixedDistinctAggregations
                     ImmutableList.of(),
                     node.getStep(),
                     Optional.empty(),
-                    node.getGroupIdSymbol());
+                    node.getGroupIdSymbol(),
+                    node.getRawInputMaskSymbol());
 
             if (coalesceSymbols.isEmpty()) {
                 return aggregationNode;
@@ -461,6 +462,7 @@ public class OptimizeMixedDistinctAggregations
                     ImmutableList.of(),
                     SINGLE,
                     originalNode.getHashSymbol(),
+                    Optional.empty(),
                     Optional.empty());
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SymbolMapper.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SymbolMapper.java
@@ -159,7 +159,8 @@ public class SymbolMapper
                 ImmutableList.of(),
                 node.getStep(),
                 node.getHashSymbol().map(this::map),
-                node.getGroupIdSymbol().map(this::map));
+                node.getGroupIdSymbol().map(this::map),
+                node.getRawInputMaskSymbol().map(this::map));
     }
 
     public Aggregation map(Aggregation aggregation)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/StatisticAggregations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/StatisticAggregations.java
@@ -60,6 +60,14 @@ public class StatisticAggregations
         return groupingSymbols;
     }
 
+    public List<Symbol> getOutputSymbols()
+    {
+        return ImmutableList.<Symbol>builder()
+                .addAll(groupingSymbols)
+                .addAll(aggregations.keySet())
+                .build();
+    }
+
     public Parts createPartialAggregations(SymbolAllocator symbolAllocator, Session session, PlannerContext plannerContext)
     {
         ImmutableMap.Builder<Symbol, Aggregation> partialAggregation = ImmutableMap.builder();

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/policy/PlanUtils.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/policy/PlanUtils.java
@@ -40,7 +40,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.SOURCE_DISTRIBUTION;
-import static io.trino.sql.planner.plan.AggregationNode.Step.FINAL;
+import static io.trino.sql.planner.plan.AggregationNode.Step.SINGLE;
 import static io.trino.sql.planner.plan.AggregationNode.singleGroupingSet;
 import static io.trino.sql.planner.plan.ExchangeNode.Type.REPARTITION;
 import static io.trino.sql.planner.plan.ExchangeNode.Type.REPLICATE;
@@ -90,7 +90,8 @@ final class PlanUtils
                 ImmutableMap.of(),
                 singleGroupingSet(ImmutableList.of()),
                 ImmutableList.of(),
-                FINAL,
+                SINGLE,
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
 

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkHashAndStreamingAggregationOperators.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkHashAndStreamingAggregationOperators.java
@@ -19,6 +19,7 @@ import io.trino.RowPagesBuilder;
 import io.trino.jmh.Benchmarks;
 import io.trino.metadata.TestingFunctionResolution;
 import io.trino.operator.HashAggregationOperator.HashAggregationOperatorFactory;
+import io.trino.operator.aggregation.AggregatorFactory;
 import io.trino.operator.aggregation.TestingAggregationFunction;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
@@ -246,17 +247,19 @@ public class BenchmarkHashAndStreamingAggregationOperators
         {
             SpillerFactory spillerFactory = (types, localSpillContext, aggregatedMemoryContext) -> null;
 
+            ImmutableList<AggregatorFactory> aggregatorFactories = ImmutableList.of(
+                    COUNT.createAggregatorFactory(SINGLE, ImmutableList.of(0), OptionalInt.empty()),
+                    LONG_SUM.createAggregatorFactory(SINGLE, ImmutableList.of(sumChannel), OptionalInt.empty()));
             return new HashAggregationOperatorFactory(
                     0,
                     new PlanNodeId("test"),
                     hashTypes,
                     hashChannels,
+                    Optional.empty(),
                     ImmutableList.of(),
                     SINGLE,
                     false,
-                    ImmutableList.of(
-                            COUNT.createAggregatorFactory(SINGLE, ImmutableList.of(0), OptionalInt.empty()),
-                            LONG_SUM.createAggregatorFactory(SINGLE, ImmutableList.of(sumChannel), OptionalInt.empty())),
+                    aggregatorFactories,
                     hashChannel,
                     Optional.empty(),
                     100_000,

--- a/core/trino-main/src/test/java/io/trino/operator/TestHashAggregationOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestHashAggregationOperator.java
@@ -24,18 +24,25 @@ import io.trino.RowPagesBuilder;
 import io.trino.memory.context.AggregatedMemoryContext;
 import io.trino.metadata.TestingFunctionResolution;
 import io.trino.operator.HashAggregationOperator.HashAggregationOperatorFactory;
+import io.trino.operator.aggregation.AggregatorFactory;
 import io.trino.operator.aggregation.TestingAggregationFunction;
 import io.trino.operator.aggregation.builder.HashAggregationBuilder;
 import io.trino.operator.aggregation.builder.InMemoryHashAggregationBuilder;
 import io.trino.operator.aggregation.partial.PartialAggregationController;
+import io.trino.operator.aggregation.partial.PartialAggregationOutputProcessor;
 import io.trino.spi.Page;
+import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.PageBuilderStatus;
+import io.trino.spi.block.RowBlockBuilder;
+import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.spi.block.SingleRowBlockWriter;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
 import io.trino.spiller.Spiller;
 import io.trino.spiller.SpillerFactory;
 import io.trino.sql.gen.JoinCompiler;
+import io.trino.sql.planner.plan.AggregationNode.Step;
 import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.sql.tree.QualifiedName;
 import io.trino.testing.MaterializedResult;
@@ -68,6 +75,8 @@ import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.airlift.units.DataSize.succinctBytes;
 import static io.trino.RowPagesBuilder.rowPagesBuilder;
 import static io.trino.SessionTestUtils.TEST_SESSION;
+import static io.trino.block.BlockAssertions.createBooleansBlock;
+import static io.trino.block.BlockAssertions.createLongSequenceBlock;
 import static io.trino.block.BlockAssertions.createLongsBlock;
 import static io.trino.block.BlockAssertions.createRLEBlock;
 import static io.trino.operator.GroupByHashYieldAssertion.GroupByHashYieldResult;
@@ -83,6 +92,7 @@ import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static io.trino.sql.planner.plan.AggregationNode.Step.FINAL;
 import static io.trino.sql.planner.plan.AggregationNode.Step.PARTIAL;
 import static io.trino.sql.planner.plan.AggregationNode.Step.SINGLE;
 import static io.trino.testing.MaterializedResult.resultBuilder;
@@ -180,6 +190,7 @@ public class TestHashAggregationOperator
                 new PlanNodeId("test"),
                 ImmutableList.of(VARCHAR),
                 hashChannels,
+                Optional.empty(),
                 ImmutableList.of(),
                 SINGLE,
                 false,
@@ -234,6 +245,7 @@ public class TestHashAggregationOperator
                 new PlanNodeId("test"),
                 ImmutableList.of(VARCHAR, BIGINT),
                 groupByChannels,
+                Optional.empty(),
                 globalAggregationGroupIds,
                 SINGLE,
                 true,
@@ -286,6 +298,7 @@ public class TestHashAggregationOperator
                 new PlanNodeId("test"),
                 ImmutableList.of(BIGINT),
                 hashChannels,
+                Optional.empty(),
                 ImmutableList.of(),
                 SINGLE,
                 true,
@@ -331,6 +344,7 @@ public class TestHashAggregationOperator
                 new PlanNodeId("test"),
                 ImmutableList.of(BIGINT),
                 hashChannels,
+                Optional.empty(),
                 ImmutableList.of(),
                 SINGLE,
                 ImmutableList.of(COUNT.createAggregatorFactory(SINGLE, ImmutableList.of(0), OptionalInt.empty()),
@@ -370,6 +384,7 @@ public class TestHashAggregationOperator
                 new PlanNodeId("test"),
                 ImmutableList.of(VARCHAR),
                 hashChannels,
+                Optional.empty(),
                 ImmutableList.of(),
                 SINGLE,
                 false,
@@ -398,6 +413,7 @@ public class TestHashAggregationOperator
                 new PlanNodeId("test"),
                 ImmutableList.of(type),
                 ImmutableList.of(0),
+                Optional.empty(),
                 ImmutableList.of(),
                 SINGLE,
                 ImmutableList.of(COUNT.createAggregatorFactory(SINGLE, ImmutableList.of(0), OptionalInt.empty())),
@@ -451,6 +467,7 @@ public class TestHashAggregationOperator
                 new PlanNodeId("test"),
                 ImmutableList.of(VARCHAR),
                 hashChannels,
+                Optional.empty(),
                 ImmutableList.of(),
                 SINGLE,
                 ImmutableList.of(COUNT.createAggregatorFactory(SINGLE, ImmutableList.of(0), OptionalInt.empty())),
@@ -485,6 +502,7 @@ public class TestHashAggregationOperator
                 new PlanNodeId("test"),
                 ImmutableList.of(BIGINT),
                 hashChannels,
+                Optional.empty(),
                 ImmutableList.of(),
                 SINGLE,
                 ImmutableList.of(COUNT.createAggregatorFactory(SINGLE, ImmutableList.of(0), OptionalInt.empty()),
@@ -518,6 +536,7 @@ public class TestHashAggregationOperator
                 new PlanNodeId("test"),
                 ImmutableList.of(BIGINT),
                 hashChannels,
+                Optional.empty(),
                 ImmutableList.of(),
                 PARTIAL,
                 ImmutableList.of(LONG_MIN.createAggregatorFactory(PARTIAL, ImmutableList.of(0), OptionalInt.empty())),
@@ -599,6 +618,7 @@ public class TestHashAggregationOperator
                 new PlanNodeId("test"),
                 ImmutableList.of(BIGINT),
                 ImmutableList.of(0),
+                Optional.empty(),
                 ImmutableList.of(),
                 SINGLE,
                 false,
@@ -652,6 +672,7 @@ public class TestHashAggregationOperator
                 new PlanNodeId("test"),
                 ImmutableList.of(BIGINT),
                 hashChannels,
+                Optional.empty(),
                 ImmutableList.of(),
                 SINGLE,
                 false,
@@ -690,6 +711,7 @@ public class TestHashAggregationOperator
                 new PlanNodeId("test"),
                 ImmutableList.of(BIGINT),
                 hashChannels,
+                Optional.empty(),
                 ImmutableList.of(),
                 SINGLE,
                 ImmutableList.of(LONG_MIN.createAggregatorFactory(SINGLE, ImmutableList.of(0), OptionalInt.empty())),
@@ -721,48 +743,54 @@ public class TestHashAggregationOperator
     {
         List<Integer> hashChannels = Ints.asList(0);
 
+        // use 5 rows threshold to trigger adaptive partial aggregation after each page flush
         PartialAggregationController partialAggregationController = new PartialAggregationController(5, 0.8);
-        HashAggregationOperatorFactory operatorFactory = new HashAggregationOperatorFactory(
-                0,
-                new PlanNodeId("test"),
-                ImmutableList.of(BIGINT),
+        HashAggregationOperatorFactory operatorFactory = createAdaptiveHashAggregationOperatorFactory(
                 hashChannels,
-                ImmutableList.of(),
                 PARTIAL,
-                ImmutableList.of(LONG_MIN.createAggregatorFactory(PARTIAL, ImmutableList.of(0), OptionalInt.empty())),
-                Optional.empty(),
-                Optional.empty(),
-                100,
-                Optional.of(DataSize.ofBytes(1)), // this setting makes operator to flush after each page
-                joinCompiler,
-                blockTypeOperators,
-                // use 5 rows threshold to trigger adaptive partial aggregation after each page flush
-                Optional.of(partialAggregationController));
+                ImmutableList.of(LONG_MIN.createAggregatorFactory(PARTIAL, ImmutableList.of(1), OptionalInt.of(2))),
+                ImmutableList.of(1),
+                Optional.of(partialAggregationController),
+                Optional.of(DataSize.ofBytes(1))); // this setting makes operator to flush after each page
 
         // at the start partial aggregation is enabled
         assertFalse(partialAggregationController.isPartialAggregationDisabled());
         // First operator will trigger adaptive partial aggregation after the first page
         List<Page> operator1Input = rowPagesBuilder(false, hashChannels, BIGINT)
-                .addBlocksPage(createLongsBlock(0, 1, 2, 3, 4, 5, 6, 7, 8, 8)) // first page will be hashed but the values are almost unique, so it will trigger adaptation
-                .addBlocksPage(createRLEBlock(1, 10)) // second page would be hashed to existing value 1. but if adaptive PA kicks in, the raw values will be passed on
+                .addBlocksPage(// first page will be hashed but the values are almost unique, so it will trigger adaptation
+                        createLongsBlock(0, 1, 2, 3, 4, 5, 6, 7, 8, 8), // hash channel
+                        createRLEBlock(0, 10), // aggregation input
+                        booleanRle(true, 10)) // mask channel
+                .addBlocksPage(// second page would be hashed to existing value 1. but if adaptive PA kicks in, the raw values will be passed on
+                        createRLEBlock(1, 10), // hash channel
+                        createRLEBlock(0, 10), // aggregation input
+                        booleanRle(false, 10)) // mask channel
                 .build();
-        List<Page> operator1Expected = rowPagesBuilder(BIGINT, BIGINT)
-                .addBlocksPage(createLongsBlock(0, 1, 2, 3, 4, 5, 6, 7, 8), createLongsBlock(0, 1, 2, 3, 4, 5, 6, 7, 8)) // the last position was aggregated
-                .addBlocksPage(createRLEBlock(1, 10), createRLEBlock(1, 10)) // we are expecting second page with raw values
-                .build();
+        RowPagesBuilder operator1Expected = rowPagesBuilder(BIGINT, BIGINT, BOOLEAN, BIGINT, BOOLEAN)
+                .addBlocksPage(
+                        createLongsBlock(0, 1, 2, 3, 4, 5, 6, 7, 8), // group ids, the last position was aggregated
+                        createRLEBlock(0, 9), // intermediate state
+                        nullRle(BOOLEAN, 10), // mask channel
+                        nullRle(BIGINT, 9), // aggregation input
+                        nullRle(BOOLEAN, 9)) // raw input mask
+                .addBlocksPage(
+                        createRLEBlock(1, 10), // group ids, we are expecting second page with raw values not aggregated
+                        nullRle(BIGINT, 10), // intermediate state
+                        booleanRle(false, 10), // mask channel
+                        createRLEBlock(0, 10), // raw aggregation input
+                        booleanRle(true, 10)); // raw input mask
         assertOperatorEquals(operatorFactory, operator1Input, operator1Expected);
 
         // the first operator flush disables partial aggregation
         assertTrue(partialAggregationController.isPartialAggregationDisabled());
         // second operator using the same factory, reuses PartialAggregationControl, so it will only produce raw pages (partial aggregation is disabled at this point)
         List<Page> operator2Input = rowPagesBuilder(false, hashChannels, BIGINT)
-                .addBlocksPage(createRLEBlock(1, 10))
-                .addBlocksPage(createRLEBlock(2, 10))
+                .addBlocksPage(createRLEBlock(1, 10), createRLEBlock(0, 10), booleanRle(false, 10))
+                .addBlocksPage(createRLEBlock(2, 10), createRLEBlock(0, 10), booleanRle(false, 10))
                 .build();
-        List<Page> operator2Expected = rowPagesBuilder(BIGINT, BIGINT)
-                .addBlocksPage(createRLEBlock(1, 10), createRLEBlock(1, 10))
-                .addBlocksPage(createRLEBlock(2, 10), createRLEBlock(2, 10))
-                .build();
+        RowPagesBuilder operator2Expected = rowPagesBuilder(BIGINT, BIGINT, BOOLEAN, BIGINT, BOOLEAN)
+                .addBlocksPage(createRLEBlock(1, 10), nullRle(BIGINT, 10), booleanRle(false, 10), createRLEBlock(0, 10), booleanRle(true, 10))
+                .addBlocksPage(createRLEBlock(2, 10), nullRle(BIGINT, 10), booleanRle(false, 10), createRLEBlock(0, 10), booleanRle(true, 10));
 
         assertOperatorEquals(operatorFactory, operator2Input, operator2Expected);
     }
@@ -772,32 +800,22 @@ public class TestHashAggregationOperator
     {
         List<Integer> hashChannels = Ints.asList(0);
 
+        // use 5 rows threshold to trigger adaptive partial aggregation after each page flush
         PartialAggregationController partialAggregationController = new PartialAggregationController(5, 0.8);
-        HashAggregationOperatorFactory operatorFactory = new HashAggregationOperatorFactory(
-                0,
-                new PlanNodeId("test"),
-                ImmutableList.of(BIGINT),
+        HashAggregationOperatorFactory operatorFactory = createAdaptiveHashAggregationOperatorFactory(
                 hashChannels,
-                ImmutableList.of(),
-                PARTIAL,
-                ImmutableList.of(LONG_MIN.createAggregatorFactory(PARTIAL, ImmutableList.of(0), OptionalInt.empty())),
-                Optional.empty(),
-                Optional.empty(),
-                10,
-                Optional.of(DataSize.of(16, MEGABYTE)), // this setting makes operator to flush only after all pages
-                joinCompiler,
-                blockTypeOperators,
-                // use 5 rows threshold to trigger adaptive partial aggregation after each page flush
-                Optional.of(partialAggregationController));
+                PARTIAL, ImmutableList.of(LONG_MIN.createAggregatorFactory(PARTIAL, ImmutableList.of(0), OptionalInt.empty())),
+                ImmutableList.of(0),
+                Optional.of(partialAggregationController),
+                Optional.of(DataSize.of(16, MEGABYTE))); // this setting makes operator to flush only after all pages
 
         List<Page> operator1Input = rowPagesBuilder(false, hashChannels, BIGINT)
                 .addSequencePage(10, 0) // first page are unique values, so it would trigger adaptation, but it won't because flush is not called
                 .addBlocksPage(createRLEBlock(1, 2)) // second page will be hashed to existing value 1
                 .build();
-        // the total unique ows ratio for the first operator will be 10/12 so > 0.8 (adaptive partial aggregation uniqueRowsRatioThreshold)
-        List<Page> operator1Expected = rowPagesBuilder(BIGINT, BIGINT)
-                .addSequencePage(10, 0, 0) // we are expecting second page to be squashed with the first
-                .build();
+        // the total unique rows ratio for the first operator will be 10/12 so > 0.8 (adaptive partial aggregation uniqueRowsRatioThreshold)
+        RowPagesBuilder operator1Expected = rowPagesBuilder(BIGINT, BIGINT, BIGINT, BOOLEAN)
+                .addBlocksPage(createLongSequenceBlock(0, 10), createLongSequenceBlock(0, 10), nullRle(BIGINT, 10), nullRle(BOOLEAN, 10)); // we are expecting second page to be squashed with the first
         assertOperatorEquals(operatorFactory, operator1Input, operator1Expected);
 
         // the first operator flush disables partial aggregation
@@ -808,21 +826,165 @@ public class TestHashAggregationOperator
                 .addBlocksPage(createRLEBlock(1, 10))
                 .addBlocksPage(createRLEBlock(2, 10))
                 .build();
-        List<Page> operator2Expected = rowPagesBuilder(BIGINT, BIGINT)
-                .addBlocksPage(createRLEBlock(1, 10), createRLEBlock(1, 10))
-                .addBlocksPage(createRLEBlock(2, 10), createRLEBlock(2, 10))
-                .build();
+        RowPagesBuilder operator2Expected = rowPagesBuilder(BIGINT, BIGINT, BIGINT, BOOLEAN)
+                .addBlocksPage(createRLEBlock(1, 10), nullRle(BIGINT, 10), createRLEBlock(1, 10), booleanRle(true, 10))
+                .addBlocksPage(createRLEBlock(2, 10), nullRle(BIGINT, 10), createRLEBlock(2, 10), booleanRle(true, 10));
 
         assertOperatorEquals(operatorFactory, operator2Input, operator2Expected);
     }
 
-    private void assertOperatorEquals(OperatorFactory operatorFactory, List<Page> input, List<Page> expectedPages)
+    @Test
+    public void testFinalAggregation()
+    {
+        List<Integer> hashChannels = Ints.asList(0);
+
+        HashAggregationOperatorFactory operatorFactory = createAdaptiveHashAggregationOperatorFactory(
+                hashChannels,
+                FINAL,
+                ImmutableList.of(LONG_SUM.createAggregatorFactory(FINAL, ImmutableList.of(1, 2), OptionalInt.empty(), OptionalInt.of(3))),
+                ImmutableList.of(2),
+                Optional.empty(),
+                Optional.empty());
+
+        List<Page> input = rowPagesBuilder(false, hashChannels, BIGINT, BIGINT, BIGINT, BOOLEAN)
+                .addBlocksPage(// aggregated page
+                        createLongsBlock(0, 1, 2, 3), // hash channels
+                        serializedLongSum(2, 2, 3, 3), // intermediate state
+                        nullRle(BIGINT, 4), // aggregation input
+                        nullRle(BOOLEAN, 4)) // raw input mask
+                .addBlocksPage(// raw input page
+                        createLongsBlock(0, 0, 2, 2), // hash channels
+                        nullRle(BIGINT, 4), // intermediate state
+                        createLongsBlock(1, 2, -1, -2), // aggregation input
+                        booleanRle(true, 4)) // raw input mask
+                .addBlocksPage(// mixed aggregated and raw input page
+                        createLongsBlock(2, 3, 3, 3), // hash channels
+                        serializedLongSum(1, 1, null, null), // intermediate state
+                        createLongsBlock(null, null, 1L, 1L), // aggregation input
+                        createBooleansBlock(null, null, true, true)) // raw input mask
+                .build();
+        RowPagesBuilder expected = rowPagesBuilder(BIGINT, BIGINT)
+                .addBlocksPage(
+                        createLongsBlock(0, 1, 2, 3), // hash channels
+                        createLongsBlock(2 + 1 + 2, 2, 3 - 1 + -2 + 1, 3 + 1 + 1 + 1)); // aggregation result
+
+        assertOperatorEquals(operatorFactory, input, expected);
+    }
+
+    @Test
+    public void testFinalAggregationWithMask()
+    {
+        List<Integer> hashChannels = Ints.asList(0);
+
+        HashAggregationOperatorFactory operatorFactory = createAdaptiveHashAggregationOperatorFactory(
+                hashChannels,
+                FINAL,
+                ImmutableList.of(LONG_SUM.createAggregatorFactory(FINAL, ImmutableList.of(1, 3), OptionalInt.of(2), OptionalInt.of(4))),
+                ImmutableList.of(2),
+                Optional.empty(),
+                Optional.empty());
+
+        List<Page> input = rowPagesBuilder(false, hashChannels, BIGINT, BIGINT, BIGINT, BOOLEAN)
+                .addBlocksPage(// aggregated page
+                        createLongsBlock(0, 1, 2, 3), // hash channels
+                        serializedLongSum(2, 2, 3, 3), // intermediate state
+                        nullRle(BOOLEAN, 4), // mask channel
+                        nullRle(BIGINT, 4), // aggregation input
+                        nullRle(BOOLEAN, 4)) // raw input mask
+                .addBlocksPage(// raw input page
+                        createLongsBlock(0, 0, 2, 2), // hash channels
+                        nullRle(BIGINT, 4), // intermediate state
+                        booleanRle(true, 4), // mask channel
+                        createLongsBlock(1, 2, -1, -2), // aggregation input
+                        booleanRle(true, 4)) // raw input mask
+                .addBlocksPage(// mixed aggregated and raw input page
+                        createLongsBlock(2, 3, 3, 3), // hash channels
+                        serializedLongSum(1, null, null, null), // intermediate state
+                        createBooleansBlock(null, false, true, true), // mask channel
+                        createLongsBlock(null, 100L, 1L, 1L), // aggregation input
+                        createBooleansBlock(null, true, true, true)) // raw input mask
+                .build();
+        RowPagesBuilder expected = rowPagesBuilder(BIGINT, BIGINT)
+                .addBlocksPage(
+                        createLongsBlock(0, 1, 2, 3), // hash channels
+                        createLongsBlock(2 + 1 + 2, 2, 3 - 1 + -2 + 1, 3 + 1 + 1)); // aggregation result
+
+        assertOperatorEquals(operatorFactory, input, expected);
+    }
+
+    private HashAggregationOperatorFactory createAdaptiveHashAggregationOperatorFactory(
+            List<Integer> hashChannels,
+            Step step,
+            List<AggregatorFactory> aggregatorFactories,
+            List<Integer> aggregationRawInputChannels,
+            Optional<PartialAggregationController> partialAggregationController,
+            Optional<DataSize> maxPartialMemory)
+    {
+        return new HashAggregationOperatorFactory(
+                0,
+                new PlanNodeId("test"),
+                ImmutableList.of(BIGINT),
+                hashChannels,
+                partialAggregationController.isPresent() ? Optional.of(new PartialAggregationOutputProcessor(
+                        hashChannels,
+                        Optional.empty(),
+                        aggregatorFactories,
+                        ImmutableList.of(BIGINT),
+                        aggregationRawInputChannels)) :
+                        Optional.empty(),
+                ImmutableList.of(),
+                step,
+                aggregatorFactories,
+                Optional.empty(),
+                Optional.empty(),
+                10,
+                maxPartialMemory,
+                joinCompiler,
+                blockTypeOperators,
+                partialAggregationController);
+    }
+
+    private Block serializedLongSum(Integer... values)
+    {
+        RowBlockBuilder builder = new RowBlockBuilder(ImmutableList.of(BIGINT, BOOLEAN, BIGINT, BOOLEAN), null, values.length);
+        for (int i = 0; i < values.length; i++) {
+            if (values[i] == null) {
+                builder.appendNull();
+            }
+            else {
+                SingleRowBlockWriter rowWriter = builder.beginBlockEntry();
+                BIGINT.writeLong(rowWriter, 1);
+                BOOLEAN.writeBoolean(rowWriter, false);
+                BIGINT.writeLong(rowWriter, values[i]);
+                BOOLEAN.writeBoolean(rowWriter, false);
+                builder.closeEntry();
+            }
+        }
+        return builder.build();
+    }
+
+    private void assertOperatorEquals(OperatorFactory operatorFactory, List<Page> input, RowPagesBuilder expectedPages)
+    {
+        assertOperatorEquals(operatorFactory, input, expectedPages.build(), expectedPages.getTypes());
+    }
+
+    private void assertOperatorEquals(OperatorFactory operatorFactory, List<Page> input, List<Page> expectedPages, List<Type> expectedTypes)
     {
         DriverContext driverContext = createDriverContext(1024);
-        MaterializedResult expected = resultBuilder(driverContext.getSession(), BIGINT, BIGINT)
+        MaterializedResult expected = resultBuilder(driverContext.getSession(), expectedTypes)
                 .pages(expectedPages)
                 .build();
         OperatorAssertion.assertOperatorEquals(operatorFactory, driverContext, input, expected, false, false);
+    }
+
+    private static Block booleanRle(boolean value, int positionCount)
+    {
+        return RunLengthEncodedBlock.create(BOOLEAN, value, positionCount);
+    }
+
+    private static Block nullRle(Type type, int positionCount)
+    {
+        return RunLengthEncodedBlock.create(type, null, positionCount);
     }
 
     private DriverContext createDriverContext()

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestingAggregationFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestingAggregationFunction.java
@@ -97,15 +97,20 @@ public class TestingAggregationFunction
 
     public AggregatorFactory createAggregatorFactory(Step step, List<Integer> inputChannels, OptionalInt maskChannel)
     {
-        return createAggregatorFactory(step, inputChannels, maskChannel, factory);
+        return createAggregatorFactory(step, inputChannels, maskChannel, OptionalInt.empty(), factory);
+    }
+
+    public AggregatorFactory createAggregatorFactory(Step step, List<Integer> inputChannels, OptionalInt maskChannel, OptionalInt rawInputMaskChannel)
+    {
+        return createAggregatorFactory(step, inputChannels, maskChannel, rawInputMaskChannel, factory);
     }
 
     public AggregatorFactory createDistinctAggregatorFactory(Step step, List<Integer> inputChannels, OptionalInt maskChannel)
     {
-        return createAggregatorFactory(step, inputChannels, maskChannel, distinctFactory);
+        return createAggregatorFactory(step, inputChannels, maskChannel, OptionalInt.empty(), distinctFactory);
     }
 
-    private AggregatorFactory createAggregatorFactory(Step step, List<Integer> inputChannels, OptionalInt maskChannel, AccumulatorFactory distinctFactory)
+    private AggregatorFactory createAggregatorFactory(Step step, List<Integer> inputChannels, OptionalInt maskChannel, OptionalInt rawInputMaskChannel, AccumulatorFactory distinctFactory)
     {
         return new AggregatorFactory(
                 distinctFactory,
@@ -113,6 +118,7 @@ public class TestingAggregationFunction
                 intermediateType,
                 finalType,
                 inputChannels,
+                rawInputMaskChannel,
                 maskChannel,
                 true,
                 ImmutableList.of());

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestEffectivePredicateExtractor.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestEffectivePredicateExtractor.java
@@ -260,7 +260,8 @@ public class TestEffectivePredicateExtractor
                 ImmutableMap.of(),
                 globalAggregation(),
                 ImmutableList.of(),
-                AggregationNode.Step.FINAL,
+                AggregationNode.Step.SINGLE,
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
@@ -220,7 +220,7 @@ public class TestLogicalPlanner
         assertDistributedPlan("SELECT orderstatus, sum(totalprice) FROM orders GROUP BY orderstatus",
                 anyTree(
                         aggregation(
-                                ImmutableMap.of("final_sum", functionCall("sum", ImmutableList.of("partial_sum"))),
+                                ImmutableMap.of("final_sum", functionCall("sum", ImmutableList.of("partial_sum", "totalprice"))),
                                 FINAL,
                                 exchange(LOCAL, GATHER,
                                         exchange(REMOTE, REPARTITION,
@@ -233,7 +233,7 @@ public class TestLogicalPlanner
         assertDistributedPlan("SELECT orderstatus, sum(totalprice) FROM orders WHERE orderstatus='O' GROUP BY orderstatus",
                 anyTree(
                         aggregation(
-                                ImmutableMap.of("final_sum", functionCall("sum", ImmutableList.of("partial_sum"))),
+                                ImmutableMap.of("final_sum", functionCall("sum", ImmutableList.of("partial_sum", "totalprice"))),
                                 FINAL,
                                 exchange(LOCAL, GATHER,
                                         exchange(REMOTE, REPARTITION,
@@ -256,8 +256,8 @@ public class TestLogicalPlanner
                                         ImmutableMap.of("row", expression("ROW(min, max)")),
                                         aggregation(
                                                 ImmutableMap.of(
-                                                        "min", functionCall("min", ImmutableList.of("min_regionkey")),
-                                                        "max", functionCall("max", ImmutableList.of("max_name"))),
+                                                        "min", functionCall("min", ImmutableList.of("min_regionkey", "REGIONKEY")),
+                                                        "max", functionCall("max", ImmutableList.of("max_name", "NAME"))),
                                                 FINAL,
                                                 any(
                                                         aggregation(
@@ -1871,7 +1871,7 @@ public class TestLogicalPlanner
                 output(
                         anyTree(
                                 aggregation(
-                                        ImmutableMap.of("final_count", functionCall("count", ImmutableList.of("partial_count"))),
+                                        ImmutableMap.of("final_count", functionCall("count", ImmutableList.of("partial_count", "CONSTANT"))),
                                         FINAL,
                                         exchange(
                                                 LOCAL,

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestTableScanNodePartitioning.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestTableScanNodePartitioning.java
@@ -169,7 +169,7 @@ public class TestTableScanNodePartitioning
         String query = "SELECT count(column_b) FROM " + table + " GROUP BY column_a";
         assertDistributedPlan(query, session,
                 anyTree(
-                        aggregation(ImmutableMap.of("COUNT", functionCall("count", ImmutableList.of("COUNT_PART"))), FINAL,
+                        aggregation(ImmutableMap.of("COUNT", functionCall("count", ImmutableList.of("COUNT_PART", "B"))), FINAL,
                                 exchange(LOCAL, REPARTITION,
                                         project(
                                                 aggregation(ImmutableMap.of("COUNT_PART", functionCall("count", ImmutableList.of("B"))), PARTIAL,
@@ -184,7 +184,7 @@ public class TestTableScanNodePartitioning
         String query = "SELECT count(column_b) FROM " + table + " GROUP BY column_a";
         assertDistributedPlan("SELECT count(column_b) FROM " + table + " GROUP BY column_a", session,
                 anyTree(
-                        aggregation(ImmutableMap.of("COUNT", functionCall("count", ImmutableList.of("COUNT_PART"))), FINAL,
+                        aggregation(ImmutableMap.of("COUNT", functionCall("count", ImmutableList.of("COUNT_PART", "B"))), FINAL,
                                 exchange(LOCAL, REPARTITION,
                                         exchange(REMOTE, REPARTITION,
                                                 project(

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushPartialAggregationThroughJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushPartialAggregationThroughJoin.java
@@ -57,7 +57,8 @@ public class TestPushPartialAggregationThroughJoin
                                         Optional.of(p.symbol("RIGHT_HASH"))))
                         .addAggregation(p.symbol("AVG", DOUBLE), expression("AVG(LEFT_AGGR)"), ImmutableList.of(DOUBLE))
                         .singleGroupingSet(p.symbol("LEFT_GROUP_BY"), p.symbol("RIGHT_GROUP_BY"))
-                        .step(PARTIAL)))
+                        .step(PARTIAL)
+                        .rawInputMaskSymbol()))
                 .matches(project(ImmutableMap.of(
                         "LEFT_GROUP_BY", PlanMatchPattern.expression("LEFT_GROUP_BY"),
                         "RIGHT_GROUP_BY", PlanMatchPattern.expression("RIGHT_GROUP_BY"),

--- a/testing/trino-benchmark/src/main/java/io/trino/benchmark/BenchmarkAggregationFunction.java
+++ b/testing/trino-benchmark/src/main/java/io/trino/benchmark/BenchmarkAggregationFunction.java
@@ -51,6 +51,7 @@ public class BenchmarkAggregationFunction
                 finalType,
                 inputChannels,
                 OptionalInt.empty(),
+                OptionalInt.empty(),
                 true,
                 ImmutableList.of());
     }

--- a/testing/trino-benchmark/src/main/java/io/trino/benchmark/HandTpchQuery1.java
+++ b/testing/trino-benchmark/src/main/java/io/trino/benchmark/HandTpchQuery1.java
@@ -106,6 +106,7 @@ public class HandTpchQuery1
                 new PlanNodeId("test"),
                 getColumnTypes("lineitem", "returnflag", "linestatus"),
                 Ints.asList(0, 1),
+                Optional.empty(),
                 ImmutableList.of(),
                 Step.SINGLE,
                 ImmutableList.of(

--- a/testing/trino-benchmark/src/main/java/io/trino/benchmark/HashAggregationBenchmark.java
+++ b/testing/trino-benchmark/src/main/java/io/trino/benchmark/HashAggregationBenchmark.java
@@ -53,6 +53,7 @@ public class HashAggregationBenchmark
                 new PlanNodeId("test"),
                 ImmutableList.of(tableTypes.get(0)),
                 Ints.asList(0),
+                Optional.empty(),
                 ImmutableList.of(),
                 Step.SINGLE,
                 ImmutableList.of(doubleSum.bind(ImmutableList.of(1))),

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerWithSplits.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerWithSplits.java
@@ -165,7 +165,7 @@ public class TestEventListenerWithSplits
         assertEquals(statistics.getPhysicalInputRows(), expectedCompletedPositions);
         assertEquals(statistics.getProcessedInputBytes(), 0);
         assertEquals(statistics.getProcessedInputRows(), expectedCompletedPositions);
-        assertEquals(statistics.getInternalNetworkBytes(), 381);
+        assertEquals(statistics.getInternalNetworkBytes(), 591);
         assertEquals(statistics.getInternalNetworkRows(), 3);
         assertEquals(statistics.getTotalBytes(), 0);
         assertEquals(statistics.getOutputBytes(), 9);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

Since partial aggregation can be disabled at runtime,
both aggregated and the input data need to be passed
through to the final step.
This change extends the partial aggregation output
with additional columns to use for raw input
and uses those columns to send raw input in case
partial aggregation is disabled.
An additional column contains information which
set of channels should be used by the final step.

This is rebased on top of https://github.com/trinodb/trino/pull/12101. Only last commit matters here.

This is an extension of https://github.com/trinodb/trino/pull/11011 and limited implementation of https://github.com/prestodb/presto/issues/10305.
It does not work on a per-group basis but rather per operator factory instance (i.e.all  operators for a given plan node id on one worker node).
It does not use `row type` because there is no support currently to operate on the `row type` fields during planning.

### Benchmarks
tpch/tpcds benchmarks on partitioned orc sf1000, with and without https://github.com/trinodb/trino/pull/11289 (that PR adds RLE support for partitioned exchange which makes this pr more efficient)
[adaptive-partial-aggregation-union-rle-hasNonNullValue-var-row.pdf](https://github.com/trinodb/trino/files/8589509/adaptive-partial-aggregation-union-rle-hasNonNullValue-var-row.pdf)

Summary
There are significant gains for TPCH, especially with partitioned exchange RLE support. Duration drops even more than CPU because of a significant drop in the data sent over the network.
For TPCDS, the improvement is only visible when combined with partitioned exchange RLE support.
<img width="1370" alt="image" src="https://user-images.githubusercontent.com/8080198/165914529-05f0e976-81bf-4b03-a8e1-624adc80c3a8.png">

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

improvement
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core query engine
> How would you describe this change to a non-technical end user or system administrator?

Improve performance of group by queries with that produce many distinct values
## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
