### PR TITLE
Minor cleanup of WindowNode constructor

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/WindowNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/WindowNode.java
@@ -69,13 +69,18 @@ public class WindowNode
         requireNonNull(specification, "specification is null");
         requireNonNull(windowFunctions, "windowFunctions is null");
         requireNonNull(hashSymbol, "hashSymbol is null");
-        checkArgument(specification.getPartitionBy().containsAll(prePartitionedInputs), "prePartitionedInputs must be contained in partitionBy");
+        requireNonNull(prePartitionedInputs, "prePartitionedInputs is null");
+        // Make the defensive copy eagerly, so it can be used for both the validation checks and assigned directly to the field afterwards
+        prePartitionedInputs = ImmutableSet.copyOf(prePartitionedInputs);
+
+        ImmutableSet<Symbol> partitionBy = ImmutableSet.copyOf(specification.getPartitionBy());
         Optional<OrderingScheme> orderingScheme = specification.getOrderingScheme();
+        checkArgument(partitionBy.containsAll(prePartitionedInputs), "prePartitionedInputs must be contained in partitionBy");
         checkArgument(preSortedOrderPrefix == 0 || (orderingScheme.isPresent() && preSortedOrderPrefix <= orderingScheme.get().getOrderBy().size()), "Cannot have sorted more symbols than those requested");
-        checkArgument(preSortedOrderPrefix == 0 || ImmutableSet.copyOf(prePartitionedInputs).equals(ImmutableSet.copyOf(specification.getPartitionBy())), "preSortedOrderPrefix can only be greater than zero if all partition symbols are pre-partitioned");
+        checkArgument(preSortedOrderPrefix == 0 || partitionBy.equals(prePartitionedInputs), "preSortedOrderPrefix can only be greater than zero if all partition symbols are pre-partitioned");
 
         this.source = source;
-        this.prePartitionedInputs = ImmutableSet.copyOf(prePartitionedInputs);
+        this.prePartitionedInputs = prePartitionedInputs;
         this.specification = specification;
         this.windowFunctions = ImmutableMap.copyOf(windowFunctions);
         this.hashSymbol = hashSymbol;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Minor cleanup to avoid redundant copies during validation and field assignment in the `WindowNode` constructor. Also changes a usage of `List#containsAll` to the `Set#containsAll` equivalent.

> Is this change a fix, improvement, new feature, refactoring, or other?

Minor refactor.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core engine.

> How would you describe this change to a non-technical end user or system administrator?

This change should not need to be described to non-technical users or administrators. 

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:
