### PR TITLE
Add bulk insert support to SQL Server connector

### DIFF
--- a/docs/src/main/sphinx/connector/sqlserver.rst
+++ b/docs/src/main/sphinx/connector/sqlserver.rst
@@ -249,6 +249,45 @@ The connector supports pushdown for a number of operations:
 
 .. include:: no-pushdown-text-type.fragment
 
+.. _sqlserver-bulk-insert:
+
+Bulk insert
+^^^^^^^^^^^
+
+You can optionally use the `bulk copy API
+<https://docs.microsoft.com/en-us/sql/connect/jdbc/use-bulk-copy-api-batch-insert-operation>`_
+to drastically speed up write operations.
+
+Enable bulk copying and a lock on the destination table to meet `minimal
+logging requirements
+<https://docs.microsoft.com/en-us/sql/relational-databases/import-export/prerequisites-for-minimal-logging-in-bulk-import>`_.
+
+The following table shows the relevant catalog configuration properties and
+their default values:
+
+.. list-table:: Bulk load properties
+  :widths: 30, 60, 10
+  :header-rows: 1
+
+  * - Property name
+    - Description
+    - Default
+  * - ``sqlserver.bulk-copy-for-write.enabled``
+    - Use the SQL Server bulk copy API for writes. The corresponding catalog
+      session property is ``bulk_copy_for_write``.
+    - ``false``
+  * - ``sqlserver.bulk-copy-for-write.lock-destination-table``
+    - Obtain a bulk update lock on the destination table for write operations.
+      The corresponding catalog session property is
+      ``bulk_copy_for_write_lock_destination_table``. Setting is only used when
+      ``bulk-copy-for-write.enabled=true``.
+    - ``false``
+
+Limitations:
+
+* Column names with leading and trailing spaces are not supported.
+
+
 Data compression
 ----------------
 

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClientModule.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClientModule.java
@@ -32,6 +32,7 @@ import io.trino.plugin.jdbc.credential.CredentialProvider;
 
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.trino.plugin.jdbc.JdbcModule.bindSessionPropertiesProvider;
 import static io.trino.plugin.jdbc.JdbcModule.bindTablePropertiesProvider;
 import static io.trino.plugin.sqlserver.SqlServerClient.SQL_SERVER_MAX_LIST_EXPRESSIONS;
 
@@ -45,6 +46,7 @@ public class SqlServerClientModule
         configBinder(binder).bindConfig(JdbcStatisticsConfig.class);
         binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class).to(SqlServerClient.class).in(Scopes.SINGLETON);
         bindTablePropertiesProvider(binder, SqlServerTableProperties.class);
+        bindSessionPropertiesProvider(binder, SqlServerSessionProperties.class);
         newOptionalBinder(binder, Key.get(int.class, MaxDomainCompactionThreshold.class)).setBinding().toInstance(SQL_SERVER_MAX_LIST_EXPRESSIONS);
         install(new JdbcJoinPushdownSupportModule());
     }

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerConfig.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerConfig.java
@@ -19,6 +19,34 @@ import io.airlift.configuration.ConfigDescription;
 public class SqlServerConfig
 {
     private boolean snapshotIsolationDisabled;
+    private boolean bulkCopyForWrite;
+    private boolean bulkCopyForWriteLockDestinationTable;
+
+    public boolean isBulkCopyForWrite()
+    {
+        return bulkCopyForWrite;
+    }
+
+    @Config("sqlserver.bulk-copy-for-write.enabled")
+    @ConfigDescription("Use SQL Server Bulk Copy API for writes")
+    public SqlServerConfig setBulkCopyForWrite(boolean bulkCopyForWrite)
+    {
+        this.bulkCopyForWrite = bulkCopyForWrite;
+        return this;
+    }
+
+    public boolean isBulkCopyForWriteLockDestinationTable()
+    {
+        return bulkCopyForWriteLockDestinationTable;
+    }
+
+    @Config("sqlserver.bulk-copy-for-write.lock-destination-table")
+    @ConfigDescription("Obtain a Bulk Update lock on destination table on write")
+    public SqlServerConfig setBulkCopyForWriteLockDestinationTable(boolean bulkCopyForWriteLockDestinationTable)
+    {
+        this.bulkCopyForWriteLockDestinationTable = bulkCopyForWriteLockDestinationTable;
+        return this;
+    }
 
     public boolean isSnapshotIsolationDisabled()
     {

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerSessionProperties.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerSessionProperties.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.sqlserver;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import io.trino.plugin.base.session.SessionPropertiesProvider;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.session.PropertyMetadata;
+
+import java.util.List;
+
+import static io.trino.spi.session.PropertyMetadata.booleanProperty;
+
+public class SqlServerSessionProperties
+        implements SessionPropertiesProvider
+{
+    public static final String BULK_COPY_FOR_WRITE = "bulk_copy_for_write";
+    public static final String BULK_COPY_FOR_WRITE_LOCK_DESTINATION_TABLE = "bulk_copy_for_write_lock_destination_table";
+
+    private final List<PropertyMetadata<?>> sessionProperties;
+
+    @Inject
+    public SqlServerSessionProperties(SqlServerConfig config)
+    {
+        sessionProperties = ImmutableList.of(
+                booleanProperty(
+                        BULK_COPY_FOR_WRITE,
+                        "Use SQL Server Bulk Copy API for writes",
+                        config.isBulkCopyForWrite(),
+                        false),
+                booleanProperty(
+                        BULK_COPY_FOR_WRITE_LOCK_DESTINATION_TABLE,
+                        "Obtain a Bulk Update lock on destination table on write",
+                        config.isBulkCopyForWriteLockDestinationTable(),
+                        false));
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getSessionProperties()
+    {
+        return sessionProperties;
+    }
+
+    /**
+     * Note that certain data types are unsupported by SQL Server and prevent
+     * bulk copies from being performed, see the <a href="https://docs.microsoft.com/en-us/sql/connect/jdbc/use-bulk-copy-api-batch-insert-operation?view=sql-server-ver15#known-limitations">
+     * SQL Server docs</a>.
+     */
+    public static boolean isBulkCopyForWrite(ConnectorSession session)
+    {
+        return session.getProperty(BULK_COPY_FOR_WRITE, Boolean.class);
+    }
+
+    public static boolean isBulkCopyForWriteLockDestinationTable(ConnectorSession session)
+    {
+        return session.getProperty(BULK_COPY_FOR_WRITE_LOCK_DESTINATION_TABLE, Boolean.class);
+    }
+}

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/SqlServerQueryRunner.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/SqlServerQueryRunner.java
@@ -36,7 +36,7 @@ public final class SqlServerQueryRunner
 
     private SqlServerQueryRunner() {}
 
-    private static final String CATALOG = "sqlserver";
+    public static final String CATALOG = "sqlserver";
 
     private static final String TEST_SCHEMA = "dbo";
 

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConfig.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConfig.java
@@ -28,6 +28,8 @@ public class TestSqlServerConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(SqlServerConfig.class)
+                .setBulkCopyForWrite(false)
+                .setBulkCopyForWriteLockDestinationTable(false)
                 .setSnapshotIsolationDisabled(false));
     }
 
@@ -35,10 +37,14 @@ public class TestSqlServerConfig
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("sqlserver.bulk-copy-for-write.enabled", "true")
+                .put("sqlserver.bulk-copy-for-write.lock-destination-table", "true")
                 .put("sqlserver.snapshot-isolation.disabled", "true")
                 .buildOrThrow();
 
         SqlServerConfig expected = new SqlServerConfig()
+                .setBulkCopyForWrite(true)
+                .setBulkCopyForWriteLockDestinationTable(true)
                 .setSnapshotIsolationDisabled(true);
 
         assertFullMapping(properties, expected);

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConnectorTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConnectorTest.java
@@ -13,11 +13,33 @@
  */
 package io.trino.plugin.sqlserver;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.sql.SqlExecutor;
+import io.trino.testing.sql.TestTable;
+import io.trino.testng.services.Flaky;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+
+import static io.trino.plugin.jdbc.JdbcWriteSessionProperties.NON_TRANSACTIONAL_INSERT;
+import static io.trino.plugin.sqlserver.SqlServerQueryRunner.CATALOG;
 import static io.trino.plugin.sqlserver.SqlServerQueryRunner.createSqlServerQueryRunner;
+import static io.trino.plugin.sqlserver.SqlServerSessionProperties.BULK_COPY_FOR_WRITE;
+import static io.trino.plugin.sqlserver.SqlServerSessionProperties.BULK_COPY_FOR_WRITE_LOCK_DESTINATION_TABLE;
+import static io.trino.testing.DataProviders.cartesianProduct;
+import static io.trino.testing.DataProviders.trueFalse;
+import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static java.lang.String.format;
+import static java.util.stream.Collectors.joining;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestSqlServerConnectorTest
         extends BaseSqlServerConnectorTest
@@ -36,5 +58,141 @@ public class TestSqlServerConnectorTest
     protected SqlExecutor onRemoteDatabase()
     {
         return sqlServer::execute;
+    }
+
+    @Flaky(issue = "fn_dblog() returns information only about the active portion of the transaction log, therefore it is flaky", match = ".*")
+    @Test(dataProvider = "doubleTrueFalse")
+    public void testCreateTableAsSelectWriteBulkiness(boolean bulkCopyForWrite, boolean bulkCopyLock)
+            throws SQLException
+    {
+        String table = "bulk_copy_ctas_" + randomTableSuffix();
+        Session session = Session.builder(getSession())
+                .setCatalogSessionProperty(CATALOG, BULK_COPY_FOR_WRITE, Boolean.toString(bulkCopyForWrite))
+                .setCatalogSessionProperty(CATALOG, BULK_COPY_FOR_WRITE_LOCK_DESTINATION_TABLE, Boolean.toString(bulkCopyLock))
+                .build();
+
+        // there should be enough rows in source table to minimal logging be enabled. `nation` table is too small.
+        assertQuerySucceeds(session, format("CREATE TABLE %s as SELECT * FROM tpch.tiny.customer", table));
+
+        // check whether minimal logging was applied.
+        // Unlike fully logged operations, which use the transaction log to keep track of every row change,
+        // minimally logged operations keep track of extent allocations and meta-data changes only.
+        assertThat(getTableOperationsCount("LOP_INSERT_ROWS", table))
+                .isEqualTo(bulkCopyForWrite && bulkCopyLock ? 0 : 1500);
+
+        // check that there are no locks remaining on the target table after bulk copy
+        assertQuery("SELECT count(*) FROM " + table, "SELECT count(*) FROM customer");
+        assertUpdate(format("INSERT INTO %s SELECT * FROM tpch.tiny.customer LIMIT 1", table), 1);
+        assertQuery("SELECT count(*) FROM " + table, "SELECT count(*) + 1 FROM customer");
+
+        assertUpdate("DROP TABLE " + table);
+    }
+
+    @Flaky(issue = "fn_dblog() returns information only about the active portion of the transaction log, therefore it is flaky", match = ".*")
+    @Test(dataProvider = "tripleTrueFalse")
+    public void testInsertWriteBulkiness(boolean nonTransactionalInsert, boolean bulkCopyForWrite, boolean bulkCopyForWriteLockDestinationTable)
+            throws SQLException
+    {
+        String table = "bulk_copy_insert_" + randomTableSuffix();
+        assertQuerySucceeds(format("CREATE TABLE %s as SELECT * FROM tpch.tiny.customer WHERE 0 = 1", table));
+        Session session = Session.builder(getSession())
+                .setCatalogSessionProperty(CATALOG, NON_TRANSACTIONAL_INSERT, Boolean.toString(nonTransactionalInsert))
+                .setCatalogSessionProperty(CATALOG, BULK_COPY_FOR_WRITE, Boolean.toString(bulkCopyForWrite))
+                .setCatalogSessionProperty(CATALOG, BULK_COPY_FOR_WRITE_LOCK_DESTINATION_TABLE, Boolean.toString(bulkCopyForWriteLockDestinationTable))
+                .build();
+
+        // there should be enough rows in source table to minimal logging be enabled. `nation` table is too small.
+        assertQuerySucceeds(session, format("INSERT INTO %s SELECT * FROM tpch.tiny.customer", table));
+
+        // check whether minimal logging was applied.
+        // Unlike fully logged operations, which use the transaction log to keep track of every row change,
+        // minimally logged operations keep track of extent allocations and meta-data changes only.
+        assertThat(getTableOperationsCount("LOP_INSERT_ROWS", table))
+                .isEqualTo(bulkCopyForWrite && bulkCopyForWriteLockDestinationTable ? 0 : 1500);
+
+        // check that there are no locks remaining on the target table after bulk copy
+        assertQuery("SELECT count(*) FROM " + table, "SELECT count(*) FROM customer");
+        assertUpdate(format("INSERT INTO %s SELECT * FROM tpch.tiny.customer LIMIT 1", table), 1);
+        assertQuery("SELECT count(*) FROM " + table, "SELECT count(*) + 1 FROM customer");
+
+        assertUpdate("DROP TABLE " + table);
+    }
+
+    @Test(dataProvider = "timestampTypes")
+    public void testInsertWriteBulkinessWithTimestamps(String timestampType)
+    {
+        Session session = Session.builder(getSession())
+                .setCatalogSessionProperty(CATALOG, BULK_COPY_FOR_WRITE, "true")
+                .setCatalogSessionProperty(CATALOG, BULK_COPY_FOR_WRITE_LOCK_DESTINATION_TABLE, "true")
+                .build();
+
+        try (TestTable table = new TestTable((String sql) -> getQueryRunner().execute(session, sql), "bulk_copy_insert", format("(timestamp_col %s)", timestampType))) {
+            // Insert values without using TestTable to ensure all the rows are written in a single batch
+            List<String> timestampValues = ImmutableList.of(
+                    "TIMESTAMP '1958-01-01 13:18:03'",
+                    "TIMESTAMP '1958-01-01 13:18:03.1'",
+                    "TIMESTAMP '1958-01-01 13:18:03.123'",
+                    "TIMESTAMP '1958-01-01 13:18:03.123000'",
+                    "TIMESTAMP '1958-01-01 13:18:03.123000000'",
+                    "TIMESTAMP '1958-01-01 13:18:03.123000000000'",
+                    "TIMESTAMP '2019-03-18 10:01:17.987000'",
+                    "TIMESTAMP '2018-10-28 01:33:17.456000000'",
+                    "TIMESTAMP '1970-01-01 00:00:00.000000000'",
+                    "TIMESTAMP '1970-01-01 00:13:42.000000000'",
+                    "TIMESTAMP '2018-04-01 02:13:55.123000000'",
+                    "TIMESTAMP '1986-01-01 00:13:07.000000000000'");
+            String valuesList = timestampValues.stream().map(s -> format("(%s)", s)).collect(joining(","));
+            assertUpdate(format("INSERT INTO %s VALUES %s", table.getName(), valuesList), 12);
+
+            // check that there are no locks remaining on the target table after bulk copy
+            assertQuery("SELECT count(*) FROM " + table.getName(), "SELECT 12");
+            assertUpdate(format("INSERT INTO %s VALUES (TIMESTAMP '2022-01-01 00:13:07.0000000')", table.getName()), 1);
+            assertQuery("SELECT count(*) FROM " + table.getName(), "SELECT 13");
+        }
+    }
+
+    private int getTableOperationsCount(String operation, String table)
+            throws SQLException
+    {
+        try (Connection connection = sqlServer.createConnection();
+                Handle handle = Jdbi.open(connection)) {
+            // fn_dblog() function only returns information about the active portion of the transaction log such as open transactions or the last activity
+            // therefore tests which use this function are flaky, but it's almost not possible to reproduce this flakiness.
+            // There was no better option found to test if minimal logging was enabled than to query `LOP_INSERT_ROWS` from fn_dblog(NULL,NULL)
+            return handle.createQuery("" +
+                            "SELECT COUNT(*) as cnt " +
+                            "FROM fn_dblog(NULL,NULL) " +
+                            "WHERE Operation = :operation " +
+                            "AND AllocUnitName = CONCAT('dbo.', :table_name)")
+                    .bind("operation", operation)
+                    .bind("table_name", table)
+                    .mapTo(Integer.class)
+                    .one();
+        }
+    }
+
+    @DataProvider
+    public static Object[][] doubleTrueFalse()
+    {
+        return cartesianProduct(trueFalse(), trueFalse());
+    }
+
+    @DataProvider
+    public static Object[][] tripleTrueFalse()
+    {
+        return cartesianProduct(trueFalse(), trueFalse(), trueFalse());
+    }
+
+    @DataProvider
+    public static Object[][] timestampTypes()
+    {
+        // Timestamp with timezone is not supported by the SqlServer connector
+        return new Object[][] {
+                {"timestamp"},
+                {"timestamp(3)"},
+                {"timestamp(6)"},
+                {"timestamp(9)"},
+                {"timestamp(12)"}
+        };
     }
 }


### PR DESCRIPTION
This allows SQL Server's bulk insert feature to be used when inserting data in Trino.

This feature was originally written for the Starburst Enterprise Platform, and is now being contributed to Trino.

This PR still needs the corresponding documentation changes.