### PR TITLE
Add AccessDeniedException overloadings with extraInfo

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/security/AccessDeniedException.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/AccessDeniedException.java
@@ -150,7 +150,12 @@ public class AccessDeniedException
 
     public static void denySetSchemaAuthorization(String schemaName, TrinoPrincipal principal)
     {
-        throw new AccessDeniedException(format("Cannot set authorization for schema %s to %s", schemaName, principal));
+        denySetSchemaAuthorization(schemaName, principal, null);
+    }
+
+    public static void denySetSchemaAuthorization(String schemaName, TrinoPrincipal principal, String extraInfo)
+    {
+        throw new AccessDeniedException(format("Cannot set authorization for schema %s to %s%s", schemaName, principal, formatExtraInfo(extraInfo)));
     }
 
     public static void denyShowSchemas()
@@ -165,7 +170,12 @@ public class AccessDeniedException
 
     public static void denyShowCreateSchema(String schemaName)
     {
-        throw new AccessDeniedException(format("Cannot show create schema for %s", schemaName));
+        denyShowCreateSchema(schemaName, null);
+    }
+
+    public static void denyShowCreateSchema(String schemaName, String extraInfo)
+    {
+        throw new AccessDeniedException(format("Cannot show create schema for %s%s", schemaName, formatExtraInfo(extraInfo)));
     }
 
     public static void denyShowCreateTable(String tableName)
@@ -275,7 +285,12 @@ public class AccessDeniedException
 
     public static void denySetTableAuthorization(String tableName, TrinoPrincipal principal)
     {
-        throw new AccessDeniedException(format("Cannot set authorization for table %s to %s", tableName, principal));
+        denySetTableAuthorization(tableName, principal, null);
+    }
+
+    public static void denySetTableAuthorization(String tableName, TrinoPrincipal principal, String extraInfo)
+    {
+        throw new AccessDeniedException(format("Cannot set authorization for table %s to %s%s", tableName, principal, formatExtraInfo(extraInfo)));
     }
 
     public static void denyRenameColumn(String tableName)
@@ -385,7 +400,12 @@ public class AccessDeniedException
 
     public static void denySetViewAuthorization(String viewName, TrinoPrincipal principal)
     {
-        throw new AccessDeniedException(format("Cannot set authorization for view %s to %s", viewName, principal));
+        denySetViewAuthorization(viewName, principal, null);
+    }
+
+    public static void denySetViewAuthorization(String viewName, TrinoPrincipal principal, String extraInfo)
+    {
+        throw new AccessDeniedException(format("Cannot set authorization for view %s to %s%s", viewName, principal, formatExtraInfo(extraInfo)));
     }
 
     public static void denyDropView(String viewName)
@@ -600,7 +620,12 @@ public class AccessDeniedException
 
     public static void denyExecuteProcedure(String procedureName)
     {
-        throw new AccessDeniedException(format("Cannot execute procedure %s", procedureName));
+        denyExecuteProcedure(procedureName, null);
+    }
+
+    public static void denyExecuteProcedure(String procedureName, String extraInfo)
+    {
+        throw new AccessDeniedException(format("Cannot execute procedure %s%s", procedureName, formatExtraInfo(extraInfo)));
     }
 
     public static void denyExecuteFunction(String functionName)


### PR DESCRIPTION
Some of the AccessDeniedException methods lack an
overloading with the extraInfo argument.  This commit
adds some of those overloadings for methods where an
explanation of why access was denied is informative.

> Is this change a fix, improvement, new feature, refactoring, or other?
Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
SPI: `AccessDeniedException`

> How would you describe this change to a non-technical end user or system administrator?
Entirely upward compatible adding of methods to pass explanations when access is denied.

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

