### PR TITLE
Skip optimize procedure if it doesn't reduce files in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -928,8 +928,8 @@ public class IcebergMetadata
             newFiles.add(builder.build());
         }
 
-        if (scannedFiles.isEmpty() && newFiles.isEmpty()) {
-            // Table scan turned out to be empty, nothing to commit
+        // Table scan turned out to be empty, or the procedure doesn't reduce file counts, nothing to commit
+        if ((scannedFiles.isEmpty() && newFiles.isEmpty()) || scannedFiles.size() <= newFiles.size()) {
             transaction = null;
             return;
         }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -3129,6 +3129,27 @@ public abstract class BaseIcebergConnectorTest
         assertUpdate("DROP TABLE " + tableName);
     }
 
+    @Test
+    public void testOptimizeSkipWhenNewFilesAreFewerThanOrEqualToScannedFiles()
+    {
+        String tableName = "test_optimize_" + randomTableSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " (key integer) WITH (format_version = 1)");
+
+        assertUpdate("INSERT INTO " + tableName + " VALUES (1)", 1);
+
+        List<String> initialFiles = getActiveFiles(tableName);
+        assertThat(initialFiles).hasSize(1);
+
+        computeActual("ALTER TABLE " + tableName + " EXECUTE OPTIMIZE");
+
+        List<String> afterFiles = getActiveFiles(tableName);
+        assertThat(afterFiles).hasSize(1);
+
+        assertThat(afterFiles).isEqualTo(initialFiles);
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
     private List<String> getActiveFiles(String tableName)
     {
         return computeActual(format("SELECT file_path FROM \"%s$files\"", tableName)).getOnlyColumn()


### PR DESCRIPTION
## Description

* Fixes #10785

## Documentation

(x) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# Iceberg
* Skip `optimize` procedure if it doesn't reduce files. ({issue}`10785`)
```
