### PR TITLE
Fix memory accounting leak in aggregation

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/SqlTaskExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTaskExecution.java
@@ -1089,7 +1089,7 @@ public class SqlTaskExecution
                 driver = this.driver;
             }
 
-            return driver.processFor(duration);
+            return driver.processForDuration(duration);
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/operator/Driver.java
+++ b/core/trino-main/src/main/java/io/trino/operator/Driver.java
@@ -309,14 +309,16 @@ public class Driver
             try {
                 long start = System.nanoTime();
                 int iterations = 0;
-                do {
+                while (!isFinishedInternal()) {
                     ListenableFuture<Void> future = processInternal(operationTimer);
                     iterations++;
                     if (!future.isDone()) {
                         return updateDriverBlockedFuture(future);
                     }
+                    if (System.nanoTime() - start >= maxRuntimeInNanos || iterations >= maxIterations) {
+                        break;
+                    }
                 }
-                while (System.nanoTime() - start < maxRuntimeInNanos && iterations < maxIterations && !isFinishedInternal());
             }
             catch (Throwable t) {
                 List<StackTraceElement> interrupterStack = exclusiveLock.getInterrupterStack();

--- a/core/trino-main/src/main/java/io/trino/operator/TableFinishOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableFinishOperator.java
@@ -30,6 +30,7 @@ import io.trino.spi.statistics.ComputedStatistics;
 import io.trino.spi.type.Type;
 import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.sql.planner.plan.StatisticAggregationsDescriptor;
+import io.trino.util.AutoCloseableCloser;
 
 import java.util.Collection;
 import java.util.List;
@@ -360,7 +361,10 @@ public class TableFinishOperator
     public void close()
             throws Exception
     {
-        statisticsAggregationOperator.close();
+        AutoCloseableCloser closer = AutoCloseableCloser.create();
+        closer.register(() -> statisticsAggregationOperator.getOperatorContext().destroy());
+        closer.register(statisticsAggregationOperator);
+        closer.close();
     }
 
     public interface TableFinisher

--- a/core/trino-main/src/main/java/io/trino/operator/TableWriterOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableWriterOperator.java
@@ -378,6 +378,7 @@ public class TableWriterOperator
                 closer.register(pageSink::abort);
             }
         }
+        closer.register(() -> statisticAggregationOperator.getOperatorContext().destroy());
         closer.register(statisticAggregationOperator);
         closer.register(pageSinkMemoryContext::close);
         closer.close();

--- a/core/trino-main/src/main/java/io/trino/operator/index/IndexLoader.java
+++ b/core/trino-main/src/main/java/io/trino/operator/index/IndexLoader.java
@@ -340,7 +340,7 @@ public class IndexLoader
                 ScheduledSplit split = new ScheduledSplit(0, sourcePlanNodeId, new Split(INDEX_CONNECTOR_ID, new IndexSplit(recordSetForLookupSource), Lifespan.taskWide()));
                 driver.updateSplitAssignment(new SplitAssignment(sourcePlanNodeId, ImmutableSet.of(split), true));
                 while (!driver.isFinished()) {
-                    ListenableFuture<Void> process = driver.process();
+                    ListenableFuture<Void> process = driver.processUntilBlocked();
                     checkState(process.isDone(), "Driver should never block");
                 }
             }

--- a/core/trino-main/src/main/java/io/trino/operator/index/StreamingIndexedData.java
+++ b/core/trino-main/src/main/java/io/trino/operator/index/StreamingIndexedData.java
@@ -101,7 +101,7 @@ public class StreamingIndexedData
             if (driver.isFinished()) {
                 return false;
             }
-            driver.process();
+            driver.processForNumberOfIterations(1);
             nextPage = extractNonEmptyPage(pageBuffer);
         }
         currentPage = nextPage;

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -831,7 +831,7 @@ public class LocalQueryRunner
                     }
 
                     if (!driver.isFinished()) {
-                        driver.process();
+                        driver.processForNumberOfIterations(1);
                         processed = true;
                     }
                 }

--- a/core/trino-main/src/test/java/io/trino/memory/TestMemoryBlocking.java
+++ b/core/trino-main/src/test/java/io/trino/memory/TestMemoryBlocking.java
@@ -118,7 +118,7 @@ public class TestMemoryBlocking
         Split testSplit = new Split(new CatalogName("test"), new TestSplit(), Lifespan.taskWide());
         driver.updateSplitAssignment(new SplitAssignment(sourceId, ImmutableSet.of(new ScheduledSplit(0, sourceId, testSplit)), true));
 
-        ListenableFuture<Void> blocked = driver.processFor(new Duration(1, NANOSECONDS));
+        ListenableFuture<Void> blocked = driver.processForDuration(new Duration(1, NANOSECONDS));
 
         // the driver shouldn't block in the first call as it will be able to move a page between source and the sink operator
         // but the operator should be blocked
@@ -128,7 +128,7 @@ public class TestMemoryBlocking
         // in the subsequent calls both the driver and the operator should be blocked
         // and they should stay blocked until more memory becomes available
         for (int i = 0; i < 10; i++) {
-            blocked = driver.processFor(new Duration(1, NANOSECONDS));
+            blocked = driver.processForDuration(new Duration(1, NANOSECONDS));
             assertFalse(blocked.isDone());
             assertFalse(source.getOperatorContext().isWaitingForMemory().isDone());
         }
@@ -140,7 +140,7 @@ public class TestMemoryBlocking
         assertTrue(source.getOperatorContext().isWaitingForMemory().isDone());
 
         // the driver shouldn't be blocked
-        blocked = driver.processFor(new Duration(1, NANOSECONDS));
+        blocked = driver.processForDuration(new Duration(1, NANOSECONDS));
         assertTrue(blocked.isDone());
     }
 

--- a/core/trino-main/src/test/java/io/trino/memory/TestMemoryPools.java
+++ b/core/trino-main/src/test/java/io/trino/memory/TestMemoryPools.java
@@ -436,7 +436,7 @@ public class TestMemoryPools
         // run driver, until it blocks
         while (!isOperatorBlocked(drivers, reason)) {
             for (Driver driver : drivers) {
-                driver.process();
+                driver.processForNumberOfIterations(1);
             }
             iterationsCount++;
         }
@@ -454,7 +454,7 @@ public class TestMemoryPools
             assertFalse(isOperatorBlocked(drivers, reason));
             boolean progress = false;
             for (Driver driver : drivers) {
-                ListenableFuture<Void> blocked = driver.process();
+                ListenableFuture<Void> blocked = driver.processUntilBlocked();
                 progress = progress | blocked.isDone();
             }
             // query should not block

--- a/core/trino-main/src/test/java/io/trino/operator/TestHashSemiJoinOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestHashSemiJoinOperator.java
@@ -121,7 +121,7 @@ public class TestHashSemiJoinOperator
 
         Driver driver = Driver.createDriver(driverContext, buildOperator, setBuilderOperator);
         while (!driver.isFinished()) {
-            driver.process();
+            driver.processUntilBlocked();
         }
 
         // probe
@@ -186,7 +186,7 @@ public class TestHashSemiJoinOperator
 
         Driver driver = Driver.createDriver(driverContext, buildOperator, setBuilderOperator);
         while (!driver.isFinished()) {
-            driver.process();
+            driver.processUntilBlocked();
         }
 
         // probe
@@ -281,7 +281,7 @@ public class TestHashSemiJoinOperator
 
         Driver driver = Driver.createDriver(driverContext, buildOperator, setBuilderOperator);
         while (!driver.isFinished()) {
-            driver.process();
+            driver.processUntilBlocked();
         }
 
         // probe
@@ -337,7 +337,7 @@ public class TestHashSemiJoinOperator
 
         Driver driver = Driver.createDriver(driverContext, buildOperator, setBuilderOperator);
         while (!driver.isFinished()) {
-            driver.process();
+            driver.processUntilBlocked();
         }
 
         // probe
@@ -397,7 +397,7 @@ public class TestHashSemiJoinOperator
 
         Driver driver = Driver.createDriver(driverContext, buildOperator, setBuilderOperator);
         while (!driver.isFinished()) {
-            driver.process();
+            driver.processUntilBlocked();
         }
 
         // probe
@@ -455,7 +455,7 @@ public class TestHashSemiJoinOperator
 
         Driver driver = Driver.createDriver(driverContext, buildOperator, setBuilderOperator);
         while (!driver.isFinished()) {
-            driver.process();
+            driver.processUntilBlocked();
         }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/join/JoinTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/JoinTestUtils.java
@@ -168,7 +168,7 @@ public final class JoinTestUtils
         sinkOperatorFactory.noMoreOperators();
 
         while (!sourceDriver.isFinished()) {
-            sourceDriver.process();
+            sourceDriver.processUntilBlocked();
         }
 
         // build side operator factories
@@ -214,7 +214,7 @@ public final class JoinTestUtils
 
         while (!lookupSourceProvider.isDone()) {
             for (Driver buildDriver : buildDrivers) {
-                buildDriver.process();
+                buildDriver.processForNumberOfIterations(1);
             }
         }
         getFutureValue(lookupSourceProvider).close();
@@ -232,7 +232,7 @@ public final class JoinTestUtils
         executor.execute(() -> {
             if (!driver.isFinished()) {
                 try {
-                    driver.process();
+                    driver.processUntilBlocked();
                 }
                 catch (TrinoException e) {
                     driver.getDriverContext().failed(e);

--- a/core/trino-main/src/test/java/io/trino/operator/join/TestNestedLoopJoinOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/TestNestedLoopJoinOperator.java
@@ -528,7 +528,7 @@ public class TestNestedLoopJoinOperator
         nestedLoopBuildOperatorFactory.noMoreOperators();
 
         while (nestedLoopBuildOperator.isBlocked().isDone()) {
-            driver.process();
+            driver.processUntilBlocked();
         }
 
         return joinOperatorFactory;

--- a/lib/trino-memory-context/src/main/java/io/trino/memory/context/ChildAggregatedMemoryContext.java
+++ b/lib/trino-memory-context/src/main/java/io/trino/memory/context/ChildAggregatedMemoryContext.java
@@ -43,6 +43,7 @@ class ChildAggregatedMemoryContext
     @Override
     synchronized boolean tryUpdateBytes(String allocationTag, long delta)
     {
+        checkState(!isClosed(), "ChildAggregatedMemoryContext is already closed");
         if (parentMemoryContext.tryUpdateBytes(allocationTag, delta)) {
             addBytes(delta);
             return true;

--- a/lib/trino-memory-context/src/main/java/io/trino/memory/context/RootAggregatedMemoryContext.java
+++ b/lib/trino-memory-context/src/main/java/io/trino/memory/context/RootAggregatedMemoryContext.java
@@ -46,6 +46,7 @@ class RootAggregatedMemoryContext
     @Override
     synchronized boolean tryUpdateBytes(String allocationTag, long delta)
     {
+        checkState(!isClosed(), "RootAggregatedMemoryContext is already closed");
         if (reservationHandler.tryReserveMemory(allocationTag, delta)) {
             addBytes(delta);
             return true;

--- a/lib/trino-memory-context/src/main/java/io/trino/memory/context/SimpleAggregatedMemoryContext.java
+++ b/lib/trino-memory-context/src/main/java/io/trino/memory/context/SimpleAggregatedMemoryContext.java
@@ -34,6 +34,7 @@ class SimpleAggregatedMemoryContext
     @Override
     synchronized boolean tryUpdateBytes(String allocationTag, long delta)
     {
+        checkState(!isClosed(), "SimpleAggregatedMemoryContext is already closed");
         addBytes(delta);
         return true;
     }

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialJoinOperator.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialJoinOperator.java
@@ -497,7 +497,7 @@ public class TestSpatialJoinOperator
         ListenableFuture<PagesSpatialIndex> pagesSpatialIndex = pagesSpatialIndexFactory.createPagesSpatialIndex();
 
         while (!pagesSpatialIndex.isDone()) {
-            driver.process();
+            driver.processUntilBlocked();
         }
 
         runDriverInThread(executor, driver);
@@ -512,7 +512,7 @@ public class TestSpatialJoinOperator
         executor.execute(() -> {
             if (!driver.isFinished()) {
                 try {
-                    driver.process();
+                    driver.processUntilBlocked();
                 }
                 catch (TrinoException e) {
                     driver.getDriverContext().failed(e);

--- a/testing/trino-benchmark/src/main/java/io/trino/benchmark/AbstractOperatorBenchmark.java
+++ b/testing/trino-benchmark/src/main/java/io/trino/benchmark/AbstractOperatorBenchmark.java
@@ -81,6 +81,7 @@ import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.SystemSessionProperties.getFilterAndProjectMinOutputPageRowCount;
 import static io.trino.SystemSessionProperties.getFilterAndProjectMinOutputPageSize;
+import static io.trino.execution.executor.PrioritizedSplitRunner.SPLIT_RUN_QUANTA;
 import static io.trino.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.UNGROUPED_SCHEDULING;
 import static io.trino.spi.connector.Constraint.alwaysTrue;
 import static io.trino.spi.connector.DynamicFilter.EMPTY;
@@ -273,7 +274,7 @@ public abstract class AbstractOperatorBenchmark
             boolean processed = false;
             for (Driver driver : drivers) {
                 if (!driver.isFinished()) {
-                    driver.process();
+                    driver.processForDuration(SPLIT_RUN_QUANTA);
                     long lastPeakMemory = peakMemory;
                     peakMemory = taskContext.getTaskStats().getUserMemoryReservation().toBytes();
                     if (peakMemory <= lastPeakMemory) {

--- a/testing/trino-benchmark/src/main/java/io/trino/benchmark/HashJoinBenchmark.java
+++ b/testing/trino-benchmark/src/main/java/io/trino/benchmark/HashJoinBenchmark.java
@@ -44,6 +44,7 @@ import java.util.concurrent.Future;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.trino.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
+import static io.trino.execution.executor.PrioritizedSplitRunner.SPLIT_RUN_QUANTA;
 import static io.trino.operator.HashArraySizeSupplier.incrementalLoadFactorHashArraySizeSupplier;
 import static io.trino.operator.PipelineExecutionStrategy.UNGROUPED_EXECUTION;
 import static io.trino.spiller.PartitioningSpillerFactory.unsupportedPartitioningSpillerFactory;
@@ -130,7 +131,7 @@ public class HashJoinBenchmark
             Driver driver = buildDriverFactory.createDriver(driverContext);
             Future<LookupSourceProvider> lookupSourceProvider = lookupSourceFactoryManager.getJoinBridge(Lifespan.taskWide()).createLookupSourceProvider();
             while (!lookupSourceProvider.isDone()) {
-                driver.process();
+                driver.processForDuration(SPLIT_RUN_QUANTA);
             }
             getFutureValue(lookupSourceProvider).close();
         }

--- a/testing/trino-benchmark/src/test/java/io/trino/benchmark/MemoryLocalQueryRunner.java
+++ b/testing/trino-benchmark/src/test/java/io/trino/benchmark/MemoryLocalQueryRunner.java
@@ -98,7 +98,7 @@ public class MemoryLocalQueryRunner
             boolean processed = false;
             for (Driver driver : drivers) {
                 if (!driver.isFinished()) {
-                    driver.process();
+                    driver.processForNumberOfIterations(1);
                     processed = true;
                 }
             }

--- a/testing/trino-testing/src/main/java/io/trino/testing/FaultTolerantExecutionConnectorTestHelper.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/FaultTolerantExecutionConnectorTestHelper.java
@@ -25,6 +25,8 @@ public final class FaultTolerantExecutionConnectorTestHelper
     {
         return ImmutableMap.<String, String>builder()
                 .put("retry-policy", "TASK")
+                .put("retry-initial-delay", "50ms")
+                .put("retry-max-delay", "100ms")
                 .put("fault-tolerant-execution-partition-count", "5")
                 .put("fault-tolerant-execution-target-task-input-size", "10MB")
                 .put("fault-tolerant-execution-target-task-split-count", "4")


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

All the memory pool related failures from #11275 I checked are `INSERT` queries with a memory leak reported in either an `AggregationOperator` or an `HashAggregationOperator`.

I managed to reproduce it locally only once by running the `INSERT INTO invalid_partition_value VALUES (4, 'test' || chr(13))` query in a loop and checking whether cluster memory pools are free upon competition. 

The issue is incredibly difficult to reproduce as there are two things that must go wrong:

1. A `TableWriterOperator` instance must happen to get used after close (fixed by `Ensure no methods are called on operator after close`)
2. The `TableWriterOperator` operator must trigger an internal aggregation state update to cause it's memory context to get updated

Under normal circumstances the `OperatorContext` is destroyed during an operator close what prevents any further memory allocations for a given operator. However the `OperatorContext` for a nested operator within the `TableWriterOperator` wasn't being properly closed (fixed by `Destroy OperatorContext for nested operators`).

Also i found that memory can be still be reserved after memory context close (by using `tryReserve`). Fixed by `Ensure no memory can be allocated after memory context close`

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core

> How would you describe this change to a non-technical end user or system administrator?

Under rare circumstances `DML` queries (`INSERT`,`CTAS`, etc.) could not release reserved memory what could potentially result in cluster eventually running out of memory.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

Fixes https://github.com/trinodb/trino/issues/11275

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
