### PR TITLE
Add base connector test to verify concurrent INSERT

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeMinioConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeMinioConnectorTest.java
@@ -122,6 +122,20 @@ public abstract class BaseDeltaLakeMinioConnectorTest
     }
 
     @Override
+    protected void verifyConcurrentInsertFailurePermissible(Exception e)
+    {
+        assertThat(e)
+                .hasMessage("Failed to write Delta Lake transaction log entry")
+                .getCause()
+                .hasMessageMatching(
+                        "Transaction log locked.*" +
+                                "|.*/_delta_log/\\d+.json already exists" +
+                                "|Conflicting concurrent writes found..*" +
+                                "|Multiple live locks found for:.*" +
+                                "|Target file .* was created during locking");
+    }
+
+    @Override
     protected Optional<DataMappingTestSetup> filterCaseSensitiveDataMappingTestData(DataMappingTestSetup dataMappingTestSetup)
     {
         String typeName = dataMappingTestSetup.getTrinoTypeName();

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaConnectorTest.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaConnectorTest.java
@@ -452,6 +452,12 @@ public class TestKafkaConnectorTest
                 .containsExactlyInAnyOrder("Hello", "hello测试􏿿world编码");
     }
 
+    @Override
+    public void testInsertRowConcurrently()
+    {
+        throw new SkipException("TODO Prepare a topic in Kafka and enable this test");
+    }
+
     private static KafkaTopicDescription createDescription(SchemaTableName schemaTableName, KafkaTopicFieldDescription key, List<KafkaTopicFieldDescription> fields)
     {
         return new KafkaTopicDescription(

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/AbstractKuduConnectorTest.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/AbstractKuduConnectorTest.java
@@ -339,6 +339,13 @@ public abstract class AbstractKuduConnectorTest
         throw new SkipException("TODO");
     }
 
+    @Override
+    public void testInsertRowConcurrently()
+    {
+        // TODO Support these test once kudu connector can create tables with default partitions
+        throw new SkipException("TODO");
+    }
+
     @Test
     @Override
     public void testDelete()


### PR DESCRIPTION
## Description

Add base connector test to verify concurrent INSERT

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
