### PR TITLE
Add support for snapshot tables in BigQuery

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ReadSessionCreator.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ReadSessionCreator.java
@@ -29,6 +29,7 @@ import io.trino.spi.connector.TableNotFoundException;
 import java.util.List;
 import java.util.Optional;
 
+import static com.google.cloud.bigquery.TableDefinition.Type.SNAPSHOT;
 import static com.google.cloud.bigquery.TableDefinition.Type.TABLE;
 import static com.google.cloud.bigquery.TableDefinition.Type.VIEW;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -98,7 +99,7 @@ public class ReadSessionCreator
     {
         TableDefinition tableDefinition = remoteTable.getDefinition();
         TableDefinition.Type tableType = tableDefinition.getType();
-        if (tableType == TABLE) {
+        if (tableType == TABLE || tableType == SNAPSHOT) {
             return remoteTable;
         }
         if (tableType == VIEW) {

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConnectorTest.java
@@ -602,6 +602,25 @@ public class TestBigQueryConnectorTest
         }
     }
 
+    @Test
+    public void testBigQuerySnapshotTable()
+    {
+        String snapshotTable = "test_snapshot" + randomTableSuffix();
+        try {
+            onBigQuery("CREATE SNAPSHOT TABLE test." + snapshotTable + " CLONE tpch.region");
+            assertQuery("SELECT table_type FROM information_schema.tables WHERE table_schema = 'test' AND table_name = '" + snapshotTable + "'", "VALUES 'BASE TABLE'");
+
+            assertThat(query("DESCRIBE test." + snapshotTable)).matches("DESCRIBE tpch.region");
+            assertThat(query("SELECT * FROM test." + snapshotTable)).matches("SELECT * FROM tpch.region");
+
+            assertUpdate("DROP TABLE test." + snapshotTable);
+            assertQueryReturnsEmptyResult("SELECT * FROM information_schema.tables WHERE table_schema = 'test' AND table_name = '" + snapshotTable + "'");
+        }
+        finally {
+            onBigQuery("DROP SNAPSHOT TABLE IF EXISTS test." + snapshotTable);
+        }
+    }
+
     private void onBigQuery(@Language("SQL") String sql)
     {
         bigQuerySqlExecutor.execute(sql);

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryInstanceCleaner.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryInstanceCleaner.java
@@ -50,7 +50,7 @@ public class TestBigQueryInstanceCleaner
             .collect(toUnmodifiableSet());
 
     // see https://cloud.google.com/bigquery/docs/information-schema-tables#tables_view for possible values
-    public static final Collection<String> tableTypesToDrop = ImmutableList.of("BASE TABLE", "VIEW", "MATERIALIZED VIEW");
+    public static final Collection<String> tableTypesToDrop = ImmutableList.of("BASE TABLE", "VIEW", "MATERIALIZED VIEW", "SNAPSHOT");
 
     private BigQuerySqlExecutor bigQuerySqlExecutor;
 
@@ -160,6 +160,8 @@ public class TestBigQueryInstanceCleaner
                 return format("DROP VIEW IF EXISTS %s.%s", quoted(schemaName), quoted(objectName));
             case "MATERIALIZED VIEW":
                 return format("DROP MATERIALIZED VIEW IF EXISTS %s.%s", quoted(schemaName), quoted(objectName));
+            case "SNAPSHOT":
+                return format("DROP SNAPSHOT TABLE IF EXISTS %s.%s", quoted(schemaName), quoted(objectName));
             default:
                 throw new IllegalArgumentException("Unexpected object type " + objectType);
         }


### PR DESCRIPTION
## Description

Add support for snapshot tables in BigQuery

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# BigQuery
* Support reading snapshot tables. ({issue}`12380`)
```
