### PR TITLE
Fix throw wrong exception in `CreateTableTask`

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/CreateTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateTableTask.java
@@ -132,7 +132,7 @@ public class CreateTableTask
         }
         catch (TrinoException e) {
             if (e.getErrorCode().equals(UNSUPPORTED_TABLE_TYPE.toErrorCode())) {
-                throw semanticException(TABLE_ALREADY_EXISTS, statement, "Table '%s' of unsupported type already exists", tableName);
+                throw new TrinoException(UNSUPPORTED_TABLE_TYPE, format("The type of table '%s' is unsupported", tableName));
             }
             throw e;
         }


### PR DESCRIPTION
## Description
Fix throw wrong exception in `CreateTableTask`.

## Documentation
(x) No documentation is needed.

## Release notes
(x) No release notes entries required.
