### PR TITLE
Remove @Flaky from trino-mysql table stats tests

### DIFF
--- a/plugin/trino-mysql/pom.xml
+++ b/plugin/trino-mysql/pom.xml
@@ -15,6 +15,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+        <air.test.parallel>instances</air.test.parallel>
     </properties>
 
     <dependencies>

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseTestMySqlTableStatisticsTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseTestMySqlTableStatisticsTest.java
@@ -19,7 +19,6 @@ import io.trino.testing.MaterializedResult;
 import io.trino.testing.MaterializedRow;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.sql.TestTable;
-import io.trino.testng.services.Flaky;
 import org.assertj.core.api.AbstractDoubleAssert;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
@@ -81,10 +80,6 @@ public abstract class BaseTestMySqlTableStatisticsTest
 
     @Override
     @Test
-    @Flaky(
-            // TODO replace @Flaky with assertEventually or @Flaky-like annotation for same purpose
-            issue = "TODO",
-            match = "Expecting.*to be close to|ComparisonFailure.*NDV for")
     public void testNotAnalyzed()
     {
         String tableName = "test_not_analyzed";

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTableStatisticsMySql5IndexStatistics.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTableStatisticsMySql5IndexStatistics.java
@@ -13,11 +13,22 @@
  */
 package io.trino.plugin.mysql;
 
+import org.testng.annotations.Test;
+
+@Test(singleThreaded = true)
 public class TestMySqlTableStatisticsMySql5IndexStatistics
         extends BaseMySqlTableStatisticsIndexStatisticsTest
 {
     public TestMySqlTableStatisticsMySql5IndexStatistics()
     {
         super("mysql:5.5.46"); // oldest available on RDS
+    }
+
+    @Test
+    public void forceTestNgToRespectSingleThreaded()
+    {
+        // TODO: Remove after updating TestNG to 7.4.0+ (https://github.com/trinodb/trino/issues/8571)
+        // TestNG doesn't enforce @Test(singleThreaded = true) when tests are defined in base class. According to
+        // https://github.com/cbeust/testng/issues/2361#issuecomment-688393166 a workaround it to add a dummy test to the leaf test class.
     }
 }

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTableStatisticsMySql8Histograms.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTableStatisticsMySql8Histograms.java
@@ -26,6 +26,7 @@ import static io.trino.testing.sql.TestTable.fromColumns;
 import static java.lang.String.format;
 import static java.lang.String.join;
 
+@Test(singleThreaded = true)
 public class TestMySqlTableStatisticsMySql8Histograms
         extends BaseTestMySqlTableStatisticsTest
 {

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTableStatisticsMySql8IndexStatistics.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTableStatisticsMySql8IndexStatistics.java
@@ -13,11 +13,22 @@
  */
 package io.trino.plugin.mysql;
 
+import org.testng.annotations.Test;
+
+@Test(singleThreaded = true)
 public class TestMySqlTableStatisticsMySql8IndexStatistics
         extends BaseMySqlTableStatisticsIndexStatisticsTest
 {
     public TestMySqlTableStatisticsMySql8IndexStatistics()
     {
         super("mysql:8.0.15");
+    }
+
+    @Test
+    public void forceTestNgToRespectSingleThreaded()
+    {
+        // TODO: Remove after updating TestNG to 7.4.0+ (https://github.com/trinodb/trino/issues/8571)
+        // TestNG doesn't enforce @Test(singleThreaded = true) when tests are defined in base class. According to
+        // https://github.com/cbeust/testng/issues/2361#issuecomment-688393166 a workaround it to add a dummy test to the leaf test class.
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

BaseTestMySqlTableStatisticsTest.testNotAnalyzed has been marked @Flaky
due to table statistics discrepencies. If the error occurs
we can use assertEventually or set singleThreaded=true to work
around MySQL information_schema concurrency issues
<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Removing unnecessary "Flaky" test annotation so a more robust fix can be applied if required

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Connector Test

> How would you describe this change to a non-technical end user or system administrator?

Testing change/improvement

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(X) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(X) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* N/A
```
