### PR TITLE
Allow purging data when dropping managed tables

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
@@ -136,6 +136,7 @@ public class HiveConfig
 
     private boolean isTemporaryStagingDirectoryEnabled = true;
     private String temporaryStagingDirectoryPath = "/tmp/presto-${USER}";
+    private boolean isPurgeTableDataOnDrop;
     private boolean delegateTransactionalManagedTableLocationToMetastore;
 
     private Duration fileStatusCacheExpireAfterWrite = new Duration(1, MINUTES);
@@ -1140,6 +1141,19 @@ public class HiveConfig
     public boolean isLegacyHiveViewTranslation()
     {
         return this.legacyHiveViewTranslation;
+    }
+
+    public boolean isPurgeTableDataOnDrop()
+    {
+        return isPurgeTableDataOnDrop;
+    }
+
+    @Config("hive.auto-purge")
+    @ConfigDescription("Skip trash when dropping tables in Hive")
+    public HiveConfig setPurgeTableDataOnDrop(boolean purgeTableDataOnDrop)
+    {
+        this.isPurgeTableDataOnDrop = purgeTableDataOnDrop;
+        return this;
     }
 
     public Optional<String> getIcebergCatalogName()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
@@ -26,6 +26,7 @@ import io.trino.plugin.hive.metastore.Partition;
 import io.trino.plugin.hive.metastore.PartitionWithStatistics;
 import io.trino.plugin.hive.metastore.PrincipalPrivileges;
 import io.trino.plugin.hive.metastore.Table;
+import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.predicate.TupleDomain;
@@ -166,9 +167,9 @@ public class HiveMetastoreClosure
         delegate.createTable(table, principalPrivileges);
     }
 
-    public void dropTable(String databaseName, String tableName, boolean deleteData)
+    public void dropTable(String databaseName, String tableName, boolean deleteData, Optional<ConnectorSession> session)
     {
-        delegate.dropTable(databaseName, tableName, deleteData);
+        delegate.dropTable(databaseName, tableName, deleteData, session);
     }
 
     public void replaceTable(String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
@@ -112,6 +112,7 @@ public final class HiveSessionProperties
     private static final String DYNAMIC_FILTERING_WAIT_TIMEOUT = "dynamic_filtering_wait_timeout";
     private static final String OPTIMIZE_SYMLINK_LISTING = "optimize_symlink_listing";
     private static final String LEGACY_HIVE_VIEW_TRANSLATION = "legacy_hive_view_translation";
+    public static final String PURGE_TABLE_DATA_ON_DROP = "auto_purge";
     private static final String ICEBERG_CATALOG_NAME = "iceberg_catalog_name";
     public static final String SIZE_BASED_SPLIT_WEIGHTS_ENABLED = "size_based_split_weights_enabled";
     public static final String MINIMUM_ASSIGNED_SPLIT_WEIGHT = "minimum_assigned_split_weight";
@@ -465,6 +466,11 @@ public final class HiveSessionProperties
                         "Use legacy Hive view translation mechanism",
                         hiveConfig.isLegacyHiveViewTranslation(),
                         false),
+                booleanProperty(
+                        PURGE_TABLE_DATA_ON_DROP,
+                        "Skip trash when dropping tables",
+                        hiveConfig.isPurgeTableDataOnDrop(),
+                        false),
                 stringProperty(
                         ICEBERG_CATALOG_NAME,
                         "Catalog to redirect to when an Iceberg table is referenced",
@@ -797,6 +803,11 @@ public final class HiveSessionProperties
     public static boolean isLegacyHiveViewTranslation(ConnectorSession session)
     {
         return session.getProperty(LEGACY_HIVE_VIEW_TRANSLATION, Boolean.class);
+    }
+
+    public static boolean isPurgeTableDataOnDrop(ConnectorSession session)
+    {
+        return session.getProperty(PURGE_TABLE_DATA_ON_DROP, Boolean.class);
     }
 
     public static Optional<String> getIcebergCatalogName(ConnectorSession session)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastore.java
@@ -19,6 +19,7 @@ import io.trino.plugin.hive.HiveType;
 import io.trino.plugin.hive.PartitionStatistics;
 import io.trino.plugin.hive.acid.AcidOperation;
 import io.trino.plugin.hive.acid.AcidTransaction;
+import io.trino.spi.connector.ConnectorSession;
 import io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.TupleDomain;
@@ -73,7 +74,7 @@ public interface HiveMetastore
 
     void createTable(Table table, PrincipalPrivileges principalPrivileges);
 
-    void dropTable(String databaseName, String tableName, boolean deleteData);
+    void dropTable(String databaseName, String tableName, boolean deleteData, Optional<ConnectorSession> session);
 
     /**
      * This should only be used if the semantic here is drop and add. Trying to

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/alluxio/AlluxioHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/alluxio/AlluxioHiveMetastore.java
@@ -39,6 +39,7 @@ import io.trino.plugin.hive.metastore.PrincipalPrivileges;
 import io.trino.plugin.hive.metastore.Table;
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreUtil;
 import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.security.RoleGrant;
 import io.trino.spi.statistics.ColumnStatisticType;
@@ -279,7 +280,7 @@ public class AlluxioHiveMetastore
     }
 
     @Override
-    public void dropTable(String databaseName, String tableName, boolean deleteData)
+    public void dropTable(String databaseName, String tableName, boolean deleteData, Optional<ConnectorSession> session)
     {
         throw new TrinoException(NOT_SUPPORTED, "dropTable");
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
@@ -45,6 +45,7 @@ import io.trino.plugin.hive.metastore.Table;
 import io.trino.plugin.hive.metastore.TablesWithParameterCacheKey;
 import io.trino.plugin.hive.metastore.UserTableKey;
 import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.predicate.TupleDomain;
@@ -479,10 +480,10 @@ public class CachingHiveMetastore
     }
 
     @Override
-    public void dropTable(String databaseName, String tableName, boolean deleteData)
+    public void dropTable(String databaseName, String tableName, boolean deleteData, Optional<ConnectorSession> session)
     {
         try {
-            delegate.dropTable(databaseName, tableName, deleteData);
+            delegate.dropTable(databaseName, tableName, deleteData, session);
         }
         finally {
             invalidateTable(databaseName, tableName);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -52,6 +52,7 @@ import io.trino.plugin.hive.metastore.file.FileHiveMetastoreConfig.VersionCompat
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreUtil;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ColumnNotFoundException;
+import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableNotFoundException;
@@ -515,7 +516,7 @@ public class FileHiveMetastore
     }
 
     @Override
-    public synchronized void dropTable(String databaseName, String tableName, boolean deleteData)
+    public synchronized void dropTable(String databaseName, String tableName, boolean deleteData, Optional<ConnectorSession> session)
     {
         requireNonNull(databaseName, "databaseName is null");
         requireNonNull(tableName, "tableName is null");

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -92,6 +92,7 @@ import io.trino.plugin.hive.util.HiveUtil;
 import io.trino.plugin.hive.util.HiveWriteUtils;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ColumnNotFoundException;
+import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableNotFoundException;
@@ -565,7 +566,7 @@ public class GlueHiveMetastore
     }
 
     @Override
-    public void dropTable(String databaseName, String tableName, boolean deleteData)
+    public void dropTable(String databaseName, String tableName, boolean deleteData, Optional<ConnectorSession> session)
     {
         Table table = getExistingTable(databaseName, tableName);
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/recording/RecordingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/recording/RecordingHiveMetastore.java
@@ -27,6 +27,7 @@ import io.trino.plugin.hive.metastore.PrincipalPrivileges;
 import io.trino.plugin.hive.metastore.Table;
 import io.trino.plugin.hive.metastore.TablesWithParameterCacheKey;
 import io.trino.plugin.hive.metastore.UserTableKey;
+import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.security.RoleGrant;
 import io.trino.spi.statistics.ColumnStatisticType;
@@ -178,10 +179,10 @@ public class RecordingHiveMetastore
     }
 
     @Override
-    public void dropTable(String databaseName, String tableName, boolean deleteData)
+    public void dropTable(String databaseName, String tableName, boolean deleteData, Optional<ConnectorSession> session)
     {
         verifyRecordingMode();
-        delegate.dropTable(databaseName, tableName, deleteData);
+        delegate.dropTable(databaseName, tableName, deleteData, session);
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -32,6 +32,7 @@ import io.trino.plugin.hive.metastore.PrincipalPrivileges;
 import io.trino.plugin.hive.metastore.Table;
 import io.trino.plugin.hive.util.HiveUtil;
 import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableNotFoundException;
@@ -206,9 +207,9 @@ public class BridgingHiveMetastore
     }
 
     @Override
-    public void dropTable(String databaseName, String tableName, boolean deleteData)
+    public void dropTable(String databaseName, String tableName, boolean deleteData, Optional<ConnectorSession> session)
     {
-        delegate.dropTable(identity, databaseName, tableName, deleteData);
+        delegate.dropTable(identity, databaseName, tableName, deleteData, session);
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/FailureAwareThriftMetastoreClient.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/FailureAwareThriftMetastoreClient.java
@@ -15,6 +15,7 @@ package io.trino.plugin.hive.metastore.thrift;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.trino.plugin.hive.acid.AcidOperation;
+import io.trino.spi.connector.ConnectorSession;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
@@ -34,6 +35,7 @@ import org.apache.thrift.TException;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.OptionalLong;
 
 import static java.util.Objects.requireNonNull;
@@ -133,10 +135,10 @@ public class FailureAwareThriftMetastoreClient
     }
 
     @Override
-    public void dropTable(String databaseName, String name, boolean deleteData)
+    public void dropTable(String databaseName, String name, boolean deleteData, Optional<ConnectorSession> session)
             throws TException
     {
-        runWithHandle(() -> delegate.dropTable(databaseName, name, deleteData));
+        runWithHandle(() -> delegate.dropTable(databaseName, name, deleteData, session));
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -47,6 +47,7 @@ import io.trino.plugin.hive.metastore.PartitionWithStatistics;
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreAuthenticationConfig.ThriftMetastoreAuthenticationType;
 import io.trino.plugin.hive.util.RetryDriver;
 import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableNotFoundException;
@@ -1091,7 +1092,7 @@ public class ThriftHiveMetastore
     }
 
     @Override
-    public void dropTable(HiveIdentity identity, String databaseName, String tableName, boolean deleteData)
+    public void dropTable(HiveIdentity identity, String databaseName, String tableName, boolean deleteData, Optional<ConnectorSession> session)
     {
         try {
             retry()
@@ -1100,7 +1101,7 @@ public class ThriftHiveMetastore
                     .run("dropTable", stats.getDropTable().wrap(() -> {
                         try (ThriftMetastoreClient client = createMetastoreClient(identity)) {
                             Table table = client.getTable(databaseName, tableName);
-                            client.dropTable(databaseName, tableName, deleteData);
+                            client.dropTable(databaseName, tableName, deleteData, session);
                             String tableLocation = table.getSd().getLocation();
                             if (deleteFilesOnDrop && deleteData && isManagedTable(table) && !isNullOrEmpty(tableLocation)) {
                                 deleteDirRecursive(hdfsContext, hdfsEnvironment, new Path(tableLocation));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastore.java
@@ -24,6 +24,7 @@ import io.trino.plugin.hive.metastore.HivePrivilegeInfo;
 import io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege;
 import io.trino.plugin.hive.metastore.PartitionWithStatistics;
 import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.predicate.TupleDomain;
@@ -55,7 +56,7 @@ public interface ThriftMetastore
 
     void createTable(HiveIdentity identity, Table table);
 
-    void dropTable(HiveIdentity identity, String databaseName, String tableName, boolean deleteData);
+    void dropTable(HiveIdentity identity, String databaseName, String tableName, boolean deleteData, Optional<ConnectorSession> session);
 
     void alterTable(HiveIdentity identity, String databaseName, String tableName, Table table);
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreClient.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreClient.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.hive.metastore.thrift;
 
 import io.trino.plugin.hive.acid.AcidOperation;
+import io.trino.spi.connector.ConnectorSession;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
@@ -34,6 +35,7 @@ import org.apache.thrift.TException;
 import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.OptionalLong;
 
 public interface ThriftMetastoreClient
@@ -69,7 +71,7 @@ public interface ThriftMetastoreClient
     void createTable(Table table)
             throws TException;
 
-    void dropTable(String databaseName, String name, boolean deleteData)
+    void dropTable(String databaseName, String name, boolean deleteData, Optional<ConnectorSession> session)
             throws TException;
 
     void alterTableWithEnvironmentContext(String databaseName, String tableName, Table newTable, EnvironmentContext context)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -2985,7 +2985,7 @@ public abstract class AbstractTestHive
         }
         finally {
             // Clean up
-            metastoreClient.dropTable(tableName.getSchemaName(), tableName.getTableName(), true);
+            metastoreClient.dropTable(tableName.getSchemaName(), tableName.getTableName(), true, Optional.of(session));
         }
     }
 
@@ -3034,7 +3034,7 @@ public abstract class AbstractTestHive
         }
         finally {
             // Clean up
-            metastoreClient.dropTable(tableName.getSchemaName(), tableName.getTableName(), true);
+            metastoreClient.dropTable(tableName.getSchemaName(), tableName.getTableName(), true, Optional.of(session));
         }
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
@@ -569,7 +569,7 @@ public abstract class AbstractTestHiveFileSystem
         }
 
         @Override
-        public void dropTable(String databaseName, String tableName, boolean deleteData)
+        public void dropTable(String databaseName, String tableName, boolean deleteData, Optional<ConnectorSession> session)
         {
             try {
                 Optional<Table> table = getTable(databaseName, tableName);
@@ -585,7 +585,7 @@ public abstract class AbstractTestHiveFileSystem
 
                 // drop table
                 replaceTable(databaseName, tableName, tableBuilder.build(), NO_PRIVILEGES);
-                super.dropTable(databaseName, tableName, false);
+                super.dropTable(databaseName, tableName, false, session);
 
                 // drop data
                 if (deleteData) {

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
@@ -108,6 +108,7 @@ public class TestHiveConfig
                 .setTimestampPrecision(HiveTimestampPrecision.DEFAULT_PRECISION)
                 .setOptimizeSymlinkListing(true)
                 .setLegacyHiveViewTranslation(false)
+                .setPurgeTableDataOnDrop(false)
                 .setIcebergCatalogName(null)
                 .setSizeBasedSplitWeightsEnabled(true)
                 .setMinimumAssignedSplitWeight(0.05));
@@ -189,6 +190,7 @@ public class TestHiveConfig
                 .put("hive.timestamp-precision", "NANOSECONDS")
                 .put("hive.optimize-symlink-listing", "false")
                 .put("hive.legacy-hive-view-translation", "true")
+                .put("hive.auto-purge", "true")
                 .put("hive.iceberg-catalog-name", "iceberg")
                 .put("hive.size-based-split-weights-enabled", "false")
                 .put("hive.minimum-assigned-split-weight", "1.0")
@@ -267,6 +269,7 @@ public class TestHiveConfig
                 .setTimestampPrecision(HiveTimestampPrecision.NANOSECONDS)
                 .setOptimizeSymlinkListing(false)
                 .setLegacyHiveViewTranslation(true)
+                .setPurgeTableDataOnDrop(false)
                 .setIcebergCatalogName("iceberg")
                 .setSizeBasedSplitWeightsEnabled(false)
                 .setMinimumAssignedSplitWeight(1.0);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/UnimplementedHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/UnimplementedHiveMetastore.java
@@ -17,6 +17,7 @@ import io.trino.plugin.hive.HiveType;
 import io.trino.plugin.hive.PartitionStatistics;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege;
+import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.security.RoleGrant;
 import io.trino.spi.statistics.ColumnStatisticType;
@@ -137,7 +138,7 @@ public class UnimplementedHiveMetastore
     }
 
     @Override
-    public void dropTable(String databaseName, String tableName, boolean deleteData)
+    public void dropTable(String databaseName, String tableName, boolean deleteData, Optional<ConnectorSession> session)
     {
         throw new UnsupportedOperationException();
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/InMemoryThriftMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/InMemoryThriftMetastore.java
@@ -26,6 +26,7 @@ import io.trino.plugin.hive.metastore.HivePrivilegeInfo;
 import io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege;
 import io.trino.plugin.hive.metastore.PartitionWithStatistics;
 import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableNotFoundException;
@@ -211,7 +212,7 @@ public class InMemoryThriftMetastore
     }
 
     @Override
-    public synchronized void dropTable(HiveIdentity identity, String databaseName, String tableName, boolean deleteData)
+    public synchronized void dropTable(HiveIdentity identity, String databaseName, String tableName, boolean deleteData, Optional<ConnectorSession> session)
     {
         List<String> locations = listAllDataPaths(identity, this, databaseName, tableName);
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import io.trino.plugin.hive.acid.AcidOperation;
+import io.trino.spi.connector.ConnectorSession;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsData;
@@ -331,7 +332,7 @@ public class MockThriftMetastoreClient
     }
 
     @Override
-    public void dropTable(String databaseName, String name, boolean deleteData)
+    public void dropTable(String databaseName, String name, boolean deleteData, Optional<ConnectorSession> session)
     {
         throw new UnsupportedOperationException();
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
@@ -211,7 +211,7 @@ public class TestConnectorPushdownRulesWithHive
                                 TupleDomain.all(),
                                 ImmutableMap.of("struct_of_int#a", partialColumn::equals))));
 
-        metastore.dropTable(SCHEMA_NAME, tableName, true);
+        metastore.dropTable(SCHEMA_NAME, tableName, true, Optional.empty());
     }
 
     @Test
@@ -243,7 +243,7 @@ public class TestConnectorPushdownRulesWithHive
                                 TupleDomain.all(),
                                 ImmutableMap.of("a", column::equals))));
 
-        metastore.dropTable(SCHEMA_NAME, tableName, true);
+        metastore.dropTable(SCHEMA_NAME, tableName, true, Optional.empty());
     }
 
     @Test
@@ -281,7 +281,7 @@ public class TestConnectorPushdownRulesWithHive
                                         TupleDomain.all(),
                                         ImmutableMap.of("COLA", columnA::equals))));
 
-        metastore.dropTable(SCHEMA_NAME, tableName, true);
+        metastore.dropTable(SCHEMA_NAME, tableName, true, Optional.empty());
     }
 
     @Test
@@ -362,7 +362,7 @@ public class TestConnectorPushdownRulesWithHive
                                 TupleDomain.all(),
                                 ImmutableMap.of("struct_of_bigint#a", partialColumn::equals))));
 
-        metastore.dropTable(SCHEMA_NAME, tableName, true);
+        metastore.dropTable(SCHEMA_NAME, tableName, true, Optional.empty());
     }
 
     @AfterClass(alwaysRun = true)


### PR DESCRIPTION
## Description

When users drop managed tables in Presto that were created with a CREATE TABLE query, sometimes the underlying directory on HDFS is not actually deleted. This can cause multiple issues:

1.) Data files can accumulate in a user's HDFS home directory until they run out of quota.
2.) If users attempt to recreate a table with the same name (an extremely common access pattern) they're not able to because a directory with the same name already exists.

Furthermore, When a table is created with CREATE TABLE AS SELECT, the directory is always deleted. Guy Cohen (from Presto community, guyco33) has taken a look at this from their perspective and it seems to be related to Hive creating temporary hidden files when creating a table and then failing to clean them up once that table is created. This "0" directory is only made when a managed table is created without any initial data. 

This PR uses a session property to allow users to decide if they want to purge data when dropping tables instead of moving the data to .Trash

> Is this change a fix, improvement, new feature, refactoring, or other?
Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
Plugin

## Documentation

( x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
