### PR TITLE
Allow executing optimize procedure for Iceberg v2 table

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergOptimizeHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergOptimizeHandle.java
@@ -30,6 +30,7 @@ import static java.util.Objects.requireNonNull;
 public class IcebergOptimizeHandle
         extends IcebergProcedureHandle
 {
+    private final long snapshotId;
     private final String schemaAsJson;
     private final String partitionSpecAsJson;
     private final List<IcebergColumnHandle> tableColumns;
@@ -40,6 +41,7 @@ public class IcebergOptimizeHandle
 
     @JsonCreator
     public IcebergOptimizeHandle(
+            long snapshotId,
             String schemaAsJson,
             String partitionSpecAsJson,
             List<IcebergColumnHandle> tableColumns,
@@ -48,6 +50,7 @@ public class IcebergOptimizeHandle
             DataSize maxScannedFileSize,
             boolean retriesEnabled)
     {
+        this.snapshotId = snapshotId;
         this.schemaAsJson = requireNonNull(schemaAsJson, "schemaAsJson is null");
         this.partitionSpecAsJson = requireNonNull(partitionSpecAsJson, "partitionSpecAsJson is null");
         this.tableColumns = ImmutableList.copyOf(requireNonNull(tableColumns, "tableColumns is null"));
@@ -55,6 +58,12 @@ public class IcebergOptimizeHandle
         this.tableStorageProperties = ImmutableMap.copyOf(requireNonNull(tableStorageProperties, "tableStorageProperties is null"));
         this.maxScannedFileSize = requireNonNull(maxScannedFileSize, "maxScannedFileSize is null");
         this.retriesEnabled = retriesEnabled;
+    }
+
+    @JsonProperty
+    public long getSnapshotId()
+    {
+        return snapshotId;
     }
 
     @JsonProperty
@@ -103,6 +112,7 @@ public class IcebergOptimizeHandle
     public String toString()
     {
         return toStringHelper(this)
+                .add("snapshotId", snapshotId)
                 .add("schemaAsJson", schemaAsJson)
                 .add("partitionSpecAsJson", partitionSpecAsJson)
                 .add("tableColumns", tableColumns)


### PR DESCRIPTION
## Description

Allow optimizing v2 table if delete files don't exist in Iceberg

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# Iceberg
* Allow executing `optimize` procedure for v2 table. ({issue}`12351`)
```
