### PR TITLE
Use builderWithExpectedSize when size is known

### DIFF
--- a/core/trino-main/src/main/java/io/trino/cost/FilterStatsCalculator.java
+++ b/core/trino-main/src/main/java/io/trino/cost/FilterStatsCalculator.java
@@ -205,9 +205,10 @@ public class FilterStatsCalculator
          **/
         private List<PlanNodeStatsEstimate> estimateCorrelatedExpressions(List<Expression> terms, double filterConjunctionIndependenceFactor)
         {
-            ImmutableList.Builder<PlanNodeStatsEstimate> estimatesBuilder = ImmutableList.builder();
+            List<List<Expression>> extractedCorrelatedGroups = extractCorrelatedGroups(terms, filterConjunctionIndependenceFactor);
+            ImmutableList.Builder<PlanNodeStatsEstimate> estimatesBuilder = ImmutableList.builderWithExpectedSize(extractedCorrelatedGroups.size());
             boolean hasUnestimatedTerm = false;
-            for (List<Expression> correlatedExpressions : extractCorrelatedGroups(terms, filterConjunctionIndependenceFactor)) {
+            for (List<Expression> correlatedExpressions : extractedCorrelatedGroups) {
                 PlanNodeStatsEstimate combinedEstimate = PlanNodeStatsEstimate.unknown();
                 for (Expression expression : correlatedExpressions) {
                     PlanNodeStatsEstimate estimate;

--- a/core/trino-main/src/main/java/io/trino/event/QueryMonitor.java
+++ b/core/trino-main/src/main/java/io/trino/event/QueryMonitor.java
@@ -254,8 +254,9 @@ public class QueryMonitor
 
     private QueryStatistics createQueryStatistics(QueryInfo queryInfo)
     {
-        ImmutableList.Builder<String> operatorSummaries = ImmutableList.builder();
-        for (OperatorStats summary : queryInfo.getQueryStats().getOperatorSummaries()) {
+        List<OperatorStats> operatorStats = queryInfo.getQueryStats().getOperatorSummaries();
+        ImmutableList.Builder<String> operatorSummaries = ImmutableList.builderWithExpectedSize(operatorStats.size());
+        for (OperatorStats summary : operatorStats) {
             operatorSummaries.add(operatorStatsCodec.toJson(summary));
         }
 
@@ -350,7 +351,7 @@ public class QueryMonitor
     {
         Multimap<FragmentNode, OperatorStats> planNodeStats = extractPlanNodeStats(queryInfo);
 
-        ImmutableList.Builder<QueryInputMetadata> inputs = ImmutableList.builder();
+        ImmutableList.Builder<QueryInputMetadata> inputs = ImmutableList.builderWithExpectedSize(queryInfo.getInputs().size());
         for (Input input : queryInfo.getInputs()) {
             // Note: input table can be mapped to multiple operators
             Collection<OperatorStats> inputTableOperatorStats = planNodeStats.get(new FragmentNode(input.getFragmentId(), input.getPlanNodeId()));

--- a/core/trino-main/src/main/java/io/trino/execution/ExecutionFailureInfo.java
+++ b/core/trino-main/src/main/java/io/trino/execution/ExecutionFailureInfo.java
@@ -147,7 +147,7 @@ public class ExecutionFailureInfo
         for (ExecutionFailureInfo suppressed : executionFailureInfo.getSuppressed()) {
             failure.addSuppressed(toException(suppressed));
         }
-        ImmutableList.Builder<StackTraceElement> stackTraceBuilder = ImmutableList.builder();
+        ImmutableList.Builder<StackTraceElement> stackTraceBuilder = ImmutableList.builderWithExpectedSize(executionFailureInfo.getStack().size());
         for (String stack : executionFailureInfo.getStack()) {
             stackTraceBuilder.add(toStackTraceElement(stack));
         }

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/ArbitraryOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/ArbitraryOutputBuffer.java
@@ -132,7 +132,7 @@ public class ArbitraryOutputBuffer
         Collection<ClientBuffer> buffers = this.buffers.values();
 
         int totalBufferedPages = masterBuffer.getBufferedPages();
-        ImmutableList.Builder<BufferInfo> infos = ImmutableList.builder();
+        ImmutableList.Builder<BufferInfo> infos = ImmutableList.builderWithExpectedSize(buffers.size());
         for (ClientBuffer buffer : buffers) {
             BufferInfo bufferInfo = buffer.getInfo();
             infos.add(bufferInfo);

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/PartitionedOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/PartitionedOutputBuffer.java
@@ -71,7 +71,7 @@ public class PartitionedOutputBuffer
                 requireNonNull(notificationExecutor, "notificationExecutor is null"));
         this.onPagesReleased = PagesReleasedListener.forOutputBufferMemoryManager(memoryManager);
 
-        ImmutableList.Builder<ClientBuffer> partitions = ImmutableList.builder();
+        ImmutableList.Builder<ClientBuffer> partitions = ImmutableList.builderWithExpectedSize(outputBuffers.getBuffers().keySet().size());
         for (OutputBufferId bufferId : outputBuffers.getBuffers().keySet()) {
             ClientBuffer partition = new ClientBuffer(taskInstanceId, bufferId, onPagesReleased);
             partitions.add(partition);

--- a/core/trino-main/src/main/java/io/trino/execution/executor/MultilevelSplitQueue.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/MultilevelSplitQueue.java
@@ -66,7 +66,7 @@ public class MultilevelSplitQueue
     {
         this.levelMinPriority = new AtomicLong[LEVEL_THRESHOLD_SECONDS.length];
         this.levelWaitingSplits = new ArrayList<>(LEVEL_THRESHOLD_SECONDS.length);
-        ImmutableList.Builder<CounterStat> counters = ImmutableList.builder();
+        ImmutableList.Builder<CounterStat> counters = ImmutableList.builderWithExpectedSize(LEVEL_THRESHOLD_SECONDS.length);
 
         for (int i = 0; i < LEVEL_THRESHOLD_SECONDS.length; i++) {
             levelScheduledTime[i] = new AtomicLong();

--- a/core/trino-main/src/main/java/io/trino/execution/executor/TaskHandle.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/TaskHandle.java
@@ -124,7 +124,7 @@ public class TaskHandle
     {
         destroyed = true;
 
-        ImmutableList.Builder<PrioritizedSplitRunner> builder = ImmutableList.builder();
+        ImmutableList.Builder<PrioritizedSplitRunner> builder = ImmutableList.builderWithExpectedSize(runningIntermediateSplits.size() + runningLeafSplits.size() + queuedLeafSplits.size());
         builder.addAll(runningIntermediateSplits);
         builder.addAll(runningLeafSplits);
         builder.addAll(queuedLeafSplits);

--- a/core/trino-main/src/test/java/io/trino/RowPageBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/RowPageBuilder.java
@@ -45,7 +45,7 @@ public class RowPageBuilder
     RowPageBuilder(Iterable<Type> types)
     {
         this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
-        ImmutableList.Builder<BlockBuilder> builders = ImmutableList.builder();
+        ImmutableList.Builder<BlockBuilder> builders = ImmutableList.builderWithExpectedSize(this.types.size());
         for (Type type : types) {
             builders.add(type.createBlockBuilder(null, 1));
         }

--- a/core/trino-main/src/test/java/io/trino/block/AbstractTestBlock.java
+++ b/core/trino-main/src/test/java/io/trino/block/AbstractTestBlock.java
@@ -194,7 +194,7 @@ public abstract class AbstractTestBlock
     protected List<Block> splitBlock(Block block, int count)
     {
         double sizePerSplit = block.getPositionCount() * 1.0 / count;
-        ImmutableList.Builder<Block> result = ImmutableList.builder();
+        ImmutableList.Builder<Block> result = ImmutableList.builderWithExpectedSize(count);
         for (int i = 0; i < count; i++) {
             int startPosition = toIntExact(Math.round(sizePerSplit * i));
             int endPosition = toIntExact(Math.round(sizePerSplit * (i + 1)));

--- a/core/trino-main/src/test/java/io/trino/execution/executor/SimulationTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/executor/SimulationTask.java
@@ -162,7 +162,7 @@ abstract class SimulationTask
         @Override
         public void schedule(TaskExecutor taskExecutor, int numSplits)
         {
-            ImmutableList.Builder<SimulationSplit> splits = ImmutableList.builder();
+            ImmutableList.Builder<SimulationSplit> splits = ImmutableList.builderWithExpectedSize(numSplits);
             for (int i = 0; i < numSplits; i++) {
                 splits.add(splitSpecification.instantiate(this));
             }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -511,10 +511,12 @@ public abstract class BaseJdbcClient
             String remoteTargetTableName = identifierMapping.toRemoteTableName(identity, connection, remoteSchema, targetTableName);
             String catalog = connection.getCatalog();
 
-            ImmutableList.Builder<String> columnNames = ImmutableList.builder();
-            ImmutableList.Builder<Type> columnTypes = ImmutableList.builder();
-            ImmutableList.Builder<String> columnList = ImmutableList.builder();
-            for (ColumnMetadata column : tableMetadata.getColumns()) {
+            List<ColumnMetadata> columns = tableMetadata.getColumns();
+            ImmutableList.Builder<String> columnNames = ImmutableList.builderWithExpectedSize(columns.size());
+            ImmutableList.Builder<Type> columnTypes = ImmutableList.builderWithExpectedSize(columns.size());
+            ImmutableList.Builder<String> columnList = ImmutableList.builderWithExpectedSize(columns.size());
+
+            for (ColumnMetadata column : columns) {
                 String columnName = identifierMapping.toRemoteColumnName(connection, column.getName());
                 columnNames.add(columnName);
                 columnTypes.add(column.getType());

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRecordSet.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRecordSet.java
@@ -43,7 +43,7 @@ public class JdbcRecordSet
 
         this.table = requireNonNull(table, "table is null");
         this.columnHandles = requireNonNull(columnHandles, "columnHandles is null");
-        ImmutableList.Builder<Type> types = ImmutableList.builder();
+        ImmutableList.Builder<Type> types = ImmutableList.builderWithExpectedSize(columnHandles.size());
         for (JdbcColumnHandle column : columnHandles) {
             types.add(column.getColumnType());
         }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRecordSetProvider.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRecordSetProvider.java
@@ -57,7 +57,7 @@ public class JdbcRecordSetProvider
         jdbcTable.getColumns()
                 .ifPresent(tableColumns -> verify(ImmutableSet.copyOf(tableColumns).containsAll(columns)));
 
-        ImmutableList.Builder<JdbcColumnHandle> handles = ImmutableList.builder();
+        ImmutableList.Builder<JdbcColumnHandle> handles = ImmutableList.builderWithExpectedSize(columns.size());
         for (ColumnHandle handle : columns) {
             handles.add((JdbcColumnHandle) handle);
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
