### PR TITLE
Improve Iceberg deletes when an entire file can be removed

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/CommitTaskData.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/CommitTaskData.java
@@ -32,6 +32,8 @@ public class CommitTaskData
     private final Optional<String> partitionDataJson;
     private final FileContent content;
     private final Optional<String> referencedDataFile;
+    private final Optional<Long> fileRecordCount;
+    private final Optional<Long> deletedRowCount;
 
     @JsonCreator
     public CommitTaskData(
@@ -42,7 +44,9 @@ public class CommitTaskData
             @JsonProperty("partitionSpecJson") String partitionSpecJson,
             @JsonProperty("partitionDataJson") Optional<String> partitionDataJson,
             @JsonProperty("content") FileContent content,
-            @JsonProperty("referencedDataFile") Optional<String> referencedDataFile)
+            @JsonProperty("referencedDataFile") Optional<String> referencedDataFile,
+            @JsonProperty("fileRecordCount") Optional<Long> fileRecordCount,
+            @JsonProperty("deletedRowCount") Optional<Long> deletedRowCount)
     {
         this.path = requireNonNull(path, "path is null");
         this.fileFormat = requireNonNull(fileFormat, "fileFormat is null");
@@ -52,6 +56,11 @@ public class CommitTaskData
         this.partitionDataJson = requireNonNull(partitionDataJson, "partitionDataJson is null");
         this.content = requireNonNull(content, "content is null");
         this.referencedDataFile = requireNonNull(referencedDataFile, "referencedDataFile is null");
+        this.fileRecordCount = requireNonNull(fileRecordCount, "fileRecordCount is null");
+        fileRecordCount.ifPresent(rowCount -> checkArgument(rowCount >= 0, "fileRecordCount cannot be negative"));
+        this.deletedRowCount = requireNonNull(deletedRowCount, "deletedRowCount is null");
+        deletedRowCount.ifPresent(rowCount -> checkArgument(rowCount >= 0, "deletedRowCount cannot be negative"));
+        checkArgument(fileRecordCount.isPresent() == deletedRowCount.isPresent(), "fileRecordCount and deletedRowCount must be specified together");
         checkArgument(fileSizeInBytes >= 0, "fileSizeInBytes is negative");
     }
 
@@ -101,5 +110,17 @@ public class CommitTaskData
     public Optional<String> getReferencedDataFile()
     {
         return referencedDataFile;
+    }
+
+    @JsonProperty
+    public Optional<Long> getFileRecordCount()
+    {
+        return fileRecordCount;
+    }
+
+    @JsonProperty
+    public Optional<Long> getDeletedRowCount()
+    {
+        return deletedRowCount;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
@@ -322,6 +322,8 @@ public class IcebergPageSink
                 PartitionSpecParser.toJson(partitionSpec),
                 writeContext.getPartitionData().map(PartitionData::toJson),
                 DATA,
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
 
         commitTasks.add(wrappedBuffer(jsonCodec.toJsonBytes(task)));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -318,7 +318,8 @@ public class IcebergPageSourceProvider
                 jsonCodec,
                 session,
                 split.getFileFormat(),
-                table.getStorageProperties());
+                table.getStorageProperties(),
+                split.getFileRecordCount());
 
         Supplier<IcebergPageSink> updatedRowPageSinkSupplier = () -> new IcebergPageSink(
                 tableSchema,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplit.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplit.java
@@ -37,6 +37,7 @@ public class IcebergSplit
     private final long start;
     private final long length;
     private final long fileSize;
+    private final long fileRecordCount;
     private final IcebergFileFormat fileFormat;
     private final List<HostAddress> addresses;
     private final String partitionSpecJson;
@@ -49,6 +50,7 @@ public class IcebergSplit
             @JsonProperty("start") long start,
             @JsonProperty("length") long length,
             @JsonProperty("fileSize") long fileSize,
+            @JsonProperty("fileRecordCount") long fileRecordCount,
             @JsonProperty("fileFormat") IcebergFileFormat fileFormat,
             @JsonProperty("addresses") List<HostAddress> addresses,
             @JsonProperty("partitionSpecJson") String partitionSpecJson,
@@ -59,6 +61,7 @@ public class IcebergSplit
         this.start = start;
         this.length = length;
         this.fileSize = fileSize;
+        this.fileRecordCount = fileRecordCount;
         this.fileFormat = requireNonNull(fileFormat, "fileFormat is null");
         this.addresses = ImmutableList.copyOf(requireNonNull(addresses, "addresses is null"));
         this.partitionSpecJson = requireNonNull(partitionSpecJson, "partitionSpecJson is null");
@@ -101,6 +104,12 @@ public class IcebergSplit
     public long getFileSize()
     {
         return fileSize;
+    }
+
+    @JsonProperty
+    public long getFileRecordCount()
+    {
+        return fileRecordCount;
     }
 
     @JsonProperty

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
@@ -383,6 +383,7 @@ public class IcebergSplitSource
                 task.start(),
                 task.length(),
                 task.file().fileSizeInBytes(),
+                task.file().recordCount(),
                 IcebergFileFormat.fromIceberg(task.file().format()),
                 ImmutableList.of(),
                 PartitionSpecParser.toJson(task.spec()),

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/IcebergPositionDeletePageSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/IcebergPositionDeletePageSink.java
@@ -61,9 +61,11 @@ public class IcebergPositionDeletePageSink
     private final JsonCodec<CommitTaskData> jsonCodec;
     private final IcebergFileWriter writer;
     private final IcebergFileFormat fileFormat;
+    private final long fileRecordCount;
 
     private long validationCpuNanos;
     private boolean writtenData;
+    private long deletedRowCount;
 
     public IcebergPositionDeletePageSink(
             String dataFilePath,
@@ -76,13 +78,15 @@ public class IcebergPositionDeletePageSink
             JsonCodec<CommitTaskData> jsonCodec,
             ConnectorSession session,
             IcebergFileFormat fileFormat,
-            Map<String, String> storageProperties)
+            Map<String, String> storageProperties,
+            long fileRecordCount)
     {
         this.dataFilePath = requireNonNull(dataFilePath, "dataFilePath is null");
         this.jsonCodec = requireNonNull(jsonCodec, "jsonCodec is null");
         this.partitionSpec = requireNonNull(partitionSpec, "partitionSpec is null");
         this.partition = requireNonNull(partition, "partition is null");
         this.fileFormat = requireNonNull(fileFormat, "fileFormat is null");
+        this.fileRecordCount = fileRecordCount;
         // prepend query id to a file name so we can determine which files were written by which query. This is needed for opportunistic cleanup of extra files
         // which may be present for successfully completing query in presence of failure recovery mechanisms.
         String fileName = fileFormat.toIceberg().addExtension(session.getQueryId() + "-" + randomUUID());
@@ -122,6 +126,7 @@ public class IcebergPositionDeletePageSink
         writer.appendRows(new Page(blocks));
 
         writtenData = true;
+        deletedRowCount += page.getPositionCount();
         return NOT_BLOCKED;
     }
 
@@ -139,7 +144,9 @@ public class IcebergPositionDeletePageSink
                     PartitionSpecParser.toJson(partitionSpec),
                     partition.map(PartitionData::toJson),
                     FileContent.POSITION_DELETES,
-                    Optional.of(dataFilePath));
+                    Optional.of(dataFilePath),
+                    Optional.of(fileRecordCount),
+                    Optional.of(deletedRowCount));
             Long recordCount = task.getMetrics().recordCount();
             if (recordCount != null && recordCount > 0) {
                 commitTasks.add(wrappedBuffer(jsonCodec.toJsonBytes(task)));

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
@@ -158,6 +158,7 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                 0,
                 outputFile.length(),
                 outputFile.length(),
+                0, // This is incorrect, but the value is only used for delete operations
                 ORC,
                 ImmutableList.of(),
                 PartitionSpecParser.toJson(PartitionSpec.unpartitioned()),

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableSet;
+import io.trino.Session;
 import io.trino.plugin.base.CatalogName;
 import io.trino.plugin.hive.HdfsConfig;
 import io.trino.plugin.hive.HdfsConfiguration;
@@ -66,6 +67,7 @@ import static io.trino.plugin.iceberg.IcebergUtil.loadIcebergTable;
 import static io.trino.testing.TestingConnectorSession.SESSION;
 import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static io.trino.tpch.TpchTable.NATION;
+import static org.apache.iceberg.TableProperties.SPLIT_SIZE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
@@ -254,6 +256,100 @@ public class TestIcebergV2
         assertTrue(table.properties().get(TableProperties.DEFAULT_FILE_FORMAT).equalsIgnoreCase("ORC"));
         assertTrue(table.spec().isUnpartitioned());
         assertQuery("SELECT * FROM " + tableName, "SELECT * FROM nation");
+    }
+
+    @Test
+    public void testDeletingEntireFile()
+    {
+        String tableName = "test_deleting_entire_file_" + randomTableSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM tpch.tiny.nation WITH NO DATA", 0);
+        assertUpdate("INSERT INTO " + tableName + " SELECT * FROM tpch.tiny.nation WHERE regionkey = 1", "SELECT count(*) FROM nation WHERE regionkey = 1");
+        assertUpdate("INSERT INTO " + tableName + " SELECT * FROM tpch.tiny.nation WHERE regionkey != 1", "SELECT count(*) FROM nation WHERE regionkey != 1");
+
+        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(2);
+        assertUpdate("DELETE FROM " + tableName + " WHERE regionkey <= 2", "SELECT count(*) FROM nation WHERE regionkey <= 2");
+        assertQuery("SELECT * FROM " + tableName, "SELECT * FROM nation WHERE regionkey > 2");
+        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(1);
+    }
+
+    @Test
+    public void testDeletingEntireFileFromPartitionedTable()
+    {
+        String tableName = "test_deleting_entire_file_from_partitioned_table_" + randomTableSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " (a INT, b INT) WITH (partitioning = ARRAY['a'])");
+        assertUpdate("INSERT INTO " + tableName + " VALUES (1, 1), (1, 3), (1, 5), (2, 1), (2, 3), (2, 5)", 6);
+        assertUpdate("INSERT INTO " + tableName + " VALUES (1, 2), (1, 4), (1, 6), (2, 2), (2, 4), (2, 6)", 6);
+
+        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(4);
+        assertUpdate("DELETE FROM " + tableName + " WHERE b % 2 = 0", 6);
+        assertQuery("SELECT * FROM " + tableName, "VALUES (1, 1), (1, 3), (1, 5), (2, 1), (2, 3), (2, 5)");
+        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(2);
+    }
+
+    @Test
+    public void testDeletingEntireFileWithNonTupleDomainConstraint()
+    {
+        String tableName = "test_deleting_entire_file_with_non_tuple_domain_constraint" + randomTableSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM tpch.tiny.nation WITH NO DATA", 0);
+        assertUpdate("INSERT INTO " + tableName + " SELECT * FROM tpch.tiny.nation WHERE regionkey = 1", "SELECT count(*) FROM nation WHERE regionkey = 1");
+        assertUpdate("INSERT INTO " + tableName + " SELECT * FROM tpch.tiny.nation WHERE regionkey != 1", "SELECT count(*) FROM nation WHERE regionkey != 1");
+
+        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(2);
+        assertUpdate("DELETE FROM " + tableName + " WHERE regionkey % 2 = 1", "SELECT count(*) FROM nation WHERE regionkey % 2 = 1");
+        assertQuery("SELECT * FROM " + tableName, "SELECT * FROM nation WHERE regionkey % 2 = 0");
+        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(1);
+    }
+
+    @Test
+    public void testDeletingEntireFileWithMultipleSplits()
+    {
+        String tableName = "test_deleting_entire_file_with_multiple_splits" + randomTableSuffix();
+        assertUpdate(
+                Session.builder(getSession()).setCatalogSessionProperty("iceberg", "orc_writer_max_stripe_rows", "5").build(),
+                "CREATE TABLE " + tableName + " WITH (format = 'ORC') AS SELECT * FROM tpch.tiny.nation", 25);
+        // Set the split size to a small number of bytes so each ORC stripe gets its own split
+        this.loadTable(tableName).updateProperties().set(SPLIT_SIZE, "100").commit();
+
+        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(1);
+        // Ensure only one snapshot is committed to the table
+        Long initialSnapshotId = (Long) computeActual("SELECT snapshot_id FROM \"" + tableName + "$snapshots\" ORDER BY committed_at DESC LIMIT 1").getOnlyValue();
+        assertUpdate("DELETE FROM " + tableName + " WHERE regionkey < 10", 25);
+        Long parentSnapshotId = (Long) computeActual("SELECT parent_id FROM \"" + tableName + "$snapshots\" ORDER BY committed_at DESC LIMIT 1").getOnlyValue();
+        assertEquals(initialSnapshotId, parentSnapshotId);
+        assertThat(query("SELECT * FROM " + tableName)).returnsEmptyResult();
+        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(0);
+    }
+
+    @Test
+    public void testMultipleDeletes()
+    {
+        // Deletes only remove entire data files from the table if the whole file is removed in a single operation
+        String tableName = "test_multiple_deletes_" + randomTableSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM tpch.tiny.nation", 25);
+        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(1);
+        // Ensure only one snapshot is committed to the table
+        Long initialSnapshotId = (Long) computeActual("SELECT snapshot_id FROM \"" + tableName + "$snapshots\" ORDER BY committed_at DESC LIMIT 1").getOnlyValue();
+        assertUpdate("DELETE FROM " + tableName + " WHERE regionkey % 2 = 1", "SELECT count(*) FROM nation WHERE regionkey % 2 = 1");
+        Long parentSnapshotId = (Long) computeActual("SELECT parent_id FROM \"" + tableName + "$snapshots\" ORDER BY committed_at DESC LIMIT 1").getOnlyValue();
+        assertEquals(initialSnapshotId, parentSnapshotId);
+
+        assertUpdate("DELETE FROM " + tableName + " WHERE regionkey % 2 = 0", "SELECT count(*) FROM nation WHERE regionkey % 2 = 0");
+        assertThat(query("SELECT * FROM " + tableName)).returnsEmptyResult();
+        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(1);
+    }
+
+    @Test
+    public void testDeletingEntirePartitionedTable()
+    {
+        String tableName = "test_deleting_entire_partitioned_table_" + randomTableSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " WITH (partitioning = ARRAY['regionkey']) AS SELECT * FROM tpch.tiny.nation", 25);
+
+        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(5);
+        assertUpdate("DELETE FROM " + tableName + " WHERE regionkey < 10", "SELECT count(*) FROM nation WHERE regionkey < 10");
+        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(0);
+        assertUpdate("DELETE FROM " + tableName + " WHERE regionkey < 10");
+        assertThat(query("SELECT * FROM " + tableName)).returnsEmptyResult();
+        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(0);
     }
 
     private void writeEqualityDeleteToNationTable(Table icebergTable)


### PR DESCRIPTION
## Description

If a delete would remove all rows from an individual file,
remove the whole file, rather than writing a position delete.
    
This does not include situations where a whole file is deleted
across multiple row-level passes. All rows must be deleted by
one delete operation.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Iceberg connector

> How would you describe this change to a non-technical end user or system administrator?

Improves performance when deleting all rows in a file.

## Related issues, pull requests, and links

* Fixes #12057 

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Iceberg
* Avoid writing positional deletes when all rows in a file have been deleted. ({issue}`12057`)
```
