### PR TITLE
Fix memory connector's renameView shadowing a table

### DIFF
--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryMetadata.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryMetadata.java
@@ -306,8 +306,8 @@ public class MemoryMetadata
     public synchronized void createView(ConnectorSession session, SchemaTableName viewName, ConnectorViewDefinition definition, boolean replace)
     {
         checkSchemaExists(viewName.getSchemaName());
-        if (tableIds.containsKey(viewName)) {
-            throw new TrinoException(ALREADY_EXISTS, "Table already exists: " + viewName);
+        if (tableIds.containsKey(viewName) && !replace) {
+            throw new TrinoException(ALREADY_EXISTS, "View already exists: " + viewName);
         }
 
         if (replace) {
@@ -316,20 +316,27 @@ public class MemoryMetadata
         else if (views.putIfAbsent(viewName, definition) != null) {
             throw new TrinoException(ALREADY_EXISTS, "View already exists: " + viewName);
         }
+        tableIds.put(viewName, nextTableId.getAndIncrement());
     }
 
     @Override
     public synchronized void renameView(ConnectorSession session, SchemaTableName viewName, SchemaTableName newViewName)
     {
         checkSchemaExists(newViewName.getSchemaName());
+
+        if (!tableIds.containsKey(viewName)) {
+            throw new TrinoException(NOT_FOUND, "View not found: " + viewName);
+        }
+
         if (tableIds.containsKey(newViewName)) {
-            throw new TrinoException(ALREADY_EXISTS, "Table already exists: " + newViewName);
+            throw new TrinoException(ALREADY_EXISTS, "View already exists: " + newViewName);
         }
 
         if (views.containsKey(newViewName)) {
             throw new TrinoException(ALREADY_EXISTS, "View already exists: " + newViewName);
         }
 
+        tableIds.put(newViewName, tableIds.remove(viewName));
         views.put(newViewName, views.remove(viewName));
     }
 
@@ -339,6 +346,7 @@ public class MemoryMetadata
         if (views.remove(viewName) == null) {
             throw new ViewNotFoundException(viewName);
         }
+        tableIds.remove(viewName);
     }
 
     @Override

--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
@@ -555,7 +555,7 @@ public class TestMemoryConnectorTest
         assertUpdate("CREATE VIEW test_view AS SELECT 123 x");
         assertUpdate("CREATE OR REPLACE VIEW test_view AS " + query);
 
-        assertQueryFails("CREATE TABLE test_view (x date)", "View \\[default.test_view] already exists");
+        assertQueryFails("CREATE TABLE test_view (x date)", ".*Table 'memory.default.test_view' already exists");
         assertQueryFails("CREATE VIEW test_view AS SELECT 123 x", ".*View already exists: 'memory.default.test_view'");
 
         assertQuery("SELECT * FROM test_view", query);


### PR DESCRIPTION
Required to allow SELECT from the view, and to ensure
that renameView works correctly.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

This is a fix for `MemoryConnector`'s `renameView`, and it prevents collisions between table names and view names.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

This is a change to the memory connector

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
