### PR TITLE
Bundle Iceberg reads into combined scan tasks

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -170,6 +170,8 @@ public final class SystemSessionProperties
     public static final String ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS = "adaptive_partial_aggregation_min_rows";
     public static final String ADAPTIVE_PARTIAL_AGGREGATION_UNIQUE_ROWS_RATIO_THRESHOLD = "adaptive_partial_aggregation_unique_rows_ratio_threshold";
     public static final String JOIN_PARTITIONED_BUILD_MIN_ROW_COUNT = "join_partitioned_build_min_row_count";
+    public static final String MAX_SPLITS_PER_NODE = "max_splits_per_node";
+    public static final String MAX_PENDING_SPLITS_PER_TASK = "mas_pending_splits_per_task";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -830,6 +832,16 @@ public final class SystemSessionProperties
                         "Minimum number of join build side rows required to use partitioned join lookup",
                         optimizerConfig.getJoinPartitionedBuildMinRowCount(),
                         value -> validateNonNegativeLongValue(value, JOIN_PARTITIONED_BUILD_MIN_ROW_COUNT),
+                        false),
+                integerProperty(
+                        MAX_SPLITS_PER_NODE,
+                        "Maximum number of splits per node",
+                        nodeSchedulerConfig.getMaxSplitsPerNode(),
+                        false),
+                integerProperty(
+                        MAX_PENDING_SPLITS_PER_TASK,
+                        "Maximum number of pending splits per task",
+                        nodeSchedulerConfig.getMaxPendingSplitsPerTask(),
                         false));
     }
 
@@ -1497,5 +1509,15 @@ public final class SystemSessionProperties
     public static long getJoinPartitionedBuildMinRowCount(Session session)
     {
         return session.getSystemProperty(JOIN_PARTITIONED_BUILD_MIN_ROW_COUNT, Long.class);
+    }
+
+    public static int getMaxSplitsPerNode(Session session)
+    {
+        return session.getSystemProperty(MAX_SPLITS_PER_NODE, Integer.class);
+    }
+
+    public static int getMaxPendingSplitsPerTask(Session session)
+    {
+        return session.getSystemProperty(MAX_PENDING_SPLITS_PER_TASK, Integer.class);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/CombinedIcebergSplit.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/CombinedIcebergSplit.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.HostAddress;
+import io.trino.spi.SplitWeight;
 import io.trino.spi.connector.ConnectorSplit;
 
 import java.util.Collection;
@@ -31,11 +32,13 @@ public class CombinedIcebergSplit
         implements ConnectorSplit
 {
     List<IcebergSplit> entries;
+    private final SplitWeight splitWeight;
 
     @JsonCreator
-    public CombinedIcebergSplit(@JsonProperty("entries") List<IcebergSplit> entries)
+    public CombinedIcebergSplit(@JsonProperty("entries") List<IcebergSplit> entries, @JsonProperty("splitWeight") SplitWeight splitWeight)
     {
         this.entries = ImmutableList.copyOf(requireNonNull(entries, "entries is null"));
+        this.splitWeight = requireNonNull(splitWeight, "splitWeight is null");
     }
 
     @JsonProperty
@@ -67,10 +70,17 @@ public class CombinedIcebergSplit
                 .collect(toImmutableList());
     }
 
+    @JsonProperty
+    @Override
+    public SplitWeight getSplitWeight()
+    {
+        return splitWeight;
+    }
+
     @Override
     public long getRetainedSizeInBytes()
     {
-        return entries.stream()
+        return splitWeight.getRetainedSizeInBytes() + entries.stream()
                 .mapToLong(IcebergSplit::getRetainedSizeInBytes)
                 .sum();
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/CombinedIcebergSplit.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/CombinedIcebergSplit.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects.ToStringHelper;
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.HostAddress;
+import io.trino.spi.connector.ConnectorSplit;
+
+import java.util.Collection;
+import java.util.List;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class CombinedIcebergSplit
+        implements ConnectorSplit
+{
+    List<IcebergSplit> entries;
+
+    @JsonCreator
+    public CombinedIcebergSplit(@JsonProperty("entries") List<IcebergSplit> entries)
+    {
+        this.entries = ImmutableList.copyOf(requireNonNull(entries, "entries is null"));
+    }
+
+    @JsonProperty
+    public List<IcebergSplit> getEntries()
+    {
+        return entries;
+    }
+
+    @Override
+    public boolean isRemotelyAccessible()
+    {
+        return true;
+    }
+
+    @Override
+    public List<HostAddress> getAddresses()
+    {
+        return entries.stream()
+                .map(IcebergSplit::getAddresses)
+                .flatMap(Collection::stream)
+                .collect(toImmutableList());
+    }
+
+    @Override
+    public Object getInfo()
+    {
+        return entries.stream()
+                .map(IcebergSplit::getInfo)
+                .collect(toImmutableList());
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return entries.stream()
+                .mapToLong(IcebergSplit::getRetainedSizeInBytes)
+                .sum();
+    }
+
+    @Override
+    public String toString()
+    {
+        ToStringHelper toStringHelper = toStringHelper(this);
+        entries.forEach(toStringHelper::addValue);
+        return toStringHelper.toString();
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergCombinedPageSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergCombinedPageSource.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Closer;
+import io.trino.spi.Page;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.EmptyPageSource;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.Collections.emptyIterator;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Concatenates the Pages for all PageSources which were grouped together an Iceberg CombinedScanTask.
+ */
+public class IcebergCombinedPageSource
+        implements ConnectorPageSource
+{
+    private final List<ConnectorPageSource> delegatePageSources;
+    private final Iterator<ConnectorPageSource> pageSourceIterator;
+    private final Closer closer = Closer.create();
+
+    private ConnectorPageSource currentPageSource;
+    private long completedBytes;
+    private long readTimeNanos;
+
+    public IcebergCombinedPageSource(List<ConnectorPageSource> delegatePageSources)
+    {
+        if (delegatePageSources.isEmpty()) {
+            this.delegatePageSources = ImmutableList.of();
+            this.pageSourceIterator = emptyIterator();
+            this.currentPageSource = new EmptyPageSource();
+        }
+        else {
+            this.delegatePageSources = ImmutableList.copyOf(requireNonNull(delegatePageSources, "delegatePageSources is null"));
+            this.pageSourceIterator = delegatePageSources.iterator();
+            this.currentPageSource = pageSourceIterator.next();
+            this.delegatePageSources.forEach(closer::register);
+        }
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return completedBytes + currentPageSource.getCompletedBytes();
+    }
+
+    @Override
+    public OptionalLong getCompletedPositions()
+    {
+        return delegatePageSources.stream()
+                .map(ConnectorPageSource::getCompletedPositions)
+                .reduce(OptionalLong.of(0), (accumulatedPositions, newPositions) -> {
+                    if (accumulatedPositions.isPresent() && newPositions.isPresent()) {
+                        return OptionalLong.of(accumulatedPositions.getAsLong() + newPositions.getAsLong());
+                    }
+                    return OptionalLong.empty();
+                });
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return readTimeNanos + currentPageSource.getReadTimeNanos();
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return !pageSourceIterator.hasNext() && currentPageSource.isFinished();
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        if (currentPageSource.isFinished()) {
+            completedBytes += currentPageSource.getReadTimeNanos();
+            readTimeNanos += currentPageSource.getReadTimeNanos();
+            try {
+                currentPageSource = pageSourceIterator.next();
+            }
+            catch (NoSuchElementException e) {
+                currentPageSource = new EmptyPageSource();
+            }
+        }
+
+        return currentPageSource.getNextPage();
+    }
+
+    @Override
+    public long getMemoryUsage()
+    {
+        return delegatePageSources.stream()
+                .mapToLong(ConnectorPageSource::getMemoryUsage)
+                .sum();
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        closer.close();
+    }
+
+    @Override
+    public CompletableFuture<?> isBlocked()
+    {
+        return currentPageSource.isBlocked();
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -297,6 +297,7 @@ public class IcebergMetadata
                 table.location(),
                 table.properties(),
                 NO_RETRIES,
+                false,
                 ImmutableList.of());
     }
 
@@ -1338,7 +1339,7 @@ public class IcebergMetadata
         }
         verify(transaction == null, "transaction already set");
         transaction = catalog.loadTable(session, table.getSchemaTableName()).newTransaction();
-        return table.withRetryMode(retryMode);
+        return table.withRetryMode(retryMode).forUpdateOrDelete();
     }
 
     @Override
@@ -1363,6 +1364,7 @@ public class IcebergMetadata
         verify(transaction == null, "transaction already set");
         transaction = catalog.loadTable(session, table.getSchemaTableName()).newTransaction();
         return table.withRetryMode(retryMode)
+                .forUpdateOrDelete()
                 .withUpdatedColumns(updatedColumns.stream()
                         .map(IcebergColumnHandle.class::cast)
                         .collect(toImmutableList()));
@@ -1660,6 +1662,7 @@ public class IcebergMetadata
                         table.getTableLocation(),
                         table.getStorageProperties(),
                         table.getRetryMode(),
+                        table.isUpdateOrDelete(),
                         table.getUpdatedColumns()),
                 remainingConstraint.transformKeys(ColumnHandle.class::cast),
                 false));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -77,6 +77,8 @@ public final class IcebergSessionProperties
     public static final String EXPIRE_SNAPSHOTS_MIN_RETENTION = "expire_snapshots_min_retention";
     public static final String REMOVE_ORPHAN_FILES_MIN_RETENTION = "remove_orphan_files_min_retention";
 
+    public static final String EXPERIMENTAL_SPLIT_BUNDLING = "experimental_split_bundling";
+
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
@@ -241,6 +243,11 @@ public final class IcebergSessionProperties
                         "Minimal retention period for remove_orphan_files procedure",
                         icebergConfig.getRemoveOrphanFilesMinRetention(),
                         false))
+                .add(booleanProperty(
+                        EXPERIMENTAL_SPLIT_BUNDLING,
+                        "experimental split bundling",
+                        true,
+                        false))
                 .build();
     }
 
@@ -395,5 +402,10 @@ public final class IcebergSessionProperties
     public static Duration getRemoveOrphanFilesMinRetention(ConnectorSession session)
     {
         return session.getProperty(REMOVE_ORPHAN_FILES_MIN_RETENTION, Duration.class);
+    }
+
+    public static boolean getExperimentalSplitBundling(ConnectorSession session)
+    {
+        return session.getProperty(EXPERIMENTAL_SPLIT_BUNDLING, Boolean.class);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -78,6 +78,8 @@ public final class IcebergSessionProperties
     public static final String REMOVE_ORPHAN_FILES_MIN_RETENTION = "remove_orphan_files_min_retention";
 
     public static final String EXPERIMENTAL_SPLIT_BUNDLING = "experimental_split_bundling";
+    public static final String SPLIT_WEIGHT_MIN = "split_weight_min";
+    public static final String SPLIT_WEIGHT_MAX = "split_weight_max";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -248,6 +250,16 @@ public final class IcebergSessionProperties
                         "experimental split bundling",
                         true,
                         false))
+                .add(doubleProperty(
+                        SPLIT_WEIGHT_MAX,
+                        "split weight max",
+                        Double.MAX_VALUE,
+                        false))
+                .add(doubleProperty(
+                        SPLIT_WEIGHT_MIN,
+                        "split weight min",
+                        0.0,
+                        false))
                 .build();
     }
 
@@ -407,5 +419,15 @@ public final class IcebergSessionProperties
     public static boolean getExperimentalSplitBundling(ConnectorSession session)
     {
         return session.getProperty(EXPERIMENTAL_SPLIT_BUNDLING, Boolean.class);
+    }
+
+    public static double getSplitWeightMax(ConnectorSession session)
+    {
+        return session.getProperty(SPLIT_WEIGHT_MAX, Double.class);
+    }
+
+    public static double getSplitWeightMin(ConnectorSession session)
+    {
+        return session.getProperty(SPLIT_WEIGHT_MIN, Double.class);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplit.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplit.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.iceberg.delete.TrinoDeleteFile;
 import io.trino.spi.HostAddress;
+import io.trino.spi.SplitWeight;
 import io.trino.spi.connector.ConnectorSplit;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -43,6 +44,7 @@ public class IcebergSplit
     private final String partitionSpecJson;
     private final String partitionDataJson;
     private final List<TrinoDeleteFile> deletes;
+    private final SplitWeight splitWeight;
 
     @JsonCreator
     public IcebergSplit(
@@ -55,7 +57,8 @@ public class IcebergSplit
             @JsonProperty("addresses") List<HostAddress> addresses,
             @JsonProperty("partitionSpecJson") String partitionSpecJson,
             @JsonProperty("partitionDataJson") String partitionDataJson,
-            @JsonProperty("deletes") List<TrinoDeleteFile> deletes)
+            @JsonProperty("deletes") List<TrinoDeleteFile> deletes,
+            @JsonProperty("splitWeight") SplitWeight splitWeight)
     {
         this.path = requireNonNull(path, "path is null");
         this.start = start;
@@ -67,6 +70,7 @@ public class IcebergSplit
         this.partitionSpecJson = requireNonNull(partitionSpecJson, "partitionSpecJson is null");
         this.partitionDataJson = requireNonNull(partitionDataJson, "partitionDataJson is null");
         this.deletes = ImmutableList.copyOf(requireNonNull(deletes, "deletes is null"));
+        this.splitWeight = requireNonNull(splitWeight, "splitWeight is null");
     }
 
     @Override
@@ -136,6 +140,13 @@ public class IcebergSplit
         return deletes;
     }
 
+    @JsonProperty
+    @Override
+    public SplitWeight getSplitWeight()
+    {
+        return splitWeight;
+    }
+
     @Override
     public Object getInfo()
     {
@@ -154,7 +165,8 @@ public class IcebergSplit
                 + estimatedSizeOf(addresses, HostAddress::getRetainedSizeInBytes)
                 + estimatedSizeOf(partitionSpecJson)
                 + estimatedSizeOf(partitionDataJson)
-                + estimatedSizeOf(deletes, TrinoDeleteFile::getRetainedSizeInBytes);
+                + estimatedSizeOf(deletes, TrinoDeleteFile::getRetainedSizeInBytes)
+                + splitWeight.getRetainedSizeInBytes();
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitManager.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitManager.java
@@ -32,6 +32,8 @@ import javax.inject.Inject;
 
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getDynamicFilteringWaitTimeout;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getExperimentalSplitBundling;
+import static io.trino.plugin.iceberg.IcebergSessionProperties.getSplitWeightMax;
+import static io.trino.plugin.iceberg.IcebergSessionProperties.getSplitWeightMin;
 import static java.util.Objects.requireNonNull;
 
 public class IcebergSplitManager
@@ -81,7 +83,9 @@ public class IcebergSplitManager
                 constraint,
                 typeManager,
                 table.isRecordScannedFiles(),
-                getExperimentalSplitBundling(session));
+                getExperimentalSplitBundling(session),
+                getSplitWeightMax(session),
+                getSplitWeightMin(session));
 
         return new ClassLoaderSafeConnectorSplitSource(splitSource, Thread.currentThread().getContextClassLoader());
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitManager.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitManager.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.TableScan;
 import javax.inject.Inject;
 
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getDynamicFilteringWaitTimeout;
+import static io.trino.plugin.iceberg.IcebergSessionProperties.getExperimentalSplitBundling;
 import static java.util.Objects.requireNonNull;
 
 public class IcebergSplitManager
@@ -79,7 +80,8 @@ public class IcebergSplitManager
                 dynamicFilteringWaitTimeout,
                 constraint,
                 typeManager,
-                table.isRecordScannedFiles());
+                table.isRecordScannedFiles(),
+                getExperimentalSplitBundling(session));
 
         return new ClassLoaderSafeConnectorSplitSource(splitSource, Thread.currentThread().getContextClassLoader());
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableHandle.java
@@ -47,6 +47,7 @@ public class IcebergTableHandle
     private final String tableLocation;
     private final Map<String, String> storageProperties;
     private final RetryMode retryMode;
+    private final boolean isUpdateOrDelete;
 
     // UPDATE only
     private final List<IcebergColumnHandle> updatedColumns;
@@ -80,6 +81,7 @@ public class IcebergTableHandle
             @JsonProperty("tableLocation") String tableLocation,
             @JsonProperty("storageProperties") Map<String, String> storageProperties,
             @JsonProperty("retryMode") RetryMode retryMode,
+            @JsonProperty("isUpdateOrDelete") boolean isUpdateOrDelete,
             @JsonProperty("updatedColumns") List<IcebergColumnHandle> updatedColumns)
     {
         this(
@@ -97,6 +99,7 @@ public class IcebergTableHandle
                 tableLocation,
                 storageProperties,
                 retryMode,
+                isUpdateOrDelete,
                 updatedColumns,
                 false,
                 Optional.empty());
@@ -117,6 +120,7 @@ public class IcebergTableHandle
             String tableLocation,
             Map<String, String> storageProperties,
             RetryMode retryMode,
+            boolean isUpdateOrDelete,
             List<IcebergColumnHandle> updatedColumns,
             boolean recordScannedFiles,
             Optional<DataSize> maxScannedFileSize)
@@ -135,6 +139,7 @@ public class IcebergTableHandle
         this.tableLocation = requireNonNull(tableLocation, "tableLocation is null");
         this.storageProperties = ImmutableMap.copyOf(requireNonNull(storageProperties, "storageProperties is null"));
         this.retryMode = requireNonNull(retryMode, "retryMode is null");
+        this.isUpdateOrDelete = isUpdateOrDelete;
         this.updatedColumns = ImmutableList.copyOf(requireNonNull(updatedColumns, "updatedColumns is null"));
         this.recordScannedFiles = recordScannedFiles;
         this.maxScannedFileSize = requireNonNull(maxScannedFileSize, "maxScannedFileSize is null");
@@ -225,6 +230,12 @@ public class IcebergTableHandle
     }
 
     @JsonProperty
+    public boolean isUpdateOrDelete()
+    {
+        return isUpdateOrDelete;
+    }
+
+    @JsonProperty
     public List<IcebergColumnHandle> getUpdatedColumns()
     {
         return updatedColumns;
@@ -269,6 +280,7 @@ public class IcebergTableHandle
                 tableLocation,
                 storageProperties,
                 retryMode,
+                isUpdateOrDelete,
                 updatedColumns,
                 recordScannedFiles,
                 maxScannedFileSize);
@@ -291,6 +303,7 @@ public class IcebergTableHandle
                 tableLocation,
                 storageProperties,
                 retryMode,
+                isUpdateOrDelete,
                 updatedColumns,
                 recordScannedFiles,
                 maxScannedFileSize);
@@ -313,6 +326,7 @@ public class IcebergTableHandle
                 tableLocation,
                 storageProperties,
                 retryMode,
+                isUpdateOrDelete,
                 updatedColumns,
                 recordScannedFiles,
                 maxScannedFileSize);
@@ -335,9 +349,33 @@ public class IcebergTableHandle
                 tableLocation,
                 storageProperties,
                 retryMode,
+                isUpdateOrDelete,
                 updatedColumns,
                 recordScannedFiles,
                 Optional.of(maxScannedFileSize));
+    }
+
+    public IcebergTableHandle forUpdateOrDelete()
+    {
+        return new IcebergTableHandle(
+                schemaName,
+                tableName,
+                tableType,
+                snapshotId,
+                tableSchemaJson,
+                partitionSpecJson,
+                formatVersion,
+                unenforcedPredicate,
+                enforcedPredicate,
+                projectedColumns,
+                nameMappingJson,
+                tableLocation,
+                storageProperties,
+                retryMode,
+                true,
+                updatedColumns,
+                recordScannedFiles,
+                maxScannedFileSize);
     }
 
     @Override
@@ -365,6 +403,7 @@ public class IcebergTableHandle
                 Objects.equals(nameMappingJson, that.nameMappingJson) &&
                 Objects.equals(tableLocation, that.tableLocation) &&
                 Objects.equals(retryMode, that.retryMode) &&
+                isUpdateOrDelete == that.isUpdateOrDelete &&
                 Objects.equals(updatedColumns, that.updatedColumns) &&
                 Objects.equals(storageProperties, that.storageProperties) &&
                 Objects.equals(maxScannedFileSize, that.maxScannedFileSize);
@@ -374,7 +413,7 @@ public class IcebergTableHandle
     public int hashCode()
     {
         return Objects.hash(schemaName, tableName, tableType, snapshotId, tableSchemaJson, partitionSpecJson, formatVersion, unenforcedPredicate, enforcedPredicate,
-                projectedColumns, nameMappingJson, tableLocation, storageProperties, retryMode, updatedColumns, recordScannedFiles, maxScannedFileSize);
+                projectedColumns, nameMappingJson, tableLocation, storageProperties, retryMode, isUpdateOrDelete, updatedColumns, recordScannedFiles, maxScannedFileSize);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
@@ -36,6 +36,7 @@ import io.trino.plugin.hive.orc.OrcWriterConfig;
 import io.trino.plugin.hive.parquet.ParquetReaderConfig;
 import io.trino.plugin.hive.parquet.ParquetWriterConfig;
 import io.trino.spi.Page;
+import io.trino.spi.SplitWeight;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorPageSource;
@@ -163,7 +164,9 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                 ImmutableList.of(),
                 PartitionSpecParser.toJson(PartitionSpec.unpartitioned()),
                 PartitionData.toJson(new PartitionData(new Object[] {})),
-                ImmutableList.of())));
+                ImmutableList.of(),
+                SplitWeight.standard())),
+                SplitWeight.standard());
 
         TableHandle tableHandle = new TableHandle(
                 new CatalogName(ICEBERG_CATALOG_NAME),

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
@@ -153,7 +153,7 @@ public class TestIcebergNodeLocalDynamicSplitPruning
 
     private static ConnectorPageSource createTestingPageSource(HiveTransactionHandle transaction, IcebergConfig icebergConfig, HiveConfig hiveConfig, File outputFile, DynamicFilter dynamicFilter)
     {
-        IcebergSplit split = new IcebergSplit(
+        CombinedIcebergSplit split = new CombinedIcebergSplit(ImmutableList.of(new IcebergSplit(
                 "file:///" + outputFile.getAbsolutePath(),
                 0,
                 outputFile.length(),
@@ -163,7 +163,7 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                 ImmutableList.of(),
                 PartitionSpecParser.toJson(PartitionSpec.unpartitioned()),
                 PartitionData.toJson(new PartitionData(new Object[] {})),
-                ImmutableList.of());
+                ImmutableList.of())));
 
         TableHandle tableHandle = new TableHandle(
                 new CatalogName(ICEBERG_CATALOG_NAME),
@@ -182,6 +182,7 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                         outputFile.getParentFile().getAbsolutePath(),
                         ImmutableMap.of(),
                         RetryMode.NO_RETRIES,
+                        false,
                         ImmutableList.of()),
                 transaction);
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
@@ -187,7 +187,9 @@ public class TestIcebergSplitSource
                 alwaysTrue(),
                 new TestingTypeManager(),
                 false,
-                false);
+                false,
+                Double.MAX_VALUE,
+                0.0);
 
         ImmutableList.Builder<IcebergSplit> splits = ImmutableList.builder();
         while (!splitSource.isFinished()) {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
@@ -137,6 +137,7 @@ public class TestIcebergSplitSource
                 nationTable.location(),
                 nationTable.properties(),
                 NO_RETRIES,
+                false,
                 ImmutableList.of());
 
         IcebergSplitSource splitSource = new IcebergSplitSource(
@@ -192,7 +193,8 @@ public class TestIcebergSplitSource
             splitSource.getNextBatch(null, 100).get()
                     .getSplits()
                     .stream()
-                    .map(IcebergSplit.class::cast)
+                    .map(CombinedIcebergSplit.class::cast)
+                    .flatMap(split -> split.getEntries().stream())
                     .forEach(splits::add);
         }
         assertThat(splits.build().size()).isGreaterThan(0);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
@@ -186,6 +186,7 @@ public class TestIcebergSplitSource
                 new Duration(2, SECONDS),
                 alwaysTrue(),
                 new TestingTypeManager(),
+                false,
                 false);
 
         ImmutableList.Builder<IcebergSplit> splits = ImmutableList.builder();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/optimizer/TestConnectorPushdownRulesWithIceberg.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/optimizer/TestConnectorPushdownRulesWithIceberg.java
@@ -166,7 +166,7 @@ public class TestConnectorPushdownRulesWithIceberg
                 Optional.empty());
 
         IcebergTableHandle icebergTable = new IcebergTableHandle(SCHEMA_NAME, tableName, DATA, Optional.of(1L), "", "", 1,
-                TupleDomain.all(), TupleDomain.all(), ImmutableSet.of(), Optional.empty(), "", ImmutableMap.of(), NO_RETRIES, ImmutableList.of());
+                TupleDomain.all(), TupleDomain.all(), ImmutableSet.of(), Optional.empty(), "", ImmutableMap.of(), NO_RETRIES, false, ImmutableList.of());
         TableHandle table = new TableHandle(new CatalogName(ICEBERG_CATALOG_NAME), icebergTable, new HiveTransactionHandle(false));
 
         IcebergColumnHandle fullColumn = partialColumn.getBaseColumn();
@@ -231,7 +231,7 @@ public class TestConnectorPushdownRulesWithIceberg
         PushPredicateIntoTableScan pushPredicateIntoTableScan = new PushPredicateIntoTableScan(tester().getPlannerContext(), tester().getTypeAnalyzer());
 
         IcebergTableHandle icebergTable = new IcebergTableHandle(SCHEMA_NAME, tableName, DATA, Optional.of(1L), "", "", 1,
-                TupleDomain.all(), TupleDomain.all(), ImmutableSet.of(), Optional.empty(), "", ImmutableMap.of(), NO_RETRIES, ImmutableList.of());
+                TupleDomain.all(), TupleDomain.all(), ImmutableSet.of(), Optional.empty(), "", ImmutableMap.of(), NO_RETRIES, false, ImmutableList.of());
         TableHandle table = new TableHandle(new CatalogName(ICEBERG_CATALOG_NAME), icebergTable, new HiveTransactionHandle(false));
 
         IcebergColumnHandle column = new IcebergColumnHandle(primitiveColumnIdentity(1, "a"), INTEGER, ImmutableList.of(), INTEGER, Optional.empty());
@@ -264,7 +264,7 @@ public class TestConnectorPushdownRulesWithIceberg
         PruneTableScanColumns pruneTableScanColumns = new PruneTableScanColumns(tester().getMetadata());
 
         IcebergTableHandle icebergTable = new IcebergTableHandle(SCHEMA_NAME, tableName, DATA, Optional.empty(), "", "", 1,
-                TupleDomain.all(), TupleDomain.all(), ImmutableSet.of(), Optional.empty(), "", ImmutableMap.of(), NO_RETRIES, ImmutableList.of());
+                TupleDomain.all(), TupleDomain.all(), ImmutableSet.of(), Optional.empty(), "", ImmutableMap.of(), NO_RETRIES, false, ImmutableList.of());
         TableHandle table = new TableHandle(new CatalogName(ICEBERG_CATALOG_NAME), icebergTable, new HiveTransactionHandle(false));
 
         IcebergColumnHandle columnA = new IcebergColumnHandle(primitiveColumnIdentity(0, "a"), INTEGER, ImmutableList.of(), INTEGER, Optional.empty());
@@ -308,7 +308,7 @@ public class TestConnectorPushdownRulesWithIceberg
                 new ScalarStatsCalculator(tester().getPlannerContext(), tester().getTypeAnalyzer()));
 
         IcebergTableHandle icebergTable = new IcebergTableHandle(SCHEMA_NAME, tableName, DATA, Optional.of(1L), "", "", 1,
-                TupleDomain.all(), TupleDomain.all(), ImmutableSet.of(), Optional.empty(), "", ImmutableMap.of(), NO_RETRIES, ImmutableList.of());
+                TupleDomain.all(), TupleDomain.all(), ImmutableSet.of(), Optional.empty(), "", ImmutableMap.of(), NO_RETRIES, false, ImmutableList.of());
         TableHandle table = new TableHandle(new CatalogName(ICEBERG_CATALOG_NAME), icebergTable, new HiveTransactionHandle(false));
 
         IcebergColumnHandle bigintColumn = new IcebergColumnHandle(primitiveColumnIdentity(1, "just_bigint"), BIGINT, ImmutableList.of(), BIGINT, Optional.empty());


### PR DESCRIPTION
Reuse the bin packing done by the Iceberg table scan
planning by keeping small reads bundled together in
a single Split.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

Fixes: https://github.com/trinodb/trino/issues/12162

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
