### PR TITLE
Fix wrong field path in Elasticsearch ROW type

### DIFF
--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
@@ -364,7 +364,7 @@ public class ElasticsearchMetadata
             ImmutableList.Builder<RowDecoder.NameAndDescriptor> decoderFields = ImmutableList.builder();
             for (IndexMetadata.Field rowField : objectType.getFields()) {
                 String name = rowField.getName();
-                TypeAndDecoder child = toTrino(appendPath(path, name), rowField);
+                TypeAndDecoder child = toTrino(path, rowField);
 
                 if (child != null) {
                     decoderFields.add(new RowDecoder.NameAndDescriptor(name, child.getDecoderDescriptor()));

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
@@ -1303,6 +1303,37 @@ public abstract class BaseElasticsearchConnectorTest
     }
 
     @Test
+    public void testNestedTimestamps()
+            throws IOException
+    {
+        String indexName = "nested_timestamps";
+
+        @Language("JSON")
+        String mappings = "" +
+                "{" +
+                "  \"properties\":{" +
+                "    \"field\": {" +
+                "      \"properties\": {" +
+                "        \"timestamp_column\": { \"type\": \"date\" }" +
+                "      }" +
+                "    }" +
+                "  }" +
+                "}";
+
+        createIndex(indexName, mappings);
+
+        index(indexName, ImmutableMap.of("field", ImmutableMap.of("timestamp_column", 0)));
+        index(indexName, ImmutableMap.of("field", ImmutableMap.of("timestamp_column", "1")));
+        index(indexName, ImmutableMap.of("field", ImmutableMap.of("timestamp_column", "1970-01-01T01:01:00+0000")));
+
+        assertThat(query("SELECT field.timestamp_column FROM " + indexName))
+                .matches("VALUES " +
+                        "(TIMESTAMP '1970-01-01 00:00:00.000')," +
+                        "(TIMESTAMP '1970-01-01 00:00:00.001')," +
+                        "(TIMESTAMP '1970-01-01 01:01:00.000')");
+    }
+
+    @Test
     public void testScaledFloat()
             throws Exception
     {


### PR DESCRIPTION
## Description

Fixes #12250

## Documentation

(x) No documentation is needed.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Elasticsearch
* Fix failure when reading not ISO 8601 formatted timestamp values in `row` type. ({issue}`12250`)
```
