### PR TITLE
Switch `air.test.parallel` to `instances`

### DIFF
--- a/plugin/trino-delta-lake/pom.xml
+++ b/plugin/trino-delta-lake/pom.xml
@@ -24,8 +24,6 @@
           TODO (https://github.com/trinodb/trino/issues/11294) remove when we upgrade to surefire with https://issues.apache.org/jira/browse/SUREFIRE-1967
           -->
         <air.test.parallel>instances</air.test.parallel>
-        <!-- TODO (https://github.com/trinodb/trino/issues/11325): enable parallel tests; disabled due to tests crashing -->
-        <air.test.thread-count>1</air.test.thread-count>
     </properties>
 
     <dependencies>

--- a/plugin/trino-delta-lake/pom.xml
+++ b/plugin/trino-delta-lake/pom.xml
@@ -17,12 +17,13 @@
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
 
         <!--
-          Project's default for air.test.parallel is 'methods'. By design, 'classes' makes TestNG run tests from one class in a single thread.
+          Project's default for air.test.parallel is 'methods'. By design, 'instances' runs all the methods in the same instance in the same thread,
+          but two methods on two different instances will be running in different threads.
           As a side effect, it prevents TestNG from initializing multiple test instances upfront, which happens with 'methods'.
           A potential downside can be long tail single-threaded execution of a single long test class.
           TODO (https://github.com/trinodb/trino/issues/11294) remove when we upgrade to surefire with https://issues.apache.org/jira/browse/SUREFIRE-1967
           -->
-        <air.test.parallel>classes</air.test.parallel>
+        <air.test.parallel>instances</air.test.parallel>
         <!-- TODO (https://github.com/trinodb/trino/issues/11325): enable parallel tests; disabled due to tests crashing -->
         <air.test.thread-count>1</air.test.thread-count>
     </properties>

--- a/plugin/trino-sqlserver/pom.xml
+++ b/plugin/trino-sqlserver/pom.xml
@@ -17,12 +17,13 @@
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
 
         <!--
-          Project's default for air.test.parallel is 'methods'. By design, 'classes' makes TestNG run tests from one class in a single thread.
+          Project's default for air.test.parallel is 'methods'. By design, 'instances' runs all the methods in the same instance in the same thread,
+          but two methods on two different instances will be running in different threads.
           As a side effect, it prevents TestNG from initializing multiple test instances upfront, which happens with 'methods'.
           A potential downside can be long tail single-threaded execution of a single long test class.
           TODO (https://github.com/trinodb/trino/issues/11294) remove when we upgrade to surefire with https://issues.apache.org/jira/browse/SUREFIRE-1967
           -->
-        <air.test.parallel>classes</air.test.parallel>
+        <air.test.parallel>instances</air.test.parallel>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

By design, 'instances' set for `parallel` configuration parameter
of the `maven-surefire-plugin`  runs all the methods in the same
instance in the same thread, but two methods on two different
instances will be running in different threads.

This change solves the issue of having Docker containers piling up
while the tests are being executed due to the ordering of the execution
for the TestNG test methods.

FYI Currently `trino-delta-lake` `test` build steps take about 35 minutes.
This PR also introduces parallel running for the tests (by default the project uses a `threadCount` set to `2` for `maven-surefire-plugin`). This should reflect therefore a lower execution time for the tests.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Test infrastructure change.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

N/A

> How would you describe this change to a non-technical end user or system administrator?

N/A

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
