### PR TITLE
Fix failure when reading long decimal in MongoDB

### DIFF
--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSource.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSource.java
@@ -29,6 +29,8 @@ import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.type.CharType;
 import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Decimals;
+import io.trino.spi.type.Int128;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeSignatureParameter;
 import io.trino.spi.type.VarbinaryType;
@@ -41,6 +43,7 @@ import org.joda.time.chrono.ISOChronology;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -65,6 +68,7 @@ import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.Decimals.encodeScaledValue;
 import static io.trino.spi.type.Decimals.encodeShortScaledValue;
+import static io.trino.spi.type.Decimals.isLongDecimal;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
@@ -207,6 +211,12 @@ public class MongoPageSource
             }
             else if (javaType == double.class) {
                 type.writeDouble(output, ((Number) value).doubleValue());
+            }
+            else if (javaType == Int128.class) {
+                verify(isLongDecimal(type), "The type should be long decimal");
+                DecimalType decimalType = (DecimalType) type;
+                BigDecimal decimal = ((Decimal128) value).bigDecimalValue();
+                type.writeObject(output, Decimals.encodeScaledValue(decimal, decimalType.getScale()));
             }
             else if (javaType == Slice.class) {
                 writeSlice(output, type, value);

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorTest.java
@@ -31,6 +31,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -161,7 +162,8 @@ public abstract class BaseMongoConnectorTest
                 ", DATE '1980-05-07' _date" +
                 ", TIMESTAMP '1980-05-07 11:22:33.456' _timestamp" +
                 ", ObjectId('ffffffffffffffffffffffff') _objectid" +
-                ", JSON '{\"name\":\"alice\"}' _json";
+                ", JSON '{\"name\":\"alice\"}' _json" +
+                ", cast(12.3 as decimal(30, 5)) _long_decimal";
 
         assertUpdate(query, 1);
 
@@ -176,6 +178,7 @@ public abstract class BaseMongoConnectorTest
         assertEquals(row.getField(5), LocalDate.of(1980, 5, 7));
         assertEquals(row.getField(6), LocalDateTime.of(1980, 5, 7, 11, 22, 33, 456_000_000));
         assertEquals(row.getField(8), "{\"name\":\"alice\"}");
+        assertEquals(row.getField(9), new BigDecimal("12.30000"));
         assertUpdate("DROP TABLE test_types_table");
 
         assertFalse(getQueryRunner().tableExists(getSession(), "test_types_table"));

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoCreateAndInsertDataSetup.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoCreateAndInsertDataSetup.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb;
+
+import com.mongodb.client.MongoClient;
+import io.trino.testing.datatype.ColumnSetup;
+import io.trino.testing.datatype.DataSetup;
+import io.trino.testing.sql.TestTable;
+import io.trino.testing.sql.TrinoSqlExecutor;
+import org.bson.Document;
+
+import java.util.List;
+
+import static io.airlift.testing.Closeables.closeAllSuppress;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public final class MongoCreateAndInsertDataSetup
+        implements DataSetup
+{
+    private final TrinoSqlExecutor trinoSqlExecutor;
+    private final MongoClient mongoClient;
+    private final String databaseName;
+    private final String tableNamePrefix;
+
+    public MongoCreateAndInsertDataSetup(TrinoSqlExecutor trinoSqlExecutor, MongoClient mongoClient, String databaseName, String tableNamePrefix)
+    {
+        this.trinoSqlExecutor = requireNonNull(trinoSqlExecutor, "trinoSqlExecutor is null");
+        this.mongoClient = requireNonNull(mongoClient, "mongoClient is null");
+        this.databaseName = requireNonNull(databaseName, "databaseName is null");
+        this.tableNamePrefix = requireNonNull(tableNamePrefix, "tableNamePrefix is null");
+    }
+
+    @Override
+    public TestTable setupTestTable(List<ColumnSetup> inputs)
+    {
+        TestTable testTable = new MongoTestTable(trinoSqlExecutor, tableNamePrefix);
+        try {
+            insertRows(testTable, inputs);
+        }
+        catch (Exception e) {
+            closeAllSuppress(e, testTable);
+            throw e;
+        }
+        return testTable;
+    }
+
+    private void insertRows(TestTable testTable, List<ColumnSetup> inputs)
+    {
+        int i = 0;
+        StringBuilder json = new StringBuilder("{");
+        for (ColumnSetup columnSetup : inputs) {
+            json.append(format("col_%d: ", i++));
+            json.append(columnSetup.getInputLiteral());
+            if (i != inputs.size()) {
+                json.append(",");
+            }
+        }
+        json.append("}");
+        mongoClient.getDatabase(databaseName).getCollection(testTable.getName()).insertOne(Document.parse(json.toString()));
+    }
+}

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoTestTable.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoTestTable.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb;
+
+import io.trino.testing.sql.SqlExecutor;
+import io.trino.testing.sql.TestTable;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class MongoTestTable
+        extends TestTable
+{
+    public MongoTestTable(SqlExecutor sqlExecutor, String namePrefix)
+    {
+        super(sqlExecutor, namePrefix, null);
+    }
+
+    @Override
+    public void createAndInsert(List<String> rowsToInsert)
+    {
+        checkArgument(rowsToInsert.isEmpty(), "rowsToInsert must be empty");
+    }
+}

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoTypeMapping.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoTypeMapping.java
@@ -1,0 +1,352 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.mongodb.client.MongoClients;
+import io.trino.Session;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.TimeZoneKey;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.TestingSession;
+import io.trino.testing.datatype.CreateAndInsertDataSetup;
+import io.trino.testing.datatype.CreateAsSelectDataSetup;
+import io.trino.testing.datatype.DataSetup;
+import io.trino.testing.datatype.SqlDataTypeTest;
+import io.trino.testing.sql.TestTable;
+import io.trino.testing.sql.TrinoSqlExecutor;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.ZoneId;
+
+import static io.trino.plugin.mongodb.MongoQueryRunner.createMongoQueryRunner;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.CharType.createCharType;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimeType.createTimeType;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static java.lang.String.format;
+import static java.time.ZoneOffset.UTC;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestMongoTypeMapping
+        extends AbstractTestQueryFramework
+{
+    private MongoServer server;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        server = closeAfterClass(new MongoServer());
+        return createMongoQueryRunner(server, ImmutableMap.of(), ImmutableList.of());
+    }
+
+    @Test
+    public void testBoolean()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("boolean", "true", BOOLEAN, "true")
+                .addRoundTrip("boolean", "false", BOOLEAN, "false")
+                .addRoundTrip("boolean", "NULL", BOOLEAN, "CAST(NULL AS BOOLEAN)")
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_boolean"))
+                .execute(getQueryRunner(), trinoCreateAndInsert("test_boolean"));
+
+        SqlDataTypeTest.create()
+                .addRoundTrip("true", "true")
+                .addRoundTrip("false", "false")
+                .execute(getQueryRunner(), mongoCreateAndInsert(getSession(), "tpch", "test_boolean"));
+    }
+
+    @Test
+    public void testTinyint()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("tinyint", "NULL", TINYINT, "CAST(NULL AS TINYINT)")
+                .addRoundTrip("tinyint", "-128", TINYINT, "TINYINT '-128'")
+                .addRoundTrip("tinyint", "5", TINYINT, "TINYINT '5'")
+                .addRoundTrip("tinyint", "127", TINYINT, "TINYINT '127'")
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_tinyint"))
+                .execute(getQueryRunner(), trinoCreateAndInsert("test_tinyint"));
+    }
+
+    @Test
+    public void testSmallint()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("smallint", "NULL", SMALLINT, "CAST(NULL AS SMALLINT)")
+                .addRoundTrip("smallint", "-32768", SMALLINT, "SMALLINT '-32768'")
+                .addRoundTrip("smallint", "32456", SMALLINT, "SMALLINT '32456'")
+                .addRoundTrip("smallint", "32767", SMALLINT, "SMALLINT '32767'")
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_smallint"))
+                .execute(getQueryRunner(), trinoCreateAndInsert("test_smallint"));
+    }
+
+    @Test
+    public void testInteger()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("integer", "NULL", INTEGER, "CAST(NULL AS INTEGER)")
+                .addRoundTrip("integer", "-2147483648", INTEGER, "-2147483648")
+                .addRoundTrip("integer", "1234567890", INTEGER, "1234567890")
+                .addRoundTrip("integer", "2147483647", INTEGER, "2147483647")
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_int"))
+                .execute(getQueryRunner(), trinoCreateAndInsert("test_int"));
+
+        // INTEGER values written by MongoDB are inferred as BIGINT in Trino
+        SqlDataTypeTest.create()
+                .addRoundTrip("-2147483648", "BIGINT '-2147483648'")
+                .addRoundTrip("0", "BIGINT '0'")
+                .addRoundTrip("2147483647", "BIGINT '2147483647'")
+                .execute(getQueryRunner(), mongoCreateAndInsert(getSession(), "tpch", "test_int"));
+    }
+
+    @Test
+    public void testBigint()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("bigint", "NULL", BIGINT, "CAST(NULL AS BIGINT)")
+                .addRoundTrip("bigint", "-9223372036854775808", BIGINT, "-9223372036854775808")
+                .addRoundTrip("bigint", "123456789012", BIGINT, "123456789012")
+                .addRoundTrip("bigint", "9223372036854775807", BIGINT, "9223372036854775807")
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_bigint"))
+                .execute(getQueryRunner(), trinoCreateAndInsert("test_bigint"));
+    }
+
+    @Test
+    public void testMongoNumberLong()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("NumberLong(-9223372036854775808)", "BIGINT '-9223372036854775808'")
+                .addRoundTrip("NumberLong(9223372036854775807)", "BIGINT '9223372036854775807'")
+                .execute(getQueryRunner(), mongoCreateAndInsert(getSession(), "tpch", "test_number_long"));
+    }
+
+    @Test
+    public void testDouble()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("double", "NULL", DOUBLE, "CAST(NULL AS double)")
+                .addRoundTrip("double", "1.0E100", DOUBLE, "1.0E100")
+                .addRoundTrip("double", "123.456E10", DOUBLE, "123.456E10")
+                .addRoundTrip("double", "nan()", DOUBLE, "nan()")
+                .addRoundTrip("double", "+infinity()", DOUBLE, "+infinity()")
+                .addRoundTrip("double", "-infinity()", DOUBLE, "-infinity()")
+                .execute(getQueryRunner(), trinoCreateAsSelect("trino_test_double"))
+                .execute(getQueryRunner(), trinoCreateAndInsert("trino_test_double"));
+    }
+
+    @Test
+    public void testDecimal()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("decimal(3, 0)", "CAST('193' AS decimal(3, 0))", createDecimalType(3, 0), "CAST('193' AS decimal(3, 0))")
+                .addRoundTrip("decimal(3, 0)", "CAST('19' AS decimal(3, 0))", createDecimalType(3, 0), "CAST('19' AS decimal(3, 0))")
+                .addRoundTrip("decimal(3, 0)", "CAST('-193' AS decimal(3, 0))", createDecimalType(3, 0), "CAST('-193' AS decimal(3, 0))")
+                .addRoundTrip("decimal(3, 1)", "CAST('10.0' AS decimal(3, 1))", createDecimalType(3, 1), "CAST('10.0' AS decimal(3, 1))")
+                .addRoundTrip("decimal(3, 1)", "CAST('10.1' AS decimal(3, 1))", createDecimalType(3, 1), "CAST('10.1' AS decimal(3, 1))")
+                .addRoundTrip("decimal(3, 1)", "CAST('-10.1' AS decimal(3, 1))", createDecimalType(3, 1), "CAST('-10.1' AS decimal(3, 1))")
+                .addRoundTrip("decimal(4, 2)", "CAST('2' AS decimal(4, 2))", createDecimalType(4, 2), "CAST('2' AS decimal(4, 2))")
+                .addRoundTrip("decimal(4, 2)", "CAST('2.3' AS decimal(4, 2))", createDecimalType(4, 2), "CAST('2.3' AS decimal(4, 2))")
+                .addRoundTrip("decimal(24, 2)", "CAST('2' AS decimal(24, 2))", createDecimalType(24, 2), "CAST('2' AS decimal(24, 2))")
+                .addRoundTrip("decimal(24, 2)", "CAST('2.3' AS decimal(24, 2))", createDecimalType(24, 2), "CAST('2.3' AS decimal(24, 2))")
+                .addRoundTrip("decimal(24, 2)", "CAST('123456789.3' AS decimal(24, 2))", createDecimalType(24, 2), "CAST('123456789.3' AS decimal(24, 2))")
+                .addRoundTrip("decimal(24, 4)", "CAST('12345678901234567890.31' AS decimal(24, 4))", createDecimalType(24, 4), "CAST('12345678901234567890.31' AS decimal(24, 4))")
+                .addRoundTrip("decimal(30, 5)", "CAST('3141592653589793238462643.38327' AS decimal(30, 5))", createDecimalType(30, 5), "CAST('3141592653589793238462643.38327' AS decimal(30, 5))")
+                .addRoundTrip("decimal(30, 5)", "CAST('-3141592653589793238462643.38327' AS decimal(30, 5))", createDecimalType(30, 5), "CAST('-3141592653589793238462643.38327' AS decimal(30, 5))")
+                // TODO: Fix NumberFormatException: Conversion to Decimal128 would require inexact rounding
+//                .addRoundTrip("decimal(38, 0)", "CAST('27182818284590452353602874713526624977' AS decimal(38, 0))", createDecimalType(38, 0), "CAST('27182818284590452353602874713526624977' AS decimal(38, 0))")
+//                .addRoundTrip("decimal(38, 0)", "CAST('-27182818284590452353602874713526624977' AS decimal(38, 0))", createDecimalType(38, 0), "CAST('-27182818284590452353602874713526624977' AS decimal(38, 0))")
+                .addRoundTrip("decimal(3, 0)", "CAST(NULL AS decimal(3, 0))", createDecimalType(3, 0), "CAST(NULL AS decimal(3, 0))")
+                .addRoundTrip("decimal(38, 0)", "CAST(NULL AS decimal(38, 0))", createDecimalType(38, 0), "CAST(NULL AS decimal(38, 0))")
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_decimal"))
+                .execute(getQueryRunner(), trinoCreateAndInsert("test_decimal"));
+    }
+
+    @Test
+    public void testChar()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("char", "''", createCharType(1), "CAST('' AS char(1))")
+                .addRoundTrip("char", "'a'", createCharType(1), "CAST('a' AS char(1))")
+                .addRoundTrip("char(1)", "''", createCharType(1), "CAST('' AS char(1))")
+                .addRoundTrip("char(1)", "'a'", createCharType(1), "CAST('a' AS char(1))")
+                .addRoundTrip("char(8)", "'abc'", createCharType(8), "CAST('abc' AS char(8))")
+                .addRoundTrip("char(8)", "'12345678'", createCharType(8), "CAST('12345678' AS char(8))")
+                .addRoundTrip("char(255)", format("'%s'", "a".repeat(255)), createCharType(255), format("CAST('%s' AS char(255))", "a".repeat(255)))
+                .addRoundTrip("char(1)", "'攻'", createCharType(1), "CAST('攻' AS char(1))")
+                .addRoundTrip("char(5)", "'攻殻'", createCharType(5), "CAST('攻殻' AS char(5))")
+                .addRoundTrip("char(5)", "'攻殻機動隊'", createCharType(5), "CAST('攻殻機動隊' AS char(5))")
+                .addRoundTrip("char", "NULL", createCharType(1), "CAST(NULL AS char(1))")
+                .addRoundTrip("char(255)", "NULL", createCharType(255), "CAST(NULL AS char(255))")
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_char"))
+                .execute(getQueryRunner(), trinoCreateAndInsert("test_char"));
+    }
+
+    @Test
+    public void testVarchar()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("varchar(10)", "'text_a'", createVarcharType(10), "CAST('text_a' AS VARCHAR(10))")
+                .addRoundTrip("varchar(255)", "'text_b'", createVarcharType(255), "CAST('text_b' AS VARCHAR(255))")
+                .addRoundTrip("varchar(65535)", "'text_d'", createVarcharType(65535), "CAST('text_d' AS VARCHAR(65535))")
+                .addRoundTrip("varchar(10485760)", "'text_f'", createVarcharType(10485760), "CAST('text_f' AS VARCHAR(10485760))")
+                .addRoundTrip("varchar", "'unbounded'", VARCHAR, "VARCHAR 'unbounded'")
+                .addRoundTrip("varchar(10)", "NULL", createVarcharType(10), "CAST(NULL AS VARCHAR(10))")
+                .addRoundTrip("varchar", "NULL", VARCHAR, "CAST(NULL AS VARCHAR)")
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_varchar"))
+                .execute(getQueryRunner(), trinoCreateAndInsert("test_varchar"));
+
+        SqlDataTypeTest.create()
+                .addRoundTrip("'unbounded'", "VARCHAR 'unbounded'")
+                .addRoundTrip("''", "VARCHAR ''")
+                .execute(getQueryRunner(), mongoCreateAndInsert(getSession(), "tpch", "test_varchar"));
+    }
+
+    @Test
+    public void testVarbinary()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("varbinary", "NULL", VARBINARY, "CAST(NULL AS varbinary)")
+                .addRoundTrip("varbinary", "X''", VARBINARY, "to_utf8('')")
+                .addRoundTrip("varbinary", "X'68656C6C6F'", VARBINARY, "to_utf8('hello')")
+                .addRoundTrip("varbinary", "X'5069C4996B6E6120C582C4856B61207720E69DB1E4BAACE983BD'", VARBINARY, "to_utf8('Piękna łąka w 東京都')")
+                .addRoundTrip("varbinary", "X'4261672066756C6C206F6620F09F92B0'", VARBINARY, "to_utf8('Bag full of 💰')")
+                .addRoundTrip("varbinary", "X'0001020304050607080DF9367AA7000000'", VARBINARY, "X'0001020304050607080DF9367AA7000000'") // non-text
+                .addRoundTrip("varbinary", "X'000000000000'", VARBINARY, "X'000000000000'")
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_varbinary"))
+                .execute(getQueryRunner(), trinoCreateAndInsert("test_varbinary"));
+    }
+
+    @Test
+    public void testTime()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("time", "NULL", createTimeType(3), "CAST(NULL AS TIME)")
+                .addRoundTrip("time", "TIME '00:00:00'", createTimeType(3), "TIME '00:00:00.000'")
+                .addRoundTrip("time", "TIME '23:59:59'", createTimeType(3), "TIME '23:59:59.000'")
+                .addRoundTrip("time", "TIME '23:59:59.9'", createTimeType(3), "TIME '23:59:59.900'")
+                .addRoundTrip("time", "TIME '23:59:59.99'", createTimeType(3), "TIME '23:59:59.990'")
+                .addRoundTrip("time", "TIME '23:59:59.999'", createTimeType(3), "TIME '23:59:59.999'")
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_time"))
+                .execute(getQueryRunner(), trinoCreateAndInsert("test_time"));
+    }
+
+    @Test(dataProvider = "sessionZonesDataProvider")
+    public void testDate(ZoneId sessionZone)
+    {
+        Session session = Session.builder(getSession())
+                .setTimeZoneKey(TimeZoneKey.getTimeZoneKey(sessionZone.getId()))
+                .build();
+
+        SqlDataTypeTest.create()
+                .addRoundTrip("date", "NULL", DATE, "CAST(NULL AS DATE)")
+                .addRoundTrip("date", "DATE '-5877641-06-23'", DATE, "DATE '-5877641-06-23'") // min value in Trino
+                .addRoundTrip("date", "DATE '-0001-01-01'", DATE, "DATE '-0001-01-01'")
+                .addRoundTrip("date", "DATE '0001-01-01'", DATE, "DATE '0001-01-01'")
+                .addRoundTrip("date", "DATE '0012-12-12'", DATE, "DATE '0012-12-12'")
+                .addRoundTrip("date", "DATE '1500-01-01'", DATE, "DATE '1500-01-01'")
+                .addRoundTrip("date", "DATE '1582-10-04'", DATE, "DATE '1582-10-04'") // before julian->gregorian switch
+                .addRoundTrip("date", "DATE '1582-10-05'", DATE, "DATE '1582-10-05'") // begin julian->gregorian switch
+                .addRoundTrip("date", "DATE '1582-10-14'", DATE, "DATE '1582-10-14'") // end julian->gregorian switch
+                .addRoundTrip("date", "DATE '1952-04-03'", DATE, "DATE '1952-04-03'")
+                .addRoundTrip("date", "DATE '1970-01-01'", DATE, "DATE '1970-01-01'")
+                .addRoundTrip("date", "DATE '1970-02-03'", DATE, "DATE '1970-02-03'")
+                .addRoundTrip("date", "DATE '1983-04-01'", DATE, "DATE '1983-04-01'")
+                .addRoundTrip("date", "DATE '1983-10-01'", DATE, "DATE '1983-10-01'")
+                .addRoundTrip("date", "DATE '2017-01-01'", DATE, "DATE '2017-01-01'") // winter on northern hemisphere (possible DST on southern hemisphere)
+                .addRoundTrip("date", "DATE '2017-07-01'", DATE, "DATE '2017-07-01'") // summer on northern hemisphere (possible DST)
+                .addRoundTrip("date", "DATE '9999-12-31'", DATE, "DATE '9999-12-31'")
+                .addRoundTrip("date", "DATE '19999-12-31'", DATE, "DATE '19999-12-31'")
+                .addRoundTrip("date", "DATE '5881580-07-11'", DATE, "DATE '5881580-07-11'") // max value in Trino
+                .execute(getQueryRunner(), session, trinoCreateAsSelect("test_date"))
+                .execute(getQueryRunner(), session, trinoCreateAndInsert("test_date"));
+    }
+
+    @Test
+    public void testArray()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("ARRAY(boolean)", "ARRAY[true, false]", new ArrayType(BOOLEAN), "ARRAY[true, false]")
+                .addRoundTrip("ARRAY(bigint)", "ARRAY[123456789012]", new ArrayType(BIGINT), "ARRAY[123456789012]")
+                .addRoundTrip("ARRAY(integer)", "ARRAY[1, 2, 1234567890]", new ArrayType(INTEGER), "ARRAY[1, 2, 1234567890]")
+                .addRoundTrip("ARRAY(smallint)", "ARRAY[32456]", new ArrayType(SMALLINT), "ARRAY[SMALLINT '32456']")
+                .addRoundTrip("ARRAY(double)", "ARRAY[123.45]", new ArrayType(DOUBLE), "ARRAY[DOUBLE '123.45']")
+                .addRoundTrip("ARRAY(real)", "ARRAY[123.45]", new ArrayType(REAL), "ARRAY[REAL '123.45']")
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_array"))
+                .execute(getQueryRunner(), trinoCreateAndInsert("test_array"));
+    }
+
+    @Test
+    public void testArrayNulls()
+    {
+        // Verify only SELECT instead of using SqlDataTypeTest because array comparison not supported for arrays with null elements
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_array_nulls", "(c1 ARRAY(boolean), c2 ARRAY(varchar), c3 ARRAY(varchar))", ImmutableList.of("(NULL, ARRAY[NULL], ARRAY['foo', NULL, 'bar', NULL])"))) {
+            assertThat(query("SELECT c1 FROM " + table.getName())).matches("VALUES CAST(NULL AS ARRAY(boolean))");
+            assertThat(query("SELECT c2 FROM " + table.getName())).matches("VALUES CAST(ARRAY[NULL] AS ARRAY(varchar))");
+            assertThat(query("SELECT c3 FROM " + table.getName())).matches("VALUES CAST(ARRAY['foo', NULL, 'bar', NULL] AS ARRAY(varchar))");
+        }
+    }
+
+    @DataProvider
+    public Object[][] sessionZonesDataProvider()
+    {
+        return new Object[][] {
+                {UTC},
+                {ZoneId.systemDefault()},
+                // no DST in 1970, but has DST in later years (e.g. 2018)
+                {ZoneId.of("Europe/Vilnius")},
+                // minutes offset change since 1970-01-01, no DST
+                {ZoneId.of("Asia/Kathmandu")},
+                {ZoneId.of(TestingSession.DEFAULT_TIME_ZONE_KEY.getId())},
+        };
+    }
+
+    private DataSetup trinoCreateAsSelect(String tableNamePrefix)
+    {
+        return trinoCreateAsSelect(getSession(), tableNamePrefix);
+    }
+
+    private DataSetup trinoCreateAsSelect(Session session, String tableNamePrefix)
+    {
+        return new CreateAsSelectDataSetup(new TrinoSqlExecutor(getQueryRunner(), session), tableNamePrefix);
+    }
+
+    private DataSetup trinoCreateAndInsert(String tableNamePrefix)
+    {
+        return trinoCreateAndInsert(getSession(), tableNamePrefix);
+    }
+
+    private DataSetup trinoCreateAndInsert(Session session, String tableNamePrefix)
+    {
+        return new CreateAndInsertDataSetup(new TrinoSqlExecutor(getQueryRunner(), session), tableNamePrefix);
+    }
+
+    private DataSetup mongoCreateAndInsert(Session session, String databaseName, String tableNamePrefix)
+    {
+        return new MongoCreateAndInsertDataSetup(new TrinoSqlExecutor(getQueryRunner(), session), MongoClients.create(server.getConnectionString()), databaseName, tableNamePrefix);
+    }
+}

--- a/testing/trino-testing/src/main/java/io/trino/testing/sql/TestTable.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/sql/TestTable.java
@@ -35,6 +35,7 @@ public class TestTable
     private static final int RANDOM_SUFFIX_LENGTH = 10;
 
     private final SqlExecutor sqlExecutor;
+    private final String tableDefinition;
     private final String name;
 
     public TestTable(SqlExecutor sqlExecutor, String namePrefix, String tableDefinition)
@@ -46,6 +47,12 @@ public class TestTable
     {
         this.sqlExecutor = sqlExecutor;
         this.name = namePrefix + randomTableSuffix();
+        this.tableDefinition = tableDefinition;
+        createAndInsert(rowsToInsert);
+    }
+
+    public void createAndInsert(List<String> rowsToInsert)
+    {
         sqlExecutor.execute(format("CREATE TABLE %s %s", name, tableDefinition));
         try {
             for (String row : rowsToInsert) {


### PR DESCRIPTION
## Description

Fix failure when reading long decimal in MongoDB

## Documentation

(x) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# MongoDB
* Fix failure when reading long decimal values. ({issue}`12205`)
```
