### PR TITLE
Fix query planning failure on multiple subqueries due to IllegalStateException at ScopeAware.scopeAwareComparison()

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/ScopeAware.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ScopeAware.java
@@ -24,7 +24,6 @@ import io.trino.sql.tree.Node;
 import java.util.OptionalInt;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 import static io.trino.sql.util.AstUtils.treeEqual;
 import static io.trino.sql.util.AstUtils.treeHash;
 import static java.util.Objects.requireNonNull;
@@ -100,6 +99,27 @@ public class ScopeAware<T extends Node>
         return "ScopeAware(" + node + ")";
     }
 
+    /**
+     * Syntactic comparison of Nodes with special handling of column references.
+     * <p>
+     * When both compared Nodes are column references, the following rules apply:
+     * <p>
+     * 1. If both columns belong to scopes associated with subqueries of the current query,
+     * they are compared by syntax (that is, textually, respecting the canonicalization rules).
+     * <p>
+     * 2. If none of the columns belongs to some subquery scope, that is, either they belong
+     * to the current query scope, or some outer scope, they are compared by resolved field.
+     * <p>
+     * 3. If only one of the columns belongs to some subquery scope, they are not equal.
+     * <p>
+     * Note: it'd appear that hash() and equal() are inconsistent with each other in the case that:
+     * - left.hasOuterParent(...) == true and right.hasOuterParent(...) == false
+     * - leftField.getFieldId().equals(rightField.getFieldId()) == true
+     * Both fields would seem to have different hashes but be equal to each other.
+     * However, this cannot happen because we *require* that both expressions being compared be
+     * rooted in the same "query scope" (i.e., sub-scopes that are local to each other) -- see ScopeAwareKey.equals().
+     * If both fields have the same field id, by definition they will produce the same result for hasOuterParent().
+     */
     private Boolean scopeAwareComparison(Node left, Node right)
     {
         if (left instanceof Expression && right instanceof Expression) {
@@ -109,25 +129,20 @@ public class ScopeAware<T extends Node>
                 ResolvedField leftField = analysis.getResolvedField(leftExpression);
                 ResolvedField rightField = analysis.getResolvedField(rightExpression);
 
-                Scope leftScope = leftField.getScope();
-                Scope rightScope = rightField.getScope();
+                boolean leftFieldInSubqueryScope = leftField.getScope().hasOuterParent(queryScope);
+                boolean rightFieldInSubqueryScope = rightField.getScope().hasOuterParent(queryScope);
 
                 // For subqueries of the query associated with the current expression, compare by syntax
-                // Note: it'd appear that hash() and equal() are inconsistent with each other in the case that:
-                //    * left.hasOuterParent(...) == true and right.hasOuterParent(...) == false
-                //    * leftField.getFieldId().equals(rightField.getFieldId()) == true
-                // Both fields would seem to have different hashes but be equal to each other.
-                // However, this cannot happen because we *require* that both expressions being compared by
-                // rooted in the same "query scope" (i.e., sub-scopes that are local to each other) -- see ScopeAwareKey.equals().
-                // If both fields have the same field id, by definition they will produce the same result for hasOuterParent().
-                checkState(leftScope.hasOuterParent(queryScope) == rightScope.hasOuterParent(queryScope));
-                if (leftScope.hasOuterParent(queryScope) && rightScope.hasOuterParent(queryScope)) {
+                if (leftFieldInSubqueryScope && rightFieldInSubqueryScope) {
                     return treeEqual(leftExpression, rightExpression, CanonicalizationAware::canonicalizationAwareComparison);
                 }
-
-                // Otherwise, for references that come from the current query scope or an outer scope of the current
+                // For references that come from the current query scope or an outer scope of the current
                 // expression, compare by resolved field
-                return leftField.getFieldId().equals(rightField.getFieldId());
+                else if (!leftFieldInSubqueryScope && !rightFieldInSubqueryScope) {
+                    return leftField.getFieldId().equals(rightField.getFieldId());
+                }
+                // References come from different scopes
+                return false;
             }
             else if (leftExpression instanceof Identifier && rightExpression instanceof Identifier) {
                 return treeEqual(leftExpression, rightExpression, CanonicalizationAware::canonicalizationAwareComparison);

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
@@ -2042,6 +2042,31 @@ public class TestLogicalPlanner
                                                         ImmutableList.of(ImmutableList.of(new LongLiteral("1"), new LongLiteral("2"), new LongLiteral("3")))))))));
     }
 
+    @Test
+    public void testDifferentOuterParentScopeSubqueries()
+    {
+        assertPlan("SELECT customer.custkey AS custkey," +
+                        "(SELECT COUNT(*) FROM orders WHERE customer.custkey = orders.custkey) AS count1," +
+                        "(SELECT COUNT(*) FROM orders WHERE orders.custkey = customer.custkey) AS count2 " +
+                        "FROM customer",
+                output(
+                        project(
+                                join(INNER,
+                                        ImmutableList.of(),
+                                        join(LEFT,
+                                                ImmutableList.of(equiJoinClause("CUSTOMER_CUSTKEY", "ORDERS2_CUSTKEY")),
+                                                project(
+                                                        join(INNER,
+                                                                ImmutableList.of(),
+                                                                join(LEFT,
+                                                                        ImmutableList.of(equiJoinClause("CUSTOMER_CUSTKEY", "ORDERS_CUSTKEY")),
+                                                                        project(tableScan("customer", ImmutableMap.of("CUSTOMER_CUSTKEY", "custkey"))),
+                                                                        anyTree(project(tableScan("orders", ImmutableMap.of("ORDERS_CUSTKEY", "custkey"))))),
+                                                                anyTree(node(ValuesNode.class)))),
+                                                anyTree(project(tableScan("orders", ImmutableMap.of("ORDERS2_CUSTKEY", "custkey"))))),
+                                        anyTree(node(ValuesNode.class))))));
+    }
+
     private Session noJoinReordering()
     {
         return Session.builder(getQueryRunner().getDefaultSession())


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

The following query fails with `IllegalStateException` at query planning on the latest master. This query works on 338 but doesn't work 339 or later.

```sql
SELECT 
  customer.custkey,
  (SELECT COUNT(*) FROM tpch.sf1.orders WHERE customer.custkey = orders.custkey) AS count1,
  (SELECT COUNT(*) FROM tpch.sf1.orders WHERE orders.custkey = customer.custkey) AS count2
FROM tpch.sf1.customer
```

Comparing `customer.custkey` and `orders.custkey` in `ScopeAware.scopeAwareComparison()` fails here because `customer.custkey` has an outer parent while `orders.custkey` doesn't :
https://github.com/trinodb/trino/blob/af33626840c61d5b2f87875cfd75fb7b84f12ac8/core/trino-main/src/main/java/io/trino/sql/planner/ScopeAware.java#L115-L123

Even though the comment above says such cases should not happen, it actually happens. It should return `false` instead of throwing `IllegalStateException` in this case? or are there better ways to fix this issue?

<details>
<summary>Full stacktrace</summary>
<pre>
java.lang.IllegalStateException: undefined
	at com.google.common.base.Preconditions.checkState(Preconditions.java:486)
	at io.trino.sql.planner.ScopeAware.scopeAwareComparison(ScopeAware.java:123)
	at io.trino.sql.util.AstUtils.treeEqual(AstUtils.java:47)
	at io.trino.sql.util.AstUtils.treeEqual(AstUtils.java:61)
	at io.trino.sql.util.AstUtils.treeEqual(AstUtils.java:61)
	at io.trino.sql.util.AstUtils.treeEqual(AstUtils.java:61)
	at io.trino.sql.util.AstUtils.treeEqual(AstUtils.java:61)
	at io.trino.sql.planner.ScopeAware.equals(ScopeAware.java:94)
	at com.google.common.collect.SingletonImmutableBiMap.containsKey(SingletonImmutableBiMap.java:73)
	at io.trino.sql.planner.TranslationMap.canTranslate(TranslationMap.java:152)
	at io.trino.sql.planner.PlanBuilder.canTranslate(PlanBuilder.java:78)
	at io.trino.sql.planner.SubqueryPlanner.lambda$selectSubqueries$0(SubqueryPlanner.java:149)
	at com.google.common.graph.Traverser.validate(Traverser.java:367)
	at com.google.common.graph.Traverser.depthFirstPreOrder(Traverser.java:297)
	at com.google.common.graph.Traverser.depthFirstPreOrder(Traverser.java:283)
	at io.trino.sql.planner.SubqueryPlanner.selectSubqueries(SubqueryPlanner.java:156)
	at io.trino.sql.planner.SubqueryPlanner.handleSubqueries(SubqueryPlanner.java:124)
	at io.trino.sql.planner.SubqueryPlanner.handleSubqueries(SubqueryPlanner.java:117)
	at io.trino.sql.planner.QueryPlanner.plan(QueryPlanner.java:404)
	at io.trino.sql.planner.RelationPlanner.visitQuerySpecification(RelationPlanner.java:983)
	at io.trino.sql.planner.RelationPlanner.visitQuerySpecification(RelationPlanner.java:131)
	at io.trino.sql.tree.QuerySpecification.accept(QuerySpecification.java:155)
	at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)
	at io.trino.sql.planner.QueryPlanner.planQueryBody(QueryPlanner.java:606)
	at io.trino.sql.planner.QueryPlanner.plan(QueryPlanner.java:193)
	at io.trino.sql.planner.RelationPlanner.visitQuery(RelationPlanner.java:976)
	at io.trino.sql.planner.RelationPlanner.visitQuery(RelationPlanner.java:131)
	at io.trino.sql.tree.Query.accept(Query.java:107)
	at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)
	at io.trino.sql.planner.LogicalPlanner.createRelationPlan(LogicalPlanner.java:786)
	at io.trino.sql.planner.LogicalPlanner.planStatementWithoutOutput(LogicalPlanner.java:308)
	at io.trino.sql.planner.LogicalPlanner.planStatement(LogicalPlanner.java:280)
	at io.trino.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:221)
	at io.trino.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:216)
	at io.trino.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:211)
	at io.trino.execution.SqlQueryExecution.doPlanQuery(SqlQueryExecution.java:477)
	at io.trino.execution.SqlQueryExecution.planQuery(SqlQueryExecution.java:458)
	at io.trino.execution.SqlQueryExecution.start(SqlQueryExecution.java:399)
	at io.trino.execution.SqlQueryManager.createQuery(SqlQueryManager.java:243)
	at io.trino.dispatcher.LocalDispatchQuery.lambda$startExecution$7(LocalDispatchQuery.java:143)
	at io.trino.$gen.Trino_dev____20220504_142451_2.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
</pre>
</details>

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
