### PR TITLE
Add anonymized json plan in QueryCompletedEvent

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/TableInfo.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TableInfo.java
@@ -21,21 +21,32 @@ import io.trino.spi.predicate.TupleDomain;
 
 import javax.annotation.concurrent.Immutable;
 
+import java.util.Optional;
+
 import static java.util.Objects.requireNonNull;
 
 @Immutable
 public class TableInfo
 {
+    private final Optional<String> connectorName;
     private final QualifiedObjectName tableName;
     private final TupleDomain<ColumnHandle> predicate;
 
     @JsonCreator
     public TableInfo(
+            @JsonProperty("connectorName") Optional<String> connectorName,
             @JsonProperty("tableName") QualifiedObjectName tableName,
             @JsonProperty("predicate") TupleDomain<ColumnHandle> predicate)
     {
+        this.connectorName = requireNonNull(connectorName, "connectorName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
         this.predicate = requireNonNull(predicate, "predicate is null");
+    }
+
+    @JsonProperty
+    public Optional<String> getConnectorName()
+    {
+        return connectorName;
     }
 
     @JsonProperty

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/SqlQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/SqlQueryScheduler.java
@@ -52,6 +52,7 @@ import io.trino.execution.scheduler.policy.ExecutionPolicy;
 import io.trino.execution.scheduler.policy.ExecutionSchedule;
 import io.trino.execution.scheduler.policy.StagesScheduleResult;
 import io.trino.failuredetector.FailureDetector;
+import io.trino.metadata.Catalog;
 import io.trino.metadata.InternalNode;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.TableProperties;
@@ -618,7 +619,12 @@ public class SqlQueryScheduler
         {
             TableSchema tableSchema = metadata.getTableSchema(session, node.getTable());
             TableProperties tableProperties = metadata.getTableProperties(session, node.getTable());
-            return new TableInfo(tableSchema.getQualifiedName(), tableProperties.getPredicate());
+            Catalog catalog = metadata.getCatalogs(session).get(tableSchema.getCatalogName().getCatalogName());
+            Optional<String> connectorName = Optional.empty();
+            if (catalog != null) {
+                connectorName = Optional.of(catalog.getConnectorName());
+            }
+            return new TableInfo(connectorName, tableSchema.getQualifiedName(), tableProperties.getPredicate());
         }
 
         private static StageId getStageId(QueryId queryId, PlanFragmentId fragmentId)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/TypeProvider.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/TypeProvider.java
@@ -17,9 +17,11 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.spi.type.Type;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Objects.requireNonNull;
 
 public class TypeProvider
@@ -39,6 +41,14 @@ public class TypeProvider
     public static TypeProvider empty()
     {
         return new TypeProvider(ImmutableMap.of());
+    }
+
+    public static TypeProvider getTypeProvider(List<PlanFragment> fragments)
+    {
+        return TypeProvider.copyOf(fragments.stream()
+                .flatMap(f -> f.getSymbols().entrySet().stream())
+                .distinct()
+                .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)));
     }
 
     private TypeProvider(Map<Symbol, Type> types)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/NodeRepresentation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/NodeRepresentation.java
@@ -16,7 +16,6 @@ package io.trino.sql.planner.planprinter;
 import io.trino.cost.PlanCostEstimate;
 import io.trino.cost.PlanNodeStatsAndCostSummary;
 import io.trino.cost.PlanNodeStatsEstimate;
-import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.plan.PlanFragmentId;
 import io.trino.sql.planner.plan.PlanNodeId;
 
@@ -145,27 +144,5 @@ public class NodeRepresentation
     public Optional<PlanNodeStatsAndCostSummary> getReorderJoinStatsAndCost()
     {
         return reorderJoinStatsAndCost;
-    }
-
-    public static class TypedSymbol
-    {
-        private final Symbol symbol;
-        private final String type;
-
-        public TypedSymbol(Symbol symbol, String type)
-        {
-            this.symbol = symbol;
-            this.type = type;
-        }
-
-        public Symbol getSymbol()
-        {
-            return symbol;
-        }
-
-        public String getType()
-        {
-            return type;
-        }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
@@ -104,7 +104,6 @@ import io.trino.sql.planner.plan.UnnestNode;
 import io.trino.sql.planner.plan.UpdateNode;
 import io.trino.sql.planner.plan.ValuesNode;
 import io.trino.sql.planner.plan.WindowNode;
-import io.trino.sql.planner.planprinter.NodeRepresentation.TypedSymbol;
 import io.trino.sql.planner.rowpattern.AggregationValuePointer;
 import io.trino.sql.planner.rowpattern.LogicalIndexExtractor.ExpressionAndValuePointers;
 import io.trino.sql.planner.rowpattern.LogicalIndexPointer;
@@ -398,7 +397,7 @@ public class PlanPrinter
         return builder.toString();
     }
 
-    private static TypeProvider getTypeProvider(List<PlanFragment> fragments)
+    public static TypeProvider getTypeProvider(List<PlanFragment> fragments)
     {
         return TypeProvider.copyOf(fragments.stream()
                 .flatMap(f -> f.getSymbols().entrySet().stream())
@@ -1674,7 +1673,7 @@ public class PlanPrinter
         return builder.toString();
     }
 
-    private static Expression unresolveFunctions(Expression expression)
+    public static Expression unresolveFunctions(Expression expression)
     {
         return ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<>()
         {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/TableInfoSupplier.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/TableInfoSupplier.java
@@ -15,11 +15,13 @@ package io.trino.sql.planner.planprinter;
 
 import io.trino.Session;
 import io.trino.execution.TableInfo;
+import io.trino.metadata.Catalog;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.TableProperties;
 import io.trino.metadata.TableSchema;
 import io.trino.sql.planner.plan.TableScanNode;
 
+import java.util.Optional;
 import java.util.function.Function;
 
 import static java.util.Objects.requireNonNull;
@@ -41,6 +43,11 @@ public class TableInfoSupplier
     {
         TableSchema tableSchema = metadata.getTableSchema(session, node.getTable());
         TableProperties tableProperties = metadata.getTableProperties(session, node.getTable());
-        return new TableInfo(tableSchema.getQualifiedName(), tableProperties.getPredicate());
+        Catalog catalog = metadata.getCatalogs(session).get(tableSchema.getCatalogName().getCatalogName());
+        Optional<String> connectorName = Optional.empty();
+        if (catalog != null) {
+            connectorName = Optional.of(catalog.getConnectorName());
+        }
+        return new TableInfo(connectorName, tableSchema.getQualifiedName(), tableProperties.getPredicate());
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/TextRenderer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/TextRenderer.java
@@ -21,7 +21,6 @@ import io.trino.cost.PlanNodeStatsEstimate;
 import io.trino.spi.metrics.Metric;
 import io.trino.spi.metrics.Metrics;
 import io.trino.sql.planner.Symbol;
-import io.trino.sql.planner.planprinter.NodeRepresentation.TypedSymbol;
 
 import java.util.Iterator;
 import java.util.List;

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/TypedSymbol.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/TypedSymbol.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.sql.planner.planprinter;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.sql.planner.Symbol;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class TypedSymbol
+{
+    private final Symbol symbol;
+    private final String type;
+
+    @JsonCreator
+    public TypedSymbol(@JsonProperty("symbol") Symbol symbol, @JsonProperty("type") String type)
+    {
+        this.symbol = requireNonNull(symbol, "symbol is null");
+        this.type = requireNonNull(type, "type is null");
+    }
+
+    @JsonProperty
+    public Symbol getSymbol()
+    {
+        return symbol;
+    }
+
+    @JsonProperty
+    public String getType()
+    {
+        return type;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(symbol, type);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        TypedSymbol o = (TypedSymbol) obj;
+        return symbol.equals(o.symbol)
+                && type.equals(o.type);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/AggregationNodeRepresentation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/AggregationNodeRepresentation.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.sql.planner.planprinter.anonymize;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.connector.SortOrder;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.TypeProvider;
+import io.trino.sql.planner.plan.AggregationNode;
+import io.trino.sql.planner.plan.PlanNodeId;
+import io.trino.sql.planner.planprinter.TypedSymbol;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.trino.sql.planner.plan.AggregationNode.Step;
+import static io.trino.sql.planner.planprinter.anonymize.AnonymizationUtils.anonymize;
+import static java.util.Objects.requireNonNull;
+
+public class AggregationNodeRepresentation
+        extends AnonymizedNodeRepresentation
+{
+    private final Map<Symbol, AggregationRepresentation> aggregations;
+    private final List<Symbol> groupingKeys;
+    private final Step step;
+    private final Optional<Symbol> hashSymbol;
+
+    @JsonCreator
+    public AggregationNodeRepresentation(
+            @JsonProperty("id") PlanNodeId id,
+            @JsonProperty("outputLayout") List<TypedSymbol> outputLayout,
+            @JsonProperty("sources") List<AnonymizedNodeRepresentation> sources,
+            @JsonProperty("aggregations") Map<Symbol, AggregationRepresentation> aggregations,
+            @JsonProperty("groupingKeys") List<Symbol> groupingKeys,
+            @JsonProperty("step") Step step,
+            @JsonProperty("hashSymbol") Optional<Symbol> hashSymbol)
+    {
+        super(id, outputLayout, sources);
+        this.aggregations = requireNonNull(aggregations, "aggregations is null");
+        this.groupingKeys = requireNonNull(groupingKeys, "groupingKeys is null");
+        this.step = requireNonNull(step, "step is null");
+        this.hashSymbol = requireNonNull(hashSymbol, "hashSymbol is null");
+    }
+
+    @JsonProperty
+    public Map<Symbol, AggregationRepresentation> getAggregations()
+    {
+        return aggregations;
+    }
+
+    @JsonProperty
+    public List<Symbol> getGroupingKeys()
+    {
+        return groupingKeys;
+    }
+
+    @JsonProperty
+    public Step getStep()
+    {
+        return step;
+    }
+
+    @JsonProperty
+    public Optional<Symbol> getHashSymbol()
+    {
+        return hashSymbol;
+    }
+
+    public static AggregationNodeRepresentation fromPlanNode(
+            AggregationNode node,
+            TypeProvider typeProvider,
+            List<AnonymizedNodeRepresentation> sources)
+    {
+        return new AggregationNodeRepresentation(
+                node.getId(),
+                anonymize(node.getOutputSymbols(), typeProvider),
+                sources,
+                node.getAggregations().entrySet().stream()
+                        .collect(toImmutableMap(
+                                entry -> anonymize(entry.getKey()),
+                                entry -> anonymize(entry.getValue()))),
+                anonymize(node.getGroupingKeys()),
+                node.getStep(),
+                node.getHashSymbol().map(AnonymizationUtils::anonymize));
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(getId(), getOutputLayout(), getSources(), aggregations, groupingKeys, step, hashSymbol);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if ((o == null) || (getClass() != o.getClass())) {
+            return false;
+        }
+        AggregationNodeRepresentation that = (AggregationNodeRepresentation) o;
+        return getId().equals(that.getId())
+                && getOutputLayout().equals(that.getOutputLayout())
+                && getSources().equals(that.getSources())
+                && aggregations.equals(that.aggregations)
+                && groupingKeys.equals(that.groupingKeys)
+                && step.equals(that.step)
+                && hashSymbol.equals(that.hashSymbol);
+    }
+
+    public static class AggregationRepresentation
+    {
+        private final String resolvedFunction;
+        private final List<String> arguments;
+        private final boolean distinct;
+        private final Optional<Symbol> filter;
+        private final Optional<Map<Symbol, SortOrder>> orderings;
+        private final Optional<Symbol> mask;
+
+        @JsonCreator
+        public AggregationRepresentation(
+                @JsonProperty("resolvedFunction") String resolvedFunction,
+                @JsonProperty("arguments") List<String> arguments,
+                @JsonProperty("distinct") boolean distinct,
+                @JsonProperty("filter") Optional<Symbol> filter,
+                @JsonProperty("orderings") Optional<Map<Symbol, SortOrder>> orderings,
+                @JsonProperty("mask") Optional<Symbol> mask)
+        {
+            this.resolvedFunction = requireNonNull(resolvedFunction, "resolvedFunction is null");
+            this.arguments = ImmutableList.copyOf(requireNonNull(arguments, "arguments is null"));
+            this.distinct = distinct;
+            this.filter = requireNonNull(filter, "filter is null");
+            this.orderings = requireNonNull(orderings, "orderings is null");
+            this.mask = requireNonNull(mask, "mask is null");
+        }
+
+        @JsonProperty
+        public String getResolvedFunction()
+        {
+            return resolvedFunction;
+        }
+
+        @JsonProperty
+        public List<String> getArguments()
+        {
+            return arguments;
+        }
+
+        @JsonProperty
+        public boolean isDistinct()
+        {
+            return distinct;
+        }
+
+        @JsonProperty
+        public Optional<Symbol> getFilter()
+        {
+            return filter;
+        }
+
+        @JsonProperty
+        public Optional<Map<Symbol, SortOrder>> getOrderings()
+        {
+            return orderings;
+        }
+
+        @JsonProperty
+        public Optional<Symbol> getMask()
+        {
+            return mask;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(resolvedFunction, arguments, distinct, filter, orderings, mask);
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if ((o == null) || (getClass() != o.getClass())) {
+                return false;
+            }
+            AggregationRepresentation that = (AggregationRepresentation) o;
+            return resolvedFunction.equals(that.resolvedFunction)
+                    && arguments.equals(that.arguments)
+                    && distinct == that.distinct
+                    && filter.equals(that.filter)
+                    && orderings.equals(that.orderings)
+                    && mask.equals(that.mask);
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/AnonymizationUtils.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/AnonymizationUtils.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.sql.planner.planprinter.anonymize;
+
+import com.google.common.base.Joiner;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.SortOrder;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.EquatableValueSet;
+import io.trino.spi.predicate.SortedRangeSet;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
+import io.trino.sql.ExpressionUtils;
+import io.trino.sql.planner.OrderingScheme;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.TypeProvider;
+import io.trino.sql.planner.planprinter.TypedSymbol;
+import io.trino.sql.tree.BinaryLiteral;
+import io.trino.sql.tree.CharLiteral;
+import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.ExpressionRewriter;
+import io.trino.sql.tree.ExpressionTreeRewriter;
+import io.trino.sql.tree.GenericLiteral;
+import io.trino.sql.tree.Literal;
+import io.trino.sql.tree.StringLiteral;
+import io.trino.sql.tree.SymbolReference;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.trino.sql.ExpressionUtils.unResolveFunctions;
+import static io.trino.sql.planner.Partitioning.ArgumentBinding;
+import static io.trino.sql.planner.plan.AggregationNode.Aggregation;
+import static io.trino.sql.planner.plan.WindowNode.Function;
+import static io.trino.sql.planner.planprinter.anonymize.AggregationNodeRepresentation.AggregationRepresentation;
+import static io.trino.sql.planner.planprinter.anonymize.TableScanNodeRepresentation.DomainRepresentation;
+import static java.lang.String.format;
+
+public final class AnonymizationUtils
+{
+    private AnonymizationUtils() {}
+
+    public enum ObjectType
+    {
+        CATALOG,
+        SCHEMA,
+        TABLE,
+        COLUMN,
+        SYMBOL,
+        LITERAL
+    }
+
+    public static List<TypedSymbol> anonymize(List<Symbol> outputSymbols, TypeProvider typeProvider)
+    {
+        return outputSymbols.stream()
+                .map(symbol -> new TypedSymbol(anonymize(symbol), typeProvider.get(symbol).getDisplayName()))
+                .collect(toImmutableList());
+    }
+
+    public static AggregationRepresentation anonymize(Aggregation aggregation)
+    {
+        return new AggregationRepresentation(
+                aggregation.getResolvedFunction().getSignature().getName(),
+                anonymizeAndUnResolveExpressions(aggregation.getArguments()),
+                aggregation.isDistinct(),
+                aggregation.getFilter().map(AnonymizationUtils::anonymize),
+                aggregation.getOrderingScheme().map(AnonymizationUtils::anonymize),
+                aggregation.getMask().map(AnonymizationUtils::anonymize));
+    }
+
+    public static String anonymize(Function function)
+    {
+        return format(
+                "%s (%s)",
+                function.getResolvedFunction().getSignature().getName(),
+                Joiner.on(", ").join(anonymizeAndUnResolveExpressions(function.getArguments())));
+    }
+
+    public static Map<Symbol, SortOrder> anonymize(OrderingScheme orderingScheme)
+    {
+        return orderingScheme.getOrderings().entrySet().stream()
+                        .collect(toImmutableMap(entry -> anonymize(entry.getKey()), Map.Entry::getValue));
+    }
+
+    public static ArgumentBinding anonymize(ArgumentBinding argument)
+    {
+        return new ArgumentBinding(anonymize(unResolveFunctions(argument.getExpression())), argument.getConstant());
+    }
+
+    public static List<Symbol> anonymize(List<Symbol> symbols)
+    {
+        return symbols.stream()
+                .map(AnonymizationUtils::anonymize)
+                .collect(toImmutableList());
+    }
+
+    public static Symbol anonymize(Symbol symbol)
+    {
+        return new Symbol(anonymize(symbol.getName(), ObjectType.SYMBOL));
+    }
+
+    public static List<String> anonymizeAndUnResolveExpressions(List<Expression> expressions)
+    {
+        return expressions.stream()
+                .map(ExpressionUtils::unResolveFunctions)
+                .map(AnonymizationUtils::anonymize)
+                .map(Expression::toString)
+                .collect(toImmutableList());
+    }
+
+    public static Expression anonymize(Expression expression)
+    {
+        return ExpressionTreeRewriter.rewriteWith(
+                new ExpressionRewriter<>()
+                {
+                    @Override
+                    public Expression rewriteSymbolReference(SymbolReference node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+                    {
+                        return anonymize(Symbol.from(node)).toSymbolReference();
+                    }
+
+                    @Override
+                    public Expression rewriteLiteral(Literal node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+                    {
+                        if (node instanceof StringLiteral) {
+                            return new StringLiteral(anonymize(((StringLiteral) node).getValue(), ObjectType.LITERAL));
+                        }
+                        else if (node instanceof GenericLiteral) {
+                            return new GenericLiteral(
+                                    ((GenericLiteral) node).getType(),
+                                    anonymize(((GenericLiteral) node).getValue(), ObjectType.LITERAL));
+                        }
+                        else if (node instanceof CharLiteral) {
+                            return new CharLiteral(anonymize(((CharLiteral) node).getValue(), ObjectType.LITERAL));
+                        }
+                        else if (node instanceof BinaryLiteral) {
+                            return new BinaryLiteral(anonymize(((BinaryLiteral) node).getValue(), ObjectType.LITERAL));
+                        }
+                        return node;
+                    }
+                },
+                expression);
+    }
+
+    public static Optional<Map<String, DomainRepresentation>> anonymize(TupleDomain<ColumnHandle> tupleDomain)
+    {
+        return tupleDomain.getDomains()
+                .map(domains -> domains.entrySet().stream()
+                        .collect(toImmutableMap(
+                                entry -> anonymize(entry.getKey(), ObjectType.COLUMN),
+                                entry -> anonymize(entry.getValue()))));
+    }
+
+    public static DomainRepresentation anonymize(Domain domain)
+    {
+        ValueSet values = domain.getValues();
+        Optional<Integer> valueSetCount = Optional.empty();
+        if (values instanceof EquatableValueSet) {
+            valueSetCount = Optional.of(((EquatableValueSet) values).getValuesCount());
+        }
+        else if (values instanceof SortedRangeSet) {
+            valueSetCount = Optional.of(((SortedRangeSet) values).getRangeCount());
+        }
+        return new DomainRepresentation(
+                domain.getValues().getClass().getSimpleName(),
+                domain.getType().getDisplayName(),
+                valueSetCount,
+                domain.isNullAllowed(),
+                domain.isNone(),
+                domain.isAll(),
+                domain.isSingleValue());
+    }
+
+    public static <T> String anonymize(T object, ObjectType objectType)
+    {
+        return objectType.name().toLowerCase(Locale.US) + "_" + object.hashCode();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/AnonymizePlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/AnonymizePlanPrinter.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.sql.planner.planprinter.anonymize;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.reflect.TypeToken;
+import io.airlift.json.JsonCodec;
+import io.trino.execution.StageInfo;
+import io.trino.execution.TableInfo;
+import io.trino.sql.planner.PlanFragment;
+import io.trino.sql.planner.TypeProvider;
+import io.trino.sql.planner.plan.AggregationNode;
+import io.trino.sql.planner.plan.ExchangeNode;
+import io.trino.sql.planner.plan.FilterNode;
+import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.PlanFragmentId;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.PlanNodeId;
+import io.trino.sql.planner.plan.PlanVisitor;
+import io.trino.sql.planner.plan.ProjectNode;
+import io.trino.sql.planner.plan.RemoteSourceNode;
+import io.trino.sql.planner.plan.SemiJoinNode;
+import io.trino.sql.planner.plan.SortNode;
+import io.trino.sql.planner.plan.TableScanNode;
+import io.trino.sql.planner.plan.TopNNode;
+import io.trino.sql.planner.plan.ValuesNode;
+import io.trino.sql.planner.plan.WindowNode;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static io.trino.execution.StageInfo.getAllStages;
+import static io.trino.sql.planner.TypeProvider.getTypeProvider;
+import static java.util.Objects.requireNonNull;
+
+public class AnonymizePlanPrinter
+{
+    private static final JsonCodec<Map<PlanFragmentId, AnonymizedNodeRepresentation>> ANONYMIZED_PLAN_JSON_CODEC = jsonCodec(new TypeToken<>() {});
+
+    private final PlanNode node;
+    private final TypeProvider typeProvider;
+    private final Function<TableScanNode, TableInfo> tableInfoSupplier;
+
+    public AnonymizePlanPrinter(PlanNode node, TypeProvider typeProvider, Function<TableScanNode, TableInfo> tableInfoSupplier)
+    {
+        this.node = requireNonNull(node, "node is null");
+        this.typeProvider = requireNonNull(typeProvider, "provider is null");
+        this.tableInfoSupplier = requireNonNull(tableInfoSupplier, "tableInfoSupplier is null");
+    }
+
+    public static String anonymizedDistributedJsonPlan(Optional<StageInfo> outputStageInfo)
+    {
+        List<StageInfo> allStages = getAllStages(outputStageInfo);
+        TypeProvider typeProvider = getTypeProvider(allStages.stream()
+                .map(StageInfo::getPlan)
+                .collect(toImmutableList()));
+        Map<PlanNodeId, TableInfo> tableInfos = allStages.stream()
+                .map(StageInfo::getTables)
+                .map(Map::entrySet)
+                .flatMap(Collection::stream)
+                .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        Map<PlanFragmentId, AnonymizedNodeRepresentation> anonymizedPlan = allStages.stream()
+                .map(StageInfo::getPlan)
+                .filter(Objects::nonNull)
+                .collect(toImmutableMap(
+                        PlanFragment::getId,
+                        plan -> new AnonymizePlanPrinter(
+                                plan.getRoot(),
+                                typeProvider,
+                                tableScanNode -> tableInfos.get(tableScanNode.getId())).generatePlanRepresentation()));
+        return ANONYMIZED_PLAN_JSON_CODEC.toJson(anonymizedPlan);
+    }
+
+    @VisibleForTesting
+    public AnonymizedNodeRepresentation generatePlanRepresentation()
+    {
+        return node.accept(new Visitor(), null);
+    }
+
+    private class Visitor
+            extends PlanVisitor<AnonymizedNodeRepresentation, Void>
+    {
+        @Override
+        protected AnonymizedNodeRepresentation visitPlan(PlanNode node, Void context)
+        {
+            return DefaultNodeRepresentation.fromPlanNode(node, typeProvider, getSourceRepresentations(node));
+        }
+
+        @Override
+        public AnonymizedNodeRepresentation visitRemoteSource(RemoteSourceNode node, Void context)
+        {
+            return RemoteSourceNodeRepresentation.fromPlanNode(node, typeProvider);
+        }
+
+        @Override
+        public AnonymizedNodeRepresentation visitAggregation(AggregationNode node, Void context)
+        {
+            return AggregationNodeRepresentation.fromPlanNode(node, typeProvider, getSourceRepresentations(node));
+        }
+
+        @Override
+        public AnonymizedNodeRepresentation visitJoin(JoinNode node, Void context)
+        {
+            return JoinNodeRepresentation.fromPlanNode(node, typeProvider, getSourceRepresentations(node));
+        }
+
+        @Override
+        public AnonymizedNodeRepresentation visitTableScan(TableScanNode node, Void context)
+        {
+            return TableScanNodeRepresentation.fromPlanNode(node, typeProvider, tableInfoSupplier.apply(node));
+        }
+
+        @Override
+        public AnonymizedNodeRepresentation visitExchange(ExchangeNode node, Void context)
+        {
+            return ExchangeNodeRepresentation.fromPlanNode(node, typeProvider, getSourceRepresentations(node));
+        }
+
+        @Override
+        public AnonymizedNodeRepresentation visitSemiJoin(SemiJoinNode node, Void context)
+        {
+            return SemiJoinNodeRepresentation.fromPlanNode(node, typeProvider, getSourceRepresentations(node));
+        }
+
+        @Override
+        public AnonymizedNodeRepresentation visitValues(ValuesNode node, Void context)
+        {
+            return ValuesNodeRepresentation.fromPlanNode(node, typeProvider);
+        }
+
+        @Override
+        public AnonymizedNodeRepresentation visitFilter(FilterNode node, Void context)
+        {
+            return FilterNodeRepresentation.fromPlanNode(node, typeProvider, getSourceRepresentations(node));
+        }
+
+        @Override
+        public AnonymizedNodeRepresentation visitProject(ProjectNode node, Void context)
+        {
+            return ProjectNodeRepresentation.fromPlanNode(node, typeProvider, getSourceRepresentations(node));
+        }
+
+        @Override
+        public AnonymizedNodeRepresentation visitSort(SortNode node, Void context)
+        {
+            return SortNodeRepresentation.fromPlanNode(node, typeProvider, getSourceRepresentations(node));
+        }
+
+        @Override
+        public AnonymizedNodeRepresentation visitWindow(WindowNode node, Void context)
+        {
+            return WindowNodeRepresentation.fromPlanNode(node, typeProvider, getSourceRepresentations(node));
+        }
+
+        @Override
+        public AnonymizedNodeRepresentation visitTopN(TopNNode node, Void context)
+        {
+            return TopNNodeRepresentation.fromPlanNode(node, typeProvider, getSourceRepresentations(node));
+        }
+
+        private List<AnonymizedNodeRepresentation> getSourceRepresentations(PlanNode node)
+        {
+            return node.getSources().stream()
+                    .map(source -> source.accept(this, null))
+                    .collect(toImmutableList());
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/AnonymizedNodeRepresentation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/AnonymizedNodeRepresentation.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.sql.planner.planprinter.anonymize;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.trino.sql.planner.plan.PlanNodeId;
+import io.trino.sql.planner.planprinter.TypedSymbol;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        property = "@type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = DefaultNodeRepresentation.class, name = "default"),
+        @JsonSubTypes.Type(value = ProjectNodeRepresentation.class, name = "project"),
+        @JsonSubTypes.Type(value = TableScanNodeRepresentation.class, name = "tableScan"),
+        @JsonSubTypes.Type(value = ValuesNodeRepresentation.class, name = "values"),
+        @JsonSubTypes.Type(value = AggregationNodeRepresentation.class, name = "aggregation"),
+        @JsonSubTypes.Type(value = FilterNodeRepresentation.class, name = "filter"),
+        @JsonSubTypes.Type(value = WindowNodeRepresentation.class, name = "window"),
+        @JsonSubTypes.Type(value = TopNNodeRepresentation.class, name = "topN"),
+        @JsonSubTypes.Type(value = SortNodeRepresentation.class, name = "sort"),
+        @JsonSubTypes.Type(value = RemoteSourceNodeRepresentation.class, name = "remoteSource"),
+        @JsonSubTypes.Type(value = ExchangeNodeRepresentation.class, name = "exchange"),
+        @JsonSubTypes.Type(value = JoinNodeRepresentation.class, name = "join"),
+        @JsonSubTypes.Type(value = SemiJoinNodeRepresentation.class, name = "semiJoin"),
+})
+public abstract class AnonymizedNodeRepresentation
+{
+    private final PlanNodeId id;
+    private final List<TypedSymbol> outputLayout;
+    private final List<AnonymizedNodeRepresentation> sources;
+
+    public AnonymizedNodeRepresentation(
+            PlanNodeId id,
+            List<TypedSymbol> outputLayout,
+            List<AnonymizedNodeRepresentation> sources)
+    {
+        this.id = requireNonNull(id, "id is null");
+        this.outputLayout = requireNonNull(outputLayout, "outputLayout is null");
+        this.sources = requireNonNull(sources, "sources is null");
+    }
+
+    @JsonProperty
+    public PlanNodeId getId()
+    {
+        return id;
+    }
+
+    @JsonProperty
+    public List<TypedSymbol> getOutputLayout()
+    {
+        return outputLayout;
+    }
+
+    @JsonProperty
+    public List<AnonymizedNodeRepresentation> getSources()
+    {
+        return sources;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/DefaultNodeRepresentation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/DefaultNodeRepresentation.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.sql.planner.planprinter.anonymize;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.sql.planner.TypeProvider;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.PlanNodeId;
+import io.trino.sql.planner.planprinter.TypedSymbol;
+
+import java.util.List;
+import java.util.Objects;
+
+import static io.trino.sql.planner.planprinter.anonymize.AnonymizationUtils.anonymize;
+import static java.util.Objects.requireNonNull;
+
+public class DefaultNodeRepresentation
+        extends AnonymizedNodeRepresentation
+{
+    private final String name;
+
+    @JsonCreator
+    public DefaultNodeRepresentation(
+            @JsonProperty("id") PlanNodeId id,
+            @JsonProperty("name") String name,
+            @JsonProperty("outputLayout") List<TypedSymbol> outputLayout,
+            @JsonProperty("sources") List<AnonymizedNodeRepresentation> sources)
+    {
+        super(id, outputLayout, sources);
+        this.name = requireNonNull(name, "name is null");
+    }
+
+    @JsonProperty
+    public String getName()
+    {
+        return name;
+    }
+
+    public static DefaultNodeRepresentation fromPlanNode(PlanNode node, TypeProvider provider, List<AnonymizedNodeRepresentation> sources)
+    {
+        return new DefaultNodeRepresentation(
+                node.getId(),
+                node.getClass().getSimpleName(),
+                anonymize(node.getOutputSymbols(), provider),
+                sources);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DefaultNodeRepresentation that = (DefaultNodeRepresentation) o;
+        return getId().equals(that.getId())
+                && getOutputLayout().equals(that.getOutputLayout())
+                && getSources().equals(that.getSources())
+                && name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(getId(), getOutputLayout(), getSources(), name);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/ExchangeNodeRepresentation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/ExchangeNodeRepresentation.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.sql.planner.planprinter.anonymize;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.connector.SortOrder;
+import io.trino.sql.planner.Partitioning;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.TypeProvider;
+import io.trino.sql.planner.plan.ExchangeNode;
+import io.trino.sql.planner.plan.PlanNodeId;
+import io.trino.sql.planner.planprinter.TypedSymbol;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.sql.planner.planprinter.anonymize.AnonymizationUtils.anonymize;
+import static java.util.Objects.requireNonNull;
+
+public class ExchangeNodeRepresentation
+        extends AnonymizedNodeRepresentation
+{
+    private final ExchangeNode.Type type;
+    private final ExchangeNode.Scope scope;
+    private final List<String> partitionArguments;
+    private final Optional<Symbol> partitionHashColumn;
+    private final boolean replicateNullsAndAny;
+    private final Optional<Map<Symbol, SortOrder>> orderings;
+
+    @JsonCreator
+    public ExchangeNodeRepresentation(
+            @JsonProperty("id") PlanNodeId id,
+            @JsonProperty("outputLayout") List<TypedSymbol> outputLayout,
+            @JsonProperty("sources") List<AnonymizedNodeRepresentation> sources,
+            @JsonProperty("type") ExchangeNode.Type type,
+            @JsonProperty("scope") ExchangeNode.Scope scope,
+            @JsonProperty("partitionArguments") List<String> partitionArguments,
+            @JsonProperty("partitionHashColumn") Optional<Symbol> partitionHashColumn,
+            @JsonProperty("replicateNullsAndAny") boolean replicateNullsAndAny,
+            @JsonProperty("orderings") Optional<Map<Symbol, SortOrder>> orderings)
+    {
+        super(id, outputLayout, sources);
+        this.type = requireNonNull(type, "type is null");
+        this.scope = requireNonNull(scope, "scope is null");
+        this.partitionArguments = requireNonNull(partitionArguments, "partitionArguments is null");
+        this.partitionHashColumn = requireNonNull(partitionHashColumn, "partitionHashColumn is null");
+        this.replicateNullsAndAny = replicateNullsAndAny;
+        this.orderings = requireNonNull(orderings, "orderings is null");
+    }
+
+    @JsonProperty
+    public ExchangeNode.Type getType()
+    {
+        return type;
+    }
+
+    @JsonProperty
+    public ExchangeNode.Scope getScope()
+    {
+        return scope;
+    }
+
+    @JsonProperty
+    public List<String> getPartitionArguments()
+    {
+        return partitionArguments;
+    }
+
+    @JsonProperty
+    public Optional<Symbol> getPartitionHashColumn()
+    {
+        return partitionHashColumn;
+    }
+
+    @JsonProperty
+    public boolean isReplicateNullsAndAny()
+    {
+        return replicateNullsAndAny;
+    }
+
+    @JsonProperty
+    public Optional<Map<Symbol, SortOrder>> getOrderings()
+    {
+        return orderings;
+    }
+
+    public static ExchangeNodeRepresentation fromPlanNode(ExchangeNode node, TypeProvider typeProvider, List<AnonymizedNodeRepresentation> sources)
+    {
+        List<String> partitionArguments = node.getPartitioningScheme().getPartitioning().getArguments().stream()
+                .map(AnonymizationUtils::anonymize)
+                .map(Partitioning.ArgumentBinding::toString)
+                .collect(toImmutableList());
+        return new ExchangeNodeRepresentation(
+                node.getId(),
+                anonymize(node.getOutputSymbols(), typeProvider),
+                sources,
+                node.getType(),
+                node.getScope(),
+                partitionArguments,
+                node.getPartitioningScheme().getHashColumn().map(AnonymizationUtils::anonymize),
+                node.getPartitioningScheme().isReplicateNullsAndAny(),
+                node.getOrderingScheme().map(AnonymizationUtils::anonymize));
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ExchangeNodeRepresentation)) {
+            return false;
+        }
+        ExchangeNodeRepresentation that = (ExchangeNodeRepresentation) o;
+        return getId().equals(that.getId())
+                && getOutputLayout().equals(that.getOutputLayout())
+                && getSources().equals(that.getSources())
+                && replicateNullsAndAny == that.replicateNullsAndAny
+                && type == that.type
+                && scope == that.scope
+                && partitionArguments.equals(that.partitionArguments)
+                && partitionHashColumn.equals(that.partitionHashColumn)
+                && orderings.equals(that.orderings);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(
+                getId(),
+                getOutputLayout(),
+                getSources(),
+                type,
+                scope,
+                partitionArguments,
+                partitionHashColumn,
+                replicateNullsAndAny,
+                orderings);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/FilterNodeRepresentation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/FilterNodeRepresentation.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.sql.planner.planprinter.anonymize;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.sql.planner.TypeProvider;
+import io.trino.sql.planner.plan.FilterNode;
+import io.trino.sql.planner.plan.PlanNodeId;
+import io.trino.sql.planner.planprinter.TypedSymbol;
+
+import java.util.List;
+import java.util.Objects;
+
+import static io.trino.sql.ExpressionUtils.unResolveFunctions;
+import static io.trino.sql.planner.planprinter.anonymize.AnonymizationUtils.anonymize;
+import static java.util.Objects.requireNonNull;
+
+public class FilterNodeRepresentation
+        extends AnonymizedNodeRepresentation
+{
+    private final String predicate;
+
+    @JsonCreator
+    public FilterNodeRepresentation(
+            @JsonProperty("id") PlanNodeId id,
+            @JsonProperty("outputLayout") List<TypedSymbol> outputLayout,
+            @JsonProperty("sources") List<AnonymizedNodeRepresentation> sources,
+            @JsonProperty("predicate") String predicate)
+    {
+        super(id, outputLayout, sources);
+        this.predicate = requireNonNull(predicate, "predicate is null");
+    }
+
+    @JsonProperty
+    public String getPredicate()
+    {
+        return predicate;
+    }
+
+    public static FilterNodeRepresentation fromPlanNode(FilterNode node, TypeProvider typeProvider, List<AnonymizedNodeRepresentation> sources)
+    {
+        return new FilterNodeRepresentation(
+                node.getId(),
+                anonymize(node.getOutputSymbols(), typeProvider),
+                sources,
+                anonymize(unResolveFunctions(node.getPredicate())).toString());
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof FilterNodeRepresentation)) {
+            return false;
+        }
+        FilterNodeRepresentation that = (FilterNodeRepresentation) o;
+        return getId().equals(that.getId())
+                && getOutputLayout().equals(that.getOutputLayout())
+                && getSources().equals(that.getSources())
+                && predicate.equals(that.predicate);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(getId(), getOutputLayout(), getSources(), predicate);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/JoinNodeRepresentation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/JoinNodeRepresentation.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.sql.planner.planprinter.anonymize;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.sql.planner.TypeProvider;
+import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.PlanNodeId;
+import io.trino.sql.planner.planprinter.TypedSymbol;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.sql.planner.plan.JoinNode.DistributionType;
+import static io.trino.sql.planner.plan.JoinNode.EquiJoinClause;
+import static io.trino.sql.planner.plan.JoinNode.Type;
+import static io.trino.sql.planner.planprinter.anonymize.AnonymizationUtils.anonymize;
+import static java.util.Objects.requireNonNull;
+
+public class JoinNodeRepresentation
+        extends AnonymizedNodeRepresentation
+{
+    private final Type type;
+    private final List<EquiJoinClause> criteria;
+    private final boolean maySkipOutputDuplicates;
+    private final Optional<DistributionType> distributionType;
+
+    @JsonCreator
+    public JoinNodeRepresentation(
+            @JsonProperty("id") PlanNodeId id,
+            @JsonProperty("outputLayout") List<TypedSymbol> outputLayout,
+            @JsonProperty("sources") List<AnonymizedNodeRepresentation> sources,
+            @JsonProperty("type") Type type,
+            @JsonProperty("criteria") List<EquiJoinClause> criteria,
+            @JsonProperty("maySkipOutputDuplicates") boolean maySkipOutputDuplicates,
+            @JsonProperty("distributionType") Optional<DistributionType> distributionType)
+    {
+        super(id, outputLayout, sources);
+        this.type = requireNonNull(type, "type is null");
+        this.criteria = requireNonNull(criteria, "criteria is null");
+        this.maySkipOutputDuplicates = maySkipOutputDuplicates;
+        this.distributionType = requireNonNull(distributionType, "distributionType is null");
+    }
+
+    @JsonProperty
+    public Type getType()
+    {
+        return type;
+    }
+
+    @JsonProperty
+    public List<EquiJoinClause> getCriteria()
+    {
+        return criteria;
+    }
+
+    @JsonProperty
+    public boolean isMaySkipOutputDuplicates()
+    {
+        return maySkipOutputDuplicates;
+    }
+
+    @JsonProperty
+    public Optional<DistributionType> getDistributionType()
+    {
+        return distributionType;
+    }
+
+    public static JoinNodeRepresentation fromPlanNode(JoinNode node, TypeProvider typeProvider, List<AnonymizedNodeRepresentation> sources)
+    {
+        return new JoinNodeRepresentation(
+                node.getId(),
+                anonymize(node.getOutputSymbols(), typeProvider),
+                sources,
+                node.getType(),
+                node.getCriteria().stream()
+                        .map(clause -> new JoinNode.EquiJoinClause(anonymize(clause.getLeft()), anonymize(clause.getRight())))
+                        .collect(toImmutableList()),
+                node.isMaySkipOutputDuplicates(),
+                node.getDistributionType());
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        JoinNodeRepresentation that = (JoinNodeRepresentation) o;
+        return getId().equals(that.getId())
+                && getOutputLayout().equals(that.getOutputLayout())
+                && getSources().equals(that.getSources())
+                && maySkipOutputDuplicates == that.maySkipOutputDuplicates
+                && type == that.type
+                && criteria.equals(that.criteria)
+                && distributionType.equals(that.distributionType);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(getId(), getOutputLayout(), getSources(), type, criteria, maySkipOutputDuplicates, distributionType);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/ProjectNodeRepresentation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/ProjectNodeRepresentation.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.sql.planner.planprinter.anonymize;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.TypeProvider;
+import io.trino.sql.planner.plan.PlanNodeId;
+import io.trino.sql.planner.plan.ProjectNode;
+import io.trino.sql.planner.planprinter.TypedSymbol;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.trino.sql.ExpressionUtils.unResolveFunctions;
+import static io.trino.sql.planner.planprinter.anonymize.AnonymizationUtils.anonymize;
+import static java.util.Objects.requireNonNull;
+
+public class ProjectNodeRepresentation
+        extends AnonymizedNodeRepresentation
+{
+    private final Map<Symbol, String> assignments;
+
+    @JsonCreator
+    public ProjectNodeRepresentation(
+            @JsonProperty("id") PlanNodeId id,
+            @JsonProperty("outputLayout") List<TypedSymbol> outputLayout,
+            @JsonProperty("sources") List<AnonymizedNodeRepresentation> sources,
+            @JsonProperty("assignments") Map<Symbol, String> assignments)
+    {
+        super(id, outputLayout, sources);
+        this.assignments = requireNonNull(assignments, "assignments is null");
+    }
+
+    @JsonProperty
+    public Map<Symbol, String> getAssignments()
+    {
+        return assignments;
+    }
+
+    public static ProjectNodeRepresentation fromPlanNode(ProjectNode node, TypeProvider typeProvider, List<AnonymizedNodeRepresentation> sources)
+    {
+        return new ProjectNodeRepresentation(
+                node.getId(),
+                anonymize(node.getOutputSymbols(), typeProvider),
+                sources,
+                node.getAssignments().entrySet().stream()
+                        .collect(toImmutableMap(
+                                entry -> anonymize(entry.getKey()),
+                                entry -> anonymize(unResolveFunctions(entry.getValue())).toString())));
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ProjectNodeRepresentation)) {
+            return false;
+        }
+        ProjectNodeRepresentation that = (ProjectNodeRepresentation) o;
+        return getId().equals(that.getId())
+                && getOutputLayout().equals(that.getOutputLayout())
+                && getSources().equals(that.getSources())
+                && assignments.equals(that.assignments);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(getId(), getOutputLayout(), getSources(), assignments);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/RemoteSourceNodeRepresentation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/RemoteSourceNodeRepresentation.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.sql.planner.planprinter.anonymize;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.connector.SortOrder;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.TypeProvider;
+import io.trino.sql.planner.plan.ExchangeNode;
+import io.trino.sql.planner.plan.PlanFragmentId;
+import io.trino.sql.planner.plan.PlanNodeId;
+import io.trino.sql.planner.plan.RemoteSourceNode;
+import io.trino.sql.planner.planprinter.TypedSymbol;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static io.trino.sql.planner.planprinter.anonymize.AnonymizationUtils.anonymize;
+import static java.util.Objects.requireNonNull;
+
+public class RemoteSourceNodeRepresentation
+        extends AnonymizedNodeRepresentation
+{
+    private final List<PlanFragmentId> sourceFragmentIds;
+    private final Optional<Map<Symbol, SortOrder>> orderings;
+    private final ExchangeNode.Type exchangeType;
+
+    @JsonCreator
+    public RemoteSourceNodeRepresentation(
+            @JsonProperty("id") PlanNodeId id,
+            @JsonProperty("outputLayout") List<TypedSymbol> outputLayout,
+            @JsonProperty("sourceFragmentIds") List<PlanFragmentId> sourceFragmentIds,
+            @JsonProperty("orderings") Optional<Map<Symbol, SortOrder>> orderings,
+            @JsonProperty("exchangeType") ExchangeNode.Type exchangeType)
+    {
+        super(id, outputLayout, ImmutableList.of());
+        this.sourceFragmentIds = requireNonNull(sourceFragmentIds, "sourceFragmentIds is null");
+        this.orderings = requireNonNull(orderings, "orderings is null");
+        this.exchangeType = requireNonNull(exchangeType, "exchangeType is null");
+    }
+
+    @JsonProperty
+    public List<PlanFragmentId> getSourceFragmentIds()
+    {
+        return sourceFragmentIds;
+    }
+
+    @JsonProperty
+    public Optional<Map<Symbol, SortOrder>> getOrderings()
+    {
+        return orderings;
+    }
+
+    @JsonProperty
+    public ExchangeNode.Type getExchangeType()
+    {
+        return exchangeType;
+    }
+
+    public static RemoteSourceNodeRepresentation fromPlanNode(RemoteSourceNode node, TypeProvider typeProvider)
+    {
+        return new RemoteSourceNodeRepresentation(
+                node.getId(),
+                anonymize(node.getOutputSymbols(), typeProvider),
+                node.getSourceFragmentIds(),
+                node.getOrderingScheme().map(AnonymizationUtils::anonymize),
+                node.getExchangeType());
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof RemoteSourceNodeRepresentation)) {
+            return false;
+        }
+        RemoteSourceNodeRepresentation that = (RemoteSourceNodeRepresentation) o;
+        return getId().equals(that.getId())
+                && getOutputLayout().equals(that.getOutputLayout())
+                && getSources().equals(that.getSources())
+                && sourceFragmentIds.equals(that.sourceFragmentIds)
+                && orderings.equals(that.orderings)
+                && exchangeType == that.exchangeType;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(getId(), getOutputLayout(), getSources(), sourceFragmentIds, orderings, exchangeType);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/SemiJoinNodeRepresentation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/SemiJoinNodeRepresentation.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.sql.planner.planprinter.anonymize;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.TypeProvider;
+import io.trino.sql.planner.plan.PlanNodeId;
+import io.trino.sql.planner.plan.SemiJoinNode;
+import io.trino.sql.planner.planprinter.TypedSymbol;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static io.trino.sql.planner.plan.SemiJoinNode.DistributionType;
+import static io.trino.sql.planner.planprinter.anonymize.AnonymizationUtils.anonymize;
+import static java.util.Objects.requireNonNull;
+
+public class SemiJoinNodeRepresentation
+        extends AnonymizedNodeRepresentation
+{
+    private final Symbol sourceJoinSymbol;
+    private final Symbol filteringSourceJoinSymbol;
+    private final Optional<Symbol> sourceHashSymbol;
+    private final Optional<Symbol> filteringSourceHashSymbol;
+    private final Optional<DistributionType> distributionType;
+
+    @JsonCreator
+    public SemiJoinNodeRepresentation(
+            @JsonProperty("id") PlanNodeId id,
+            @JsonProperty("outputLayout") List<TypedSymbol> outputLayout,
+            @JsonProperty("sources") List<AnonymizedNodeRepresentation> sources,
+            @JsonProperty("sourceJoinSymbol") Symbol sourceJoinSymbol,
+            @JsonProperty("filteringSourceJoinSymbol") Symbol filteringSourceJoinSymbol,
+            @JsonProperty("sourceHashSymbol") Optional<Symbol> sourceHashSymbol,
+            @JsonProperty("filteringSourceHashSymbol") Optional<Symbol> filteringSourceHashSymbol,
+            @JsonProperty("distributionType") Optional<DistributionType> distributionType)
+    {
+        super(id, outputLayout, sources);
+        this.sourceJoinSymbol = requireNonNull(sourceJoinSymbol, "sourceJoinSymbol is null");
+        this.filteringSourceJoinSymbol = requireNonNull(filteringSourceJoinSymbol, "filteringSourceJoinSymbol is null");
+        this.sourceHashSymbol = requireNonNull(sourceHashSymbol, "sourceHashSymbol is null");
+        this.filteringSourceHashSymbol = requireNonNull(filteringSourceHashSymbol, "filteringSourceHashSymbol is null");
+        this.distributionType = requireNonNull(distributionType, "distributionType is null");
+    }
+
+    @JsonProperty
+    public Symbol getSourceJoinSymbol()
+    {
+        return sourceJoinSymbol;
+    }
+
+    @JsonProperty
+    public Symbol getFilteringSourceJoinSymbol()
+    {
+        return filteringSourceJoinSymbol;
+    }
+
+    @JsonProperty("sourceHashSymbol")
+    public Optional<Symbol> getSourceHashSymbol()
+    {
+        return sourceHashSymbol;
+    }
+
+    @JsonProperty("filteringSourceHashSymbol")
+    public Optional<Symbol> getFilteringSourceHashSymbol()
+    {
+        return filteringSourceHashSymbol;
+    }
+
+    @JsonProperty
+    public Optional<SemiJoinNode.DistributionType> getDistributionType()
+    {
+        return distributionType;
+    }
+
+    public static SemiJoinNodeRepresentation fromPlanNode(SemiJoinNode node, TypeProvider typeProvider, List<AnonymizedNodeRepresentation> sources)
+    {
+        return new SemiJoinNodeRepresentation(
+                node.getId(),
+                anonymize(node.getOutputSymbols(), typeProvider),
+                sources,
+                anonymize(node.getSourceJoinSymbol()),
+                anonymize(node.getFilteringSourceJoinSymbol()),
+                node.getSourceHashSymbol().map(AnonymizationUtils::anonymize),
+                node.getFilteringSourceHashSymbol().map(AnonymizationUtils::anonymize),
+                node.getDistributionType());
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof SemiJoinNodeRepresentation)) {
+            return false;
+        }
+        SemiJoinNodeRepresentation that = (SemiJoinNodeRepresentation) o;
+        return getId().equals(that.getId())
+                && getOutputLayout().equals(that.getOutputLayout())
+                && getSources().equals(that.getSources())
+                && sourceJoinSymbol.equals(that.sourceJoinSymbol)
+                && filteringSourceJoinSymbol.equals(that.filteringSourceJoinSymbol)
+                && sourceHashSymbol.equals(that.sourceHashSymbol)
+                && filteringSourceHashSymbol.equals(that.filteringSourceHashSymbol)
+                && distributionType.equals(that.distributionType);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(
+                getId(),
+                getOutputLayout(),
+                getSources(),
+                sourceJoinSymbol,
+                filteringSourceJoinSymbol,
+                sourceHashSymbol,
+                filteringSourceHashSymbol,
+                distributionType);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/SortNodeRepresentation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/SortNodeRepresentation.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.sql.planner.planprinter.anonymize;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.connector.SortOrder;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.TypeProvider;
+import io.trino.sql.planner.plan.PlanNodeId;
+import io.trino.sql.planner.plan.SortNode;
+import io.trino.sql.planner.planprinter.TypedSymbol;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static io.trino.sql.planner.planprinter.anonymize.AnonymizationUtils.anonymize;
+import static java.util.Objects.requireNonNull;
+
+public class SortNodeRepresentation
+        extends AnonymizedNodeRepresentation
+{
+    private final Map<Symbol, SortOrder> orderings;
+    private final boolean partial;
+
+    @JsonCreator
+    public SortNodeRepresentation(
+            @JsonProperty("id") PlanNodeId id,
+            @JsonProperty("outputLayout") List<TypedSymbol> outputLayout,
+            @JsonProperty("sources") List<AnonymizedNodeRepresentation> sources,
+            @JsonProperty("orderings") Map<Symbol, SortOrder> orderings,
+            @JsonProperty("partial") boolean partial)
+    {
+        super(id, outputLayout, sources);
+        this.orderings = requireNonNull(orderings, "orderings is null");
+        this.partial = partial;
+    }
+
+    @JsonProperty
+    public Map<Symbol, SortOrder> getOrderings()
+    {
+        return orderings;
+    }
+
+    @JsonProperty
+    public boolean isPartial()
+    {
+        return partial;
+    }
+
+    public static SortNodeRepresentation fromPlanNode(SortNode node, TypeProvider typeProvider, List<AnonymizedNodeRepresentation> sources)
+    {
+        return new SortNodeRepresentation(
+                node.getId(),
+                anonymize(node.getOutputSymbols(), typeProvider),
+                sources,
+                anonymize(node.getOrderingScheme()),
+                node.isPartial());
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof SortNodeRepresentation)) {
+            return false;
+        }
+        SortNodeRepresentation that = (SortNodeRepresentation) o;
+        return getId().equals(that.getId())
+                && getOutputLayout().equals(that.getOutputLayout())
+                && getSources().equals(that.getSources())
+                && partial == that.partial
+                && orderings.equals(that.orderings);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(getId(), getOutputLayout(), getSources(), orderings, partial);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/TableScanNodeRepresentation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/TableScanNodeRepresentation.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.sql.planner.planprinter.anonymize;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import io.trino.execution.TableInfo;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.TypeProvider;
+import io.trino.sql.planner.plan.PlanNodeId;
+import io.trino.sql.planner.plan.TableScanNode;
+import io.trino.sql.planner.planprinter.TypedSymbol;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.trino.sql.planner.planprinter.anonymize.AnonymizationUtils.ObjectType.CATALOG;
+import static io.trino.sql.planner.planprinter.anonymize.AnonymizationUtils.ObjectType.COLUMN;
+import static io.trino.sql.planner.planprinter.anonymize.AnonymizationUtils.ObjectType.SCHEMA;
+import static io.trino.sql.planner.planprinter.anonymize.AnonymizationUtils.ObjectType.TABLE;
+import static io.trino.sql.planner.planprinter.anonymize.AnonymizationUtils.anonymize;
+import static java.util.Objects.requireNonNull;
+
+public class TableScanNodeRepresentation
+        extends AnonymizedNodeRepresentation
+{
+    private final Optional<String> connector;
+    private final String catalog;
+    private final String schema;
+    private final String table;
+    private final Map<Symbol, String> assignments;
+    private final Optional<Map<String, DomainRepresentation>> enforcedConstraint;
+    private final Optional<Map<String, DomainRepresentation>> predicate;
+
+    @JsonCreator
+    public TableScanNodeRepresentation(
+            @JsonProperty("id") PlanNodeId id,
+            @JsonProperty("outputLayout") List<TypedSymbol> outputLayout,
+            @JsonProperty("connector") Optional<String> connector,
+            @JsonProperty("catalog") String catalog,
+            @JsonProperty("schema") String schema,
+            @JsonProperty("table") String table,
+            @JsonProperty("assignments") Map<Symbol, String> assignments,
+            @JsonProperty("enforcedConstraint") Optional<Map<String, DomainRepresentation>> enforcedConstraint,
+            @JsonProperty("predicate") Optional<Map<String, DomainRepresentation>> predicate)
+    {
+        super(id, outputLayout, ImmutableList.of());
+        this.connector = requireNonNull(connector, "connector is null");
+        this.catalog = requireNonNull(catalog, "catalog is null");
+        this.schema = requireNonNull(schema, "schema is null");
+        this.table = requireNonNull(table, "table is null");
+        this.assignments = requireNonNull(assignments, "assignments is null");
+        this.enforcedConstraint = requireNonNull(enforcedConstraint, "enforcedConstraint is null");
+        this.predicate = requireNonNull(predicate, "predicate is null");
+    }
+
+    @JsonProperty
+    public Optional<String> getConnector()
+    {
+        return connector;
+    }
+
+    @JsonProperty
+    public String getCatalog()
+    {
+        return catalog;
+    }
+
+    @JsonProperty
+    public String getSchema()
+    {
+        return schema;
+    }
+
+    @JsonProperty
+    public String getTable()
+    {
+        return table;
+    }
+
+    @JsonProperty
+    public Map<Symbol, String> getAssignments()
+    {
+        return assignments;
+    }
+
+    @JsonProperty
+    public Optional<Map<String, DomainRepresentation>> getEnforcedConstraint()
+    {
+        return enforcedConstraint;
+    }
+
+    @JsonProperty
+    public Optional<Map<String, DomainRepresentation>> getPredicate()
+    {
+        return predicate;
+    }
+
+    public static TableScanNodeRepresentation fromPlanNode(TableScanNode node, TypeProvider typeProvider, TableInfo tableInfo)
+    {
+        return new TableScanNodeRepresentation(
+                node.getId(),
+                anonymize(node.getOutputSymbols(), typeProvider),
+                tableInfo.getConnectorName(),
+                anonymize(tableInfo.getTableName().getCatalogName(), CATALOG),
+                anonymize(tableInfo.getTableName().getSchemaName(), SCHEMA),
+                anonymize(tableInfo.getTableName().getObjectName(), TABLE),
+                node.getAssignments().entrySet().stream()
+                        .collect(toImmutableMap(
+                                entry -> anonymize(entry.getKey()),
+                                entry -> anonymize(entry.getValue(), COLUMN))),
+                anonymize(node.getEnforcedConstraint()),
+                anonymize(tableInfo.getPredicate()));
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TableScanNodeRepresentation that = (TableScanNodeRepresentation) o;
+        return getId().equals(that.getId())
+                && getOutputLayout().equals(that.getOutputLayout())
+                && getSources().equals(that.getSources())
+                && connector.equals(that.connector)
+                && catalog.equals(that.catalog)
+                && schema.equals(that.schema)
+                && table.equals(that.table)
+                && assignments.equals(that.assignments)
+                && enforcedConstraint.equals(that.enforcedConstraint)
+                && predicate.equals(that.predicate);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(
+                getId(),
+                getOutputLayout(),
+                getSources(),
+                connector,
+                catalog,
+                schema,
+                table,
+                assignments,
+                enforcedConstraint,
+                predicate);
+    }
+
+    public static class DomainRepresentation
+    {
+        private final String valueSetClass;
+        private final String valueSetType;
+        private final Optional<Integer> valueSetCount;
+        private final boolean nullAllowed;
+        private final boolean none;
+        private final boolean all;
+        private final boolean singleValue;
+
+        @JsonCreator
+        public DomainRepresentation(
+                @JsonProperty("valueSetClass") String valueSetClass,
+                @JsonProperty("valueSetType") String valueSetType,
+                @JsonProperty("valueSetCount") Optional<Integer> valueSetCount,
+                @JsonProperty("nullAllowed") boolean nullAllowed,
+                @JsonProperty("none") boolean none,
+                @JsonProperty("all") boolean all,
+                @JsonProperty("singleValue") boolean singleValue)
+        {
+            this.valueSetClass = requireNonNull(valueSetClass, "valueSetClass is null");
+            this.valueSetType = requireNonNull(valueSetType, "valueSetType is null");
+            this.valueSetCount = requireNonNull(valueSetCount, "valueSetCount is null");
+            this.nullAllowed = nullAllowed;
+            this.none = none;
+            this.all = all;
+            this.singleValue = singleValue;
+        }
+
+        @JsonProperty
+        public String getValueSetClass()
+        {
+            return valueSetClass;
+        }
+
+        @JsonProperty
+        public String getValueSetType()
+        {
+            return valueSetType;
+        }
+
+        @JsonProperty
+        public Optional<Integer> getValueSetCount()
+        {
+            return valueSetCount;
+        }
+
+        @JsonProperty
+        public boolean isNullAllowed()
+        {
+            return nullAllowed;
+        }
+
+        @JsonProperty
+        public boolean isNone()
+        {
+            return none;
+        }
+
+        @JsonProperty
+        public boolean isAll()
+        {
+            return all;
+        }
+
+        @JsonProperty
+        public boolean isSingleValue()
+        {
+            return singleValue;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof DomainRepresentation)) {
+                return false;
+            }
+            DomainRepresentation that = (DomainRepresentation) o;
+            return nullAllowed == that.nullAllowed
+                    && none == that.none
+                    && all == that.all
+                    && singleValue == that.singleValue
+                    && valueSetClass.equals(that.valueSetClass)
+                    && valueSetType.equals(that.valueSetType)
+                    && valueSetCount.equals(that.valueSetCount);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(valueSetClass, valueSetType, valueSetCount, nullAllowed, none, all, singleValue);
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/TopNNodeRepresentation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/TopNNodeRepresentation.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.sql.planner.planprinter.anonymize;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.connector.SortOrder;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.TypeProvider;
+import io.trino.sql.planner.plan.PlanNodeId;
+import io.trino.sql.planner.plan.TopNNode;
+import io.trino.sql.planner.planprinter.TypedSymbol;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static io.trino.sql.planner.plan.TopNNode.Step;
+import static io.trino.sql.planner.planprinter.anonymize.AnonymizationUtils.anonymize;
+import static java.util.Objects.requireNonNull;
+
+public class TopNNodeRepresentation
+        extends AnonymizedNodeRepresentation
+{
+    private final long count;
+    private final Map<Symbol, SortOrder> orderings;
+    private final Step step;
+
+    @JsonCreator
+    public TopNNodeRepresentation(
+            @JsonProperty("id") PlanNodeId id,
+            @JsonProperty("outputLayout") List<TypedSymbol> outputLayout,
+            @JsonProperty("sources") List<AnonymizedNodeRepresentation> sources,
+            @JsonProperty("count") long count,
+            @JsonProperty("orderings") Map<Symbol, SortOrder> orderings,
+            @JsonProperty("step") Step step)
+    {
+        super(id, outputLayout, sources);
+        this.count = count;
+        this.orderings = requireNonNull(orderings, "orderings is null");
+        this.step = requireNonNull(step, "step is null");
+    }
+
+    @JsonProperty
+    public long getCount()
+    {
+        return count;
+    }
+
+    @JsonProperty
+    public Map<Symbol, SortOrder> getOrderings()
+    {
+        return orderings;
+    }
+
+    @JsonProperty
+    public Step getStep()
+    {
+        return step;
+    }
+
+    public static TopNNodeRepresentation fromPlanNode(TopNNode node, TypeProvider typeProvider, List<AnonymizedNodeRepresentation> sources)
+    {
+        return new TopNNodeRepresentation(
+                node.getId(),
+                anonymize(node.getOutputSymbols(), typeProvider),
+                sources,
+                node.getCount(),
+                anonymize(node.getOrderingScheme()),
+                node.getStep());
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TopNNodeRepresentation)) {
+            return false;
+        }
+        TopNNodeRepresentation that = (TopNNodeRepresentation) o;
+        return getId().equals(that.getId())
+                && getOutputLayout().equals(that.getOutputLayout())
+                && getSources().equals(that.getSources())
+                && count == that.count
+                && orderings.equals(that.orderings)
+                && step == that.step;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(getId(), getOutputLayout(), getSources(), count, orderings, step);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/ValuesNodeRepresentation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/ValuesNodeRepresentation.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.sql.planner.planprinter.anonymize;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import io.trino.sql.planner.TypeProvider;
+import io.trino.sql.planner.plan.PlanNodeId;
+import io.trino.sql.planner.plan.ValuesNode;
+import io.trino.sql.planner.planprinter.TypedSymbol;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static io.trino.sql.planner.planprinter.anonymize.AnonymizationUtils.anonymize;
+import static java.util.Objects.requireNonNull;
+
+public class ValuesNodeRepresentation
+        extends AnonymizedNodeRepresentation
+{
+    private final int rowCount;
+    private final Optional<List<String>> rows;
+
+    @JsonCreator
+    public ValuesNodeRepresentation(
+            @JsonProperty("id") PlanNodeId id,
+            @JsonProperty("outputLayout") List<TypedSymbol> outputLayout,
+            @JsonProperty("rowCount") int rowCount,
+            @JsonProperty("rows") Optional<List<String>> rows)
+    {
+        super(id, outputLayout, ImmutableList.of());
+        this.rowCount = rowCount;
+        this.rows = requireNonNull(rows, "rows is null");
+    }
+
+    @JsonProperty
+    public int getRowCount()
+    {
+        return rowCount;
+    }
+
+    @JsonProperty
+    public Optional<List<String>> getRows()
+    {
+        return rows;
+    }
+
+    public static ValuesNodeRepresentation fromPlanNode(ValuesNode node, TypeProvider typeProvider)
+    {
+        return new ValuesNodeRepresentation(
+                node.getId(),
+                anonymize(node.getOutputSymbols(), typeProvider),
+                node.getRowCount(),
+                node.getRows().map(AnonymizationUtils::anonymizeAndUnResolveExpressions));
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ValuesNodeRepresentation that = (ValuesNodeRepresentation) o;
+        return getId().equals(that.getId())
+                && getOutputLayout().equals(that.getOutputLayout())
+                && getSources().equals(that.getSources())
+                && rowCount == that.rowCount
+                && rows.equals(that.rows);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(getId(), getOutputLayout(), getSources(), rowCount, rows);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/WindowNodeRepresentation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/anonymize/WindowNodeRepresentation.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.sql.planner.planprinter.anonymize;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.connector.SortOrder;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.TypeProvider;
+import io.trino.sql.planner.plan.PlanNodeId;
+import io.trino.sql.planner.plan.WindowNode;
+import io.trino.sql.planner.planprinter.TypedSymbol;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.trino.sql.planner.planprinter.anonymize.AnonymizationUtils.anonymize;
+import static java.util.Objects.requireNonNull;
+
+public class WindowNodeRepresentation
+        extends AnonymizedNodeRepresentation
+{
+    private final Map<Symbol, String> windowFunctions;
+    private final List<Symbol> partitionBy;
+    private final Optional<Map<Symbol, SortOrder>> orderings;
+    private final Optional<Symbol> hashSymbol;
+    private final Set<Symbol> prePartitionedInputs;
+    private final int preSortedOrderPrefix;
+
+    @JsonCreator
+    public WindowNodeRepresentation(
+            @JsonProperty("id") PlanNodeId id,
+            @JsonProperty("outputLayout") List<TypedSymbol> outputLayout,
+            @JsonProperty("sources") List<AnonymizedNodeRepresentation> sources,
+            @JsonProperty("windowFunctions") Map<Symbol, String> windowFunctions,
+            @JsonProperty("partitionBy") List<Symbol> partitionBy,
+            @JsonProperty("orderings") Optional<Map<Symbol, SortOrder>> orderings,
+            @JsonProperty("hashSymbol") Optional<Symbol> hashSymbol,
+            @JsonProperty("prePartitionedInputs") Set<Symbol> prePartitionedInputs,
+            @JsonProperty("preSortedOrderPrefix") int preSortedOrderPrefix)
+    {
+        super(id, outputLayout, sources);
+        this.partitionBy = requireNonNull(partitionBy, "partitionBy is null");
+        this.orderings = requireNonNull(orderings, "orderings is null");
+        this.windowFunctions = requireNonNull(windowFunctions, "windowFunctions is null");
+        this.hashSymbol = requireNonNull(hashSymbol, "hashSymbol is null");
+        this.prePartitionedInputs = requireNonNull(prePartitionedInputs, "prePartitionedInputs is null");
+        this.preSortedOrderPrefix = preSortedOrderPrefix;
+    }
+
+    @JsonProperty
+    public Map<Symbol, String> getWindowFunctions()
+    {
+        return windowFunctions;
+    }
+
+    @JsonProperty
+    public List<Symbol> getPartitionBy()
+    {
+        return partitionBy;
+    }
+
+    @JsonProperty
+    public Optional<Map<Symbol, SortOrder>> getOrderings()
+    {
+        return orderings;
+    }
+
+    @JsonProperty
+    public Optional<Symbol> getHashSymbol()
+    {
+        return hashSymbol;
+    }
+
+    @JsonProperty
+    public Set<Symbol> getPrePartitionedInputs()
+    {
+        return prePartitionedInputs;
+    }
+
+    @JsonProperty
+    public int getPreSortedOrderPrefix()
+    {
+        return preSortedOrderPrefix;
+    }
+
+    public static WindowNodeRepresentation fromPlanNode(WindowNode node, TypeProvider typeProvider, List<AnonymizedNodeRepresentation> sources)
+    {
+        return new WindowNodeRepresentation(
+                node.getId(),
+                anonymize(node.getOutputSymbols(), typeProvider),
+                sources,
+                node.getWindowFunctions().entrySet().stream()
+                        .collect(toImmutableMap(
+                                entry -> anonymize(entry.getKey()),
+                                entry -> anonymize(entry.getValue()))),
+                anonymize(node.getPartitionBy()),
+                node.getOrderingScheme().map(AnonymizationUtils::anonymize),
+                node.getHashSymbol().map(AnonymizationUtils::anonymize),
+                node.getPrePartitionedInputs().stream()
+                        .map(AnonymizationUtils::anonymize)
+                        .collect(toImmutableSet()),
+                node.getPreSortedOrderPrefix());
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof WindowNodeRepresentation)) {
+            return false;
+        }
+        WindowNodeRepresentation that = (WindowNodeRepresentation) o;
+        return getId().equals(that.getId())
+                && getOutputLayout().equals(that.getOutputLayout())
+                && getSources().equals(that.getSources())
+                && preSortedOrderPrefix == that.preSortedOrderPrefix
+                && windowFunctions.equals(that.windowFunctions)
+                && partitionBy.equals(that.partitionBy)
+                && orderings.equals(that.orderings)
+                && hashSymbol.equals(that.hashSymbol)
+                && prePartitionedInputs.equals(that.prePartitionedInputs);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(
+                getId(),
+                getOutputLayout(),
+                getSources(),
+                windowFunctions,
+                partitionBy,
+                orderings,
+                hashSymbol,
+                prePartitionedInputs,
+                preSortedOrderPrefix);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -736,7 +736,7 @@ public class TestSourcePartitionedScheduler
         StageId stageId = new StageId(QUERY_ID, 0);
         SqlStage stage = SqlStage.createSqlStage(stageId,
                 fragment,
-                ImmutableMap.of(TABLE_SCAN_NODE_ID, new TableInfo(new QualifiedObjectName("test", "test", "test"), TupleDomain.all())),
+                ImmutableMap.of(TABLE_SCAN_NODE_ID, new TableInfo(Optional.of("test"), new QualifiedObjectName("test", "test", "test"), TupleDomain.all())),
                 new MockRemoteTaskFactory(queryExecutor, scheduledExecutor),
                 TEST_SESSION,
                 true,

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -28,6 +28,7 @@ import io.trino.metadata.OutputTableHandle;
 import io.trino.metadata.ResolvedFunction;
 import io.trino.metadata.TableExecuteHandle;
 import io.trino.metadata.TableHandle;
+import io.trino.operator.RetryPolicy;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SortOrder;
@@ -71,9 +72,11 @@ import io.trino.sql.planner.plan.MarkDistinctNode;
 import io.trino.sql.planner.plan.OffsetNode;
 import io.trino.sql.planner.plan.OutputNode;
 import io.trino.sql.planner.plan.PatternRecognitionNode;
+import io.trino.sql.planner.plan.PlanFragmentId;
 import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.sql.planner.plan.ProjectNode;
+import io.trino.sql.planner.plan.RemoteSourceNode;
 import io.trino.sql.planner.plan.RowNumberNode;
 import io.trino.sql.planner.plan.SampleNode;
 import io.trino.sql.planner.plan.SemiJoinNode;
@@ -1371,6 +1374,16 @@ public class PlanBuilder
         PatternRecognitionBuilder patternRecognitionBuilder = new PatternRecognitionBuilder();
         consumer.accept(patternRecognitionBuilder);
         return patternRecognitionBuilder.build(idAllocator);
+    }
+
+    public RemoteSourceNode remoteSource(
+            List<PlanFragmentId> sourceFragmentIds,
+            List<Symbol> outputs,
+            Optional<OrderingScheme> orderingScheme,
+            ExchangeNode.Type exchangeType,
+            RetryPolicy retryPolicy)
+    {
+        return new RemoteSourceNode(idAllocator.getNextId(), sourceFragmentIds, outputs, orderingScheme, exchangeType, retryPolicy);
     }
 
     public static Expression expression(String sql)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestAnonymizePlanPrinter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestAnonymizePlanPrinter.java
@@ -1,0 +1,440 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.sql.planner.planprinter;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.trino.connector.CatalogName;
+import io.trino.execution.TableInfo;
+import io.trino.metadata.QualifiedObjectName;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.metadata.TableHandle;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.operator.RetryPolicy;
+import io.trino.plugin.tpch.TpchConnectorFactory;
+import io.trino.plugin.tpch.TpchTableHandle;
+import io.trino.plugin.tpch.TpchTransactionHandle;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.SortOrder;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.sql.planner.OrderingScheme;
+import io.trino.sql.planner.PlanNodeIdAllocator;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
+import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.DynamicFilterId;
+import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.PlanFragmentId;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.PlanNodeId;
+import io.trino.sql.planner.plan.TopNNode;
+import io.trino.sql.planner.plan.WindowNode;
+import io.trino.sql.planner.planprinter.anonymize.AggregationNodeRepresentation;
+import io.trino.sql.planner.planprinter.anonymize.AnonymizePlanPrinter;
+import io.trino.sql.planner.planprinter.anonymize.AnonymizedNodeRepresentation;
+import io.trino.sql.planner.planprinter.anonymize.ExchangeNodeRepresentation;
+import io.trino.sql.planner.planprinter.anonymize.FilterNodeRepresentation;
+import io.trino.sql.planner.planprinter.anonymize.JoinNodeRepresentation;
+import io.trino.sql.planner.planprinter.anonymize.ProjectNodeRepresentation;
+import io.trino.sql.planner.planprinter.anonymize.RemoteSourceNodeRepresentation;
+import io.trino.sql.planner.planprinter.anonymize.SemiJoinNodeRepresentation;
+import io.trino.sql.planner.planprinter.anonymize.SortNodeRepresentation;
+import io.trino.sql.planner.planprinter.anonymize.TableScanNodeRepresentation;
+import io.trino.sql.planner.planprinter.anonymize.TopNNodeRepresentation;
+import io.trino.sql.planner.planprinter.anonymize.ValuesNodeRepresentation;
+import io.trino.sql.planner.planprinter.anonymize.WindowNodeRepresentation;
+import io.trino.sql.tree.QualifiedName;
+import io.trino.sql.tree.WindowFrame;
+import io.trino.testing.LocalQueryRunner;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import static io.trino.SessionTestUtils.TEST_SESSION;
+import static io.trino.plugin.tpch.TpchMetadata.TINY_SCALE_FACTOR;
+import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static io.trino.spi.connector.SortOrder.ASC_NULLS_FIRST;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expression;
+import static io.trino.sql.planner.plan.AggregationNode.Step.FINAL;
+import static io.trino.sql.planner.plan.ExchangeNode.Scope.REMOTE;
+import static io.trino.sql.planner.plan.ExchangeNode.Type.GATHER;
+import static io.trino.sql.planner.plan.ExchangeNode.Type.REPARTITION;
+import static io.trino.sql.planner.plan.JoinNode.EquiJoinClause;
+import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
+import static io.trino.sql.planner.plan.SemiJoinNode.DistributionType.REPLICATED;
+import static io.trino.sql.planner.planprinter.anonymize.AggregationNodeRepresentation.AggregationRepresentation;
+import static io.trino.sql.planner.planprinter.anonymize.TableScanNodeRepresentation.DomainRepresentation;
+import static io.trino.sql.tree.BooleanLiteral.TRUE_LITERAL;
+import static io.trino.sql.tree.FrameBound.Type.CURRENT_ROW;
+import static io.trino.sql.tree.FrameBound.Type.UNBOUNDED_PRECEDING;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestAnonymizePlanPrinter
+{
+    private static final TableInfo TABLE_INFO = new TableInfo(
+            Optional.of("tpch"),
+            new QualifiedObjectName("tpch", TINY_SCHEMA_NAME, "orders"),
+            TupleDomain.all());
+    private static final ValuesNodeRepresentation VALUE_A_REPRESENTATION = new ValuesNodeRepresentation(
+            new PlanNodeId("0"),
+            ImmutableList.of(typedSymbol("symbol_97", "bigint")),
+            0,
+            Optional.of(ImmutableList.of()));
+    private static final ResolvedFunction MIN_FUNCTION = new TestingFunctionResolution().resolveFunction(QualifiedName.of("min"), fromTypes(BIGINT));
+
+    private LocalQueryRunner queryRunner;
+
+    @BeforeClass
+    public void setUp()
+    {
+        queryRunner = LocalQueryRunner.create(TEST_SESSION);
+        queryRunner.createCatalog(TEST_SESSION.getCatalog().get(), new TpchConnectorFactory(1), ImmutableMap.of());
+    }
+
+    @Test
+    public void testAggregationNodeAnonymization()
+    {
+        assertAnonymizedPlan(
+                pb -> pb.aggregation(ab -> ab
+                        .step(FINAL)
+                        .addAggregation(pb.symbol("sum", BIGINT), expression("sum(x)"), ImmutableList.of(BIGINT))
+                        .singleGroupingSet(pb.symbol("y", BIGINT), pb.symbol("z", BIGINT))
+                        .source(pb.values(pb.symbol("x", BIGINT), pb.symbol("y", BIGINT), pb.symbol("z", BIGINT)))),
+                new AggregationNodeRepresentation(
+                        new PlanNodeId("1"),
+                        ImmutableList.of(
+                                typedSymbol("symbol_121", "bigint"),
+                                typedSymbol("symbol_122", "bigint"),
+                                typedSymbol("symbol_114251", "bigint")),
+                        ImmutableList.of(
+                                new ValuesNodeRepresentation(
+                                        new PlanNodeId("0"),
+                                        ImmutableList.of(
+                                                typedSymbol("symbol_120", "bigint"),
+                                                typedSymbol("symbol_121", "bigint"),
+                                                typedSymbol("symbol_122", "bigint")),
+                                        0,
+                                        Optional.of(ImmutableList.of()))),
+                        ImmutableMap.of(symbol("symbol_114251"), new AggregationRepresentation(
+                                "sum",
+                                ImmutableList.of("\"symbol_120\""),
+                                false,
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty())),
+                        ImmutableList.of(symbol("symbol_121"), symbol("symbol_122")),
+                        FINAL,
+                        Optional.empty()));
+    }
+
+    @Test
+    public void testJoinNodeAnonymization()
+    {
+        assertAnonymizedPlan(
+                pb -> pb.join(
+                        INNER,
+                        pb.values(pb.symbol("a", BIGINT), pb.symbol("b", BIGINT)),
+                        pb.values(pb.symbol("c", BIGINT), pb.symbol("d", BIGINT)),
+                        ImmutableList.of(new JoinNode.EquiJoinClause(pb.symbol("a", BIGINT), pb.symbol("d", BIGINT))),
+                        ImmutableList.of(pb.symbol("b", BIGINT)),
+                        ImmutableList.of(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        ImmutableMap.of(new DynamicFilterId("DF"), pb.symbol("d", BIGINT))),
+                new JoinNodeRepresentation(
+                        new PlanNodeId("2"),
+                        ImmutableList.of(typedSymbol("symbol_98", "bigint")),
+                        ImmutableList.of(
+                                new ValuesNodeRepresentation(
+                                        new PlanNodeId("0"),
+                                        ImmutableList.of(
+                                                typedSymbol("symbol_97", "bigint"),
+                                                typedSymbol("symbol_98", "bigint")),
+                                        0,
+                                        Optional.of(ImmutableList.of())),
+                                new ValuesNodeRepresentation(
+                                        new PlanNodeId("1"),
+                                        ImmutableList.of(
+                                                typedSymbol("symbol_99", "bigint"),
+                                                typedSymbol("symbol_100", "bigint")),
+                                        0,
+                                        Optional.of(ImmutableList.of()))),
+                        INNER,
+                        ImmutableList.of(new EquiJoinClause(symbol("symbol_97"), symbol("symbol_100"))),
+                        false,
+                        Optional.empty()));
+    }
+
+    @Test
+    public void testTableScanNodeAnonymization()
+    {
+        ColumnHandle columnHandle = new ColumnHandle() {
+            @Override
+            public int hashCode()
+            {
+                return 1234;
+            }
+
+            @Override
+            public boolean equals(Object obj)
+            {
+                return true;
+            }
+        };
+        assertAnonymizedPlan(
+                pb -> pb.tableScan(
+                        new TableHandle(
+                                new CatalogName("tpch"),
+                                new TpchTableHandle(TINY_SCHEMA_NAME, "orders", TINY_SCALE_FACTOR),
+                                TpchTransactionHandle.INSTANCE),
+                        ImmutableList.of(pb.symbol("a", BIGINT)),
+                        ImmutableMap.of(pb.symbol("a", BIGINT), columnHandle),
+                        TupleDomain.withColumnDomains(ImmutableMap.of(columnHandle, Domain.singleValue(BIGINT, 1L)))),
+                new TableScanNodeRepresentation(
+                        new PlanNodeId("0"),
+                        ImmutableList.of(typedSymbol("symbol_97", "bigint")),
+                        Optional.of("tpch"),
+                        "catalog_3566561",
+                        "schema_3560192",
+                        "table_-1008770331",
+                        ImmutableMap.of(symbol("symbol_97"), "column_1234"),
+                        Optional.of(ImmutableMap.of("column_1234", new DomainRepresentation(
+                                "SortedRangeSet",
+                                "bigint",
+                                Optional.of(1),
+                                false,
+                                false,
+                                false,
+                                true))),
+                        Optional.of(ImmutableMap.of())));
+    }
+
+    @Test
+    public void testExchangeNodeAnonymization()
+    {
+        assertAnonymizedPlan(
+                pb -> {
+                    Symbol a = pb.symbol("a", BIGINT);
+                    return pb.exchange(e -> e
+                            .addSource(pb.values(a))
+                            .addInputsSet(a)
+                            .orderingScheme(new OrderingScheme(ImmutableList.of(a), ImmutableMap.of(a, ASC_NULLS_FIRST)))
+                            .singleDistributionPartitioningScheme(a));
+                },
+                new ExchangeNodeRepresentation(
+                        new PlanNodeId("1"),
+                        ImmutableList.of(typedSymbol("symbol_97", "bigint")),
+                        ImmutableList.of(VALUE_A_REPRESENTATION),
+                        GATHER,
+                        REMOTE,
+                        ImmutableList.of(),
+                        Optional.empty(),
+                        false,
+                        Optional.of(ImmutableMap.of(symbol("symbol_97"), ASC_NULLS_FIRST))));
+    }
+
+    @Test
+    public void testFilterNodeRepresentation()
+    {
+        assertAnonymizedPlan(
+                pb -> pb.filter(
+                        TRUE_LITERAL,
+                        pb.values(pb.symbol("a", BIGINT))),
+                new FilterNodeRepresentation(
+                        new PlanNodeId("1"),
+                        ImmutableList.of(typedSymbol("symbol_97", "bigint")),
+                        ImmutableList.of(VALUE_A_REPRESENTATION),
+                        "true"));
+    }
+
+    @Test
+    public void testProjectNodeRepresentation()
+    {
+        assertAnonymizedPlan(
+                pb -> pb.project(
+                        Assignments.of(pb.symbol("x", BIGINT), expression("a")),
+                        pb.values(pb.symbol("a", BIGINT))),
+                new ProjectNodeRepresentation(
+                        new PlanNodeId("1"),
+                        ImmutableList.of(typedSymbol("symbol_120", "bigint")),
+                        ImmutableList.of(VALUE_A_REPRESENTATION),
+                        ImmutableMap.of(symbol("symbol_120"), "\"symbol_97\"")));
+    }
+
+    @Test
+    public void testRemoteSourceNodeRepresentation()
+    {
+        assertAnonymizedPlan(
+                pb -> {
+                    Symbol a = pb.symbol("a", BIGINT);
+                    return pb.remoteSource(
+                            ImmutableList.of(new PlanFragmentId("source")),
+                            ImmutableList.of(a),
+                            Optional.of(new OrderingScheme(ImmutableList.of(a), ImmutableMap.of(a, ASC_NULLS_FIRST))),
+                            REPARTITION,
+                            RetryPolicy.NONE);
+                },
+                new RemoteSourceNodeRepresentation(
+                        new PlanNodeId("0"),
+                        ImmutableList.of(typedSymbol("symbol_97", "bigint")),
+                        ImmutableList.of(new PlanFragmentId("source")),
+                        Optional.of(ImmutableMap.of(symbol("symbol_97"), ASC_NULLS_FIRST)),
+                        REPARTITION));
+    }
+
+    @Test
+    public void testSemiJoinNodeRepresentation()
+    {
+        assertAnonymizedPlan(
+                pb -> {
+                    Symbol a = pb.symbol("a", BIGINT);
+                    Symbol b = pb.symbol("b", BIGINT);
+                    Symbol c = pb.symbol("c", BIGINT);
+                    return pb.semiJoin(
+                            pb.values(a),
+                            pb.values(b, c),
+                            a,
+                            c,
+                            b,
+                            Optional.of(a),
+                            Optional.of(c),
+                            Optional.of(REPLICATED));
+                },
+                new SemiJoinNodeRepresentation(
+                        new PlanNodeId("2"),
+                        ImmutableList.of(typedSymbol("symbol_97", "bigint"), typedSymbol("symbol_98", "bigint")),
+                        ImmutableList.of(
+                                VALUE_A_REPRESENTATION,
+                                new ValuesNodeRepresentation(
+                                        new PlanNodeId("1"),
+                                        ImmutableList.of(typedSymbol("symbol_98", "bigint"), typedSymbol("symbol_99", "bigint")),
+                                        0,
+                                        Optional.of(ImmutableList.of()))),
+                        symbol("symbol_97"),
+                        symbol("symbol_99"),
+                        Optional.of(symbol("symbol_97")),
+                        Optional.of(symbol("symbol_99")),
+                        Optional.of(REPLICATED)));
+    }
+
+    @Test
+    public void testSortNodeRepresentation()
+    {
+        assertAnonymizedPlan(
+                pb -> pb.sort(ImmutableList.of(pb.symbol("a", BIGINT)), pb.values(pb.symbol("a", BIGINT))),
+                new SortNodeRepresentation(
+                        new PlanNodeId("1"),
+                        ImmutableList.of(typedSymbol("symbol_97", "bigint")),
+                        ImmutableList.of(VALUE_A_REPRESENTATION),
+                        ImmutableMap.of(symbol("symbol_97"), ASC_NULLS_FIRST),
+                        false));
+    }
+
+    @Test
+    public void testTopNNodeRepresentation()
+    {
+        assertAnonymizedPlan(
+                pb -> pb.topN(1, ImmutableList.of(pb.symbol("a", BIGINT)), TopNNode.Step.FINAL, pb.values(pb.symbol("a", BIGINT))),
+                new TopNNodeRepresentation(
+                        new PlanNodeId("1"),
+                        ImmutableList.of(typedSymbol("symbol_97", "bigint")),
+                        ImmutableList.of(VALUE_A_REPRESENTATION),
+                        1,
+                        ImmutableMap.of(symbol("symbol_97"), ASC_NULLS_FIRST),
+                        TopNNode.Step.FINAL));
+    }
+
+    @Test
+    public void testWindowNodeRepresentation()
+    {
+        assertAnonymizedPlan(
+                pb -> {
+                    Symbol orderKey = pb.symbol("orderKey", BIGINT);
+                    Symbol partitionKey = pb.symbol("partitionKey", BIGINT);
+                    Symbol hash = pb.symbol("hash", BIGINT);
+                    Symbol startValue = pb.symbol("startValue", BIGINT);
+                    Symbol endValue1 = pb.symbol("endValue1", BIGINT);
+                    Symbol endValue2 = pb.symbol("endValue2", BIGINT);
+                    Symbol input = pb.symbol("input", BIGINT);
+                    Symbol output = pb.symbol("output", BIGINT);
+                    return pb.window(
+                            new WindowNode.Specification(
+                                    ImmutableList.of(partitionKey),
+                                    Optional.of(new OrderingScheme(
+                                            ImmutableList.of(orderKey),
+                                            ImmutableMap.of(orderKey, SortOrder.ASC_NULLS_FIRST)))),
+                            ImmutableMap.of(
+                                    output,
+                                    new WindowNode.Function(
+                                            MIN_FUNCTION,
+                                            ImmutableList.of(input.toSymbolReference()),
+                                            new WindowNode.Frame(
+                                                    WindowFrame.Type.RANGE,
+                                                    UNBOUNDED_PRECEDING,
+                                                    Optional.of(startValue),
+                                                    Optional.of(orderKey),
+                                                    CURRENT_ROW,
+                                                    Optional.of(endValue1),
+                                                    Optional.of(orderKey),
+                                                    Optional.of(startValue.toSymbolReference()),
+                                                    Optional.of(endValue2.toSymbolReference())),
+                                            false)),
+                            hash,
+                            pb.values(input));
+                },
+                new WindowNodeRepresentation(
+                        new PlanNodeId("1"),
+                        ImmutableList.of(typedSymbol("symbol_100358090", "bigint"), typedSymbol("symbol_-1005512447", "bigint")),
+                        ImmutableList.of(new ValuesNodeRepresentation(
+                                new PlanNodeId("0"),
+                                ImmutableList.of(typedSymbol("symbol_100358090", "bigint")),
+                                0,
+                                Optional.of(ImmutableList.of()))),
+                        ImmutableMap.of(symbol("symbol_-1005512447"), "min (\"symbol_100358090\")"),
+                        ImmutableList.of(symbol("symbol_222376725")),
+                        Optional.of(ImmutableMap.of(symbol("symbol_1234285617"), ASC_NULLS_FIRST)),
+                        Optional.of(symbol("symbol_3195150")),
+                        ImmutableSet.of(),
+                        0));
+    }
+
+    private void assertAnonymizedPlan(Function<PlanBuilder, PlanNode> sourceNodeSupplier, AnonymizedNodeRepresentation representation)
+    {
+        PlanBuilder planBuilder = new PlanBuilder(new PlanNodeIdAllocator(), queryRunner.getMetadata(), queryRunner.getDefaultSession());
+        AnonymizedNodeRepresentation actualRepresentation = new AnonymizePlanPrinter(
+                sourceNodeSupplier.apply(planBuilder),
+                planBuilder.getTypes(),
+                tableScanNode -> TABLE_INFO)
+                .generatePlanRepresentation();
+        assertThat(actualRepresentation).isEqualTo(representation);
+    }
+
+    private static Symbol symbol(String symbol)
+    {
+        return new Symbol(symbol);
+    }
+
+    private static TypedSymbol typedSymbol(String symbol, String type)
+    {
+        return new TypedSymbol(new Symbol(symbol), type);
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryMetadata.java
@@ -42,6 +42,8 @@ public class QueryMetadata
 
     private final Optional<String> plan;
 
+    private final Optional<String> anonymizedPlan;
+
     private final Optional<String> payload;
 
     @JsonCreator
@@ -56,6 +58,7 @@ public class QueryMetadata
             List<RoutineInfo> routines,
             URI uri,
             Optional<String> plan,
+            Optional<String> anonymizedPlan,
             Optional<String> payload)
     {
         this.queryId = requireNonNull(queryId, "queryId is null");
@@ -68,6 +71,7 @@ public class QueryMetadata
         this.routines = requireNonNull(routines, "routines is null");
         this.uri = requireNonNull(uri, "uri is null");
         this.plan = requireNonNull(plan, "plan is null");
+        this.anonymizedPlan = requireNonNull(anonymizedPlan, "anonymizedPlan is null");
         this.payload = requireNonNull(payload, "payload is null");
     }
 
@@ -129,6 +133,12 @@ public class QueryMetadata
     public Optional<String> getPlan()
     {
         return plan;
+    }
+
+    @JsonProperty
+    public Optional<String> getAnonymizedPlan()
+    {
+        return anonymizedPlan;
     }
 
     @JsonProperty

--- a/core/trino-spi/src/test/java/io/trino/spi/TestSpiBackwardCompatibility.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/TestSpiBackwardCompatibility.java
@@ -56,7 +56,8 @@ public class TestSpiBackwardCompatibility
             .put("382", ImmutableSet.of(
                     "Method: public io.trino.spi.ptf.TableArgumentSpecification$Builder io.trino.spi.ptf.TableArgumentSpecification$Builder.rowSemantics(boolean)",
                     "Method: public io.trino.spi.ptf.TableArgumentSpecification$Builder io.trino.spi.ptf.TableArgumentSpecification$Builder.pruneWhenEmpty(boolean)",
-                    "Method: public io.trino.spi.ptf.TableArgumentSpecification$Builder io.trino.spi.ptf.TableArgumentSpecification$Builder.passThroughColumns(boolean)"))
+                    "Method: public io.trino.spi.ptf.TableArgumentSpecification$Builder io.trino.spi.ptf.TableArgumentSpecification$Builder.passThroughColumns(boolean)",
+                    "Constructor: public io.trino.spi.eventlistener.QueryMetadata(java.lang.String,java.util.Optional<java.lang.String>,java.lang.String,java.util.Optional<java.lang.String>,java.util.Optional<java.lang.String>,java.lang.String,java.util.List<io.trino.spi.eventlistener.TableInfo>,java.util.List<io.trino.spi.eventlistener.RoutineInfo>,java.net.URI,java.util.Optional<java.lang.String>,java.util.Optional<java.lang.String>)"))
             .buildOrThrow();
 
     @Test

--- a/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpEventListener.java
+++ b/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpEventListener.java
@@ -127,7 +127,9 @@ public class TestHttpEventListener
                 List.of(),
                 List.of(),
                 URI.create("http://localhost"),
-                Optional.empty(), Optional.empty());
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
 
         splitStatistics = new SplitStatistics(
                 ofMillis(1000),

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
@@ -1138,6 +1138,86 @@ public class TestEventListenerBasic
         }
     }
 
+    @Test
+    public void testAnonymizedPlan()
+            throws Exception
+    {
+        runQueryAndWaitForEvents("SELECT nationkey FROM customer LIMIT 10", 2);
+        QueryCompletedEvent event = getOnlyElement(generatedEvents.getQueryCompletedEvents());
+        String anonymizedPlan = "{\n" +
+                "  \"0\" : {\n" +
+                "    \"@type\" : \"default\",\n" +
+                "    \"id\" : \"6\",\n" +
+                "    \"name\" : \"OutputNode\",\n" +
+                "    \"outputLayout\" : [ {\n" +
+                "      \"symbol\" : \"symbol_-1014417992\",\n" +
+                "      \"type\" : \"bigint\"\n" +
+                "    } ],\n" +
+                "    \"sources\" : [ {\n" +
+                "      \"@type\" : \"default\",\n" +
+                "      \"id\" : \"98\",\n" +
+                "      \"name\" : \"LimitNode\",\n" +
+                "      \"outputLayout\" : [ {\n" +
+                "        \"symbol\" : \"symbol_-1014417992\",\n" +
+                "        \"type\" : \"bigint\"\n" +
+                "      } ],\n" +
+                "      \"sources\" : [ {\n" +
+                "        \"@type\" : \"exchange\",\n" +
+                "        \"id\" : \"171\",\n" +
+                "        \"outputLayout\" : [ {\n" +
+                "          \"symbol\" : \"symbol_-1014417992\",\n" +
+                "          \"type\" : \"bigint\"\n" +
+                "        } ],\n" +
+                "        \"sources\" : [ {\n" +
+                "          \"@type\" : \"remoteSource\",\n" +
+                "          \"id\" : \"138\",\n" +
+                "          \"outputLayout\" : [ {\n" +
+                "            \"symbol\" : \"symbol_-1014417992\",\n" +
+                "            \"type\" : \"bigint\"\n" +
+                "          } ],\n" +
+                "          \"sourceFragmentIds\" : [ \"1\" ],\n" +
+                "          \"exchangeType\" : \"GATHER\",\n" +
+                "          \"sources\" : [ ]\n" +
+                "        } ],\n" +
+                "        \"type\" : \"GATHER\",\n" +
+                "        \"scope\" : \"LOCAL\",\n" +
+                "        \"partitionArguments\" : [ ],\n" +
+                "        \"replicateNullsAndAny\" : false\n" +
+                "      } ]\n" +
+                "    } ]\n" +
+                "  },\n" +
+                "  \"1\" : {\n" +
+                "    \"@type\" : \"default\",\n" +
+                "    \"id\" : \"137\",\n" +
+                "    \"name\" : \"LimitNode\",\n" +
+                "    \"outputLayout\" : [ {\n" +
+                "      \"symbol\" : \"symbol_-1014417992\",\n" +
+                "      \"type\" : \"bigint\"\n" +
+                "    } ],\n" +
+                "    \"sources\" : [ {\n" +
+                "      \"@type\" : \"tableScan\",\n" +
+                "      \"id\" : \"0\",\n" +
+                "      \"outputLayout\" : [ {\n" +
+                "        \"symbol\" : \"symbol_-1014417992\",\n" +
+                "        \"type\" : \"bigint\"\n" +
+                "      } ],\n" +
+                "      \"connector\" : \"tpch\",\n" +
+                "      \"catalog\" : \"catalog_3566561\",\n" +
+                "      \"schema\" : \"schema_3560192\",\n" +
+                "      \"table\" : \"table_606175198\",\n" +
+                "      \"assignments\" : {\n" +
+                "        \"symbol_-1014417992\" : \"column_-1014417961\"\n" +
+                "      },\n" +
+                "      \"enforcedConstraint\" : { },\n" +
+                "      \"predicate\" : { },\n" +
+                "      \"sources\" : [ ]\n" +
+                "    } ]\n" +
+                "  }\n" +
+                "}";
+        assertThat(event.getMetadata().getAnonymizedPlan())
+                .isEqualTo(Optional.of(anonymizedPlan));
+    }
+
     private static String getQualifiedName(TableInfo tableInfo)
     {
         return tableInfo.getCatalog() + '.' + tableInfo.getSchema() + '.' + tableInfo.getTable();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

> How would you describe this change to a non-technical end user or system administrator?

This change will eventually help us collect query plans from trino (or products built on trino) users without leaking any sensitive data. These plans then can be used to drive analytics around how people are using trino which essentially helps in improving the product.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
