### PR TITLE
Add Delta synchronizer for GCS

### DIFF
--- a/plugin/trino-delta-lake/pom.xml
+++ b/plugin/trino-delta-lake/pom.xml
@@ -123,6 +123,28 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.api-client</groupId>
+            <artifactId>google-api-client</artifactId>
+            <version>1.30.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.apis</groupId>
+            <artifactId>google-api-services-storage</artifactId>
+            <version>v1-rev20190624-1.30.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.cloud.bigdataoss</groupId>
+            <artifactId>gcs-connector</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.cloud.bigdataoss</groupId>
+            <artifactId>gcsio</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <optional>true</optional>
@@ -136,6 +158,12 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.http-client</groupId>
+            <artifactId>google-http-client</artifactId>
+            <version>1.30.1</version>
         </dependency>
 
         <dependency>

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeModule.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeModule.java
@@ -36,6 +36,7 @@ import io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointSchemaManag
 import io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointWriterManager;
 import io.trino.plugin.deltalake.transactionlog.checkpoint.LastCheckpoint;
 import io.trino.plugin.deltalake.transactionlog.writer.AzureTransactionLogSynchronizer;
+import io.trino.plugin.deltalake.transactionlog.writer.GcsTransactionLogSynchronizer;
 import io.trino.plugin.deltalake.transactionlog.writer.NoIsolationSynchronizer;
 import io.trino.plugin.deltalake.transactionlog.writer.S3TransactionLogSynchronizer;
 import io.trino.plugin.deltalake.transactionlog.writer.TransactionLogSynchronizer;
@@ -140,6 +141,8 @@ public class DeltaLakeModule
         // Azure
         logSynchronizerMapBinder.addBinding("abfs").to(AzureTransactionLogSynchronizer.class).in(Scopes.SINGLETON);
         logSynchronizerMapBinder.addBinding("abfss").to(AzureTransactionLogSynchronizer.class).in(Scopes.SINGLETON);
+        // GCS
+        logSynchronizerMapBinder.addBinding("gs").to(GcsTransactionLogSynchronizer.class).in(Scopes.SINGLETON);
 
         newOptionalBinder(binder, DeltaLakeRedirectionsProvider.class)
                 .setDefault().toInstance(DeltaLakeRedirectionsProvider.NOOP);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/writer/GcsTransactionLogSynchronizer.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/writer/GcsTransactionLogSynchronizer.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake.transactionlog.writer;
+
+import com.google.api.client.http.InputStreamContent;
+import com.google.api.client.util.Data;
+import com.google.api.services.storage.Storage;
+import com.google.api.services.storage.model.StorageObject;
+import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem;
+import com.google.cloud.hadoop.gcsio.CreateFileOptions;
+import com.google.cloud.hadoop.gcsio.CreateObjectOptions;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorage;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageImpl;
+import com.google.cloud.hadoop.gcsio.PathCodec;
+import com.google.cloud.hadoop.gcsio.StorageResourceId;
+import com.google.common.collect.Maps;
+import io.trino.plugin.hive.HdfsEnvironment;
+import io.trino.spi.connector.ConnectorSession;
+import org.apache.hadoop.fs.Path;
+
+import javax.inject.Inject;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+
+import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystem.objectOptionsFromFileOptions;
+import static io.trino.plugin.hive.util.HiveWriteUtils.getRawFileSystem;
+
+public class GcsTransactionLogSynchronizer
+        implements TransactionLogSynchronizer
+{
+    private static final Field STORAGE_FIELD;
+
+    private static final Base64.Encoder base64Encoder = Base64.getEncoder();
+
+    static {
+        try {
+            STORAGE_FIELD = GoogleCloudStorageImpl.class.getDeclaredField("gcs");
+            STORAGE_FIELD.setAccessible(true);
+        }
+        catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private final HdfsEnvironment hdfsEnvironment;
+
+    @Inject
+    public GcsTransactionLogSynchronizer(HdfsEnvironment hdfsEnvironment)
+    {
+        this.hdfsEnvironment = hdfsEnvironment;
+    }
+
+    // This approach should be compatible with OSS Delta Lake.
+    @Override
+    public void write(ConnectorSession session, String clusterId, Path newLogEntryPath, byte[] entryContents)
+    {
+        GoogleHadoopFileSystem googleHadoopFileSystem;
+        try {
+            googleHadoopFileSystem = (GoogleHadoopFileSystem) getRawFileSystem(hdfsEnvironment.getFileSystem(new HdfsEnvironment.HdfsContext(session), newLogEntryPath));
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        Storage storage = getStorage(googleHadoopFileSystem);
+        PathCodec pathCodec = googleHadoopFileSystem.getGcsFs().getOptions().getPathCodec();
+        try {
+            createStorageObject(newLogEntryPath.toUri(), entryContents, pathCodec, storage);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public boolean isUnsafe()
+    {
+        return false;
+    }
+
+    /**
+     * Retrieves through reflection the service definition instance for Google Cloud Storage API.
+     * The {@link GoogleHadoopFileSystem} class from `hadoop-connectors` library does not expose
+     * directly the {@link Storage}.
+     */
+    private Storage getStorage(GoogleHadoopFileSystem fs)
+    {
+        try {
+            GoogleCloudStorage googleCloudStorage = fs.getGcsFs().getGcs();
+            return (Storage) STORAGE_FIELD.get(googleCloudStorage);
+        }
+        catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    /**
+     * This method uses {@link Storage} Cloud Storage API client for creating synchronously a storage object
+     * with the specified path and content.
+     * <p>
+     * This approach avoids dealing with `FSDataOutputStream` exposed by the method
+     * `org.apache.hadoop.fs.FileSystem#create(org.apache.hadoop.fs.Path)` and the intricacies of handling
+     * exceptions which may occur while writing the content to the output stream.
+     */
+    private static StorageObject createStorageObject(URI blobPath, byte[] content, PathCodec pathCodec, Storage storage)
+            throws IOException
+    {
+        CreateFileOptions createFileOptions = new CreateFileOptions(false);
+        CreateObjectOptions createObjectOptions = objectOptionsFromFileOptions(createFileOptions);
+        StorageResourceId storageResourceId = pathCodec.validatePathAndGetId(blobPath, false);
+
+        StorageObject object =
+                new StorageObject()
+                        .setContentEncoding(createObjectOptions.getContentEncoding())
+                        .setMetadata(encodeMetadata(createObjectOptions.getMetadata()))
+                        .setName(storageResourceId.getObjectName());
+
+        InputStream inputStream = new ByteArrayInputStream(content, 0, content.length);
+        Storage.Objects.Insert insert = storage.objects().insert(
+                storageResourceId.getBucketName(),
+                object,
+                new InputStreamContent(createObjectOptions.getContentType(), inputStream));
+        // By setting `ifGenerationMatch` setting to `0`, the creation of the blob will succeed only
+        // if there are no live versions of the object.
+        insert.setIfGenerationMatch(0L);
+        insert.getMediaHttpUploader().setDirectUploadEnabled(true);
+        insert.setName(storageResourceId.getObjectName());
+        return insert.execute();
+    }
+
+    /**
+     * Helper for converting from a Map&lt;String, byte[]&gt; metadata map that may be in a
+     * StorageObject into a Map&lt;String, String&gt; suitable for placement inside a
+     * GoogleCloudStorageItemInfo.
+     */
+    private static Map<String, String> encodeMetadata(Map<String, byte[]> metadata)
+    {
+        return Maps.transformValues(metadata, GcsTransactionLogSynchronizer::encodeMetadataValues);
+    }
+
+    // A function to encode metadata map values
+    private static String encodeMetadataValues(byte[] bytes)
+    {
+        return bytes == null ? Data.NULL_STRING : new String(base64Encoder.encode(bytes), StandardCharsets.UTF_8);
+    }
+}


### PR DESCRIPTION



<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

The implementation makes use of reflection for retrieving
from `GoogleHadoopFileSystem` an instance of `Storage`
Cloud Storage API client.
The client is used for fine-tuning an API `Insert` call
in order to be able to create the blob corresponding to
the transaction log file.
the creation of the blob will succeed only
The creation of the blob will succeed if and only if
there are no live versions of the object.

This approach is a workaround for the limitations of the
`hadoop-connectors` GCS library which is exposing only
output streams when in need to create a blob.
In case of dealing mid-write of the blob with I/O exceptions,
the output stream can't be closed because this action would
expose the blob in a corrupted state on GCS. Effectively in
such a situation, the output stream would need to be intentionally
leaked - not closed, which can lead to multiple unforeseen
consequences.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)


Delta Lake connector

> How would you describe this change to a non-technical end user or system administrator?


Add the ability to perform DML statements of tables backed by Google Cloud Storage

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

Fixes: #12264

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Delta Lake
* Add support for DML statements on tables backed by GCS
```
