### PR TITLE
Limit maximum number of output partitions for filesystem exchange

### DIFF
--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeConfig.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeConfig.java
@@ -42,6 +42,7 @@ public class FileSystemExchangeConfig
     private int exchangeSinkBuffersPerPartition = 2;
     private DataSize exchangeSinkMaxFileSize = DataSize.of(1, GIGABYTE);
     private int exchangeSourceConcurrentReaders = 4;
+    private int maxOutputPartitionCount = 50;
 
     @NotNull
     @NotEmpty(message = "At least one base directory needs to be configured")
@@ -145,6 +146,19 @@ public class FileSystemExchangeConfig
     public FileSystemExchangeConfig setExchangeSourceConcurrentReaders(int exchangeSourceConcurrentReaders)
     {
         this.exchangeSourceConcurrentReaders = exchangeSourceConcurrentReaders;
+        return this;
+    }
+
+    @Min(1)
+    public int getMaxOutputPartitionCount()
+    {
+        return maxOutputPartitionCount;
+    }
+
+    @Config("exchange.max-output-partition-count")
+    public FileSystemExchangeConfig setMaxOutputPartitionCount(int maxOutputPartitionCount)
+    {
+        this.maxOutputPartitionCount = maxOutputPartitionCount;
         return this;
     }
 }

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeErrorCode.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeErrorCode.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.exchange.filesystem;
+
+import io.trino.spi.ErrorCode;
+import io.trino.spi.ErrorCodeSupplier;
+import io.trino.spi.ErrorType;
+
+import static io.trino.spi.ErrorType.USER_ERROR;
+
+public enum FileSystemExchangeErrorCode
+        implements ErrorCodeSupplier
+{
+    MAX_OUTPUT_PARTITION_COUNT_EXCEEDED(0, USER_ERROR),
+    /**/;
+
+    private final ErrorCode errorCode;
+
+    FileSystemExchangeErrorCode(int code, ErrorType type)
+    {
+        errorCode = new ErrorCode(code + 0x0510_0000, name(), type);
+    }
+
+    @Override
+    public ErrorCode toErrorCode()
+    {
+        return errorCode;
+    }
+}

--- a/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/TestFileSystemExchangeConfig.java
+++ b/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/TestFileSystemExchangeConfig.java
@@ -37,7 +37,8 @@ public class TestFileSystemExchangeConfig
                 .setExchangeSinkBufferPoolMinSize(10)
                 .setExchangeSinkBuffersPerPartition(2)
                 .setExchangeSinkMaxFileSize(DataSize.of(1, GIGABYTE))
-                .setExchangeSourceConcurrentReaders(4));
+                .setExchangeSourceConcurrentReaders(4)
+                .setMaxOutputPartitionCount(50));
     }
 
     @Test
@@ -51,6 +52,7 @@ public class TestFileSystemExchangeConfig
                 .put("exchange.sink-buffers-per-partition", "3")
                 .put("exchange.sink-max-file-size", "2GB")
                 .put("exchange.source-concurrent-readers", "10")
+                .put("exchange.max-output-partition-count", "53")
                 .buildOrThrow();
 
         FileSystemExchangeConfig expected = new FileSystemExchangeConfig()
@@ -60,7 +62,8 @@ public class TestFileSystemExchangeConfig
                 .setExchangeSinkBufferPoolMinSize(20)
                 .setExchangeSinkBuffersPerPartition(3)
                 .setExchangeSinkMaxFileSize(DataSize.of(2, GIGABYTE))
-                .setExchangeSourceConcurrentReaders(10);
+                .setExchangeSourceConcurrentReaders(10)
+                .setMaxOutputPartitionCount(53);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

File system exchange is not designed to scale beyond 50 output partitions. An explicit enforcement is needed to avoid the exchange subsystem being unstable if not configured properly.  

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Exchange

> How would you describe this change to a non-technical end user or system administrator?

When trying to use `Tardigrade` with the `query.hash-partition-count` configuration property (or  the `hash_partition_count` session property) set to a value higher than 50 users will see an error message (`Max number of output partitions exceeded for exchange`). Before this change when supported number of output partitions was exceeded cluster could be unstable. 

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

`-`

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
