### PR TITLE
Fix LDAP Authenticator validation issues with ActiveDirectory service

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/ldap/JdkLdapClient.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/ldap/JdkLdapClient.java
@@ -85,6 +85,15 @@ public class JdkLdapClient
     }
 
     @Override
+    public <T> T processLdapContext(String userName, String password, LdapContextProcessor<T> contextProcessor)
+            throws NamingException
+    {
+        try (CloseableContext context = createUserDirContext(userName, password)) {
+            return contextProcessor.process(context.context);
+        }
+    }
+
+    @Override
     public <T> T executeLdapQuery(String userName, String password, LdapQuery ldapQuery, LdapSearchResultProcessor<T> resultProcessor)
             throws NamingException
     {

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/ldap/LdapClient.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/ldap/LdapClient.java
@@ -15,16 +15,26 @@ package io.trino.plugin.base.ldap;
 
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
+import javax.naming.directory.DirContext;
 import javax.naming.directory.SearchResult;
 
 public interface LdapClient
 {
+    <T> T processLdapContext(String userName, String password, LdapContextProcessor<T> contextProcessor)
+            throws NamingException;
+
     <T> T executeLdapQuery(String userName, String password, LdapQuery ldapQuery, LdapSearchResultProcessor<T> resultProcessor)
             throws NamingException;
 
     interface LdapSearchResultProcessor<T>
     {
         T process(NamingEnumeration<SearchResult> searchResults)
+                throws NamingException;
+    }
+
+    interface LdapContextProcessor<T>
+    {
+        T process(DirContext dirContext)
                 throws NamingException;
     }
 }

--- a/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/ldap/LdapAuthenticatorClient.java
+++ b/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/ldap/LdapAuthenticatorClient.java
@@ -38,14 +38,7 @@ public class LdapAuthenticatorClient
     public void validatePassword(String userDistinguishedName, String password)
             throws NamingException
     {
-        ldapClient.executeLdapQuery(
-                userDistinguishedName,
-                password,
-                new LdapQuery.LdapQueryBuilder()
-                        .withSearchBase(userDistinguishedName)
-                        .withSearchFilter(userDistinguishedName)
-                        .build(),
-                searchResults -> null);
+        ldapClient.processLdapContext(userDistinguishedName, password, context -> null);
     }
 
     public boolean isGroupMember(String searchBase, String groupSearch, String contextUserDistinguishedName, String contextPassword)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

In regards with testing - There isn't any dockerized setup for ActiveDirectory (which uses UPN aka Unique Principal Name for login purpose) .. But have tested locally and it works as expected. 


<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fixes #12321. 

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

This is specific to LDAP password authenticator. 

> How would you describe this change to a non-technical end user or system administrator?

This PR fixes LDAP Authenticator validation issues with ActiveDirectory

## Related issues, pull requests, and links
https://github.com/trinodb/trino/pull/11909

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
