### PR TITLE
Add property for partition count for fault tolerant execution

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -165,6 +165,7 @@ public final class SystemSessionProperties
     public static final String FAULT_TOLERANT_EXECUTION_TASK_MEMORY = "fault_tolerant_execution_task_memory";
     public static final String FAULT_TOLERANT_EXECUTION_TASK_MEMORY_GROWTH_FACTOR = "fault_tolerant_execution_task_memory_growth_factor";
     public static final String FAULT_TOLERANT_EXECUTION_TASK_MEMORY_ESTIMATION_QUANTILE = "fault_tolerant_execution_task_memory_estimation_quantile";
+    public static final String FAULT_TOLERANT_EXECUTION_PARTITION_COUNT = "fault_tolerant_execution_partition_count";
     public static final String ADAPTIVE_PARTIAL_AGGREGATION_ENABLED = "adaptive_partial_aggregation_enabled";
     public static final String ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS = "adaptive_partial_aggregation_min_rows";
     public static final String ADAPTIVE_PARTIAL_AGGREGATION_UNIQUE_ROWS_RATIO_THRESHOLD = "adaptive_partial_aggregation_unique_rows_ratio_threshold";
@@ -802,6 +803,11 @@ public final class SystemSessionProperties
                         "What quantile of memory usage of completed tasks to look at when estimating memory usage for upcoming tasks",
                         memoryManagerConfig.getFaultTolerantExecutionTaskMemoryEstimationQuantile(),
                         value -> validateDoubleRange(value, FAULT_TOLERANT_EXECUTION_TASK_MEMORY_ESTIMATION_QUANTILE, 0.0, 1.0),
+                        false),
+                integerProperty(
+                        FAULT_TOLERANT_EXECUTION_PARTITION_COUNT,
+                        "Number of partitions for distributed joins and aggregations executed with fault tolerant execution enabled",
+                        queryManagerConfig.getFaultTolerantExecutionPartitionCount(),
                         false),
                 booleanProperty(
                         ADAPTIVE_PARTIAL_AGGREGATION_ENABLED,
@@ -1452,6 +1458,11 @@ public final class SystemSessionProperties
     public static double getFaultTolerantExecutionTaskMemoryEstimationQuantile(Session session)
     {
         return session.getSystemProperty(FAULT_TOLERANT_EXECUTION_TASK_MEMORY_ESTIMATION_QUANTILE, Double.class);
+    }
+
+    public static int getFaultTolerantExecutionPartitionCount(Session session)
+    {
+        return session.getSystemProperty(FAULT_TOLERANT_EXECUTION_PARTITION_COUNT, Integer.class);
     }
 
     public static boolean isAdaptivePartialAggregationEnabled(Session session)

--- a/core/trino-main/src/main/java/io/trino/cost/TaskCountEstimator.java
+++ b/core/trino-main/src/main/java/io/trino/cost/TaskCountEstimator.java
@@ -17,6 +17,7 @@ import io.trino.Session;
 import io.trino.execution.scheduler.NodeSchedulerConfig;
 import io.trino.metadata.InternalNode;
 import io.trino.metadata.InternalNodeManager;
+import io.trino.operator.RetryPolicy;
 
 import javax.inject.Inject;
 
@@ -24,7 +25,9 @@ import java.util.Set;
 import java.util.function.IntSupplier;
 
 import static io.trino.SystemSessionProperties.getCostEstimationWorkerCount;
+import static io.trino.SystemSessionProperties.getFaultTolerantExecutionPartitionCount;
 import static io.trino.SystemSessionProperties.getHashPartitionCount;
+import static io.trino.SystemSessionProperties.getRetryPolicy;
 import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
@@ -66,6 +69,13 @@ public class TaskCountEstimator
 
     public int estimateHashedTaskCount(Session session)
     {
-        return min(estimateSourceDistributedTaskCount(session), getHashPartitionCount(session));
+        int partitionCount;
+        if (getRetryPolicy(session) == RetryPolicy.TASK) {
+            partitionCount = getFaultTolerantExecutionPartitionCount(session);
+        }
+        else {
+            partitionCount = getHashPartitionCount(session);
+        }
+        return min(estimateSourceDistributedTaskCount(session), partitionCount);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/QueryManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryManagerConfig.java
@@ -92,6 +92,7 @@ public class QueryManagerConfig
     private int faultTolerantExecutionTargetTaskSplitCount = 16;
     private int faultTolerantExecutionMaxTaskSplitCount = 256;
     private DataSize faultTolerantExecutionTaskDescriptorStorageMaxMemory = DataSize.ofBytes(Math.round(AVAILABLE_HEAP_MEMORY * 0.15));
+    private int faultTolerantExecutionPartitionCount = 50;
 
     @Min(1)
     public int getScheduleSplitBatchSize()
@@ -583,6 +584,20 @@ public class QueryManagerConfig
     public QueryManagerConfig setFaultTolerantExecutionTaskDescriptorStorageMaxMemory(DataSize faultTolerantExecutionTaskDescriptorStorageMaxMemory)
     {
         this.faultTolerantExecutionTaskDescriptorStorageMaxMemory = faultTolerantExecutionTaskDescriptorStorageMaxMemory;
+        return this;
+    }
+
+    @Min(1)
+    public int getFaultTolerantExecutionPartitionCount()
+    {
+        return faultTolerantExecutionPartitionCount;
+    }
+
+    @Config("fault-tolerant-execution-partition-count")
+    @ConfigDescription("Number of partitions for distributed joins and aggregations executed with fault tolerant execution enabled")
+    public QueryManagerConfig setFaultTolerantExecutionPartitionCount(int faultTolerantExecutionPartitionCount)
+    {
+        this.faultTolerantExecutionPartitionCount = faultTolerantExecutionPartitionCount;
         return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RewriteSpatialPartitioningAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RewriteSpatialPartitioningAggregation.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
 import io.trino.metadata.ResolvedFunction;
+import io.trino.operator.RetryPolicy;
 import io.trino.spi.type.TypeSignature;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.planner.FunctionCallBuilder;
@@ -36,7 +37,9 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.SystemSessionProperties.getFaultTolerantExecutionPartitionCount;
 import static io.trino.SystemSessionProperties.getHashPartitionCount;
+import static io.trino.SystemSessionProperties.getRetryPolicy;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypeSignatures;
 import static io.trino.sql.planner.plan.Patterns.aggregation;
@@ -55,7 +58,7 @@ import static java.util.Objects.requireNonNull;
  *    - Project: envelope := ST_Envelope(geometry)
  *        - source
  * </pre>
- * , where partition_count is the value of session property hash_partition_count
+ * , where partition_count is the value of session property hash_partition_count (or fault_tolerant_execution_partition_count when task level retries are enabled)
  */
 public class RewriteSpatialPartitioningAggregation
         implements Rule<AggregationNode>
@@ -122,6 +125,13 @@ public class RewriteSpatialPartitioningAggregation
             }
         }
 
+        int partitionCount;
+        if (getRetryPolicy(context.getSession()) == RetryPolicy.TASK) {
+            partitionCount = getFaultTolerantExecutionPartitionCount(context.getSession());
+        }
+        else {
+            partitionCount = getHashPartitionCount(context.getSession());
+        }
         return Result.ofPlanNode(
                 new AggregationNode(
                         node.getId(),
@@ -130,7 +140,7 @@ public class RewriteSpatialPartitioningAggregation
                                 node.getSource(),
                                 Assignments.builder()
                                         .putIdentities(node.getSource().getOutputSymbols())
-                                        .put(partitionCountSymbol, new LongLiteral(Integer.toString(getHashPartitionCount(context.getSession()))))
+                                        .put(partitionCountSymbol, new LongLiteral(Integer.toString(partitionCount)))
                                         .putAll(envelopeAssignments.buildOrThrow())
                                         .build()),
                         aggregations.buildOrThrow(),

--- a/core/trino-main/src/test/java/io/trino/execution/TestQueryManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestQueryManagerConfig.java
@@ -74,7 +74,8 @@ public class TestQueryManagerConfig
                 .setFaultTolerantExecutionMinTaskSplitCount(16)
                 .setFaultTolerantExecutionTargetTaskSplitCount(16)
                 .setFaultTolerantExecutionMaxTaskSplitCount(256)
-                .setFaultTolerantExecutionTaskDescriptorStorageMaxMemory(DataSize.ofBytes(Math.round(AVAILABLE_HEAP_MEMORY * 0.15))));
+                .setFaultTolerantExecutionTaskDescriptorStorageMaxMemory(DataSize.ofBytes(Math.round(AVAILABLE_HEAP_MEMORY * 0.15)))
+                .setFaultTolerantExecutionPartitionCount(50));
     }
 
     @Test
@@ -117,6 +118,7 @@ public class TestQueryManagerConfig
                 .put("fault-tolerant-execution-target-task-split-count", "3")
                 .put("fault-tolerant-execution-max-task-split-count", "22")
                 .put("fault-tolerant-execution-task-descriptor-storage-max-memory", "3GB")
+                .put("fault-tolerant-execution-partition-count", "123")
                 .buildOrThrow();
 
         QueryManagerConfig expected = new QueryManagerConfig()
@@ -155,7 +157,8 @@ public class TestQueryManagerConfig
                 .setFaultTolerantExecutionMinTaskSplitCount(2)
                 .setFaultTolerantExecutionTargetTaskSplitCount(3)
                 .setFaultTolerantExecutionMaxTaskSplitCount(22)
-                .setFaultTolerantExecutionTaskDescriptorStorageMaxMemory(DataSize.of(3, GIGABYTE));
+                .setFaultTolerantExecutionTaskDescriptorStorageMaxMemory(DataSize.of(3, GIGABYTE))
+                .setFaultTolerantExecutionPartitionCount(123);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFaultTolerantExecutionConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFaultTolerantExecutionConnectorTest.java
@@ -19,7 +19,7 @@ import io.trino.testing.QueryRunner;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
-import static io.trino.SystemSessionProperties.HASH_PARTITION_COUNT;
+import static io.trino.SystemSessionProperties.FAULT_TOLERANT_EXECUTION_PARTITION_COUNT;
 import static io.trino.plugin.exchange.filesystem.containers.MinioStorage.getExchangeManagerProperties;
 import static io.trino.testing.FaultTolerantExecutionConnectorTestHelper.getExtraProperties;
 import static io.trino.testing.sql.TestTable.randomTableSuffix;
@@ -110,7 +110,7 @@ public class TestHiveFaultTolerantExecutionConnectorTest
     public void testMaxOutputPartitionCountCheck()
     {
         Session session = Session.builder(getSession())
-                .setSystemProperty(HASH_PARTITION_COUNT, "51")
+                .setSystemProperty(FAULT_TOLERANT_EXECUTION_PARTITION_COUNT, "51")
                 .build();
         assertQueryFails(session, "SELECT nationkey, count(*) FROM nation GROUP BY nationkey", "Max number of output partitions exceeded for exchange.*");
     }

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseFailureRecoveryTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseFailureRecoveryTest.java
@@ -107,7 +107,7 @@ public abstract class BaseFailureRecoveryTest
                         .put("failure-injection.request-timeout", new Duration(REQUEST_TIMEOUT.toMillis() * 2, MILLISECONDS).toString())
                         // making http timeouts shorter so tests which simulate communication timeouts finish in reasonable amount of time
                         .put("exchange.http-client.idle-timeout", REQUEST_TIMEOUT.toString())
-                        .put("query.hash-partition-count", "5")
+                        .put("fault-tolerant-execution-partition-count", "5")
                         // to trigger spilling
                         .put("exchange.deduplication-buffer-size", "1kB")
                         .put("fault-tolerant-execution-task-memory", "1GB")

--- a/testing/trino-testing/src/main/java/io/trino/testing/FaultTolerantExecutionConnectorTestHelper.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/FaultTolerantExecutionConnectorTestHelper.java
@@ -25,7 +25,7 @@ public final class FaultTolerantExecutionConnectorTestHelper
     {
         return ImmutableMap.<String, String>builder()
                 .put("retry-policy", "TASK")
-                .put("query.hash-partition-count", "5")
+                .put("fault-tolerant-execution-partition-count", "5")
                 .put("fault-tolerant-execution-target-task-input-size", "10MB")
                 .put("fault-tolerant-execution-target-task-split-count", "4")
                 // to trigger spilling


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

Use dedicated property to set number of desired partitions for joins and
aggregations executed with fault tolerant execution enabled.

The original hash_partition_count session property has a slightly
different semantics and the practical limits and values for it could be
different than the values for fault tolerant execution.

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core engine (fault tolerant execution)

> How would you describe this change to a non-technical end user or system administrator?

With fault tolerant execution enabled use the `fault_tolerant_execution_partition_count` session property (or the `fault-tolerant-execution-partition-count` configuration property) to adjust the number of partitions for distributed joins and aggregations.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

https://github.com/trinodb/trino/pull/12228
https://github.com/trinodb/trino/pull/12231

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
(x) Documentation PR is available with #12231 (needs to be updated).
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Core (fault tolerant execution)
* Use the `fault_tolerant_execution_partition_count` session property (or the `fault-tolerant-execution-partition-count` configuration property) to adjust the number of partitions for distributed joins and aggregations executed with fault tolerant execution enabled (`retry-policy=TASK`).
```
