### PR TITLE
Fix SourceDistributionTaskSource#getMoreTasks

### DIFF
--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestStageTaskSourceFactory.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestStageTaskSourceFactory.java
@@ -795,23 +795,25 @@ public class TestStageTaskSourceFactory
     @Test
     public void testSourceDistributionTaskSourceLastIncompleteTaskAlwaysCreated()
     {
-        for (int targetSplitsPerTask = 1; targetSplitsPerTask <= 21; targetSplitsPerTask += 5) {
+        for (int targetSplitsPerTask = 1; targetSplitsPerTask <= 21; targetSplitsPerTask++) {
             List<Split> splits = new ArrayList<>();
             for (int i = 0; i < targetSplitsPerTask + 1 /* to make last task incomplete with only a single split */; i++) {
                 splits.add(createWeightedSplit(i, STANDARD_WEIGHT));
             }
             for (int finishDelayIterations = 1; finishDelayIterations < 20; finishDelayIterations++) {
-                TaskSource taskSource = createSourceDistributionTaskSource(
-                        new TestingSplitSource(CATALOG, splits, finishDelayIterations),
-                        ImmutableListMultimap.of(),
-                        1,
-                        targetSplitsPerTask,
-                        STANDARD_WEIGHT * targetSplitsPerTask,
-                        targetSplitsPerTask);
-                List<TaskDescriptor> tasks = readAllTasks(taskSource);
-                assertThat(tasks).hasSize(2);
-                TaskDescriptor lastTask = findLast(tasks.stream()).orElseThrow();
-                assertThat(lastTask.getSplits()).hasSize(1);
+                for (int splitBatchSize = 1; splitBatchSize <= 5; splitBatchSize++) {
+                    TaskSource taskSource = createSourceDistributionTaskSource(
+                            new TestingSplitSource(CATALOG, splits, finishDelayIterations),
+                            ImmutableListMultimap.of(),
+                            splitBatchSize,
+                            targetSplitsPerTask,
+                            STANDARD_WEIGHT * targetSplitsPerTask,
+                            targetSplitsPerTask);
+                    List<TaskDescriptor> tasks = readAllTasks(taskSource);
+                    assertThat(tasks).hasSize(2);
+                    TaskDescriptor lastTask = findLast(tasks.stream()).orElseThrow();
+                    assertThat(lastTask.getSplits()).hasSize(1);
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

In some cases the last task containing the last batch of splits may not
have been created.

This happened when the last split batch happend to return enough splits
for a single task to be created, but not enough to create two full tasks
and when the in a mean time the `isFinished` flag changed from `false`
to `true` before the second `isFinished` check was executed.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core (fault tolerant execution)

> How would you describe this change to a non-technical end user or system administrator?

In certain rare cases queries running with fault tolerant execution enabled could return incorrect results

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

Issue: https://github.com/trinodb/trino/issues/11825
Previous (incomplete) attempt of a fix: https://github.com/trinodb/trino/pull/11870

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
