### PR TITLE
Add table stats cache

### DIFF
--- a/core/trino-main/src/main/java/io/trino/cost/AggregationStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/AggregationStatsRule.java
@@ -47,7 +47,7 @@ public class AggregationStatsRule
     }
 
     @Override
-    protected Optional<PlanNodeStatsEstimate> doCalculate(AggregationNode node, StatsProvider statsProvider, Lookup lookup, Session session, TypeProvider types)
+    protected Optional<PlanNodeStatsEstimate> doCalculate(AggregationNode node, StatsProvider statsProvider, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
     {
         if (node.getGroupingSetCount() != 1) {
             return Optional.empty();

--- a/core/trino-main/src/main/java/io/trino/cost/AssignUniqueIdStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/AssignUniqueIdStatsRule.java
@@ -36,7 +36,7 @@ public class AssignUniqueIdStatsRule
     }
 
     @Override
-    public Optional<PlanNodeStatsEstimate> calculate(AssignUniqueId assignUniqueId, StatsProvider statsProvider, Lookup lookup, Session session, TypeProvider types)
+    public Optional<PlanNodeStatsEstimate> calculate(AssignUniqueId assignUniqueId, StatsProvider statsProvider, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
     {
         PlanNodeStatsEstimate sourceStats = statsProvider.getStats(assignUniqueId.getSource());
         return Optional.of(PlanNodeStatsEstimate.buildFrom(sourceStats)

--- a/core/trino-main/src/main/java/io/trino/cost/CachingStatsProvider.java
+++ b/core/trino-main/src/main/java/io/trino/cost/CachingStatsProvider.java
@@ -41,21 +41,23 @@ public final class CachingStatsProvider
     private final Lookup lookup;
     private final Session session;
     private final TypeProvider types;
+    private final TableStatsProvider tableStatsProvider;
 
     private final Map<PlanNode, PlanNodeStatsEstimate> cache = new IdentityHashMap<>();
 
-    public CachingStatsProvider(StatsCalculator statsCalculator, Session session, TypeProvider types)
+    public CachingStatsProvider(StatsCalculator statsCalculator, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
     {
-        this(statsCalculator, Optional.empty(), noLookup(), session, types);
+        this(statsCalculator, Optional.empty(), noLookup(), session, types, tableStatsProvider);
     }
 
-    public CachingStatsProvider(StatsCalculator statsCalculator, Optional<Memo> memo, Lookup lookup, Session session, TypeProvider types)
+    public CachingStatsProvider(StatsCalculator statsCalculator, Optional<Memo> memo, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
     {
         this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator is null");
         this.memo = requireNonNull(memo, "memo is null");
         this.lookup = requireNonNull(lookup, "lookup is null");
         this.session = requireNonNull(session, "session is null");
         this.types = requireNonNull(types, "types is null");
+        this.tableStatsProvider = requireNonNull(tableStatsProvider, "tableStatsProvider is null");
     }
 
     @Override
@@ -77,7 +79,7 @@ public final class CachingStatsProvider
                 return stats;
             }
 
-            stats = statsCalculator.calculateStats(node, this, lookup, session, types);
+            stats = statsCalculator.calculateStats(node, this, lookup, session, types, tableStatsProvider);
             verify(cache.put(node, stats) == null, "Stats already set");
             return stats;
         }

--- a/core/trino-main/src/main/java/io/trino/cost/CachingTableStatsProvider.java
+++ b/core/trino-main/src/main/java/io/trino/cost/CachingTableStatsProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.cost;
+
+import io.trino.Session;
+import io.trino.metadata.Metadata;
+import io.trino.metadata.TableHandle;
+import io.trino.spi.statistics.TableStatistics;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CachingTableStatsProvider
+        implements TableStatsProvider
+{
+    private final Metadata metadata;
+    private final Map<TableHandle, TableStatistics> cache = new HashMap<>();
+
+    public CachingTableStatsProvider(Metadata metadata)
+    {
+        this.metadata = metadata;
+    }
+
+    @Override
+    public TableStatistics getTableStatistics(Session session, TableHandle tableHandle)
+    {
+        TableStatistics stats = cache.get(tableHandle);
+        if (stats == null) {
+            stats = metadata.getTableStatistics(session, tableHandle);
+            cache.put(tableHandle, stats);
+        }
+        return stats;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/cost/CachingTableStatsProvider.java
+++ b/core/trino-main/src/main/java/io/trino/cost/CachingTableStatsProvider.java
@@ -21,6 +21,8 @@ import io.trino.spi.statistics.TableStatistics;
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.util.Objects.requireNonNull;
+
 public class CachingTableStatsProvider
         implements TableStatsProvider
 {
@@ -29,7 +31,7 @@ public class CachingTableStatsProvider
 
     public CachingTableStatsProvider(Metadata metadata)
     {
-        this.metadata = metadata;
+        this.metadata = requireNonNull(metadata, "metadata is null");
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/cost/ComposableStatsCalculator.java
+++ b/core/trino-main/src/main/java/io/trino/cost/ComposableStatsCalculator.java
@@ -65,12 +65,12 @@ public class ComposableStatsCalculator
     }
 
     @Override
-    public PlanNodeStatsEstimate calculateStats(PlanNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types)
+    public PlanNodeStatsEstimate calculateStats(PlanNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
     {
         Iterator<Rule<?>> ruleIterator = getCandidates(node).iterator();
         while (ruleIterator.hasNext()) {
             Rule<?> rule = ruleIterator.next();
-            Optional<PlanNodeStatsEstimate> calculatedStats = calculateStats(rule, node, sourceStats, lookup, session, types);
+            Optional<PlanNodeStatsEstimate> calculatedStats = calculateStats(rule, node, sourceStats, lookup, session, types, tableStatsProvider);
             if (calculatedStats.isPresent()) {
                 return calculatedStats.get();
             }
@@ -78,11 +78,11 @@ public class ComposableStatsCalculator
         return PlanNodeStatsEstimate.unknown();
     }
 
-    private static <T extends PlanNode> Optional<PlanNodeStatsEstimate> calculateStats(Rule<T> rule, PlanNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types)
+    private static <T extends PlanNode> Optional<PlanNodeStatsEstimate> calculateStats(Rule<T> rule, PlanNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
     {
         @SuppressWarnings("unchecked")
         T typedNode = (T) node;
-        return rule.calculate(typedNode, sourceStats, lookup, session, types);
+        return rule.calculate(typedNode, sourceStats, lookup, session, types, tableStatsProvider);
     }
 
     public interface Rule<T extends PlanNode>
@@ -90,5 +90,10 @@ public class ComposableStatsCalculator
         Pattern<T> getPattern();
 
         Optional<PlanNodeStatsEstimate> calculate(T node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types);
+
+        default Optional<PlanNodeStatsEstimate> calculate(T node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
+        {
+            return calculate(node, sourceStats, lookup, session, types);
+        }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/cost/ComposableStatsCalculator.java
+++ b/core/trino-main/src/main/java/io/trino/cost/ComposableStatsCalculator.java
@@ -89,11 +89,6 @@ public class ComposableStatsCalculator
     {
         Pattern<T> getPattern();
 
-        Optional<PlanNodeStatsEstimate> calculate(T node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types);
-
-        default Optional<PlanNodeStatsEstimate> calculate(T node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
-        {
-            return calculate(node, sourceStats, lookup, session, types);
-        }
+        Optional<PlanNodeStatsEstimate> calculate(T node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/cost/DistinctLimitStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/DistinctLimitStatsRule.java
@@ -42,7 +42,7 @@ public class DistinctLimitStatsRule
     }
 
     @Override
-    protected Optional<PlanNodeStatsEstimate> doCalculate(DistinctLimitNode node, StatsProvider statsProvider, Lookup lookup, Session session, TypeProvider types)
+    protected Optional<PlanNodeStatsEstimate> doCalculate(DistinctLimitNode node, StatsProvider statsProvider, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
     {
         if (node.isPartial()) {
             return Optional.empty();

--- a/core/trino-main/src/main/java/io/trino/cost/EnforceSingleRowStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/EnforceSingleRowStatsRule.java
@@ -40,7 +40,7 @@ public class EnforceSingleRowStatsRule
     }
 
     @Override
-    protected Optional<PlanNodeStatsEstimate> doCalculate(EnforceSingleRowNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types)
+    protected Optional<PlanNodeStatsEstimate> doCalculate(EnforceSingleRowNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
     {
         return Optional.of(PlanNodeStatsEstimate.buildFrom(sourceStats.getStats(node.getSource()))
                 .setOutputRowCount(1)

--- a/core/trino-main/src/main/java/io/trino/cost/ExchangeStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/ExchangeStatsRule.java
@@ -46,7 +46,7 @@ public class ExchangeStatsRule
     }
 
     @Override
-    protected Optional<PlanNodeStatsEstimate> doCalculate(ExchangeNode node, StatsProvider statsProvider, Lookup lookup, Session session, TypeProvider types)
+    protected Optional<PlanNodeStatsEstimate> doCalculate(ExchangeNode node, StatsProvider statsProvider, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
     {
         Optional<PlanNodeStatsEstimate> estimate = Optional.empty();
         for (int i = 0; i < node.getSources().size(); i++) {

--- a/core/trino-main/src/main/java/io/trino/cost/FilterProjectAggregationStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/FilterProjectAggregationStatsRule.java
@@ -56,7 +56,7 @@ public class FilterProjectAggregationStatsRule
     }
 
     @Override
-    protected Optional<PlanNodeStatsEstimate> doCalculate(FilterNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types)
+    protected Optional<PlanNodeStatsEstimate> doCalculate(FilterNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
     {
         if (!isNonEstimatablePredicateApproximationEnabled(session)) {
             return Optional.empty();

--- a/core/trino-main/src/main/java/io/trino/cost/FilterStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/FilterStatsRule.java
@@ -45,7 +45,7 @@ public class FilterStatsRule
     }
 
     @Override
-    public Optional<PlanNodeStatsEstimate> doCalculate(FilterNode node, StatsProvider statsProvider, Lookup lookup, Session session, TypeProvider types)
+    public Optional<PlanNodeStatsEstimate> doCalculate(FilterNode node, StatsProvider statsProvider, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
     {
         PlanNodeStatsEstimate sourceStats = statsProvider.getStats(node.getSource());
         PlanNodeStatsEstimate estimate = filterStatsCalculator.filterStats(sourceStats, node.getPredicate(), session, types);

--- a/core/trino-main/src/main/java/io/trino/cost/JoinStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/JoinStatsRule.java
@@ -78,7 +78,7 @@ public class JoinStatsRule
     }
 
     @Override
-    protected Optional<PlanNodeStatsEstimate> doCalculate(JoinNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types)
+    protected Optional<PlanNodeStatsEstimate> doCalculate(JoinNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
     {
         PlanNodeStatsEstimate leftStats = sourceStats.getStats(node.getLeft());
         PlanNodeStatsEstimate rightStats = sourceStats.getStats(node.getRight());

--- a/core/trino-main/src/main/java/io/trino/cost/LimitStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/LimitStatsRule.java
@@ -40,7 +40,7 @@ public class LimitStatsRule
     }
 
     @Override
-    protected Optional<PlanNodeStatsEstimate> doCalculate(LimitNode node, StatsProvider statsProvider, Lookup lookup, Session session, TypeProvider types)
+    protected Optional<PlanNodeStatsEstimate> doCalculate(LimitNode node, StatsProvider statsProvider, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
     {
         PlanNodeStatsEstimate sourceStats = statsProvider.getStats(node.getSource());
         if (sourceStats.getOutputRowCount() <= node.getCount()) {

--- a/core/trino-main/src/main/java/io/trino/cost/OutputStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/OutputStatsRule.java
@@ -36,7 +36,7 @@ public class OutputStatsRule
     }
 
     @Override
-    public Optional<PlanNodeStatsEstimate> calculate(OutputNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types)
+    public Optional<PlanNodeStatsEstimate> calculate(OutputNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
     {
         return Optional.of(sourceStats.getStats(node.getSource()));
     }

--- a/core/trino-main/src/main/java/io/trino/cost/ProjectStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/ProjectStatsRule.java
@@ -47,7 +47,7 @@ public class ProjectStatsRule
     }
 
     @Override
-    protected Optional<PlanNodeStatsEstimate> doCalculate(ProjectNode node, StatsProvider statsProvider, Lookup lookup, Session session, TypeProvider types)
+    protected Optional<PlanNodeStatsEstimate> doCalculate(ProjectNode node, StatsProvider statsProvider, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
     {
         PlanNodeStatsEstimate sourceStats = statsProvider.getStats(node.getSource());
         PlanNodeStatsEstimate.Builder calculatedStats = PlanNodeStatsEstimate.builder()

--- a/core/trino-main/src/main/java/io/trino/cost/RowNumberStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/RowNumberStatsRule.java
@@ -44,7 +44,7 @@ public class RowNumberStatsRule
     }
 
     @Override
-    public Optional<PlanNodeStatsEstimate> doCalculate(RowNumberNode node, StatsProvider statsProvider, Lookup lookup, Session session, TypeProvider types)
+    public Optional<PlanNodeStatsEstimate> doCalculate(RowNumberNode node, StatsProvider statsProvider, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
     {
         PlanNodeStatsEstimate sourceStats = statsProvider.getStats(node.getSource());
         if (sourceStats.isOutputRowCountUnknown()) {

--- a/core/trino-main/src/main/java/io/trino/cost/SampleStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/SampleStatsRule.java
@@ -40,7 +40,7 @@ public class SampleStatsRule
     }
 
     @Override
-    protected Optional<PlanNodeStatsEstimate> doCalculate(SampleNode node, StatsProvider statsProvider, Lookup lookup, Session session, TypeProvider types)
+    protected Optional<PlanNodeStatsEstimate> doCalculate(SampleNode node, StatsProvider statsProvider, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
     {
         PlanNodeStatsEstimate sourceStats = statsProvider.getStats(node.getSource());
         PlanNodeStatsEstimate calculatedStats = sourceStats.mapOutputRowCount(outputRowCount -> outputRowCount * node.getSampleRatio());

--- a/core/trino-main/src/main/java/io/trino/cost/SemiJoinStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/SemiJoinStatsRule.java
@@ -36,7 +36,7 @@ public class SemiJoinStatsRule
     }
 
     @Override
-    public Optional<PlanNodeStatsEstimate> calculate(SemiJoinNode node, StatsProvider statsProvider, Lookup lookup, Session session, TypeProvider types)
+    public Optional<PlanNodeStatsEstimate> calculate(SemiJoinNode node, StatsProvider statsProvider, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
     {
         PlanNodeStatsEstimate sourceStats = statsProvider.getStats(node.getSource());
 

--- a/core/trino-main/src/main/java/io/trino/cost/SimpleFilterProjectSemiJoinStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/SimpleFilterProjectSemiJoinStatsRule.java
@@ -66,7 +66,7 @@ public class SimpleFilterProjectSemiJoinStatsRule
     }
 
     @Override
-    protected Optional<PlanNodeStatsEstimate> doCalculate(FilterNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types)
+    protected Optional<PlanNodeStatsEstimate> doCalculate(FilterNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
     {
         PlanNode nodeSource = lookup.resolve(node.getSource());
         SemiJoinNode semiJoinNode;

--- a/core/trino-main/src/main/java/io/trino/cost/SimpleStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/SimpleStatsRule.java
@@ -34,22 +34,11 @@ public abstract class SimpleStatsRule<T extends PlanNode>
     }
 
     @Override
-    public final Optional<PlanNodeStatsEstimate> calculate(T node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types)
-    {
-        throw new IllegalStateException("This is not expected to be called because the other overload is implemented.");
-    }
-
-    @Override
     public final Optional<PlanNodeStatsEstimate> calculate(T node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
     {
         return doCalculate(node, sourceStats, lookup, session, types, tableStatsProvider)
                 .map(estimate -> normalizer.normalize(estimate, node.getOutputSymbols(), types));
     }
 
-    protected abstract Optional<PlanNodeStatsEstimate> doCalculate(T node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types);
-
-    protected Optional<PlanNodeStatsEstimate> doCalculate(T node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
-    {
-        return doCalculate(node, sourceStats, lookup, session, types);
-    }
+    protected abstract Optional<PlanNodeStatsEstimate> doCalculate(T node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider);
 }

--- a/core/trino-main/src/main/java/io/trino/cost/SimpleStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/SimpleStatsRule.java
@@ -36,9 +36,20 @@ public abstract class SimpleStatsRule<T extends PlanNode>
     @Override
     public final Optional<PlanNodeStatsEstimate> calculate(T node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types)
     {
-        return doCalculate(node, sourceStats, lookup, session, types)
+        throw new IllegalStateException("This is not expected to be called because the other overload is implemented.");
+    }
+
+    @Override
+    public final Optional<PlanNodeStatsEstimate> calculate(T node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
+    {
+        return doCalculate(node, sourceStats, lookup, session, types, tableStatsProvider)
                 .map(estimate -> normalizer.normalize(estimate, node.getOutputSymbols(), types));
     }
 
     protected abstract Optional<PlanNodeStatsEstimate> doCalculate(T node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types);
+
+    protected Optional<PlanNodeStatsEstimate> doCalculate(T node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
+    {
+        return doCalculate(node, sourceStats, lookup, session, types);
+    }
 }

--- a/core/trino-main/src/main/java/io/trino/cost/SortStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/SortStatsRule.java
@@ -36,7 +36,7 @@ public class SortStatsRule
     }
 
     @Override
-    public Optional<PlanNodeStatsEstimate> calculate(SortNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types)
+    public Optional<PlanNodeStatsEstimate> calculate(SortNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
     {
         return Optional.of(sourceStats.getStats(node.getSource()));
     }

--- a/core/trino-main/src/main/java/io/trino/cost/SpatialJoinStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/SpatialJoinStatsRule.java
@@ -38,7 +38,7 @@ public class SpatialJoinStatsRule
     }
 
     @Override
-    protected Optional<PlanNodeStatsEstimate> doCalculate(SpatialJoinNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types)
+    protected Optional<PlanNodeStatsEstimate> doCalculate(SpatialJoinNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
     {
         PlanNodeStatsEstimate leftStats = sourceStats.getStats(node.getLeft());
         PlanNodeStatsEstimate rightStats = sourceStats.getStats(node.getRight());

--- a/core/trino-main/src/main/java/io/trino/cost/StatsCalculator.java
+++ b/core/trino-main/src/main/java/io/trino/cost/StatsCalculator.java
@@ -28,16 +28,18 @@ public interface StatsCalculator
      * @param sourceStats The stats provider for any child nodes' stats, if needed to compute stats for the {@code node}
      * @param lookup Lookup to be used when resolving source nodes, allowing stats calculation to work within {@link IterativeOptimizer}
      * @param types The type provider for all symbols in the scope.
+     * @param tableStatsProvider The table stats provider.
      */
     PlanNodeStatsEstimate calculateStats(
             PlanNode node,
             StatsProvider sourceStats,
             Lookup lookup,
             Session session,
-            TypeProvider types);
+            TypeProvider types,
+            TableStatsProvider tableStatsProvider);
 
     static StatsCalculator noopStatsCalculator()
     {
-        return (node, sourceStats, lookup, ignore, types) -> PlanNodeStatsEstimate.unknown();
+        return (node, sourceStats, lookup, ignore, types, tableStatsProvider) -> PlanNodeStatsEstimate.unknown();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/cost/StatsCalculatorModule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/StatsCalculatorModule.java
@@ -65,7 +65,7 @@ public class StatsCalculatorModule
             ImmutableList.Builder<ComposableStatsCalculator.Rule<?>> rules = ImmutableList.builder();
 
             rules.add(new OutputStatsRule());
-            rules.add(new TableScanStatsRule(plannerContext.getMetadata(), normalizer));
+            rules.add(new TableScanStatsRule(normalizer));
             rules.add(new SimpleFilterProjectSemiJoinStatsRule(plannerContext.getMetadata(), normalizer, filterStatsCalculator)); // this must be before FilterStatsRule
             rules.add(new FilterProjectAggregationStatsRule(normalizer, filterStatsCalculator)); // this must be before FilterStatsRule
             rules.add(new FilterStatsRule(normalizer, filterStatsCalculator));

--- a/core/trino-main/src/main/java/io/trino/cost/TableScanStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/TableScanStatsRule.java
@@ -15,7 +15,6 @@ package io.trino.cost;
 
 import io.trino.Session;
 import io.trino.matching.Pattern;
-import io.trino.metadata.Metadata;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.statistics.ColumnStatistics;
 import io.trino.spi.statistics.TableStatistics;
@@ -40,12 +39,9 @@ public class TableScanStatsRule
 {
     private static final Pattern<TableScanNode> PATTERN = tableScan();
 
-    private final Metadata metadata;
-
-    public TableScanStatsRule(Metadata metadata, StatsNormalizer normalizer)
+    public TableScanStatsRule(StatsNormalizer normalizer)
     {
         super(normalizer); // Use stats normalization since connector can return inconsistent stats values
-        this.metadata = requireNonNull(metadata, "metadata is null");
     }
 
     @Override
@@ -57,11 +53,17 @@ public class TableScanStatsRule
     @Override
     protected Optional<PlanNodeStatsEstimate> doCalculate(TableScanNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types)
     {
+        throw new IllegalStateException("This is not expected to be called because the other overload is implemented.");
+    }
+
+    @Override
+    protected Optional<PlanNodeStatsEstimate> doCalculate(TableScanNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
+    {
         if (isStatisticsPrecalculationForPushdownEnabled(session) && node.getStatistics().isPresent()) {
             return node.getStatistics();
         }
 
-        TableStatistics tableStatistics = metadata.getTableStatistics(session, node.getTable());
+        TableStatistics tableStatistics = tableStatsProvider.getTableStatistics(session, node.getTable());
 
         Map<Symbol, SymbolStatsEstimate> outputSymbolStats = new HashMap<>();
 

--- a/core/trino-main/src/main/java/io/trino/cost/TableScanStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/TableScanStatsRule.java
@@ -51,12 +51,6 @@ public class TableScanStatsRule
     }
 
     @Override
-    protected Optional<PlanNodeStatsEstimate> doCalculate(TableScanNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types)
-    {
-        throw new IllegalStateException("This is not expected to be called because the other overload is implemented.");
-    }
-
-    @Override
     protected Optional<PlanNodeStatsEstimate> doCalculate(TableScanNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
     {
         if (isStatisticsPrecalculationForPushdownEnabled(session) && node.getStatistics().isPresent()) {

--- a/core/trino-main/src/main/java/io/trino/cost/TableStatsProvider.java
+++ b/core/trino-main/src/main/java/io/trino/cost/TableStatsProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.cost;
+
+import io.trino.Session;
+import io.trino.metadata.TableHandle;
+import io.trino.spi.statistics.TableStatistics;
+
+public interface TableStatsProvider
+{
+    TableStatsProvider EMPTY = (session, tableHandle) -> TableStatistics.empty();
+
+    public TableStatistics getTableStatistics(Session session, TableHandle tableHandle);
+}

--- a/core/trino-main/src/main/java/io/trino/cost/TableStatsProvider.java
+++ b/core/trino-main/src/main/java/io/trino/cost/TableStatsProvider.java
@@ -19,7 +19,5 @@ import io.trino.spi.statistics.TableStatistics;
 
 public interface TableStatsProvider
 {
-    TableStatsProvider EMPTY = (session, tableHandle) -> TableStatistics.empty();
-
-    public TableStatistics getTableStatistics(Session session, TableHandle tableHandle);
+    TableStatistics getTableStatistics(Session session, TableHandle tableHandle);
 }

--- a/core/trino-main/src/main/java/io/trino/cost/TopNStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/TopNStatsRule.java
@@ -42,7 +42,7 @@ public class TopNStatsRule
     }
 
     @Override
-    protected Optional<PlanNodeStatsEstimate> doCalculate(TopNNode node, StatsProvider statsProvider, Lookup lookup, Session session, TypeProvider types)
+    protected Optional<PlanNodeStatsEstimate> doCalculate(TopNNode node, StatsProvider statsProvider, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
     {
         PlanNodeStatsEstimate sourceStats = statsProvider.getStats(node.getSource());
         double rowCount = sourceStats.getOutputRowCount();

--- a/core/trino-main/src/main/java/io/trino/cost/UnionStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/UnionStatsRule.java
@@ -46,7 +46,7 @@ public class UnionStatsRule
     }
 
     @Override
-    protected final Optional<PlanNodeStatsEstimate> doCalculate(UnionNode node, StatsProvider statsProvider, Lookup lookup, Session session, TypeProvider types)
+    protected final Optional<PlanNodeStatsEstimate> doCalculate(UnionNode node, StatsProvider statsProvider, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
     {
         checkArgument(!node.getSources().isEmpty(), "Empty Union is not supported");
 

--- a/core/trino-main/src/main/java/io/trino/cost/ValuesStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/ValuesStatsRule.java
@@ -63,7 +63,7 @@ public class ValuesStatsRule
     }
 
     @Override
-    public Optional<PlanNodeStatsEstimate> calculate(ValuesNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types)
+    public Optional<PlanNodeStatsEstimate> calculate(ValuesNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
     {
         PlanNodeStatsEstimate.Builder statsBuilder = PlanNodeStatsEstimate.builder();
         statsBuilder.setOutputRowCount(node.getRowCount());

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/IterativeOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/IterativeOptimizer.java
@@ -99,12 +99,6 @@ public class IterativeOptimizer
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
-    {
-        throw new IllegalStateException("This is not expected to be called because the other overload is implemented.");
-    }
-
-    @Override
     public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, TableStatsProvider tableStatsProvider)
     {
         // only disable new rules if we have legacy rules to fall back to

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveUnsupportedDynamicFilters.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveUnsupportedDynamicFilters.java
@@ -16,6 +16,7 @@ package io.trino.sql.planner.iterative.rule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
+import io.trino.cost.TableStatsProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.AnalyzePropertyManager;
 import io.trino.metadata.OperatorNotFoundException;
@@ -108,7 +109,7 @@ public class RemoveUnsupportedDynamicFilters
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, TableStatsProvider tableStatsProvider)
     {
         PlanWithConsumedDynamicFilters result = plan.accept(new RemoveUnsupportedDynamicFilters.Rewriter(session, types), ImmutableSet.of());
         return result.getNode();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
@@ -24,6 +24,7 @@ import io.trino.SystemSessionProperties;
 import io.trino.cost.CachingStatsProvider;
 import io.trino.cost.StatsCalculator;
 import io.trino.cost.StatsProvider;
+import io.trino.cost.TableStatsProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.spi.connector.GroupingProperty;
 import io.trino.spi.connector.LocalProperty;
@@ -136,7 +137,13 @@ public class AddExchanges
     @Override
     public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
     {
-        PlanWithProperties result = plan.accept(new Rewriter(idAllocator, symbolAllocator, session), PreferredProperties.any());
+        throw new IllegalStateException("This is not expected to be called because the other overload is implemented.");
+    }
+
+    @Override
+    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, TableStatsProvider tableStatsProvider)
+    {
+        PlanWithProperties result = plan.accept(new Rewriter(idAllocator, symbolAllocator, session, tableStatsProvider), PreferredProperties.any());
         return result.getNode();
     }
 
@@ -154,12 +161,12 @@ public class AddExchanges
         private final boolean redistributeWrites;
         private final boolean scaleWriters;
 
-        public Rewriter(PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
+        public Rewriter(PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session, TableStatsProvider tableStatsProvider)
         {
             this.idAllocator = idAllocator;
             this.symbolAllocator = symbolAllocator;
             this.types = symbolAllocator.getTypes();
-            this.statsProvider = new CachingStatsProvider(statsCalculator, session, types);
+            this.statsProvider = new CachingStatsProvider(statsCalculator, session, types, tableStatsProvider);
             this.session = session;
             this.domainTranslator = new DomainTranslator(plannerContext);
             this.distributedIndexJoins = SystemSessionProperties.isDistributedIndexJoinEnabled(session);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
@@ -135,12 +135,6 @@ public class AddExchanges
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
-    {
-        throw new IllegalStateException("This is not expected to be called because the other overload is implemented.");
-    }
-
-    @Override
     public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, TableStatsProvider tableStatsProvider)
     {
         PlanWithProperties result = plan.accept(new Rewriter(idAllocator, symbolAllocator, session, tableStatsProvider), PreferredProperties.any());

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddLocalExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddLocalExchanges.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import io.trino.Session;
+import io.trino.cost.TableStatsProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.spi.connector.ConstantProperty;
 import io.trino.spi.connector.GroupingProperty;
@@ -113,7 +114,7 @@ public class AddLocalExchanges
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, TableStatsProvider tableStatsProvider)
     {
         PlanWithProperties result = plan.accept(new Rewriter(symbolAllocator, idAllocator, session), any());
         return result.getNode();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/BeginTableWrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/BeginTableWrite.java
@@ -15,6 +15,7 @@ package io.trino.sql.planner.optimizations;
 
 import io.trino.Session;
 import io.trino.cost.StatsAndCosts;
+import io.trino.cost.TableStatsProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.FunctionManager;
 import io.trino.metadata.Metadata;
@@ -83,7 +84,7 @@ public class BeginTableWrite
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, TableStatsProvider tableStatsProvider)
     {
         try {
             return SimplePlanRewriter.rewriteWith(new Rewriter(session), plan, Optional.empty());

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/CheckSubqueryNodesAreRewritten.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/CheckSubqueryNodesAreRewritten.java
@@ -15,6 +15,7 @@
 package io.trino.sql.planner.optimizations;
 
 import io.trino.Session;
+import io.trino.cost.TableStatsProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.spi.TrinoException;
 import io.trino.sql.planner.PlanNodeIdAllocator;
@@ -37,7 +38,7 @@ public class CheckSubqueryNodesAreRewritten
         implements PlanOptimizer
 {
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, TableStatsProvider tableStatsProvider)
     {
         searchFrom(plan).where(ApplyNode.class::isInstance)
                 .findFirst()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import io.trino.Session;
 import io.trino.SystemSessionProperties;
+import io.trino.cost.TableStatsProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
 import io.trino.spi.function.OperatorType;
@@ -106,7 +107,7 @@ public class HashGenerationOptimizer
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, TableStatsProvider tableStatsProvider)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/IndexJoinOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/IndexJoinOptimizer.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import io.trino.Session;
+import io.trino.cost.TableStatsProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.BoundSignature;
 import io.trino.metadata.ResolvedFunction;
@@ -80,7 +81,7 @@ public class IndexJoinOptimizer
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider type, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, TableStatsProvider tableStatsProvider)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/LimitPushDown.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/LimitPushDown.java
@@ -15,6 +15,7 @@ package io.trino.sql.planner.optimizations;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.Session;
+import io.trino.cost.TableStatsProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.SymbolAllocator;
@@ -43,7 +44,7 @@ public class LimitPushDown
         implements PlanOptimizer
 {
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, TableStatsProvider tableStatsProvider)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/MetadataQueryOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/MetadataQueryOptimizer.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import io.trino.Session;
 import io.trino.SystemSessionProperties;
+import io.trino.cost.TableStatsProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.TableProperties;
 import io.trino.spi.connector.ColumnHandle;
@@ -73,7 +74,7 @@ public class MetadataQueryOptimizer
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, TableStatsProvider tableStatsProvider)
     {
         if (!SystemSessionProperties.isOptimizeMetadataQueries(session)) {
             return plan;

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import io.trino.Session;
+import io.trino.cost.TableStatsProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
 import io.trino.spi.type.Type;
@@ -83,7 +84,7 @@ public class OptimizeMixedDistinctAggregations
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, TableStatsProvider tableStatsProvider)
     {
         if (isOptimizeDistinctAggregationEnabled(session)) {
             return SimplePlanRewriter.rewriteWith(new Optimizer(session, idAllocator, symbolAllocator, metadata), plan, Optional.empty());

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PlanOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PlanOptimizer.java
@@ -29,17 +29,6 @@ public interface PlanOptimizer
             TypeProvider types,
             SymbolAllocator symbolAllocator,
             PlanNodeIdAllocator idAllocator,
-            WarningCollector warningCollector);
-
-    default PlanNode optimize(
-            PlanNode plan,
-            Session session,
-            TypeProvider types,
-            SymbolAllocator symbolAllocator,
-            PlanNodeIdAllocator idAllocator,
             WarningCollector warningCollector,
-            TableStatsProvider tableStatsProvider)
-    {
-        return optimize(plan, session, types, symbolAllocator, idAllocator, warningCollector);
-    }
+            TableStatsProvider tableStatsProvider);
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PlanOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PlanOptimizer.java
@@ -14,6 +14,7 @@
 package io.trino.sql.planner.optimizations;
 
 import io.trino.Session;
+import io.trino.cost.TableStatsProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.SymbolAllocator;
@@ -29,4 +30,16 @@ public interface PlanOptimizer
             SymbolAllocator symbolAllocator,
             PlanNodeIdAllocator idAllocator,
             WarningCollector warningCollector);
+
+    default PlanNode optimize(
+            PlanNode plan,
+            Session session,
+            TypeProvider types,
+            SymbolAllocator symbolAllocator,
+            PlanNodeIdAllocator idAllocator,
+            WarningCollector warningCollector,
+            TableStatsProvider tableStatsProvider)
+    {
+        return optimize(plan, session, types, symbolAllocator, idAllocator, warningCollector);
+    }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import io.trino.Session;
+import io.trino.cost.TableStatsProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
 import io.trino.spi.type.Type;
@@ -143,7 +144,7 @@ public class PredicatePushDown
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, TableStatsProvider tableStatsProvider)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/ReplicateSemiJoinInDelete.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/ReplicateSemiJoinInDelete.java
@@ -14,6 +14,7 @@
 package io.trino.sql.planner.optimizations;
 
 import io.trino.Session;
+import io.trino.cost.TableStatsProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.SymbolAllocator;
@@ -30,7 +31,7 @@ public class ReplicateSemiJoinInDelete
         implements PlanOptimizer
 {
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, TableStatsProvider tableStatsProvider)
     {
         requireNonNull(plan, "plan is null");
         return SimplePlanRewriter.rewriteWith(new Rewriter(), plan);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/StatsRecordingPlanOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/StatsRecordingPlanOptimizer.java
@@ -38,12 +38,6 @@ public final class StatsRecordingPlanOptimizer
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
-    {
-        throw new IllegalStateException("This is not expected to be called because the other overload is implemented.");
-    }
-
-    @Override
     public PlanNode optimize(
             PlanNode plan,
             Session session,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/StatsRecordingPlanOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/StatsRecordingPlanOptimizer.java
@@ -14,6 +14,7 @@
 package io.trino.sql.planner.optimizations;
 
 import io.trino.Session;
+import io.trino.cost.TableStatsProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.sql.planner.OptimizerStatsRecorder;
 import io.trino.sql.planner.PlanNodeIdAllocator;
@@ -37,19 +38,26 @@ public final class StatsRecordingPlanOptimizer
     }
 
     @Override
+    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    {
+        throw new IllegalStateException("This is not expected to be called because the other overload is implemented.");
+    }
+
+    @Override
     public PlanNode optimize(
             PlanNode plan,
             Session session,
             TypeProvider types,
             SymbolAllocator symbolAllocator,
             PlanNodeIdAllocator idAllocator,
-            WarningCollector warningCollector)
+            WarningCollector warningCollector,
+            TableStatsProvider tableStatsProvider)
     {
         PlanNode result;
         long duration;
         try {
             long start = System.nanoTime();
-            result = delegate.optimize(plan, session, types, symbolAllocator, idAllocator, warningCollector);
+            result = delegate.optimize(plan, session, types, symbolAllocator, idAllocator, warningCollector, tableStatsProvider);
             duration = System.nanoTime() - start;
         }
         catch (RuntimeException e) {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/TransformQuantifiedComparisonApplyToCorrelatedJoin.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/TransformQuantifiedComparisonApplyToCorrelatedJoin.java
@@ -16,6 +16,7 @@ package io.trino.sql.planner.optimizations;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
+import io.trino.cost.TableStatsProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
 import io.trino.spi.type.BigintType;
@@ -81,7 +82,7 @@ public class TransformQuantifiedComparisonApplyToCorrelatedJoin
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, TableStatsProvider tableStatsProvider)
     {
         return rewriteWith(new Rewriter(idAllocator, types, symbolAllocator, metadata, session), plan, null);
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Sets;
 import io.trino.Session;
 import io.trino.cost.PlanNodeStatsEstimate;
+import io.trino.cost.TableStatsProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
 import io.trino.spi.connector.ColumnHandle;
@@ -135,7 +136,7 @@ public class UnaliasSymbolReferences
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, TableStatsProvider tableStatsProvider)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/WindowFilterPushDown.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/WindowFilterPushDown.java
@@ -15,6 +15,7 @@ package io.trino.sql.planner.optimizations;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.Session;
+import io.trino.cost.TableStatsProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.FunctionId;
 import io.trino.spi.predicate.Domain;
@@ -67,7 +68,7 @@ public class WindowFilterPushDown
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, TableStatsProvider tableStatsProvider)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowStatsRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowStatsRewrite.java
@@ -16,10 +16,12 @@ package io.trino.sql.rewrite;
 import com.google.common.collect.ImmutableList;
 import io.trino.Session;
 import io.trino.cost.CachingStatsProvider;
+import io.trino.cost.CachingTableStatsProvider;
 import io.trino.cost.PlanNodeStatsEstimate;
 import io.trino.cost.StatsCalculator;
 import io.trino.cost.SymbolStatsEstimate;
 import io.trino.execution.warnings.WarningCollector;
+import io.trino.metadata.Metadata;
 import io.trino.operator.scalar.timestamp.TimestampToVarcharCast;
 import io.trino.operator.scalar.timestamptz.TimestampWithTimeZoneToVarcharCast;
 import io.trino.spi.type.BigintType;
@@ -87,12 +89,14 @@ public class ShowStatsRewrite
     private static final Expression NULL_DOUBLE = new Cast(new NullLiteral(), toSqlType(DOUBLE));
     private static final Expression NULL_VARCHAR = new Cast(new NullLiteral(), toSqlType(VARCHAR));
 
+    private final Metadata metadata;
     private final QueryExplainerFactory queryExplainerFactory;
     private final StatsCalculator statsCalculator;
 
     @Inject
-    public ShowStatsRewrite(QueryExplainerFactory queryExplainerFactory, StatsCalculator statsCalculator)
+    public ShowStatsRewrite(Metadata metadata, QueryExplainerFactory queryExplainerFactory, StatsCalculator statsCalculator)
     {
+        this.metadata = requireNonNull(metadata, "metadata is null");
         this.queryExplainerFactory = requireNonNull(queryExplainerFactory, "queryExplainerFactory is null");
         this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator is null");
     }
@@ -106,7 +110,7 @@ public class ShowStatsRewrite
             Map<NodeRef<Parameter>, Expression> parameterLookup,
             WarningCollector warningCollector)
     {
-        return (Statement) new Visitor(session, parameters, queryExplainerFactory.createQueryExplainer(analyzerFactory), warningCollector, statsCalculator).process(node, null);
+        return (Statement) new Visitor(session, parameters, metadata, queryExplainerFactory.createQueryExplainer(analyzerFactory), warningCollector, statsCalculator).process(node, null);
     }
 
     private static class Visitor
@@ -114,14 +118,16 @@ public class ShowStatsRewrite
     {
         private final Session session;
         private final List<Expression> parameters;
+        private final Metadata metadata;
         private final QueryExplainer queryExplainer;
         private final WarningCollector warningCollector;
         private final StatsCalculator statsCalculator;
 
-        private Visitor(Session session, List<Expression> parameters, QueryExplainer queryExplainer, WarningCollector warningCollector, StatsCalculator statsCalculator)
+        private Visitor(Session session, List<Expression> parameters, Metadata metadata, QueryExplainer queryExplainer, WarningCollector warningCollector, StatsCalculator statsCalculator)
         {
             this.session = requireNonNull(session, "session is null");
             this.parameters = requireNonNull(parameters, "parameters is null");
+            this.metadata = requireNonNull(metadata, "metadata is null");
             this.queryExplainer = requireNonNull(queryExplainer, "queryExplainer is null");
             this.warningCollector = requireNonNull(warningCollector, "warningCollector is null");
             this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator is null");
@@ -132,7 +138,7 @@ public class ShowStatsRewrite
         {
             Query query = getRelation(node);
             Plan plan = queryExplainer.getLogicalPlan(session, query, parameters, warningCollector);
-            CachingStatsProvider cachingStatsProvider = new CachingStatsProvider(statsCalculator, session, plan.getTypes());
+            CachingStatsProvider cachingStatsProvider = new CachingStatsProvider(statsCalculator, session, plan.getTypes(), new CachingTableStatsProvider(metadata));
             PlanNodeStatsEstimate stats = cachingStatsProvider.getStats(plan.getRoot());
             return rewriteShowStats(plan, stats);
         }

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -1129,7 +1129,7 @@ public class LocalQueryRunner
                                 columnPropertyManager,
                                 tablePropertyManager,
                                 materializedViewPropertyManager),
-                        new ShowStatsRewrite(queryExplainerFactory, statsCalculator),
+                        new ShowStatsRewrite(plannerContext.getMetadata(), queryExplainerFactory, statsCalculator),
                         new ExplainRewrite(queryExplainerFactory, new QueryPreparer(sqlParser)))));
     }
 

--- a/core/trino-main/src/test/java/io/trino/cost/StatsCalculatorAssertion.java
+++ b/core/trino-main/src/test/java/io/trino/cost/StatsCalculatorAssertion.java
@@ -15,6 +15,7 @@ package io.trino.cost;
 
 import io.trino.Session;
 import io.trino.cost.ComposableStatsCalculator.Rule;
+import io.trino.metadata.Metadata;
 import io.trino.security.AllowAllAccessControl;
 import io.trino.sql.planner.TypeProvider;
 import io.trino.sql.planner.iterative.Lookup;
@@ -36,6 +37,7 @@ import static java.util.Objects.requireNonNull;
 
 public class StatsCalculatorAssertion
 {
+    private final Metadata metadata;
     private final StatsCalculator statsCalculator;
     private final Session session;
     private final PlanNode planNode;
@@ -43,10 +45,11 @@ public class StatsCalculatorAssertion
 
     private final Map<PlanNode, PlanNodeStatsEstimate> sourcesStats;
 
-    public StatsCalculatorAssertion(StatsCalculator statsCalculator, Session session, PlanNode planNode, TypeProvider types)
+    public StatsCalculatorAssertion(Metadata metadata, StatsCalculator statsCalculator, Session session, PlanNode planNode, TypeProvider types)
     {
+        this.metadata = requireNonNull(metadata, "metadata cannot be null");
         this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator cannot be null");
-        this.session = requireNonNull(session, "session cannot be null");
+        this.session = requireNonNull(session, "sesssion cannot be null");
         this.planNode = requireNonNull(planNode, "planNode is null");
         this.types = requireNonNull(types, "types is null");
 
@@ -84,7 +87,7 @@ public class StatsCalculatorAssertion
     {
         PlanNodeStatsEstimate statsEstimate = transaction(new TestingTransactionManager(), new AllowAllAccessControl())
                 .execute(session, transactionSession -> {
-                    return statsCalculator.calculateStats(planNode, this::getSourceStats, noLookup(), transactionSession, types);
+                    return statsCalculator.calculateStats(planNode, this::getSourceStats, noLookup(), transactionSession, types, new CachingTableStatsProvider(metadata));
                 });
         statisticsAssertionConsumer.accept(PlanNodeStatsAssertion.assertThat(statsEstimate));
         return this;
@@ -92,16 +95,16 @@ public class StatsCalculatorAssertion
 
     public StatsCalculatorAssertion check(Rule<?> rule, Consumer<PlanNodeStatsAssertion> statisticsAssertionConsumer)
     {
-        Optional<PlanNodeStatsEstimate> statsEstimate = calculatedStats(rule, planNode, this::getSourceStats, noLookup(), session, types);
+        Optional<PlanNodeStatsEstimate> statsEstimate = calculatedStats(rule, planNode, this::getSourceStats, noLookup(), session, types, new CachingTableStatsProvider(metadata));
         checkState(statsEstimate.isPresent(), "Expected stats estimates to be present");
         statisticsAssertionConsumer.accept(PlanNodeStatsAssertion.assertThat(statsEstimate.get()));
         return this;
     }
 
     @SuppressWarnings("unchecked")
-    private static <T extends PlanNode> Optional<PlanNodeStatsEstimate> calculatedStats(Rule<T> rule, PlanNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types)
+    private static <T extends PlanNode> Optional<PlanNodeStatsEstimate> calculatedStats(Rule<T> rule, PlanNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
     {
-        return rule.calculate((T) node, sourceStats, lookup, session, types);
+        return rule.calculate((T) node, sourceStats, lookup, session, types, tableStatsProvider);
     }
 
     private PlanNodeStatsEstimate getSourceStats(PlanNode sourceNode)

--- a/core/trino-main/src/test/java/io/trino/cost/StatsCalculatorTester.java
+++ b/core/trino-main/src/test/java/io/trino/cost/StatsCalculatorTester.java
@@ -75,7 +75,7 @@ public class StatsCalculatorTester
     {
         PlanBuilder planBuilder = new PlanBuilder(new PlanNodeIdAllocator(), metadata, session);
         PlanNode planNode = planProvider.apply(planBuilder);
-        return new StatsCalculatorAssertion(statsCalculator, session, planNode, planBuilder.getTypes());
+        return new StatsCalculatorAssertion(metadata, statsCalculator, session, planNode, planBuilder.getTypes());
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanAssert.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanAssert.java
@@ -15,6 +15,7 @@ package io.trino.sql.planner.assertions;
 
 import io.trino.Session;
 import io.trino.cost.CachingStatsProvider;
+import io.trino.cost.CachingTableStatsProvider;
 import io.trino.cost.StatsAndCosts;
 import io.trino.cost.StatsCalculator;
 import io.trino.cost.StatsProvider;
@@ -44,7 +45,7 @@ public final class PlanAssert
 
     public static void assertPlan(Session session, Metadata metadata, FunctionManager functionManager, StatsCalculator statsCalculator, Plan actual, Lookup lookup, PlanMatchPattern pattern)
     {
-        StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, session, actual.getTypes());
+        StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, session, actual.getTypes(), new CachingTableStatsProvider(metadata));
         assertPlan(session, metadata, functionManager, statsProvider, actual, lookup, pattern);
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestJoinEnumerator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestJoinEnumerator.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
 import io.trino.cost.CachingCostProvider;
 import io.trino.cost.CachingStatsProvider;
+import io.trino.cost.CachingTableStatsProvider;
 import io.trino.cost.CostComparator;
 import io.trino.cost.CostProvider;
 import io.trino.cost.PlanCostEstimate;
@@ -117,7 +118,8 @@ public class TestJoinEnumerator
                 Optional.empty(),
                 noLookup(),
                 queryRunner.getDefaultSession(),
-                symbolAllocator.getTypes());
+                symbolAllocator.getTypes(),
+                new CachingTableStatsProvider(queryRunner.getMetadata()));
         CachingCostProvider costProvider = new CachingCostProvider(
                 queryRunner.getCostCalculator(),
                 statsProvider,

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/RuleAssert.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/RuleAssert.java
@@ -17,12 +17,14 @@ import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
 import io.trino.cost.CachingCostProvider;
 import io.trino.cost.CachingStatsProvider;
+import io.trino.cost.CachingTableStatsProvider;
 import io.trino.cost.CostCalculator;
 import io.trino.cost.CostProvider;
 import io.trino.cost.PlanNodeStatsEstimate;
 import io.trino.cost.StatsAndCosts;
 import io.trino.cost.StatsCalculator;
 import io.trino.cost.StatsProvider;
+import io.trino.cost.TableStatsProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.matching.Capture;
 import io.trino.matching.Match;
@@ -204,7 +206,7 @@ public class RuleAssert
     private String formatPlan(PlanNode plan, TypeProvider types)
     {
         return inTransaction(session -> {
-            StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, session, types);
+            StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, session, types, new CachingTableStatsProvider(metadata));
             CostProvider costProvider = new CachingCostProvider(costCalculator, statsProvider, session, types);
             return textLogicalPlan(plan, types, metadata, functionManager, StatsAndCosts.create(plan, statsProvider, costProvider), session, 2, false);
         });
@@ -223,7 +225,7 @@ public class RuleAssert
 
     private Rule.Context ruleContext(StatsCalculator statsCalculator, CostCalculator costCalculator, SymbolAllocator symbolAllocator, Memo memo, Lookup lookup, Session session)
     {
-        StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, Optional.of(memo), lookup, session, symbolAllocator.getTypes());
+        StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, Optional.of(memo), lookup, session, symbolAllocator.getTypes(), new CachingTableStatsProvider(metadata));
         CostProvider costProvider = new CachingCostProvider(costCalculator, statsProvider, Optional.of(memo), session, symbolAllocator.getTypes());
 
         return new Rule.Context()
@@ -313,12 +315,12 @@ public class RuleAssert
         }
 
         @Override
-        public PlanNodeStatsEstimate calculateStats(PlanNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types)
+        public PlanNodeStatsEstimate calculateStats(PlanNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
         {
             if (stats.containsKey(node.getId())) {
                 return stats.get(node.getId());
             }
-            return delegate.calculateStats(node, sourceStats, lookup, session, types);
+            return delegate.calculateStats(node, sourceStats, lookup, session, types, tableStatsProvider);
         }
 
         public void setNodeStats(PlanNodeId nodeId, PlanNodeStatsEstimate nodeStats)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestBeginTableWrite.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestBeginTableWrite.java
@@ -15,6 +15,7 @@ package io.trino.sql.planner.optimizations;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.Session;
+import io.trino.cost.TableStatsProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.AbstractMockMetadata;
 import io.trino.metadata.Metadata;
@@ -141,7 +142,8 @@ public class TestBeginTableWrite
                         empty(),
                         new SymbolAllocator(),
                         new PlanNodeIdAllocator(),
-                        WarningCollector.NOOP);
+                        WarningCollector.NOOP,
+                        TableStatsProvider.EMPTY);
     }
 
     private static class MockMetadata

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestBeginTableWrite.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestBeginTableWrite.java
@@ -15,7 +15,7 @@ package io.trino.sql.planner.optimizations;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.Session;
-import io.trino.cost.TableStatsProvider;
+import io.trino.cost.CachingTableStatsProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.AbstractMockMetadata;
 import io.trino.metadata.Metadata;
@@ -143,7 +143,7 @@ public class TestBeginTableWrite
                         new SymbolAllocator(),
                         new PlanNodeIdAllocator(),
                         WarningCollector.NOOP,
-                        TableStatsProvider.EMPTY);
+                        new CachingTableStatsProvider(metadata));
     }
 
     private static class MockMetadata

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestRemoveUnsupportedDynamicFilters.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestRemoveUnsupportedDynamicFilters.java
@@ -16,8 +16,8 @@ package io.trino.sql.planner.optimizations;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.connector.CatalogName;
+import io.trino.cost.CachingTableStatsProvider;
 import io.trino.cost.StatsAndCosts;
-import io.trino.cost.TableStatsProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.TableHandle;
@@ -478,7 +478,13 @@ public class TestRemoveUnsupportedDynamicFilters
         return getQueryRunner().inTransaction(session -> {
             // metadata.getCatalogHandle() registers the catalog for the transaction
             session.getCatalog().ifPresent(catalog -> metadata.getCatalogHandle(session, catalog));
-            PlanNode rewrittenPlan = new RemoveUnsupportedDynamicFilters(plannerContext).optimize(root, session, builder.getTypes(), new SymbolAllocator(), new PlanNodeIdAllocator(), WarningCollector.NOOP, TableStatsProvider.EMPTY);
+            PlanNode rewrittenPlan = new RemoveUnsupportedDynamicFilters(plannerContext).optimize(root,
+                    session,
+                    builder.getTypes(),
+                    new SymbolAllocator(),
+                    new PlanNodeIdAllocator(),
+                    WarningCollector.NOOP,
+                    new CachingTableStatsProvider(metadata));
             new DynamicFiltersChecker().validate(rewrittenPlan,
                     session,
                     plannerContext, createTestingTypeAnalyzer(plannerContext),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestRemoveUnsupportedDynamicFilters.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestRemoveUnsupportedDynamicFilters.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.connector.CatalogName;
 import io.trino.cost.StatsAndCosts;
+import io.trino.cost.TableStatsProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.TableHandle;
@@ -477,7 +478,7 @@ public class TestRemoveUnsupportedDynamicFilters
         return getQueryRunner().inTransaction(session -> {
             // metadata.getCatalogHandle() registers the catalog for the transaction
             session.getCatalog().ifPresent(catalog -> metadata.getCatalogHandle(session, catalog));
-            PlanNode rewrittenPlan = new RemoveUnsupportedDynamicFilters(plannerContext).optimize(root, session, builder.getTypes(), new SymbolAllocator(), new PlanNodeIdAllocator(), WarningCollector.NOOP);
+            PlanNode rewrittenPlan = new RemoveUnsupportedDynamicFilters(plannerContext).optimize(root, session, builder.getTypes(), new SymbolAllocator(), new PlanNodeIdAllocator(), WarningCollector.NOOP, TableStatsProvider.EMPTY);
             new DynamicFiltersChecker().validate(rewrittenPlan,
                     session,
                     plannerContext, createTestingTypeAnalyzer(plannerContext),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestUnaliasSymbolReferences.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestUnaliasSymbolReferences.java
@@ -17,8 +17,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.connector.CatalogName;
+import io.trino.cost.CachingTableStatsProvider;
 import io.trino.cost.StatsAndCosts;
-import io.trino.cost.TableStatsProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.TableHandle;
@@ -133,7 +133,7 @@ public class TestUnaliasSymbolReferences
                     symbolAllocator,
                     idAllocator,
                     WarningCollector.NOOP,
-                    TableStatsProvider.EMPTY);
+                    new CachingTableStatsProvider(metadata));
 
             Plan actual = new Plan(optimized, planBuilder.getTypes(), StatsAndCosts.empty());
             PlanAssert.assertPlan(session, queryRunner.getMetadata(), queryRunner.getFunctionManager(), queryRunner.getStatsCalculator(), actual, pattern);

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestUnaliasSymbolReferences.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestUnaliasSymbolReferences.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.connector.CatalogName;
 import io.trino.cost.StatsAndCosts;
+import io.trino.cost.TableStatsProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.TableHandle;
@@ -131,7 +132,8 @@ public class TestUnaliasSymbolReferences
                     planBuilder.getTypes(),
                     symbolAllocator,
                     idAllocator,
-                    WarningCollector.NOOP);
+                    WarningCollector.NOOP,
+                    TableStatsProvider.EMPTY);
 
             Plan actual = new Plan(optimized, planBuilder.getTypes(), StatsAndCosts.empty());
             PlanAssert.assertPlan(session, queryRunner.getMetadata(), queryRunner.getFunctionManager(), queryRunner.getStatsCalculator(), actual, pattern);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGetTableStatisticsOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGetTableStatisticsOperations.java
@@ -107,7 +107,7 @@ public class TestIcebergGetTableStatisticsOperations
                 "WHERE o.orderkey = l.orderkey");
         assertThat(metadata.getMethodInvocations()).containsExactlyInAnyOrderElementsOf(
                 ImmutableMultiset.<CountingAccessMetadata.Methods>builder()
-                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 5)
+                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 2)
                         .build());
     }
 
@@ -119,7 +119,7 @@ public class TestIcebergGetTableStatisticsOperations
                 "WHERE o.orderkey = l.orderkey AND c.custkey = o.custkey");
         assertThat(metadata.getMethodInvocations()).containsExactlyInAnyOrderElementsOf(
                 ImmutableMultiset.<CountingAccessMetadata.Methods>builder()
-                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 9)
+                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 3)
                         .build());
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

Cache table statistics during query planning. So they can be shared by CBOs like `ReorderJoins` and `DetermineJoinDistributionType`. It helps reduce Iceberg metadata processing when planning a query joining Iceberg tables.


To demo the helpfulness of this PR and #11858, I did some experiment with a locally-running Trino and a production join query, 
- Without `#11858` and this PR: the planning takes **2 min 24s**
- With `#11858` but not this PR: the planning takes **1 min 12s**
- With this PR: the planning takes **49s**


## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Engine.

> How would you describe this change to a non-technical end user or system administrator?

Improve query planning performance.

## Related issues, pull requests, and links

#11708 #11858
<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Section
* Improve query planning performance.
```
