### PR TITLE
Don't drop destination table when non-transactional insert fails

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcOutputTableHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcOutputTableHandle.java
@@ -39,7 +39,7 @@ public class JdbcOutputTableHandle
     private final List<String> columnNames;
     private final List<Type> columnTypes;
     private final Optional<List<JdbcTypeHandle>> jdbcColumnTypes;
-    private final String temporaryTableName;
+    private final Optional<String> temporaryTableName;
 
     @JsonCreator
     public JdbcOutputTableHandle(
@@ -49,7 +49,7 @@ public class JdbcOutputTableHandle
             @JsonProperty("columnNames") List<String> columnNames,
             @JsonProperty("columnTypes") List<Type> columnTypes,
             @JsonProperty("jdbcColumnTypes") Optional<List<JdbcTypeHandle>> jdbcColumnTypes,
-            @JsonProperty("temporaryTableName") String temporaryTableName)
+            @JsonProperty("temporaryTableName") Optional<String> temporaryTableName)
     {
         this.catalogName = catalogName;
         this.schemaName = schemaName;
@@ -105,7 +105,7 @@ public class JdbcOutputTableHandle
     }
 
     @JsonProperty
-    public String getTemporaryTableName()
+    public Optional<String> getTemporaryTableName()
     {
         return temporaryTableName;
     }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcOutputTableHandle.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcOutputTableHandle.java
@@ -35,7 +35,7 @@ public class TestJdbcOutputTableHandle
                 ImmutableList.of("abc", "xyz"),
                 ImmutableList.of(VARCHAR, VARCHAR),
                 Optional.empty(),
-                "tmp_table");
+                Optional.of("tmp_table"));
 
         assertJsonRoundTrip(OUTPUT_TABLE_CODEC, handleForCreate);
 
@@ -46,7 +46,7 @@ public class TestJdbcOutputTableHandle
                 ImmutableList.of("abc", "xyz"),
                 ImmutableList.of(VARCHAR, VARCHAR),
                 Optional.of(ImmutableList.of(JDBC_VARCHAR, JDBC_VARCHAR)),
-                "tmp_table");
+                Optional.of("tmp_table"));
 
         assertJsonRoundTrip(OUTPUT_TABLE_CODEC, handleForInsert);
     }

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixOutputTableHandle.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixOutputTableHandle.java
@@ -40,7 +40,7 @@ public class PhoenixOutputTableHandle
             @JsonProperty("jdbcColumnTypes") Optional<List<JdbcTypeHandle>> jdbcColumnTypes,
             @JsonProperty("rowkeyColumn") Optional<String> rowkeyColumn)
     {
-        super("", schemaName, tableName, columnNames, columnTypes, jdbcColumnTypes, "");
+        super("", schemaName, tableName, columnNames, columnTypes, jdbcColumnTypes, Optional.empty());
         this.rowkeyColumn = requireNonNull(rowkeyColumn, "rowkeyColumn is null");
     }
 

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixOutputTableHandle.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixOutputTableHandle.java
@@ -40,7 +40,7 @@ public class PhoenixOutputTableHandle
             @JsonProperty("jdbcColumnTypes") Optional<List<JdbcTypeHandle>> jdbcColumnTypes,
             @JsonProperty("rowkeyColumn") Optional<String> rowkeyColumn)
     {
-        super("", schemaName, tableName, columnNames, columnTypes, jdbcColumnTypes, "");
+        super("", schemaName, tableName, columnNames, columnTypes, jdbcColumnTypes, Optional.empty());
         this.rowkeyColumn = requireNonNull(rowkeyColumn, "rowkeyColumn is null");
     }
 

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
@@ -260,7 +260,7 @@ public class SqlServerClient
             // 'table lock on bulk load' table option causes the bulk load processes on user-defined tables to obtain a bulk update lock
             // note: this is not a request to lock a table immediately
             String sql = format("EXEC sp_tableoption '%s', 'table lock on bulk load', '1'",
-                    quoted(table.getCatalogName(), table.getSchemaName(), table.getTemporaryTableName()));
+                    quoted(table.getCatalogName(), table.getSchemaName(), table.getTemporaryTableName().orElseGet(table::getTableName)));
             execute(connection, sql);
         }
         catch (SQLException e) {


### PR DESCRIPTION
## Description
See #12225

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Most JDBC connectors will have this issue. Verified with Postgres.

> How would you describe this change to a non-technical end user or system administrator?

Trino will happily drop your entire table if it encounters an error during a non-transactional insert.
This is a pretty SERIOUS issue.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->
Fixes #12225

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
