### PR TITLE
Correct release notes entry

### DIFF
--- a/docs/src/main/sphinx/release/release-376.md
+++ b/docs/src/main/sphinx/release/release-376.md
@@ -62,6 +62,8 @@
   max value exceeds 64 bytes. This improves query performance when filtering on
   such column. ({issue}`11652`)
 * Improve performance when reading Parquet data. ({issue}`11675`)
+* Improve query performance when the same table is referenced multiple times
+  within a query. ({issue}`11650`)
 
 ## Iceberg connector
 
@@ -74,8 +76,6 @@
   max value exceeds 64 bytes. This improves query performance when filtering on
   such column. ({issue}`11652`)
 * Improve performance when reading Parquet data. ({issue}`11675`)
-* Improve query performance when the same table is referenced multiple times
-  within a query. ({issue}`11650`)
 * Fix NPE when an Iceberg data file is missing null count statistics. ({issue}`11832`)
 
 ## Kudu connector

--- a/docs/src/main/sphinx/release/release-378.md
+++ b/docs/src/main/sphinx/release/release-378.md
@@ -27,12 +27,12 @@
 * Fix failure when reading from `information_schema.columns` when metastore
   contains views. ({issue}`11946`)
 * Add support for dropping tables with invalid metadata. ({issue}`11924`)
+* Fix query failure when partition column has a `null` value and query has a
+  complex predicate on that partition column. ({issue}`12056`)
 
 ## Hive connector
 
 * Improve query planning performance. ({issue}`11858`)
-* Fix query failure when partition column has a `null` value and query has a
-  complex predicate on that partition column. ({issue}`12056`)
 
 ## Iceberg connector
 


### PR DESCRIPTION
## Description
Correct release notes entry in release-378.
Refer to: https://github.com/trinodb/trino/issues/11947#issuecomment-1104814745

Correct release notes entry in release-376.
Refer to: https://github.com/trinodb/trino/issues/11692#issuecomment-1088699993

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.