### PR TITLE
Avoid blocking on a split source in fault tolerant task scheduling

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/FaultTolerantStageScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/FaultTolerantStageScheduler.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Ordering;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.concurrent.MoreFutures;
@@ -80,6 +81,7 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.util.concurrent.Futures.allAsList;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static com.google.common.util.concurrent.Futures.nonCancellationPropagating;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.asVoid;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.concurrent.MoreFutures.toListenableFuture;
@@ -285,18 +287,29 @@ public class FaultTolerantStageScheduler
 
         while (!pendingPartitions.isEmpty() || !queuedPartitions.isEmpty() || !taskSource.isFinished()) {
             while (queuedPartitions.isEmpty() && pendingPartitions.size() < maxTasksWaitingForNodePerStage && !taskSource.isFinished()) {
-                List<TaskDescriptor> tasks = taskSource.getMoreTasks();
-                for (TaskDescriptor task : tasks) {
-                    queuedPartitions.add(task.getPartitionId());
-                    allPartitions.add(task.getPartitionId());
-                    taskDescriptorStorage.put(stage.getStageId(), task);
-                    sinkExchange.ifPresent(exchange -> {
-                        ExchangeSinkHandle exchangeSinkHandle = exchange.addSink(task.getPartitionId());
-                        partitionToExchangeSinkHandleMap.put(task.getPartitionId(), exchangeSinkHandle);
-                    });
-                }
-                if (taskSource.isFinished()) {
-                    sinkExchange.ifPresent(Exchange::noMoreSinks);
+                ListenableFuture<Void> tasksPopulatedFuture = Futures.transform(
+                        taskSource.getMoreTasks(),
+                        tasks -> {
+                            synchronized (this) {
+                                for (TaskDescriptor task : tasks) {
+                                    queuedPartitions.add(task.getPartitionId());
+                                    allPartitions.add(task.getPartitionId());
+                                    taskDescriptorStorage.put(stage.getStageId(), task);
+                                    sinkExchange.ifPresent(exchange -> {
+                                        ExchangeSinkHandle exchangeSinkHandle = exchange.addSink(task.getPartitionId());
+                                        partitionToExchangeSinkHandleMap.put(task.getPartitionId(), exchangeSinkHandle);
+                                    });
+                                }
+                                if (taskSource.isFinished()) {
+                                    sinkExchange.ifPresent(Exchange::noMoreSinks);
+                                }
+                                return null;
+                            }
+                        },
+                        directExecutor());
+                if (!tasksPopulatedFuture.isDone()) {
+                    blocked = tasksPopulatedFuture;
+                    return;
                 }
             }
 

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/StageTaskSourceFactory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/StageTaskSourceFactory.java
@@ -214,6 +214,9 @@ public class StageTaskSourceFactory
         @Override
         public ListenableFuture<List<TaskDescriptor>> getMoreTasks()
         {
+            if (finished) {
+                return immediateFuture(ImmutableList.of());
+            }
             List<TaskDescriptor> result = ImmutableList.of(new TaskDescriptor(
                     0,
                     ImmutableListMultimap.of(),
@@ -291,6 +294,9 @@ public class StageTaskSourceFactory
         @Override
         public ListenableFuture<List<TaskDescriptor>> getMoreTasks()
         {
+            if (finished) {
+                return immediateFuture(ImmutableList.of());
+            }
             NodeRequirements nodeRequirements = new NodeRequirements(Optional.empty(), ImmutableSet.of(), taskMemory);
 
             ImmutableList.Builder<TaskDescriptor> result = ImmutableList.builder();

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/StageTaskSourceFactory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/StageTaskSourceFactory.java
@@ -26,11 +26,15 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.AbstractFuture;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.log.Logger;
 import io.airlift.units.DataSize;
 import io.trino.Session;
 import io.trino.connector.CatalogName;
+import io.trino.execution.ForQueryExecution;
 import io.trino.execution.Lifespan;
 import io.trino.execution.QueryManagerConfig;
 import io.trino.execution.TableExecuteContext;
@@ -52,6 +56,7 @@ import io.trino.sql.planner.plan.PlanFragmentId;
 import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.sql.planner.plan.RemoteSourceNode;
 
+import javax.annotation.concurrent.GuardedBy;
 import javax.inject.Inject;
 
 import java.util.ArrayList;
@@ -62,6 +67,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.function.LongConsumer;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -71,8 +78,10 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Sets.newIdentityHashSet;
 import static com.google.common.collect.Sets.union;
+import static com.google.common.util.concurrent.Futures.addCallback;
+import static com.google.common.util.concurrent.Futures.allAsList;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static io.airlift.concurrent.MoreFutures.addSuccessCallback;
-import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.trino.SystemSessionProperties.getFaultTolerantExecutionDefaultTaskMemory;
 import static io.trino.SystemSessionProperties.getFaultTolerantExecutionMaxTaskSplitCount;
 import static io.trino.SystemSessionProperties.getFaultTolerantExecutionMinTaskSplitCount;
@@ -97,27 +106,32 @@ public class StageTaskSourceFactory
     private final SplitSourceFactory splitSourceFactory;
     private final TableExecuteContextManager tableExecuteContextManager;
     private final int splitBatchSize;
+    private final Executor executor;
 
     @Inject
     public StageTaskSourceFactory(
             SplitSourceFactory splitSourceFactory,
             TableExecuteContextManager tableExecuteContextManager,
-            QueryManagerConfig queryManagerConfig)
+            QueryManagerConfig queryManagerConfig,
+            @ForQueryExecution ExecutorService executor)
     {
         this(
                 splitSourceFactory,
                 tableExecuteContextManager,
-                requireNonNull(queryManagerConfig, "queryManagerConfig is null").getScheduleSplitBatchSize());
+                requireNonNull(queryManagerConfig, "queryManagerConfig is null").getScheduleSplitBatchSize(),
+                executor);
     }
 
     public StageTaskSourceFactory(
             SplitSourceFactory splitSourceFactory,
             TableExecuteContextManager tableExecuteContextManager,
-            int splitBatchSize)
+            int splitBatchSize,
+            ExecutorService executor)
     {
         this.splitSourceFactory = requireNonNull(splitSourceFactory, "splitSourceFactory is null");
         this.tableExecuteContextManager = requireNonNull(tableExecuteContextManager, "tableExecuteContextManager is null");
         this.splitBatchSize = splitBatchSize;
+        this.executor = requireNonNull(executor, "executor is null");
     }
 
     @Override
@@ -155,7 +169,8 @@ public class StageTaskSourceFactory
                     bucketToPartitionMap.orElseThrow(() -> new IllegalArgumentException("bucketToPartitionMap is expected to be present for hash distributed stages")),
                     bucketNodeMap,
                     getFaultTolerantExecutionTargetTaskSplitCount(session) * SplitWeight.standard().getRawValue(),
-                    getFaultTolerantExecutionTargetTaskInputSize(session));
+                    getFaultTolerantExecutionTargetTaskInputSize(session),
+                    executor);
         }
         if (partitioning.equals(SOURCE_DISTRIBUTION)) {
             return SourceDistributionTaskSource.create(
@@ -168,7 +183,8 @@ public class StageTaskSourceFactory
                     getSplitTimeRecorder,
                     getFaultTolerantExecutionMinTaskSplitCount(session),
                     getFaultTolerantExecutionTargetTaskSplitCount(session) * SplitWeight.standard().getRawValue(),
-                    getFaultTolerantExecutionMaxTaskSplitCount(session));
+                    getFaultTolerantExecutionMaxTaskSplitCount(session),
+                    executor);
         }
 
         // other partitioning handles are not expected to be set as a fragment partitioning
@@ -196,7 +212,7 @@ public class StageTaskSourceFactory
         }
 
         @Override
-        public List<TaskDescriptor> getMoreTasks()
+        public ListenableFuture<List<TaskDescriptor>> getMoreTasks()
         {
             List<TaskDescriptor> result = ImmutableList.of(new TaskDescriptor(
                     0,
@@ -204,7 +220,7 @@ public class StageTaskSourceFactory
                     exchangeSourceHandles,
                     new NodeRequirements(Optional.empty(), ImmutableSet.of(), taskMemory)));
             finished = true;
-            return result;
+            return immediateFuture(result);
         }
 
         @Override
@@ -273,7 +289,7 @@ public class StageTaskSourceFactory
         }
 
         @Override
-        public List<TaskDescriptor> getMoreTasks()
+        public ListenableFuture<List<TaskDescriptor>> getMoreTasks()
         {
             NodeRequirements nodeRequirements = new NodeRequirements(Optional.empty(), ImmutableSet.of(), taskMemory);
 
@@ -322,7 +338,7 @@ public class StageTaskSourceFactory
             }
 
             finished = true;
-            return result.build();
+            return immediateFuture(result.build());
         }
 
         @Override
@@ -353,8 +369,13 @@ public class StageTaskSourceFactory
         private final Optional<CatalogName> catalogRequirement;
         private final long targetPartitionSourceSizeInBytes; // compared data read from ExchangeSources
         private final long targetPartitionSplitWeight; // compared against splits from SplitSources
+        private final Executor executor;
 
+        @GuardedBy("this")
+        private ListenableFuture<List<LoadedSplits>> loadedSplitsFuture;
+        @GuardedBy("this")
         private boolean finished;
+        @GuardedBy("this")
         private boolean closed;
 
         public static HashDistributionTaskSource create(
@@ -368,7 +389,8 @@ public class StageTaskSourceFactory
                 int[] bucketToPartitionMap,
                 Optional<BucketNodeMap> bucketNodeMap,
                 long targetPartitionSplitWeight,
-                DataSize targetPartitionSourceSize)
+                DataSize targetPartitionSourceSize,
+                Executor executor)
         {
             checkArgument(bucketNodeMap.isPresent() || fragment.getPartitionedSources().isEmpty(), "bucketNodeMap is expected to be set when the fragment reads partitioned sources (tables)");
             Map<PlanNodeId, SplitSource> splitSources = splitSourceFactory.createSplitSources(session, fragment);
@@ -384,7 +406,8 @@ public class StageTaskSourceFactory
                     bucketNodeMap,
                     fragment.getPartitioning().getConnectorId(),
                     targetPartitionSplitWeight, targetPartitionSourceSize,
-                    getFaultTolerantExecutionDefaultTaskMemory(session));
+                    getFaultTolerantExecutionDefaultTaskMemory(session),
+                    executor);
         }
 
         public HashDistributionTaskSource(
@@ -399,7 +422,8 @@ public class StageTaskSourceFactory
                 Optional<CatalogName> catalogRequirement,
                 long targetPartitionSplitWeight,
                 DataSize targetPartitionSourceSize,
-                DataSize taskMemory)
+                DataSize taskMemory,
+                Executor executor)
         {
             this.splitSources = ImmutableMap.copyOf(requireNonNull(splitSources, "splitSources is null"));
             this.exchangeForHandle = new IdentityHashMap<>();
@@ -415,105 +439,107 @@ public class StageTaskSourceFactory
             this.catalogRequirement = requireNonNull(catalogRequirement, "catalogRequirement is null");
             this.targetPartitionSourceSizeInBytes = requireNonNull(targetPartitionSourceSize, "targetPartitionSourceSize is null").toBytes();
             this.targetPartitionSplitWeight = targetPartitionSplitWeight;
+            this.executor = requireNonNull(executor, "executor is null");
         }
 
         @Override
-        public List<TaskDescriptor> getMoreTasks()
+        public synchronized ListenableFuture<List<TaskDescriptor>> getMoreTasks()
         {
             if (finished || closed) {
-                return ImmutableList.of();
+                return immediateFuture(ImmutableList.of());
             }
+            checkState(loadedSplitsFuture == null, "getMoreTasks called again while splits are being loaded");
 
-            Map<Integer, ListMultimap<PlanNodeId, Split>> partitionToSplitsMap = new HashMap<>();
-            SetMultimap<Integer, HostAddress> partitionToNodeMap = HashMultimap.create();
-            for (Map.Entry<PlanNodeId, SplitSource> entry : splitSources.entrySet()) {
-                SplitSource splitSource = entry.getValue();
-                BucketNodeMap bucketNodeMap = this.bucketNodeMap
-                        .orElseThrow(() -> new VerifyException("bucket to node map is expected to be present"));
-                while (!splitSource.isFinished()) {
-                    ListenableFuture<SplitBatch> splitBatchFuture = splitSource.getNextBatch(NOT_PARTITIONED, Lifespan.taskWide(), splitBatchSize);
+            List<ListenableFuture<LoadedSplits>> splitSourceCompletionFutures = splitSources.entrySet().stream()
+                    .map(entry -> {
+                        SplitLoadingFuture future = new SplitLoadingFuture(entry.getKey(), entry.getValue(), splitBatchSize, getSplitTimeRecorder, executor);
+                        future.load();
+                        return future;
+                    })
+                    .collect(toImmutableList());
 
-                    long start = System.nanoTime();
-                    addSuccessCallback(splitBatchFuture, () -> getSplitTimeRecorder.accept(start));
+            loadedSplitsFuture = allAsList(splitSourceCompletionFutures);
+            return Futures.transform(
+                    loadedSplitsFuture,
+                    loadedSplitsList -> {
+                        synchronized (this) {
+                            Map<Integer, ListMultimap<PlanNodeId, Split>> partitionToSplitsMap = new HashMap<>();
+                            SetMultimap<Integer, HostAddress> partitionToNodeMap = HashMultimap.create();
+                            for (LoadedSplits loadedSplits : loadedSplitsList) {
+                                BucketNodeMap bucketNodeMap = this.bucketNodeMap
+                                        .orElseThrow(() -> new VerifyException("bucket to node map is expected to be present"));
+                                for (Split split : loadedSplits.getSplits()) {
+                                    int bucket = bucketNodeMap.getBucket(split);
+                                    int partition = getPartitionForBucket(bucket);
 
-                    SplitBatch splitBatch = getFutureValue(splitBatchFuture);
+                                    if (!bucketNodeMap.isDynamic()) {
+                                        HostAddress requiredAddress = bucketNodeMap.getAssignedNode(split).get().getHostAndPort();
+                                        Set<HostAddress> existingRequirement = partitionToNodeMap.get(partition);
+                                        if (existingRequirement.isEmpty()) {
+                                            existingRequirement.add(requiredAddress);
+                                        }
+                                        else {
+                                            checkState(
+                                                    existingRequirement.contains(requiredAddress),
+                                                    "Unable to satisfy host requirement for partition %s. Existing requirement %s; Current split requirement: %s;",
+                                                    partition,
+                                                    existingRequirement,
+                                                    requiredAddress);
+                                            existingRequirement.removeIf(host -> !host.equals(requiredAddress));
+                                        }
+                                    }
 
-                    for (Split split : splitBatch.getSplits()) {
-                        int bucket = bucketNodeMap.getBucket(split);
-                        int partition = getPartitionForBucket(bucket);
+                                    if (!split.isRemotelyAccessible()) {
+                                        Set<HostAddress> requiredAddresses = ImmutableSet.copyOf(split.getAddresses());
+                                        verify(!requiredAddresses.isEmpty(), "split is not remotely accessible but the list of addresses is empty: %s", split);
+                                        Set<HostAddress> existingRequirement = partitionToNodeMap.get(partition);
+                                        if (existingRequirement.isEmpty()) {
+                                            existingRequirement.addAll(requiredAddresses);
+                                        }
+                                        else {
+                                            Set<HostAddress> intersection = Sets.intersection(requiredAddresses, existingRequirement);
+                                            checkState(
+                                                    !intersection.isEmpty(),
+                                                    "Unable to satisfy host requirement for partition %s. Existing requirement %s; Current split requirement: %s;",
+                                                    partition,
+                                                    existingRequirement,
+                                                    requiredAddresses);
+                                            partitionToNodeMap.replaceValues(partition, ImmutableSet.copyOf(intersection));
+                                        }
+                                    }
 
-                        if (!bucketNodeMap.isDynamic()) {
-                            HostAddress requiredAddress = bucketNodeMap.getAssignedNode(split).get().getHostAndPort();
-                            Set<HostAddress> existingRequirement = partitionToNodeMap.get(partition);
-                            if (existingRequirement.isEmpty()) {
-                                existingRequirement.add(requiredAddress);
+                                    Multimap<PlanNodeId, Split> partitionSplits = partitionToSplitsMap.computeIfAbsent(partition, (p) -> ArrayListMultimap.create());
+                                    partitionSplits.put(loadedSplits.getPlanNodeId(), split);
+                                }
                             }
-                            else {
-                                checkState(
-                                        existingRequirement.contains(requiredAddress),
-                                        "Unable to satisfy host requirement for partition %s. Existing requirement %s; Current split requirement: %s;",
-                                        partition,
-                                        existingRequirement,
-                                        requiredAddress);
-                                existingRequirement.removeIf(host -> !host.equals(requiredAddress));
+
+                            Map<Integer, Multimap<PlanNodeId, ExchangeSourceHandle>> partitionToExchangeSourceHandlesMap = new HashMap<>();
+                            for (Map.Entry<PlanNodeId, ExchangeSourceHandle> entry : partitionedExchangeSourceHandles.entries()) {
+                                PlanNodeId planNodeId = entry.getKey();
+                                ExchangeSourceHandle handle = entry.getValue();
+                                int partition = handle.getPartitionId();
+                                Multimap<PlanNodeId, ExchangeSourceHandle> partitionSourceHandles = partitionToExchangeSourceHandlesMap.computeIfAbsent(partition, (p) -> ArrayListMultimap.create());
+                                partitionSourceHandles.put(planNodeId, handle);
                             }
+
+                            int taskPartitionId = 0;
+                            ImmutableList.Builder<TaskDescriptor> partitionTasks = ImmutableList.builder();
+                            for (Integer partition : union(partitionToSplitsMap.keySet(), partitionToExchangeSourceHandlesMap.keySet())) {
+                                ListMultimap<PlanNodeId, Split> splits = partitionToSplitsMap.getOrDefault(partition, ImmutableListMultimap.of());
+                                ListMultimap<PlanNodeId, ExchangeSourceHandle> exchangeSourceHandles = ImmutableListMultimap.<PlanNodeId, ExchangeSourceHandle>builder()
+                                        .putAll(partitionToExchangeSourceHandlesMap.getOrDefault(partition, ImmutableMultimap.of()))
+                                        // replicated exchange source will be added in postprocessTasks below
+                                        .build();
+                                Set<HostAddress> hostRequirement = partitionToNodeMap.get(partition);
+                                partitionTasks.add(new TaskDescriptor(taskPartitionId++, splits, exchangeSourceHandles, new NodeRequirements(catalogRequirement, hostRequirement, taskMemory)));
+                            }
+
+                            List<TaskDescriptor> result = postprocessTasks(partitionTasks.build());
+                            finished = true;
+                            return result;
                         }
-
-                        if (!split.isRemotelyAccessible()) {
-                            Set<HostAddress> requiredAddresses = ImmutableSet.copyOf(split.getAddresses());
-                            verify(!requiredAddresses.isEmpty(), "split is not remotely accessible but the list of addresses is empty: %s", split);
-                            Set<HostAddress> existingRequirement = partitionToNodeMap.get(partition);
-                            if (existingRequirement.isEmpty()) {
-                                existingRequirement.addAll(requiredAddresses);
-                            }
-                            else {
-                                Set<HostAddress> intersection = Sets.intersection(requiredAddresses, existingRequirement);
-                                checkState(
-                                        !intersection.isEmpty(),
-                                        "Unable to satisfy host requirement for partition %s. Existing requirement %s; Current split requirement: %s;",
-                                        partition,
-                                        existingRequirement,
-                                        requiredAddresses);
-                                partitionToNodeMap.replaceValues(partition, ImmutableSet.copyOf(intersection));
-                            }
-                        }
-
-                        Multimap<PlanNodeId, Split> partitionSplits = partitionToSplitsMap.computeIfAbsent(partition, (p) -> ArrayListMultimap.create());
-                        partitionSplits.put(entry.getKey(), split);
-                    }
-
-                    if (splitBatch.isLastBatch()) {
-                        splitSource.close();
-                        break;
-                    }
-                }
-            }
-
-            Map<Integer, Multimap<PlanNodeId, ExchangeSourceHandle>> partitionToExchangeSourceHandlesMap = new HashMap<>();
-            for (Map.Entry<PlanNodeId, ExchangeSourceHandle> entry : partitionedExchangeSourceHandles.entries()) {
-                PlanNodeId planNodeId = entry.getKey();
-                ExchangeSourceHandle handle = entry.getValue();
-                int partition = handle.getPartitionId();
-                Multimap<PlanNodeId, ExchangeSourceHandle> partitionSourceHandles = partitionToExchangeSourceHandlesMap.computeIfAbsent(partition, (p) -> ArrayListMultimap.create());
-                partitionSourceHandles.put(planNodeId, handle);
-            }
-
-            int taskPartitionId = 0;
-            ImmutableList.Builder<TaskDescriptor> partitionTasks = ImmutableList.builder();
-            for (Integer partition : union(partitionToSplitsMap.keySet(), partitionToExchangeSourceHandlesMap.keySet())) {
-                ListMultimap<PlanNodeId, Split> splits = partitionToSplitsMap.getOrDefault(partition, ImmutableListMultimap.of());
-                ListMultimap<PlanNodeId, ExchangeSourceHandle> exchangeSourceHandles = ImmutableListMultimap.<PlanNodeId, ExchangeSourceHandle>builder()
-                        .putAll(partitionToExchangeSourceHandlesMap.getOrDefault(partition, ImmutableMultimap.of()))
-                        // replicated exchange source will be added in postprocessTasks below
-                        .build();
-                Set<HostAddress> hostRequirement = partitionToNodeMap.get(partition);
-                partitionTasks.add(new TaskDescriptor(taskPartitionId++, splits, exchangeSourceHandles, new NodeRequirements(catalogRequirement, hostRequirement, taskMemory)));
-            }
-
-            List<TaskDescriptor> result = postprocessTasks(partitionTasks.build());
-
-            finished = true;
-            return result;
+                    },
+                    executor);
         }
 
         private List<TaskDescriptor> postprocessTasks(List<TaskDescriptor> tasks)
@@ -584,13 +610,13 @@ public class StageTaskSourceFactory
         }
 
         @Override
-        public boolean isFinished()
+        public synchronized boolean isFinished()
         {
             return finished;
         }
 
         @Override
-        public void close()
+        public synchronized void close()
         {
             if (closed) {
                 return;
@@ -622,13 +648,21 @@ public class StageTaskSourceFactory
         private final long targetPartitionSplitWeight;
         private final int maxPartitionSplitCount;
         private final DataSize taskMemory;
+        private final Executor executor;
 
+        @GuardedBy("this")
         private final Set<Split> remotelyAccessibleSplitBuffer = newIdentityHashSet();
+        @GuardedBy("this")
         private final Map<HostAddress, Set<Split>> locallyAccessibleSplitBuffer = new HashMap<>();
 
+        @GuardedBy("this")
         private int currentPartitionId;
+        @GuardedBy("this")
         private boolean finished;
+        @GuardedBy("this")
         private boolean closed;
+        @GuardedBy("this")
+        private ListenableFuture<SplitBatch> currentSplitBatchFuture = immediateFuture(null);
 
         public static SourceDistributionTaskSource create(
                 Session session,
@@ -640,7 +674,8 @@ public class StageTaskSourceFactory
                 LongConsumer getSplitTimeRecorder,
                 int minPartitionSplitCount,
                 long targetPartitionSplitWeight,
-                int maxPartitionSplitCount)
+                int maxPartitionSplitCount,
+                Executor executor)
         {
             checkArgument(fragment.getPartitionedSources().size() == 1, "single partitioned source is expected, got: %s", fragment.getPartitionedSources());
 
@@ -666,7 +701,8 @@ public class StageTaskSourceFactory
                     minPartitionSplitCount,
                     targetPartitionSplitWeight,
                     maxPartitionSplitCount,
-                    getFaultTolerantExecutionDefaultTaskMemory(session));
+                    getFaultTolerantExecutionDefaultTaskMemory(session),
+                    executor);
         }
 
         public SourceDistributionTaskSource(
@@ -681,7 +717,8 @@ public class StageTaskSourceFactory
                 int minPartitionSplitCount,
                 long targetPartitionSplitWeight,
                 int maxPartitionSplitCount,
-                DataSize taskMemory)
+                DataSize taskMemory,
+                Executor executor)
         {
             this.queryId = requireNonNull(queryId, "queryId is null");
             this.partitionedSourceNodeId = requireNonNull(partitionedSourceNodeId, "partitionedSourceNodeId is null");
@@ -702,77 +739,80 @@ public class StageTaskSourceFactory
                     minPartitionSplitCount);
             this.maxPartitionSplitCount = maxPartitionSplitCount;
             this.taskMemory = requireNonNull(taskMemory, "taskMemory is null");
+            this.executor = requireNonNull(executor, "executor is null");
         }
 
         @Override
-        public List<TaskDescriptor> getMoreTasks()
+        public synchronized ListenableFuture<List<TaskDescriptor>> getMoreTasks()
         {
             if (finished || closed) {
-                return ImmutableList.of();
+                return immediateFuture(ImmutableList.of());
             }
 
-            List<TaskDescriptor> result = new ArrayList<>();
+            checkState(currentSplitBatchFuture.isDone(), "getMoreTasks called again before the previous batch of splits was ready");
+            currentSplitBatchFuture = splitSource.getNextBatch(NOT_PARTITIONED, Lifespan.taskWide(), splitBatchSize);
 
-            boolean splitSourceFinished = false;
-            while (result.isEmpty()) {
-                ListenableFuture<SplitBatch> splitBatchFuture = splitSource.getNextBatch(NOT_PARTITIONED, Lifespan.taskWide(), splitBatchSize);
+            long start = System.nanoTime();
+            addSuccessCallback(currentSplitBatchFuture, () -> getSplitTimeRecorder.accept(start));
 
-                long start = System.nanoTime();
-                addSuccessCallback(splitBatchFuture, () -> getSplitTimeRecorder.accept(start));
+            return Futures.transform(
+                    currentSplitBatchFuture,
+                    splitBatch -> {
+                        synchronized (this) {
+                            for (Split split : splitBatch.getSplits()) {
+                                if (split.isRemotelyAccessible()) {
+                                    remotelyAccessibleSplitBuffer.add(split);
+                                }
+                                else {
+                                    List<HostAddress> addresses = split.getAddresses();
+                                    checkArgument(!addresses.isEmpty(), "split is not remotely accessible but the list of addresses is empty");
+                                    for (HostAddress hostAddress : addresses) {
+                                        locallyAccessibleSplitBuffer.computeIfAbsent(hostAddress, key -> newIdentityHashSet()).add(split);
+                                    }
+                                }
+                            }
 
-                SplitBatch splitBatch = getFutureValue(splitBatchFuture);
-                List<Split> splits = splitBatch.getSplits();
+                            ImmutableList.Builder<TaskDescriptor> readyTasksBuilder = ImmutableList.builder();
+                            boolean isLastBatch = splitBatch.isLastBatch();
+                            readyTasksBuilder.addAll(getReadyTasks(
+                                    remotelyAccessibleSplitBuffer,
+                                    ImmutableList.of(),
+                                    new NodeRequirements(catalogRequirement, ImmutableSet.of(), taskMemory),
+                                    isLastBatch));
+                            for (HostAddress remoteHost : locallyAccessibleSplitBuffer.keySet()) {
+                                readyTasksBuilder.addAll(getReadyTasks(
+                                        locallyAccessibleSplitBuffer.get(remoteHost),
+                                        locallyAccessibleSplitBuffer.entrySet().stream()
+                                                .filter(entry -> !entry.getKey().equals(remoteHost))
+                                                .map(Map.Entry::getValue)
+                                                .collect(toImmutableList()),
+                                        new NodeRequirements(catalogRequirement, ImmutableSet.of(remoteHost), taskMemory),
+                                        isLastBatch));
+                            }
+                            List<TaskDescriptor> readyTasks = readyTasksBuilder.build();
 
-                for (Split split : splits) {
-                    if (split.isRemotelyAccessible()) {
-                        remotelyAccessibleSplitBuffer.add(split);
-                    }
-                    else {
-                        List<HostAddress> addresses = split.getAddresses();
-                        checkArgument(!addresses.isEmpty(), "split is not remotely accessible but the list of addresses is empty");
-                        for (HostAddress hostAddress : addresses) {
-                            locallyAccessibleSplitBuffer.computeIfAbsent(hostAddress, key -> newIdentityHashSet()).add(split);
+                            if (isLastBatch) {
+                                Optional<List<Object>> tableExecuteSplitsInfo = splitSource.getTableExecuteSplitsInfo();
+
+                                // Here we assume that we can get non-empty tableExecuteSplitsInfo only for queries which facilitate single split source.
+                                tableExecuteSplitsInfo.ifPresent(info -> {
+                                    TableExecuteContext tableExecuteContext = tableExecuteContextManager.getTableExecuteContextForQuery(queryId);
+                                    tableExecuteContext.setSplitsInfo(info);
+                                });
+
+                                try {
+                                    splitSource.close();
+                                }
+                                catch (RuntimeException e) {
+                                    log.error(e, "Error closing split source");
+                                }
+                                finished = true;
+                            }
+
+                            return readyTasks;
                         }
-                    }
-                }
-
-                splitSourceFinished = splitSource.isFinished();
-
-                result.addAll(getReadyTasks(
-                        remotelyAccessibleSplitBuffer,
-                        ImmutableList.of(),
-                        new NodeRequirements(catalogRequirement, ImmutableSet.of(), taskMemory),
-                        splitSourceFinished));
-                for (HostAddress remoteHost : locallyAccessibleSplitBuffer.keySet()) {
-                    result.addAll(getReadyTasks(
-                            locallyAccessibleSplitBuffer.get(remoteHost),
-                            locallyAccessibleSplitBuffer.entrySet().stream()
-                                    .filter(entry -> !entry.getKey().equals(remoteHost))
-                                    .map(Map.Entry::getValue)
-                                    .collect(toImmutableList()),
-                            new NodeRequirements(catalogRequirement, ImmutableSet.of(remoteHost), taskMemory),
-                            splitSourceFinished));
-                }
-
-                if (splitSourceFinished) {
-                    break;
-                }
-            }
-
-            if (splitSourceFinished) {
-                Optional<List<Object>> tableExecuteSplitsInfo = splitSource.getTableExecuteSplitsInfo();
-
-                // Here we assume that we can get non-empty tableExecuteSplitsInfo only for queries which facilitate single split source.
-                tableExecuteSplitsInfo.ifPresent(info -> {
-                    TableExecuteContext tableExecuteContext = tableExecuteContextManager.getTableExecuteContextForQuery(queryId);
-                    tableExecuteContext.setSplitsInfo(info);
-                });
-
-                finished = true;
-                splitSource.close();
-            }
-
-            return ImmutableList.copyOf(result);
+                    },
+                    executor);
         }
 
         private List<TaskDescriptor> getReadyTasks(Set<Split> splits, List<Set<Split>> otherSplitSets, NodeRequirements nodeRequirements, boolean includeRemainder)
@@ -818,7 +858,7 @@ public class StageTaskSourceFactory
             return Optional.empty();
         }
 
-        private TaskDescriptor buildTaskDescriptor(Collection<Split> splits, NodeRequirements nodeRequirements)
+        private synchronized TaskDescriptor buildTaskDescriptor(Collection<Split> splits, NodeRequirements nodeRequirements)
         {
             return new TaskDescriptor(
                     currentPartitionId++,
@@ -828,13 +868,13 @@ public class StageTaskSourceFactory
         }
 
         @Override
-        public boolean isFinished()
+        public synchronized boolean isFinished()
         {
             return finished;
         }
 
         @Override
-        public void close()
+        public synchronized void close()
         {
             if (closed) {
                 return;
@@ -903,5 +943,105 @@ public class StageTaskSourceFactory
             }
         }
         return result.build();
+    }
+
+    private static class LoadedSplits
+    {
+        private final PlanNodeId planNodeId;
+        private final List<Split> splits;
+
+        private LoadedSplits(PlanNodeId planNodeId, List<Split> splits)
+        {
+            this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
+            this.splits = ImmutableList.copyOf(requireNonNull(splits, "splits is null"));
+        }
+
+        public PlanNodeId getPlanNodeId()
+        {
+            return planNodeId;
+        }
+
+        public List<Split> getSplits()
+        {
+            return splits;
+        }
+    }
+
+    private static class SplitLoadingFuture
+            extends AbstractFuture<LoadedSplits>
+    {
+        private final PlanNodeId planNodeId;
+        private final SplitSource splitSource;
+        private final int splitBatchSize;
+        private final LongConsumer getSplitTimeRecorder;
+        private final Executor executor;
+        @GuardedBy("this")
+        private final List<Split> loadedSplits = new ArrayList<>();
+        @GuardedBy("this")
+        private ListenableFuture<SplitBatch> currentSplitBatch = immediateFuture(null);
+
+        SplitLoadingFuture(PlanNodeId planNodeId, SplitSource splitSource, int splitBatchSize, LongConsumer getSplitTimeRecorder, Executor executor)
+        {
+            this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
+            this.splitSource = requireNonNull(splitSource, "splitSource is null");
+            this.splitBatchSize = splitBatchSize;
+            this.getSplitTimeRecorder = requireNonNull(getSplitTimeRecorder, "getSplitTimeRecorder is null");
+            this.executor = requireNonNull(executor, "executor is null");
+        }
+
+        // Called to initiate loading and to load next batch if not finished
+        public synchronized void load()
+        {
+            if (currentSplitBatch == null) {
+                checkState(isCancelled(), "SplitLoadingFuture should be in cancelled state");
+                return;
+            }
+            checkState(currentSplitBatch.isDone(), "next batch of splits requested before previous batch is done");
+            currentSplitBatch = splitSource.getNextBatch(NOT_PARTITIONED, Lifespan.taskWide(), splitBatchSize);
+
+            long start = System.nanoTime();
+            addCallback(
+                    currentSplitBatch,
+                    new FutureCallback<>()
+                    {
+                        @Override
+                        public void onSuccess(SplitBatch splitBatch)
+                        {
+                            getSplitTimeRecorder.accept(start);
+                            synchronized (SplitLoadingFuture.this) {
+                                loadedSplits.addAll(splitBatch.getSplits());
+
+                                if (splitBatch.isLastBatch()) {
+                                    set(new LoadedSplits(planNodeId, loadedSplits));
+                                    try {
+                                        splitSource.close();
+                                    }
+                                    catch (RuntimeException e) {
+                                        log.error(e, "Error closing split source");
+                                    }
+                                }
+                                else {
+                                    load();
+                                }
+                            }
+                        }
+
+                        @Override
+                        public void onFailure(Throwable throwable)
+                        {
+                            setException(throwable);
+                        }
+                    },
+                    executor);
+        }
+
+        @Override
+        protected synchronized void interruptTask()
+        {
+            if (currentSplitBatch != null) {
+                currentSplitBatch.cancel(true);
+                currentSplitBatch = null;
+            }
+        }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/TaskSource.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/TaskSource.java
@@ -13,13 +13,15 @@
  */
 package io.trino.execution.scheduler;
 
+import com.google.common.util.concurrent.ListenableFuture;
+
 import java.io.Closeable;
 import java.util.List;
 
 public interface TaskSource
         extends Closeable
 {
-    List<TaskDescriptor> getMoreTasks();
+    ListenableFuture<List<TaskDescriptor>> getMoreTasks();
 
     boolean isFinished();
 


### PR DESCRIPTION
It's possible for the probe side table scan of a join to block
producing splits until the build side collects dynamic filters.
In such a scenario, we need to avoid waiting on the blocked splits
synchronously and allow other stages to schedule.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

fix
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core query engine
> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( x) No release notes entries required.
( ) Release notes entries required with the following suggested text:
