### PR TITLE
Enable Trino to detect and fail queries that have tasks stuck in long running JONI parsing. 

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/TaskManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TaskManagerConfig.java
@@ -70,6 +70,11 @@ public class TaskManagerConfig
     private Duration statusRefreshMaxWait = new Duration(1, TimeUnit.SECONDS);
     private Duration infoUpdateInterval = new Duration(3, TimeUnit.SECONDS);
 
+    private boolean interruptStuckSplitTasksEnabled = true;
+    private Duration interruptStuckSplitTasksWarningThreshold = new Duration(10, TimeUnit.MINUTES);
+    private Duration interruptStuckSplitTasksTimeout = new Duration(15, TimeUnit.MINUTES);
+    private Duration interruptStuckSplitTasksDetectionInterval = new Duration(2, TimeUnit.MINUTES);
+
     private int writerCount = 1;
     // cap task concurrency to 32 in order to avoid small pages produced by local partitioning exchanges
     private int taskConcurrency = min(nextPowerOfTwo(getAvailablePhysicalProcessorCount()), 32);
@@ -461,6 +466,60 @@ public class TaskManagerConfig
     public TaskManagerConfig setTaskYieldThreads(int taskYieldThreads)
     {
         this.taskYieldThreads = taskYieldThreads;
+        return this;
+    }
+
+    public boolean isInterruptStuckSplitTasksEnabled()
+    {
+        return interruptStuckSplitTasksEnabled;
+    }
+
+    @Config("task.interrupt-stuck-split-tasks-enabled")
+    public TaskManagerConfig setInterruptStuckSplitTasksEnabled(boolean interruptStuckSplitTasksEnabled)
+    {
+        this.interruptStuckSplitTasksEnabled = interruptStuckSplitTasksEnabled;
+        return this;
+    }
+
+    @MinDuration("1m")
+    public Duration getInterruptStuckSplitTasksWarningThreshold()
+    {
+        return interruptStuckSplitTasksWarningThreshold;
+    }
+
+    @Config("task.interrupt-stuck-split-tasks-warning-threshold")
+    @ConfigDescription("Print out call stacks and generate JMX metrics for splits running longer than the threshold")
+    public TaskManagerConfig setInterruptStuckSplitTasksWarningThreshold(Duration interruptStuckSplitTasksWarningThreshold)
+    {
+        this.interruptStuckSplitTasksWarningThreshold = interruptStuckSplitTasksWarningThreshold;
+        return this;
+    }
+
+    @MinDuration("3m")
+    public Duration getInterruptStuckSplitTasksTimeout()
+    {
+        return interruptStuckSplitTasksTimeout;
+    }
+
+    @Config("task.interrupt-stuck-split-tasks-timeout")
+    @ConfigDescription("Interrupt task processing thread after this timeout if the thread is stuck in certain external libraries used by Trino functions")
+    public TaskManagerConfig setInterruptStuckSplitTasksTimeout(Duration interruptStuckSplitTasksTimeout)
+    {
+        this.interruptStuckSplitTasksTimeout = interruptStuckSplitTasksTimeout;
+        return this;
+    }
+
+    @MinDuration("1m")
+    public Duration getInterruptStuckSplitTasksDetectionInterval()
+    {
+        return interruptStuckSplitTasksDetectionInterval;
+    }
+
+    @Config("task.interrupt-stuck-split-tasks-detection-interval")
+    @ConfigDescription("Interval between detecting stuck split")
+    public TaskManagerConfig setInterruptStuckSplitTasksDetectionInterval(Duration interruptStuckSplitTasksDetectionInterval)
+    {
+        this.interruptStuckSplitTasksDetectionInterval = interruptStuckSplitTasksDetectionInterval;
         return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/executor/PrioritizedSplitRunner.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/PrioritizedSplitRunner.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static io.trino.operator.Operator.NOT_BLOCKED;
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 public class PrioritizedSplitRunner
@@ -81,15 +82,15 @@ public class PrioritizedSplitRunner
             TimeStat blockedQuantaWallTime,
             TimeStat unblockedQuantaWallTime)
     {
-        this.taskHandle = taskHandle;
+        this.taskHandle = requireNonNull(taskHandle, "taskHandle is null");
         this.splitId = taskHandle.getNextSplitId();
-        this.split = split;
-        this.ticker = ticker;
+        this.split = requireNonNull(split, "split is null");
+        this.ticker = requireNonNull(ticker, "ticker is null");
         this.workerId = NEXT_WORKER_ID.getAndIncrement();
-        this.globalCpuTimeMicros = globalCpuTimeMicros;
-        this.globalScheduledTimeMicros = globalScheduledTimeMicros;
-        this.blockedQuantaWallTime = blockedQuantaWallTime;
-        this.unblockedQuantaWallTime = unblockedQuantaWallTime;
+        this.globalCpuTimeMicros = requireNonNull(globalCpuTimeMicros, "globalCpuTimeMicros is null");
+        this.globalScheduledTimeMicros = requireNonNull(globalScheduledTimeMicros, "globalScheduledTimeMicros is null");
+        this.blockedQuantaWallTime = requireNonNull(blockedQuantaWallTime, "blockedQuantaWallTime is null");
+        this.unblockedQuantaWallTime = requireNonNull(unblockedQuantaWallTime, "unblockedQuantaWallTime is null");
 
         this.updateLevelPriority();
     }

--- a/core/trino-main/src/test/java/io/trino/execution/TestTaskManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestTaskManagerConfig.java
@@ -65,7 +65,11 @@ public class TestTaskManagerConfig
                 .setTaskNotificationThreads(5)
                 .setTaskYieldThreads(3)
                 .setLevelTimeMultiplier(new BigDecimal("2"))
-                .setStatisticsCpuTimerEnabled(true));
+                .setStatisticsCpuTimerEnabled(true)
+                .setInterruptStuckSplitTasksEnabled(true)
+                .setInterruptStuckSplitTasksWarningThreshold(new Duration(10, TimeUnit.MINUTES))
+                .setInterruptStuckSplitTasksTimeout(new Duration(15, TimeUnit.MINUTES))
+                .setInterruptStuckSplitTasksDetectionInterval(new Duration(2, TimeUnit.MINUTES)));
     }
 
     @Test
@@ -101,6 +105,10 @@ public class TestTaskManagerConfig
                 .put("task.task-yield-threads", "8")
                 .put("task.level-time-multiplier", "2.1")
                 .put("task.statistics-cpu-timer-enabled", "false")
+                .put("task.interrupt-stuck-split-tasks-enabled", "false")
+                .put("task.interrupt-stuck-split-tasks-warning-threshold", "3m")
+                .put("task.interrupt-stuck-split-tasks-timeout", "4m")
+                .put("task.interrupt-stuck-split-tasks-detection-interval", "10m")
                 .buildOrThrow();
 
         TaskManagerConfig expected = new TaskManagerConfig()
@@ -131,7 +139,11 @@ public class TestTaskManagerConfig
                 .setTaskNotificationThreads(13)
                 .setTaskYieldThreads(8)
                 .setLevelTimeMultiplier(new BigDecimal("2.1"))
-                .setStatisticsCpuTimerEnabled(false);
+                .setStatisticsCpuTimerEnabled(false)
+                .setInterruptStuckSplitTasksEnabled(false)
+                .setInterruptStuckSplitTasksWarningThreshold(new Duration(3, TimeUnit.MINUTES))
+                .setInterruptStuckSplitTasksTimeout(new Duration(4, TimeUnit.MINUTES))
+                .setInterruptStuckSplitTasksDetectionInterval(new Duration(10, TimeUnit.MINUTES));
 
         assertFullMapping(properties, expected);
     }

--- a/docs/src/main/sphinx/admin/properties-task.rst
+++ b/docs/src/main/sphinx/admin/properties-task.rst
@@ -124,3 +124,47 @@ of additional CPU for parallel writes. Some connectors can be bottlenecked on CP
 writing due to compression or other factors. Setting this too high may cause the cluster
 to become overloaded due to excessive resource utilization. This can also be specified on
 a per-query basis using the ``task_writer_count`` session property.
+
+``task.interrupt-stuck-split-tasks-enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** :ref:`prop-type-boolean`
+* **Default value:** ``true``
+
+Enables Trino detecting and failing tasks containing splits that have been stuck. Can be
+specified by ``task.interrupt-stuck-split-tasks-timeout`` and
+``task.interrupt-stuck-split-tasks-detection-interval``. Only applies to threads that
+are blocked by the third-party Joni regular expression library.
+
+
+``task.interrupt-stuck-split-tasks-warning-threshold``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** :ref:`prop-type-duration`
+* **Minimum value:** ``1m``
+* **Default value:** ``10m``
+
+Print out call stacks at ``/v1/maxActiveSplits`` endpoint and generate JMX metrics
+for splits running longer than the threshold.
+
+``task.interrupt-stuck-split-tasks-timeout``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** :ref:`prop-type-duration`
+* **Minimum value:** ``3m``
+* **Default value:** ``10m``
+
+The length of time Trino waits for a blocked split processing thread before failing the
+task. Only applies to threads that are blocked by the third-party Joni regular
+expression library.
+
+``task.interrupt-stuck-split-tasks-detection-interval``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** :ref:`prop-type-duration`
+* **Minimum value:** ``1m``
+* **Default value:** ``2m``
+
+The interval of Trino checks for splits that have processing time exceeding
+``task.interrupt-stuck-split-tasks-timeout``. Only applies to threads that are blocked
+by the third-party Joni regular expression library.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->
Enable Trino to detect and fail tasks that are stuck in long running JONI parsing. 

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->


> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

 Query Engine

> How would you describe this change to a non-technical end user or system administrator?

Trino is a time shared multi-tenant system. For context switching, trino relies on the threadpool workers cooperatively yield itself to the scheduling logic. It is not like an operating system which used a hard interrupt signal to force the process to do the context switch.

Most of the split processing can be finished in a relative short interval, whereas the JONI processing is an exception.

Furthermore, some of the trino features: gathering statistics, relaying on the trino to do callback function(to execute splitFinished() after yield) after the context switch, since there is no context switch in this case, trino can't gather accurate CPU usage for that split. 

This PR allows trino to detect and fail tasks that are stuck in long running JONI parsing. 

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

Enable Trino to detect and fail queries that have tasks stuck in long running JONI parsing. 
 