### PR TITLE
Add Iceberg support for ALTER TABLE ... SET PROPERTIES

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -238,6 +238,25 @@ otherwise the procedure will fail with similar message:
 ``Retention specified (1.00d) is shorter than the minimum retention configured in the system (7.00d)``.
 The default value for this property is ``7d``.
 
+.. _iceberg-alter-table-set-properties:
+
+ALTER TABLE SET PROPERTIES
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The connector supports modifying the properties on existing tables using
+:ref:`ALTER TABLE SET PROPERTIES <alter-table-set-properties>`.
+
+The following table properties can be updated after a table is created:
+
+* ``format``
+* ``format_version``
+
+For example, to update a table from v1 of the Iceberg specification to v2:
+
+.. code-block:: sql
+
+    ALTER TABLE table_name SET PROPERTIES format_version = 2;
+
 .. _iceberg-type-mapping:
 
 Type mapping

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -104,6 +104,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.Transaction;
+import org.apache.iceberg.UpdateProperties;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.types.Type;
 
@@ -146,6 +147,7 @@ import static io.trino.plugin.hive.util.HiveUtil.isStructuralType;
 import static io.trino.plugin.iceberg.ExpressionConverter.toIcebergExpression;
 import static io.trino.plugin.iceberg.IcebergColumnHandle.pathColumnHandle;
 import static io.trino.plugin.iceberg.IcebergColumnHandle.pathColumnMetadata;
+import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_COMMIT_ERROR;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_FILESYSTEM_ERROR;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
 import static io.trino.plugin.iceberg.IcebergMetadataColumn.FILE_PATH;
@@ -190,6 +192,7 @@ import static org.apache.iceberg.SnapshotSummary.REMOVED_EQ_DELETES_PROP;
 import static org.apache.iceberg.SnapshotSummary.REMOVED_POS_DELETES_PROP;
 import static org.apache.iceberg.TableProperties.DELETE_ISOLATION_LEVEL;
 import static org.apache.iceberg.TableProperties.DELETE_ISOLATION_LEVEL_DEFAULT;
+import static org.apache.iceberg.TableProperties.FORMAT_VERSION;
 import static org.apache.iceberg.TableProperties.WRITE_LOCATION_PROVIDER_IMPL;
 
 public class IcebergMetadata
@@ -1144,6 +1147,52 @@ public class IcebergMetadata
     public void renameTable(ConnectorSession session, ConnectorTableHandle tableHandle, SchemaTableName newTable)
     {
         catalog.renameTable(session, ((IcebergTableHandle) tableHandle).getSchemaTableName(), newTable);
+    }
+
+    @Override
+    public void setTableProperties(ConnectorSession session, ConnectorTableHandle tableHandle, Map<String, Optional<Object>> properties)
+    {
+        IcebergTableHandle table = (IcebergTableHandle) tableHandle;
+        BaseTable icebergTable = (BaseTable) catalog.loadTable(session, table.getSchemaTableName());
+
+        transaction = icebergTable.newTransaction();
+        UpdateProperties updateProperties = transaction.updateProperties();
+
+        for (Map.Entry<String, Optional<Object>> propertyEntry : properties.entrySet()) {
+            String trinoPropertyName = propertyEntry.getKey();
+            Optional<Object> propertyValue = propertyEntry.getValue();
+
+            switch (trinoPropertyName) {
+                case FILE_FORMAT_PROPERTY:
+                    updateProperties.defaultFormat(((IcebergFileFormat) propertyValue.orElseThrow()).toIceberg());
+                    break;
+                case FORMAT_VERSION_PROPERTY:
+                    // UpdateProperties#commit will trigger any necessary metadata updates required for the new spec version
+                    updateProperty(updateProperties, FORMAT_VERSION, propertyValue, formatVersion -> Integer.toString((int) formatVersion));
+                    break;
+                default:
+                    // TODO: Support updating partitioning https://github.com/trinodb/trino/issues/12174
+                    throw new TrinoException(NOT_SUPPORTED, "Updating the " + trinoPropertyName + " property is not supported");
+            }
+        }
+
+        try {
+            updateProperties.commit();
+            transaction.commitTransaction();
+        }
+        catch (RuntimeException e) {
+            throw new TrinoException(ICEBERG_COMMIT_ERROR, "Failed to commit new table properties", e);
+        }
+    }
+
+    private static void updateProperty(UpdateProperties updateProperties, String icebergPropertyName, Optional<Object> value, Function<Object, String> toIcebergString)
+    {
+        if (value.isPresent()) {
+            updateProperties.set(icebergPropertyName, toIcebergString.apply(value.get()));
+        }
+        else {
+            updateProperties.remove(icebergPropertyName);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Description

The two properties which can be set are `format` and `format_version`.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

New feature

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Iceberg connector

> How would you describe this change to a non-technical end user or system administrator?

Allows updating specific metadata for an Iceberg table. The format_version, and the format of the underlying data files.

## Related issues, pull requests, and links

Fixes: https://github.com/trinodb/trino/issues/12138
<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Iceberg
* Add support for updating the `format` and `format_version` table properties using `ALTER TABLE ... SET PROPERTIES`. This allows for updating tables from v1 of the Iceberg specification to v2.
```
