### PR TITLE
Add tracking for Trino's FileSystem cache size.

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/FileSystemCacheTracker.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/FileSystemCacheTracker.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import io.trino.plugin.hive.fs.TrinoFileSystemCache;
+import org.weakref.jmx.Managed;
+
+public class FileSystemCacheTracker
+{
+    @Managed
+    public long getCacheSize()
+    {
+        return TrinoFileSystemCache.INSTANCE.getSize();
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveHdfsModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveHdfsModule.java
@@ -38,5 +38,8 @@ public class HiveHdfsModule
 
         binder.bind(NamenodeStats.class).in(Scopes.SINGLETON);
         newExporter(binder).export(NamenodeStats.class).withGeneratedName();
+
+        binder.bind(FileSystemCacheTracker.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(FileSystemCacheTracker.class).withGeneratedName();
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/TrinoFileSystemCache.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/TrinoFileSystemCache.java
@@ -69,6 +69,11 @@ public class TrinoFileSystemCache
 
     private TrinoFileSystemCache() {}
 
+    public synchronized long getSize()
+    {
+        return map.size();
+    }
+
     @Override
     public FileSystem get(URI uri, Configuration conf)
             throws IOException


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->
This PR adds support to track Trino's FS cache size.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

It is a new feature, provide the getter to track cache size. The getter is only when JMX endpoint is queried, soo it won't cause many contentions. Also, the method performs a trivial lookup on map size.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

It is a change to Hive Plugin.

> How would you describe this change to a non-technical end user or system administrator?

Provide another metric FileSystem cache size to developers/users.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
(x) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
