### PR TITLE
Add -XX:+UnlockDiagnosticVMOptions and -XX:+UseAESCTRIntrinsics

### DIFF
--- a/core/docker/default/etc/jvm.config
+++ b/core/docker/default/etc/jvm.config
@@ -12,3 +12,6 @@
 -XX:PerBytecodeRecompilationCutoff=10000
 -Djdk.attach.allowAttachSelf=true
 -Djdk.nio.maxCachedBufferSize=2000000
+# Improve AES performance for S3, etc. on ARM64 (JDK-8271567)
+-XX:+UnlockDiagnosticVMOptions
+-XX:+UseAESCTRIntrinsics

--- a/core/trino-server-rpm/src/main/resources/dist/config/jvm.config
+++ b/core/trino-server-rpm/src/main/resources/dist/config/jvm.config
@@ -12,3 +12,6 @@
 -XX:PerBytecodeRecompilationCutoff=10000
 -Djdk.attach.allowAttachSelf=true
 -Djdk.nio.maxCachedBufferSize=2000000
+# Improve AES performance for S3, etc. on ARM64 (JDK-8271567)
+-XX:+UnlockDiagnosticVMOptions
+-XX:+UseAESCTRIntrinsics

--- a/docs/src/main/sphinx/installation/deployment.rst
+++ b/docs/src/main/sphinx/installation/deployment.rst
@@ -141,6 +141,8 @@ The following provides a good starting point for creating ``etc/jvm.config``:
     -XX:PerBytecodeRecompilationCutoff=10000
     -Djdk.attach.allowAttachSelf=true
     -Djdk.nio.maxCachedBufferSize=2000000
+    -XX:+UnlockDiagnosticVMOptions
+    -XX:+UseAESCTRIntrinsics
 
 Because an ``OutOfMemoryError`` typically leaves the JVM in an
 inconsistent state, we write a heap dump, for debugging, and forcibly
@@ -152,6 +154,8 @@ Specifically, the mount must not have the ``noexec`` flag set. The default
 prevents Trino from starting. You can workaround this by overriding the
 temporary directory by adding ``-Djava.io.tmpdir=/path/to/other/tmpdir`` to the
 list of JVM options.
+
+We enable ``-XX:+UnlockDiagnosticVMOptions`` and ``-XX:+UseAESCTRIntrinsics`` to improve AES performance for S3, etc. on ARM64 (`JDK-8271567 <https://bugs.openjdk.java.net/browse/JDK-8271567>`_)
 
 .. _config_properties:
 

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode/multinode-master-jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode/multinode-master-jvm.config
@@ -18,3 +18,5 @@
 -DHADOOP_USER_NAME=hive
 -Duser.timezone=Asia/Kathmandu
 -XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
+-XX:+UnlockDiagnosticVMOptions
+-XX:+UseAESCTRIntrinsics

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode/multinode-worker-jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode/multinode-worker-jvm.config
@@ -17,3 +17,5 @@
 -DHADOOP_USER_NAME=hive
 -Duser.timezone=Asia/Kathmandu
 -XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
+-XX:+UnlockDiagnosticVMOptions
+-XX:+UseAESCTRIntrinsics

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/presto/etc/jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/presto/etc/jvm.config
@@ -16,3 +16,5 @@
 -DHADOOP_USER_NAME=hive
 -Duser.timezone=Asia/Kathmandu
 -XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
+-XX:+UnlockDiagnosticVMOptions
+-XX:+UseAESCTRIntrinsics


### PR DESCRIPTION
## Description

This PR adds options `-XX:+UnlockDiagnosticVMOptions` and `-XX:+UseAESCTRIntrinsics` to the `core/docker/default/etc/jvm.config` and `core/trino-server-rpm/src/main/resources/config/jvm.config` to enable intrinsic support for `AES CTR/GCM` on `ARM64`.
This is motivated by the SSL communication overhead observed with S3.

> Is this change a fix, improvement, new feature, refactoring, or other?

It is a kind of improvement.

> How would you describe this change to a no

n-technical end user or system administrator?

We make cryptography stuff (TLS) faster on ARM64 architectures by configuration JVM.

## Documentation

( ) No documentation is needed.
( x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes
I do not know whether we should put that information in release notes.

## TPC(DS/H) benchmarks result:

[tpcds_tpch_benchmark.pdf](https://github.com/trinodb/trino/files/8630066/tpcds_tpch_benchmark.pdf)
