### PR TITLE
Fix NPE assertions on JDK17 for MemSQL negative date test

### DIFF
--- a/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/TestSingleStoreConnectorTest.java
+++ b/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/TestSingleStoreConnectorTest.java
@@ -313,9 +313,7 @@ public class TestSingleStoreConnectorTest
     {
         // TODO (https://github.com/trinodb/trino/issues/10320) SingleStore stores '0000-00-00' when inserted negative dates and it throws an exception during reading the row
         assertThatThrownBy(super::testCreateTableAsSelectNegativeDate)
-                .hasCauseInstanceOf(RuntimeException.class)
-                .hasStackTraceContaining("JDBC_ERROR")
-                .hasStackTraceContaining("JdbcRecordCursor.getLong");
+                .hasStackTraceContaining("TrinoException: Driver returned null LocalDate for a non-null value");
     }
 
     @Test
@@ -324,9 +322,7 @@ public class TestSingleStoreConnectorTest
     {
         // TODO (https://github.com/trinodb/trino/issues/10320) SingleStore stores '0000-00-00' when inserted negative dates and it throws an exception during reading the row
         assertThatThrownBy(super::testInsertNegativeDate)
-                .hasCauseInstanceOf(RuntimeException.class)
-                .hasStackTraceContaining("JDBC_ERROR")
-                .hasStackTraceContaining("JdbcRecordCursor.getLong");
+                .hasStackTraceContaining("TrinoException: Driver returned null LocalDate for a non-null value");
     }
 
     /**


### PR DESCRIPTION
JDK17 have more meaningfull NPE exception messages. This break assertions for negative date tests in Singlestore/MemSQL connector