### PR TITLE
Do not fail query immediately if no matching nodes available

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeSchedulerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeSchedulerConfig.java
@@ -17,11 +17,14 @@ import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.DefunctConfig;
 import io.airlift.configuration.LegacyConfig;
+import io.airlift.units.Duration;
 
 import javax.validation.constraints.DecimalMax;
 import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
+
+import java.util.concurrent.TimeUnit;
 
 import static java.util.Locale.ENGLISH;
 
@@ -48,6 +51,7 @@ public class NodeSchedulerConfig
     private int maxUnacknowledgedSplitsPerTask = 500;
     private int maxAbsoluteFullNodesPerQuery = Integer.MAX_VALUE;
     private double maxFractionFullNodesPerQuery = 0.5;
+    private Duration allowedNoMatchingNodePeriod = new Duration(2, TimeUnit.MINUTES);
     private NodeAllocatorType nodeAllocatorType = NodeAllocatorType.BIN_PACKING;
 
     @NotNull
@@ -193,6 +197,19 @@ public class NodeSchedulerConfig
     public double getMaxFractionFullNodesPerQuery()
     {
         return maxFractionFullNodesPerQuery;
+    }
+
+    @Config("node-scheduler.allowed-no-matching-node-period")
+    @ConfigDescription("How long scheduler should wait before failing a query for which hard task requirements (e.g. node exposing specific catalog) cannot be satisfied")
+    public NodeSchedulerConfig setAllowedNoMatchingNodePeriod(Duration allowedNoMatchingNodePeriod)
+    {
+        this.allowedNoMatchingNodePeriod = allowedNoMatchingNodePeriod;
+        return this;
+    }
+
+    public Duration getAllowedNoMatchingNodePeriod()
+    {
+        return allowedNoMatchingNodePeriod;
     }
 
     public enum NodeAllocatorType

--- a/core/trino-main/src/test/java/io/trino/execution/TestNodeSchedulerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestNodeSchedulerConfig.java
@@ -14,6 +14,7 @@
 package io.trino.execution;
 
 import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
 import io.trino.execution.scheduler.NodeSchedulerConfig;
 import org.testng.annotations.Test;
 
@@ -24,6 +25,7 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDe
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static io.trino.execution.scheduler.NodeSchedulerConfig.NodeSchedulerPolicy.UNIFORM;
 import static io.trino.execution.scheduler.NodeSchedulerConfig.SplitsBalancingPolicy.NODE;
+import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class TestNodeSchedulerConfig
 {
@@ -41,6 +43,7 @@ public class TestNodeSchedulerConfig
                 .setOptimizedLocalScheduling(true)
                 .setMaxAbsoluteFullNodesPerQuery(Integer.MAX_VALUE)
                 .setMaxFractionFullNodesPerQuery(0.5)
+                .setAllowedNoMatchingNodePeriod(new Duration(2, MINUTES))
                 .setNodeAllocatorType("bin_packing"));
     }
 
@@ -58,6 +61,7 @@ public class TestNodeSchedulerConfig
                 .put("node-scheduler.optimized-local-scheduling", "false")
                 .put("node-scheduler.max-absolute-full-nodes-per-query", "17")
                 .put("node-scheduler.max-fraction-full-nodes-per-query", "0.3")
+                .put("node-scheduler.allowed-no-matching-node-period", "1m")
                 .put("node-scheduler.allocator-type", "fixed_count")
                 .buildOrThrow();
 
@@ -72,6 +76,7 @@ public class TestNodeSchedulerConfig
                 .setOptimizedLocalScheduling(false)
                 .setMaxAbsoluteFullNodesPerQuery(17)
                 .setMaxFractionFullNodesPerQuery(0.3)
+                .setAllowedNoMatchingNodePeriod(new Duration(1, MINUTES))
                 .setNodeAllocatorType("fixed_count");
 
         assertFullMapping(properties, expected);

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestExponentialGrowthPartitionMemoryEstimator.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestExponentialGrowthPartitionMemoryEstimator.java
@@ -13,6 +13,7 @@
  */
 package io.trino.execution.scheduler;
 
+import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 import io.trino.Session;
@@ -28,6 +29,7 @@ import io.trino.testing.TestingSession;
 import org.testng.annotations.Test;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.Optional;
 
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
@@ -35,6 +37,7 @@ import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.spi.StandardErrorCode.ADMINISTRATIVELY_PREEMPTED;
 import static io.trino.spi.StandardErrorCode.CLUSTER_OUT_OF_MEMORY;
 import static io.trino.spi.StandardErrorCode.EXCEEDED_LOCAL_MEMORY_LIMIT;
+import static java.time.temporal.ChronoUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestExponentialGrowthPartitionMemoryEstimator
@@ -49,7 +52,9 @@ public class TestExponentialGrowthPartitionMemoryEstimator
                 nodeManager,
                 () -> ImmutableMap.of(new InternalNode("a-node", URI.create("local://blah"), NodeVersion.UNKNOWN, false).getNodeIdentifier(), Optional.of(buildWorkerMemoryInfo(DataSize.ofBytes(0)))),
                 false,
-                DataSize.ofBytes(0));
+                Duration.of(1, MINUTES),
+                DataSize.ofBytes(0),
+                Ticker.systemTicker());
         nodeAllocatorService.refreshNodePoolMemoryInfos();
         PartitionMemoryEstimator estimator = nodeAllocatorService.createPartitionMemoryEstimator();
 


### PR DESCRIPTION
## Description

Do not fail query immediately if there are no nodes available that match tasks' hard requirements (e.g. expose given catalog).
If such a situation occurs wait for some time and only fail if we still cannot find any matching node.

fixes: #11020


> Is this change a fix, improvement, new feature, refactoring, or other?

improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core 

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
