### PR TITLE
Use JDBC type handle null information

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -531,7 +531,9 @@ public abstract class BaseJdbcClient
                     remoteTable,
                     columnNames.build(),
                     columnTypes.build(),
-                    Optional.empty(),
+                    getColumns(session, new JdbcTableHandle(schemaTableName, remoteTableName, Optional.empty())).stream()
+                            .map(JdbcColumnHandle::getJdbcTypeHandle)
+                            .collect(toImmutableList()),
                     Optional.of(remoteTargetTableName));
         }
     }
@@ -581,7 +583,7 @@ public abstract class BaseJdbcClient
                         remoteTable,
                         columnNames.build(),
                         columnTypes.build(),
-                        Optional.of(jdbcColumnTypes.build()),
+                        jdbcColumnTypes.build(),
                         Optional.empty());
             }
 
@@ -594,7 +596,7 @@ public abstract class BaseJdbcClient
                     remoteTable,
                     columnNames.build(),
                     columnTypes.build(),
-                    Optional.of(jdbcColumnTypes.build()),
+                    jdbcColumnTypes.build(),
                     Optional.of(remoteTemporaryTableName));
         }
         catch (SQLException e) {

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ColumnMapping.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ColumnMapping.java
@@ -131,6 +131,9 @@ public final class ColumnMapping
         return readFunction;
     }
 
+    @Deprecated
+    // @TODO: we should either remove WriteFunction from ColumnMapping or use jdbcClient.toWriteMapping result
+    // while constructing it as it's now used in one place only.
     public WriteFunction getWriteFunction()
     {
         return writeFunction;

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
@@ -170,7 +170,7 @@ public class DefaultQueryBuilder
         for (int i = 0; i < parameters.size(); i++) {
             QueryParameter parameter = parameters.get(i);
             int parameterIndex = i + 1;
-            WriteFunction writeFunction = getWriteFunction(client, session, connection, parameter.getJdbcType(), parameter.getType());
+            WriteFunction writeFunction = getWriteFunction(client, session, parameter.getType());
             Class<?> javaType = writeFunction.getJavaType();
             Object value = parameter.getValue()
                     // The value must be present, since DefaultQueryBuilder never creates null parameters. Values coming from Domain's ValueSet are non-null, and
@@ -325,7 +325,7 @@ public class DefaultQueryBuilder
 
         JdbcTypeHandle jdbcType = column.getJdbcTypeHandle();
         Type type = column.getColumnType();
-        WriteFunction writeFunction = getWriteFunction(client, session, connection, jdbcType, type);
+        WriteFunction writeFunction = getWriteFunction(client, session, type);
 
         List<String> disjuncts = new ArrayList<>();
         List<Object> singleValues = new ArrayList<>();
@@ -405,11 +405,9 @@ public class DefaultQueryBuilder
                         .collect(joining(", ", "(", ")"));
     }
 
-    private static WriteFunction getWriteFunction(JdbcClient client, ConnectorSession session, Connection connection, JdbcTypeHandle jdbcType, Type type)
+    private static WriteFunction getWriteFunction(JdbcClient client, ConnectorSession session, Type type)
     {
-        WriteFunction writeFunction = client.toColumnMapping(session, connection, jdbcType)
-                .orElseThrow(() -> new VerifyException(format("Unsupported type %s with handle %s", type, jdbcType)))
-                .getWriteFunction();
+        WriteFunction writeFunction = client.toWriteMapping(session, type).getWriteFunction();
         verify(writeFunction.getJavaType() == type.getJavaType(), "Java type mismatch: %s, %s", writeFunction, type);
         return writeFunction;
     }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcOutputTableHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcOutputTableHandle.java
@@ -38,7 +38,7 @@ public class JdbcOutputTableHandle
     private final String tableName;
     private final List<String> columnNames;
     private final List<Type> columnTypes;
-    private final Optional<List<JdbcTypeHandle>> jdbcColumnTypes;
+    private final List<JdbcTypeHandle> jdbcColumnTypes;
     private final Optional<String> temporaryTableName;
 
     @JsonCreator
@@ -48,7 +48,7 @@ public class JdbcOutputTableHandle
             @JsonProperty("tableName") String tableName,
             @JsonProperty("columnNames") List<String> columnNames,
             @JsonProperty("columnTypes") List<Type> columnTypes,
-            @JsonProperty("jdbcColumnTypes") Optional<List<JdbcTypeHandle>> jdbcColumnTypes,
+            @JsonProperty("jdbcColumnTypes") List<JdbcTypeHandle> jdbcColumnTypes,
             @JsonProperty("temporaryTableName") Optional<String> temporaryTableName)
     {
         this.catalogName = catalogName;
@@ -62,8 +62,8 @@ public class JdbcOutputTableHandle
         this.columnNames = ImmutableList.copyOf(columnNames);
         this.columnTypes = ImmutableList.copyOf(columnTypes);
         requireNonNull(jdbcColumnTypes, "jdbcColumnTypes is null");
-        jdbcColumnTypes.ifPresent(jdbcTypeHandles -> checkArgument(jdbcTypeHandles.size() == columnNames.size(), "columnNames and jdbcColumnTypes sizes don't match"));
-        this.jdbcColumnTypes = jdbcColumnTypes.map(ImmutableList::copyOf);
+        checkArgument(jdbcColumnTypes.size() == columnNames.size(), "columnNames and jdbcColumnTypes sizes don't match");
+        this.jdbcColumnTypes = ImmutableList.copyOf(jdbcColumnTypes);
     }
 
     @JsonProperty
@@ -99,7 +99,7 @@ public class JdbcOutputTableHandle
     }
 
     @JsonProperty
-    public Optional<List<JdbcTypeHandle>> getJdbcColumnTypes()
+    public List<JdbcTypeHandle> getJdbcColumnTypes()
     {
         return jdbcColumnTypes;
     }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/WriteFunction.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/WriteFunction.java
@@ -25,9 +25,14 @@ public interface WriteFunction
         return "?";
     }
 
-    default void setNull(PreparedStatement statement, int index)
+    default void setNull(PreparedStatement statement, JdbcTypeHandle typeHandle, int index)
             throws SQLException
     {
-        statement.setObject(index, null);
+        if (typeHandle.getJdbcTypeName().isPresent()) {
+            statement.setNull(index, typeHandle.getJdbcType(), typeHandle.getJdbcTypeName().get());
+        }
+        else {
+            statement.setNull(index, typeHandle.getJdbcType());
+        }
     }
 }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcOutputTableHandle.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcOutputTableHandle.java
@@ -28,24 +28,13 @@ public class TestJdbcOutputTableHandle
     @Test
     public void testJsonRoundTrip()
     {
-        JdbcOutputTableHandle handleForCreate = new JdbcOutputTableHandle(
-                "catalog",
-                "schema",
-                "table",
-                ImmutableList.of("abc", "xyz"),
-                ImmutableList.of(VARCHAR, VARCHAR),
-                Optional.empty(),
-                Optional.of("tmp_table"));
-
-        assertJsonRoundTrip(OUTPUT_TABLE_CODEC, handleForCreate);
-
         JdbcOutputTableHandle handleForInsert = new JdbcOutputTableHandle(
                 "catalog",
                 "schema",
                 "table",
                 ImmutableList.of("abc", "xyz"),
                 ImmutableList.of(VARCHAR, VARCHAR),
-                Optional.of(ImmutableList.of(JDBC_VARCHAR, JDBC_VARCHAR)),
+                ImmutableList.of(JDBC_VARCHAR, JDBC_VARCHAR),
                 Optional.of("tmp_table"));
 
         assertJsonRoundTrip(OUTPUT_TABLE_CODEC, handleForInsert);

--- a/plugin/trino-mariadb/src/main/java/io/trino/plugin/mariadb/MariaDbClient.java
+++ b/plugin/trino-mariadb/src/main/java/io/trino/plugin/mariadb/MariaDbClient.java
@@ -240,6 +240,18 @@ public class MariaDbClient
                 getTableTypes().map(types -> types.toArray(String[]::new)).orElse(null));
     }
 
+    protected ResultSet getColumns(JdbcTableHandle tableHandle, DatabaseMetaData metadata)
+            throws SQLException
+    {
+        RemoteTableName remoteTableName = tableHandle.getRequiredNamedRelation().getRemoteTableName();
+        // MariaDB maps their "database" to SQL catalogs and does not have schemas
+        return metadata.getColumns(
+                remoteTableName.getSchemaName().orElse(null),
+                null,
+                escapeNamePattern(Optional.of(remoteTableName.getTableName()), metadata.getSearchStringEscape()).orElse(null),
+                null);
+    }
+
     @Override
     protected String getTableSchemaName(ResultSet resultSet)
             throws SQLException

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
@@ -93,7 +93,6 @@ import static io.trino.plugin.jdbc.PredicatePushdownController.FULL_PUSHDOWN;
 import static io.trino.plugin.jdbc.StandardColumnMappings.bigintColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.bigintWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.charReadFunction;
-import static io.trino.plugin.jdbc.StandardColumnMappings.charWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.integerWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.longDecimalReadFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.longDecimalWriteFunction;
@@ -626,7 +625,7 @@ public class OracleClient
             else {
                 dataType = "char(" + ((CharType) type).getLength() + " CHAR)";
             }
-            return WriteMapping.sliceMapping(dataType, charWriteFunction());
+            return WriteMapping.sliceMapping(dataType, oracleCharWriteFunction());
         }
         if (type instanceof DecimalType) {
             String dataType = format("number(%s, %s)", ((DecimalType) type).getPrecision(), ((DecimalType) type).getScale());

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
@@ -32,6 +32,7 @@ import io.trino.plugin.jdbc.ObjectWriteFunction;
 import io.trino.plugin.jdbc.PredicatePushdownController;
 import io.trino.plugin.jdbc.PreparedQuery;
 import io.trino.plugin.jdbc.QueryBuilder;
+import io.trino.plugin.jdbc.RemoteTableName;
 import io.trino.plugin.jdbc.WriteFunction;
 import io.trino.plugin.jdbc.WriteMapping;
 import io.trino.plugin.jdbc.mapping.IdentifierMapping;
@@ -113,6 +114,7 @@ import java.util.function.BiFunction;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.jdbc.DecimalConfig.DecimalMapping.ALLOW_OVERFLOW;
 import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalDefaultScale;
 import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalRounding;
@@ -642,7 +644,9 @@ public class PhoenixClient
                     table,
                     columnNames.build(),
                     columnTypes.build(),
-                    Optional.empty(),
+                    getColumns(session, new JdbcTableHandle(schemaTableName, new RemoteTableName(Optional.empty(), Optional.of(schema), table), Optional.empty())).stream()
+                        .map(JdbcColumnHandle::getJdbcTypeHandle)
+                        .collect(toImmutableList()),
                     rowkeyColumn);
         }
         catch (SQLException e) {

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixMetadata.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixMetadata.java
@@ -184,7 +184,7 @@ public class PhoenixMetadata
                 handle.getTableName(),
                 columnHandles.stream().map(JdbcColumnHandle::getColumnName).collect(toImmutableList()),
                 columnHandles.stream().map(JdbcColumnHandle::getColumnType).collect(toImmutableList()),
-                Optional.of(columnHandles.stream().map(JdbcColumnHandle::getJdbcTypeHandle).collect(toImmutableList())),
+                columnHandles.stream().map(JdbcColumnHandle::getJdbcTypeHandle).collect(toImmutableList()),
                 rowkeyColumn);
     }
 

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixOutputTableHandle.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixOutputTableHandle.java
@@ -37,7 +37,7 @@ public class PhoenixOutputTableHandle
             @JsonProperty("tableName") String tableName,
             @JsonProperty("columnNames") List<String> columnNames,
             @JsonProperty("columnTypes") List<Type> columnTypes,
-            @JsonProperty("jdbcColumnTypes") Optional<List<JdbcTypeHandle>> jdbcColumnTypes,
+            @JsonProperty("jdbcColumnTypes") List<JdbcTypeHandle> jdbcColumnTypes,
             @JsonProperty("rowkeyColumn") Optional<String> rowkeyColumn)
     {
         super("", schemaName, tableName, columnNames, columnTypes, jdbcColumnTypes, Optional.empty());

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
@@ -32,6 +32,7 @@ import io.trino.plugin.jdbc.ObjectWriteFunction;
 import io.trino.plugin.jdbc.PredicatePushdownController;
 import io.trino.plugin.jdbc.PreparedQuery;
 import io.trino.plugin.jdbc.QueryBuilder;
+import io.trino.plugin.jdbc.RemoteTableName;
 import io.trino.plugin.jdbc.WriteFunction;
 import io.trino.plugin.jdbc.WriteMapping;
 import io.trino.plugin.jdbc.mapping.IdentifierMapping;
@@ -114,6 +115,7 @@ import java.util.function.BiFunction;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.jdbc.DecimalConfig.DecimalMapping.ALLOW_OVERFLOW;
 import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalDefaultScale;
 import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalRounding;
@@ -634,7 +636,9 @@ public class PhoenixClient
                     table,
                     columnNames.build(),
                     columnTypes.build(),
-                    Optional.empty(),
+                    getColumns(session, new JdbcTableHandle(schemaTableName, new RemoteTableName(Optional.empty(), Optional.of(schema), table), Optional.empty())).stream()
+                            .map(JdbcColumnHandle::getJdbcTypeHandle)
+                            .collect(toImmutableList()),
                     rowkeyColumn);
         }
         catch (SQLException e) {

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
@@ -205,7 +205,7 @@ public class PhoenixMetadata
                 handle.getTableName(),
                 columnHandles.stream().map(JdbcColumnHandle::getColumnName).collect(toImmutableList()),
                 columnHandles.stream().map(JdbcColumnHandle::getColumnType).collect(toImmutableList()),
-                Optional.of(columnHandles.stream().map(JdbcColumnHandle::getJdbcTypeHandle).collect(toImmutableList())),
+                columnHandles.stream().map(JdbcColumnHandle::getJdbcTypeHandle).collect(toImmutableList()),
                 rowkeyColumn);
     }
 

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixOutputTableHandle.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixOutputTableHandle.java
@@ -37,7 +37,7 @@ public class PhoenixOutputTableHandle
             @JsonProperty("tableName") String tableName,
             @JsonProperty("columnNames") List<String> columnNames,
             @JsonProperty("columnTypes") List<Type> columnTypes,
-            @JsonProperty("jdbcColumnTypes") Optional<List<JdbcTypeHandle>> jdbcColumnTypes,
+            @JsonProperty("jdbcColumnTypes") List<JdbcTypeHandle> jdbcColumnTypes,
             @JsonProperty("rowkeyColumn") Optional<String> rowkeyColumn)
     {
         super("", schemaName, tableName, columnNames, columnTypes, jdbcColumnTypes, Optional.empty());

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
@@ -956,7 +956,7 @@ public class SqlServerClient
             }
 
             @Override
-            public void setNull(PreparedStatement statement, int index)
+            public void setNull(PreparedStatement statement, JdbcTypeHandle typeHandle, int index)
                     throws SQLException
             {
                 statement.setBytes(index, null);


### PR DESCRIPTION
It turns out that some databases expect NULLs to be typed during INSERT and if they are not this could be extremely slow.

In Oracle:

Before:

```
trino:trino_test> create table nullstep11  as select orderkey, partkey, linenumber,
               -> case when rand(0,2) = 1 then NULL
               ->  else 1
               -> end as tab1,
               -> case when rand(0,2) = 1 then NULL
               ->  else 1
               -> end as tab4,
               -> case when rand(0,2) = 1 then NULL
               ->  else 1
               -> end as tab2,
               -> case when rand(0,2) = 1 then NULL
               ->  else 1
               -> end as tab91
               -> from tpch.sf1.lineitem limit 1000000;
CREATE TABLE: 1000000 rows

Query 20220513_145237_00024_bnpr7, FINISHED, 3 nodes
Splits: 77 total, 66 done (85.71%)
3:14 [5.3M rows, 0B] [27.4K rows/s, 0B/s]
```

After:

```
trino:trino_test> create table nullstep11  as select orderkey, partkey, linenumber,
               -> case when rand(0,2) = 1 then NULL
               ->  else 1
               -> end as tab1,
               -> case when rand(0,2) = 1 then NULL
               ->  else 1
               -> end as tab4,
               -> case when rand(0,2) = 1 then NULL
               ->  else 1
               -> end as tab2,
               -> case when rand(0,2) = 1 then NULL
               ->  else 1
               -> end as tab91
               -> from tpch.sf1.lineitem limit 1000000;
CREATE TABLE: 1000000 rows

Query 20220513_150128_00027_trnd2, FINISHED, 3 nodes
Splits: 77 total, 59 done (76.62%)
3.37 [4.02M rows, 0B] [1.19M rows/s, 0B/s]
```