### PR TITLE
Use gather over partitioned exchange for small join build side

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -168,6 +168,7 @@ public final class SystemSessionProperties
     public static final String ADAPTIVE_PARTIAL_AGGREGATION_ENABLED = "adaptive_partial_aggregation_enabled";
     public static final String ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS = "adaptive_partial_aggregation_min_rows";
     public static final String ADAPTIVE_PARTIAL_AGGREGATION_UNIQUE_ROWS_RATIO_THRESHOLD = "adaptive_partial_aggregation_unique_rows_ratio_threshold";
+    public static final String JOIN_PARTITIONED_BUILD_MIN_ROW_COUNT = "join_partitioned_build_min_row_count";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -817,6 +818,12 @@ public final class SystemSessionProperties
                         ADAPTIVE_PARTIAL_AGGREGATION_UNIQUE_ROWS_RATIO_THRESHOLD,
                         "Ratio between aggregation output and input rows above which partial aggregation might be adaptively turned off",
                         optimizerConfig.getAdaptivePartialAggregationUniqueRowsRatioThreshold(),
+                        false),
+                longProperty(
+                        JOIN_PARTITIONED_BUILD_MIN_ROW_COUNT,
+                        "Minimum number of join build side rows required to use partitioned join lookup",
+                        optimizerConfig.getJoinPartitionedBuildMinRowCount(),
+                        value -> validateNonNegativeLongValue(value, JOIN_PARTITIONED_BUILD_MIN_ROW_COUNT),
                         false));
     }
 
@@ -1198,6 +1205,13 @@ public final class SystemSessionProperties
         return intValue;
     }
 
+    private static void validateNonNegativeLongValue(Long value, String property)
+    {
+        if (value < 0) {
+            throw new TrinoException(INVALID_SESSION_PROPERTY, format("%s must be equal or greater than 0", property));
+        }
+    }
+
     private static double validateDoubleRange(Object value, String property, double lowerBoundIncluded, double upperBoundIncluded)
     {
         double doubleValue = (double) value;
@@ -1467,5 +1481,10 @@ public final class SystemSessionProperties
     public static double getAdaptivePartialAggregationUniqueRowsRatioThreshold(Session session)
     {
         return session.getSystemProperty(ADAPTIVE_PARTIAL_AGGREGATION_UNIQUE_ROWS_RATIO_THRESHOLD, Double.class);
+    }
+
+    public static long getJoinPartitionedBuildMinRowCount(Session session)
+    {
+        return session.getSystemProperty(JOIN_PARTITIONED_BUILD_MIN_ROW_COUNT, Long.class);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/OptimizerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/OptimizerConfig.java
@@ -85,6 +85,7 @@ public class OptimizerConfig
     private boolean adaptivePartialAggregationEnabled = true;
     private long adaptivePartialAggregationMinRows = 100_000;
     private double adaptivePartialAggregationUniqueRowsRatioThreshold = 0.8;
+    private long joinPartitionedBuildMinRowCount = 1_000_000L;
 
     public enum JoinReorderingStrategy
     {
@@ -711,6 +712,20 @@ public class OptimizerConfig
     public OptimizerConfig setAdaptivePartialAggregationUniqueRowsRatioThreshold(double adaptivePartialAggregationUniqueRowsRatioThreshold)
     {
         this.adaptivePartialAggregationUniqueRowsRatioThreshold = adaptivePartialAggregationUniqueRowsRatioThreshold;
+        return this;
+    }
+
+    @Min(0)
+    public long getJoinPartitionedBuildMinRowCount()
+    {
+        return joinPartitionedBuildMinRowCount;
+    }
+
+    @Config("optimizer.join-partitioned-build-min-row-count")
+    @ConfigDescription("Minimum number of join build side rows required to use partitioned join lookup")
+    public OptimizerConfig setJoinPartitionedBuildMinRowCount(long joinPartitionedBuildMinRowCount)
+    {
+        this.joinPartitionedBuildMinRowCount = joinPartitionedBuildMinRowCount;
         return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -234,6 +234,7 @@ import io.trino.sql.planner.iterative.rule.UnwrapCastInComparison;
 import io.trino.sql.planner.iterative.rule.UnwrapRowSubscript;
 import io.trino.sql.planner.iterative.rule.UnwrapSingleColumnRowInApply;
 import io.trino.sql.planner.iterative.rule.UnwrapTimestampToDateCastInComparison;
+import io.trino.sql.planner.iterative.rule.UseNonPartitionedJoinLookupSource;
 import io.trino.sql.planner.optimizations.AddExchanges;
 import io.trino.sql.planner.optimizations.AddLocalExchanges;
 import io.trino.sql.planner.optimizations.BeginTableWrite;
@@ -917,6 +918,13 @@ public class PlanOptimizers
 
         // Optimizers above this don't understand local exchanges, so be careful moving this.
         builder.add(new AddLocalExchanges(plannerContext, typeAnalyzer));
+        // UseNonPartitionedJoinLookupSource needs to run after AddLocalExchanges since it operates on ExchangeNodes added by this optimizer.
+        builder.add(new IterativeOptimizer(
+                plannerContext,
+                ruleStats,
+                statsCalculator,
+                costCalculator,
+                ImmutableSet.of(new UseNonPartitionedJoinLookupSource())));
 
         // Optimizers above this do not need to care about aggregations with the type other than SINGLE
         // This optimizer must be run after all exchange-related optimizers

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UseNonPartitionedJoinLookupSource.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UseNonPartitionedJoinLookupSource.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import io.trino.Session;
+import io.trino.cost.StatsProvider;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.operator.join.LookupJoinOperator;
+import io.trino.sql.planner.Partitioning;
+import io.trino.sql.planner.PartitioningScheme;
+import io.trino.sql.planner.iterative.Lookup;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.optimizations.PlanNodeSearcher;
+import io.trino.sql.planner.plan.ExchangeNode;
+import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.TableScanNode;
+import io.trino.sql.planner.plan.UnnestNode;
+import io.trino.sql.planner.plan.ValuesNode;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.SystemSessionProperties.getJoinPartitionedBuildMinRowCount;
+import static io.trino.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
+import static io.trino.sql.planner.plan.ExchangeNode.Scope.LOCAL;
+import static io.trino.sql.planner.plan.ExchangeNode.Type.GATHER;
+import static io.trino.sql.planner.plan.Patterns.Join.right;
+import static io.trino.sql.planner.plan.Patterns.exchange;
+import static io.trino.sql.planner.plan.Patterns.join;
+
+/**
+ * Rule that transforms
+ * <pre>
+ *     join
+ *       probe
+ *       build
+ *         localExchange(partitioned)
+ * </pre>
+ * into:
+ * <pre>
+ *     join
+ *       probe
+ *       build
+ *         localExchange(gather)
+ * </pre>
+ * for small build sides.
+ * Avoiding partitioned exchange on the probe side improves {@link LookupJoinOperator} performance.
+ */
+public class UseNonPartitionedJoinLookupSource
+        implements Rule<JoinNode>
+{
+    private static final Capture<ExchangeNode> RIGHT_EXCHANGE_NODE = Capture.newCapture();
+    private static final Pattern<JoinNode> JOIN_PATTERN = join()
+            .with(right().matching(exchange()
+                    .matching(UseNonPartitionedJoinLookupSource::canBeTranslatedToLocalGather)
+                    .capturedAs(RIGHT_EXCHANGE_NODE)));
+
+    @Override
+    public Pattern<JoinNode> getPattern()
+    {
+        return JOIN_PATTERN;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return getJoinPartitionedBuildMinRowCount(session) > 0;
+    }
+
+    @Override
+    public Result apply(JoinNode node, Captures captures, Context context)
+    {
+        double buildSideRowCount = getSourceTablesRowCount(node.getRight(), context);
+        if (Double.isNaN(buildSideRowCount)) {
+            // buildSideRowCount = NaN means stats are not available or build side contains join
+            return Result.empty();
+        }
+        if (buildSideRowCount >= getJoinPartitionedBuildMinRowCount(context.getSession())) {
+            // build side has too many rows
+            return Result.empty();
+        }
+
+        ExchangeNode rightSideExchange = captures.get(RIGHT_EXCHANGE_NODE);
+        ExchangeNode singleThreadedExchange = toGatheringExchange(rightSideExchange);
+        return Result.ofPlanNode(node.replaceChildren(ImmutableList.of(node.getLeft(), singleThreadedExchange)));
+    }
+
+    private static ExchangeNode toGatheringExchange(ExchangeNode exchangeNode)
+    {
+        return new ExchangeNode(
+                exchangeNode.getId(),
+                GATHER,
+                LOCAL,
+                new PartitioningScheme(
+                        Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()),
+                        exchangeNode.getPartitioningScheme().getOutputLayout()),
+                exchangeNode.getSources(),
+                exchangeNode.getInputs(),
+                Optional.empty());
+    }
+
+    private static boolean canBeTranslatedToLocalGather(ExchangeNode exchangeNode)
+    {
+        return exchangeNode.getScope() == LOCAL
+                && !isSingleGather(exchangeNode)
+                && exchangeNode.getOrderingScheme().isEmpty()
+                && exchangeNode.getPartitioningScheme().getBucketToPartition().isEmpty()
+                && !exchangeNode.getPartitioningScheme().isReplicateNullsAndAny();
+    }
+
+    private static boolean isSingleGather(ExchangeNode exchangeNode)
+    {
+        return exchangeNode.getType() == GATHER
+                && exchangeNode.getPartitioningScheme().getPartitioning().getHandle() == SINGLE_DISTRIBUTION;
+    }
+
+    private static double getSourceTablesRowCount(PlanNode node, Context context)
+    {
+        return getSourceTablesRowCount(node, context.getLookup(), context.getStatsProvider());
+    }
+
+    @VisibleForTesting
+    static double getSourceTablesRowCount(PlanNode node, Lookup lookup, StatsProvider statsProvider)
+    {
+        boolean hasExpandingNodes = PlanNodeSearcher.searchFrom(node, lookup)
+                .whereIsInstanceOfAny(JoinNode.class, UnnestNode.class)
+                .matches();
+        if (hasExpandingNodes) {
+            return Double.NaN;
+        }
+
+        List<PlanNode> sourceNodes = PlanNodeSearcher.searchFrom(node, lookup)
+                .whereIsInstanceOfAny(TableScanNode.class, ValuesNode.class)
+                .findAll();
+
+        return sourceNodes.stream()
+                .mapToDouble(sourceNode -> statsProvider.getStats(sourceNode).getOutputRowCount())
+                .sum();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/cost/TestOptimizerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/cost/TestOptimizerConfig.java
@@ -86,7 +86,8 @@ public class TestOptimizerConfig
                 .setForceSingleNodeOutput(true)
                 .setAdaptivePartialAggregationEnabled(true)
                 .setAdaptivePartialAggregationMinRows(100_000)
-                .setAdaptivePartialAggregationUniqueRowsRatioThreshold(0.8));
+                .setAdaptivePartialAggregationUniqueRowsRatioThreshold(0.8)
+                .setJoinPartitionedBuildMinRowCount(1_000_000));
     }
 
     @Test
@@ -141,6 +142,7 @@ public class TestOptimizerConfig
                 .put("adaptive-partial-aggregation.enabled", "false")
                 .put("adaptive-partial-aggregation.min-rows", "1")
                 .put("adaptive-partial-aggregation.unique-rows-ratio-threshold", "0.99")
+                .put("optimizer.join-partitioned-build-min-row-count", "1")
                 .buildOrThrow();
 
         OptimizerConfig expected = new OptimizerConfig()
@@ -191,7 +193,8 @@ public class TestOptimizerConfig
                 .setForceSingleNodeOutput(false)
                 .setAdaptivePartialAggregationEnabled(false)
                 .setAdaptivePartialAggregationMinRows(1)
-                .setAdaptivePartialAggregationUniqueRowsRatioThreshold(0.99);
+                .setAdaptivePartialAggregationUniqueRowsRatioThreshold(0.99)
+                .setJoinPartitionedBuildMinRowCount(1);
         assertFullMapping(properties, expected);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestGetSourceTablesRowCount.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestGetSourceTablesRowCount.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+import io.trino.cost.PlanNodeStatsEstimate;
+import io.trino.cost.StatsProvider;
+import io.trino.sql.planner.PlanNodeIdAllocator;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.PlanNodeId;
+import io.trino.sql.planner.plan.TableScanNode;
+import io.trino.sql.planner.plan.ValuesNode;
+import io.trino.testing.TestingMetadata.TestingColumnHandle;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.trino.cost.PlanNodeStatsEstimate.unknown;
+import static io.trino.metadata.AbstractMockMetadata.dummyMetadata;
+import static io.trino.sql.planner.iterative.Lookup.noLookup;
+import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.lang.Double.NaN;
+import static org.testng.Assert.assertEquals;
+
+public class TestGetSourceTablesRowCount
+{
+    @Test
+    public void testMissingSourceStats()
+    {
+        PlanBuilder planBuilder = planBuilder();
+        Symbol symbol = planBuilder.symbol("col");
+
+        assertEquals(
+                getSourceTablesRowCount(
+                        planBuilder.tableScan(
+                                tableScan -> tableScan
+                                        .setSymbols(ImmutableList.of(symbol))
+                                        .setAssignments(ImmutableMap.of(symbol, new TestingColumnHandle("col")))
+                                        .setStatistics(Optional.of(unknown())))),
+                NaN);
+    }
+
+    @Test
+    public void testTwoSourcePlanNodes()
+    {
+        PlanBuilder planBuilder = planBuilder();
+        Symbol symbol = planBuilder.symbol("col");
+        Symbol sourceSymbol1 = planBuilder.symbol("source1");
+        Symbol sourceSymbol2 = planBuilder.symbol("soruce2");
+
+        assertEquals(
+                getSourceTablesRowCount(
+                        planBuilder.union(
+                                ImmutableListMultimap.<Symbol, Symbol>builder()
+                                        .put(symbol, sourceSymbol1)
+                                        .put(symbol, sourceSymbol2)
+                                        .build(),
+                                ImmutableList.of(
+                                        planBuilder.tableScan(
+                                                tableScan -> tableScan
+                                                        .setSymbols(ImmutableList.of(sourceSymbol1))
+                                                        .setAssignments(ImmutableMap.of(sourceSymbol1, new TestingColumnHandle("col")))
+                                                        .setStatistics(Optional.of(stats(10)))),
+                                        planBuilder.values(new PlanNodeId("valuesNode"), 20, sourceSymbol2)))),
+                30.0);
+    }
+
+    @Test
+    public void testJoinNode()
+    {
+        PlanBuilder planBuilder = planBuilder();
+        Symbol sourceSymbol1 = planBuilder.symbol("source1");
+        Symbol sourceSymbol2 = planBuilder.symbol("soruce2");
+
+        assertEquals(
+                getSourceTablesRowCount(
+                        planBuilder.join(
+                                INNER,
+                                planBuilder.values(sourceSymbol1),
+                                planBuilder.values(sourceSymbol2))),
+                NaN);
+    }
+
+    private double getSourceTablesRowCount(PlanNode planNode)
+    {
+        return UseNonPartitionedJoinLookupSource.getSourceTablesRowCount(
+                planNode,
+                noLookup(),
+                testStatsProvider());
+    }
+
+    private PlanBuilder planBuilder()
+    {
+        return new PlanBuilder(new PlanNodeIdAllocator(), dummyMetadata(), testSessionBuilder().build());
+    }
+
+    private static StatsProvider testStatsProvider()
+    {
+        return node -> {
+            if (node instanceof TableScanNode) {
+                return ((TableScanNode) node).getStatistics().orElse(unknown());
+            }
+
+            if (node instanceof ValuesNode) {
+                return stats(((ValuesNode) node).getRowCount());
+            }
+
+            return unknown();
+        };
+    }
+
+    private static PlanNodeStatsEstimate stats(int rowCount)
+    {
+        return PlanNodeStatsEstimate.builder()
+                .setOutputRowCount(rowCount)
+                .build();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestUseNonPartitionedJoinLookupSource.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestUseNonPartitionedJoinLookupSource.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.cost.PlanNodeStatsEstimate;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
+import io.trino.sql.planner.plan.ExchangeNode;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.PlanNodeId;
+import io.trino.sql.planner.plan.UnnestNode;
+import org.testng.annotations.Test;
+
+import static io.trino.SystemSessionProperties.JOIN_PARTITIONED_BUILD_MIN_ROW_COUNT;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.exchange;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.sql.planner.plan.ExchangeNode.Scope.LOCAL;
+import static io.trino.sql.planner.plan.ExchangeNode.Type.GATHER;
+import static io.trino.sql.planner.plan.ExchangeNode.Type.REPARTITION;
+import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
+import static java.lang.Double.NaN;
+
+public class TestUseNonPartitionedJoinLookupSource
+        extends BaseRuleTest
+{
+    @Test
+    public void testLocalGatheringExchangeNotChanged()
+    {
+        tester().assertThat(new UseNonPartitionedJoinLookupSource())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    return p.join(
+                            INNER,
+                            p.values(a),
+                            p.gatheringExchange(LOCAL, p.values(b)));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testLocalRepartitioningExchangeChangedToGather()
+    {
+        tester().assertThat(new UseNonPartitionedJoinLookupSource())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    return p.join(
+                            INNER,
+                            p.values(a),
+                            repartitioningExchange(p, b, p.values(b)));
+                })
+                .matches(
+                        join(
+                                INNER,
+                                ImmutableList.of(),
+                                values("a"),
+                                exchange(LOCAL, GATHER, values("b"))));
+    }
+
+    @Test
+    public void testLeftRepartitionNotChanged()
+    {
+        tester().assertThat(new UseNonPartitionedJoinLookupSource())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    return p.join(
+                            INNER,
+                            repartitioningExchange(p, a, p.values(a)),
+                            p.values(b));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testRepartitioningExchangeNotChangedIfBuildSideTooBig()
+    {
+        tester()
+                .assertThat(new UseNonPartitionedJoinLookupSource())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    return p.join(
+                            INNER,
+                            p.values(a),
+                            repartitioningExchange(p, b, p.values(new PlanNodeId("source"), b)));
+                })
+                .overrideStats("source", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(5_000_001)
+                        .build())
+                .doesNotFire();
+    }
+
+    @Test
+    public void testRepartitioningExchangeNotChangedIfRuleDisabled()
+    {
+        tester().assertThat(new UseNonPartitionedJoinLookupSource())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    return p.join(
+                            INNER,
+                            p.values(a),
+                            repartitioningExchange(p, b, p.values(b)));
+                })
+                .setSystemProperty(JOIN_PARTITIONED_BUILD_MIN_ROW_COUNT, "0")
+                .doesNotFire();
+    }
+
+    @Test
+    public void testRepartitioningExchangeNotChangedIfBuildSideContainsJoin()
+    {
+        tester()
+                .assertThat(new UseNonPartitionedJoinLookupSource())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    Symbol c = p.symbol("c");
+                    return p.join(
+                            INNER,
+                            p.values(a),
+                            repartitioningExchange(p, b, p.join(INNER, p.values(c), p.values(b))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testRepartitioningExchangeNotChangedIfBuildSideContainsUnnest()
+    {
+        tester()
+                .assertThat(new UseNonPartitionedJoinLookupSource())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    Symbol c = p.symbol("c");
+                    return p.join(
+                            INNER,
+                            p.values(a),
+                            repartitioningExchange(p, b, p.unnest(
+                                    ImmutableList.of(),
+                                    ImmutableList.of(new UnnestNode.Mapping(c, ImmutableList.of(b))),
+                                    p.values(c))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testRepartitioningExchangeNotChangedIfBuildSideRowCountUnknown()
+    {
+        tester()
+                .assertThat(new UseNonPartitionedJoinLookupSource())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    return p.join(
+                            INNER,
+                            p.values(a),
+                            repartitioningExchange(p, b, p.values(new PlanNodeId("source"), b)));
+                })
+                .overrideStats("source", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(NaN)
+                        .build())
+                .doesNotFire();
+    }
+
+    private ExchangeNode repartitioningExchange(PlanBuilder p, Symbol symbol, PlanNode source)
+    {
+        return p.exchange(builder -> builder
+                .type(REPARTITION)
+                .scope(LOCAL)
+                .fixedHashDistributionPartitioningScheme(ImmutableList.of(symbol), ImmutableList.of(symbol))
+                .addSource(source)
+                .addInputsSet(symbol));
+    }
+}

--- a/docs/src/main/sphinx/admin/properties-optimizer.rst
+++ b/docs/src/main/sphinx/admin/properties-optimizer.rst
@@ -187,3 +187,15 @@ Enables approximation of the output row count of filters whose costs cannot be
 accurately estimated even with complete statistics. This allows the optimizer to
 produce more efficient plans in the presence of filters which were previously
 not estimated.
+
+``optimizer.join-partitioned-build-min-row-count``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** :ref:`prop-type-integer`
+* **Default value:** ``1000000``
+* **Min allowed value:** ``0``
+
+The minimum number of join build side rows required to use partitioned join lookup.
+If the build side of a join is estimated to be smaller than the configured threshold,
+single threaded join lookup is used to improve join performance.
+A value of ``0`` disables this optimization.

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGetTableStatisticsOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGetTableStatisticsOperations.java
@@ -107,7 +107,7 @@ public class TestIcebergGetTableStatisticsOperations
                 "WHERE o.orderkey = l.orderkey");
         assertThat(metadata.getMethodInvocations()).containsExactlyInAnyOrderElementsOf(
                 ImmutableMultiset.<CountingAccessMetadata.Methods>builder()
-                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 4)
+                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 5)
                         .build());
     }
 
@@ -119,7 +119,7 @@ public class TestIcebergGetTableStatisticsOperations
                 "WHERE o.orderkey = l.orderkey AND c.custkey = o.custkey");
         assertThat(metadata.getMethodInvocations()).containsExactlyInAnyOrderElementsOf(
                 ImmutableMultiset.<CountingAccessMetadata.Methods>builder()
-                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 7)
+                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 9)
                         .build());
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
@@ -159,8 +159,8 @@ public class TestIcebergMetadataFileOperations
 
         assertFileSystemAccesses("SELECT name, age FROM test_join_t1 JOIN test_join_t2 ON test_join_t2.id = test_join_t1.id",
                 ImmutableMultiset.builder()
-                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 8)
-                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 8)
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 10)
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 10)
                         .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM), 2)
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH), 2)
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM), 2)
@@ -177,8 +177,8 @@ public class TestIcebergMetadataFileOperations
 
         assertFileSystemAccesses("SELECT count(*) FROM test_join_partitioned_t1 t1 join test_join_partitioned_t2 t2 on t1.a = t2.foo",
                 ImmutableMultiset.builder()
-                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 8)
-                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 8)
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 10)
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 10)
                         .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM), 2)
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH), 2)
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM), 2)

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestGetTableStatisticsOperations.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestGetTableStatisticsOperations.java
@@ -66,7 +66,7 @@ public class TestGetTableStatisticsOperations
                 "WHERE o.orderkey = l.orderkey");
         assertThat(metadata.getMethodInvocations()).containsExactlyInAnyOrderElementsOf(
                 ImmutableMultiset.<CountingAccessMetadata.Methods>builder()
-                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 2)
+                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 3)
                         .build());
     }
 
@@ -78,7 +78,7 @@ public class TestGetTableStatisticsOperations
                 "WHERE o.orderkey = l.orderkey AND c.custkey = o.custkey");
         assertThat(metadata.getMethodInvocations()).containsExactlyInAnyOrderElementsOf(
                 ImmutableMultiset.<CountingAccessMetadata.Methods>builder()
-                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 3)
+                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 5)
                         .build());
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
Not partitioned lookup source has better performance
than partitioned one so for small build side the overall
join performance is better even if the lookup source is
created using a single thread.

#### Benchmarks
orc sf1000 part
~6% gain for tpcds, tpch no diff
![image](https://user-images.githubusercontent.com/8080198/167215137-57e6c706-7c2b-4d68-b08e-6f085bbfdac6.png)

[use-gather-on-small-build-rule-part.pdf](https://github.com/trinodb/trino/files/8643568/use-gather-on-small-build-rule-part.pdf)

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

improvement
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core query engine, planner
> How would you describe this change to a non-technical end user or system administrator?

Improve join performance for some subset of queries
## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
