### PR TITLE
Make CLI automatically switch from aligned to vertical format

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/AutoTablePrinter.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/AutoTablePrinter.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.cli;
+
+import io.trino.client.Column;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class AutoTablePrinter
+        implements OutputPrinter
+{
+    private final int maxWidth;
+    private OutputPrinter delegate;
+    private final OutputPrinter fallback;
+
+    private final StringWriter bufferWriter = new StringWriter();
+    private final Writer writer;
+
+    public AutoTablePrinter(List<Column> columns, Writer writer, int maxWidth)
+    {
+        requireNonNull(columns, "columns is null");
+        this.writer = requireNonNull(writer, "writer is null");
+        this.maxWidth = maxWidth;
+
+        this.delegate = new AlignedTablePrinter(columns, bufferWriter);
+        List<String> fieldNames = columns.stream()
+                .map(Column::getName)
+                .collect(toImmutableList());
+        this.fallback = new VerticalRecordPrinter(fieldNames, bufferWriter);
+    }
+
+    @Override
+    public void finish()
+            throws IOException
+    {
+        delegate.finish();
+        flush();
+    }
+
+    @Override
+    public void printRows(List<List<?>> rows, boolean complete)
+            throws IOException
+    {
+        delegate.printRows(rows, complete);
+        if (!delegate.equals(fallback)) {
+            if (bufferWriter.toString().indexOf("\n") > maxWidth) {
+                delegate = fallback;
+                bufferWriter.getBuffer().setLength(0);
+                delegate.printRows(rows, complete);
+            }
+        }
+
+        flush();
+    }
+
+    private void flush()
+            throws IOException
+    {
+        writer.write(bufferWriter.toString());
+        writer.flush();
+        bufferWriter.getBuffer().setLength(0);
+    }
+}

--- a/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
@@ -148,6 +148,9 @@ public class ClientOptions
     @Option(names = "--output-format", paramLabel = "<format>", defaultValue = "CSV", description = "Output format for batch mode [${COMPLETION-CANDIDATES}] " + DEFAULT_VALUE)
     public OutputFormat outputFormat;
 
+    @Option(names = "--output-format-interactive", paramLabel = "<format>", defaultValue = "ALIGNED", description = "Output format for interactive mode [${COMPLETION-CANDIDATES}] " + DEFAULT_VALUE)
+    public OutputFormat outputFormatInteractive;
+
     @Option(names = "--resource-estimate", paramLabel = "<estimate>", description = "Resource estimate (property can be used multiple times; format is key=value)")
     public final List<ClientResourceEstimate> resourceEstimates = new ArrayList<>();
 
@@ -186,6 +189,7 @@ public class ClientOptions
 
     public enum OutputFormat
     {
+        AUTO,
         ALIGNED,
         VERTICAL,
         TSV,

--- a/client/trino-cli/src/main/java/io/trino/cli/Console.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/Console.java
@@ -191,7 +191,13 @@ public class Console
                         clientOptions.progress.orElse(false));
             }
 
-            runConsole(queryRunner, exiting, clientOptions.editingMode, clientOptions.progress.orElse(true), clientOptions.disableAutoSuggestion);
+            runConsole(
+                    queryRunner,
+                    exiting,
+                    clientOptions.outputFormatInteractive,
+                    clientOptions.editingMode,
+                    clientOptions.progress.orElse(true),
+                    clientOptions.disableAutoSuggestion);
             return true;
         }
         finally {
@@ -221,7 +227,13 @@ public class Console
         return reader.readLine("Password: ", (char) 0);
     }
 
-    private static void runConsole(QueryRunner queryRunner, AtomicBoolean exiting, ClientOptions.EditingMode editingMode, boolean progress, boolean disableAutoSuggestion)
+    private static void runConsole(
+            QueryRunner queryRunner,
+            AtomicBoolean exiting,
+            OutputFormat outputFormat,
+            ClientOptions.EditingMode editingMode,
+            boolean progress,
+            boolean disableAutoSuggestion)
     {
         try (TableNameCompleter tableNameCompleter = new TableNameCompleter(queryRunner);
                 InputReader reader = new InputReader(editingMode, getHistoryFile(), disableAutoSuggestion, commandCompleter(), tableNameCompleter)) {
@@ -284,12 +296,12 @@ public class Console
                 // execute any complete statements
                 StatementSplitter splitter = new StatementSplitter(line, STATEMENT_DELIMITERS);
                 for (Statement split : splitter.getCompleteStatements()) {
-                    OutputFormat outputFormat = OutputFormat.ALIGNED;
+                    OutputFormat currentOutputFormat = outputFormat;
                     if (split.terminator().equals("\\G")) {
-                        outputFormat = OutputFormat.VERTICAL;
+                        currentOutputFormat = OutputFormat.VERTICAL;
                     }
 
-                    process(queryRunner, split.statement(), outputFormat, tableNameCompleter::populateCache, true, progress, reader.getTerminal(), System.out, System.out);
+                    process(queryRunner, split.statement(), currentOutputFormat, tableNameCompleter::populateCache, true, progress, reader.getTerminal(), System.out, System.out);
                 }
 
                 // replace remaining with trailing partial statement

--- a/client/trino-cli/src/test/java/io/trino/cli/TestAutoTablePrinter.java
+++ b/client/trino-cli/src/test/java/io/trino/cli/TestAutoTablePrinter.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.cli;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.client.ClientTypeSignature;
+import io.trino.client.Column;
+import org.testng.annotations.Test;
+
+import java.io.StringWriter;
+import java.util.List;
+
+import static io.trino.client.ClientStandardTypes.BIGINT;
+import static io.trino.client.ClientStandardTypes.VARCHAR;
+import static java.util.Arrays.asList;
+import static org.testng.Assert.assertEquals;
+
+public class TestAutoTablePrinter
+{
+    @Test
+    public void testNarrowPrinting()
+            throws Exception
+    {
+        List<Column> columns = ImmutableList.<Column>builder()
+                .add(column("first", VARCHAR))
+                .add(column("last", VARCHAR))
+                .add(column("quantity", BIGINT))
+                .build();
+        StringWriter writer = new StringWriter();
+        OutputPrinter printer = new AutoTablePrinter(columns, writer, 100);
+
+        printer.printRows(rows(
+                row("hello", "world", 123),
+                row("a", null, 4.5),
+                row("b", null, null),
+                row("bye", "done", -15)),
+                true);
+        printer.finish();
+
+        String expected = "" +
+                " first | last  | quantity \n" +
+                "-------+-------+----------\n" +
+                " hello | world |      123 \n" +
+                " a     | NULL  |      4.5 \n" +
+                " b     | NULL  |     NULL \n" +
+                " bye   | done  |      -15 \n" +
+                "(4 rows)\n";
+
+        assertEquals(writer.getBuffer().toString(), expected);
+    }
+
+    @Test
+    public void testWidePrinting()
+            throws Exception
+    {
+        StringWriter writer = new StringWriter();
+        List<Column> columns = ImmutableList.<Column>builder()
+                .add(column("first", VARCHAR))
+                .add(column("last", VARCHAR))
+                .add(column("quantity", BIGINT))
+                .build();
+        OutputPrinter printer = new AutoTablePrinter(columns, writer, 10);
+
+        printer.printRows(rows(
+                        row("hello", "world", 123),
+                        row("a", null, 4.5),
+                        row("bye", "done", -15)),
+                true);
+        printer.finish();
+
+        String expected = "" +
+                "-[ RECORD 1 ]---\n" +
+                "first    | hello\n" +
+                "last     | world\n" +
+                "quantity | 123\n" +
+                "-[ RECORD 2 ]---\n" +
+                "first    | a\n" +
+                "last     | NULL\n" +
+                "quantity | 4.5\n" +
+                "-[ RECORD 3 ]---\n" +
+                "first    | bye\n" +
+                "last     | done\n" +
+                "quantity | -15\n";
+
+        assertEquals(writer.getBuffer().toString(), expected);
+    }
+
+    static Column column(String name, String type)
+    {
+        return new Column(name, type, new ClientTypeSignature(type));
+    }
+
+    static List<?> row(Object... values)
+    {
+        return asList(values);
+    }
+
+    static List<List<?>> rows(List<?>... rows)
+    {
+        return asList(rows);
+    }
+}

--- a/docs/src/main/sphinx/client/cli.rst
+++ b/docs/src/main/sphinx/client/cli.rst
@@ -165,6 +165,9 @@ mode:
     - Configures the level of detail provided for network logging of the CLI.
       Defaults to ``NONE``, other options are ``BASIC``, ``HEADERS``, or
       ``BODY``.
+  * - ``--output-format-interactive=<format>``
+    - Specify the :ref:`format <cli-output-format>` to use
+      for printing query results. Defaults to ``ALIGNED``.
   * - ``--no-progress``
     - Do not show query processing progress.
   * - ``--password``
@@ -473,6 +476,7 @@ set them to either ``true`` or ``false``. For example:
 
 .. code-block:: properties
 
+    output-format-interactive=AUTO
     timezone=Europe/Warsaw
     user=trino-client
     network-logging=BASIC
@@ -505,49 +509,10 @@ mode:
       exit immediately.
   * - ``--output-format=<format>``
     - Specify the :ref:`format <cli-output-format>` to use
-      for printing query results.
+      for printing query results. Defaults to ``CSV``.
   * - ``--progress``
     - Show query progress in batch mode. It does not affect the output,
       which, for example can be safely redirected to a file.
-
-.. _cli-output-format:
-
-Output formats
-^^^^^^^^^^^^^^
-
-The Trino CLI provides the option ``--output-format`` to control how the output
-is displayed when running in non-interactive mode. The available options
-shown in the following table must be entered in uppercase. The default value
-is ``CSV``.
-
-.. list-table:: Output format options
-  :widths: 25, 75
-  :header-rows: 1
-
-  * - Option
-    - Description
-  * - ``CSV``
-    - Comma-separated values, each value quoted. No header row.
-  * - ``CSV_HEADER``
-    - Comma-separated values, quoted with header row.
-  * - ``CSV_UNQUOTED``
-    - Comma-separated values without quotes.
-  * - ``CSV_HEADER_UNQUOTED``
-    - Comma-separated values with header row but no quotes.
-  * - ``TSV``
-    - Tab-separated values.
-  * - ``TSV_HEADER``
-    - Tab-separated values with header row.
-  * - ``JSON``
-    - Output rows emitted as JSON objects with name-value pairs.
-  * - ``ALIGNED``
-    - Output emitted as an ASCII character table with values.
-  * - ``VERTICAL``
-    - Output emitted as record-oriented top-down lines, one per value.
-  * - ``NULL``
-    - Suppresses normal query results. This can be useful during development
-      to test a query's shell return code or to see whether it results in
-      error messages.
 
 Examples
 ^^^^^^^^
@@ -612,6 +577,49 @@ and displays an error message (which is unaffected by the output format):
 
     Query 20200707_170726_00030_2iup9 failed: line 1:25: Column 'region' cannot be resolved
     SELECT nationkey, name, region FROM tpch.sf1.nation LIMIT 3
+
+.. _cli-output-format:
+
+Output formats
+--------------
+
+The Trino CLI provides the options ``--output-format``
+and ``--output-format-interactive`` to control how the output is displayed.
+The available options shown in the following table must be entered
+in uppercase. The default value is ``ALIGNED`` in interactive mode,
+and ``CSV`` in non-interactive mode.
+
+.. list-table:: Output format options
+  :widths: 25, 75
+  :header-rows: 1
+
+  * - Option
+    - Description
+  * - ``CSV``
+    - Comma-separated values, each value quoted. No header row.
+  * - ``CSV_HEADER``
+    - Comma-separated values, quoted with header row.
+  * - ``CSV_UNQUOTED``
+    - Comma-separated values without quotes.
+  * - ``CSV_HEADER_UNQUOTED``
+    - Comma-separated values with header row but no quotes.
+  * - ``TSV``
+    - Tab-separated values.
+  * - ``TSV_HEADER``
+    - Tab-separated values with header row.
+  * - ``JSON``
+    - Output rows emitted as JSON objects with name-value pairs.
+  * - ``ALIGNED``
+    - Output emitted as an ASCII character table with values.
+  * - ``VERTICAL``
+    - Output emitted as record-oriented top-down lines, one per value.
+  * - ``AUTO``
+    - Same as ``ALIGNED`` if output would fit the current terminal width,
+      and ``VERTICAL`` otherwise.
+  * - ``NULL``
+    - Suppresses normal query results. This can be useful during development
+      to test a query's shell return code or to see whether it results in
+      error messages.
 
 .. _cli-troubleshooting:
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->
Make CLI automatically switch from aligned to vertical format when the output wouldn't fit the current terminal's width. Currently, users can terminate the query with `\G`, but this has a few drawbacks:
* users need to run the query twice if they notice it's too wide
* a table that's too wide will be opened in the pager and won't remain on the screen when writing a follow-up query - users might want to refer to the values from the first query, so they'd need to interrupt writing the second one
* users have to notice the output is too wide - check out the output of `SHOW FUNCTIONS` where the second column is so wide you might not notice there are more
* it's kinda hard to type - backslash is unusual and `G` has to be upper-case

This PR introduces a new `AUTO` output format that automatically switches from `ALIGNED` to `VERTICAL` if the aligned table is wider than the current terminal. But it doesn't make the auto format the default, for backward compatibility. Users need to enable it by using `--output-format-interactive=AUTO` or by adding it to the config file.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

cli

> How would you describe this change to a non-technical end user or system administrator?

Add a new `AUTO` output format to the CLI client, that switches from `ALIGNED` to `VERTICAL` if the output wouldn't fit the current terminal. 

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# CLI
* Add a new `AUTO` output format, that switches from `ALIGNED` to `VERTICAL` if the output wouldn't fit the current terminal.  ({issue}`issuenumber`)
```
