### PR TITLE
Add builders for table function arguments

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -1669,7 +1669,10 @@ class StatementAnalyzer
                 Type expectedArgumentType = ((ScalarArgumentSpecification) argumentSpecification).getType();
                 // currently, only constant arguments are supported
                 Object constantValue = ExpressionInterpreter.evaluateConstantExpression(expression, expectedArgumentType, plannerContext, session, accessControl, analysis.getParameters());
-                return new ScalarArgument(expectedArgumentType, constantValue); // TODO test coercion, test parameter
+                return ScalarArgument.builder()
+                        .type(expectedArgumentType)
+                        .value(constantValue)
+                        .build(); // TODO test coercion, test parameter
             }
 
             throw new IllegalStateException("Unexpected argument specification: " + argumentSpecification.getClass().getSimpleName());
@@ -1687,7 +1690,10 @@ class StatementAnalyzer
                 throw semanticException(NOT_SUPPORTED, errorLocation, "Descriptor arguments are not yet supported for table functions");
             }
             if (argumentSpecification instanceof ScalarArgumentSpecification) {
-                return new ScalarArgument(((ScalarArgumentSpecification) argumentSpecification).getType(), argumentSpecification.getDefaultValue());
+                return ScalarArgument.builder()
+                        .type(((ScalarArgumentSpecification) argumentSpecification).getType())
+                        .value(argumentSpecification.getDefaultValue())
+                        .build();
             }
 
             throw new IllegalStateException("Unexpected argument specification: " + argumentSpecification.getClass().getSimpleName());

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/ArgumentSpecification.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/ArgumentSpecification.java
@@ -36,7 +36,7 @@ public abstract class ArgumentSpecification
     // native representation
     private final Object defaultValue;
 
-    public ArgumentSpecification(String name, boolean required, @Nullable Object defaultValue)
+    ArgumentSpecification(String name, boolean required, @Nullable Object defaultValue)
     {
         this.name = checkNotNullOrEmpty(name, "name");
         checkArgument(!required || defaultValue == null, "non-null default value for a required argument");

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/DescriptorArgument.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/DescriptorArgument.java
@@ -30,17 +30,11 @@ import static java.util.Objects.requireNonNull;
 public class DescriptorArgument
         extends Argument
 {
-    public static final DescriptorArgument NULL_DESCRIPTOR = new DescriptorArgument(Optional.empty());
+    public static final DescriptorArgument NULL_DESCRIPTOR = builder().build();
     private final Optional<Descriptor> descriptor;
 
-    public static DescriptorArgument descriptorArgument(Descriptor descriptor)
-    {
-        requireNonNull(descriptor, "descriptor is null");
-        return new DescriptorArgument(Optional.of(descriptor));
-    }
-
     @JsonCreator
-    private DescriptorArgument(@JsonProperty("descriptor") Optional<Descriptor> descriptor)
+    public DescriptorArgument(@JsonProperty("descriptor") Optional<Descriptor> descriptor)
     {
         this.descriptor = requireNonNull(descriptor, "descriptor is null");
     }
@@ -49,5 +43,28 @@ public class DescriptorArgument
     public Optional<Descriptor> getDescriptor()
     {
         return descriptor;
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private Descriptor descriptor;
+
+        private Builder() {}
+
+        public Builder descriptor(Descriptor descriptor)
+        {
+            this.descriptor = descriptor;
+            return this;
+        }
+
+        public DescriptorArgument build()
+        {
+            return new DescriptorArgument(Optional.ofNullable(descriptor));
+        }
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/DescriptorArgumentSpecification.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/DescriptorArgumentSpecification.java
@@ -16,13 +16,40 @@ package io.trino.spi.ptf;
 public class DescriptorArgumentSpecification
         extends ArgumentSpecification
 {
-    public DescriptorArgumentSpecification(String name)
+    private DescriptorArgumentSpecification(String name, boolean required, Descriptor defaultValue)
     {
-        super(name, true, null);
+        super(name, required, defaultValue);
     }
 
-    public DescriptorArgumentSpecification(String name, Descriptor defaultValue)
+    public static Builder builder()
     {
-        super(name, false, defaultValue);
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private String name;
+        private boolean required = true;
+        private Descriptor defaultValue;
+
+        private Builder() {}
+
+        public Builder name(String name)
+        {
+            this.name = name;
+            return this;
+        }
+
+        public Builder defaultValue(Descriptor defaultValue)
+        {
+            this.required = false;
+            this.defaultValue = defaultValue;
+            return this;
+        }
+
+        public DescriptorArgumentSpecification build()
+        {
+            return new DescriptorArgumentSpecification(name, required, defaultValue);
+        }
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/ScalarArgument.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/ScalarArgument.java
@@ -55,4 +55,34 @@ public class ScalarArgument
     {
         return value;
     }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private Type type;
+        private Object value;
+
+        private Builder() {}
+
+        public Builder type(Type type)
+        {
+            this.type = type;
+            return this;
+        }
+
+        public Builder value(Object value)
+        {
+            this.value = value;
+            return this;
+        }
+
+        public ScalarArgument build()
+        {
+            return new ScalarArgument(type, value);
+        }
+    }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/ScalarArgumentSpecification.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/ScalarArgumentSpecification.java
@@ -24,21 +24,56 @@ public class ScalarArgumentSpecification
 {
     private final Type type;
 
-    public ScalarArgumentSpecification(String name, Type type)
+    private ScalarArgumentSpecification(String name, Type type, boolean required, Object defaultValue)
     {
-        super(name, true, null);
+        super(name, required, defaultValue);
         this.type = requireNonNull(type, "type is null");
-    }
-
-    public ScalarArgumentSpecification(String name, Type type, Object defaultValue)
-    {
-        super(name, false, defaultValue);
-        this.type = requireNonNull(type, "type is null");
-        checkArgument(type.getJavaType().equals(defaultValue.getClass()), format("default value %s does not match the declared type: %s", defaultValue, type));
+        if (defaultValue != null) {
+            checkArgument(type.getJavaType().equals(defaultValue.getClass()), format("default value %s does not match the declared type: %s", defaultValue, type));
+        }
     }
 
     public Type getType()
     {
         return type;
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private String name;
+        private Type type;
+        private boolean required = true;
+        private Object defaultValue;
+
+        private Builder() {}
+
+        public Builder name(String name)
+        {
+            this.name = name;
+            return this;
+        }
+
+        public Builder type(Type type)
+        {
+            this.type = type;
+            return this;
+        }
+
+        public Builder defaultValue(Object defaultValue)
+        {
+            this.required = false;
+            this.defaultValue = defaultValue;
+            return this;
+        }
+
+        public ScalarArgumentSpecification build()
+        {
+            return new ScalarArgumentSpecification(name, type, required, defaultValue);
+        }
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/TableArgument.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/TableArgument.java
@@ -102,6 +102,71 @@ public class TableArgument
         return passThroughColumns;
     }
 
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private Optional<QualifiedName> name;
+        private RowType rowType;
+        private List<String> partitionBy = List.of();
+        private List<SortItem> orderBy = List.of();
+        private boolean rowSemantics;
+        private boolean pruneWhenEmpty;
+        private boolean passThroughColumns;
+
+        private Builder() {}
+
+        public Builder name(Optional<QualifiedName> name)
+        {
+            this.name = name;
+            return this;
+        }
+
+        public Builder rowType(RowType rowType)
+        {
+            this.rowType = rowType;
+            return this;
+        }
+
+        public Builder partitionBy(List<String> partitionBy)
+        {
+            this.partitionBy = partitionBy;
+            return this;
+        }
+
+        public Builder orderBy(List<SortItem> orderBy)
+        {
+            this.orderBy = orderBy;
+            return this;
+        }
+
+        public Builder rowSemantics(boolean rowSemantics)
+        {
+            this.rowSemantics = rowSemantics;
+            return this;
+        }
+
+        public Builder pruneWhenEmpty(boolean pruneWhenEmpty)
+        {
+            this.pruneWhenEmpty = pruneWhenEmpty;
+            return this;
+        }
+
+        public Builder passThroughColumns(boolean passThroughColumns)
+        {
+            this.passThroughColumns = passThroughColumns;
+            return this;
+        }
+
+        public TableArgument build()
+        {
+            return new TableArgument(name, rowType, partitionBy, orderBy, rowSemantics, pruneWhenEmpty, passThroughColumns);
+        }
+    }
+
     public static class QualifiedName
     {
         private final String catalogName;

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/TableArgumentSpecification.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/TableArgumentSpecification.java
@@ -20,19 +20,13 @@ public class TableArgumentSpecification
     private final boolean pruneWhenEmpty;
     private final boolean passThroughColumns;
 
-    public TableArgumentSpecification(String name, boolean rowSemantics, boolean pruneWhenEmpty, boolean passThroughColumns)
+    private TableArgumentSpecification(String name, boolean rowSemantics, boolean pruneWhenEmpty, boolean passThroughColumns)
     {
         super(name, true, null);
 
         this.rowSemantics = rowSemantics;
         this.pruneWhenEmpty = pruneWhenEmpty;
         this.passThroughColumns = passThroughColumns;
-    }
-
-    public TableArgumentSpecification(String name)
-    {
-        // defaults
-        this(name, false, false, false);
     }
 
     public boolean isRowSemantics()
@@ -48,5 +42,49 @@ public class TableArgumentSpecification
     public boolean isPassThroughColumns()
     {
         return passThroughColumns;
+    }
+
+    public static Builder builder(String name)
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private String name;
+        private boolean rowSemantics;
+        private boolean pruneWhenEmpty;
+        private boolean passThroughColumns;
+
+        private Builder() {}
+
+        public Builder name(String name)
+        {
+            this.name = name;
+            return this;
+        }
+
+        public Builder rowSemantics(boolean rowSemantics)
+        {
+            this.rowSemantics = rowSemantics;
+            return this;
+        }
+
+        public Builder pruneWhenEmpty(boolean pruneWhenEmpty)
+        {
+            this.pruneWhenEmpty = pruneWhenEmpty;
+            return this;
+        }
+
+        public Builder passThroughColumns(boolean passThroughColumns)
+        {
+            this.passThroughColumns = passThroughColumns;
+            return this;
+        }
+
+        public TableArgumentSpecification build()
+        {
+            return new TableArgumentSpecification(name, rowSemantics, pruneWhenEmpty, passThroughColumns);
+        }
     }
 }


### PR DESCRIPTION
Adds builders for
- table function argument specifications
- table function passed arguments

Makes constructors of those classes private.

This is a SPI change. No release notes needed if this change is merged before the upcoming release (the main change has not been yet released)

This change has to be taken into account in the documentation (https://github.com/trinodb/trino/pull/12338)