### PR TITLE
Support query pass-through for Elasticsearch connector

### DIFF
--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchConnector.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchConnector.java
@@ -22,6 +22,7 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.SystemTable;
+import io.trino.spi.ptf.ConnectorTableFunction;
 import io.trino.spi.transaction.IsolationLevel;
 
 import javax.inject.Inject;
@@ -40,6 +41,7 @@ public class ElasticsearchConnector
     private final ElasticsearchSplitManager splitManager;
     private final ElasticsearchPageSourceProvider pageSourceProvider;
     private final NodesSystemTable nodesSystemTable;
+    private final Set<ConnectorTableFunction> connectorTableFunctions;
 
     @Inject
     public ElasticsearchConnector(
@@ -47,13 +49,15 @@ public class ElasticsearchConnector
             ElasticsearchMetadata metadata,
             ElasticsearchSplitManager splitManager,
             ElasticsearchPageSourceProvider pageSourceProvider,
-            NodesSystemTable nodesSystemTable)
+            NodesSystemTable nodesSystemTable,
+            Set<ConnectorTableFunction> connectorTableFunctions)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
         this.nodesSystemTable = requireNonNull(nodesSystemTable, "nodesSystemTable is null");
+        this.connectorTableFunctions = ImmutableSet.copyOf(requireNonNull(connectorTableFunctions, "connectorTableFunctions is null"));
     }
 
     @Override
@@ -85,6 +89,12 @@ public class ElasticsearchConnector
     public Set<SystemTable> getSystemTables()
     {
         return ImmutableSet.of(nodesSystemTable);
+    }
+
+    @Override
+    public Set<ConnectorTableFunction> getTableFunctions()
+    {
+        return connectorTableFunctions;
     }
 
     @Override

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchConnectorModule.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchConnectorModule.java
@@ -17,7 +17,10 @@ import com.google.inject.Binder;
 import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.trino.plugin.elasticsearch.client.ElasticsearchClient;
+import io.trino.plugin.elasticsearch.ptf.RawQuery;
+import io.trino.spi.ptf.ConnectorTableFunction;
 
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigBinder.configBinder;
@@ -45,6 +48,8 @@ public class ElasticsearchConnectorModule
 
         newOptionalBinder(binder, AwsSecurityConfig.class);
         newOptionalBinder(binder, PasswordConfig.class);
+
+        newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(RawQuery.class).in(Scopes.SINGLETON);
 
         install(conditionalModule(
                 ElasticsearchConfig.class,

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ptf/RawQuery.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ptf/RawQuery.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.elasticsearch.ptf;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.airlift.slice.Slice;
+import io.trino.plugin.elasticsearch.ElasticsearchColumnHandle;
+import io.trino.plugin.elasticsearch.ElasticsearchMetadata;
+import io.trino.plugin.elasticsearch.ElasticsearchTableHandle;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ColumnSchema;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTableSchema;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.ptf.AbstractConnectorTableFunction;
+import io.trino.spi.ptf.Argument;
+import io.trino.spi.ptf.ConnectorTableFunction;
+import io.trino.spi.ptf.ConnectorTableFunctionHandle;
+import io.trino.spi.ptf.Descriptor;
+import io.trino.spi.ptf.ScalarArgument;
+import io.trino.spi.ptf.ScalarArgumentSpecification;
+import io.trino.spi.ptf.TableFunctionAnalysis;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.elasticsearch.ElasticsearchTableHandle.Type.QUERY;
+import static io.trino.spi.ptf.ReturnTypeSpecification.GenericTable.GENERIC_TABLE;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+
+public class RawQuery
+        implements Provider<ConnectorTableFunction>
+{
+    public static final String SCHEMA_NAME = "system";
+    public static final String NAME = "raw_query";
+
+    private final ElasticsearchMetadata metadata;
+
+    @Inject
+    public RawQuery(ElasticsearchMetadata metadata)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
+    @Override
+    public ConnectorTableFunction get()
+    {
+        return new RawQueryFunction(metadata);
+    }
+
+    public static class RawQueryFunction
+            extends AbstractConnectorTableFunction
+    {
+        private final ElasticsearchMetadata metadata;
+
+        public RawQueryFunction(ElasticsearchMetadata metadata)
+        {
+            super(
+                    SCHEMA_NAME,
+                    NAME,
+                    List.of(
+                            ScalarArgumentSpecification.builder()
+                                    .name("SCHEMA")
+                                    .type(VARCHAR)
+                                    .build(),
+                            ScalarArgumentSpecification.builder()
+                                    .name("INDEX")
+                                    .type(VARCHAR)
+                                    .build(),
+                            ScalarArgumentSpecification.builder()
+                                    .name("QUERY")
+                                    .type(VARCHAR)
+                                    .build()),
+                    GENERIC_TABLE);
+            this.metadata = requireNonNull(metadata, "metadata is null");
+        }
+
+        @Override
+        public TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments)
+        {
+            String schema = ((Slice) ((ScalarArgument) arguments.get("SCHEMA")).getValue()).toStringUtf8();
+            String index = ((Slice) ((ScalarArgument) arguments.get("INDEX")).getValue()).toStringUtf8();
+            String query = ((Slice) ((ScalarArgument) arguments.get("QUERY")).getValue()).toStringUtf8();
+
+            ElasticsearchTableHandle tableHandle = new ElasticsearchTableHandle(QUERY, schema, index, Optional.of(query));
+            ConnectorTableSchema tableSchema = metadata.getTableSchema(session, tableHandle);
+            Map<String, ColumnHandle> columnsByName = metadata.getColumnHandles(session, tableHandle);
+            List<ColumnHandle> columns = tableSchema.getColumns().stream()
+                    .map(ColumnSchema::getName)
+                    .map(columnsByName::get)
+                    .collect(toImmutableList());
+
+            Descriptor returnedType = new Descriptor(columns.stream()
+                    .map(ElasticsearchColumnHandle.class::cast)
+                    .map(column -> new Descriptor.Field(column.getName(), Optional.of(column.getType())))
+                    .collect(toList()));
+
+            RawQueryFunctionHandle handle = new RawQueryFunctionHandle(tableHandle);
+
+            return TableFunctionAnalysis.builder()
+                    .returnedType(returnedType)
+                    .handle(handle)
+                    .build();
+        }
+    }
+
+    public static class RawQueryFunctionHandle
+            implements ConnectorTableFunctionHandle
+    {
+        private final ElasticsearchTableHandle tableHandle;
+
+        @JsonCreator
+        public RawQueryFunctionHandle(@JsonProperty("tableHandle") ElasticsearchTableHandle tableHandle)
+        {
+            this.tableHandle = requireNonNull(tableHandle, "tableHandle is null");
+        }
+
+        @JsonProperty
+        public ConnectorTableHandle getTableHandle()
+        {
+            return tableHandle;
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces `raw_query` Polymorphic Table Function for full query pass-through to Elasticsearch connector.

```markdown
# Elasticsearch
* Add `raw_query` table function for full query pass-through to the connector.
```


## Documentation

Documentation issue is filed: https://github.com/trinodb/trino/issues/13007.
When documenting, also deprecate the legacy query pass-through mechanism: https://trino.io/docs/current/connector/elasticsearch.html?highlight=elasticsearch#pass-through-queries