### PR TITLE
Support quoted identifiers in Iceberg partitioning

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableProperties.java
@@ -21,7 +21,6 @@ import io.trino.spi.type.ArrayType;
 
 import javax.inject.Inject;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -68,9 +67,7 @@ public class IcebergTableProperties
                         List.class,
                         ImmutableList.of(),
                         false,
-                        value -> ((Collection<?>) value).stream()
-                                .map(name -> ((String) name).toLowerCase(ENGLISH))
-                                .collect(toImmutableList()),
+                        value -> (List<?>) value,
                         value -> value))
                 .add(stringProperty(
                         LOCATION_PROPERTY,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionFields.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionFields.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.iceberg;
 
+import io.trino.spi.TrinoException;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -24,24 +25,31 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
 import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
+import static java.util.regex.Pattern.CASE_INSENSITIVE;
 
 public final class PartitionFields
 {
-    private static final String NAME = "[a-zA-Z_][a-zA-Z0-9_]*";
-    private static final String FUNCTION_ARGUMENT_NAME = "\\((" + NAME + ")\\)";
-    private static final String FUNCTION_ARGUMENT_NAME_AND_INT = "\\((" + NAME + "), *(\\d+)\\)";
+    private static final String UNQUOTED_IDENTIFIER = "[a-z_][a-z0-9_]*";
+    private static final String QUOTED_IDENTIFIER = "\"(?:\"\"|[^\"])*\"";
+    public static final String IDENTIFIER = "(" + UNQUOTED_IDENTIFIER + "|" + QUOTED_IDENTIFIER + ")";
+    private static final Pattern UNQUOTED_IDENTIFIER_PATTERN = Pattern.compile(UNQUOTED_IDENTIFIER);
+    private static final Pattern QUOTED_IDENTIFIER_PATTERN = Pattern.compile(QUOTED_IDENTIFIER);
 
-    private static final Pattern IDENTITY_PATTERN = Pattern.compile(NAME);
-    private static final Pattern YEAR_PATTERN = Pattern.compile("(?i:year)" + FUNCTION_ARGUMENT_NAME);
-    private static final Pattern MONTH_PATTERN = Pattern.compile("(?i:month)" + FUNCTION_ARGUMENT_NAME);
-    private static final Pattern DAY_PATTERN = Pattern.compile("(?i:day)" + FUNCTION_ARGUMENT_NAME);
-    private static final Pattern HOUR_PATTERN = Pattern.compile("(?i:hour)" + FUNCTION_ARGUMENT_NAME);
-    private static final Pattern BUCKET_PATTERN = Pattern.compile("(?i:bucket)" + FUNCTION_ARGUMENT_NAME_AND_INT);
-    private static final Pattern TRUNCATE_PATTERN = Pattern.compile("(?i:truncate)" + FUNCTION_ARGUMENT_NAME_AND_INT);
-    private static final Pattern VOID_PATTERN = Pattern.compile("(?i:void)" + FUNCTION_ARGUMENT_NAME);
+    private static final String FUNCTION_ARGUMENT_NAME = "\\(" + IDENTIFIER + "\\)\\s*";
+    private static final String FUNCTION_ARGUMENT_NAME_AND_INT = "\\(" + IDENTIFIER + ",\\s*(\\d+)\\)";
+
+    private static final Pattern IDENTITY_PATTERN = Pattern.compile(IDENTIFIER, CASE_INSENSITIVE);
+    private static final Pattern YEAR_PATTERN = Pattern.compile("year" + FUNCTION_ARGUMENT_NAME, CASE_INSENSITIVE);
+    private static final Pattern MONTH_PATTERN = Pattern.compile("month" + FUNCTION_ARGUMENT_NAME, CASE_INSENSITIVE);
+    private static final Pattern DAY_PATTERN = Pattern.compile("day" + FUNCTION_ARGUMENT_NAME, CASE_INSENSITIVE);
+    private static final Pattern HOUR_PATTERN = Pattern.compile("hour" + FUNCTION_ARGUMENT_NAME, CASE_INSENSITIVE);
+    private static final Pattern BUCKET_PATTERN = Pattern.compile("bucket" + FUNCTION_ARGUMENT_NAME_AND_INT, CASE_INSENSITIVE);
+    private static final Pattern TRUNCATE_PATTERN = Pattern.compile("truncate" + FUNCTION_ARGUMENT_NAME_AND_INT, CASE_INSENSITIVE);
+    private static final Pattern VOID_PATTERN = Pattern.compile("void" + FUNCTION_ARGUMENT_NAME, CASE_INSENSITIVE);
 
     private static final Pattern ICEBERG_BUCKET_PATTERN = Pattern.compile("bucket\\[(\\d+)]");
     private static final Pattern ICEBERG_TRUNCATE_PATTERN = Pattern.compile("truncate\\[(\\d+)]");
@@ -50,33 +58,51 @@ public final class PartitionFields
 
     public static PartitionSpec parsePartitionFields(Schema schema, List<String> fields)
     {
-        PartitionSpec.Builder builder = PartitionSpec.builderFor(schema);
-        for (String field : fields) {
-            parsePartitionField(builder, field);
+        try {
+            PartitionSpec.Builder builder = PartitionSpec.builderFor(schema);
+            for (String field : fields) {
+                parsePartitionField(builder, field);
+            }
+            return builder.build();
         }
-        return builder.build();
+        catch (RuntimeException e) {
+            throw new TrinoException(INVALID_TABLE_PROPERTY, "Unable to parse partitioning value: " + e.getMessage(), e);
+        }
     }
 
     public static void parsePartitionField(PartitionSpec.Builder builder, String field)
     {
         @SuppressWarnings("PointlessBooleanExpression")
         boolean matched = false ||
-                tryMatch(field, IDENTITY_PATTERN, match -> builder.identity(fromIdentifier(match.group()))) ||
-                tryMatch(field, YEAR_PATTERN, match -> builder.year(fromIdentifier(match.group(1)))) ||
-                tryMatch(field, MONTH_PATTERN, match -> builder.month(fromIdentifier(match.group(1)))) ||
-                tryMatch(field, DAY_PATTERN, match -> builder.day(fromIdentifier(match.group(1)))) ||
-                tryMatch(field, HOUR_PATTERN, match -> builder.hour(fromIdentifier(match.group(1)))) ||
-                tryMatch(field, BUCKET_PATTERN, match -> builder.bucket(fromIdentifier(match.group(1)), parseInt(match.group(2)))) ||
-                tryMatch(field, TRUNCATE_PATTERN, match -> builder.truncate(fromIdentifier(match.group(1)), parseInt(match.group(2)))) ||
-                tryMatch(field, VOID_PATTERN, match -> builder.alwaysNull(fromIdentifier(match.group(1)))) ||
+                tryMatch(field, IDENTITY_PATTERN, match -> builder.identity(fromIdentifierToColumn(match.group()))) ||
+                tryMatch(field, YEAR_PATTERN, match -> builder.year(fromIdentifierToColumn(match.group(1)))) ||
+                tryMatch(field, MONTH_PATTERN, match -> builder.month(fromIdentifierToColumn(match.group(1)))) ||
+                tryMatch(field, DAY_PATTERN, match -> builder.day(fromIdentifierToColumn(match.group(1)))) ||
+                tryMatch(field, HOUR_PATTERN, match -> builder.hour(fromIdentifierToColumn(match.group(1)))) ||
+                tryMatch(field, BUCKET_PATTERN, match -> builder.bucket(fromIdentifierToColumn(match.group(1)), parseInt(match.group(2)))) ||
+                tryMatch(field, TRUNCATE_PATTERN, match -> builder.truncate(fromIdentifierToColumn(match.group(1)), parseInt(match.group(2)))) ||
+                tryMatch(field, VOID_PATTERN, match -> builder.alwaysNull(fromIdentifierToColumn(match.group(1)))) ||
                 false;
         if (!matched) {
             throw new IllegalArgumentException("Invalid partition field declaration: " + field);
         }
     }
 
-    private static String fromIdentifier(String identifier)
+    private static String fromIdentifierToColumn(String identifier)
     {
+        if (QUOTED_IDENTIFIER_PATTERN.matcher(identifier).matches()) {
+            // We only support lowercase quoted identifiers for now.
+            // See https://github.com/trinodb/trino/issues/12226#issuecomment-1128839259
+            // TODO: Enhance quoted identifiers support in Iceberg partitioning to support mixed case identifiers
+            //  See https://github.com/trinodb/trino/issues/12668
+            if (!identifier.toLowerCase(ENGLISH).equals(identifier)) {
+                throw new IllegalArgumentException(format("Uppercase characters in identifier '%s' are not supported.", identifier));
+            }
+            return identifier.substring(1, identifier.length() - 1).replace("\"\"", "\"");
+        }
+        // Currently, all Iceberg columns are stored in lowercase in the Iceberg metadata files.
+        // Unquoted identifiers are canonicalized to lowercase here which is not according ANSI SQL spec.
+        // See https://github.com/trinodb/trino/issues/17
         return identifier.toLowerCase(ENGLISH);
     }
 
@@ -99,7 +125,7 @@ public final class PartitionFields
 
     private static String toPartitionField(PartitionSpec spec, PartitionField field)
     {
-        String name = spec.schema().findColumnName(field.sourceId());
+        String name = fromColumnToIdentifier(spec.schema().findColumnName(field.sourceId()));
         String transform = field.transform().toString();
 
         switch (transform) {
@@ -124,5 +150,18 @@ public final class PartitionFields
         }
 
         throw new UnsupportedOperationException("Unsupported partition transform: " + field);
+    }
+
+    private static String fromColumnToIdentifier(String column)
+    {
+        return quotedName(column);
+    }
+
+    private static String quotedName(String name)
+    {
+        if (UNQUOTED_IDENTIFIER_PATTERN.matcher(name).matches()) {
+            return name;
+        }
+        return '"' + name.replace("\"", "\"\"") + '"';
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionFields.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionFields.java
@@ -26,21 +26,22 @@ import java.util.regex.Pattern;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
 
 public final class PartitionFields
 {
-    private static final String NAME = "[a-z_][a-z0-9_]*";
+    private static final String NAME = "[a-zA-Z_][a-zA-Z0-9_]*";
     private static final String FUNCTION_ARGUMENT_NAME = "\\((" + NAME + ")\\)";
     private static final String FUNCTION_ARGUMENT_NAME_AND_INT = "\\((" + NAME + "), *(\\d+)\\)";
 
     private static final Pattern IDENTITY_PATTERN = Pattern.compile(NAME);
-    private static final Pattern YEAR_PATTERN = Pattern.compile("year" + FUNCTION_ARGUMENT_NAME);
-    private static final Pattern MONTH_PATTERN = Pattern.compile("month" + FUNCTION_ARGUMENT_NAME);
-    private static final Pattern DAY_PATTERN = Pattern.compile("day" + FUNCTION_ARGUMENT_NAME);
-    private static final Pattern HOUR_PATTERN = Pattern.compile("hour" + FUNCTION_ARGUMENT_NAME);
-    private static final Pattern BUCKET_PATTERN = Pattern.compile("bucket" + FUNCTION_ARGUMENT_NAME_AND_INT);
-    private static final Pattern TRUNCATE_PATTERN = Pattern.compile("truncate" + FUNCTION_ARGUMENT_NAME_AND_INT);
-    private static final Pattern VOID_PATTERN = Pattern.compile("void" + FUNCTION_ARGUMENT_NAME);
+    private static final Pattern YEAR_PATTERN = Pattern.compile("(?i:year)" + FUNCTION_ARGUMENT_NAME);
+    private static final Pattern MONTH_PATTERN = Pattern.compile("(?i:month)" + FUNCTION_ARGUMENT_NAME);
+    private static final Pattern DAY_PATTERN = Pattern.compile("(?i:day)" + FUNCTION_ARGUMENT_NAME);
+    private static final Pattern HOUR_PATTERN = Pattern.compile("(?i:hour)" + FUNCTION_ARGUMENT_NAME);
+    private static final Pattern BUCKET_PATTERN = Pattern.compile("(?i:bucket)" + FUNCTION_ARGUMENT_NAME_AND_INT);
+    private static final Pattern TRUNCATE_PATTERN = Pattern.compile("(?i:truncate)" + FUNCTION_ARGUMENT_NAME_AND_INT);
+    private static final Pattern VOID_PATTERN = Pattern.compile("(?i:void)" + FUNCTION_ARGUMENT_NAME);
 
     private static final Pattern ICEBERG_BUCKET_PATTERN = Pattern.compile("bucket\\[(\\d+)]");
     private static final Pattern ICEBERG_TRUNCATE_PATTERN = Pattern.compile("truncate\\[(\\d+)]");
@@ -60,18 +61,23 @@ public final class PartitionFields
     {
         @SuppressWarnings("PointlessBooleanExpression")
         boolean matched = false ||
-                tryMatch(field, IDENTITY_PATTERN, match -> builder.identity(match.group())) ||
-                tryMatch(field, YEAR_PATTERN, match -> builder.year(match.group(1))) ||
-                tryMatch(field, MONTH_PATTERN, match -> builder.month(match.group(1))) ||
-                tryMatch(field, DAY_PATTERN, match -> builder.day(match.group(1))) ||
-                tryMatch(field, HOUR_PATTERN, match -> builder.hour(match.group(1))) ||
-                tryMatch(field, BUCKET_PATTERN, match -> builder.bucket(match.group(1), parseInt(match.group(2)))) ||
-                tryMatch(field, TRUNCATE_PATTERN, match -> builder.truncate(match.group(1), parseInt(match.group(2)))) ||
-                tryMatch(field, VOID_PATTERN, match -> builder.alwaysNull(match.group(1))) ||
+                tryMatch(field, IDENTITY_PATTERN, match -> builder.identity(fromIdentifier(match.group()))) ||
+                tryMatch(field, YEAR_PATTERN, match -> builder.year(fromIdentifier(match.group(1)))) ||
+                tryMatch(field, MONTH_PATTERN, match -> builder.month(fromIdentifier(match.group(1)))) ||
+                tryMatch(field, DAY_PATTERN, match -> builder.day(fromIdentifier(match.group(1)))) ||
+                tryMatch(field, HOUR_PATTERN, match -> builder.hour(fromIdentifier(match.group(1)))) ||
+                tryMatch(field, BUCKET_PATTERN, match -> builder.bucket(fromIdentifier(match.group(1)), parseInt(match.group(2)))) ||
+                tryMatch(field, TRUNCATE_PATTERN, match -> builder.truncate(fromIdentifier(match.group(1)), parseInt(match.group(2)))) ||
+                tryMatch(field, VOID_PATTERN, match -> builder.alwaysNull(fromIdentifier(match.group(1)))) ||
                 false;
         if (!matched) {
             throw new IllegalArgumentException("Invalid partition field declaration: " + field);
         }
+    }
+
+    private static String fromIdentifier(String identifier)
+    {
+        return identifier.toLowerCase(ENGLISH);
     }
 
     private static boolean tryMatch(CharSequence value, Pattern pattern, Consumer<MatchResult> match)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestPartitionFields.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestPartitionFields.java
@@ -56,6 +56,17 @@ public class TestPartitionFields
         assertParse("TRuncate(comment, 13)", partitionSpec(builder -> builder.truncate("comment", 13)), "truncate(comment, 13)");
         assertParse("TRUNCATE(order_key, 88)", partitionSpec(builder -> builder.truncate("order_key", 88)), "truncate(order_key, 88)");
         assertParse("VOId(order_key)", partitionSpec(builder -> builder.alwaysNull("order_key")), "void(order_key)");
+        assertParse("\"quoted field\"", partitionSpec(builder -> builder.identity("quoted field")));
+        assertParse("\"\"\"another\"\" \"\"quoted\"\" \"\"field\"\"\"", partitionSpec(builder -> builder.identity("\"another\" \"quoted\" \"field\"")));
+        assertParse("year(\"quoted ts\")", partitionSpec(builder -> builder.year("quoted ts")));
+        assertParse("month(\"quoted ts\")", partitionSpec(builder -> builder.month("quoted ts")));
+        assertParse("day(\"quoted ts\")", partitionSpec(builder -> builder.day("quoted ts")));
+        assertParse("hour(\"quoted ts\")", partitionSpec(builder -> builder.hour("quoted ts")));
+        assertParse("bucket(\"quoted field\", 42)", partitionSpec(builder -> builder.bucket("quoted field", 42)));
+        assertParse("truncate(\"quoted field\", 13)", partitionSpec(builder -> builder.truncate("quoted field", 13)));
+        assertParse("void(\"quoted field\")", partitionSpec(builder -> builder.alwaysNull("quoted field")));
+        assertParse("truncate(\"\"\"another\"\" \"\"quoted\"\" \"\"field\"\"\", 13)", partitionSpec(builder -> builder.truncate("\"another\" \"quoted\" \"field\"", 13)));
+        assertParse("void(\"\"\"another\"\" \"\"quoted\"\" \"\"field\"\"\")", partitionSpec(builder -> builder.alwaysNull("\"another\" \"quoted\" \"field\"")));
 
         assertInvalid("bucket()", "Invalid partition field declaration: bucket()");
         assertInvalid("abc", "Cannot find source column: abc");
@@ -64,8 +75,14 @@ public class TestPartitionFields
         assertInvalid("bucket(notes, 88)", "Cannot bucket by type: list<string>");
         assertInvalid("truncate(ts, 13)", "Cannot truncate type: timestamp");
         assertInvalid("year(order_key)", "Cannot partition type long by year");
+        assertInvalid("\"test\"", "Cannot find source column: test");
+        assertInvalid("\"test with space\"", "Cannot find source column: test with space");
+        assertInvalid("\"test \"with space\"", "Invalid partition field declaration: \"test \"with space\"");
+        assertInvalid("\"test \"\"\"with space\"", "Invalid partition field declaration: \"test \"\"\"with space\"");
         assertInvalid("ABC", "Cannot find source column: abc");
+        assertInvalid("\"ABC\"", "Uppercase characters in identifier '\"ABC\"' are not supported.");
         assertInvalid("year(ABC)", "Cannot find source column: abc");
+        assertInvalid("bucket(\"ABC\", 12)", "Uppercase characters in identifier '\"ABC\"' are not supported.");
     }
 
     private static void assertParse(String value, PartitionSpec expected, String canonicalRepresentation)
@@ -102,7 +119,10 @@ public class TestPartitionFields
                 NestedField.required(2, "ts", TimestampType.withoutZone()),
                 NestedField.required(3, "price", DoubleType.get()),
                 NestedField.optional(4, "comment", StringType.get()),
-                NestedField.optional(5, "notes", ListType.ofRequired(6, StringType.get())));
+                NestedField.optional(5, "notes", ListType.ofRequired(6, StringType.get())),
+                NestedField.optional(7, "quoted field", StringType.get()),
+                NestedField.optional(8, "quoted ts", TimestampType.withoutZone()),
+                NestedField.optional(9, "\"another\" \"quoted\" \"field\"", StringType.get()));
 
         PartitionSpec.Builder builder = PartitionSpec.builderFor(schema);
         consumer.accept(builder);


### PR DESCRIPTION
## Description

Adds support for quoted identifiers in Iceberg partitioning.

Trino Iceberg allows tables to be created using quoted identifiers.

`CREATE TABLE test AS SELECT 1 as "a quoted identifier";`

However when a partitioning property is added these columns can't be declared.

`CREATE TABLE test WITH(partitioning=ARRAY['a quoted identifier']) ...` fails with error `Invalid partition field declaration: a quoted identifier`


> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Change to Iceberg connector

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

resources. For example:
* Fixes #12226

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
