### PR TITLE
Distribute spooling data randomly across prefix groups

### DIFF
--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
@@ -311,11 +311,14 @@ for your storage solution.
    * - ``exchange.sink-max-file-size``
      - Max size of files written by exchange sinks.
      - ``1GB``
-   * - ``exchange.source-concurrent-reader``
+   * - ``exchange.source-concurrent-readers``
      - The number of concurrent readers to read from spooling storage. The
        larger the number of concurrent readers, the larger the read parallelism
        and memory usage.
      - ``4``
+   * - ``exchange.prefix-groups``
+     - The number of prefix groups for an exchange spooling directory.
+     - ``1000``
    * - ``exchange.s3.aws-access-key``
      - AWS access key to use. Required for a connection to AWS S3, can be
        ignored for other S3 storage systems.

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeConfig.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeConfig.java
@@ -42,6 +42,7 @@ public class FileSystemExchangeConfig
     private int exchangeSinkBuffersPerPartition = 2;
     private DataSize exchangeSinkMaxFileSize = DataSize.of(1, GIGABYTE);
     private int exchangeSourceConcurrentReaders = 4;
+    private int exchangePrefixGroups = 1000;
 
     @NotNull
     @NotEmpty(message = "At least one base directory needs to be configured")
@@ -145,6 +146,20 @@ public class FileSystemExchangeConfig
     public FileSystemExchangeConfig setExchangeSourceConcurrentReaders(int exchangeSourceConcurrentReaders)
     {
         this.exchangeSourceConcurrentReaders = exchangeSourceConcurrentReaders;
+        return this;
+    }
+
+    @Min(1)
+    public int getExchangePrefixGroups()
+    {
+        return exchangePrefixGroups;
+    }
+
+    @Config("exchange.prefix-groups")
+    @ConfigDescription("Number of prefix groups per base directory")
+    public FileSystemExchangeConfig setExchangePrefixGroups(int exchangePrefixGroups)
+    {
+        this.exchangePrefixGroups = exchangePrefixGroups;
         return this;
     }
 }

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeManager.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeManager.java
@@ -58,6 +58,7 @@ public class FileSystemExchangeManager
     private final int exchangeSinkBuffersPerPartition;
     private final long exchangeSinkMaxFileSizeInBytes;
     private final int exchangeSourceConcurrentReaders;
+    private final int exchangePrefixGroups;
     private final ExecutorService executor;
 
     @Inject
@@ -77,6 +78,7 @@ public class FileSystemExchangeManager
         this.exchangeSinkBuffersPerPartition = fileSystemExchangeConfig.getExchangeSinkBuffersPerPartition();
         this.exchangeSinkMaxFileSizeInBytes = fileSystemExchangeConfig.getExchangeSinkMaxFileSize().toBytes();
         this.exchangeSourceConcurrentReaders = fileSystemExchangeConfig.getExchangeSourceConcurrentReaders();
+        this.exchangePrefixGroups = fileSystemExchangeConfig.getExchangePrefixGroups();
         this.executor = newCachedThreadPool(daemonThreadsNamed("exchange-source-handles-creation-%s"));
     }
 
@@ -98,6 +100,7 @@ public class FileSystemExchangeManager
                 baseDirectories,
                 exchangeStorage,
                 stats,
+                exchangePrefixGroups,
                 context,
                 outputPartitionCount,
                 secretKey,

--- a/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/TestFileSystemExchangeConfig.java
+++ b/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/TestFileSystemExchangeConfig.java
@@ -37,7 +37,8 @@ public class TestFileSystemExchangeConfig
                 .setExchangeSinkBufferPoolMinSize(10)
                 .setExchangeSinkBuffersPerPartition(2)
                 .setExchangeSinkMaxFileSize(DataSize.of(1, GIGABYTE))
-                .setExchangeSourceConcurrentReaders(4));
+                .setExchangeSourceConcurrentReaders(4)
+                .setExchangePrefixGroups(1000));
     }
 
     @Test
@@ -51,6 +52,7 @@ public class TestFileSystemExchangeConfig
                 .put("exchange.sink-buffers-per-partition", "3")
                 .put("exchange.sink-max-file-size", "2GB")
                 .put("exchange.source-concurrent-readers", "10")
+                .put("exchange.prefix-groups", "100")
                 .buildOrThrow();
 
         FileSystemExchangeConfig expected = new FileSystemExchangeConfig()
@@ -60,7 +62,8 @@ public class TestFileSystemExchangeConfig
                 .setExchangeSinkBufferPoolMinSize(20)
                 .setExchangeSinkBuffersPerPartition(3)
                 .setExchangeSinkMaxFileSize(DataSize.of(2, GIGABYTE))
-                .setExchangeSourceConcurrentReaders(10);
+                .setExchangeSourceConcurrentReaders(10)
+                .setExchangePrefixGroups(100);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

Data output file path format becomes `{prefixGroupId}/{queryId}.{stageId}/{sinkPartitionId}/{attemptId}/{sourcePartitionId}_{splitId}.data`. Such that S3 can adaptively partition/shard data based on prefixes so data is spread across shards, reducing the likelihood of running into throttling.

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

trino-exchange-filesystem

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
