### PR TITLE
Fix the explain (TYPE IO) Exception when table is hive partition tabl…

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/IoPlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/IoPlanPrinter.java
@@ -56,7 +56,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static java.lang.String.format;
@@ -205,17 +204,17 @@ public class IoPlanPrinter
         public static class TableColumnInfo
         {
             private final CatalogSchemaTableName table;
-            private final Set<ColumnConstraint> columnConstraints;
+            private final Constraint constraint;
             private final EstimatedStatsAndCost estimate;
 
             @JsonCreator
             public TableColumnInfo(
                     @JsonProperty("table") CatalogSchemaTableName table,
-                    @JsonProperty("columnConstraints") Set<ColumnConstraint> columnConstraints,
+                    @JsonProperty("constraint") Constraint constraint,
                     @JsonProperty("estimate") EstimatedStatsAndCost estimate)
             {
                 this.table = requireNonNull(table, "table is null");
-                this.columnConstraints = requireNonNull(columnConstraints, "columnConstraints is null");
+                this.constraint = requireNonNull(constraint, "constraint is null");
                 this.estimate = requireNonNull(estimate, "estimate is null");
             }
 
@@ -226,9 +225,9 @@ public class IoPlanPrinter
             }
 
             @JsonProperty
-            public Set<ColumnConstraint> getColumnConstraints()
+            public Constraint getConstraint()
             {
-                return columnConstraints;
+                return constraint;
             }
 
             @JsonProperty
@@ -248,14 +247,14 @@ public class IoPlanPrinter
                 }
                 TableColumnInfo o = (TableColumnInfo) obj;
                 return Objects.equals(table, o.table) &&
-                        Objects.equals(columnConstraints, o.columnConstraints) &&
+                        Objects.equals(constraint, o.constraint) &&
                         Objects.equals(estimate, o.estimate);
             }
 
             @Override
             public int hashCode()
             {
-                return Objects.hash(table, columnConstraints, estimate);
+                return Objects.hash(table, constraint, estimate);
             }
 
             @Override
@@ -263,10 +262,66 @@ public class IoPlanPrinter
             {
                 return toStringHelper(this)
                         .add("table", table)
-                        .add("columnConstraints", columnConstraints)
+                        .add("constraint", constraint)
                         .add("estimate", estimate)
                         .toString();
             }
+        }
+    }
+
+    public static class Constraint
+    {
+        private final boolean isNone;
+        private final Set<ColumnConstraint> columnConstraints;
+
+        @JsonCreator
+        public Constraint(
+                @JsonProperty("none") boolean isNone,
+                @JsonProperty("columnConstraints") Set<ColumnConstraint> columnConstraints)
+        {
+            this.isNone = isNone;
+            this.columnConstraints = ImmutableSet.copyOf(requireNonNull(columnConstraints, "columnConstraints is null"));
+        }
+
+        @JsonProperty
+        public boolean isNone()
+        {
+            return isNone;
+        }
+
+        @JsonProperty
+        public Set<ColumnConstraint> getColumnConstraints()
+        {
+            return columnConstraints;
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            Constraint o = (Constraint) obj;
+            return Objects.equals(isNone, o.isNone) &&
+                    Objects.equals(columnConstraints, o.columnConstraints);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(isNone, columnConstraints);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("none", isNone)
+                    .add("columnConstraints", columnConstraints)
+                    .toString();
         }
     }
 
@@ -703,7 +758,7 @@ public class IoPlanPrinter
                                     tableMetadata.getCatalogName(),
                                     tableMetadata.getTable().getSchemaName(),
                                     tableMetadata.getTable().getTableName()),
-                            parseConstraints(table, predicateDomain.intersect(filterDomain)),
+                            parseConstraint(table, predicateDomain.intersect(filterDomain)),
                             estimatedStatsAndCost));
         }
 
@@ -722,18 +777,20 @@ public class IoPlanPrinter
             return estimatedStatsAndCost;
         }
 
-        private Set<ColumnConstraint> parseConstraints(TableHandle tableHandle, TupleDomain<ColumnHandle> constraint)
+        private Constraint parseConstraint(TableHandle tableHandle, TupleDomain<ColumnHandle> constraint)
         {
-            checkArgument(!constraint.isNone());
+            if (constraint.isNone()) {
+                return new Constraint(true, ImmutableSet.of());
+            }
             ImmutableSet.Builder<ColumnConstraint> columnConstraints = ImmutableSet.builder();
-            for (Map.Entry<ColumnHandle, Domain> entry : constraint.getDomains().get().entrySet()) {
+            for (Map.Entry<ColumnHandle, Domain> entry : constraint.getDomains().orElseThrow().entrySet()) {
                 ColumnMetadata columnMetadata = plannerContext.getMetadata().getColumnMetadata(session, tableHandle, entry.getKey());
                 columnConstraints.add(new ColumnConstraint(
                         columnMetadata.getName(),
                         columnMetadata.getType(),
                         parseDomain(entry.getValue().simplify())));
             }
-            return columnConstraints.build();
+            return new Constraint(false, columnConstraints.build());
         }
 
         private FormattedDomain parseDomain(Domain domain)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -41,6 +41,7 @@ import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 import io.trino.sql.planner.Plan;
 import io.trino.sql.planner.plan.ExchangeNode;
+import io.trino.sql.planner.planprinter.IoPlanPrinter;
 import io.trino.sql.planner.planprinter.IoPlanPrinter.ColumnConstraint;
 import io.trino.sql.planner.planprinter.IoPlanPrinter.EstimatedStatsAndCost;
 import io.trino.sql.planner.planprinter.IoPlanPrinter.FormattedDomain;
@@ -1050,37 +1051,39 @@ public abstract class BaseHiveConnectorTest
                         ImmutableSet.of(
                                 new TableColumnInfo(
                                         new CatalogSchemaTableName(catalog, "tpch", "test_io_explain"),
-                                        ImmutableSet.of(
-                                                new ColumnConstraint(
-                                                        "orderkey",
-                                                        BIGINT,
-                                                        new FormattedDomain(
-                                                                false,
-                                                                ImmutableSet.of(
-                                                                        new FormattedRange(
-                                                                                new FormattedMarker(Optional.of("1"), EXACTLY),
-                                                                                new FormattedMarker(Optional.of("1"), EXACTLY)),
-                                                                        new FormattedRange(
-                                                                                new FormattedMarker(Optional.of("2"), EXACTLY),
-                                                                                new FormattedMarker(Optional.of("2"), EXACTLY))))),
-                                                new ColumnConstraint(
-                                                        "processing",
-                                                        BOOLEAN,
-                                                        new FormattedDomain(
-                                                                false,
-                                                                ImmutableSet.of(
-                                                                        new FormattedRange(
-                                                                                new FormattedMarker(Optional.of("false"), EXACTLY),
-                                                                                new FormattedMarker(Optional.of("false"), EXACTLY))))),
-                                                new ColumnConstraint(
-                                                        "custkey",
-                                                        BIGINT,
-                                                        new FormattedDomain(
-                                                                false,
-                                                                ImmutableSet.of(
-                                                                        new FormattedRange(
-                                                                                new FormattedMarker(Optional.empty(), ABOVE),
-                                                                                new FormattedMarker(Optional.of("10"), EXACTLY)))))),
+                                        new IoPlanPrinter.Constraint(
+                                                false,
+                                                ImmutableSet.of(
+                                                        new ColumnConstraint(
+                                                                "orderkey",
+                                                                BIGINT,
+                                                                new FormattedDomain(
+                                                                        false,
+                                                                        ImmutableSet.of(
+                                                                                new FormattedRange(
+                                                                                        new FormattedMarker(Optional.of("1"), EXACTLY),
+                                                                                        new FormattedMarker(Optional.of("1"), EXACTLY)),
+                                                                                new FormattedRange(
+                                                                                        new FormattedMarker(Optional.of("2"), EXACTLY),
+                                                                                        new FormattedMarker(Optional.of("2"), EXACTLY))))),
+                                                        new ColumnConstraint(
+                                                                "processing",
+                                                                BOOLEAN,
+                                                                new FormattedDomain(
+                                                                        false,
+                                                                        ImmutableSet.of(
+                                                                                new FormattedRange(
+                                                                                        new FormattedMarker(Optional.of("false"), EXACTLY),
+                                                                                        new FormattedMarker(Optional.of("false"), EXACTLY))))),
+                                                        new ColumnConstraint(
+                                                                "custkey",
+                                                                BIGINT,
+                                                                new FormattedDomain(
+                                                                        false,
+                                                                        ImmutableSet.of(
+                                                                                new FormattedRange(
+                                                                                        new FormattedMarker(Optional.empty(), ABOVE),
+                                                                                        new FormattedMarker(Optional.of("10"), EXACTLY))))))),
                                         estimate)),
                         Optional.of(new CatalogSchemaTableName(catalog, "tpch", "test_io_explain")),
                         estimate));
@@ -1098,25 +1101,27 @@ public abstract class BaseHiveConnectorTest
                         ImmutableSet.of(
                                 new TableColumnInfo(
                                         new CatalogSchemaTableName(catalog, "tpch", "test_io_explain"),
-                                        ImmutableSet.of(
-                                                new ColumnConstraint(
-                                                        "orderkey",
-                                                        BIGINT,
-                                                        new FormattedDomain(
-                                                                false,
-                                                                ImmutableSet.of(
-                                                                        new FormattedRange(
-                                                                                new FormattedMarker(Optional.of("1"), EXACTLY),
-                                                                                new FormattedMarker(Optional.of("199"), EXACTLY))))),
-                                                new ColumnConstraint(
-                                                        "custkey",
-                                                        BIGINT,
-                                                        new FormattedDomain(
-                                                                false,
-                                                                ImmutableSet.of(
-                                                                        new FormattedRange(
-                                                                                new FormattedMarker(Optional.empty(), ABOVE),
-                                                                                new FormattedMarker(Optional.of("10"), EXACTLY)))))),
+                                        new IoPlanPrinter.Constraint(
+                                                false,
+                                                ImmutableSet.of(
+                                                        new ColumnConstraint(
+                                                                "orderkey",
+                                                                BIGINT,
+                                                                new FormattedDomain(
+                                                                        false,
+                                                                        ImmutableSet.of(
+                                                                                new FormattedRange(
+                                                                                        new FormattedMarker(Optional.of("1"), EXACTLY),
+                                                                                        new FormattedMarker(Optional.of("199"), EXACTLY))))),
+                                                        new ColumnConstraint(
+                                                                "custkey",
+                                                                BIGINT,
+                                                                new FormattedDomain(
+                                                                        false,
+                                                                        ImmutableSet.of(
+                                                                                new FormattedRange(
+                                                                                        new FormattedMarker(Optional.empty(), ABOVE),
+                                                                                        new FormattedMarker(Optional.of("10"), EXACTLY))))))),
                                         estimate)),
                         Optional.of(new CatalogSchemaTableName(catalog, "tpch", "test_io_explain")),
                         estimate));
@@ -1130,25 +1135,27 @@ public abstract class BaseHiveConnectorTest
                         ImmutableSet.of(
                                 new TableColumnInfo(
                                         new CatalogSchemaTableName(catalog, "tpch", "test_io_explain"),
-                                        ImmutableSet.of(
-                                                new ColumnConstraint(
-                                                        "orderkey",
-                                                        BIGINT,
-                                                        new FormattedDomain(
-                                                                false,
-                                                                ImmutableSet.of(
-                                                                        new FormattedRange(
-                                                                                new FormattedMarker(Optional.of("100"), EXACTLY),
-                                                                                new FormattedMarker(Optional.of("100"), EXACTLY))))),
-                                                new ColumnConstraint(
-                                                        "orderkey",
-                                                        BIGINT,
-                                                        new FormattedDomain(
-                                                                false,
-                                                                ImmutableSet.of(
-                                                                        new FormattedRange(
-                                                                                new FormattedMarker(Optional.of("100"), EXACTLY),
-                                                                                new FormattedMarker(Optional.of("100"), EXACTLY)))))),
+                                        new IoPlanPrinter.Constraint(
+                                                false,
+                                                ImmutableSet.of(
+                                                        new ColumnConstraint(
+                                                                "orderkey",
+                                                                BIGINT,
+                                                                new FormattedDomain(
+                                                                        false,
+                                                                        ImmutableSet.of(
+                                                                                new FormattedRange(
+                                                                                        new FormattedMarker(Optional.of("100"), EXACTLY),
+                                                                                        new FormattedMarker(Optional.of("100"), EXACTLY))))),
+                                                        new ColumnConstraint(
+                                                                "orderkey",
+                                                                BIGINT,
+                                                                new FormattedDomain(
+                                                                        false,
+                                                                        ImmutableSet.of(
+                                                                                new FormattedRange(
+                                                                                        new FormattedMarker(Optional.of("100"), EXACTLY),
+                                                                                        new FormattedMarker(Optional.of("100"), EXACTLY))))))),
                                         estimate)),
                         Optional.of(new CatalogSchemaTableName(catalog, "tpch", "test_io_explain")),
                         finalEstimate));
@@ -1171,37 +1178,39 @@ public abstract class BaseHiveConnectorTest
                         ImmutableSet.of(
                                 new TableColumnInfo(
                                         new CatalogSchemaTableName(catalog, "tpch", "test_io_explain_column_filters"),
-                                        ImmutableSet.of(
-                                                new ColumnConstraint(
-                                                        "orderkey",
-                                                        BIGINT,
-                                                        new FormattedDomain(
-                                                                false,
-                                                                ImmutableSet.of(
-                                                                        new FormattedRange(
-                                                                                new FormattedMarker(Optional.of("1"), EXACTLY),
-                                                                                new FormattedMarker(Optional.of("1"), EXACTLY)),
-                                                                        new FormattedRange(
-                                                                                new FormattedMarker(Optional.of("2"), EXACTLY),
-                                                                                new FormattedMarker(Optional.of("2"), EXACTLY))))),
-                                                new ColumnConstraint(
-                                                        "custkey",
-                                                        BIGINT,
-                                                        new FormattedDomain(
-                                                                false,
-                                                                ImmutableSet.of(
-                                                                        new FormattedRange(
-                                                                                new FormattedMarker(Optional.empty(), ABOVE),
-                                                                                new FormattedMarker(Optional.of("10"), EXACTLY))))),
-                                                new ColumnConstraint(
-                                                        "orderstatus",
-                                                        VarcharType.createVarcharType(1),
-                                                        new FormattedDomain(
-                                                                false,
-                                                                ImmutableSet.of(
-                                                                        new FormattedRange(
-                                                                                new FormattedMarker(Optional.of("P"), EXACTLY),
-                                                                                new FormattedMarker(Optional.of("P"), EXACTLY)))))),
+                                        new IoPlanPrinter.Constraint(
+                                                false,
+                                                ImmutableSet.of(
+                                                        new ColumnConstraint(
+                                                                "orderkey",
+                                                                BIGINT,
+                                                                new FormattedDomain(
+                                                                        false,
+                                                                        ImmutableSet.of(
+                                                                                new FormattedRange(
+                                                                                        new FormattedMarker(Optional.of("1"), EXACTLY),
+                                                                                        new FormattedMarker(Optional.of("1"), EXACTLY)),
+                                                                                new FormattedRange(
+                                                                                        new FormattedMarker(Optional.of("2"), EXACTLY),
+                                                                                        new FormattedMarker(Optional.of("2"), EXACTLY))))),
+                                                        new ColumnConstraint(
+                                                                "custkey",
+                                                                BIGINT,
+                                                                new FormattedDomain(
+                                                                        false,
+                                                                        ImmutableSet.of(
+                                                                                new FormattedRange(
+                                                                                        new FormattedMarker(Optional.empty(), ABOVE),
+                                                                                        new FormattedMarker(Optional.of("10"), EXACTLY))))),
+                                                        new ColumnConstraint(
+                                                                "orderstatus",
+                                                                VarcharType.createVarcharType(1),
+                                                                new FormattedDomain(
+                                                                        false,
+                                                                        ImmutableSet.of(
+                                                                                new FormattedRange(
+                                                                                        new FormattedMarker(Optional.of("P"), EXACTLY),
+                                                                                        new FormattedMarker(Optional.of("P"), EXACTLY))))))),
                                         estimate)),
                         Optional.empty(),
                         finalEstimate));
@@ -1212,40 +1221,42 @@ public abstract class BaseHiveConnectorTest
                         ImmutableSet.of(
                                 new TableColumnInfo(
                                         new CatalogSchemaTableName(catalog, "tpch", "test_io_explain_column_filters"),
-                                        ImmutableSet.of(
-                                                new ColumnConstraint(
-                                                        "orderkey",
-                                                        BIGINT,
-                                                        new FormattedDomain(
-                                                                false,
-                                                                ImmutableSet.of(
-                                                                        new FormattedRange(
-                                                                                new FormattedMarker(Optional.of("1"), EXACTLY),
-                                                                                new FormattedMarker(Optional.of("1"), EXACTLY)),
-                                                                        new FormattedRange(
-                                                                                new FormattedMarker(Optional.of("2"), EXACTLY),
-                                                                                new FormattedMarker(Optional.of("2"), EXACTLY))))),
-                                                new ColumnConstraint(
-                                                        "orderstatus",
-                                                        VarcharType.createVarcharType(1),
-                                                        new FormattedDomain(
-                                                                false,
-                                                                ImmutableSet.of(
-                                                                        new FormattedRange(
-                                                                                new FormattedMarker(Optional.of("P"), EXACTLY),
-                                                                                new FormattedMarker(Optional.of("P"), EXACTLY)),
-                                                                        new FormattedRange(
-                                                                                new FormattedMarker(Optional.of("S"), EXACTLY),
-                                                                                new FormattedMarker(Optional.of("S"), EXACTLY))))),
-                                                new ColumnConstraint(
-                                                        "custkey",
-                                                        BIGINT,
-                                                        new FormattedDomain(
-                                                                false,
-                                                                ImmutableSet.of(
-                                                                        new FormattedRange(
-                                                                                new FormattedMarker(Optional.empty(), ABOVE),
-                                                                                new FormattedMarker(Optional.of("10"), EXACTLY)))))),
+                                        new IoPlanPrinter.Constraint(
+                                                false,
+                                                ImmutableSet.of(
+                                                        new ColumnConstraint(
+                                                                "orderkey",
+                                                                BIGINT,
+                                                                new FormattedDomain(
+                                                                        false,
+                                                                        ImmutableSet.of(
+                                                                                new FormattedRange(
+                                                                                        new FormattedMarker(Optional.of("1"), EXACTLY),
+                                                                                        new FormattedMarker(Optional.of("1"), EXACTLY)),
+                                                                                new FormattedRange(
+                                                                                        new FormattedMarker(Optional.of("2"), EXACTLY),
+                                                                                        new FormattedMarker(Optional.of("2"), EXACTLY))))),
+                                                        new ColumnConstraint(
+                                                                "orderstatus",
+                                                                VarcharType.createVarcharType(1),
+                                                                new FormattedDomain(
+                                                                        false,
+                                                                        ImmutableSet.of(
+                                                                                new FormattedRange(
+                                                                                        new FormattedMarker(Optional.of("P"), EXACTLY),
+                                                                                        new FormattedMarker(Optional.of("P"), EXACTLY)),
+                                                                                new FormattedRange(
+                                                                                        new FormattedMarker(Optional.of("S"), EXACTLY),
+                                                                                        new FormattedMarker(Optional.of("S"), EXACTLY))))),
+                                                        new ColumnConstraint(
+                                                                "custkey",
+                                                                BIGINT,
+                                                                new FormattedDomain(
+                                                                        false,
+                                                                        ImmutableSet.of(
+                                                                                new FormattedRange(
+                                                                                        new FormattedMarker(Optional.empty(), ABOVE),
+                                                                                        new FormattedMarker(Optional.of("10"), EXACTLY))))))),
                                         estimate)),
                         Optional.empty(),
                         finalEstimate));
@@ -1256,33 +1267,57 @@ public abstract class BaseHiveConnectorTest
                         ImmutableSet.of(
                                 new TableColumnInfo(
                                         new CatalogSchemaTableName(catalog, "tpch", "test_io_explain_column_filters"),
-                                        ImmutableSet.of(
-                                                new ColumnConstraint(
-                                                        "orderkey",
-                                                        BIGINT,
-                                                        new FormattedDomain(
-                                                                false,
-                                                                ImmutableSet.of(
-                                                                        new FormattedRange(
-                                                                                new FormattedMarker(Optional.of("1"), EXACTLY),
-                                                                                new FormattedMarker(Optional.of("1"), EXACTLY)),
-                                                                        new FormattedRange(
-                                                                                new FormattedMarker(Optional.of("2"), EXACTLY),
-                                                                                new FormattedMarker(Optional.of("2"), EXACTLY))))),
-                                                new ColumnConstraint(
-                                                        "custkey",
-                                                        BIGINT,
-                                                        new FormattedDomain(
-                                                                false,
-                                                                ImmutableSet.of(
-                                                                        new FormattedRange(
-                                                                                new FormattedMarker(Optional.empty(), ABOVE),
-                                                                                new FormattedMarker(Optional.of("10"), EXACTLY)))))),
+                                        new IoPlanPrinter.Constraint(
+                                                false,
+                                                ImmutableSet.of(
+                                                        new ColumnConstraint(
+                                                                "orderkey",
+                                                                BIGINT,
+                                                                new FormattedDomain(
+                                                                        false,
+                                                                        ImmutableSet.of(
+                                                                                new FormattedRange(
+                                                                                        new FormattedMarker(Optional.of("1"), EXACTLY),
+                                                                                        new FormattedMarker(Optional.of("1"), EXACTLY)),
+                                                                                new FormattedRange(
+                                                                                        new FormattedMarker(Optional.of("2"), EXACTLY),
+                                                                                        new FormattedMarker(Optional.of("2"), EXACTLY))))),
+                                                        new ColumnConstraint(
+                                                                "custkey",
+                                                                BIGINT,
+                                                                new FormattedDomain(
+                                                                        false,
+                                                                        ImmutableSet.of(
+                                                                                new FormattedRange(
+                                                                                        new FormattedMarker(Optional.empty(), ABOVE),
+                                                                                        new FormattedMarker(Optional.of("10"), EXACTLY))))))),
                                         estimate)),
                         Optional.empty(),
                         finalEstimate));
 
         assertUpdate("DROP TABLE test_io_explain_column_filters");
+    }
+
+    @Test
+    public void testIoExplainWithEmptyPartitionedTable()
+    {
+        // Test IO explain a partitioned table with no data.
+        assertUpdate("CREATE TABLE test_io_explain_with_empty_partitioned_table WITH (partitioned_by = ARRAY['orderkey']) AS SELECT custkey, orderkey FROM orders WITH NO DATA", 0);
+
+        EstimatedStatsAndCost estimate = new EstimatedStatsAndCost(0.0, 0.0, 0.0, 0.0, 0.0);
+        MaterializedResult result = computeActual("EXPLAIN (TYPE IO, FORMAT JSON) SELECT custkey, orderkey FROM test_io_explain_with_empty_partitioned_table");
+        assertEquals(
+                getIoPlanCodec().fromJson((String) getOnlyElement(result.getOnlyColumnAsSet())),
+                new IoPlan(
+                        ImmutableSet.of(
+                                new TableColumnInfo(
+                                        new CatalogSchemaTableName(catalog, "tpch", "test_io_explain_with_empty_partitioned_table"),
+                                        new IoPlanPrinter.Constraint(true, ImmutableSet.of()),
+                                        estimate)),
+                        Optional.empty(),
+                        estimate));
+
+        assertUpdate("DROP TABLE test_io_explain_with_empty_partitioned_table");
     }
 
     @Test
@@ -1314,16 +1349,18 @@ public abstract class BaseHiveConnectorTest
                         ImmutableSet.of(
                                 new TableColumnInfo(
                                         new CatalogSchemaTableName(catalog, "tpch", "io_explain_test_no_filter"),
-                                        ImmutableSet.of(
-                                                new ColumnConstraint(
-                                                        "ds",
-                                                        VARCHAR,
-                                                        new FormattedDomain(
-                                                                false,
-                                                                ImmutableSet.of(
-                                                                        new FormattedRange(
-                                                                                new FormattedMarker(Optional.of("a"), EXACTLY),
-                                                                                new FormattedMarker(Optional.of("a"), EXACTLY)))))),
+                                        new IoPlanPrinter.Constraint(
+                                                false,
+                                                ImmutableSet.of(
+                                                        new ColumnConstraint(
+                                                                "ds",
+                                                                VARCHAR,
+                                                                new FormattedDomain(
+                                                                        false,
+                                                                        ImmutableSet.of(
+                                                                                new FormattedRange(
+                                                                                        new FormattedMarker(Optional.of("a"), EXACTLY),
+                                                                                        new FormattedMarker(Optional.of("a"), EXACTLY))))))),
                                         estimate)),
                         Optional.empty(),
                         finalEstimate));
@@ -1359,25 +1396,27 @@ public abstract class BaseHiveConnectorTest
                         ImmutableSet.of(
                                 new TableColumnInfo(
                                         new CatalogSchemaTableName(catalog, "tpch", "io_explain_test_filter_on_agg"),
-                                        ImmutableSet.of(
-                                                new ColumnConstraint(
-                                                        "ds",
-                                                        VARCHAR,
-                                                        new FormattedDomain(
-                                                                false,
-                                                                ImmutableSet.of(
-                                                                        new FormattedRange(
-                                                                                new FormattedMarker(Optional.of("a"), EXACTLY),
-                                                                                new FormattedMarker(Optional.of("a"), EXACTLY))))),
-                                                new ColumnConstraint(
-                                                        "b",
-                                                        VARCHAR,
-                                                        new FormattedDomain(
-                                                                false,
-                                                                ImmutableSet.of(
-                                                                        new FormattedRange(
-                                                                                new FormattedMarker(Optional.of("b"), EXACTLY),
-                                                                                new FormattedMarker(Optional.of("b"), EXACTLY)))))),
+                                        new IoPlanPrinter.Constraint(
+                                                false,
+                                                ImmutableSet.of(
+                                                        new ColumnConstraint(
+                                                                "ds",
+                                                                VARCHAR,
+                                                                new FormattedDomain(
+                                                                        false,
+                                                                        ImmutableSet.of(
+                                                                                new FormattedRange(
+                                                                                        new FormattedMarker(Optional.of("a"), EXACTLY),
+                                                                                        new FormattedMarker(Optional.of("a"), EXACTLY))))),
+                                                        new ColumnConstraint(
+                                                                "b",
+                                                                VARCHAR,
+                                                                new FormattedDomain(
+                                                                        false,
+                                                                        ImmutableSet.of(
+                                                                                new FormattedRange(
+                                                                                        new FormattedMarker(Optional.of("b"), EXACTLY),
+                                                                                        new FormattedMarker(Optional.of("b"), EXACTLY))))))),
                                         estimate)),
                         Optional.empty(),
                         finalEstimate));
@@ -1413,21 +1452,24 @@ public abstract class BaseHiveConnectorTest
                     type.getDisplayName());
 
             assertUpdate(query, 1);
+
             assertEquals(
                     getIoPlanCodec().fromJson((String) getOnlyElement(computeActual("EXPLAIN (TYPE IO, FORMAT JSON) SELECT * FROM test_types_table").getOnlyColumnAsSet())),
                     new IoPlan(
                             ImmutableSet.of(new TableColumnInfo(
                                     new CatalogSchemaTableName(catalog, "tpch", "test_types_table"),
-                                    ImmutableSet.of(
-                                            new ColumnConstraint(
-                                                    "my_col",
-                                                    type,
-                                                    new FormattedDomain(
-                                                            false,
-                                                            ImmutableSet.of(
-                                                                    new FormattedRange(
-                                                                            new FormattedMarker(Optional.of(entry.getKey().toString()), EXACTLY),
-                                                                            new FormattedMarker(Optional.of(entry.getKey().toString()), EXACTLY)))))),
+                                    new IoPlanPrinter.Constraint(
+                                            false,
+                                            ImmutableSet.of(
+                                                    new ColumnConstraint(
+                                                            "my_col",
+                                                            type,
+                                                            new FormattedDomain(
+                                                                    false,
+                                                                    ImmutableSet.of(
+                                                                            new FormattedRange(
+                                                                                    new FormattedMarker(Optional.of(entry.getKey().toString()), EXACTLY),
+                                                                                    new FormattedMarker(Optional.of(entry.getKey().toString()), EXACTLY))))))),
                                     estimate)),
                             Optional.empty(),
                             estimate),
@@ -8301,6 +8343,7 @@ public abstract class BaseHiveConnectorTest
         Set<ColumnConstraint> constraints = getIoPlanCodec().fromJson((String) getOnlyElement(result.getOnlyColumnAsSet()))
                 .getInputTableColumnInfos().stream()
                 .findFirst().get()
+                .getConstraint()
                 .getColumnConstraints();
 
         assertTrue(constraints.containsAll(expected));

--- a/testing/trino-tests/src/test/java/io/trino/tests/tpch/TestTpchConnectorTest.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/tpch/TestTpchConnectorTest.java
@@ -97,24 +97,27 @@ public class TestTpchConnectorTest
         MaterializedResult result = computeActual("EXPLAIN (TYPE IO, FORMAT JSON) " + query);
         EstimatedStatsAndCost scanEstimate = new EstimatedStatsAndCost(15000.0, 1597294.0, 1597294.0, 0.0, 0.0);
         EstimatedStatsAndCost totalEstimate = new EstimatedStatsAndCost(15000.0, 1597294.0, 1597294.0, 0.0, 1597294.0);
+
         IoPlanPrinter.IoPlan.TableColumnInfo input = new IoPlanPrinter.IoPlan.TableColumnInfo(
                 new CatalogSchemaTableName("tpch", "tiny", "orders"),
-                ImmutableSet.of(
-                        new IoPlanPrinter.ColumnConstraint(
-                                "orderstatus",
-                                createVarcharType(1),
-                                new IoPlanPrinter.FormattedDomain(
-                                        false,
-                                        ImmutableSet.of(
-                                                new IoPlanPrinter.FormattedRange(
-                                                        new IoPlanPrinter.FormattedMarker(Optional.of("F"), EXACTLY),
-                                                        new IoPlanPrinter.FormattedMarker(Optional.of("F"), EXACTLY)),
-                                                new IoPlanPrinter.FormattedRange(
-                                                        new IoPlanPrinter.FormattedMarker(Optional.of("O"), EXACTLY),
-                                                        new IoPlanPrinter.FormattedMarker(Optional.of("O"), EXACTLY)),
-                                                new IoPlanPrinter.FormattedRange(
-                                                        new IoPlanPrinter.FormattedMarker(Optional.of("P"), EXACTLY),
-                                                        new IoPlanPrinter.FormattedMarker(Optional.of("P"), EXACTLY)))))),
+                new IoPlanPrinter.Constraint(
+                        false,
+                        ImmutableSet.of(
+                                new IoPlanPrinter.ColumnConstraint(
+                                        "orderstatus",
+                                        createVarcharType(1),
+                                        new IoPlanPrinter.FormattedDomain(
+                                                false,
+                                                ImmutableSet.of(
+                                                        new IoPlanPrinter.FormattedRange(
+                                                                new IoPlanPrinter.FormattedMarker(Optional.of("F"), EXACTLY),
+                                                                new IoPlanPrinter.FormattedMarker(Optional.of("F"), EXACTLY)),
+                                                        new IoPlanPrinter.FormattedRange(
+                                                                new IoPlanPrinter.FormattedMarker(Optional.of("O"), EXACTLY),
+                                                                new IoPlanPrinter.FormattedMarker(Optional.of("O"), EXACTLY)),
+                                                        new IoPlanPrinter.FormattedRange(
+                                                                new IoPlanPrinter.FormattedMarker(Optional.of("P"), EXACTLY),
+                                                                new IoPlanPrinter.FormattedMarker(Optional.of("P"), EXACTLY))))))),
                 scanEstimate);
 
         ObjectMapperProvider objectMapperProvider = new ObjectMapperProvider();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
Fix the explain (TYPE IO) Exception when table is hive partition table which is empty
<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
Yes, [a bug fix](https://github.com/trinodb/trino/issues/10398)
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
This a change for HIVE connector
> How would you describe this change to a non-technical end user or system administrator?
Fix the explain (TYPE IO) Exception when table is hive partition table which is empty
## Related issues, pull requests, and links
https://github.com/trinodb/trino/issues/10398

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #10398
* Related documentation in #10398
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(+) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(+) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`10398`)
```
