### PR TITLE
Add support for partition filtering based on column transforms to Hive connector

### DIFF
--- a/plugin/trino-hive-hidden-partitioning/pom.xml
+++ b/plugin/trino-hive-hidden-partitioning/pom.xml
@@ -1,0 +1,248 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.trino</groupId>
+        <artifactId>trino-root</artifactId>
+        <version>380-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>trino-hive-hidden-partitioning</artifactId>
+    <description>Hive connector with hidden partitioning for Trino</description>
+    <packaging>trino-plugin</packaging>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-hive</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-plugin-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino.hadoop</groupId>
+            <artifactId>hadoop-apache</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino.hive</groupId>
+            <artifactId>hive-apache</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>concurrent</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>event</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-api</artifactId>
+            <version>0.11.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.weakref</groupId>
+            <artifactId>jmxutils</artifactId>
+        </dependency>
+
+        <!-- used by tests but also needed transitively -->
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log-manager</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Trino SPI -->
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jol</groupId>
+            <artifactId>jol-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- for testing -->
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-benchmark</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-hive</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-parser</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-spi</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino.tpch</groupId>
+            <artifactId>tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningConfig.java
+++ b/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hidden.partitioning;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+
+public class HiddenPartitioningConfig
+{
+    private boolean partitionSpecEnabled;
+
+    @Config("hive.partition-spec-enabled")
+    @ConfigDescription("Use partition spec if defined in table properties")
+    public HiddenPartitioningConfig setPartitionSpecEnabled(boolean partitionSpecEnabled)
+    {
+        this.partitionSpecEnabled = partitionSpecEnabled;
+        return this;
+    }
+
+    public boolean isPartitionSpecEnabled()
+    {
+        return partitionSpecEnabled;
+    }
+}

--- a/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningConnectorFactory.java
+++ b/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningConnectorFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hidden.partitioning;
+
+import com.google.inject.Module;
+import io.trino.plugin.hive.HiveConnectorFactory;
+import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorContext;
+import io.trino.spi.connector.ConnectorFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.base.Throwables.throwIfUnchecked;
+import static java.util.Objects.requireNonNull;
+
+public class HiddenPartitioningConnectorFactory
+        implements ConnectorFactory
+{
+    private final String name;
+    private final Class<? extends Module> module;
+
+    public HiddenPartitioningConnectorFactory(String name)
+    {
+        this(name, HiveConnectorFactory.EmptyModule.class);
+    }
+
+    public HiddenPartitioningConnectorFactory(String name, Class<? extends Module> module)
+    {
+        checkArgument(!isNullOrEmpty(name), "name is null or empty");
+        this.name = name;
+        this.module = requireNonNull(module, "module is null");
+    }
+
+    @Override
+    public String getName()
+    {
+        return name;
+    }
+
+    @Override
+    public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
+    {
+        ClassLoader classLoader = context.duplicatePluginClassLoader();
+        try {
+            Object moduleInstance = classLoader.loadClass(module.getName()).getConstructor().newInstance();
+            Class<?> moduleClass = classLoader.loadClass(Module.class.getName());
+            return (Connector) classLoader.loadClass(HiddenPartitioningInternalConnectorFactory.class.getName())
+                    .getMethod("createConnector", String.class, Map.class, ConnectorContext.class, moduleClass)
+                    .invoke(null, catalogName, config, context, moduleInstance);
+        }
+        catch (InvocationTargetException e) {
+            Throwable targetException = e.getTargetException();
+            throwIfUnchecked(targetException);
+            throw new RuntimeException(targetException);
+        }
+        catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningExpressionConverter.java
+++ b/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningExpressionConverter.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hidden.partitioning;
+
+import com.google.common.base.VerifyException;
+import io.airlift.slice.Slice;
+import io.trino.plugin.hive.HiveColumnHandle;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
+import io.trino.spi.predicate.SortedRangeSet;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.BigintType;
+import io.trino.spi.type.BooleanType;
+import io.trino.spi.type.DateType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Decimals;
+import io.trino.spi.type.DoubleType;
+import io.trino.spi.type.Int128;
+import io.trino.spi.type.IntegerType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RealType;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.UuidType;
+import io.trino.spi.type.VarbinaryType;
+import io.trino.spi.type.VarcharType;
+import org.apache.iceberg.expressions.Expression;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static io.trino.spi.type.TimeType.TIME_MICROS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
+import static io.trino.spi.type.UuidType.trinoUuidToJavaUuid;
+import static java.lang.Float.intBitsToFloat;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+import static org.apache.iceberg.expressions.Expressions.alwaysFalse;
+import static org.apache.iceberg.expressions.Expressions.alwaysTrue;
+import static org.apache.iceberg.expressions.Expressions.and;
+import static org.apache.iceberg.expressions.Expressions.equal;
+import static org.apache.iceberg.expressions.Expressions.greaterThan;
+import static org.apache.iceberg.expressions.Expressions.greaterThanOrEqual;
+import static org.apache.iceberg.expressions.Expressions.isNull;
+import static org.apache.iceberg.expressions.Expressions.lessThan;
+import static org.apache.iceberg.expressions.Expressions.lessThanOrEqual;
+import static org.apache.iceberg.expressions.Expressions.not;
+import static org.apache.iceberg.expressions.Expressions.or;
+
+/**
+ * Adapted from Iceberg connector's {@code io.trino.plugin.iceberg.ExpressionConverter}
+ */
+public final class HiddenPartitioningExpressionConverter
+{
+    private HiddenPartitioningExpressionConverter() {}
+
+    public static Expression toIcebergExpression(TupleDomain<HiveColumnHandle> tupleDomain)
+    {
+        if (tupleDomain.isAll()) {
+            return alwaysTrue();
+        }
+        if (tupleDomain.getDomains().isEmpty()) {
+            return alwaysFalse();
+        }
+        Map<HiveColumnHandle, Domain> domainMap = tupleDomain.getDomains().get();
+        Expression expression = alwaysTrue();
+        for (Map.Entry<HiveColumnHandle, Domain> entry : domainMap.entrySet()) {
+            HiveColumnHandle columnHandle = entry.getKey();
+            Domain domain = entry.getValue();
+            expression = and(expression, toIcebergExpression(columnHandle.getName(), columnHandle.getType(), domain));
+        }
+        return expression;
+    }
+
+    private static Expression toIcebergExpression(String columnName, Type type, Domain domain)
+    {
+        if (domain.isAll()) {
+            return alwaysTrue();
+        }
+        if (domain.getValues().isNone()) {
+            return domain.isNullAllowed() ? isNull(columnName) : alwaysFalse();
+        }
+
+        if (domain.getValues().isAll()) {
+            return domain.isNullAllowed() ? alwaysTrue() : not(isNull(columnName));
+        }
+
+        // Skip structural types. TODO: Evaluate Apache Iceberg's support for predicate on structural types
+        if (type instanceof ArrayType || type instanceof MapType || type instanceof RowType) {
+            return alwaysTrue();
+        }
+
+        ValueSet domainValues = domain.getValues();
+        Expression expression = null;
+        if (domain.isNullAllowed()) {
+            expression = isNull(columnName);
+        }
+
+        if (domainValues instanceof SortedRangeSet) {
+            List<Range> orderedRanges = ((SortedRangeSet) domainValues).getOrderedRanges();
+            expression = firstNonNull(expression, alwaysFalse());
+
+            for (Range range : orderedRanges) {
+                expression = or(expression, toIcebergExpression(columnName, range));
+            }
+            return expression;
+        }
+
+        throw new VerifyException("Did not expect a domain value set other than SortedRangeSet but got " + domainValues.getClass().getSimpleName());
+    }
+
+    private static Expression toIcebergExpression(String columnName, Range range)
+    {
+        Type type = range.getType();
+
+        if (range.isSingleValue()) {
+            Object icebergValue = getIcebergLiteralValue(type, range.getSingleValue());
+            return equal(columnName, icebergValue);
+        }
+
+        Expression lowBound;
+        if (range.isLowUnbounded()) {
+            lowBound = alwaysTrue();
+        }
+        else {
+            Object icebergLow = getIcebergLiteralValue(type, range.getLowBoundedValue());
+            if (range.isLowInclusive()) {
+                lowBound = greaterThanOrEqual(columnName, icebergLow);
+            }
+            else {
+                lowBound = greaterThan(columnName, icebergLow);
+            }
+        }
+
+        Expression highBound;
+        if (range.isHighUnbounded()) {
+            highBound = alwaysTrue();
+        }
+        else {
+            Object icebergHigh = getIcebergLiteralValue(type, range.getHighBoundedValue());
+            if (range.isHighInclusive()) {
+                highBound = lessThanOrEqual(columnName, icebergHigh);
+            }
+            else {
+                highBound = lessThan(columnName, icebergHigh);
+            }
+        }
+
+        return and(lowBound, highBound);
+    }
+
+    private static Object getIcebergLiteralValue(Type type, Object trinoNativeValue)
+    {
+        requireNonNull(trinoNativeValue, "trinoNativeValue is null");
+
+        if (type instanceof BooleanType) {
+            return (boolean) trinoNativeValue;
+        }
+
+        if (type instanceof IntegerType) {
+            return toIntExact((long) trinoNativeValue);
+        }
+
+        if (type instanceof BigintType) {
+            return (long) trinoNativeValue;
+        }
+
+        if (type instanceof RealType) {
+            return intBitsToFloat(toIntExact((long) trinoNativeValue));
+        }
+
+        if (type instanceof DoubleType) {
+            return (double) trinoNativeValue;
+        }
+
+        if (type instanceof DateType) {
+            return toIntExact(((Long) trinoNativeValue));
+        }
+
+        if (type.equals(TIME_MICROS)) {
+            return ((long) trinoNativeValue) / PICOSECONDS_PER_MICROSECOND;
+        }
+
+        if (type.equals(TIMESTAMP_MICROS)) {
+            return (long) trinoNativeValue;
+        }
+
+        if (type instanceof VarcharType) {
+            return ((Slice) trinoNativeValue).toStringUtf8();
+        }
+
+        if (type instanceof VarbinaryType) {
+            return ByteBuffer.wrap(((Slice) trinoNativeValue).getBytes());
+        }
+
+        if (type instanceof UuidType) {
+            return trinoUuidToJavaUuid(((Slice) trinoNativeValue));
+        }
+
+        if (type instanceof DecimalType) {
+            DecimalType decimalType = (DecimalType) type;
+            if (Decimals.isShortDecimal(decimalType)) {
+                return BigDecimal.valueOf((long) trinoNativeValue).movePointLeft(decimalType.getScale());
+            }
+            return new BigDecimal(((Int128) trinoNativeValue).toBigInteger(), decimalType.getScale());
+        }
+
+        if (type instanceof TimestampType) {
+            return (long) trinoNativeValue;
+        }
+
+        throw new UnsupportedOperationException("Unsupported type: " + type);
+    }
+}

--- a/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningHiveMetadata.java
+++ b/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningHiveMetadata.java
@@ -1,0 +1,952 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hidden.partitioning;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import io.airlift.json.JsonCodec;
+import io.trino.plugin.base.CatalogName;
+import io.trino.plugin.hive.HdfsEnvironment;
+import io.trino.plugin.hive.HiveBasicStatistics;
+import io.trino.plugin.hive.HiveBucketProperty;
+import io.trino.plugin.hive.HiveColumnHandle;
+import io.trino.plugin.hive.HiveMaterializedViewMetadata;
+import io.trino.plugin.hive.HiveMetadata;
+import io.trino.plugin.hive.HiveOutputTableHandle;
+import io.trino.plugin.hive.HivePartitionManager;
+import io.trino.plugin.hive.HivePartitionResult;
+import io.trino.plugin.hive.HiveRedirectionsProvider;
+import io.trino.plugin.hive.HiveSessionProperties;
+import io.trino.plugin.hive.HiveStorageFormat;
+import io.trino.plugin.hive.HiveTableHandle;
+import io.trino.plugin.hive.HiveTableRedirectionsProvider;
+import io.trino.plugin.hive.HiveType;
+import io.trino.plugin.hive.LocationHandle;
+import io.trino.plugin.hive.LocationService;
+import io.trino.plugin.hive.PartitionStatistics;
+import io.trino.plugin.hive.PartitionUpdate;
+import io.trino.plugin.hive.SystemTableProvider;
+import io.trino.plugin.hive.fs.DirectoryLister;
+import io.trino.plugin.hive.metastore.Column;
+import io.trino.plugin.hive.metastore.PrincipalPrivileges;
+import io.trino.plugin.hive.metastore.SemiTransactionalHiveMetastore;
+import io.trino.plugin.hive.metastore.SortingColumn;
+import io.trino.plugin.hive.metastore.StorageFormat;
+import io.trino.plugin.hive.metastore.Table;
+import io.trino.plugin.hive.security.AccessControlMetadata;
+import io.trino.plugin.hive.statistics.HiveStatisticsProvider;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorOutputTableHandle;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTableLayout;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.Constraint;
+import io.trino.spi.connector.ConstraintApplicationResult;
+import io.trino.spi.connector.MetadataProvider;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.TableNotFoundException;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeManager;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.TableType;
+import org.apache.hadoop.hive.serde.serdeConstants;
+import org.apache.hadoop.hive.serde2.OpenCSVSerde;
+import org.apache.iceberg.PartitionSpec;
+import org.joda.time.DateTimeZone;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.concat;
+import static io.trino.plugin.hidden.partitioning.HiddenPartitioningSessionProperties.isPartitionSpecEnabled;
+import static io.trino.plugin.hidden.partitioning.HiddenPartitioningSpecParser.validateSpecJson;
+import static io.trino.plugin.hidden.partitioning.HiddenPartitioningTableProperties.PARTITION_SPEC_PROPERTY;
+import static io.trino.plugin.hidden.partitioning.HiddenPartitioningTableProperties.getPartitionSpecJson;
+import static io.trino.plugin.hidden.partitioning.HiddenPartitioningUtil.toIcebergPartitionSpec;
+import static io.trino.plugin.hidden.partitioning.HiddenPartitioningUtil.transformFilteredPartitionResult;
+import static io.trino.plugin.hive.HiveBasicStatistics.createEmptyStatistics;
+import static io.trino.plugin.hive.HiveBasicStatistics.createZeroStatistics;
+import static io.trino.plugin.hive.HiveColumnHandle.BUCKET_COLUMN_NAME;
+import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
+import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.SYNTHESIZED;
+import static io.trino.plugin.hive.HiveColumnHandle.FILE_MODIFIED_TIME_COLUMN_NAME;
+import static io.trino.plugin.hive.HiveColumnHandle.FILE_SIZE_COLUMN_NAME;
+import static io.trino.plugin.hive.HiveColumnHandle.PARTITION_COLUMN_NAME;
+import static io.trino.plugin.hive.HiveColumnHandle.PATH_COLUMN_NAME;
+import static io.trino.plugin.hive.HiveErrorCode.HIVE_COLUMN_ORDER_MISMATCH;
+import static io.trino.plugin.hive.HiveErrorCode.HIVE_INVALID_METADATA;
+import static io.trino.plugin.hive.HiveErrorCode.HIVE_TIMEZONE_MISMATCH;
+import static io.trino.plugin.hive.HiveErrorCode.HIVE_UNSUPPORTED_FORMAT;
+import static io.trino.plugin.hive.HiveSessionProperties.getTimestampPrecision;
+import static io.trino.plugin.hive.HiveSessionProperties.isRespectTableFormat;
+import static io.trino.plugin.hive.HiveTableProperties.ANALYZE_COLUMNS_PROPERTY;
+import static io.trino.plugin.hive.HiveTableProperties.AVRO_SCHEMA_URL;
+import static io.trino.plugin.hive.HiveTableProperties.BUCKETED_BY_PROPERTY;
+import static io.trino.plugin.hive.HiveTableProperties.BUCKET_COUNT_PROPERTY;
+import static io.trino.plugin.hive.HiveTableProperties.CSV_ESCAPE;
+import static io.trino.plugin.hive.HiveTableProperties.CSV_QUOTE;
+import static io.trino.plugin.hive.HiveTableProperties.CSV_SEPARATOR;
+import static io.trino.plugin.hive.HiveTableProperties.EXTERNAL_LOCATION_PROPERTY;
+import static io.trino.plugin.hive.HiveTableProperties.ORC_BLOOM_FILTER_COLUMNS;
+import static io.trino.plugin.hive.HiveTableProperties.ORC_BLOOM_FILTER_FPP;
+import static io.trino.plugin.hive.HiveTableProperties.PARTITIONED_BY_PROPERTY;
+import static io.trino.plugin.hive.HiveTableProperties.SKIP_FOOTER_LINE_COUNT;
+import static io.trino.plugin.hive.HiveTableProperties.SKIP_HEADER_LINE_COUNT;
+import static io.trino.plugin.hive.HiveTableProperties.SORTED_BY_PROPERTY;
+import static io.trino.plugin.hive.HiveTableProperties.STORAGE_FORMAT_PROPERTY;
+import static io.trino.plugin.hive.HiveTableProperties.TEXTFILE_FIELD_SEPARATOR;
+import static io.trino.plugin.hive.HiveTableProperties.TEXTFILE_FIELD_SEPARATOR_ESCAPE;
+import static io.trino.plugin.hive.HiveTableProperties.getAvroSchemaUrl;
+import static io.trino.plugin.hive.HiveTableProperties.getBucketProperty;
+import static io.trino.plugin.hive.HiveTableProperties.getExternalLocation;
+import static io.trino.plugin.hive.HiveTableProperties.getFooterSkipCount;
+import static io.trino.plugin.hive.HiveTableProperties.getHeaderSkipCount;
+import static io.trino.plugin.hive.HiveTableProperties.getHiveStorageFormat;
+import static io.trino.plugin.hive.HiveTableProperties.getOrcBloomFilterColumns;
+import static io.trino.plugin.hive.HiveTableProperties.getOrcBloomFilterFpp;
+import static io.trino.plugin.hive.HiveTableProperties.getPartitionedBy;
+import static io.trino.plugin.hive.HiveTableProperties.getSingleCharacterProperty;
+import static io.trino.plugin.hive.HiveType.toHiveType;
+import static io.trino.plugin.hive.acid.AcidTransaction.NO_ACID_TRANSACTION;
+import static io.trino.plugin.hive.metastore.MetastoreUtil.buildInitialPrivilegeSet;
+import static io.trino.plugin.hive.metastore.StorageFormat.fromHiveStorageFormat;
+import static io.trino.plugin.hive.util.HiveUtil.columnExtraInfo;
+import static io.trino.plugin.hive.util.HiveUtil.hiveColumnHandles;
+import static io.trino.plugin.hive.util.HiveUtil.verifyPartitionTypeSupported;
+import static io.trino.plugin.hive.util.HiveWriteUtils.isS3FileSystem;
+import static io.trino.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static java.lang.String.format;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+import static org.apache.hadoop.hive.metastore.TableType.EXTERNAL_TABLE;
+import static org.apache.hadoop.hive.metastore.TableType.MANAGED_TABLE;
+
+public class HiddenPartitioningHiveMetadata
+        extends HiveMetadata
+{
+    public static final String PARTITION_SPEC_KEY = "trino_partition_spec";
+
+    private static final String TRANSACTIONAL = "transactional";
+
+    private static final String ORC_BLOOM_FILTER_COLUMNS_KEY = "orc.bloom.filter.columns";
+    private static final String ORC_BLOOM_FILTER_FPP_KEY = "orc.bloom.filter.fpp";
+
+    private static final String TEXT_FIELD_SEPARATOR_KEY = serdeConstants.FIELD_DELIM;
+    private static final String TEXT_FIELD_SEPARATOR_ESCAPE_KEY = serdeConstants.ESCAPE_CHAR;
+
+    private static final String CSV_SEPARATOR_KEY = OpenCSVSerde.SEPARATORCHAR;
+    private static final String CSV_QUOTE_KEY = OpenCSVSerde.QUOTECHAR;
+    private static final String CSV_ESCAPE_KEY = OpenCSVSerde.ESCAPECHAR;
+
+    private final SemiTransactionalHiveMetastore metastore;
+    private final HdfsEnvironment hdfsEnvironment;
+    private final HivePartitionManager partitionManager;
+    private final DateTimeZone timeZone;
+    private final boolean writesToNonManagedTablesEnabled;
+    private final boolean createsOfNonManagedTablesEnabled;
+    private final boolean translateHiveViews;
+    private final TypeManager typeManager;
+    private final LocationService locationService;
+    private final String prestoVersion;
+
+    public HiddenPartitioningHiveMetadata(
+            CatalogName catalogName,
+            SemiTransactionalHiveMetastore metastore,
+            HdfsEnvironment hdfsEnvironment,
+            HivePartitionManager partitionManager,
+            DateTimeZone timeZone,
+            boolean writesToNonManagedTablesEnabled,
+            boolean createsOfNonManagedTablesEnabled,
+            boolean hideDeltaLakeTables,
+            boolean translateHiveViews,
+            TypeManager typeManager,
+            MetadataProvider metadataProvider,
+            LocationService locationService,
+            JsonCodec<PartitionUpdate> partitionUpdateCodec,
+            String trinoVersion,
+            HiveStatisticsProvider hiveStatisticsProvider,
+            HiveRedirectionsProvider hiveRedirectionsProvider,
+            Set<SystemTableProvider> systemTableProviders,
+            HiveMaterializedViewMetadata hiveMaterializedViewMetadata,
+            AccessControlMetadata accessControlMetadata,
+            HiveTableRedirectionsProvider hiveTableRedirectionsProvider,
+            boolean autocommit,
+            DirectoryLister directoryLister)
+    {
+        super(
+                catalogName,
+                metastore,
+                autocommit,
+                hdfsEnvironment,
+                partitionManager,
+                writesToNonManagedTablesEnabled,
+                createsOfNonManagedTablesEnabled,
+                translateHiveViews,
+                hideDeltaLakeTables,
+                typeManager,
+                metadataProvider,
+                locationService,
+                partitionUpdateCodec,
+                trinoVersion,
+                hiveStatisticsProvider,
+                hiveRedirectionsProvider,
+                systemTableProviders,
+                hiveMaterializedViewMetadata,
+                accessControlMetadata,
+                hiveTableRedirectionsProvider,
+                directoryLister);
+        this.metastore = metastore;
+        this.hdfsEnvironment = hdfsEnvironment;
+        this.partitionManager = partitionManager;
+        this.timeZone = timeZone;
+        this.writesToNonManagedTablesEnabled = writesToNonManagedTablesEnabled;
+        this.createsOfNonManagedTablesEnabled = createsOfNonManagedTablesEnabled;
+        this.translateHiveViews = translateHiveViews;
+        this.typeManager = typeManager;
+        this.locationService = locationService;
+        this.prestoVersion = trinoVersion;
+    }
+
+    @Override
+    public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        HiveTableHandle hiveTableHandle = (HiveTableHandle) tableHandle;
+        ConnectorTableMetadata tableMetadata = getTableMetadata(session, hiveTableHandle.getSchemaTableName());
+
+        return hiveTableHandle.getAnalyzeColumnNames()
+                .map(columnNames -> new ConnectorTableMetadata(
+                        tableMetadata.getTable(),
+                        tableMetadata.getColumns(),
+                        ImmutableMap.<String, Object>builder()
+                                .putAll(tableMetadata.getProperties())
+                                // we use table properties as a vehicle to pass to the analyzer the subset of columns to be analyzed
+                                .put(ANALYZE_COLUMNS_PROPERTY, columnNames)
+                                .buildOrThrow(),
+                        tableMetadata.getComment()))
+                .orElse(tableMetadata);
+    }
+
+    @Override
+    public void createTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, boolean ignoreExisting)
+    {
+        SchemaTableName schemaTableName = tableMetadata.getTable();
+        String schemaName = schemaTableName.getSchemaName();
+        String tableName = schemaTableName.getTableName();
+        List<String> partitionedBy = getPartitionedBy(tableMetadata.getProperties());
+        Optional<HiveBucketProperty> bucketProperty = getBucketProperty(tableMetadata.getProperties());
+
+        if ((bucketProperty.isPresent() || !partitionedBy.isEmpty()) && getAvroSchemaUrl(tableMetadata.getProperties()) != null) {
+            throw new TrinoException(NOT_SUPPORTED, "Bucketing/Partitioning columns not supported when Avro schema url is set");
+        }
+
+        List<HiveColumnHandle> columnHandles = getColumnHandles(tableMetadata, ImmutableSet.copyOf(partitionedBy));
+        HiveStorageFormat hiveStorageFormat = getHiveStorageFormat(tableMetadata.getProperties());
+        Map<String, String> tableProperties = getEmptyTableProperties(tableMetadata, bucketProperty, new HdfsEnvironment.HdfsContext(session));
+
+        hiveStorageFormat.validateColumns(columnHandles);
+
+        Map<String, HiveColumnHandle> columnHandlesByName = Maps.uniqueIndex(columnHandles, HiveColumnHandle::getName);
+        List<Column> partitionColumns = partitionedBy.stream()
+                .map(columnHandlesByName::get)
+                .map(column -> new Column(column.getName(), column.getHiveType(), column.getComment()))
+                .collect(toList());
+        checkPartitionTypesSupported(partitionColumns);
+
+        Path targetPath;
+        boolean external;
+        String externalLocation = getExternalLocation(tableMetadata.getProperties());
+        if (externalLocation != null) {
+            if (!createsOfNonManagedTablesEnabled) {
+                throw new TrinoException(NOT_SUPPORTED, "Cannot create non-managed Hive table");
+            }
+
+            external = true;
+            targetPath = getExternalPath(new HdfsEnvironment.HdfsContext(session), externalLocation);
+        }
+        else {
+            external = false;
+            LocationHandle locationHandle = locationService.forNewTable(metastore, session, schemaName, tableName, Optional.empty());
+            targetPath = locationService.getQueryWriteInfo(locationHandle).getTargetPath();
+        }
+
+        Table table = buildTableObject(
+                session.getQueryId(),
+                schemaName,
+                tableName,
+                session.getUser(),
+                columnHandles,
+                hiveStorageFormat,
+                partitionedBy,
+                bucketProperty,
+                tableProperties,
+                targetPath,
+                external,
+                prestoVersion);
+        PrincipalPrivileges principalPrivileges = buildInitialPrivilegeSet(table.getOwner().get());
+        HiveBasicStatistics basicStatistics = table.getPartitionColumns().isEmpty() ? createZeroStatistics() : createEmptyStatistics();
+        metastore.createTable(
+                session,
+                table,
+                principalPrivileges,
+                Optional.empty(),
+                Optional.empty(),
+                ignoreExisting,
+                new PartitionStatistics(basicStatistics, ImmutableMap.of()),
+                false);
+    }
+
+    private String validateAndNormalizeAvroSchemaUrl(String url, HdfsEnvironment.HdfsContext context)
+    {
+        try {
+            new URL(url).openStream().close();
+            return url;
+        }
+        catch (MalformedURLException e) {
+            // try locally
+            if (new File(url).exists()) {
+                // hive needs url to have a protocol
+                return new File(url).toURI().toString();
+            }
+            // try hdfs
+            try {
+                if (!hdfsEnvironment.getFileSystem(context, new Path(url)).exists(new Path(url))) {
+                    throw new TrinoException(INVALID_TABLE_PROPERTY, "Cannot locate Avro schema file: " + url);
+                }
+                return url;
+            }
+            catch (IOException ex) {
+                throw new TrinoException(INVALID_TABLE_PROPERTY, "Avro schema file is not a valid file system URI: " + url, ex);
+            }
+        }
+        catch (IOException e) {
+            throw new TrinoException(INVALID_TABLE_PROPERTY, "Cannot open Avro schema file: " + url, e);
+        }
+    }
+
+    private Path getExternalPath(HdfsEnvironment.HdfsContext context, String location)
+    {
+        try {
+            Path path = new Path(location);
+            if (!isS3FileSystem(context, hdfsEnvironment, path)) {
+                if (!hdfsEnvironment.getFileSystem(context, path).isDirectory(path)) {
+                    throw new TrinoException(INVALID_TABLE_PROPERTY, "External location must be a directory: " + location);
+                }
+            }
+            return path;
+        }
+        catch (IllegalArgumentException | IOException e) {
+            throw new TrinoException(INVALID_TABLE_PROPERTY, "External location is not a valid file system URI: " + location, e);
+        }
+    }
+
+    private static Table buildTableObject(
+            String queryId,
+            String schemaName,
+            String tableName,
+            String tableOwner,
+            List<HiveColumnHandle> columnHandles,
+            HiveStorageFormat hiveStorageFormat,
+            List<String> partitionedBy,
+            Optional<HiveBucketProperty> bucketProperty,
+            Map<String, String> additionalTableParameters,
+            Path targetPath,
+            boolean external,
+            String prestoVersion)
+    {
+        Map<String, HiveColumnHandle> columnHandlesByName = Maps.uniqueIndex(columnHandles, HiveColumnHandle::getName);
+        List<Column> partitionColumns = partitionedBy.stream()
+                .map(columnHandlesByName::get)
+                .map(column -> new Column(column.getName(), column.getHiveType(), column.getComment()))
+                .collect(toList());
+
+        Set<String> partitionColumnNames = ImmutableSet.copyOf(partitionedBy);
+
+        ImmutableList.Builder<Column> columns = ImmutableList.builder();
+        for (HiveColumnHandle columnHandle : columnHandles) {
+            String name = columnHandle.getName();
+            HiveType type = columnHandle.getHiveType();
+            if (!partitionColumnNames.contains(name)) {
+                verify(!columnHandle.isPartitionKey(), "Column handles are not consistent with partitioned by property");
+                columns.add(new Column(name, type, columnHandle.getComment()));
+            }
+            else {
+                verify(columnHandle.isPartitionKey(), "Column handles are not consistent with partitioned by property");
+            }
+        }
+
+        ImmutableMap.Builder<String, String> tableParameters = ImmutableMap.<String, String>builder()
+                .put(PRESTO_VERSION_NAME, prestoVersion)
+                .put(PRESTO_QUERY_ID_NAME, queryId)
+                .putAll(additionalTableParameters);
+
+        if (external) {
+            tableParameters.put("EXTERNAL", "TRUE");
+        }
+
+        Table.Builder tableBuilder = Table.builder()
+                .setDatabaseName(schemaName)
+                .setTableName(tableName)
+                .setOwner(Optional.of(tableOwner))
+                .setTableType((external ? EXTERNAL_TABLE : MANAGED_TABLE).name())
+                .setDataColumns(columns.build())
+                .setPartitionColumns(partitionColumns)
+                .setParameters(tableParameters.buildOrThrow());
+
+        tableBuilder.getStorageBuilder()
+                .setStorageFormat(fromHiveStorageFormat(hiveStorageFormat))
+                .setBucketProperty(bucketProperty)
+                .setLocation(targetPath.toString());
+
+        return tableBuilder.build();
+    }
+
+    @Override
+    public ConnectorOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, Optional<ConnectorTableLayout> layout)
+    {
+        verifyJvmTimeZone();
+
+        if ((!writesToNonManagedTablesEnabled || !createsOfNonManagedTablesEnabled) && getExternalLocation(tableMetadata.getProperties()) != null) {
+            throw new TrinoException(NOT_SUPPORTED, "Cannot create a non-managed Hive table using CREATE TABLE AS");
+        }
+
+        if (getAvroSchemaUrl(tableMetadata.getProperties()) != null) {
+            throw new TrinoException(NOT_SUPPORTED, "CREATE TABLE AS not supported when Avro schema url is set");
+        }
+
+        HiveStorageFormat tableStorageFormat = getHiveStorageFormat(tableMetadata.getProperties());
+        List<String> partitionedBy = getPartitionedBy(tableMetadata.getProperties());
+        Optional<HiveBucketProperty> bucketProperty = getBucketProperty(tableMetadata.getProperties());
+
+        // get the root directory for the database
+        SchemaTableName schemaTableName = tableMetadata.getTable();
+        String schemaName = schemaTableName.getSchemaName();
+        String tableName = schemaTableName.getTableName();
+
+        Map<String, String> tableProperties = getEmptyTableProperties(tableMetadata, bucketProperty, new HdfsEnvironment.HdfsContext(session));
+        List<HiveColumnHandle> columnHandles = getColumnHandles(tableMetadata, ImmutableSet.copyOf(partitionedBy));
+        HiveStorageFormat partitionStorageFormat = isRespectTableFormat(session) ? tableStorageFormat : HiveSessionProperties.getHiveStorageFormat(session);
+
+        // unpartitioned tables ignore the partition storage format
+        HiveStorageFormat actualStorageFormat = partitionedBy.isEmpty() ? tableStorageFormat : partitionStorageFormat;
+        actualStorageFormat.validateColumns(columnHandles);
+
+        Map<String, HiveColumnHandle> columnHandlesByName = Maps.uniqueIndex(columnHandles, HiveColumnHandle::getName);
+        List<Column> partitionColumns = partitionedBy.stream()
+                .map(columnHandlesByName::get)
+                .map(column -> new Column(column.getName(), column.getHiveType(), column.getComment()))
+                .collect(toList());
+        checkPartitionTypesSupported(partitionColumns);
+
+        LocationHandle locationHandle = locationService.forNewTable(metastore, session, schemaName, tableName, Optional.empty());
+        Optional<String> externalLocation = Optional.ofNullable(getExternalLocation(tableMetadata.getProperties()));
+        HiveOutputTableHandle result = new HiveOutputTableHandle(
+                schemaName,
+                tableName,
+                columnHandles,
+                metastore.generatePageSinkMetadata(schemaTableName),
+                locationHandle,
+                tableStorageFormat,
+                partitionStorageFormat,
+                partitionedBy,
+                bucketProperty,
+                session.getUser(),
+                tableProperties,
+                NO_ACID_TRANSACTION,
+                externalLocation.isPresent(),
+                true);
+
+        LocationService.WriteInfo writeInfo = locationService.getQueryWriteInfo(locationHandle);
+        metastore.declareIntentionToWrite(session, writeInfo.getWriteMode(), writeInfo.getWritePath(), schemaTableName);
+
+        return result;
+    }
+
+    private ConnectorTableMetadata getTableMetadata(ConnectorSession session, SchemaTableName tableName)
+    {
+        try {
+            return doGetTableMetadata(session, tableName);
+        }
+        catch (TrinoException e) {
+            throw e;
+        }
+        catch (RuntimeException e) {
+            // Errors related to invalid or unsupported information in the Metastore should be handled explicitly (eg. as TrinoException(HIVE_INVALID_METADATA)).
+            // This is just a catch-all solution so that we have any actionable information when eg. SELECT * FROM information_schema.columns fails.
+            throw new RuntimeException("Failed to construct table metadata for table " + tableName, e);
+        }
+    }
+
+    private ConnectorTableMetadata doGetTableMetadata(ConnectorSession session, SchemaTableName tableName)
+    {
+        Optional<Table> table = metastore.getTable(tableName.getSchemaName(), tableName.getTableName());
+        if (!table.isPresent() || (!translateHiveViews && isHiveOrPrestoView(table.get()))) {
+            throw new TableNotFoundException(tableName);
+        }
+
+        Function<HiveColumnHandle, ColumnMetadata> metadataGetter = columnMetadataGetter(table.get());
+        ImmutableList.Builder<ColumnMetadata> columns = ImmutableList.builder();
+        for (HiveColumnHandle columnHandle : hiveColumnHandles(table.get(), typeManager, getTimestampPrecision(session))) {
+            columns.add(metadataGetter.apply(columnHandle));
+        }
+
+        // External location property
+        ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
+        if (table.get().getTableType().equals(EXTERNAL_TABLE.name())) {
+            properties.put(EXTERNAL_LOCATION_PROPERTY, table.get().getStorage().getLocation());
+        }
+
+        // Storage format property
+        try {
+            HiveStorageFormat format = extractHiveStorageFormat(table.get());
+            properties.put(STORAGE_FORMAT_PROPERTY, format);
+        }
+        catch (TrinoException ignored) {
+            // todo fail if format is not known
+        }
+
+        // Partitioning property
+        List<String> partitionedBy = table.get().getPartitionColumns().stream()
+                .map(Column::getName)
+                .collect(toList());
+        if (!partitionedBy.isEmpty()) {
+            properties.put(PARTITIONED_BY_PROPERTY, partitionedBy);
+        }
+
+        // Bucket properties
+        table.get().getStorage().getBucketProperty().ifPresent(property -> {
+            properties.put(BUCKETING_VERSION, property.getBucketingVersion().getVersion());
+            properties.put(BUCKET_COUNT_PROPERTY, property.getBucketCount());
+            properties.put(BUCKETED_BY_PROPERTY, property.getBucketedBy());
+            properties.put(SORTED_BY_PROPERTY, property.getSortedBy());
+        });
+
+        // ORC format specific properties
+        String orcBloomFilterColumns = table.get().getParameters().get(ORC_BLOOM_FILTER_COLUMNS_KEY);
+        if (orcBloomFilterColumns != null) {
+            properties.put(ORC_BLOOM_FILTER_COLUMNS, Splitter.on(',').trimResults().omitEmptyStrings().splitToList(orcBloomFilterColumns));
+        }
+        String orcBloomFilterFfp = table.get().getParameters().get(ORC_BLOOM_FILTER_FPP_KEY);
+        if (orcBloomFilterFfp != null) {
+            properties.put(ORC_BLOOM_FILTER_FPP, Double.parseDouble(orcBloomFilterFfp));
+        }
+
+        // Avro specific property
+        String avroSchemaUrl = table.get().getParameters().get(AVRO_SCHEMA_URL_KEY);
+        if (avroSchemaUrl != null) {
+            properties.put(AVRO_SCHEMA_URL, avroSchemaUrl);
+        }
+
+        // Textfile and CSV specific property
+        getSerdeProperty(table.get(), SKIP_HEADER_COUNT_KEY)
+                .ifPresent(skipHeaderCount -> properties.put(SKIP_HEADER_LINE_COUNT, Integer.valueOf(skipHeaderCount)));
+        getSerdeProperty(table.get(), SKIP_FOOTER_COUNT_KEY)
+                .ifPresent(skipFooterCount -> properties.put(SKIP_FOOTER_LINE_COUNT, Integer.valueOf(skipFooterCount)));
+
+        // Textfile specific property
+        getSerdeProperty(table.get(), TEXT_FIELD_SEPARATOR_KEY)
+                .ifPresent(fieldSeparator -> properties.put(TEXTFILE_FIELD_SEPARATOR, fieldSeparator));
+        getSerdeProperty(table.get(), TEXT_FIELD_SEPARATOR_ESCAPE_KEY)
+                .ifPresent(fieldEscape -> properties.put(TEXTFILE_FIELD_SEPARATOR_ESCAPE, fieldEscape));
+
+        // CSV specific property
+        getCsvSerdeProperty(table.get(), CSV_SEPARATOR_KEY)
+                .ifPresent(csvSeparator -> properties.put(CSV_SEPARATOR, csvSeparator));
+        getCsvSerdeProperty(table.get(), CSV_QUOTE_KEY)
+                .ifPresent(csvQuote -> properties.put(CSV_QUOTE, csvQuote));
+        getCsvSerdeProperty(table.get(), CSV_ESCAPE_KEY)
+                .ifPresent(csvEscape -> properties.put(CSV_ESCAPE, csvEscape));
+
+        String trinoPartitionSpec = table.get().getParameters().get(PARTITION_SPEC_KEY);
+        if (trinoPartitionSpec != null) {
+            properties.put(PARTITION_SPEC_PROPERTY, trinoPartitionSpec);
+        }
+
+        Optional<String> comment = Optional.ofNullable(table.get().getParameters().get(TABLE_COMMENT));
+
+        return new ConnectorTableMetadata(tableName, columns.build(), properties.buildOrThrow(), comment);
+    }
+
+    private static Optional<String> getCsvSerdeProperty(Table table, String key)
+    {
+        return getSerdeProperty(table, key).map(csvSerdeProperty -> {
+            if (csvSerdeProperty.length() > 1) {
+                throw new TrinoException(HIVE_INVALID_METADATA, "Only single character can be set for property: " + key);
+            }
+            return csvSerdeProperty;
+        });
+    }
+
+    private static Optional<String> getSerdeProperty(Table table, String key)
+    {
+        String serdePropertyValue = table.getStorage().getSerdeParameters().get(key);
+        String tablePropertyValue = table.getParameters().get(key);
+        if (serdePropertyValue != null && tablePropertyValue != null && !tablePropertyValue.equals(serdePropertyValue)) {
+            // in Hive one can set conflicting values for the same property, in such case it looks like table properties are used
+            throw new TrinoException(
+                    HIVE_INVALID_METADATA,
+                    format("Different values for '%s' set in serde properties and table properties: '%s' and '%s'", key, serdePropertyValue, tablePropertyValue));
+        }
+        return firstNonNullable(tablePropertyValue, serdePropertyValue);
+    }
+
+    private void verifyJvmTimeZone()
+    {
+        if (!timeZone.equals(DateTimeZone.getDefault())) {
+            throw new TrinoException(HIVE_TIMEZONE_MISMATCH, format(
+                    "To write Hive data, your JVM timezone must match the Hive storage timezone. Add -Duser.timezone=%s to your JVM arguments.",
+                    timeZone.getID()));
+        }
+    }
+
+    private Map<String, String> getEmptyTableProperties(ConnectorTableMetadata tableMetadata, Optional<HiveBucketProperty> bucketProperty, HdfsEnvironment.HdfsContext hdfsContext)
+    {
+        HiveStorageFormat hiveStorageFormat = getHiveStorageFormat(tableMetadata.getProperties());
+        ImmutableMap.Builder<String, String> tableProperties = ImmutableMap.builder();
+
+        // When metastore is configured with metastore.create.as.acid=true, it will also change Presto-created tables
+        // behind the scenes. In particular, this won't work with CTAS.
+        // TODO (https://github.com/trino/presto/issues/1956) convert this into normal table property
+        tableProperties.put(TRANSACTIONAL, "false");
+
+        bucketProperty.ifPresent(hiveBucketProperty ->
+                tableProperties.put(BUCKETING_VERSION, Integer.toString(hiveBucketProperty.getBucketingVersion().getVersion())));
+
+        // ORC format specific properties
+        List<String> columns = getOrcBloomFilterColumns(tableMetadata.getProperties());
+        if (columns != null && !columns.isEmpty()) {
+            checkFormatForProperty(hiveStorageFormat, HiveStorageFormat.ORC, ORC_BLOOM_FILTER_COLUMNS);
+            tableProperties.put(ORC_BLOOM_FILTER_COLUMNS_KEY, Joiner.on(",").join(columns));
+            tableProperties.put(ORC_BLOOM_FILTER_FPP_KEY, String.valueOf(getOrcBloomFilterFpp(tableMetadata.getProperties())));
+        }
+
+        // Avro specific properties
+        String avroSchemaUrl = getAvroSchemaUrl(tableMetadata.getProperties());
+        if (avroSchemaUrl != null) {
+            checkFormatForProperty(hiveStorageFormat, HiveStorageFormat.AVRO, AVRO_SCHEMA_URL);
+            tableProperties.put(AVRO_SCHEMA_URL_KEY, validateAndNormalizeAvroSchemaUrl(avroSchemaUrl, hdfsContext));
+        }
+
+        String partitionSpecJson = getPartitionSpecJson(tableMetadata.getProperties());
+        if (partitionSpecJson != null) {
+            validateSpecJson(partitionSpecJson);
+            tableProperties.put(PARTITION_SPEC_KEY, partitionSpecJson);
+        }
+
+        // Textfile and CSV specific properties
+        Set<HiveStorageFormat> csvAndTextFile = ImmutableSet.of(HiveStorageFormat.TEXTFILE, HiveStorageFormat.CSV);
+        getHeaderSkipCount(tableMetadata.getProperties()).ifPresent(headerSkipCount -> {
+            if (headerSkipCount > 0) {
+                checkFormatForProperty(hiveStorageFormat, csvAndTextFile, SKIP_HEADER_LINE_COUNT);
+                tableProperties.put(SKIP_HEADER_COUNT_KEY, String.valueOf(headerSkipCount));
+            }
+            if (headerSkipCount < 0) {
+                throw new TrinoException(HIVE_INVALID_METADATA, format("Invalid value for %s property: %s", SKIP_HEADER_LINE_COUNT, headerSkipCount));
+            }
+        });
+
+        getFooterSkipCount(tableMetadata.getProperties()).ifPresent(footerSkipCount -> {
+            if (footerSkipCount > 0) {
+                checkFormatForProperty(hiveStorageFormat, csvAndTextFile, SKIP_FOOTER_LINE_COUNT);
+                tableProperties.put(SKIP_FOOTER_COUNT_KEY, String.valueOf(footerSkipCount));
+            }
+            if (footerSkipCount < 0) {
+                throw new TrinoException(HIVE_INVALID_METADATA, format("Invalid value for %s property: %s", SKIP_FOOTER_LINE_COUNT, footerSkipCount));
+            }
+        });
+
+        getSingleCharacterProperty(tableMetadata.getProperties(), TEXTFILE_FIELD_SEPARATOR)
+                .ifPresent(separator -> {
+                    checkFormatForProperty(hiveStorageFormat, HiveStorageFormat.TEXTFILE, TEXT_FIELD_SEPARATOR_KEY);
+                    tableProperties.put(TEXT_FIELD_SEPARATOR_KEY, separator.toString());
+                });
+
+        getSingleCharacterProperty(tableMetadata.getProperties(), TEXTFILE_FIELD_SEPARATOR_ESCAPE)
+                .ifPresent(escape -> {
+                    checkFormatForProperty(hiveStorageFormat, HiveStorageFormat.TEXTFILE, TEXT_FIELD_SEPARATOR_ESCAPE_KEY);
+                    tableProperties.put(TEXT_FIELD_SEPARATOR_ESCAPE_KEY, escape.toString());
+                });
+
+        // CSV specific properties
+        getSingleCharacterProperty(tableMetadata.getProperties(), CSV_ESCAPE)
+                .ifPresent(escape -> {
+                    checkFormatForProperty(hiveStorageFormat, HiveStorageFormat.CSV, CSV_ESCAPE);
+                    tableProperties.put(CSV_ESCAPE_KEY, escape.toString());
+                });
+        getSingleCharacterProperty(tableMetadata.getProperties(), CSV_QUOTE)
+                .ifPresent(quote -> {
+                    checkFormatForProperty(hiveStorageFormat, HiveStorageFormat.CSV, CSV_QUOTE);
+                    tableProperties.put(CSV_QUOTE_KEY, quote.toString());
+                });
+        getSingleCharacterProperty(tableMetadata.getProperties(), CSV_SEPARATOR)
+                .ifPresent(separator -> {
+                    checkFormatForProperty(hiveStorageFormat, HiveStorageFormat.CSV, CSV_SEPARATOR);
+                    tableProperties.put(CSV_SEPARATOR_KEY, separator.toString());
+                });
+
+        // Table comment property
+        tableMetadata.getComment().ifPresent(value -> tableProperties.put(TABLE_COMMENT, value));
+
+        return tableProperties.buildOrThrow();
+    }
+
+    private static void checkFormatForProperty(HiveStorageFormat actualStorageFormat, HiveStorageFormat expectedStorageFormat, String propertyName)
+    {
+        if (actualStorageFormat != expectedStorageFormat) {
+            throw new TrinoException(INVALID_TABLE_PROPERTY, format("Cannot specify %s table property for storage format: %s", propertyName, actualStorageFormat));
+        }
+    }
+
+    private static void checkFormatForProperty(HiveStorageFormat actualStorageFormat, Set<HiveStorageFormat> expectedStorageFormats, String propertyName)
+    {
+        if (!expectedStorageFormats.contains(actualStorageFormat)) {
+            throw new TrinoException(INVALID_TABLE_PROPERTY, format("Cannot specify %s table property for storage format: %s", propertyName, actualStorageFormat));
+        }
+    }
+
+    private void checkPartitionTypesSupported(List<Column> partitionColumns)
+    {
+        for (Column partitionColumn : partitionColumns) {
+            Type partitionType = typeManager.getType(partitionColumn.getType().getTypeSignature());
+            verifyPartitionTypeSupported(partitionColumn.getName(), partitionType);
+        }
+    }
+
+    private boolean isHiveOrPrestoView(Table table)
+    {
+        return table.getTableType().equals(TableType.VIRTUAL_VIEW.name());
+    }
+
+    @Override
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle tableHandle, Constraint constraint)
+    {
+        HiveTableHandle handle = (HiveTableHandle) tableHandle;
+        checkArgument(!handle.getAnalyzePartitionValues().isPresent() || constraint.getSummary().isAll(), "Analyze should not have a constraint");
+
+        HivePartitionResult partitionResult = partitionManager.getPartitions(metastore, handle, constraint);
+
+        if (isPartitionSpecEnabled(session)) {
+            ConnectorTableMetadata tableMetadata = getTableMetadata(session, tableHandle);
+            String partitionSpecJson = getPartitionSpecJson(tableMetadata.getProperties());
+            if (partitionSpecJson != null) {
+                PartitionSpec partitionSpec = toIcebergPartitionSpec(tableMetadata, HiddenPartitioningSpecParser.fromJson(partitionSpecJson));
+                partitionResult = transformFilteredPartitionResult(partitionResult, partitionSpec);
+            }
+        }
+
+        HiveTableHandle newHandle = partitionManager.applyPartitionResult(handle, partitionResult, constraint);
+
+        if (handle.getPartitions().equals(newHandle.getPartitions()) &&
+                handle.getPartitionNames().equals(newHandle.getPartitionNames()) &&
+                handle.getCompactEffectivePredicate().equals(newHandle.getCompactEffectivePredicate()) &&
+                handle.getBucketFilter().equals(newHandle.getBucketFilter()) &&
+                handle.getConstraintColumns().equals(newHandle.getConstraintColumns())) {
+            return Optional.empty();
+        }
+
+        TupleDomain<ColumnHandle> unenforcedConstraint = partitionResult.getEffectivePredicate();
+        if (newHandle.getPartitions().isPresent()) {
+            List<HiveColumnHandle> partitionColumns = partitionResult.getPartitionColumns();
+            unenforcedConstraint = partitionResult.getEffectivePredicate().filter((column, domain) -> !partitionColumns.contains(column));
+        }
+
+        return Optional.of(new ConstraintApplicationResult<>(newHandle, unenforcedConstraint, false));
+    }
+
+    private static HiveStorageFormat extractHiveStorageFormat(Table table)
+    {
+        StorageFormat storageFormat = table.getStorage().getStorageFormat();
+        String outputFormat = storageFormat.getOutputFormat();
+        String serde = storageFormat.getSerde();
+
+        for (HiveStorageFormat format : HiveStorageFormat.values()) {
+            if (format.getOutputFormat().equals(outputFormat) && format.getSerde().equals(serde)) {
+                return format;
+            }
+        }
+        throw new TrinoException(HIVE_UNSUPPORTED_FORMAT, format("Output format %s with SerDe %s is not supported", outputFormat, serde));
+    }
+
+    private static Function<HiveColumnHandle, ColumnMetadata> columnMetadataGetter(Table table)
+    {
+        ImmutableList.Builder<String> columnNames = ImmutableList.builder();
+        table.getPartitionColumns().stream().map(Column::getName).forEach(columnNames::add);
+        table.getDataColumns().stream().map(Column::getName).forEach(columnNames::add);
+        List<String> allColumnNames = columnNames.build();
+        if (allColumnNames.size() > Sets.newHashSet(allColumnNames).size()) {
+            throw new TrinoException(HIVE_INVALID_METADATA,
+                    format("Hive metadata for table %s is invalid: Table descriptor contains duplicate columns", table.getTableName()));
+        }
+
+        List<Column> tableColumns = table.getDataColumns();
+        ImmutableMap.Builder<String, Optional<String>> builder = ImmutableMap.builder();
+        for (Column field : concat(tableColumns, table.getPartitionColumns())) {
+            if (field.getComment().isPresent() && !field.getComment().get().equals("from deserializer")) {
+                builder.put(field.getName(), field.getComment());
+            }
+            else {
+                builder.put(field.getName(), Optional.empty());
+            }
+        }
+        // add hidden columns
+        builder.put(PATH_COLUMN_NAME, Optional.empty());
+        if (table.getStorage().getBucketProperty().isPresent()) {
+            builder.put(BUCKET_COLUMN_NAME, Optional.empty());
+        }
+        builder.put(FILE_SIZE_COLUMN_NAME, Optional.empty());
+        builder.put(FILE_MODIFIED_TIME_COLUMN_NAME, Optional.empty());
+        if (!table.getPartitionColumns().isEmpty()) {
+            builder.put(PARTITION_COLUMN_NAME, Optional.empty());
+        }
+        Map<String, Optional<String>> columnComment = builder.buildOrThrow();
+
+        return handle -> ColumnMetadata.builder()
+                .setName(handle.getName())
+                .setType(handle.getType())
+                .setComment(columnComment.get(handle.getName()))
+                .setExtraInfo(Optional.ofNullable(columnExtraInfo(handle.isPartitionKey())))
+                .setHidden(handle.isHidden())
+                .build();
+    }
+
+    private static void validateBucketColumns(ConnectorTableMetadata tableMetadata)
+    {
+        Optional<HiveBucketProperty> bucketProperty = getBucketProperty(tableMetadata.getProperties());
+        if (!bucketProperty.isPresent()) {
+            return;
+        }
+        Set<String> allColumns = tableMetadata.getColumns().stream()
+                .map(ColumnMetadata::getName)
+                .collect(toSet());
+
+        List<String> bucketedBy = bucketProperty.get().getBucketedBy();
+        if (!allColumns.containsAll(bucketedBy)) {
+            throw new TrinoException(INVALID_TABLE_PROPERTY, format("Bucketing columns %s not present in schema", Sets.difference(ImmutableSet.copyOf(bucketedBy), ImmutableSet.copyOf(allColumns))));
+        }
+
+        List<String> sortedBy = bucketProperty.get().getSortedBy().stream()
+                .map(SortingColumn::getColumnName)
+                .collect(toImmutableList());
+        if (!allColumns.containsAll(sortedBy)) {
+            throw new TrinoException(INVALID_TABLE_PROPERTY, format("Sorting columns %s not present in schema", Sets.difference(ImmutableSet.copyOf(sortedBy), ImmutableSet.copyOf(allColumns))));
+        }
+    }
+
+    private static void validatePartitionColumns(ConnectorTableMetadata tableMetadata)
+    {
+        List<String> partitionedBy = getPartitionedBy(tableMetadata.getProperties());
+
+        List<String> allColumns = tableMetadata.getColumns().stream()
+                .map(ColumnMetadata::getName)
+                .collect(toList());
+
+        if (!allColumns.containsAll(partitionedBy)) {
+            throw new TrinoException(INVALID_TABLE_PROPERTY, format("Partition columns %s not present in schema", Sets.difference(ImmutableSet.copyOf(partitionedBy), ImmutableSet.copyOf(allColumns))));
+        }
+
+        if (allColumns.size() == partitionedBy.size()) {
+            throw new TrinoException(INVALID_TABLE_PROPERTY, "Table contains only partition columns");
+        }
+
+        if (!allColumns.subList(allColumns.size() - partitionedBy.size(), allColumns.size()).equals(partitionedBy)) {
+            throw new TrinoException(HIVE_COLUMN_ORDER_MISMATCH, "Partition keys must be the last columns in the table and in the same order as the table properties: " + partitionedBy);
+        }
+    }
+
+    private static List<HiveColumnHandle> getColumnHandles(ConnectorTableMetadata tableMetadata, Set<String> partitionColumnNames)
+    {
+        validatePartitionColumns(tableMetadata);
+        validateBucketColumns(tableMetadata);
+        validateCsvColumns(tableMetadata);
+
+        ImmutableList.Builder<HiveColumnHandle> columnHandles = ImmutableList.builder();
+        int ordinal = 0;
+        for (ColumnMetadata column : tableMetadata.getColumns()) {
+            HiveColumnHandle.ColumnType columnType;
+            if (partitionColumnNames.contains(column.getName())) {
+                columnType = PARTITION_KEY;
+            }
+            else if (column.isHidden()) {
+                columnType = SYNTHESIZED;
+            }
+            else {
+                columnType = REGULAR;
+            }
+            columnHandles.add(new HiveColumnHandle(
+                    column.getName(),
+                    ordinal,
+                    toHiveType(column.getType()),
+                    column.getType(),
+                    Optional.empty(),
+                    columnType,
+                    Optional.ofNullable(column.getComment())));
+            ordinal++;
+        }
+
+        return columnHandles.build();
+    }
+
+    private static void validateCsvColumns(ConnectorTableMetadata tableMetadata)
+    {
+        if (getHiveStorageFormat(tableMetadata.getProperties()) != HiveStorageFormat.CSV) {
+            return;
+        }
+
+        Set<String> partitionedBy = ImmutableSet.copyOf(getPartitionedBy(tableMetadata.getProperties()));
+        List<ColumnMetadata> unsupportedColumns = tableMetadata.getColumns().stream()
+                .filter(columnMetadata -> !partitionedBy.contains(columnMetadata.getName()))
+                .filter(columnMetadata -> !columnMetadata.getType().equals(createUnboundedVarcharType()))
+                .collect(toImmutableList());
+
+        if (!unsupportedColumns.isEmpty()) {
+            String joinedUnsupportedColumns = unsupportedColumns.stream()
+                    .map(columnMetadata -> format("%s %s", columnMetadata.getName(), columnMetadata.getType()))
+                    .collect(joining(", "));
+            throw new TrinoException(NOT_SUPPORTED, "Hive CSV storage format only supports VARCHAR (unbounded). Unsupported columns: " + joinedUnsupportedColumns);
+        }
+    }
+
+    @SafeVarargs
+    private static <T> Optional<T> firstNonNullable(T... values)
+    {
+        for (T value : values) {
+            if (value != null) {
+                return Optional.of(value);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningInternalConnectorFactory.java
+++ b/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningInternalConnectorFactory.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hidden.partitioning;
+
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.TypeLiteral;
+import com.google.inject.util.Modules;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.bootstrap.LifeCycleManager;
+import io.airlift.event.client.EventModule;
+import io.airlift.json.JsonModule;
+import io.trino.plugin.base.CatalogName;
+import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorAccessControl;
+import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorPageSinkProvider;
+import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorPageSourceProvider;
+import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorSplitManager;
+import io.trino.plugin.base.classloader.ClassLoaderSafeEventListener;
+import io.trino.plugin.base.classloader.ClassLoaderSafeNodePartitioningProvider;
+import io.trino.plugin.base.jmx.ConnectorObjectNameGeneratorModule;
+import io.trino.plugin.base.jmx.MBeanServerModule;
+import io.trino.plugin.base.session.SessionPropertiesProvider;
+import io.trino.plugin.hive.HiveAnalyzeProperties;
+import io.trino.plugin.hive.HiveConfig;
+import io.trino.plugin.hive.HiveConnector;
+import io.trino.plugin.hive.HiveHdfsModule;
+import io.trino.plugin.hive.HiveMaterializedViewPropertiesProvider;
+import io.trino.plugin.hive.HiveModule;
+import io.trino.plugin.hive.HiveSchemaProperties;
+import io.trino.plugin.hive.HiveTransactionManager;
+import io.trino.plugin.hive.InternalHiveConnectorFactory;
+import io.trino.plugin.hive.NodeVersion;
+import io.trino.plugin.hive.authentication.HdfsAuthenticationModule;
+import io.trino.plugin.hive.azure.HiveAzureModule;
+import io.trino.plugin.hive.fs.CachingDirectoryListerModule;
+import io.trino.plugin.hive.fs.DirectoryLister;
+import io.trino.plugin.hive.gcs.HiveGcsModule;
+import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.plugin.hive.metastore.HiveMetastoreModule;
+import io.trino.plugin.hive.procedure.HiveProcedureModule;
+import io.trino.plugin.hive.rubix.RubixEnabledConfig;
+import io.trino.plugin.hive.rubix.RubixModule;
+import io.trino.plugin.hive.s3.HiveS3Module;
+import io.trino.plugin.hive.security.HiveSecurityModule;
+import io.trino.plugin.hive.security.SystemTableAwareAccessControl;
+import io.trino.spi.NodeManager;
+import io.trino.spi.PageIndexerFactory;
+import io.trino.spi.PageSorter;
+import io.trino.spi.VersionEmbedder;
+import io.trino.spi.classloader.ThreadContextClassLoader;
+import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorAccessControl;
+import io.trino.spi.connector.ConnectorContext;
+import io.trino.spi.connector.ConnectorNodePartitioningProvider;
+import io.trino.spi.connector.ConnectorPageSinkProvider;
+import io.trino.spi.connector.ConnectorPageSourceProvider;
+import io.trino.spi.connector.ConnectorSplitManager;
+import io.trino.spi.connector.MetadataProvider;
+import io.trino.spi.connector.TableProcedureMetadata;
+import io.trino.spi.eventlistener.EventListener;
+import io.trino.spi.procedure.Procedure;
+import io.trino.spi.type.TypeManager;
+import org.weakref.jmx.guice.MBeanModule;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static io.airlift.configuration.ConditionalModule.installModuleIf;
+import static io.trino.plugin.hive.InternalHiveConnectorFactory.bindSessionPropertiesProvider;
+import static java.util.Objects.requireNonNull;
+
+public final class HiddenPartitioningInternalConnectorFactory
+{
+    private HiddenPartitioningInternalConnectorFactory() {}
+
+    public static Connector createConnector(String catalogName, Map<String, String> config, ConnectorContext context, Module module)
+    {
+        return createConnector(catalogName, config, context, module, Optional.empty(), Optional.empty());
+    }
+
+    public static Connector createConnector(
+            String catalogName,
+            Map<String, String> config,
+            ConnectorContext context,
+            Module module,
+            Optional<HiveMetastore> metastore,
+            Optional<DirectoryLister> directoryLister)
+    {
+        requireNonNull(config, "config is null");
+
+        ClassLoader classLoader = InternalHiveConnectorFactory.class.getClassLoader();
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            Bootstrap app = new Bootstrap(
+                    new EventModule(),
+                    new MBeanModule(),
+                    new ConnectorObjectNameGeneratorModule(catalogName, "io.trino.plugin.hive", "trino.plugin.hive"),
+                    new JsonModule(),
+                    Modules.override(new HiveModule()).with(new HiddenPartitioningModule()),
+                    new CachingDirectoryListerModule(directoryLister),
+                    new HiveHdfsModule(),
+                    new HiveS3Module(),
+                    new HiveGcsModule(),
+                    new HiveAzureModule(),
+                    installModuleIf(RubixEnabledConfig.class, RubixEnabledConfig::isCacheEnabled, new RubixModule()),
+                    new HiveMetastoreModule(metastore),
+                    new HiveSecurityModule(),
+                    new HdfsAuthenticationModule(),
+                    new HiveProcedureModule(),
+                    new MBeanServerModule(),
+                    binder -> {
+                        binder.bind(NodeVersion.class).toInstance(new NodeVersion(context.getNodeManager().getCurrentNode().getVersion()));
+                        binder.bind(NodeManager.class).toInstance(context.getNodeManager());
+                        binder.bind(VersionEmbedder.class).toInstance(context.getVersionEmbedder());
+                        binder.bind(TypeManager.class).toInstance(context.getTypeManager());
+                        binder.bind(PageIndexerFactory.class).toInstance(context.getPageIndexerFactory());
+                        binder.bind(PageSorter.class).toInstance(context.getPageSorter());
+                        binder.bind(CatalogName.class).toInstance(new CatalogName(catalogName));
+                        binder.bind(MetadataProvider.class).toInstance(context.getMetadataProvider());
+                    },
+                    binder -> newSetBinder(binder, EventListener.class),
+                    binder -> bindSessionPropertiesProvider(binder, HiddenPartitioningSessionProperties.class),
+                    module);
+
+            Injector injector = app
+                    .doNotInitializeLogging()
+                    .setRequiredConfigurationProperties(config)
+                    .initialize();
+
+            LifeCycleManager lifeCycleManager = injector.getInstance(LifeCycleManager.class);
+            HiddenPartitioningMetadataFactory metadataFactory = injector.getInstance(HiddenPartitioningMetadataFactory.class);
+            HiveTransactionManager transactionManager = injector.getInstance(HiveTransactionManager.class);
+            ConnectorSplitManager splitManager = injector.getInstance(ConnectorSplitManager.class);
+            ConnectorPageSourceProvider connectorPageSource = injector.getInstance(ConnectorPageSourceProvider.class);
+            ConnectorPageSinkProvider pageSinkProvider = injector.getInstance(ConnectorPageSinkProvider.class);
+            ConnectorNodePartitioningProvider connectorDistributionProvider = injector.getInstance(ConnectorNodePartitioningProvider.class);
+            Set<SessionPropertiesProvider> sessionPropertiesProviders = injector.getInstance(Key.get(new TypeLiteral<Set<SessionPropertiesProvider>>() {}));
+            HiddenPartitioningTableProperties tableProperties = injector.getInstance(HiddenPartitioningTableProperties.class);
+            HiveAnalyzeProperties hiveAnalyzeProperties = injector.getInstance(HiveAnalyzeProperties.class);
+            HiveMaterializedViewPropertiesProvider hiveMaterializedViewPropertiesProvider = injector.getInstance(HiveMaterializedViewPropertiesProvider.class);
+            ConnectorAccessControl accessControl = new ClassLoaderSafeConnectorAccessControl(
+                    new SystemTableAwareAccessControl(injector.getInstance(ConnectorAccessControl.class), metadataFactory.getSystemTableProviders()),
+                    classLoader);
+            Set<Procedure> procedures = injector.getInstance(Key.get(new TypeLiteral<Set<Procedure>>() {}));
+            Set<TableProcedureMetadata> tableProcedures = injector.getInstance(Key.get(new TypeLiteral<Set<TableProcedureMetadata>>() {}));
+            Set<EventListener> eventListeners = injector.getInstance(Key.get(new TypeLiteral<Set<EventListener>>() {}))
+                    .stream()
+                    .map(listener -> new ClassLoaderSafeEventListener(listener, classLoader))
+                    .collect(toImmutableSet());
+
+            return new HiveConnector(
+                    lifeCycleManager,
+                    transactionManager,
+                    new ClassLoaderSafeConnectorSplitManager(splitManager, classLoader),
+                    new ClassLoaderSafeConnectorPageSourceProvider(connectorPageSource, classLoader),
+                    new ClassLoaderSafeConnectorPageSinkProvider(pageSinkProvider, classLoader),
+                    new ClassLoaderSafeNodePartitioningProvider(connectorDistributionProvider, classLoader),
+                    procedures,
+                    tableProcedures,
+                    eventListeners,
+                    sessionPropertiesProviders,
+                    HiveSchemaProperties.SCHEMA_PROPERTIES,
+                    tableProperties.getTableProperties(),
+                    hiveAnalyzeProperties.getAnalyzeProperties(),
+                    hiveMaterializedViewPropertiesProvider.getMaterializedViewProperties(),
+                    Optional.of(accessControl),
+                    injector.getInstance(HiveConfig.class).isSingleStatementWritesOnly(),
+                    classLoader);
+        }
+    }
+}

--- a/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningManifestFile.java
+++ b/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningManifestFile.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hidden.partitioning;
+
+import org.apache.iceberg.ManifestContent;
+import org.apache.iceberg.ManifestFile;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Dummy implementation that wraps a single Hive partition.
+ * Used to filter Hive partitions using {@link HiddenPartitioningPartitionSpec} transforms
+ */
+public class HiddenPartitioningManifestFile
+        implements ManifestFile
+{
+    private final List<PartitionFieldSummary> partitions;
+
+    public HiddenPartitioningManifestFile(List<PartitionFieldSummary> partitions)
+    {
+        this.partitions = requireNonNull(partitions, "partitions is null");
+    }
+
+    @Override
+    public String path()
+    {
+        return null;
+    }
+
+    @Override
+    public long length()
+    {
+        return 0;
+    }
+
+    @Override
+    public int partitionSpecId()
+    {
+        return 0;
+    }
+
+    @Override
+    public ManifestContent content()
+    {
+        return null;
+    }
+
+    @Override
+    public long sequenceNumber()
+    {
+        return 0;
+    }
+
+    @Override
+    public long minSequenceNumber()
+    {
+        return 0;
+    }
+
+    @Override
+    public Long snapshotId()
+    {
+        return null;
+    }
+
+    @Override
+    public Integer addedFilesCount()
+    {
+        return null;
+    }
+
+    @Override
+    public Long addedRowsCount()
+    {
+        return null;
+    }
+
+    @Override
+    public Integer existingFilesCount()
+    {
+        return null;
+    }
+
+    @Override
+    public Long existingRowsCount()
+    {
+        return null;
+    }
+
+    @Override
+    public Integer deletedFilesCount()
+    {
+        return null;
+    }
+
+    @Override
+    public Long deletedRowsCount()
+    {
+        return null;
+    }
+
+    @Override
+    public List<PartitionFieldSummary> partitions()
+    {
+        return partitions;
+    }
+
+    @Override
+    public ManifestFile copy()
+    {
+        return null;
+    }
+
+    public static class TrinoPartitionFieldSummary
+            implements ManifestFile.PartitionFieldSummary
+    {
+        private final boolean containsNull;
+        private final ByteBuffer lowerBound;
+        private final ByteBuffer upperBound;
+
+        public TrinoPartitionFieldSummary(boolean containsNull, ByteBuffer lowerBound, ByteBuffer upperBound)
+        {
+            this.containsNull = containsNull;
+            this.lowerBound = lowerBound;
+            this.upperBound = upperBound;
+        }
+
+        @Override
+        public boolean containsNull()
+        {
+            return containsNull;
+        }
+
+        @Override
+        public ByteBuffer lowerBound()
+        {
+            return lowerBound;
+        }
+
+        @Override
+        public ByteBuffer upperBound()
+        {
+            return upperBound;
+        }
+
+        @Override
+        public ManifestFile.PartitionFieldSummary copy()
+        {
+            return this;
+        }
+    }
+}

--- a/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningMetadataFactory.java
+++ b/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningMetadataFactory.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hidden.partitioning;
+
+import io.airlift.concurrent.BoundedExecutor;
+import io.airlift.json.JsonCodec;
+import io.airlift.log.Logger;
+import io.airlift.units.Duration;
+import io.trino.plugin.base.CatalogName;
+import io.trino.plugin.hive.ForHiveTransactionHeartbeats;
+import io.trino.plugin.hive.HdfsEnvironment;
+import io.trino.plugin.hive.HiveConfig;
+import io.trino.plugin.hive.HiveMaterializedViewMetadata;
+import io.trino.plugin.hive.HiveMetadataFactory;
+import io.trino.plugin.hive.HiveMetastoreClosure;
+import io.trino.plugin.hive.HivePartitionManager;
+import io.trino.plugin.hive.HiveRedirectionsProvider;
+import io.trino.plugin.hive.HiveTableRedirectionsProvider;
+import io.trino.plugin.hive.LocationService;
+import io.trino.plugin.hive.NodeVersion;
+import io.trino.plugin.hive.PartitionUpdate;
+import io.trino.plugin.hive.SystemTableProvider;
+import io.trino.plugin.hive.TransactionalMetadata;
+import io.trino.plugin.hive.TransactionalMetadataFactory;
+import io.trino.plugin.hive.fs.DirectoryLister;
+import io.trino.plugin.hive.fs.TransactionScopeCachingDirectoryLister;
+import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
+import io.trino.plugin.hive.metastore.MetastoreConfig;
+import io.trino.plugin.hive.metastore.SemiTransactionalHiveMetastore;
+import io.trino.plugin.hive.security.AccessControlMetadataFactory;
+import io.trino.plugin.hive.statistics.MetastoreHiveStatisticsProvider;
+import io.trino.spi.connector.MetadataProvider;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.spi.type.TypeManager;
+import org.joda.time.DateTimeZone;
+
+import javax.inject.Inject;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static io.trino.plugin.hive.metastore.cache.CachingHiveMetastore.memoizeMetastore;
+import static java.util.Objects.requireNonNull;
+
+public class HiddenPartitioningMetadataFactory
+        implements TransactionalMetadataFactory
+{
+    private static final Logger log = Logger.get(HiveMetadataFactory.class);
+
+    private final CatalogName catalogName;
+    private final boolean skipDeletionForAlter;
+    private final boolean skipTargetCleanupOnRollback;
+    private final boolean writesToNonManagedTablesEnabled;
+    private final boolean createsOfNonManagedTablesEnabled;
+    private final boolean translateHiveViews;
+    private final boolean hideDeltaLakeTables;
+    private final long perTransactionCacheMaximumSize;
+    private final HiveMetastoreFactory metastoreFactory;
+    private final HdfsEnvironment hdfsEnvironment;
+    private final HivePartitionManager partitionManager;
+    private final DateTimeZone timeZone;
+    private final TypeManager typeManager;
+    private final LocationService locationService;
+    private final JsonCodec<PartitionUpdate> partitionUpdateCodec;
+    private final BoundedExecutor renameExecution;
+    private final BoundedExecutor dropExecutor;
+    private final BoundedExecutor updateExecutor;
+    private final String prestoVersion;
+    private final HiveRedirectionsProvider hiveRedirectionsProvider;
+    private final HiveMaterializedViewMetadata hiveMaterializedViewMetadata;
+    private final AccessControlMetadataFactory accessControlMetadataFactory;
+    private final Optional<Duration> hiveTransactionHeartbeatInterval;
+    private final ScheduledExecutorService heartbeatService;
+
+    private Set<SystemTableProvider> systemTableProviders;
+    private MetadataProvider metadataProvider;
+    private HiveTableRedirectionsProvider hiveTableRedirectionsProvider;
+    private final DirectoryLister directoryLister;
+    private final long perTransactionFileStatusCacheMaximumSize;
+
+    @Inject
+    @SuppressWarnings("deprecation")
+    public HiddenPartitioningMetadataFactory(
+            CatalogName catalogName,
+            HiveConfig hiveConfig,
+            MetastoreConfig metastoreConfig,
+            HiveMetastoreFactory metastoreFactory,
+            HdfsEnvironment hdfsEnvironment,
+            HivePartitionManager partitionManager,
+            ExecutorService executorService,
+            @ForHiveTransactionHeartbeats ScheduledExecutorService heartbeatService,
+            TypeManager typeManager,
+            MetadataProvider metadataProvider,
+            LocationService locationService,
+            JsonCodec<PartitionUpdate> partitionUpdateCodec,
+            NodeVersion nodeVersion,
+            HiveRedirectionsProvider hiveRedirectionsProvider,
+            Set<SystemTableProvider> systemTableProviders,
+            HiveMaterializedViewMetadata hiveMaterializedViewMetadata,
+            AccessControlMetadataFactory accessControlMetadataFactory,
+            HiveTableRedirectionsProvider hiveTableRedirectionsProvider,
+            DirectoryLister directoryLister)
+    {
+        this(
+                catalogName,
+                metastoreFactory,
+                hdfsEnvironment,
+                partitionManager,
+                hiveConfig.getOrcLegacyDateTimeZone(),
+                hiveConfig.getMaxConcurrentFileRenames(),
+                hiveConfig.getMaxConcurrentMetastoreDrops(),
+                hiveConfig.getMaxConcurrentMetastoreUpdates(),
+                hiveConfig.isSkipDeletionForAlter(),
+                hiveConfig.isSkipTargetCleanupOnRollback(),
+                hiveConfig.getWritesToNonManagedTablesEnabled(),
+                hiveConfig.getCreatesOfNonManagedTablesEnabled(),
+                hiveConfig.isTranslateHiveViews(),
+                metastoreConfig.isHideDeltaLakeTables(),
+                hiveConfig.getPerTransactionMetastoreCacheMaximumSize(),
+                hiveConfig.getHiveTransactionHeartbeatInterval(),
+                typeManager,
+                metadataProvider,
+                locationService,
+                partitionUpdateCodec,
+                executorService,
+                heartbeatService,
+                nodeVersion.toString(),
+                hiveRedirectionsProvider,
+                systemTableProviders,
+                hiveMaterializedViewMetadata,
+                accessControlMetadataFactory,
+                hiveTableRedirectionsProvider,
+                directoryLister,
+                hiveConfig.getPerTransactionFileStatusCacheMaximumSize());
+    }
+
+    public HiddenPartitioningMetadataFactory(
+            CatalogName catalogName,
+            HiveMetastoreFactory metastoreFactory,
+            HdfsEnvironment hdfsEnvironment,
+            HivePartitionManager partitionManager,
+            DateTimeZone timeZone,
+            int maxConcurrentFileRenames,
+            int maxConcurrentMetastoreDrops,
+            int maxConcurrentMetastoreUpdates,
+            boolean skipDeletionForAlter,
+            boolean skipTargetCleanupOnRollback,
+            boolean writesToNonManagedTablesEnabled,
+            boolean createsOfNonManagedTablesEnabled,
+            boolean translateHiveViews,
+            boolean hideDeltaLakeTables,
+            long perTransactionCacheMaximumSize,
+            Optional<Duration> hiveTransactionHeartbeatInterval,
+            TypeManager typeManager,
+            MetadataProvider metadataProvider,
+            LocationService locationService,
+            JsonCodec<PartitionUpdate> partitionUpdateCodec,
+            ExecutorService executorService,
+            ScheduledExecutorService heartbeatService,
+            String prestoVersion,
+            HiveRedirectionsProvider hiveRedirectionsProvider,
+            Set<SystemTableProvider> systemTableProviders,
+            HiveMaterializedViewMetadata hiveMaterializedViewMetadata,
+            AccessControlMetadataFactory accessControlMetadataFactory,
+            HiveTableRedirectionsProvider hiveTableRedirectionsProvider,
+            DirectoryLister directoryLister,
+            long perTransactionFileStatusCacheMaximumSize)
+    {
+        this.catalogName = requireNonNull(catalogName, "catalogName is null");
+        this.skipDeletionForAlter = skipDeletionForAlter;
+        this.skipTargetCleanupOnRollback = skipTargetCleanupOnRollback;
+        this.writesToNonManagedTablesEnabled = writesToNonManagedTablesEnabled;
+        this.createsOfNonManagedTablesEnabled = createsOfNonManagedTablesEnabled;
+        this.translateHiveViews = translateHiveViews;
+        this.hideDeltaLakeTables = hideDeltaLakeTables;
+        this.perTransactionCacheMaximumSize = perTransactionCacheMaximumSize;
+
+        this.metastoreFactory = requireNonNull(metastoreFactory, "metastore is null");
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+        this.partitionManager = requireNonNull(partitionManager, "partitionManager is null");
+        this.timeZone = requireNonNull(timeZone, "timeZone is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.metadataProvider = requireNonNull(metadataProvider, "metadata provider is null");
+        this.locationService = requireNonNull(locationService, "locationService is null");
+        this.partitionUpdateCodec = requireNonNull(partitionUpdateCodec, "partitionUpdateCodec is null");
+        this.prestoVersion = requireNonNull(prestoVersion, "prestoVersion is null");
+        this.hiveRedirectionsProvider = requireNonNull(hiveRedirectionsProvider, "hiveRedirectionsProvider is null");
+        this.hiveMaterializedViewMetadata = requireNonNull(hiveMaterializedViewMetadata, "hiveMaterializedViewMetadata is null");
+        this.accessControlMetadataFactory = requireNonNull(accessControlMetadataFactory, "accessControlMetadataFactory is null");
+        this.hiveTransactionHeartbeatInterval = requireNonNull(hiveTransactionHeartbeatInterval, "hiveTransactionHeartbeatInterval is null");
+        this.systemTableProviders = requireNonNull(systemTableProviders, "systemTableProviders is null");
+
+        if (!timeZone.equals(DateTimeZone.getDefault())) {
+            log.warn("Hive writes are disabled. " +
+                            "To write data to Hive, your JVM timezone must match the Hive storage timezone. " +
+                            "Add -Duser.timezone=%s to your JVM arguments",
+                    timeZone.getID());
+        }
+
+        renameExecution = new BoundedExecutor(executorService, maxConcurrentFileRenames);
+        dropExecutor = new BoundedExecutor(executorService, maxConcurrentMetastoreDrops);
+        updateExecutor = new BoundedExecutor(executorService, maxConcurrentMetastoreUpdates);
+        this.heartbeatService = requireNonNull(heartbeatService, "heartbeatService is null");
+        this.hiveTableRedirectionsProvider = requireNonNull(hiveTableRedirectionsProvider, "hiveTableRedirectionsProvider is null");
+        this.directoryLister = requireNonNull(directoryLister, "directoryLister is null");
+        this.perTransactionFileStatusCacheMaximumSize = perTransactionFileStatusCacheMaximumSize;
+    }
+
+    @Override
+    public TransactionalMetadata create(ConnectorIdentity connectorIdentity, boolean autocommit)
+    {
+        DirectoryLister directoryLister = new TransactionScopeCachingDirectoryLister(this.directoryLister, perTransactionFileStatusCacheMaximumSize);
+
+        SemiTransactionalHiveMetastore metastore = new SemiTransactionalHiveMetastore(
+                hdfsEnvironment,
+                new HiveMetastoreClosure(memoizeMetastore(this.metastoreFactory.createMetastore(Optional.of(connectorIdentity)), perTransactionCacheMaximumSize)), // per-transaction cache
+                renameExecution,
+                dropExecutor,
+                updateExecutor,
+                skipDeletionForAlter,
+                skipTargetCleanupOnRollback,
+                autocommit,
+                hiveTransactionHeartbeatInterval,
+                heartbeatService,
+                directoryLister);
+
+        return new HiddenPartitioningHiveMetadata(
+                catalogName,
+                metastore,
+                hdfsEnvironment,
+                partitionManager,
+                timeZone,
+                writesToNonManagedTablesEnabled,
+                createsOfNonManagedTablesEnabled,
+                translateHiveViews,
+                hideDeltaLakeTables,
+                typeManager,
+                metadataProvider,
+                locationService,
+                partitionUpdateCodec,
+                prestoVersion,
+                new MetastoreHiveStatisticsProvider(metastore),
+                hiveRedirectionsProvider,
+                systemTableProviders,
+                hiveMaterializedViewMetadata,
+                accessControlMetadataFactory.create(metastore),
+                hiveTableRedirectionsProvider,
+                autocommit,
+                directoryLister);
+    }
+
+    public Set<SystemTableProvider> getSystemTableProviders()
+    {
+        return systemTableProviders;
+    }
+}

--- a/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningModule.java
+++ b/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningModule.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hidden.partitioning;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import io.trino.plugin.hive.HiveMaterializedViewMetadata;
+import io.trino.plugin.hive.NoneHiveMaterializedViewMetadata;
+import io.trino.plugin.hive.TransactionalMetadataFactory;
+
+import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class HiddenPartitioningModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(HiddenPartitioningSessionProperties.class).in(Scopes.SINGLETON);
+        newOptionalBinder(binder, HiveMaterializedViewMetadata.class)
+                .setDefault().to(NoneHiveMaterializedViewMetadata.class).in(Scopes.SINGLETON);
+        binder.bind(HiddenPartitioningMetadataFactory.class).in(Scopes.SINGLETON);
+        binder.bind(TransactionalMetadataFactory.class).to(HiddenPartitioningMetadataFactory.class).in(Scopes.SINGLETON);
+        binder.bind(HiddenPartitioningTableProperties.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfig(HiddenPartitioningConfig.class);
+    }
+}

--- a/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningPartitionSpec.java
+++ b/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningPartitionSpec.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hidden.partitioning;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class HiddenPartitioningPartitionSpec
+{
+    private final List<PartitionField> fields;
+
+    @JsonCreator
+    public HiddenPartitioningPartitionSpec(@JsonProperty("fields") List<PartitionField> fields)
+    {
+        this.fields = fields;
+    }
+
+    public List<PartitionField> getFields()
+    {
+        return fields;
+    }
+
+    public static class PartitionField
+    {
+        private final String sourceName;
+        private final String name;
+        private final String transform;
+
+        @JsonCreator
+        public PartitionField(
+                @JsonProperty("source-name") String sourceName,
+                @JsonProperty("name") String name,
+                @JsonProperty("transform") String transform)
+        {
+            this.sourceName = sourceName;
+            this.name = name;
+            this.transform = transform;
+        }
+
+        public String getSourceName()
+        {
+            return sourceName;
+        }
+
+        public String getName()
+        {
+            return name;
+        }
+
+        public String getTransform()
+        {
+            return transform;
+        }
+    }
+}

--- a/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningPlugin.java
+++ b/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningPlugin.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hidden.partitioning;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.Plugin;
+import io.trino.spi.connector.ConnectorFactory;
+
+public class HiddenPartitioningPlugin
+        implements Plugin
+{
+    @Override
+    public Iterable<ConnectorFactory> getConnectorFactories()
+    {
+        return ImmutableList.of(new HiddenPartitioningConnectorFactory("hive-hidden-partitioning"));
+    }
+}

--- a/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningSessionProperties.java
+++ b/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningSessionProperties.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hidden.partitioning;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.plugin.base.session.SessionPropertiesProvider;
+import io.trino.plugin.hive.HiveSessionProperties;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.session.PropertyMetadata;
+
+import javax.inject.Inject;
+
+import java.util.List;
+
+import static io.trino.spi.session.PropertyMetadata.booleanProperty;
+
+public class HiddenPartitioningSessionProperties
+        implements SessionPropertiesProvider
+{
+    private static final String PARTITION_SPEC_ENABLED = "partition_spec_enabled";
+
+    private final List<PropertyMetadata<?>> sessionProperties;
+
+    @Inject
+    public HiddenPartitioningSessionProperties(HiveSessionProperties hiveSessionProperties, HiddenPartitioningConfig config)
+    {
+        ImmutableList.Builder<PropertyMetadata<?>> builder = ImmutableList.builder();
+        builder.addAll(hiveSessionProperties.getSessionProperties());
+        builder.add(
+                booleanProperty(
+                        PARTITION_SPEC_ENABLED,
+                        "Use partition spec if defined in table properties",
+                        config.isPartitionSpecEnabled(),
+                        false));
+        sessionProperties = builder.build();
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getSessionProperties()
+    {
+        return sessionProperties;
+    }
+
+    public static boolean isPartitionSpecEnabled(ConnectorSession session)
+    {
+        return session.getProperty(PARTITION_SPEC_ENABLED, Boolean.class);
+    }
+}

--- a/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningSpecParser.java
+++ b/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningSpecParser.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hidden.partitioning;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
+import io.trino.spi.TrinoException;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.trino.plugin.hive.HiveErrorCode.HIVE_INVALID_METADATA;
+import static java.lang.Integer.parseInt;
+import static java.util.Objects.requireNonNull;
+
+public class HiddenPartitioningSpecParser
+{
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static final String FUNCTION_INT = "\\[ *(\\d+) *\\]";
+    private static final Pattern IDENTITY_PATTERN = Pattern.compile("identity");
+    private static final Pattern YEAR_PATTERN = Pattern.compile("year");
+    private static final Pattern MONTH_PATTERN = Pattern.compile("month");
+    private static final Pattern DAY_PATTERN = Pattern.compile("day");
+    private static final Pattern HOUR_PATTERN = Pattern.compile("hour");
+    private static final Pattern BUCKET_PATTERN = Pattern.compile("bucket" + FUNCTION_INT);
+    private static final Pattern TRUNCATE_PATTERN = Pattern.compile("truncate" + FUNCTION_INT);
+
+    private HiddenPartitioningSpecParser()
+    {
+    }
+
+    public static HiddenPartitioningPartitionSpec fromJson(String partitionSpecJson)
+    {
+        try {
+            return MAPPER.readValue(partitionSpecJson, HiddenPartitioningPartitionSpec.class);
+        }
+        catch (JsonProcessingException e) {
+            throw new TrinoException(HIVE_INVALID_METADATA, "Unable to parse partition spec: " + partitionSpecJson);
+        }
+    }
+
+    public static void validateSpecJson(String partitionSpecJson)
+    {
+        HiddenPartitioningPartitionSpec hiddenPartitioningPartitionSpec = fromJson(partitionSpecJson);
+        for (HiddenPartitioningPartitionSpec.PartitionField specField : hiddenPartitioningPartitionSpec.getFields()) {
+            requireNonNull(specField.getName(), "partition spec name is null");
+            requireNonNull(specField.getTransform(), "partition spec transform is null");
+            requireNonNull(specField.getSourceName(), "partition spec source name is null");
+        }
+    }
+
+    private static boolean tryMatch(CharSequence value, Pattern pattern, Consumer<MatchResult> match)
+    {
+        Matcher matcher = pattern.matcher(value);
+        if (matcher.matches()) {
+            match.accept(matcher.toMatchResult());
+            return true;
+        }
+        return false;
+    }
+
+    public static org.apache.iceberg.PartitionSpec toIcebergPartitionSpec(HiddenPartitioningPartitionSpec hiddenPartitioningPartitionSpec, Schema icebergSchema)
+    {
+        // Iceberg's PartitionSpec builder requires names that aren't already in the Schema, so first remove the spec field names from the Schema
+        ImmutableSet<String> partitionColNames = hiddenPartitioningPartitionSpec.getFields().stream()
+                .map(HiddenPartitioningPartitionSpec.PartitionField::getName)
+                .map(String::toLowerCase)
+                .collect(toImmutableSet());
+        List<Types.NestedField> baseFields = icebergSchema.columns().stream()
+                .filter(schemaField -> !partitionColNames.contains(schemaField.name()))
+                .collect(Collectors.toList());
+        Schema baseSchema = new Schema(baseFields);
+        AtomicInteger nextFieldId = new AtomicInteger(1);
+        TypeUtil.assignFreshIds(baseSchema, nextFieldId::getAndIncrement);
+
+        org.apache.iceberg.PartitionSpec.Builder builder = org.apache.iceberg.PartitionSpec.builderFor(baseSchema);
+        for (HiddenPartitioningPartitionSpec.PartitionField trinoPartitionField : hiddenPartitioningPartitionSpec.getFields()) {
+            boolean matched = tryMatch(trinoPartitionField.getTransform(), IDENTITY_PATTERN, match -> builder.identity(match.group())) ||
+                    tryMatch(trinoPartitionField.getTransform(), YEAR_PATTERN, match -> builder.year(trinoPartitionField.getSourceName(), trinoPartitionField.getName())) ||
+                    tryMatch(trinoPartitionField.getTransform(), MONTH_PATTERN, match -> builder.month(trinoPartitionField.getSourceName(), trinoPartitionField.getName())) ||
+                    tryMatch(trinoPartitionField.getTransform(), DAY_PATTERN, match -> builder.day(trinoPartitionField.getSourceName(), trinoPartitionField.getName())) ||
+                    tryMatch(trinoPartitionField.getTransform(), HOUR_PATTERN, match -> builder.hour(trinoPartitionField.getSourceName(), trinoPartitionField.getName())) ||
+                    tryMatch(trinoPartitionField.getTransform(), BUCKET_PATTERN, match -> builder.bucket(trinoPartitionField.getSourceName(), parseInt(match.group(1)), trinoPartitionField.getName())) ||
+                    tryMatch(trinoPartitionField.getTransform(), TRUNCATE_PATTERN, match -> builder.truncate(trinoPartitionField.getSourceName(), parseInt(match.group(1)), trinoPartitionField.getName()));
+
+            if (!matched) {
+                throw new IllegalArgumentException("Invalid partition field declaration: " + trinoPartitionField.getTransform());
+            }
+        }
+        return builder.build();
+    }
+}

--- a/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningTableProperties.java
+++ b/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningTableProperties.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hidden.partitioning;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.plugin.hive.HiveTableProperties;
+import io.trino.spi.session.PropertyMetadata;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.trino.spi.session.PropertyMetadata.stringProperty;
+
+public class HiddenPartitioningTableProperties
+{
+    public static final String PARTITION_SPEC_PROPERTY = "partition_spec";
+
+    private final List<PropertyMetadata<?>> tableProperties;
+
+    @Inject
+    public HiddenPartitioningTableProperties(HiveTableProperties hiveTableProperties)
+    {
+        ImmutableList.Builder<PropertyMetadata<?>> builder = ImmutableList.builder();
+        builder.addAll(hiveTableProperties.getTableProperties());
+        builder.add(stringProperty(PARTITION_SPEC_PROPERTY, "Partition spec for hidden partitioning", null, false));
+        tableProperties = builder.build();
+    }
+
+    public List<PropertyMetadata<?>> getTableProperties()
+    {
+        return tableProperties;
+    }
+
+    public static String getPartitionSpecJson(Map<String, Object> tableProperties)
+    {
+        return (String) tableProperties.get(PARTITION_SPEC_PROPERTY);
+    }
+}

--- a/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningTypeConverter.java
+++ b/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningTypeConverter.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hidden.partitioning;
+
+import io.trino.spi.TrinoException;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.BigintType;
+import io.trino.spi.type.BooleanType;
+import io.trino.spi.type.DateType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.DoubleType;
+import io.trino.spi.type.IntegerType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RealType;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.TimeType;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.TimestampWithTimeZoneType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarbinaryType;
+import io.trino.spi.type.VarcharType;
+import org.apache.iceberg.types.Types;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.type.TimeType.TIME_MICROS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MICROS;
+
+/**
+ * Taken from Iceberg connector's {@code io.trino.plugin.iceberg.TypeConverter}
+ */
+public final class HiddenPartitioningTypeConverter
+{
+    private HiddenPartitioningTypeConverter() {}
+
+    public static org.apache.iceberg.types.Type toIcebergType(Type type)
+    {
+        if (type instanceof BooleanType) {
+            return Types.BooleanType.get();
+        }
+        if (type instanceof IntegerType) {
+            return Types.IntegerType.get();
+        }
+        if (type instanceof BigintType) {
+            return Types.LongType.get();
+        }
+        if (type instanceof RealType) {
+            return Types.FloatType.get();
+        }
+        if (type instanceof DoubleType) {
+            return Types.DoubleType.get();
+        }
+        if (type instanceof DecimalType) {
+            return fromDecimal((DecimalType) type);
+        }
+        if (type instanceof VarcharType) {
+            return Types.StringType.get();
+        }
+        if (type instanceof VarbinaryType) {
+            return Types.BinaryType.get();
+        }
+        if (type instanceof DateType) {
+            return Types.DateType.get();
+        }
+        if (type.equals(TIME_MICROS)) {
+            return Types.TimeType.get();
+        }
+        if (type.equals(TIMESTAMP_MICROS)) {
+            return Types.TimestampType.withoutZone();
+        }
+        if (type.equals(TIMESTAMP_TZ_MICROS)) {
+            return Types.TimestampType.withZone();
+        }
+        if (type instanceof RowType) {
+            return fromRow((RowType) type);
+        }
+        if (type instanceof ArrayType) {
+            return fromArray((ArrayType) type);
+        }
+        if (type instanceof MapType) {
+            return fromMap((MapType) type);
+        }
+        if (type instanceof TimeType) {
+            return Types.TimeType.get();
+        }
+        if (type instanceof TimestampType) {
+            return Types.TimestampType.withoutZone();
+        }
+        if (type instanceof TimestampWithTimeZoneType) {
+            return Types.TimestampType.withZone();
+        }
+        throw new TrinoException(NOT_SUPPORTED, "Type not supported for Iceberg: " + type.getDisplayName());
+    }
+
+    private static org.apache.iceberg.types.Type fromDecimal(DecimalType type)
+    {
+        return Types.DecimalType.of(type.getPrecision(), type.getScale());
+    }
+
+    private static org.apache.iceberg.types.Type fromRow(RowType type)
+    {
+        List<Types.NestedField> fields = new ArrayList<>();
+        for (RowType.Field field : type.getFields()) {
+            String name = field.getName().orElseThrow(() ->
+                    new TrinoException(NOT_SUPPORTED, "Row type field does not have a name: " + type.getDisplayName()));
+            fields.add(Types.NestedField.optional(fields.size() + 1, name, toIcebergType(field.getType())));
+        }
+        return Types.StructType.of(fields);
+    }
+
+    private static org.apache.iceberg.types.Type fromArray(ArrayType type)
+    {
+        return Types.ListType.ofOptional(1, toIcebergType(type.getElementType()));
+    }
+
+    private static org.apache.iceberg.types.Type fromMap(MapType type)
+    {
+        return Types.MapType.ofOptional(1, 2, toIcebergType(type.getKeyType()), toIcebergType(type.getValueType()));
+    }
+}

--- a/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningUtil.java
+++ b/plugin/trino-hive-hidden-partitioning/src/main/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningUtil.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hidden.partitioning;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.plugin.hive.HiveColumnHandle;
+import io.trino.plugin.hive.HivePartition;
+import io.trino.plugin.hive.HivePartitionResult;
+import io.trino.spi.StandardErrorCode;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.predicate.NullableValue;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.BigintType;
+import io.trino.spi.type.DateType;
+import io.trino.spi.type.IntegerType;
+import io.trino.spi.type.TimeType;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.Type;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.expressions.ManifestEvaluator;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
+
+import javax.annotation.Nullable;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.google.common.collect.Streams.stream;
+import static io.trino.plugin.hidden.partitioning.HiddenPartitioningExpressionConverter.toIcebergExpression;
+import static io.trino.plugin.hidden.partitioning.HiddenPartitioningTypeConverter.toIcebergType;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.stream.Collectors.toMap;
+
+public final class HiddenPartitioningUtil
+{
+    private HiddenPartitioningUtil() {}
+
+    public static org.apache.iceberg.PartitionSpec toIcebergPartitionSpec(ConnectorTableMetadata tableMetadata, HiddenPartitioningPartitionSpec hiddenPartitioningPartitionSpec)
+    {
+        Schema icebergSchema = toIcebergSchema(tableMetadata.getColumns());
+        return HiddenPartitioningSpecParser.toIcebergPartitionSpec(hiddenPartitioningPartitionSpec, icebergSchema);
+    }
+
+    public static HivePartitionResult transformFilteredPartitionResult(HivePartitionResult partitionResult, org.apache.iceberg.PartitionSpec icebergPartitionSpec)
+    {
+        List<HiveColumnHandle> partitionColumns = partitionResult.getPartitionColumns();
+        TupleDomain<ColumnHandle> unenforcedConstraint = partitionResult.getEffectivePredicate().filter((column, domain) -> !partitionColumns.contains(column));
+        ManifestEvaluator manifestEvaluator = getManifestEvaluator(unenforcedConstraint, icebergPartitionSpec);
+
+        Iterable<HivePartition> filteredPartitions = () -> stream(partitionResult.getPartitions())
+                .filter(partition -> transformedPartitionMatches(partitionResult.getPartitionColumns(), partition, manifestEvaluator, icebergPartitionSpec))
+                .iterator();
+
+        return new HivePartitionResult(
+                partitionResult.getPartitionColumns(),
+                partitionResult.getPartitionNames(),
+                filteredPartitions,
+                partitionResult.getEffectivePredicate(),
+                partitionResult.getCompactEffectivePredicate(),
+                partitionResult.getBucketHandle(),
+                partitionResult.getBucketFilter());
+    }
+
+    private static boolean transformedPartitionMatches(
+            List<HiveColumnHandle> partitionColumns,
+            HivePartition partition,
+            ManifestEvaluator evaluator,
+            org.apache.iceberg.PartitionSpec icebergPartitionSpec)
+    {
+        Map<ColumnHandle, NullableValue> keyVals = partition.getKeys();
+        Map<String, NullableValue> valueMap = partitionColumns.stream().collect(toMap(HiveColumnHandle::getName, keyVals::get));
+
+        ImmutableList.Builder<ManifestFile.PartitionFieldSummary> fieldSummaryList = ImmutableList.builder();
+        for (PartitionField specField : icebergPartitionSpec.fields()) {
+            NullableValue partitionValue = requireNonNull(valueMap.get(specField.name()), "Didn't find partition value for field: " + specField.name());
+            ByteBuffer value = toIcebergValue(partitionValue);
+            fieldSummaryList.add(new HiddenPartitioningManifestFile.TrinoPartitionFieldSummary(partitionValue.isNull(), value, value));
+        }
+        return evaluator.eval(new HiddenPartitioningManifestFile(fieldSummaryList.build()));
+    }
+
+    private static ManifestEvaluator getManifestEvaluator(TupleDomain<ColumnHandle> predicate, org.apache.iceberg.PartitionSpec icebergPartitionSpec)
+    {
+        TupleDomain<HiveColumnHandle> hivePredicate = predicate.transformKeys(HiveColumnHandle.class::cast);
+        return ManifestEvaluator.forRowFilter(toIcebergExpression(hivePredicate), icebergPartitionSpec, false);
+    }
+
+    @Nullable
+    private static ByteBuffer toIcebergValue(NullableValue partitionValue)
+    {
+        if (partitionValue.isNull()) {
+            return null;
+        }
+        Type type = partitionValue.getType();
+        // hour() transform
+        if (type instanceof TimestampType || type instanceof TimeType) {
+            long epochMicros = MICROSECONDS.toHours((Long) partitionValue.getValue());
+            return Conversions.toByteBuffer(Types.TimestampType.withoutZone(), epochMicros);
+        }
+
+        // Trino and Iceberg both store date as days from epoch
+        if (type instanceof DateType) {
+            final int epochDays = toIntExact(((Long) partitionValue.getValue()));
+            return Conversions.toByteBuffer(Types.DateType.get(), epochDays);
+        }
+
+        if (type instanceof IntegerType || type instanceof BigintType) {
+            final long val = (Long) partitionValue.getValue();
+            return Conversions.toByteBuffer(Types.LongType.get(), val);
+        }
+        throw new TrinoException(StandardErrorCode.NOT_SUPPORTED, "Unsupported type for hidden partitioning: " + type);
+    }
+
+    private static Schema toIcebergSchema(List<ColumnMetadata> columns)
+    {
+        List<Types.NestedField> icebergColumns = new ArrayList<>();
+        for (ColumnMetadata column : columns) {
+            if (!column.isHidden()) {
+                int index = icebergColumns.size();
+                org.apache.iceberg.types.Type type = toIcebergType(column.getType());
+                Types.NestedField field = column.isNullable()
+                        ? Types.NestedField.optional(index, column.getName(), type, column.getComment())
+                        : Types.NestedField.required(index, column.getName(), type, column.getComment());
+                icebergColumns.add(field);
+            }
+        }
+        Schema schema = new Schema(icebergColumns);
+        AtomicInteger nextFieldId = new AtomicInteger(1);
+        return TypeUtil.assignFreshIds(schema, nextFieldId::getAndIncrement);
+    }
+}

--- a/plugin/trino-hive-hidden-partitioning/src/test/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningQueryRunner.java
+++ b/plugin/trino-hive-hidden-partitioning/src/test/java/io/trino/plugin/hidden/partitioning/HiddenPartitioningQueryRunner.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hidden.partitioning;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Module;
+import io.airlift.log.Logging;
+import io.trino.Session;
+import io.trino.plugin.hive.NodeVersion;
+import io.trino.plugin.hive.metastore.Database;
+import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.plugin.hive.metastore.MetastoreConfig;
+import io.trino.plugin.hive.metastore.file.FileHiveMetastore;
+import io.trino.plugin.hive.metastore.file.FileHiveMetastoreConfig;
+import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.spi.security.Identity;
+import io.trino.spi.security.PrincipalType;
+import io.trino.spi.security.SelectedRole;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.tpch.TpchTable;
+import org.joda.time.DateTimeZone;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static com.google.inject.util.Modules.EMPTY_MODULE;
+import static io.airlift.log.Level.WARN;
+import static io.trino.plugin.hive.HiveQueryRunner.HIVE_CATALOG;
+import static io.trino.plugin.hive.HiveQueryRunner.TPCH_SCHEMA;
+import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
+import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static io.trino.spi.security.SelectedRole.Type.ROLE;
+import static io.trino.testing.QueryAssertions.copyTpchTables;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertEquals;
+
+public final class HiddenPartitioningQueryRunner
+{
+    private static final String HIVE_BUCKETED_CATALOG = "hive_bucketed";
+    private static final DateTimeZone TIME_ZONE = DateTimeZone.forID("America/Bahia_Banderas");
+
+    private HiddenPartitioningQueryRunner() {}
+
+    public static class Builder
+            extends DistributedQueryRunner.Builder
+    {
+        private Map<String, String> hiveProperties = ImmutableMap.of();
+        private List<TpchTable<?>> initialTables = ImmutableList.of();
+        private Function<DistributedQueryRunner, HiveMetastore> metastore = queryRunner -> {
+            File baseDir = queryRunner.getCoordinator().getBaseDataDir().resolve("hive_data").toFile();
+            return new FileHiveMetastore(
+                    new NodeVersion("test_version"),
+                    HDFS_ENVIRONMENT,
+                    new MetastoreConfig(),
+                    new FileHiveMetastoreConfig()
+                            .setCatalogDirectory(baseDir.toURI().toString())
+                            .setMetastoreUser("test"));
+        };
+        private Module module = EMPTY_MODULE;
+
+        protected Builder()
+        {
+            super(createSession(Optional.of(new SelectedRole(ROLE, Optional.of("admin")))));
+        }
+
+        public Builder setHiveProperties(Map<String, String> hiveProperties)
+        {
+            this.hiveProperties = ImmutableMap.copyOf(requireNonNull(hiveProperties, "hiveProperties is null"));
+            return this;
+        }
+
+        public Builder setInitialTables(Iterable<TpchTable<?>> initialTables)
+        {
+            this.initialTables = ImmutableList.copyOf(requireNonNull(initialTables, "initialTables is null"));
+            return this;
+        }
+
+        public Builder setMetastore(Function<DistributedQueryRunner, HiveMetastore> metastore)
+        {
+            this.metastore = requireNonNull(metastore, "metastore is null");
+            return this;
+        }
+
+        public Builder setModule(Module module)
+        {
+            this.module = requireNonNull(module, "module is null");
+            return this;
+        }
+
+        @Override
+        public DistributedQueryRunner build()
+                throws Exception
+        {
+            assertEquals(DateTimeZone.getDefault(), TIME_ZONE, "Timezone not configured correctly. Add -Duser.timezone=America/Bahia_Banderas to your JVM arguments");
+            setupLogging();
+
+            DistributedQueryRunner queryRunner = super.build();
+
+            try {
+                queryRunner.installPlugin(new TpchPlugin());
+                queryRunner.createCatalog("tpch", "tpch");
+
+                HiveMetastore metastore = this.metastore.apply(queryRunner);
+                queryRunner.installPlugin(new TestingHiddenPartitioningPlugin(metastore, module));
+
+                Map<String, String> hiveProperties = ImmutableMap.<String, String>builder()
+                        .put("hive.orc.time-zone", TIME_ZONE.getID())
+                        .put("hive.max-partitions-per-scan", "1000")
+                        .buildOrThrow();
+
+                hiveProperties = new HashMap<>(hiveProperties);
+                hiveProperties.putAll(this.hiveProperties);
+                hiveProperties.putIfAbsent("hive.security", "sql-standard");
+
+                Map<String, String> hiveBucketedProperties = ImmutableMap.<String, String>builder()
+                        .putAll(hiveProperties)
+                        .put("hive.max-initial-split-size", "10kB") // so that each bucket has multiple splits
+                        .put("hive.max-split-size", "10kB") // so that each bucket has multiple splits
+                        .put("hive.storage-format", "TEXTFILE") // so that there's no minimum split size for the file
+                        .put("hive.compression-codec", "NONE") // so that the file is splittable
+                        .buildOrThrow();
+                queryRunner.createCatalog(HIVE_CATALOG, "test-hidden-partitioning", hiveProperties);
+
+                if (!initialTables.isEmpty()) {
+                    populateData(queryRunner, metastore);
+                }
+
+                return queryRunner;
+            }
+            catch (Exception e) {
+                queryRunner.close();
+                throw e;
+            }
+        }
+
+        private void populateData(DistributedQueryRunner queryRunner, HiveMetastore metastore)
+        {
+            if (!metastore.getDatabase(TPCH_SCHEMA).isPresent()) {
+                metastore.createDatabase(createDatabaseMetastoreObject(TPCH_SCHEMA));
+                copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(Optional.empty()), initialTables);
+            }
+        }
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    private static void setupLogging()
+    {
+        Logging logging = Logging.initialize();
+        logging.setLevel("org.apache.parquet.hadoop", WARN);
+    }
+
+    private static Database createDatabaseMetastoreObject(String name)
+    {
+        return Database.builder()
+                .setDatabaseName(name)
+                .setOwnerName(Optional.of("public"))
+                .setOwnerType(Optional.of(PrincipalType.ROLE))
+                .build();
+    }
+
+    private static Session createSession(Optional<SelectedRole> role)
+    {
+        return testSessionBuilder()
+                .setIdentity(Identity.forUser("hive")
+                        .withRoles(role.map(selectedRole -> ImmutableMap.of("hive", selectedRole))
+                                .orElse(ImmutableMap.of()))
+                        .build())
+                .setCatalog(HIVE_CATALOG)
+                .setSchema(TPCH_SCHEMA)
+                .build();
+    }
+}

--- a/plugin/trino-hive-hidden-partitioning/src/test/java/io/trino/plugin/hidden/partitioning/TestHiddenPartitioningPartitionSpecParser.java
+++ b/plugin/trino-hive-hidden-partitioning/src/test/java/io/trino/plugin/hidden/partitioning/TestHiddenPartitioningPartitionSpecParser.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hidden.partitioning;
+
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Types;
+import org.testng.annotations.Test;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.testng.Assert.assertEquals;
+
+public class TestHiddenPartitioningPartitionSpecParser
+{
+    private static final Schema SCHEMA = new Schema(
+            required(1, "id", Types.IntegerType.get()),
+            optional(2, "val", Types.StringType.get()),
+            optional(3, "event_time", Types.TimestampType.withoutZone()),
+            optional(4, "event_date", Types.TimestampType.withoutZone()));
+
+    public static final String DAY_SPEC = "{\n" +
+            "  \"fields\" : [ {\n" +
+            "    \"name\" : \"event_date\",\n" +
+            "    \"transform\" : \"day\",\n" +
+            "    \"source-name\" : \"event_time\"\n" +
+            "  } ]\n" +
+            "}";
+
+    public static final String TRUNCATE_SPEC = "{\n" +
+            "  \"fields\": [\n" +
+            "    {\n" +
+            "      \"source-name\": \"epoch_timestamp\",\n" +
+            "      \"transform\": \"truncate[86400]\",\n" +
+            "      \"name\": \"event_date\"\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}";
+
+    @Test
+    public void testFromJson()
+            throws Exception
+    {
+        HiddenPartitioningPartitionSpec hiddenPartitionSpec = HiddenPartitioningSpecParser.fromJson(DAY_SPEC);
+        assertEquals(1, hiddenPartitionSpec.getFields().size());
+        HiddenPartitioningPartitionSpec.PartitionField partitionField = hiddenPartitionSpec.getFields().get(0);
+        assertEquals("event_date", partitionField.getName());
+        assertEquals("day", partitionField.getTransform());
+        assertEquals("event_time", partitionField.getSourceName());
+    }
+
+    @Test
+    public void testToIcebergPartitionSpec()
+            throws Exception
+    {
+        HiddenPartitioningPartitionSpec hiddenPartitionSpec = HiddenPartitioningSpecParser.fromJson(DAY_SPEC);
+        PartitionSpec partitionSpec = HiddenPartitioningSpecParser.toIcebergPartitionSpec(hiddenPartitionSpec, SCHEMA);
+        assertEquals(1, partitionSpec.getFieldsBySourceId(3).size());
+    }
+
+    @Test
+    public void testValidateSpecJson()
+    {
+        HiddenPartitioningSpecParser.validateSpecJson(DAY_SPEC);
+    }
+
+    @Test
+    public void testValidateTruncateSpecJson()
+    {
+        HiddenPartitioningSpecParser.validateSpecJson(TRUNCATE_SPEC);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "partition spec name is null")
+    public void testValidateSpecJsonMissingName()
+    {
+        String badSpec = "{\n" +
+                "  \"fields\" : [ {\n" +
+                "    \"transform\" : \"day\",\n" +
+                "    \"source-name\" : \"event_time\"\n" +
+                "  } ]\n" +
+                "}";
+        HiddenPartitioningSpecParser.validateSpecJson(badSpec);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "partition spec transform is null")
+    public void testValidateSpecJsonMissingTransform()
+    {
+        String badSpec = "{\n" +
+                "  \"fields\" : [ {\n" +
+                "    \"name\" : \"event_date\",\n" +
+                "    \"source-name\" : \"event_time\"\n" +
+                "  } ]\n" +
+                "}";
+        HiddenPartitioningSpecParser.validateSpecJson(badSpec);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "partition spec source name is null")
+    public void testValidateSpecJsonMissingSourceName()
+    {
+        String badSpec = "{\n" +
+                "  \"fields\" : [ {\n" +
+                "    \"name\" : \"event_date\",\n" +
+                "    \"transform\" : \"day\"\n" +
+                "  } ]\n" +
+                "}";
+        HiddenPartitioningSpecParser.validateSpecJson(badSpec);
+    }
+}

--- a/plugin/trino-hive-hidden-partitioning/src/test/java/io/trino/plugin/hidden/partitioning/TestHiddenPartitioningPartitionTransforms.java
+++ b/plugin/trino-hive-hidden-partitioning/src/test/java/io/trino/plugin/hidden/partitioning/TestHiddenPartitioningPartitionTransforms.java
@@ -1,0 +1,503 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hidden.partitioning;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
+import io.trino.spi.security.Identity;
+import io.trino.spi.security.SelectedRole;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.trino.plugin.hive.HiveQueryRunner.HIVE_CATALOG;
+import static io.trino.plugin.hive.HiveQueryRunner.TPCH_SCHEMA;
+import static io.trino.spi.security.SelectedRole.Type.ROLE;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.tpch.TpchTable.NATION;
+
+public class TestHiddenPartitioningPartitionTransforms
+        extends AbstractTestQueryFramework
+{
+    private static final String DAY_SPEC = "{\n" +
+            "  \"fields\" : [ {\n" +
+            "    \"name\" : \"event_date\",\n" +
+            "    \"transform\" : \"day\",\n" +
+            "    \"source-name\" : \"event_time\"\n" +
+            "  } ]\n" +
+            "}";
+    private static final String HOUR_SPEC = "{\n" +
+            "  \"fields\" : [ {\n" +
+            "    \"name\" : \"event_hour\",\n" +
+            "    \"transform\" : \"hour\",\n" +
+            "    \"source-name\" : \"event_time\"\n" +
+            "  } ]\n" +
+            "}";
+
+    private final Session session;
+
+    public TestHiddenPartitioningPartitionTransforms()
+    {
+        session = getHiveSession();
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return HiddenPartitioningQueryRunner.builder()
+                .setInitialTables(ImmutableList.of(NATION)) // create TPCH schema
+                .setHiveProperties(ImmutableMap.of("hive.partition-spec-enabled", "true"))
+                .build();
+    }
+
+    @Test
+    public void testDayTransformEqualityFilter()
+    {
+        createTableDaySpec(session, "dayTransformEqualityFilter");
+
+        // Purposely put some rows with the event_time in the wrong partitions, to test the hidden partition filtering
+        assertUpdate(session, "INSERT INTO dayTransformEqualityFilter(id, event_time, event_date) VALUES (1, timestamp '2020-04-20 00:00:00', date '2020-04-19')", 1);
+        assertUpdate(session, "INSERT INTO dayTransformEqualityFilter(id, event_time, event_date) VALUES (2, timestamp '2020-04-20 00:00:00', date '2020-04-20')", 1);
+        assertUpdate(session, "INSERT INTO dayTransformEqualityFilter(id, event_time, event_date) VALUES (3, timestamp '2020-04-20 00:00:00', date '2020-04-21')", 1);
+
+        // Partition spec transform of event_time ensures only 1 result
+        String query = "SELECT id FROM dayTransformEqualityFilter WHERE event_time = timestamp '2020-04-20 00:00:00'";
+        assertQuery(session, query, "select 2");
+
+        assertUpdate(session, "DELETE FROM dayTransformEqualityFilter");
+
+        assertUpdate(session, "INSERT INTO dayTransformEqualityFilter(id, event_time, event_date) VALUES (1, timestamp '2020-04-19 00:00:00', date '2020-04-19')", 1);
+        assertUpdate(session, "INSERT INTO dayTransformEqualityFilter(id, event_time, event_date) VALUES (2, timestamp '2020-04-19 00:00:00', date '2020-04-20')", 1);
+        assertUpdate(session, "INSERT INTO dayTransformEqualityFilter(id, event_time, event_date) VALUES (3, timestamp '2020-04-21 00:00:00', date '2020-04-21')", 1);
+
+        query = "SELECT id FROM dayTransformEqualityFilter WHERE event_time = timestamp '2020-04-19 00:00:00' OR event_time = timestamp '2020-04-21 00:00:00'";
+        assertQuery(session, query, "VALUES (1), (3)");
+
+        query = "SELECT id FROM dayTransformEqualityFilter WHERE event_time IN (timestamp '2020-04-19 00:00:00', timestamp '2020-04-21 00:00:00')";
+        assertQuery(session, query, "VALUES (1), (3)");
+
+        // '2020-04-20' partition included because it could still have timestamps satisfying the predicate, e.g. '2020-04-20 11:24:32'
+        query = "SELECT id FROM dayTransformEqualityFilter WHERE event_time != timestamp '2020-04-20 00:00:00'";
+        assertQuery(session, query, "VALUES (1), (2), (3)");
+
+        query = "SELECT id FROM dayTransformEqualityFilter WHERE event_time NOT IN (timestamp '2020-04-20 00:00:00')";
+        assertQuery(session, query, "VALUES (1), (2), (3)");
+
+        query = "SELECT count(*) FROM dayTransformEqualityFilter WHERE event_time = timestamp '2020-04-19 00:00:00' AND event_time = timestamp '2020-04-21 00:00:00'";
+        assertQuery(session, query, "SELECT 0");
+
+        query = "SELECT count(*) FROM dayTransformEqualityFilter WHERE event_time IS NULL";
+        assertQuery(session, query, "SELECT 0");
+
+        query = "SELECT count(*) FROM dayTransformEqualityFilter WHERE event_time IS NOT NULL";
+        assertQuery(session, query, "SELECT 3");
+
+        assertUpdate(session, "DROP TABLE dayTransformEqualityFilter");
+    }
+
+    @Test
+    public void testDayTransformRangeFilter()
+    {
+        createTableDaySpec(session, "dayTransformRangeFilter");
+
+        assertUpdate(session, "INSERT INTO dayTransformRangeFilter(id, event_time, event_date) VALUES (1, timestamp '2020-04-20 00:00:00', date '2020-04-18')", 1);
+        assertUpdate(session, "INSERT INTO dayTransformRangeFilter(id, event_time, event_date) VALUES (2, timestamp '2020-04-20 00:00:00', date '2020-04-19')", 1);
+        assertUpdate(session, "INSERT INTO dayTransformRangeFilter(id, event_time, event_date) VALUES (3, timestamp '2020-04-20 00:00:00', date '2020-04-20')", 1);
+        assertUpdate(session, "INSERT INTO dayTransformRangeFilter(id, event_time, event_date) VALUES (4, timestamp '2020-04-20 00:00:00', date '2020-04-21')", 1);
+
+        String query = "SELECT id FROM dayTransformRangeFilter WHERE event_time > timestamp '2020-04-18 00:00:00' AND event_time <= timestamp '2020-04-21 23:59:59'";
+        assertQuery(session, query, "VALUES (1), (2), (3), (4)");
+
+        query = "SELECT id FROM dayTransformRangeFilter WHERE event_time > timestamp '2020-04-19 00:00:00' AND event_time < timestamp '2020-04-20 23:59:59'";
+        assertQuery(session, query, "VALUES (2), (3)");
+
+        query = "SELECT id FROM dayTransformRangeFilter WHERE event_time >= timestamp '2020-04-19 00:00:00' AND event_time <= timestamp '2020-04-20 23:59:59'";
+        assertQuery(session, query, "VALUES (2), (3)");
+
+        query = "SELECT count(*) FROM dayTransformRangeFilter WHERE event_time > timestamp '2020-04-19 23:59:59' AND event_time < timestamp '2020-04-20 00:00:00'";
+        assertQuery(session, query, "SELECT 0");
+
+        // Iceberg has microsecond precision whereas Presto only has millisecond precision, so the partition with 23:59:59.999 is still included in these cases
+        query = "SELECT count(*) FROM dayTransformRangeFilter WHERE event_time > timestamp '2020-04-19 23:59:59.999' AND event_time <= timestamp '2020-04-20 00:00:00'";
+        assertQuery(session, query, "SELECT 2");
+        query = "SELECT id FROM dayTransformRangeFilter WHERE event_time > timestamp '2020-04-18 23:59:59.999' AND event_time < timestamp '2020-04-21 00:00:00'";
+        assertQuery(session, query, "VALUES (1), (2), (3)");
+
+        query = "SELECT id FROM dayTransformRangeFilter WHERE event_time >= timestamp '2020-04-18 23:59:59' AND event_time <= timestamp '2020-04-20 00:00:00'";
+        assertQuery(session, query, "VALUES (1), (2), (3)");
+
+        assertUpdate(session, "DELETE FROM dayTransformRangeFilter");
+
+        assertUpdate(session, "INSERT INTO dayTransformRangeFilter(id, event_time, event_date) VALUES (1, timestamp '2020-04-18 00:00:00', date '2020-04-18')", 1);
+        assertUpdate(session, "INSERT INTO dayTransformRangeFilter(id, event_time, event_date) VALUES (2, timestamp '2020-04-18 00:00:00', date '2020-04-19')", 1);
+        assertUpdate(session, "INSERT INTO dayTransformRangeFilter(id, event_time, event_date) VALUES (3, timestamp '2020-04-20 00:00:00', date '2020-04-20')", 1);
+        assertUpdate(session, "INSERT INTO dayTransformRangeFilter(id, event_time, event_date) VALUES (4, timestamp '2020-04-20 00:00:00', date '2020-04-21')", 1);
+
+        // disjoint
+        query = "SELECT id FROM dayTransformRangeFilter " +
+                "WHERE (event_time >= timestamp '2020-04-18 00:00:00' AND event_time < timestamp '2020-04-19 00:00:00') " +
+                "OR (event_time >= timestamp '2020-04-20 00:00:00' AND event_time < timestamp '2020-04-21 00:00:00')";
+        assertQuery(session, query, "VALUES (1), (3)");
+
+        // overlapping
+        query = "SELECT id FROM dayTransformRangeFilter " +
+                "WHERE (event_time >= timestamp '2020-04-18 00:00:00' AND event_time < timestamp '2020-04-19 00:00:00') " +
+                "OR (event_time > timestamp '2020-04-18 00:00:00' AND event_time < timestamp '2020-04-20 00:00:00')";
+        assertQuery(session, query, "VALUES (1), (2)");
+
+        assertUpdate(session, "DROP TABLE dayTransformRangeFilter");
+    }
+
+    @Test
+    public void testDayTransformFilterOnPartitionCol()
+    {
+        createTableDaySpec(session, "dayTransformFilterOnPartitionCol");
+
+        assertUpdate(session, "INSERT INTO dayTransformFilterOnPartitionCol(id, event_time, event_date) VALUES (1, timestamp '2020-04-19 00:00:00', date '2020-04-18')", 1);
+        assertUpdate(session, "INSERT INTO dayTransformFilterOnPartitionCol(id, event_time, event_date) VALUES (2, timestamp '2020-04-18 11:00:00', date '2020-04-19')", 1);
+        assertUpdate(session, "INSERT INTO dayTransformFilterOnPartitionCol(id, event_time, event_date) VALUES (3, timestamp '2020-04-20 00:00:00', date '2020-04-20')", 1);
+        assertUpdate(session, "INSERT INTO dayTransformFilterOnPartitionCol(id, event_time, event_date) VALUES (4, timestamp '2020-04-20 00:00:00', date '2020-04-21')", 1);
+
+        // event_time filter more restrictive
+        String query = "SELECT id FROM dayTransformFilterOnPartitionCol WHERE event_time > timestamp '2020-04-18 00:00:00' AND event_time <= timestamp '2020-04-20 23:59:59'" +
+                " AND event_date >= date '2020-04-18'";
+        assertQuery(session, query, "VALUES (1), (2), (3)");
+
+        // event_date filter more restrictive
+        query = "SELECT id FROM dayTransformFilterOnPartitionCol WHERE event_time > timestamp '2020-04-18 00:00:00' AND event_time < timestamp '2020-04-21 23:59:59'" +
+                " AND event_date >= date '2020-04-18' AND event_date < date '2020-04-20'";
+        assertQuery(session, query, "VALUES (1), (2)");
+
+        assertUpdate(session, "DROP TABLE dayTransformFilterOnPartitionCol");
+    }
+
+    @Test
+    public void testHourTransformEqualityFilter()
+    {
+        createTableHourSpec(session, "hourTransformEqualityFilter");
+
+        assertUpdate(session, "INSERT INTO hourTransformEqualityFilter(id, event_time, event_hour) VALUES (1, timestamp '2020-04-20 20:00:00', timestamp '2020-04-20 19:00:00')", 1);
+        assertUpdate(session, "INSERT INTO hourTransformEqualityFilter(id, event_time, event_hour) VALUES (2, timestamp '2020-04-20 20:00:00', timestamp '2020-04-20 20:00:00')", 1);
+        assertUpdate(session, "INSERT INTO hourTransformEqualityFilter(id, event_time, event_hour) VALUES (3, timestamp '2020-04-20 20:00:00', timestamp '2020-04-20 21:00:00')", 1);
+
+        String query = "SELECT id FROM hourTransformEqualityFilter WHERE event_time = timestamp '2020-04-20 20:00:00'";
+        assertQuery(session, query, "select 2");
+
+        assertUpdate(session, "DELETE FROM hourTransformEqualityFilter");
+
+        assertUpdate(session, "INSERT INTO hourTransformEqualityFilter(id, event_time, event_hour) VALUES (1, timestamp '2020-04-20 19:00:00', timestamp '2020-04-20 19:00:00')", 1);
+        assertUpdate(session, "INSERT INTO hourTransformEqualityFilter(id, event_time, event_hour) VALUES (2, timestamp '2020-04-20 19:00:00', timestamp '2020-04-20 20:00:00')", 1);
+        assertUpdate(session, "INSERT INTO hourTransformEqualityFilter(id, event_time, event_hour) VALUES (3, timestamp '2020-04-20 21:00:00', timestamp '2020-04-20 21:00:00')", 1);
+
+        query = "SELECT id FROM hourTransformEqualityFilter WHERE event_time = timestamp '2020-04-20 19:00:00' OR event_time = timestamp '2020-04-20 21:00:00'";
+        assertQuery(session, query, "VALUES (1), (3)");
+
+        query = "SELECT id FROM hourTransformEqualityFilter WHERE event_time IN (timestamp '2020-04-20 19:00:00', timestamp '2020-04-20 21:00:00')";
+        assertQuery(session, query, "VALUES (1), (3)");
+
+        // '2020-04-20 20:00:00' partition included because it could still have timestamps satisfying the predicate, e.g. '2020-04-20 20:24:32'
+        query = "SELECT id FROM hourTransformEqualityFilter WHERE event_time != timestamp '2020-04-20 20:00:00'";
+        assertQuery(session, query, "VALUES (1), (2), (3)");
+
+        query = "SELECT id FROM hourTransformEqualityFilter WHERE event_time NOT IN (timestamp '2020-04-20 20:00:00')";
+        assertQuery(session, query, "VALUES (1), (2), (3)");
+
+        query = "SELECT count(*) FROM hourTransformEqualityFilter WHERE event_time = timestamp '2020-04-20 19:00:00' AND event_time = timestamp '2020-04-20 21:00:00'";
+        assertQuery(session, query, "SELECT 0");
+
+        query = "SELECT count(*) FROM hourTransformEqualityFilter WHERE event_time IS NULL";
+        assertQuery(session, query, "SELECT 0");
+
+        query = "SELECT count(*) FROM hourTransformEqualityFilter WHERE event_time IS NOT NULL";
+        assertQuery(session, query, "SELECT 3");
+
+        assertUpdate(session, "DROP TABLE hourTransformEqualityFilter");
+    }
+
+    @Test
+    public void testHourTransformRangeFilter()
+    {
+        createTableHourSpec(session, "hourTransformRangeFilter");
+
+        assertUpdate(session, "INSERT INTO hourTransformRangeFilter(id, event_time, event_hour) VALUES (1, timestamp '2020-04-20 20:00:00', timestamp '2020-04-20 18:00:00')", 1);
+        assertUpdate(session, "INSERT INTO hourTransformRangeFilter(id, event_time, event_hour) VALUES (2, timestamp '2020-04-20 20:00:00', timestamp '2020-04-20 19:00:00')", 1);
+        assertUpdate(session, "INSERT INTO hourTransformRangeFilter(id, event_time, event_hour) VALUES (3, timestamp '2020-04-20 20:00:00', timestamp '2020-04-20 20:00:00')", 1);
+        assertUpdate(session, "INSERT INTO hourTransformRangeFilter(id, event_time, event_hour) VALUES (4, timestamp '2020-04-20 20:00:00', timestamp '2020-04-20 21:00:00')", 1);
+
+        String query = "SELECT id FROM hourTransformRangeFilter WHERE event_time > timestamp '2020-04-20 18:00:00' AND event_time <= timestamp '2020-04-20 21:59:59'";
+        assertQuery(session, query, "VALUES (1), (2), (3), (4)");
+
+        query = "SELECT id FROM hourTransformRangeFilter WHERE event_time > timestamp '2020-04-20 19:00:00' AND event_time < timestamp '2020-04-20 20:59:59'";
+        assertQuery(session, query, "VALUES (2), (3)");
+
+        query = "SELECT id FROM hourTransformRangeFilter WHERE event_time >= timestamp '2020-04-20 19:00:00' AND event_time <= timestamp '2020-04-20 20:59:59'";
+        assertQuery(session, query, "VALUES (2), (3)");
+
+        query = "SELECT count(*) FROM hourTransformRangeFilter WHERE event_time > timestamp '2020-04-20 19:59:59' AND event_time < timestamp '2020-04-20 20:00:00'";
+        assertQuery(session, query, "SELECT 0");
+
+        // Iceberg has microsecond precision whereas Presto only has millisecond precision, so the partition with 23:59:59.999 is still included in these cases
+        query = "SELECT id FROM hourTransformRangeFilter WHERE event_time > timestamp '2020-04-20 18:59:59.999' AND event_time < timestamp '2020-04-20 21:00:00'";
+        assertQuery(session, query, "VALUES (1), (2), (3)");
+
+        query = "SELECT id FROM hourTransformRangeFilter WHERE event_time >= timestamp '2020-04-20 18:59:59' AND event_time <= timestamp '2020-04-20 20:00:00'";
+        assertQuery(session, query, "VALUES (1), (2), (3)");
+
+        assertUpdate(session, "DELETE FROM hourTransformRangeFilter");
+
+        assertUpdate(session, "INSERT INTO hourTransformRangeFilter(id, event_time, event_hour) VALUES (1, timestamp '2020-04-20 18:00:00', timestamp '2020-04-20 18:00:00')", 1);
+        assertUpdate(session, "INSERT INTO hourTransformRangeFilter(id, event_time, event_hour) VALUES (2, timestamp '2020-04-20 18:00:00', timestamp '2020-04-20 19:00:00')", 1);
+        assertUpdate(session, "INSERT INTO hourTransformRangeFilter(id, event_time, event_hour) VALUES (3, timestamp '2020-04-20 20:00:00', timestamp '2020-04-20 20:00:00')", 1);
+        assertUpdate(session, "INSERT INTO hourTransformRangeFilter(id, event_time, event_hour) VALUES (4, timestamp '2020-04-20 20:00:00', timestamp '2020-04-20 21:00:00')", 1);
+
+        // disjoint
+        query = "SELECT id FROM hourTransformRangeFilter " +
+                "WHERE (event_time >= timestamp '2020-04-20 18:00:00' AND event_time < timestamp '2020-04-20 19:00:00') " +
+                "OR (event_time >= timestamp '2020-04-20 20:00:00' AND event_time < timestamp '2020-04-20 21:00:00')";
+        assertQuery(session, query, "VALUES (1), (3)");
+
+        // overlapping
+        query = "SELECT id FROM hourTransformRangeFilter " +
+                "WHERE (event_time >= timestamp '2020-04-20 18:00:00' AND event_time < timestamp '2020-04-20 19:00:00') " +
+                "OR (event_time > timestamp '2020-04-20 18:00:00' AND event_time < timestamp '2020-04-20 20:00:00')";
+        assertQuery(session, query, "VALUES (1), (2)");
+
+        assertUpdate(session, "DROP TABLE hourTransformRangeFilter");
+    }
+
+    @Test
+    public void testHourTransformFilterOnPartitionCol()
+    {
+        createTableHourSpec(session, "hourTransformFilterOnPartitionCol");
+
+        assertUpdate(session, "INSERT INTO hourTransformFilterOnPartitionCol(id, event_time, event_hour) VALUES (1, timestamp '2020-04-20 19:00:00', timestamp '2020-04-20 18:00:00')", 1);
+        assertUpdate(session, "INSERT INTO hourTransformFilterOnPartitionCol(id, event_time, event_hour) VALUES (2, timestamp '2020-04-20 18:33:00', timestamp '2020-04-20 19:00:00')", 1);
+        assertUpdate(session, "INSERT INTO hourTransformFilterOnPartitionCol(id, event_time, event_hour) VALUES (3, timestamp '2020-04-20 20:00:00', timestamp '2020-04-20 20:00:00')", 1);
+        assertUpdate(session, "INSERT INTO hourTransformFilterOnPartitionCol(id, event_time, event_hour) VALUES (4, timestamp '2020-04-20 20:00:00', timestamp '2020-04-20 21:00:00')", 1);
+
+        // event_time filter more restrictive
+        String query = "SELECT id FROM hourTransformFilterOnPartitionCol WHERE event_time > timestamp '2020-04-20 18:00:00' AND event_time < timestamp '2020-04-20 20:59:59'" +
+                " AND event_hour >= timestamp '2020-04-20 18:00:00'";
+        assertQuery(session, query, "VALUES (1), (2), (3)");
+
+        // event_hour filter more restrictive
+        query = "SELECT id FROM hourTransformFilterOnPartitionCol WHERE event_time > timestamp '2020-04-20 18:00:00' AND event_time < timestamp '2020-04-20 21:59:59'" +
+                " AND event_hour >= timestamp '2020-04-20 18:00:00' AND event_hour < timestamp '2020-04-20 20:00:00'";
+        assertQuery(session, query, "VALUES (1), (2)");
+
+        assertUpdate(session, "DROP TABLE hourTransformFilterOnPartitionCol");
+    }
+
+    @Test
+    public void testFunctions()
+    {
+        createTableHourSpec(session, "functions_partition");
+
+        assertUpdate(session, "INSERT INTO functions_partition(id, event_time, event_hour) VALUES (1, timestamp '2020-04-20 20:00:00', timestamp '2020-04-20 18:00:00')", 1);
+        assertUpdate(session, "INSERT INTO functions_partition(id, event_time, event_hour) VALUES (2, timestamp '2020-04-20 20:00:00', timestamp '2020-04-20 19:00:00')", 1);
+        assertUpdate(session, "INSERT INTO functions_partition(id, event_time, event_hour) VALUES (3, timestamp '2020-04-20 20:00:00', timestamp '2020-04-20 20:00:00')", 1);
+        assertUpdate(session, "INSERT INTO functions_partition(id, event_time, event_hour) VALUES (4, timestamp '2020-04-20 20:00:00', timestamp '2020-04-20 21:00:00')", 1);
+
+        String query = "SELECT id FROM functions_partition WHERE event_time > date_trunc('HOUR', timestamp '2020-04-20 19:23:12')" +
+                " AND event_time < date_trunc('MINUTE', timestamp '2020-04-20 20:59:59')";
+        assertQuery(session, query, "VALUES (2), (3)");
+
+        query = "SELECT id FROM functions_partition WHERE event_time > date_trunc('HOUR', timestamp '2020-04-20 18:00:00')" +
+                " AND event_time < date_trunc('MINUTE', timestamp '2020-04-20 23:59:59')" +
+                " AND date_trunc('HOUR', event_hour) >= timestamp '2020-04-20 19:00:00' AND date_trunc('HOUR', event_hour) <= timestamp '2020-04-20 20:00:00'";
+        assertQuery(session, query, "VALUES (2), (3)");
+
+        assertUpdate(session, "DROP TABLE functions_partition");
+    }
+
+    @Test
+    public void testTruncateToHourFromSeconds()
+    {
+        createTableWithSpec(session, "truncate_partition_hour_from_sec", "{\n" +
+                "  \"fields\": [\n" +
+                "    {\n" +
+                "      \"source-name\": \"epoch_timestamp\",\n" +
+                "      \"transform\": \"truncate[3600]\",\n" +
+                "      \"name\": \"event_hour\"\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}", "event_hour", "INTEGER", Optional.of("epoch_timestamp"), Optional.of("INTEGER"));
+
+        assertUpdate(session, "INSERT INTO truncate_partition_hour_from_sec(id, epoch_timestamp, event_hour) VALUES (1, 1587405601, 1587405600)", 1);
+        assertUpdate(session, "INSERT INTO truncate_partition_hour_from_sec(id, epoch_timestamp, event_hour) VALUES (2, 1587409201, 1587409200)", 1);
+        assertUpdate(session, "INSERT INTO truncate_partition_hour_from_sec(id, epoch_timestamp, event_hour) VALUES (3, 1587412801, 1587412800)", 1);
+        assertUpdate(session, "INSERT INTO truncate_partition_hour_from_sec(id, epoch_timestamp, event_hour) VALUES (4, 1587416401, 1587416400)", 1);
+
+        String query = "SELECT id FROM truncate_partition_hour_from_sec WHERE epoch_timestamp > 1587405601 AND epoch_timestamp < 1587416401";
+        assertQuery(session, query, "VALUES (2), (3)");
+
+        query = "SELECT id FROM truncate_partition_hour_from_sec WHERE epoch_timestamp > 1587405601 AND epoch_timestamp < 1587416401 AND " +
+                "epoch_timestamp >= 1587409201 AND epoch_timestamp <= 1587412801";
+        assertQuery(session, query, "VALUES (2), (3)");
+
+        assertUpdate(session, "DROP TABLE truncate_partition_hour_from_sec");
+    }
+
+    @Test
+    public void testTruncateToDayFromSeconds()
+    {
+        createTableWithSpec(session, "truncate_partition_day_from_sec", "{\n" +
+                "  \"fields\": [\n" +
+                "    {\n" +
+                "      \"source-name\": \"epoch_timestamp\",\n" +
+                "      \"transform\": \"truncate[86400]\",\n" +
+                "      \"name\": \"event_day\"\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}", "event_day", "INTEGER", Optional.of("epoch_timestamp"), Optional.of("INTEGER"));
+
+        assertUpdate(session, "INSERT INTO truncate_partition_day_from_sec(id, epoch_timestamp, event_day) VALUES (1, 1587405601, 1587340800)", 1);
+        assertUpdate(session, "INSERT INTO truncate_partition_day_from_sec(id, epoch_timestamp, event_day) VALUES (2, 1587409201, 1587340800)", 1);
+        assertUpdate(session, "INSERT INTO truncate_partition_day_from_sec(id, epoch_timestamp, event_day) VALUES (3, 1587412801, 1587340800)", 1);
+        assertUpdate(session, "INSERT INTO truncate_partition_day_from_sec(id, epoch_timestamp, event_day) VALUES (4, 1587416401, 1587340800)", 1);
+
+        assertUpdate(session, "INSERT INTO truncate_partition_day_from_sec(id, epoch_timestamp, event_day) VALUES (5, 1587492001, 1587427200)", 1);
+        assertUpdate(session, "INSERT INTO truncate_partition_day_from_sec(id, epoch_timestamp, event_day) VALUES (6, 1587495601, 1587427200)", 1);
+        assertUpdate(session, "INSERT INTO truncate_partition_day_from_sec(id, epoch_timestamp, event_day) VALUES (7, 1587499201, 1587427200)", 1);
+        assertUpdate(session, "INSERT INTO truncate_partition_day_from_sec(id, epoch_timestamp, event_day) VALUES (8, 1587502801, 1587427200)", 1);
+
+        String query = "SELECT id FROM truncate_partition_day_from_sec WHERE epoch_timestamp > 1587405601 AND epoch_timestamp < 1587416401";
+        assertQuery(session, query, "VALUES (2), (3)");
+
+        query = "SELECT id FROM truncate_partition_day_from_sec WHERE epoch_timestamp > 1587405601 AND epoch_timestamp < 1587416401 AND " +
+                "epoch_timestamp >= 1587409201 AND epoch_timestamp <= 1587412801";
+        assertQuery(session, query, "VALUES (2), (3)");
+
+        query = "SELECT id FROM truncate_partition_day_from_sec WHERE epoch_timestamp > 1587412801 AND epoch_timestamp < 1587495601";
+        assertQuery(session, query, "VALUES (4), (5)");
+
+        query = "SELECT id FROM truncate_partition_day_from_sec WHERE epoch_timestamp >= 1587502801";
+        assertQuery(session, query, "VALUES (8)");
+        assertUpdate(session, "DROP TABLE truncate_partition_day_from_sec");
+    }
+
+    @Test
+    public void testTruncateToDayFromMilliseconds()
+    {
+        createTableWithSpec(session, "truncate_partition_day_from_ms", "{\n" +
+                "  \"fields\": [\n" +
+                "    {\n" +
+                "      \"source-name\": \"epoch_timestamp\",\n" +
+                "      \"transform\": \"truncate[86400000]\",\n" +
+                "      \"name\": \"event_day\"\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}", "event_day", "BIGINT", Optional.of("epoch_timestamp"), Optional.of("BIGINT"));
+
+        assertUpdate(session, "INSERT INTO truncate_partition_day_from_ms(id, epoch_timestamp, event_day) VALUES (1, 1587405601000, 1587340800000)", 1);
+        assertUpdate(session, "INSERT INTO truncate_partition_day_from_ms(id, epoch_timestamp, event_day) VALUES (2, 1587409201000, 1587340800000)", 1);
+        assertUpdate(session, "INSERT INTO truncate_partition_day_from_ms(id, epoch_timestamp, event_day) VALUES (3, 1587412801000, 1587340800000)", 1);
+        assertUpdate(session, "INSERT INTO truncate_partition_day_from_ms(id, epoch_timestamp, event_day) VALUES (4, 1587416401000, 1587340800000)", 1);
+
+        assertUpdate(session, "INSERT INTO truncate_partition_day_from_ms(id, epoch_timestamp, event_day) VALUES (5, 1587492001000, 1587427200000)", 1);
+        assertUpdate(session, "INSERT INTO truncate_partition_day_from_ms(id, epoch_timestamp, event_day) VALUES (6, 1587495601000, 1587427200000)", 1);
+        assertUpdate(session, "INSERT INTO truncate_partition_day_from_ms(id, epoch_timestamp, event_day) VALUES (7, 1587499201000, 1587427200000)", 1);
+        assertUpdate(session, "INSERT INTO truncate_partition_day_from_ms(id, epoch_timestamp, event_day) VALUES (8, 1587502801000, 1587427200000)", 1);
+
+        String query = "SELECT id FROM truncate_partition_day_from_ms WHERE epoch_timestamp > 1587405601000 AND epoch_timestamp < 1587416401000";
+        assertQuery(session, query, "VALUES (2), (3)");
+
+        query = "SELECT id FROM truncate_partition_day_from_ms WHERE epoch_timestamp > 1587405601000 AND epoch_timestamp < 1587416401000 AND " +
+                "epoch_timestamp >= 1587409201000 AND epoch_timestamp <= 1587412801000";
+        assertQuery(session, query, "VALUES (2), (3)");
+
+        query = "SELECT id FROM truncate_partition_day_from_ms WHERE epoch_timestamp > 1587412801000 AND epoch_timestamp < 1587495601000";
+        assertQuery(session, query, "VALUES (4), (5)");
+
+        query = "SELECT id FROM truncate_partition_day_from_ms WHERE epoch_timestamp >= 1587502801000";
+        assertQuery(session, query, "VALUES (8)");
+        assertUpdate(session, "DROP TABLE truncate_partition_day_from_ms");
+    }
+
+    @Test
+    public void testQueryThroughView()
+    {
+        createTableHourSpec(session, "queryThroughView");
+        assertUpdate(session, "CREATE VIEW queryThroughView_view AS SELECT * FROM queryThroughView WHERE event_hour >= timestamp '2020-04-20 19:00:00'");
+
+        assertUpdate(session, "INSERT INTO queryThroughView(id, event_time, event_hour) VALUES (1, timestamp '2020-04-20 20:00:00', timestamp '2020-04-20 18:00:00')", 1);
+        assertUpdate(session, "INSERT INTO queryThroughView(id, event_time, event_hour) VALUES (2, timestamp '2020-04-20 20:00:00', timestamp '2020-04-20 19:00:00')", 1);
+        assertUpdate(session, "INSERT INTO queryThroughView(id, event_time, event_hour) VALUES (3, timestamp '2020-04-20 20:00:00', timestamp '2020-04-20 20:00:00')", 1);
+        assertUpdate(session, "INSERT INTO queryThroughView(id, event_time, event_hour) VALUES (4, timestamp '2020-04-20 20:00:00', timestamp '2020-04-20 21:00:00')", 1);
+
+        String query = "SELECT id FROM queryThroughView_view WHERE event_hour >= timestamp '2020-04-20 20:00:00' AND event_hour < timestamp '2020-04-20 21:00:00'";
+        assertQuery(session, query, "SELECT 3");
+
+        query = "SELECT id FROM queryThroughView_view WHERE event_time >= timestamp '2020-04-20 20:00:00' AND event_time < timestamp '2020-04-20 21:00:00'";
+        assertQuery(session, query, "SELECT 3");
+
+        assertUpdate(session, "DROP VIEW queryThroughView_view");
+        assertUpdate(session, "DROP TABLE queryThroughView");
+    }
+
+    @Test
+    public void testNullPartitionValue()
+    {
+        createTableDaySpec(session, "nullPartitionValue");
+
+        assertUpdate(session, "INSERT INTO nullPartitionValue(id, event_time, event_date) VALUES (1, timestamp '2020-04-19 00:00:00', date '2020-04-18')", 1);
+        assertUpdate(session, "INSERT INTO nullPartitionValue(id, event_time, event_date) VALUES (2, timestamp '2020-04-18 11:00:00', date '2020-04-19')", 1);
+        assertUpdate(session, "INSERT INTO nullPartitionValue(id, event_time, event_date) VALUES (3, timestamp '2020-04-20 00:00:00', null)", 1);
+        assertUpdate(session, "INSERT INTO nullPartitionValue(id, event_time, event_date) VALUES (4, timestamp '2020-04-20 00:00:00', date '2020-04-21')", 1);
+
+        String query = "SELECT id FROM nullPartitionValue WHERE event_time > timestamp '2020-04-18 00:00:00' AND event_time <= timestamp '2020-04-20 23:59:59'";
+        assertQuery(session, query, "VALUES (1), (2)");
+
+        assertUpdate(session, "DROP TABLE nullPartitionValue");
+    }
+
+    private void createTableHourSpec(Session session, String tableName)
+    {
+        createTableWithSpec(session, tableName, HOUR_SPEC, "event_hour", "timestamp", Optional.empty(), Optional.empty());
+    }
+
+    private void createTableDaySpec(Session session, String tableName)
+    {
+        createTableWithSpec(session, tableName, DAY_SPEC, "event_date", "date", Optional.empty(), Optional.empty());
+    }
+
+    private void createTableWithSpec(Session session, String tableName, String partitionSpec, String partitionColName, String partitionColType, Optional<String> additionalColName, Optional<String> additionalColType)
+    {
+        String additionalCol = (additionalColName.isPresent() && additionalColType.isPresent()) ? String.format("%s %s,", additionalColName.get(), additionalColType.get()) : "";
+        assertUpdate(
+                session,
+                "CREATE TABLE " + tableName + "(\n"
+                        + "id integer,\n"
+                        + "event_time timestamp,"
+                        + additionalCol
+                        + partitionColName + " " + partitionColType + ")"
+                        + "WITH (format='ORC', partitioned_by = ARRAY['" + partitionColName
+                        + "'], partition_spec = '" + partitionSpec + "')");
+    }
+
+    private Session getHiveSession()
+    {
+        return testSessionBuilder()
+                .setCatalog(HIVE_CATALOG)
+                .setSchema(TPCH_SCHEMA)
+                .setIdentity(Identity.forUser(HIVE_CATALOG)
+                        .withRole(HIVE_CATALOG, new SelectedRole(ROLE, Optional.of("admin")))
+                        .build())
+                .build();
+    }
+}

--- a/plugin/trino-hive-hidden-partitioning/src/test/java/io/trino/plugin/hidden/partitioning/TestingHiddenPartitioningConnectorFactory.java
+++ b/plugin/trino-hive-hidden-partitioning/src/test/java/io/trino/plugin/hidden/partitioning/TestingHiddenPartitioningConnectorFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hidden.partitioning;
+
+import com.google.inject.Module;
+import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorContext;
+import io.trino.spi.connector.ConnectorFactory;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class TestingHiddenPartitioningConnectorFactory
+        implements ConnectorFactory
+{
+    private final HiveMetastore metastore;
+    private final Module module;
+
+    public TestingHiddenPartitioningConnectorFactory(HiveMetastore metastore, Module module)
+    {
+        this.metastore = requireNonNull(metastore, "metastore is null");
+        this.module = requireNonNull(module, "module is null");
+    }
+
+    @Override
+    public String getName()
+    {
+        return "test-hidden-partitioning";
+    }
+
+    @Override
+    public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
+    {
+        return HiddenPartitioningInternalConnectorFactory.createConnector(catalogName, config, context, module, Optional.of(metastore), Optional.empty());
+    }
+}

--- a/plugin/trino-hive-hidden-partitioning/src/test/java/io/trino/plugin/hidden/partitioning/TestingHiddenPartitioningPlugin.java
+++ b/plugin/trino-hive-hidden-partitioning/src/test/java/io/trino/plugin/hidden/partitioning/TestingHiddenPartitioningPlugin.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hidden.partitioning;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Module;
+import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.spi.Plugin;
+import io.trino.spi.connector.ConnectorFactory;
+
+import static com.google.inject.util.Modules.EMPTY_MODULE;
+import static java.util.Objects.requireNonNull;
+
+public class TestingHiddenPartitioningPlugin
+        implements Plugin
+{
+    private final HiveMetastore metastore;
+    private final Module module;
+
+    public TestingHiddenPartitioningPlugin(HiveMetastore metastore)
+    {
+        this(metastore, EMPTY_MODULE);
+    }
+
+    public TestingHiddenPartitioningPlugin(HiveMetastore metastore, Module module)
+    {
+        this.metastore = requireNonNull(metastore, "metastore is null");
+        this.module = requireNonNull(module, "module is null");
+    }
+
+    @Override
+    public Iterable<ConnectorFactory> getConnectorFactories()
+    {
+        return ImmutableList.of(new TestingHiddenPartitioningConnectorFactory(metastore, module));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,7 @@
         <module>plugin/trino-google-sheets</module>
         <module>plugin/trino-hive</module>
         <module>plugin/trino-hive-hadoop2</module>
+        <module>plugin/trino-hive-hidden-partitioning</module>
         <module>plugin/trino-http-event-listener</module>
         <module>plugin/trino-iceberg</module>
         <module>plugin/trino-jmx</module>


### PR DESCRIPTION
## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->
The concepts of column transforms and hidden partitioning come from Iceberg.  This PR adds column transform functionality to the Hive connector - specifically, it prunes the partitions considered based on filters on the source column(s).  The partition columns can then be hidden via a view from users, while still allowing for effective partition pruning with filters on the source columns.
Note this only impacts reads - partition column values still need to be inserted properly (they aren't auto populated based on the transforms of the source columns).

The code is implemented here as a separate plugin, but it is derived from the Hive plugin, and if there is interest, this could be converted into a PR on the Hive plugin.

## Usage

A json partition spec specifies transforms from source columns to partition columns, for example:

{ “fields” : [
“name" : "day_partition",
“transform” : “day”,
“source-name” : “event_timestamp”]
}

This spec applies the day transform to the event_timestamp column, e.g. it would extract the date 2020-06-12 from the event_timestamp value 2020-06-12 12:55:30.333, and use that to filter on the daily_partition key column.

Examples:

* SELECT * WHERE event_timestamp < '2020-06-12 10:05:11.123'
    * translates to WHERE day_partition <= '2020-06-12'
* SELECT * WHERE event_timestamp < '2020-06-12 00:00:00'
    * translates to WHERE day_partition < '2020-06-12'
* SELECT * WHERE event_timestamp != ‘2020-06-12 10:05:11.123'
    * all partitions included

Available transforms:  *hour*, *day*, month, year, truncate, bucket[N], identity
<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
New feature

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
Hive connector

> How would you describe this change to a non-technical end user or system administrator?
This allows for more efficient queries without users having to specify the partition columns in their queries.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) Sufficient documentation is included in this PR.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Hive connector
* Add support for partition filtering based on column transforms
```
