### PR TITLE
Fix date column in tpcds connector

### DIFF
--- a/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsRecordSet.java
+++ b/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsRecordSet.java
@@ -25,10 +25,9 @@ import io.trino.spi.type.Type;
 import io.trino.tpcds.Results;
 import io.trino.tpcds.column.Column;
 import io.trino.tpcds.column.ColumnType;
-import org.joda.time.Days;
-import org.joda.time.LocalDate;
 import org.joda.time.LocalTime;
 
+import java.time.LocalDate;
 import java.util.Iterator;
 import java.util.List;
 
@@ -131,7 +130,7 @@ public class TpcdsRecordSet
             checkState(row != null, "No current row");
             Column column = columns.get(field);
             if (column.getType().getBase() == ColumnType.Base.DATE) {
-                return Days.daysBetween(new LocalDate(0), LocalDate.parse(row.get(column.getPosition()))).getDays();
+                return LocalDate.parse(row.get(column.getPosition())).toEpochDay();
             }
             if (column.getType().getBase() == ColumnType.Base.TIME) {
                 return LocalTime.parse(row.get(column.getPosition())).getMillisOfDay();

--- a/plugin/trino-tpcds/src/test/java/io/trino/plugin/tpcds/TestTpcds.java
+++ b/plugin/trino-tpcds/src/test/java/io/trino/plugin/tpcds/TestTpcds.java
@@ -86,6 +86,13 @@ public class TestTpcds
         assertQueryFails("SHOW TABLES FROM sf0", "line 1:1: Schema 'sf0' does not exist");
     }
 
+    @Test
+    public void testDateColumnValuesCorrectness()
+    {
+        // make sure date values are correct regardless of the system timezone selected (test are executed with the system timezone set to America/Bahia_Banderas)
+        assertQuery("SELECT d_date FROM date_dim WHERE d_date_id = 'AAAAAAAAOKJNECAA'", "SELECT DATE '1900-01-02'");
+    }
+
     private Session createSession(String schemaName)
     {
         return testSessionBuilder()


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

Number of days since epoch could be incorrect when Trino is run not in
the UTC time zone as `new LocalDate(...)` returns a local date
corresponding to the number of milliseconds since epoch in UTC.

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

TPC-DS connector

> How would you describe this change to a non-technical end user or system administrator?

`TPC-DS` connector tables contain incorrect values in date columns when Trino is run in a timezone other than UTC

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

`-`

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
