### PR TITLE
Support setting username in Redis

### DIFF
--- a/docs/src/main/sphinx/connector/redis.rst
+++ b/docs/src/main/sphinx/connector/redis.rst
@@ -64,6 +64,7 @@ Property Name                           Description
 ``redis.table-description-cache-ttl``   The cache time for table description files
 ``redis.hide-internal-columns``         Controls whether internal columns are part of the table schema or not
 ``redis.database-index``                Redis database index
+``redis.user``                          Redis server username
 ``redis.password``                      Redis server password
 ======================================  ==============================================================
 
@@ -171,6 +172,14 @@ This property is optional; the default is ``true``.
 The Redis database to query.
 
 This property is optional; the default is ``0``.
+
+``redis.user``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The username for Redis server.
+
+This property is optional; the default is ``null``.
+
 
 ``redis.password``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisConnectorConfig.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisConnectorConfig.java
@@ -22,6 +22,7 @@ import io.airlift.units.Duration;
 import io.airlift.units.MinDuration;
 import io.trino.spi.HostAddress;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -43,6 +44,7 @@ public class RedisConnectorConfig
     private int redisMaxKeysPerFetch = 100;
     private int redisDataBaseIndex;
     private char redisKeyDelimiter = ':';
+    private String redisUser;
     private String redisPassword;
     private Duration redisConnectTimeout = new Duration(2000, MILLISECONDS);
     private String defaultSchema = "default";
@@ -187,6 +189,20 @@ public class RedisConnectorConfig
     public RedisConnectorConfig setRedisKeyDelimiter(String redisKeyDelimiter)
     {
         this.redisKeyDelimiter = redisKeyDelimiter.charAt(0);
+        return this;
+    }
+
+    @Nullable
+    public String getRedisUser()
+    {
+        return redisUser;
+    }
+
+    @Config("redis.user")
+    @ConfigDescription("Username for a Redis server")
+    public RedisConnectorConfig setRedisUser(String redisUser)
+    {
+        this.redisUser = redisUser;
         return this;
     }
 

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisJedisManager.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisJedisManager.java
@@ -78,6 +78,7 @@ public class RedisJedisManager
                 host.getHostText(),
                 host.getPort(),
                 toIntExact(redisConnectorConfig.getRedisConnectTimeout().toMillis()),
+                redisConnectorConfig.getRedisUser(),
                 redisConnectorConfig.getRedisPassword(),
                 redisConnectorConfig.getRedisDataBaseIndex());
     }

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/RedisQueryRunner.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/RedisQueryRunner.java
@@ -49,6 +49,7 @@ public final class RedisQueryRunner
     public static DistributedQueryRunner createRedisQueryRunner(
             RedisServer redisServer,
             Map<String, String> extraProperties,
+            Map<String, String> connectorProperties,
             String dataFormat,
             Iterable<TpchTable<?>> tables)
             throws Exception
@@ -64,7 +65,7 @@ public final class RedisQueryRunner
 
             Map<SchemaTableName, RedisTableDescription> tableDescriptions = createTpchTableDescriptions(queryRunner.getCoordinator().getTypeManager(), tables, dataFormat);
 
-            installRedisPlugin(redisServer, queryRunner, tableDescriptions);
+            installRedisPlugin(redisServer, queryRunner, tableDescriptions, connectorProperties);
 
             TestingTrinoClient trinoClient = queryRunner.getClient();
 
@@ -130,6 +131,7 @@ public final class RedisQueryRunner
         DistributedQueryRunner queryRunner = createRedisQueryRunner(
                 new RedisServer(),
                 ImmutableMap.of("http-server.http.port", "8080"),
+                ImmutableMap.of(),
                 "string",
                 TpchTable.getTables());
 

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestMinimalFunctionality.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestMinimalFunctionality.java
@@ -76,7 +76,8 @@ public class TestMinimalFunctionality
         installRedisPlugin(redisServer, queryRunner,
                 ImmutableMap.<SchemaTableName, RedisTableDescription>builder()
                         .put(createEmptyTableDescription(new SchemaTableName("default", tableName)))
-                        .buildOrThrow());
+                        .buildOrThrow(),
+                ImmutableMap.of());
     }
 
     @AfterMethod(alwaysRun = true)

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisConnectorConfig.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisConnectorConfig.java
@@ -41,6 +41,7 @@ public class TestRedisConnectorConfig
                 .setRedisKeyDelimiter(":")
                 .setRedisConnectTimeout("2000ms")
                 .setRedisDataBaseIndex(0)
+                .setRedisUser(null)
                 .setRedisPassword(null)
                 .setRedisScanCount(100)
                 .setRedisMaxKeysPerFetch(100)
@@ -63,6 +64,7 @@ public class TestRedisConnectorConfig
                 .put("redis.hide-internal-columns", "false")
                 .put("redis.connect-timeout", "10s")
                 .put("redis.database-index", "5")
+                .put("redis.user", "test")
                 .put("redis.password", "secret")
                 .buildOrThrow();
 
@@ -77,6 +79,7 @@ public class TestRedisConnectorConfig
                 .setRedisMaxKeysPerFetch(10)
                 .setRedisConnectTimeout("10s")
                 .setRedisDataBaseIndex(5)
+                .setRedisUser("test")
                 .setRedisPassword("secret")
                 .setRedisKeyDelimiter(",")
                 .setKeyPrefixSchemaTable(true);

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisConnectorTest.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisConnectorTest.java
@@ -27,6 +27,6 @@ public class TestRedisConnectorTest
             throws Exception
     {
         RedisServer redisServer = closeAfterClass(new RedisServer());
-        return createRedisQueryRunner(redisServer, ImmutableMap.of(), "string", REQUIRED_TPCH_TABLES);
+        return createRedisQueryRunner(redisServer, ImmutableMap.of(), ImmutableMap.of(), "string", REQUIRED_TPCH_TABLES);
     }
 }

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisDistributedHash.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisDistributedHash.java
@@ -28,6 +28,6 @@ public class TestRedisDistributedHash
             throws Exception
     {
         RedisServer redisServer = closeAfterClass(new RedisServer());
-        return createRedisQueryRunner(redisServer, ImmutableMap.of(), "hash", REQUIRED_TPCH_TABLES);
+        return createRedisQueryRunner(redisServer, ImmutableMap.of(), ImmutableMap.of(), "hash", REQUIRED_TPCH_TABLES);
     }
 }

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisLatestConnectorTest.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisLatestConnectorTest.java
@@ -19,6 +19,8 @@ import io.trino.testing.QueryRunner;
 
 import static io.trino.plugin.redis.RedisQueryRunner.createRedisQueryRunner;
 import static io.trino.plugin.redis.util.RedisServer.LATEST_VERSION;
+import static io.trino.plugin.redis.util.RedisServer.PASSWORD;
+import static io.trino.plugin.redis.util.RedisServer.USER;
 
 public class TestRedisLatestConnectorTest
         extends BaseRedisConnectorTest
@@ -31,7 +33,7 @@ public class TestRedisLatestConnectorTest
         return createRedisQueryRunner(
                 redisServer,
                 ImmutableMap.of(),
-                ImmutableMap.of(),
+                ImmutableMap.of("redis.user", USER, "redis.password", PASSWORD),
                 "string",
                 REQUIRED_TPCH_TABLES);
     }

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisLatestConnectorTest.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisLatestConnectorTest.java
@@ -27,7 +27,12 @@ public class TestRedisLatestConnectorTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        RedisServer redisServer = closeAfterClass(new RedisServer(LATEST_VERSION));
-        return createRedisQueryRunner(redisServer, ImmutableMap.of(), "string", REQUIRED_TPCH_TABLES);
+        RedisServer redisServer = closeAfterClass(new RedisServer(LATEST_VERSION, true));
+        return createRedisQueryRunner(
+                redisServer,
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                "string",
+                REQUIRED_TPCH_TABLES);
     }
 }

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/util/RedisTestUtils.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/util/RedisTestUtils.java
@@ -27,6 +27,7 @@ import io.trino.testing.TestingTrinoClient;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.AbstractMap;
+import java.util.HashMap;
 import java.util.Map;
 
 import static java.lang.String.format;
@@ -35,17 +36,18 @@ public final class RedisTestUtils
 {
     private RedisTestUtils() {}
 
-    public static void installRedisPlugin(RedisServer redisServer, QueryRunner queryRunner, Map<SchemaTableName, RedisTableDescription> tableDescriptions)
+    public static void installRedisPlugin(RedisServer redisServer, QueryRunner queryRunner, Map<SchemaTableName, RedisTableDescription> tableDescriptions, Map<String, String> connectorProperties)
     {
         queryRunner.installPlugin(new TestingRedisPlugin(tableDescriptions));
 
-        Map<String, String> redisConfig = ImmutableMap.of(
-                "redis.nodes", redisServer.getHostAndPort().toString(),
-                "redis.table-names", Joiner.on(",").join(tableDescriptions.keySet()),
-                "redis.default-schema", "default",
-                "redis.hide-internal-columns", "true",
-                "redis.key-prefix-schema-table", "true");
-        queryRunner.createCatalog("redis", "redis", redisConfig);
+        connectorProperties = new HashMap<>(ImmutableMap.copyOf(connectorProperties));
+        connectorProperties.putIfAbsent("redis.nodes", redisServer.getHostAndPort().toString());
+        connectorProperties.putIfAbsent("redis.table-names", Joiner.on(",").join(tableDescriptions.keySet()));
+        connectorProperties.putIfAbsent("redis.default-schema", "default");
+        connectorProperties.putIfAbsent("redis.hide-internal-columns", "true");
+        connectorProperties.putIfAbsent("redis.key-prefix-schema-table", "true");
+
+        queryRunner.createCatalog("redis", "redis", connectorProperties);
     }
 
     public static void loadTpchTable(RedisServer redisServer, TestingTrinoClient trinoClient, String tableName, QualifiedObjectName tpchTableName, String dataFormat)


### PR DESCRIPTION
## Description

Fixes #12279

## Documentation

(x) Sufficient documentation is included in this PR.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# Redis
* Support setting username via `redis.user` config property. ({issue}`12279`)
```
