### PR TITLE
Support Redis key pushdown in Redis connector

### DIFF
--- a/docs/src/main/sphinx/connector/redis.rst
+++ b/docs/src/main/sphinx/connector/redis.rst
@@ -273,3 +273,38 @@ SQL support
 The connector provides :ref:`globally available <sql-globally-available>` and
 :ref:`read operation <sql-read-operations>` statements to access data and
 metadata in Redis.
+
+Performance
+-----------
+
+The connector includes a number of performance improvements, detailed in the
+following sections.
+
+.. _redis-pushdown:
+
+Pushdown
+^^^^^^^^
+
+.. _redis-predicate-pushdown:
+
+Predicate pushdown support
+""""""""""""""""""""""""""
+
+The connector supports pushdown of keys, only Redis key of string type supports
+pushdown, the zset type does not support. Currently, key pushdown is not supported
+when multiple key fields are defined in the table definition file.
+
+The connector supports pushdown of equality predicates, such as ``IN`` or ``=``.
+Range predicates, such as ``>``, ``<``, or ``BETWEEN``, and inequality predicates,
+such as ``!=`` are not pushed down.
+
+In the following example, the predicate of the first query is not pushed down
+since ``>`` is a range predicate. The other queries are pushed down.
+
+.. code-block:: sql
+
+    -- Not pushed down
+    SELECT * FROM nation WHERE redis_key > 'CANADA';
+    -- Pushed down
+    SELECT * FROM nation WHERE redis_key = 'CANADA';
+    SELECT * FROM nation WHERE redis_key IN ('CANADA', 'POLAND');

--- a/plugin/trino-redis/pom.xml
+++ b/plugin/trino-redis/pom.xml
@@ -154,6 +154,13 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-testing</artifactId>
             <scope>test</scope>
         </dependency>
@@ -173,6 +180,12 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisColumnHandle.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisColumnHandle.java
@@ -18,15 +18,20 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.decoder.DecoderColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.type.Type;
+import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.sizeOf;
 import static java.util.Objects.requireNonNull;
 
 public final class RedisColumnHandle
         implements DecoderColumnHandle, Comparable<RedisColumnHandle>
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(RedisColumnHandle.class).instanceSize();
+
     private final int ordinalPosition;
     private final String name;
     private final Type type;
@@ -198,5 +203,15 @@ public final class RedisColumnHandle
                 .add("hidden", hidden)
                 .add("internal", internal)
                 .toString();
+    }
+
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE
+                + sizeOf(ordinalPosition)
+                + estimatedSizeOf(name)
+                + estimatedSizeOf(mapping)
+                + estimatedSizeOf(dataFormat)
+                + estimatedSizeOf(formatHint);
     }
 }

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisMetadata.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisMetadata.java
@@ -26,13 +26,22 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTableProperties;
+import io.trino.spi.connector.Constraint;
+import io.trino.spi.connector.ConstraintApplicationResult;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
 import io.trino.spi.connector.TableNotFoundException;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
+import io.trino.spi.predicate.Ranges;
+import io.trino.spi.predicate.SortedRangeSet;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -41,6 +50,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static io.trino.plugin.redis.RedisSplit.toRedisDataType;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -104,7 +114,8 @@ public class RedisMetadata
                 schemaTableName.getTableName(),
                 getDataFormat(table.getKey()),
                 getDataFormat(table.getValue()),
-                keyName);
+                keyName,
+                TupleDomain.all());
     }
 
     private static String getDataFormat(RedisTableFieldGroup fieldGroup)
@@ -180,6 +191,62 @@ public class RedisMetadata
     }
 
     @Override
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint constraint)
+    {
+        RedisTableHandle handle = (RedisTableHandle) table;
+        TupleDomain<ColumnHandle> oldDomain = handle.getConstraint();
+        TupleDomain<ColumnHandle> newDomain = oldDomain.intersect(constraint.getSummary());
+        TupleDomain<ColumnHandle> remainingFilter;
+        if (newDomain.isNone()) {
+            remainingFilter = TupleDomain.all();
+        }
+        else {
+            Map<ColumnHandle, Domain> domains = newDomain.getDomains().orElseThrow();
+
+            Map<ColumnHandle, Domain> supported = new HashMap<>();
+            Map<ColumnHandle, Domain> unsupported = new HashMap<>();
+
+            // Currently, only Redis key of string type supports pushdown.
+            // Key pushdown is not supported when multiple key fields are defined in the table definition file.
+            if (toRedisDataType(handle.getKeyDataFormat()) != RedisDataType.STRING) {
+                unsupported = domains;
+            }
+            else if (getUserDefinedKeySize(session, handle) > 1) {
+                unsupported = domains;
+            }
+            else {
+                for (Map.Entry<ColumnHandle, Domain> entry : domains.entrySet()) {
+                    RedisColumnHandle columnHandle = (RedisColumnHandle) entry.getKey();
+                    Domain domain = entry.getValue();
+                    if (isColumnSupportsPushdown(columnHandle, domain)) {
+                        supported.put(columnHandle, domain);
+                    }
+                    else {
+                        unsupported.put(columnHandle, domain);
+                    }
+                }
+            }
+
+            newDomain = TupleDomain.withColumnDomains(supported);
+            remainingFilter = TupleDomain.withColumnDomains(unsupported);
+        }
+
+        if (oldDomain.equals(newDomain)) {
+            return Optional.empty();
+        }
+
+        handle = new RedisTableHandle(
+                handle.getSchemaName(),
+                handle.getTableName(),
+                handle.getKeyDataFormat(),
+                handle.getValueDataFormat(),
+                handle.getKeyName(),
+                newDomain);
+
+        return Optional.of(new ConstraintApplicationResult<>(handle, remainingFilter, false));
+    }
+
+    @Override
     public Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
     {
         requireNonNull(prefix, "prefix is null");
@@ -252,5 +319,28 @@ public class RedisMetadata
                 }
             }
         }
+    }
+
+    private boolean isColumnSupportsPushdown(RedisColumnHandle columnHandle, Domain domain)
+    {
+        if (columnHandle.isKeyDecoder()) {
+            if (domain.isSingleValue()) {
+                return true;
+            }
+            ValueSet valueSet = domain.getValues();
+            if (valueSet instanceof SortedRangeSet) {
+                Ranges ranges = ((SortedRangeSet) valueSet).getRanges();
+                List<Range> rangeList = ranges.getOrderedRanges();
+                return rangeList.stream().allMatch(Range::isSingleValue);
+            }
+        }
+        return false;
+    }
+
+    private long getUserDefinedKeySize(ConnectorSession session, RedisTableHandle handle)
+    {
+        return getColumnHandles(session, handle).values().stream()
+                .filter(column -> ((RedisColumnHandle) column).isKeyDecoder())
+                .count();
     }
 }

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisSplit.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisSplit.java
@@ -17,7 +17,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.HostAddress;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.predicate.TupleDomain;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
@@ -48,6 +50,8 @@ public final class RedisSplit
     private final long start;
     private final long end;
 
+    private final TupleDomain<ColumnHandle> constraint;
+
     @JsonCreator
     public RedisSplit(
             @JsonProperty("schemaName") String schemaName,
@@ -55,6 +59,7 @@ public final class RedisSplit
             @JsonProperty("keyDataFormat") String keyDataFormat,
             @JsonProperty("valueDataFormat") String valueDataFormat,
             @JsonProperty("keyName") String keyName,
+            @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint,
             @JsonProperty("start") long start,
             @JsonProperty("end") long end,
             @JsonProperty("nodes") List<HostAddress> nodes)
@@ -64,6 +69,7 @@ public final class RedisSplit
         this.keyDataFormat = requireNonNull(keyDataFormat, "keyDataFormat is null");
         this.valueDataFormat = requireNonNull(valueDataFormat, "valueDataFormat is null");
         this.keyName = keyName;
+        this.constraint = requireNonNull(constraint, "constraint is null");
         this.nodes = ImmutableList.copyOf(requireNonNull(nodes, "nodes is null"));
         this.start = start;
         this.end = end;
@@ -99,6 +105,12 @@ public final class RedisSplit
     public String getKeyName()
     {
         return keyName;
+    }
+
+    @JsonProperty
+    public TupleDomain<ColumnHandle> getConstraint()
+    {
+        return constraint;
     }
 
     @JsonProperty
@@ -156,10 +168,11 @@ public final class RedisSplit
                 + estimatedSizeOf(keyDataFormat)
                 + estimatedSizeOf(keyName)
                 + estimatedSizeOf(valueDataFormat)
-                + estimatedSizeOf(nodes, HostAddress::getRetainedSizeInBytes);
+                + estimatedSizeOf(nodes, HostAddress::getRetainedSizeInBytes)
+                + constraint.getRetainedSizeInBytes(columnHandle -> ((RedisColumnHandle) columnHandle).getRetainedSizeInBytes());
     }
 
-    private static RedisDataType toRedisDataType(String dataFormat)
+    public static RedisDataType toRedisDataType(String dataFormat)
     {
         switch (dataFormat) {
             case "hash":
@@ -183,6 +196,7 @@ public final class RedisSplit
                 .add("start", start)
                 .add("end", end)
                 .add("nodes", nodes)
+                .add("constraint", constraint)
                 .toString();
     }
 }

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisSplitManager.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisSplitManager.java
@@ -98,6 +98,7 @@ public class RedisSplitManager
                     redisTableHandle.getKeyDataFormat(),
                     redisTableHandle.getValueDataFormat(),
                     redisTableHandle.getKeyName(),
+                    redisTableHandle.getConstraint(),
                     startIndex,
                     endIndex,
                     nodes);

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisTableHandle.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisTableHandle.java
@@ -15,8 +15,10 @@ package io.trino.plugin.redis;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.predicate.TupleDomain;
 
 import java.util.Objects;
 
@@ -45,19 +47,23 @@ public final class RedisTableHandle
 
     private final String valueDataFormat;
 
+    private final TupleDomain<ColumnHandle> constraint;
+
     @JsonCreator
     public RedisTableHandle(
             @JsonProperty("schemaName") String schemaName,
             @JsonProperty("tableName") String tableName,
             @JsonProperty("keyDataFormat") String keyDataFormat,
             @JsonProperty("valueDataFormat") String valueDataFormat,
-            @JsonProperty("keyName") String keyName)
+            @JsonProperty("keyName") String keyName,
+            @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
         this.keyDataFormat = requireNonNull(keyDataFormat, "keyDataFormat is null");
         this.valueDataFormat = requireNonNull(valueDataFormat, "valueDataFormat is null");
         this.keyName = keyName;
+        this.constraint = requireNonNull(constraint, "constraint is null");
     }
 
     @JsonProperty
@@ -90,6 +96,12 @@ public final class RedisTableHandle
         return valueDataFormat;
     }
 
+    @JsonProperty
+    public TupleDomain<ColumnHandle> getConstraint()
+    {
+        return constraint;
+    }
+
     public SchemaTableName toSchemaTableName()
     {
         return new SchemaTableName(schemaName, tableName);
@@ -98,7 +110,7 @@ public final class RedisTableHandle
     @Override
     public int hashCode()
     {
-        return Objects.hash(schemaName, tableName, keyDataFormat, valueDataFormat, keyName);
+        return Objects.hash(schemaName, tableName, keyDataFormat, valueDataFormat, keyName, constraint);
     }
 
     @Override
@@ -116,7 +128,8 @@ public final class RedisTableHandle
                 && Objects.equals(this.tableName, other.tableName)
                 && Objects.equals(this.keyDataFormat, other.keyDataFormat)
                 && Objects.equals(this.valueDataFormat, other.valueDataFormat)
-                && Objects.equals(this.keyName, other.keyName);
+                && Objects.equals(this.keyName, other.keyName)
+                && Objects.equals(this.constraint, other.constraint);
     }
 
     @Override
@@ -128,6 +141,7 @@ public final class RedisTableHandle
                 .add("keyDataFormat", keyDataFormat)
                 .add("valueDataFormat", valueDataFormat)
                 .add("keyName", keyName)
+                .add("constraint", constraint)
                 .toString();
     }
 }

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/AbstractTestMinimalFunctionality.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/AbstractTestMinimalFunctionality.java
@@ -15,60 +15,41 @@ package io.trino.plugin.redis;
 
 import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
-import io.trino.metadata.QualifiedObjectName;
-import io.trino.metadata.TableHandle;
 import io.trino.plugin.redis.util.JsonEncoder;
 import io.trino.plugin.redis.util.RedisServer;
-import io.trino.security.AllowAllAccessControl;
 import io.trino.spi.connector.SchemaTableName;
-import io.trino.spi.type.BigintType;
-import io.trino.testing.MaterializedResult;
 import io.trino.testing.StandaloneQueryRunner;
 import org.testng.annotations.AfterClass;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import redis.clients.jedis.Jedis;
 
-import java.util.Optional;
+import java.util.Map;
 import java.util.UUID;
 
 import static io.trino.plugin.redis.util.RedisTestUtils.createEmptyTableDescription;
 import static io.trino.plugin.redis.util.RedisTestUtils.installRedisPlugin;
 import static io.trino.testing.TestingSession.testSessionBuilder;
-import static io.trino.testing.assertions.Assert.assertEquals;
-import static io.trino.transaction.TransactionBuilder.transaction;
-import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true)
-public class TestMinimalFunctionality
+public abstract class AbstractTestMinimalFunctionality
 {
-    private static final Session SESSION = testSessionBuilder()
+    protected static final Session SESSION = testSessionBuilder()
             .setCatalog("redis")
             .setSchema("default")
             .build();
 
-    private RedisServer redisServer;
-    private String tableName;
-    private StandaloneQueryRunner queryRunner;
+    protected RedisServer redisServer;
+    protected String tableName;
+    protected StandaloneQueryRunner queryRunner;
+
+    protected abstract Map<String, String> connectorProperties();
 
     @BeforeClass
     public void startRedis()
     {
         redisServer = new RedisServer();
-    }
 
-    @AfterClass(alwaysRun = true)
-    public void stopRedis()
-    {
-        redisServer.close();
-        redisServer = null;
-    }
-
-    @BeforeMethod
-    public void spinUp()
-    {
         this.tableName = "test_" + UUID.randomUUID().toString().replaceAll("-", "_");
 
         this.queryRunner = new StandaloneQueryRunner(SESSION);
@@ -77,17 +58,24 @@ public class TestMinimalFunctionality
                 ImmutableMap.<SchemaTableName, RedisTableDescription>builder()
                         .put(createEmptyTableDescription(new SchemaTableName("default", tableName)))
                         .buildOrThrow(),
-                ImmutableMap.of());
+                connectorProperties());
+
+        populateData(1000);
     }
 
-    @AfterMethod(alwaysRun = true)
-    public void tearDown()
+    @AfterClass(alwaysRun = true)
+    public void stopRedis()
     {
+        clearData();
+
         queryRunner.close();
         queryRunner = null;
+
+        redisServer.close();
+        redisServer = null;
     }
 
-    private void populateData(int count)
+    protected void populateData(int count)
     {
         JsonEncoder jsonEncoder = new JsonEncoder();
         for (long i = 0; i < count; i++) {
@@ -98,38 +86,10 @@ public class TestMinimalFunctionality
         }
     }
 
-    @Test
-    public void testTableExists()
+    protected void clearData()
     {
-        QualifiedObjectName name = new QualifiedObjectName("redis", "default", tableName);
-        transaction(queryRunner.getTransactionManager(), new AllowAllAccessControl())
-                .singleStatement()
-                .execute(SESSION, session -> {
-                    Optional<TableHandle> handle = queryRunner.getServer().getMetadata().getTableHandle(session, name);
-                    assertTrue(handle.isPresent());
-                });
-    }
-
-    @Test
-    public void testTableHasData()
-    {
-        MaterializedResult result = queryRunner.execute("SELECT count(1) from " + tableName);
-
-        MaterializedResult expected = MaterializedResult.resultBuilder(SESSION, BigintType.BIGINT)
-                .row(0L)
-                .build();
-
-        assertEquals(result, expected);
-
-        int count = 1000;
-        populateData(count);
-
-        result = queryRunner.execute("SELECT count(1) from " + tableName);
-
-        expected = MaterializedResult.resultBuilder(SESSION, BigintType.BIGINT)
-                .row((long) count)
-                .build();
-
-        assertEquals(result, expected);
+        try (Jedis jedis = redisServer.getJedisPool().getResource()) {
+            jedis.flushAll();
+        }
     }
 }

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestMinimalFunctionality.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestMinimalFunctionality.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.redis;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.metadata.QualifiedObjectName;
+import io.trino.metadata.TableHandle;
+import io.trino.security.AllowAllAccessControl;
+import io.trino.spi.type.BigintType;
+import io.trino.testing.MaterializedResult;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.testing.assertions.Assert.assertEquals;
+import static io.trino.transaction.TransactionBuilder.transaction;
+import static java.lang.String.format;
+import static org.testng.Assert.assertTrue;
+
+@Test(singleThreaded = true)
+public class TestMinimalFunctionality
+        extends AbstractTestMinimalFunctionality
+{
+    @Override
+    protected Map<String, String> connectorProperties()
+    {
+        return ImmutableMap.of();
+    }
+
+    @Test
+    public void testTableExists()
+    {
+        QualifiedObjectName name = new QualifiedObjectName("redis", "default", tableName);
+        transaction(queryRunner.getTransactionManager(), new AllowAllAccessControl())
+                .singleStatement()
+                .execute(SESSION, session -> {
+                    Optional<TableHandle> handle = queryRunner.getServer().getMetadata().getTableHandle(session, name);
+                    assertTrue(handle.isPresent());
+                });
+    }
+
+    @Test
+    public void testTableHasData()
+    {
+        clearData();
+
+        MaterializedResult result = queryRunner.execute("SELECT count(1) FROM " + tableName);
+        MaterializedResult expected = MaterializedResult.resultBuilder(SESSION, BigintType.BIGINT)
+                .row(0L)
+                .build();
+        assertEquals(result, expected);
+
+        int count = 1000;
+        populateData(count);
+
+        result = queryRunner.execute("SELECT count(1) FROM " + tableName);
+        expected = MaterializedResult.resultBuilder(SESSION, BigintType.BIGINT)
+                .row((long) count)
+                .build();
+        assertEquals(result, expected);
+    }
+
+    @Test
+    public void testStringValueWhereClauseHasData()
+    {
+        MaterializedResult result = queryRunner.execute(format("SELECT count(1) FROM %s WHERE redis_key = '%s:999'", stringValueTableName, stringValueTableName));
+        MaterializedResult expected = MaterializedResult.resultBuilder(SESSION, BigintType.BIGINT)
+                .row(1L)
+                .build();
+        assertEquals(result, expected);
+
+        result = queryRunner.execute(format("SELECT count(1) FROM %s WHERE redis_key IN ('%s:0', '%s:999')", stringValueTableName, stringValueTableName, stringValueTableName));
+        expected = MaterializedResult.resultBuilder(SESSION, BigintType.BIGINT)
+                .row(2L)
+                .build();
+        assertEquals(result, expected);
+
+        result = queryRunner.execute(format("SELECT count(1) FROM %s WHERE redis_key IN ('%s:0', '%s:999')", stringValueTableName, stringValueTableName, tableName));
+        expected = MaterializedResult.resultBuilder(SESSION, BigintType.BIGINT)
+                .row(1L)
+                .build();
+        assertEquals(result, expected);
+    }
+
+    @Test
+    public void testHashValueWhereClauseHasData()
+    {
+        MaterializedResult result = queryRunner.execute(format("SELECT count(1) FROM %s WHERE redis_key = '%s:999'", hashValueTableName, hashValueTableName));
+        MaterializedResult expected = MaterializedResult.resultBuilder(SESSION, BigintType.BIGINT)
+                .row(1L)
+                .build();
+        assertEquals(result, expected);
+
+        result = queryRunner.execute(format("SELECT count(1) FROM %s WHERE redis_key IN ('%s:0', '%s:999')", hashValueTableName, hashValueTableName, hashValueTableName));
+        expected = MaterializedResult.resultBuilder(SESSION, BigintType.BIGINT)
+                .row(2L)
+                .build();
+        assertEquals(result, expected);
+
+        result = queryRunner.execute(format("SELECT count(1) FROM %s WHERE redis_key IN ('%s:0', '%s:999')", hashValueTableName, hashValueTableName, tableName));
+        expected = MaterializedResult.resultBuilder(SESSION, BigintType.BIGINT)
+                .row(1L)
+                .build();
+        assertEquals(result, expected);
+    }
+
+    @Test
+    public void testStringValueWhereClauseHasNoData()
+    {
+        MaterializedResult result = queryRunner.execute(format("SELECT count(1) FROM %s WHERE redis_key = '%s:999'", stringValueTableName, tableName));
+        MaterializedResult expected = MaterializedResult.resultBuilder(SESSION, BigintType.BIGINT)
+                .row(0L)
+                .build();
+        assertEquals(result, expected);
+
+        result = queryRunner.execute(format("SELECT count(1) FROM %s WHERE redis_key IN ('%s:0', '%s:999')", stringValueTableName, tableName, tableName));
+        expected = MaterializedResult.resultBuilder(SESSION, BigintType.BIGINT)
+                .row(0L)
+                .build();
+        assertEquals(result, expected);
+
+        result = queryRunner.execute(format("SELECT count(1) FROM %s WHERE redis_key = '%s:999' AND id = 1", stringValueTableName, stringValueTableName));
+        expected = MaterializedResult.resultBuilder(SESSION, BigintType.BIGINT)
+                .row(0L)
+                .build();
+        assertEquals(result, expected);
+    }
+
+    @Test
+    public void testHashValueWhereClauseHasNoData()
+    {
+        MaterializedResult result = queryRunner.execute(format("SELECT count(1) FROM %s WHERE redis_key = '%s:999'", hashValueTableName, tableName));
+        MaterializedResult expected = MaterializedResult.resultBuilder(SESSION, BigintType.BIGINT)
+                .row(0L)
+                .build();
+        assertEquals(result, expected);
+
+        result = queryRunner.execute(format("SELECT count(1) FROM %s WHERE redis_key IN ('%s:0', '%s:999')", hashValueTableName, tableName, tableName));
+        expected = MaterializedResult.resultBuilder(SESSION, BigintType.BIGINT)
+                .row(0L)
+                .build();
+        assertEquals(result, expected);
+
+        result = queryRunner.execute(format("SELECT count(1) FROM %s WHERE redis_key = '%s:999' AND id = 1", hashValueTableName, hashValueTableName));
+        expected = MaterializedResult.resultBuilder(SESSION, BigintType.BIGINT)
+                .row(0L)
+                .build();
+        assertEquals(result, expected);
+    }
+}

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestMinimalFunctionalityWithoutKeyPrefix.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestMinimalFunctionalityWithoutKeyPrefix.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.redis;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.spi.type.BigintType;
+import io.trino.testing.MaterializedResult;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static io.trino.testing.assertions.Assert.assertEquals;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Test(singleThreaded = true)
+public class TestMinimalFunctionalityWithoutKeyPrefix
+        extends AbstractTestMinimalFunctionality
+{
+    @Override
+    protected Map<String, String> connectorProperties()
+    {
+        return ImmutableMap.of("redis.key-prefix-schema-table", "false");
+    }
+
+    @Test
+    public void testStringValueWhereClauseHasData()
+    {
+        MaterializedResult result = queryRunner.execute(format("SELECT count(1) FROM %s WHERE redis_key IN ('%s:0', '%s:999')", stringValueTableName, stringValueTableName, tableName));
+        MaterializedResult expected = MaterializedResult.resultBuilder(SESSION, BigintType.BIGINT)
+                .row(2L)
+                .build();
+        assertEquals(result, expected);
+
+        result = queryRunner.execute(format("SELECT count(1) FROM %s WHERE redis_key = '%s:999'", stringValueTableName, tableName));
+        expected = MaterializedResult.resultBuilder(SESSION, BigintType.BIGINT)
+                .row(1L)
+                .build();
+        assertEquals(result, expected);
+
+        result = queryRunner.execute(format("SELECT count(1) FROM %s WHERE redis_key IN ('%s:0', '%s:999')", stringValueTableName, tableName, tableName));
+        expected = MaterializedResult.resultBuilder(SESSION, BigintType.BIGINT)
+                .row(2L)
+                .build();
+        assertEquals(result, expected);
+    }
+
+    @Test
+    public void testHashValueWhereClauseHasData()
+    {
+        MaterializedResult result = queryRunner.execute(format("SELECT count(1) FROM %s WHERE redis_key IN ('%s:0', '%s:999')", hashValueTableName, hashValueTableName, hashValueTableName));
+        MaterializedResult expected = MaterializedResult.resultBuilder(SESSION, BigintType.BIGINT)
+                .row(2L)
+                .build();
+        assertEquals(result, expected);
+
+        result = queryRunner.execute(format("SELECT count(1) FROM %s WHERE redis_key = '%s:999'", hashValueTableName, hashValueTableName));
+        expected = MaterializedResult.resultBuilder(SESSION, BigintType.BIGINT)
+                .row(1L)
+                .build();
+        assertEquals(result, expected);
+    }
+
+    @Test
+    public void testHashValueWhereClauseHasNoData()
+    {
+        MaterializedResult result = queryRunner.execute(format("SELECT count(1) FROM %s WHERE redis_key = 'does_not_exist'", hashValueTableName));
+        MaterializedResult expected = MaterializedResult.resultBuilder(SESSION, BigintType.BIGINT)
+                .row(0L)
+                .build();
+        assertEquals(result, expected);
+
+        result = queryRunner.execute(format("SELECT count(1) FROM %s WHERE redis_key = '%s:999' AND id = 1", hashValueTableName, hashValueTableName));
+        expected = MaterializedResult.resultBuilder(SESSION, BigintType.BIGINT)
+                .row(0L)
+                .build();
+        assertEquals(result, expected);
+    }
+
+    @Test
+    public void testHashValueWhereClauseError()
+    {
+        assertThatThrownBy(() -> queryRunner.execute(
+                format("SELECT count(1) FROM %s WHERE redis_key = '%s:999'", hashValueTableName, stringValueTableName)))
+                .hasMessageContaining("WRONGTYPE Operation against a key holding the wrong kind of value");
+    }
+}

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisConnectorTest.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisConnectorTest.java
@@ -15,9 +15,12 @@ package io.trino.plugin.redis;
 
 import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.redis.util.RedisServer;
+import io.trino.sql.planner.plan.FilterNode;
 import io.trino.testing.QueryRunner;
+import org.testng.annotations.Test;
 
 import static io.trino.plugin.redis.RedisQueryRunner.createRedisQueryRunner;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestRedisConnectorTest
         extends BaseRedisConnectorTest
@@ -28,5 +31,44 @@ public class TestRedisConnectorTest
     {
         RedisServer redisServer = closeAfterClass(new RedisServer());
         return createRedisQueryRunner(redisServer, ImmutableMap.of(), ImmutableMap.of(), "string", REQUIRED_TPCH_TABLES);
+    }
+
+    @Test
+    public void testPredicatePushdown()
+    {
+        // redis key equality
+        assertThat(query("SELECT regionkey, nationkey, name FROM tpch.nation WHERE redis_key = 'tpch:nation:19'"))
+                .matches("VALUES (BIGINT '3', BIGINT '19', CAST('ROMANIA' AS varchar(25)))")
+                .isFullyPushedDown();
+
+        // redis key equality
+        assertThat(query("SELECT regionkey, nationkey, name FROM tpch.nation WHERE redis_key = 'tpch:nation:19' AND regionkey = 3"))
+                .matches("VALUES (BIGINT '3', BIGINT '19', CAST('ROMANIA' AS varchar(25)))")
+                .isNotFullyPushedDown(FilterNode.class);
+
+        // redis key equality
+        assertThat(query("SELECT regionkey, nationkey, name FROM tpch.nation WHERE redis_key = 'tpch:nation:19' AND regionkey = 4"))
+                .returnsEmptyResult()
+                .isNotFullyPushedDown(FilterNode.class);
+
+        // redis key different case
+        assertThat(query("SELECT regionkey, nationkey, name FROM nation WHERE redis_key = 'tpch:nation:100'"))
+                .returnsEmptyResult()
+                .isFullyPushedDown();
+
+        // redis key IN case
+        assertThat(query("SELECT regionkey, nationkey, name FROM tpch.nation WHERE redis_key IN ('tpch:nation:19', 'tpch:nation:2', 'tpch:nation:24')"))
+                .matches("VALUES " +
+                        "(BIGINT '3', BIGINT '19', CAST('ROMANIA' AS varchar(25))), " +
+                        "(BIGINT '1', BIGINT '2', CAST('BRAZIL' AS varchar(25))), " +
+                        "(BIGINT '1', BIGINT '24', CAST('UNITED STATES' AS varchar(25)))")
+                .isFullyPushedDown();
+
+        // redis key range
+        assertThat(query("SELECT regionkey, nationkey, name FROM tpch.nation WHERE redis_key BETWEEN 'tpch:nation:23' AND 'tpch:nation:24'"))
+                .matches("VALUES " +
+                        "(BIGINT '3', BIGINT '23', CAST('UNITED KINGDOM' AS varchar(25))), " +
+                        "(BIGINT '1', BIGINT '24', CAST('UNITED STATES' AS varchar(25)))")
+                .isNotFullyPushedDown(FilterNode.class);
     }
 }

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisDistributedHash.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisDistributedHash.java
@@ -15,10 +15,13 @@ package io.trino.plugin.redis;
 
 import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.redis.util.RedisServer;
+import io.trino.sql.planner.plan.FilterNode;
 import io.trino.testing.AbstractTestQueries;
 import io.trino.testing.QueryRunner;
+import org.testng.annotations.Test;
 
 import static io.trino.plugin.redis.RedisQueryRunner.createRedisQueryRunner;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestRedisDistributedHash
         extends AbstractTestQueries
@@ -29,5 +32,44 @@ public class TestRedisDistributedHash
     {
         RedisServer redisServer = closeAfterClass(new RedisServer());
         return createRedisQueryRunner(redisServer, ImmutableMap.of(), ImmutableMap.of(), "hash", REQUIRED_TPCH_TABLES);
+    }
+
+    @Test
+    public void testPredicatePushdown()
+    {
+        // redis key equality
+        assertThat(query("SELECT regionkey, nationkey, name FROM tpch.nation WHERE redis_key = 'tpch:nation:19'"))
+                .matches("VALUES (BIGINT '3', BIGINT '19', CAST('ROMANIA' AS varchar(25)))")
+                .isFullyPushedDown();
+
+        // redis key equality
+        assertThat(query("SELECT regionkey, nationkey, name FROM tpch.nation WHERE redis_key = 'tpch:nation:19' AND regionkey = 3"))
+                .matches("VALUES (BIGINT '3', BIGINT '19', CAST('ROMANIA' AS varchar(25)))")
+                .isNotFullyPushedDown(FilterNode.class);
+
+        // redis key equality
+        assertThat(query("SELECT regionkey, nationkey, name FROM tpch.nation WHERE redis_key = 'tpch:nation:19' AND regionkey = 4"))
+                .returnsEmptyResult()
+                .isNotFullyPushedDown(FilterNode.class);
+
+        // redis key different case
+        assertThat(query("SELECT regionkey, nationkey, name FROM nation WHERE redis_key = 'tpch:nation:100'"))
+                .returnsEmptyResult()
+                .isFullyPushedDown();
+
+        // redis key IN case
+        assertThat(query("SELECT regionkey, nationkey, name FROM tpch.nation WHERE redis_key IN ('tpch:nation:19', 'tpch:nation:2', 'tpch:nation:24')"))
+                .matches("VALUES " +
+                        "(BIGINT '3', BIGINT '19', CAST('ROMANIA' AS varchar(25))), " +
+                        "(BIGINT '1', BIGINT '2', CAST('BRAZIL' AS varchar(25))), " +
+                        "(BIGINT '1', BIGINT '24', CAST('UNITED STATES' AS varchar(25)))")
+                .isFullyPushedDown();
+
+        // redis key range
+        assertThat(query("SELECT regionkey, nationkey, name FROM tpch.nation WHERE redis_key BETWEEN 'tpch:nation:23' AND 'tpch:nation:24'"))
+                .matches("VALUES " +
+                        "(BIGINT '3', BIGINT '23', CAST('UNITED KINGDOM' AS varchar(25))), " +
+                        "(BIGINT '1', BIGINT '24', CAST('UNITED STATES' AS varchar(25)))")
+                .isNotFullyPushedDown(FilterNode.class);
     }
 }

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/util/RedisTestUtils.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/util/RedisTestUtils.java
@@ -76,14 +76,21 @@ public final class RedisTestUtils
         return new AbstractMap.SimpleImmutableEntry<>(schemaTableName, tableDescription);
     }
 
-    public static Map.Entry<SchemaTableName, RedisTableDescription> createEmptyTableDescription(SchemaTableName schemaTableName)
+    public static Map.Entry<SchemaTableName, RedisTableDescription> createTableDescription(RedisTableDescription tableDescription)
     {
-        RedisTableDescription tableDescription = new RedisTableDescription(
-                schemaTableName.getTableName(),
-                schemaTableName.getSchemaName(),
-                null,
-                null);
+        SchemaTableName schemaTableName = new SchemaTableName(
+                tableDescription.getSchemaName(),
+                tableDescription.getTableName());
 
         return new AbstractMap.SimpleImmutableEntry<>(schemaTableName, tableDescription);
+    }
+
+    public static RedisTableDescription loadSimpleTableDescription(QueryRunner queryRunner, String valueDataFormat)
+            throws Exception
+    {
+        JsonCodec<RedisTableDescription> tableDescriptionJsonCodec = new CodecSupplier<>(RedisTableDescription.class, queryRunner.getTypeManager()).get();
+        try (InputStream data = RedisTestUtils.class.getResourceAsStream(format("/simple/%s_value_table.json", valueDataFormat))) {
+            return tableDescriptionJsonCodec.fromJson(ByteStreams.toByteArray(data));
+        }
     }
 }

--- a/plugin/trino-redis/src/test/resources/simple/hash_value_table.json
+++ b/plugin/trino-redis/src/test/resources/simple/hash_value_table.json
@@ -1,0 +1,29 @@
+{
+    "tableName": "hash_value_table",
+    "schemaName": "default",
+    "key": {
+        "dataFormat": "raw",
+        "fields": [
+            {
+                "name": "redis_key",
+                "type": "VARCHAR(64)",
+                "hidden": "true"
+            }
+        ]
+    },
+    "value": {
+        "dataFormat": "hash",
+        "fields": [
+            {
+                "name": "id",
+                "mapping": "id",
+                "type": "BIGINT"
+            },
+            {
+                "name": "value",
+                "mapping": "value",
+                "type": "VARCHAR(36)"
+            }
+        ]
+    }
+}

--- a/plugin/trino-redis/src/test/resources/simple/string_value_table.json
+++ b/plugin/trino-redis/src/test/resources/simple/string_value_table.json
@@ -1,0 +1,29 @@
+{
+    "tableName": "string_value_table",
+    "schemaName": "default",
+    "key": {
+        "dataFormat": "raw",
+        "fields": [
+            {
+                "name": "redis_key",
+                "type": "VARCHAR(64)",
+                "hidden": "true"
+            }
+        ]
+    },
+    "value": {
+        "dataFormat": "json",
+        "fields": [
+            {
+                "name": "id",
+                "mapping": "id",
+                "type": "BIGINT"
+            },
+            {
+                "name": "value",
+                "mapping": "value",
+                "type": "VARCHAR(36)"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## Description
Support Redis key pushdown in Redis connector

## Related issues, pull requests, and links
Fixes https://github.com/trinodb/trino/issues/12218 

## Documentation
(x) Sufficient documentation is included in this PR.

## Release notes
(x) Release notes entries required with the following suggested text:
```markdown
# Redis
* Add support for predicate pushdown for Redis key column on `string` value table. ({issue}`12218`)
```