### PR TITLE
Add cause exception message to JDBC query failure message

### DIFF
--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoStatement.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoStatement.java
@@ -284,7 +284,7 @@ public class TrinoStatement
             throw new SQLException(e.getMessage(), e);
         }
         catch (RuntimeException e) {
-            throw new SQLException("Error executing query", e);
+            throw new SQLException("Error executing query: " + e.getMessage(), e);
         }
         finally {
             executingClient.set(null);

--- a/service/trino-verifier/src/main/java/io/trino/verifier/Validator.java
+++ b/service/trino-verifier/src/main/java/io/trino/verifier/Validator.java
@@ -545,7 +545,7 @@ public class Validator
         }
         catch (SQLException e) {
             Exception exception = e;
-            if (("Error executing query".equals(e.getMessage()) || "Error fetching results".equals(e.getMessage())) &&
+            if ((e.getMessage().startsWith("Error executing query") || "Error fetching results".equals(e.getMessage())) &&
                     (e.getCause() instanceof Exception)) {
                 exception = (Exception) e.getCause();
             }


### PR DESCRIPTION
## Description

Improve error reporting in JDBC driver.  Before the error message would just be `Error executing query`, and not it is `Error executing query: <cause message>`
## Related issues, pull requests, and links

## Documentation

(X) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(X) No release notes entries required.
( ) Release notes entries required with the following suggested text:
