### PR TITLE
Enlarge font size on tables in docs

### DIFF
--- a/docs/src/main/sphinx/static/trino.css
+++ b/docs/src/main/sphinx/static/trino.css
@@ -60,6 +60,10 @@ pre.literal-block {
     font-size: 0.8rem
 }
 
+.md-typeset table:not([class]) {
+    font-size: unset;
+}
+
 @media only screen and (min-width: 88.25em) {
     .md-grid {
         max-width: 61rem;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Font size in tables in docs is quite small, this is a simple CSS change to enhance readability. Screenshots in comments below.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Docs

> How would you describe this change to a non-technical end user or system administrator?

We're improving the readability of docs.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
