### PR TITLE
Support coercion within union type for ORC format

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
@@ -45,6 +45,7 @@ import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.VarcharType;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.MapTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
@@ -349,6 +350,11 @@ public class HivePageSource
             return Optional.of(new MapCoercer(typeManager, fromHiveType, toHiveType));
         }
         if (isRowType(fromType) && isRowType(toType)) {
+            if (fromHiveType.getCategory() == ObjectInspector.Category.UNION || toHiveType.getCategory() == ObjectInspector.Category.UNION) {
+                HiveType fromHiveTypeStruct = HiveType.toHiveType(typeManager.getType(fromHiveType.getTypeSignature()));
+                HiveType toHiveTypeStruct = HiveType.toHiveType(typeManager.getType(toHiveType.getTypeSignature()));
+                return Optional.of(new StructCoercer(typeManager, fromHiveTypeStruct, toHiveTypeStruct));
+            }
             return Optional.of(new StructCoercer(typeManager, fromHiveType, toHiveType));
         }
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestReadUniontype.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestReadUniontype.java
@@ -160,7 +160,7 @@ public class TestReadUniontype
             /**
              * The following insertion fails on avro.
              *
-             * hive (default)> INSERT INTO TABLE  u_padesai.test_ut_avro partition (c2 = 5)
+             * hive (default)> INSERT INTO TABLE  u_username.test_ut_avro partition (c2 = 5)
              *               > SELECT 1, create_union(1, named_struct('a', 'ignore', 'b', 'ignore'), named_struct('c', 'c1'));
              *
              * Error: java.lang.RuntimeException: org.apache.hadoop.hive.ql.metadata.HiveException: Hive Runtime Error while processing writable (null)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestReadUniontype.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestReadUniontype.java
@@ -35,31 +35,20 @@ public class TestReadUniontype
         extends HiveProductTest
 {
     private static final String TABLE_NAME = "test_read_uniontype";
+    private static final String TABLE_NAME_SCHEMA_EVOLUTION = "test_read_uniontype_with_schema_evolution";
 
     @BeforeTestWithContext
     @AfterTestWithContext
     public void cleanup()
     {
         onHive().executeQuery(format("DROP TABLE IF EXISTS %s", TABLE_NAME));
+        onHive().executeQuery(format("DROP TABLE IF EXISTS %s", TABLE_NAME_SCHEMA_EVOLUTION));
     }
 
     @DataProvider(name = "storage_formats")
     public static Object[][] storageFormats()
     {
         return new String[][] {{"ORC"}, {"AVRO"}};
-    }
-
-    private void createTestTable(String storageFormat)
-    {
-        cleanup();
-        onHive().executeQuery(format(
-                "CREATE TABLE %s (id INT,foo UNIONTYPE<" +
-                        "INT," +
-                        "DOUBLE," +
-                        "ARRAY<STRING>>)" +
-                        "STORED AS %s",
-                TABLE_NAME,
-                storageFormat));
     }
 
     @Test(dataProvider = "storage_formats", groups = SMOKE)
@@ -69,7 +58,16 @@ public class TestReadUniontype
         if (getHiveVersionMajor() != 1 || getHiveVersionMinor() != 2) {
             throw new SkipException("This test can only be run with Hive 1.2 (default config)");
         }
-        createTestTable(storageFormat);
+
+        onHive().executeQuery(format(
+                "CREATE TABLE %s (id INT,foo UNIONTYPE<" +
+                        "INT," +
+                        "DOUBLE," +
+                        "ARRAY<STRING>>)" +
+                        "STORED AS %s",
+                TABLE_NAME,
+                storageFormat));
+
         // Generate a file with rows:
         //   0, {0: 36}
         //   1, {1: 7.2}
@@ -139,6 +137,127 @@ public class TestReadUniontype
         }
     }
 
+    @Test(dataProvider = "storage_formats", groups = SMOKE)
+    public void testUnionTypeSchemaEvolution(String storageFormat)
+    {
+        // According to testing results, the Hive INSERT queries here only work in Hive 1.2
+        if (getHiveVersionMajor() != 1 || getHiveVersionMinor() != 2) {
+            throw new SkipException("This test can only be run with Hive 1.2 (default config)");
+        }
+
+        onHive().executeQuery(format(
+                "CREATE TABLE %s ("
+                        + "c0 INT,"
+                        + "c1 UNIONTYPE<"
+                        + "     STRUCT<a:STRING, b:STRING>, "
+                        + "     STRUCT<c:STRING>>) "
+                        + "PARTITIONED BY (c2 INT) "
+                        + "STORED AS %s",
+                TABLE_NAME_SCHEMA_EVOLUTION,
+                storageFormat));
+
+        if (storageFormat.equals("AVRO")) {
+            /**
+             * The following insertion fails on avro.
+             *
+             * hive (default)> INSERT INTO TABLE  u_padesai.test_ut_avro partition (c2 = 5)
+             *               > SELECT 1, create_union(1, named_struct('a', 'ignore', 'b', 'ignore'), named_struct('c', 'c1'));
+             *
+             * Error: java.lang.RuntimeException: org.apache.hadoop.hive.ql.metadata.HiveException: Hive Runtime Error while processing writable (null)
+             * at org.apache.hadoop.hive.ql.exec.mr.ExecMapper.map(ExecMapper.java:179)
+             *  at org.apache.hadoop.mapred.MapRunner.run(MapRunner.java:54)
+             *  at org.apache.hadoop.mapred.MapTask.runOldMapper(MapTask.java:459)
+             *  at org.apache.hadoop.mapred.MapTask.run(MapTask.java:343)
+             *  at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:177)
+             *  at java.security.AccessController.doPrivileged(Native Method)
+             *  at javax.security.auth.Subject.doAs(Subject.java:422)
+             *  at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1893)
+             *  at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:171)
+             * Caused by: org.apache.hadoop.hive.ql.metadata.HiveException: Hive Runtime Error while processing writable (null)
+             *  at org.apache.hadoop.hive.ql.exec.MapOperator.process(MapOperator.java:505)
+             *  at org.apache.hadoop.hive.ql.exec.mr.ExecMapper.map(ExecMapper.java:170)
+             *  ... 8 more
+             * Caused by: java.lang.ArrayIndexOutOfBoundsException: 1
+             *  at org.apache.avro.generic.GenericData$Record.get(GenericData.java:135)
+             *  at org.apache.avro.generic.GenericData.getField(GenericData.java:580)
+             *  at org.apache.avro.generic.GenericData.validate(GenericData.java:373)
+             *  at org.apache.avro.generic.GenericData.validate(GenericData.java:395)
+             *  at org.apache.avro.generic.GenericData.validate(GenericData.java:373)
+             *  at org.apache.hadoop.hive.serde2.avro.AvroSerializer.serialize(AvroSerializer.java:96)
+             *
+             * So we try coercion logic on the first struct field only.
+             *
+             */
+
+            // Generate a file with rows:
+            //   0, {0: <a="a1",b="b1">}
+            //   1, {1: <c="c1">}
+            onHive().executeQuery(format(
+                    "INSERT INTO TABLE %s PARTITION (c2 = 5) "
+                            + "SELECT 0, create_union(0, named_struct('a', 'a1', 'b', 'b1'), named_struct('c', 'ignore')) "
+                            + "UNION ALL "
+                            + "SELECT 1, create_union(0, named_struct('a', 'a2', 'b', 'b2'), named_struct('c', 'ignore'))",
+                    TABLE_NAME_SCHEMA_EVOLUTION));
+
+            // Add a coercible change inside union type column.
+            onHive().executeQuery(format("ALTER TABLE %S CHANGE COLUMN c1 c1 UNIONTYPE<STRUCT<a:STRING, b:STRING, d:STRING>, STRUCT<c:STRING>>", TABLE_NAME_SCHEMA_EVOLUTION));
+
+            QueryResult selectAllResult = onTrino().executeQuery(format("SELECT c0, c1 FROM %s", TABLE_NAME_SCHEMA_EVOLUTION));
+            assertEquals(selectAllResult.rows().size(), 2);
+            for (List<?> row : selectAllResult.rows()) {
+                int id = (Integer) row.get(0);
+                switch (id) {
+                    case 0:
+                        Row rowValueFirst = rowBuilder()
+                                .addField("a", "a1")
+                                .addField("b", "b1")
+                                .addField("d", null)
+                                .build();
+                        assertStructEquals(row.get(1), new Object[] {(byte) 0, rowValueFirst, null});
+                        break;
+                    case 1:
+                        Row rowValueSecond = rowBuilder()
+                                .addField("a", "a2")
+                                .addField("b", "b2")
+                                .addField("d", null)
+                                .build();
+                        assertStructEquals(row.get(1), new Object[] {(byte) 0, rowValueSecond, null});
+                        break;
+                }
+            }
+        }
+        else {
+            // Generate a file with rows:
+            //   0, {0: <a="a1",b="b1">}
+            //   1, {1: <c="c1">}
+            onHive().executeQuery(format("INSERT INTO TABLE %s PARTITION (c2 = 5) "
+                            + "SELECT 0, create_union(0, named_struct('a', 'a1', 'b', 'b1'), named_struct('c', 'ignore')) "
+                            + "UNION ALL "
+                            + "SELECT 1, create_union(1, named_struct('a', 'ignore', 'b', 'ignore'), named_struct('c', 'c1'))",
+                    TABLE_NAME_SCHEMA_EVOLUTION));
+
+            // Add a coercible change inside union type column.
+            onHive().executeQuery(format("ALTER TABLE %S CHANGE COLUMN c1 c1 UNIONTYPE<STRUCT<a:STRING, B:STRING>, STRUCT<c:STRING, d:STRING>>",
+                    TABLE_NAME_SCHEMA_EVOLUTION));
+
+            QueryResult selectAllResult = onTrino().executeQuery(format("SELECT c0, c1 FROM %s", TABLE_NAME_SCHEMA_EVOLUTION));
+            assertEquals(selectAllResult.rows().size(), 2);
+            for (List<?> row : selectAllResult.rows()) {
+                int id = (Integer) row.get(0);
+                switch (id) {
+                    case 0:
+                        Row rowValueFirst = rowBuilder().addField("a", "a1").addField("b", "b1").build();
+                        assertStructEquals(row.get(1), new Object[]{(byte) 0, rowValueFirst, null});
+                        break;
+                    case 1:
+                        Row rowValueSecond = rowBuilder().addField("c", "c1").addField("d", null).build();
+                        assertStructEquals(row.get(1), new Object[]{(byte) 1, null, rowValueSecond});
+                        break;
+                }
+            }
+        }
+    }
+
     // TODO use Row as expected too, and use tempto QueryAssert
     private static void assertStructEquals(Object actual, Object[] expected)
     {
@@ -148,5 +267,10 @@ public class TestReadUniontype
         for (int i = 0; i < actualRow.getFields().size(); i++) {
             assertEquals(actualRow.getFields().get(i).getValue(), expected[i]);
         }
+    }
+
+    private io.trino.jdbc.Row.Builder rowBuilder()
+    {
+        return io.trino.jdbc.Row.builder();
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->
This PR adds support for union-type coercion in ORC format. Mainly two changes here:
- Allow struct-like coercion during table-partition compatibility check 
- Adapt reader to convert data to comply with table schema


<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->
> Is this change a fix, improvement, new feature, refactoring, or other?

 It's a fix for Trino queries with table/partition mismatch errors. 
The reason is that even though unions are treated as structs, union coercion isn't handled.
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Hive Plugin

> How would you describe this change to a non-technical end user or system administrator?

This PR handles the schema evolution for union-type(struct), coercion policy is added for ORC format.

## Related issues, pull requests, and links

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
