### PR TITLE
Add progress bar support for fault tolerant execution

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/StatusPrinter.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/StatusPrinter.java
@@ -324,10 +324,14 @@ Spilled: 20GB
             int progressWidth = (min(terminalWidth, 100) - 75) + 17; // progress bar is 17-42 characters wide
 
             if (stats.isScheduled()) {
-                String progressBar = formatProgressBar(progressWidth,
-                        stats.getCompletedSplits(),
-                        max(0, stats.getRunningSplits()),
-                        stats.getTotalSplits());
+                int completed = stats.getCompletedSplits();
+                int running = stats.getRunningSplits();
+                int total = stats.getTotalSplits();
+                if (progressPercentage > 0) {
+                    // prevent progress bar from going back and forth for fault tolerant execution
+                    total = max(total, (completed * 100 + progressPercentage - 1) / progressPercentage);
+                }
+                String progressBar = formatProgressBar(progressWidth, completed, running, total);
 
                 // 0:17 [ 103MB,  802K rows] [5.74MB/s, 44.9K rows/s] [=====>>                                   ] 10%
                 String progressLine = format("%s [%5s rows, %6s] [%5s rows/s, %8s] [%s] %d%%",

--- a/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
@@ -618,7 +618,7 @@ public class QueryStateMachine
 
         boolean isScheduled = rootStage.isPresent() && allStages.stream()
                 .map(StageInfo::getState)
-                .allMatch(state -> state == StageState.RUNNING || state == StageState.PENDING || state.isDone());
+                .anyMatch(state -> state == StageState.RUNNING || state == StageState.PENDING || state.isDone());
 
         return new QueryStats(
                 queryStateTimer.getCreateTime(),


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

Unlike pipelined execution, fault tolerant execution doesn't execute stages all at once. This means in the middle of execution, some stages will be in PLANNED state, which is seen as not scheduled. Therefore, we don't know the number of total splits upfront for fault tolerant execution.

The way we deal with this is, we calculate the percentages of each stage (if it's not scheduled, percentage is 0), and average them as the progress of fault tolerant execution.

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Client library

> How would you describe this change to a non-technical end user or system administrator?

This adds progress bar support for queries executing in fault-tolerant mode.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
