### PR TITLE
Prometheus connector always requires labels column #12301

### DIFF
--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusStandardizedRow.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusStandardizedRow.java
@@ -27,7 +27,7 @@ public class PrometheusStandardizedRow
 
     public PrometheusStandardizedRow(Block labels, Instant timestamp, Double value)
     {
-        this.labels = requireNonNull(labels, "labels is null");
+        this.labels = labels;
         this.timestamp = requireNonNull(timestamp, "timestamp is null");
         this.value = requireNonNull(value, "value is null");
     }


### PR DESCRIPTION
## Description
Fix prometheus connector always requires labels column
## Related issues, pull requests, and links
Fixes https://github.com/trinodb/trino/issues/12301
## Documentation
No documentation is needed.
## Release notes
No release notes entries required.

