### PR TITLE
Allow PasswordAuthenticator to configure Extra credential

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/ui/PasswordManagerFormAuthenticator.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/PasswordManagerFormAuthenticator.java
@@ -20,11 +20,11 @@ import io.trino.server.security.SecurityConfig;
 import io.trino.server.security.UserMapping;
 import io.trino.server.security.UserMappingException;
 import io.trino.spi.security.AccessDeniedException;
+import io.trino.spi.security.Identity;
 import io.trino.spi.security.PasswordAuthenticator;
 
 import javax.inject.Inject;
 
-import java.security.Principal;
 import java.util.List;
 import java.util.Optional;
 
@@ -80,8 +80,8 @@ public class PasswordManagerFormAuthenticator
         List<PasswordAuthenticator> authenticators = passwordAuthenticatorManager.getAuthenticators();
         for (PasswordAuthenticator authenticator : authenticators) {
             try {
-                Principal principal = authenticator.createAuthenticatedPrincipal(username, password);
-                String authenticatedUser = userMapping.mapUser(principal.toString());
+                Identity identity = authenticator.createAuthenticatedIdentity(username, password);
+                String authenticatedUser = userMapping.mapUser(identity.getUser());
                 return Optional.of(authenticatedUser);
             }
             catch (AccessDeniedException | UserMappingException e) {

--- a/core/trino-spi/src/main/java/io/trino/spi/security/PasswordAuthenticator.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/PasswordAuthenticator.java
@@ -24,4 +24,18 @@ public interface PasswordAuthenticator
      * @throws AccessDeniedException if not allowed
      */
     Principal createAuthenticatedPrincipal(String user, String password);
+
+    /**
+     * Authenticate the provided user and password.
+     *
+     * @return the authenticated {@link Identity}
+     * @throws AccessDeniedException if not allowed
+     */
+    default Identity createAuthenticatedIdentity(String user, String password)
+    {
+        Principal principal = createAuthenticatedPrincipal(user, password);
+        return Identity.forUser(principal.toString())
+                .withPrincipal(principal)
+                .build();
+    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Allows PasswordAuthenticator to configure ExtraCredential.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

SPI interface

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
