### PR TITLE
Extend WriteFunction with JDBC type information

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BooleanWriteFunction.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BooleanWriteFunction.java
@@ -16,6 +16,8 @@ package io.trino.plugin.jdbc;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
+import static java.util.Objects.requireNonNull;
+
 public interface BooleanWriteFunction
         extends WriteFunction
 {
@@ -27,4 +29,32 @@ public interface BooleanWriteFunction
 
     void set(PreparedStatement statement, int index, boolean value)
             throws SQLException;
+
+    static BooleanWriteFunction of(int nullJdbcType, BooleanWriteFunctionImplementation implementation)
+    {
+        requireNonNull(implementation, "implementation is null");
+
+        return new BooleanWriteFunction() {
+            @Override
+            public void set(PreparedStatement statement, int index, boolean value)
+                    throws SQLException
+            {
+                implementation.set(statement, index, value);
+            }
+
+            @Override
+            public void setNull(PreparedStatement statement, int index)
+                    throws SQLException
+            {
+                statement.setNull(index, nullJdbcType);
+            }
+        };
+    }
+
+    @FunctionalInterface
+    interface BooleanWriteFunctionImplementation
+    {
+        void set(PreparedStatement statement, int index, boolean value)
+                throws SQLException;
+    }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DoubleWriteFunction.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DoubleWriteFunction.java
@@ -27,4 +27,30 @@ public interface DoubleWriteFunction
 
     void set(PreparedStatement statement, int index, double value)
             throws SQLException;
+
+    static DoubleWriteFunction of(int nullJdbcType, DoubleWriteFunctionImplementation implementation)
+    {
+        return new DoubleWriteFunction() {
+            @Override
+            public void set(PreparedStatement statement, int index, double value)
+                    throws SQLException
+            {
+                implementation.set(statement, index, value);
+            }
+
+            @Override
+            public void setNull(PreparedStatement statement, int index)
+                    throws SQLException
+            {
+                statement.setNull(index, nullJdbcType);
+            }
+        };
+    }
+
+    @FunctionalInterface
+    interface DoubleWriteFunctionImplementation
+    {
+        void set(PreparedStatement statement, int index, double value)
+                throws SQLException;
+    }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/LongWriteFunction.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/LongWriteFunction.java
@@ -16,6 +16,8 @@ package io.trino.plugin.jdbc;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
+import static java.util.Objects.requireNonNull;
+
 public interface LongWriteFunction
         extends WriteFunction
 {
@@ -27,4 +29,32 @@ public interface LongWriteFunction
 
     void set(PreparedStatement statement, int index, long value)
             throws SQLException;
+
+    static LongWriteFunction of(int nullJdbcType, LongWriteFunctionImplementation implementation)
+    {
+        requireNonNull(implementation, "implementation is null");
+
+        return new LongWriteFunction() {
+            @Override
+            public void set(PreparedStatement statement, int index, long value)
+                    throws SQLException
+            {
+                implementation.set(statement, index, value);
+            }
+
+            @Override
+            public void setNull(PreparedStatement statement, int index)
+                    throws SQLException
+            {
+                statement.setNull(index, nullJdbcType);
+            }
+        };
+    }
+
+    @FunctionalInterface
+    interface LongWriteFunctionImplementation
+    {
+        void set(PreparedStatement statement, int index, long value)
+                throws SQLException;
+    }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/SliceWriteFunction.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/SliceWriteFunction.java
@@ -18,6 +18,8 @@ import io.airlift.slice.Slice;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
+import static java.util.Objects.requireNonNull;
+
 public interface SliceWriteFunction
         extends WriteFunction
 {
@@ -29,4 +31,32 @@ public interface SliceWriteFunction
 
     void set(PreparedStatement statement, int index, Slice value)
             throws SQLException;
+
+    static SliceWriteFunction of(int nullJdbcType, SliceWriteFunctionImplementation implementation)
+    {
+        requireNonNull(implementation, "implementation is null");
+
+        return new SliceWriteFunction() {
+            @Override
+            public void set(PreparedStatement statement, int index, Slice value)
+                    throws SQLException
+            {
+                implementation.set(statement, index, value);
+            }
+
+            @Override
+            public void setNull(PreparedStatement statement, int index)
+                    throws SQLException
+            {
+                statement.setNull(index, nullJdbcType);
+            }
+        };
+    }
+
+    @FunctionalInterface
+    interface SliceWriteFunctionImplementation
+    {
+        void set(PreparedStatement statement, int index, Slice value)
+                throws SQLException;
+    }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/WriteFunction.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/WriteFunction.java
@@ -28,6 +28,9 @@ public interface WriteFunction
     default void setNull(PreparedStatement statement, int index)
             throws SQLException
     {
+        // This method of setting null for parameter could be suboptimal for some databases.
+        // In Oracle, lack of type on NULL value will invalidate prepared statement cache
+        // on every INSERT statement, which drastically degrades write performance.
         statement.setObject(index, null);
     }
 }

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
@@ -93,7 +93,6 @@ import static io.trino.plugin.jdbc.PredicatePushdownController.FULL_PUSHDOWN;
 import static io.trino.plugin.jdbc.StandardColumnMappings.bigintColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.bigintWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.charReadFunction;
-import static io.trino.plugin.jdbc.StandardColumnMappings.charWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.integerWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.longDecimalReadFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.longDecimalWriteFunction;
@@ -626,7 +625,7 @@ public class OracleClient
             else {
                 dataType = "char(" + ((CharType) type).getLength() + " CHAR)";
             }
-            return WriteMapping.sliceMapping(dataType, charWriteFunction());
+            return WriteMapping.sliceMapping(dataType, oracleCharWriteFunction());
         }
         if (type instanceof DecimalType) {
             String dataType = format("number(%s, %s)", ((DecimalType) type).getPrecision(), ((DecimalType) type).getScale());

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
@@ -21,6 +21,7 @@ import io.trino.plugin.base.aggregation.AggregateFunctionRule;
 import io.trino.plugin.base.expression.ConnectorExpressionRewriter;
 import io.trino.plugin.jdbc.BaseJdbcClient;
 import io.trino.plugin.jdbc.BaseJdbcConfig;
+import io.trino.plugin.jdbc.BooleanWriteFunction;
 import io.trino.plugin.jdbc.ColumnMapping;
 import io.trino.plugin.jdbc.ConnectionFactory;
 import io.trino.plugin.jdbc.DoubleWriteFunction;
@@ -496,6 +497,13 @@ public class OracleClient
                 LocalDateTime date = LocalDateTime.from(Instant.ofEpochMilli(utcMillis).atZone(ZoneOffset.UTC));
                 statement.setString(index, DATE_FORMATTER.format(date));
             }
+
+            @Override
+            public void setNull(PreparedStatement statement, int index)
+                    throws SQLException
+            {
+                statement.setNull(index, Types.VARCHAR);
+            }
         };
     }
 
@@ -520,6 +528,13 @@ public class OracleClient
                 LocalDateTime localDateTime = LocalDateTime.ofEpochSecond(epochSecond, 0, ZoneOffset.UTC);
                 statement.setString(index, TIMESTAMP_SECONDS_FORMATTER.format(localDateTime));
             }
+
+            @Override
+            public void setNull(PreparedStatement statement, int index)
+                    throws SQLException
+            {
+                statement.setNull(index, Types.VARCHAR);
+            }
         };
     }
 
@@ -541,6 +556,13 @@ public class OracleClient
                 int nanoFraction = floorMod(utcMillis, MICROSECONDS_PER_SECOND) * NANOSECONDS_PER_MICROSECOND;
                 LocalDateTime localDateTime = LocalDateTime.ofEpochSecond(epochSecond, nanoFraction, ZoneOffset.UTC);
                 statement.setString(index, TIMESTAMP_MILLIS_FORMATTER.format(localDateTime));
+            }
+
+            @Override
+            public void setNull(PreparedStatement statement, int index)
+                    throws SQLException
+            {
+                statement.setNull(index, Types.VARCHAR);
             }
         };
     }
@@ -573,34 +595,38 @@ public class OracleClient
 
     public static LongWriteFunction oracleTimestampWithTimeZoneWriteFunction()
     {
-        return (statement, index, encodedTimeWithZone) -> {
+        return LongWriteFunction.of(OracleTypes.TIMESTAMPTZ, (statement, index, encodedTimeWithZone) -> {
             Instant time = Instant.ofEpochMilli(unpackMillisUtc(encodedTimeWithZone));
             ZoneId zone = ZoneId.of(unpackZoneKey(encodedTimeWithZone).getId());
             statement.setObject(index, time.atZone(zone));
-        };
+        });
     }
 
     private static WriteMapping oracleBooleanWriteMapping()
     {
-        return WriteMapping.booleanMapping("number(1)", (statement, index, value) -> {
-            statement.setInt(index, value ? 1 : 0);
-        });
+        return WriteMapping.booleanMapping("number(1)", oracleBooleanWriteFunction());
+    }
+
+    private static BooleanWriteFunction oracleBooleanWriteFunction()
+    {
+        return BooleanWriteFunction.of(Types.TINYINT, (statement, index, value) -> statement.setInt(index, value ? 1 : 0));
     }
 
     public static LongWriteFunction oracleRealWriteFunction()
     {
-        return (statement, index, value) -> ((OraclePreparedStatement) statement).setBinaryFloat(index, intBitsToFloat(toIntExact(value)));
+        return LongWriteFunction.of(Types.REAL, (statement, index, value) ->
+                ((OraclePreparedStatement) statement).setBinaryFloat(index, intBitsToFloat(toIntExact(value))));
     }
 
     public static DoubleWriteFunction oracleDoubleWriteFunction()
     {
-        return ((statement, index, value) -> ((OraclePreparedStatement) statement).setBinaryDouble(index, value));
+        return DoubleWriteFunction.of(Types.DOUBLE, (statement, index, value) ->
+                ((OraclePreparedStatement) statement).setBinaryDouble(index, value));
     }
 
     private SliceWriteFunction oracleCharWriteFunction()
     {
-        return (statement, index, value) ->
-                ((OraclePreparedStatement) statement).setFixedCHAR(index, value.toStringUtf8());
+        return SliceWriteFunction.of(Types.NCHAR, (statement, index, value) -> ((OraclePreparedStatement) statement).setFixedCHAR(index, value.toStringUtf8()));
     }
 
     @Override

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleClient.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleClient.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.oracle;
+
+import io.trino.plugin.jdbc.BaseJdbcConfig;
+import io.trino.plugin.jdbc.DefaultQueryBuilder;
+import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.WriteFunction;
+import io.trino.plugin.jdbc.WriteMapping;
+import io.trino.plugin.jdbc.mapping.DefaultIdentifierMapping;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.type.Type;
+import io.trino.testing.TestingConnectorSession;
+import oracle.jdbc.OracleTypes;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+
+import static com.google.common.reflect.Reflection.newProxy;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.CharType.createCharType;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_SECONDS;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestOracleClient
+{
+    private static final JdbcClient CLIENT = new OracleClient(
+            new BaseJdbcConfig(),
+            new OracleConfig(),
+            session -> {
+                throw new UnsupportedOperationException();
+            },
+            new DefaultQueryBuilder(),
+            new DefaultIdentifierMapping());
+
+    private static final ConnectorSession SESSION = TestingConnectorSession.SESSION;
+
+    @Test(dataProvider = "writeMappingsProvider")
+    public void testTypedNullWriteMapping(Type type, String bindExpression, int nullJdbcType)
+            throws SQLException
+    {
+        WriteMapping writeMapping = CLIENT.toWriteMapping(SESSION, type);
+        assertThat(writeMapping.getWriteFunction()).isNotNull();
+        WriteFunction writeFunction = writeMapping.getWriteFunction();
+
+        assertThat(writeFunction.getBindExpression()).isEqualTo(bindExpression);
+
+        PreparedStatement statementProxy = newProxy(PreparedStatement.class, (proxy, method, args) -> {
+            // Calling setNull with a proper JDBC type is important for Oracle as it
+            // allows prepared statement to be cached and reused by the database cursor
+            // while writing. If the default implementation of the WriteFunction is used,
+            // NULL is sent with the JDBC type 0, which invalidates the cache for prepared statement.
+            // After invalidation, statement needs to be parsed and analyzed again,
+            // which has severe performance cost when writing large datasets containing NULLs.
+            assertThat(method.getName()).isEqualTo("setNull");
+            assertThat(args.length).isEqualTo(2);
+            assertThat(args[0]).isEqualTo(1325);
+            assertThat(args[1])
+                    .describedAs("expected jdbc type for NULL value")
+                    .isEqualTo(nullJdbcType);
+
+            return null;
+        });
+
+        writeFunction.setNull(statementProxy, 1325);
+    }
+
+    @DataProvider
+    public Object[][] writeMappingsProvider()
+    {
+        return new Object[][]{
+                {BOOLEAN, "?", Types.TINYINT},
+                {TINYINT, "?", Types.TINYINT},
+                {SMALLINT, "?", Types.SMALLINT},
+                {INTEGER, "?", Types.INTEGER},
+                {BIGINT, "?", Types.BIGINT},
+                {REAL, "?", Types.REAL},
+                {DOUBLE, "?", Types.DOUBLE},
+                {VARBINARY, "?", Types.VARBINARY},
+                {createCharType(25), "?", Types.NCHAR},
+                {createDecimalType(16, 6), "?", Types.DECIMAL},
+                {createDecimalType(36, 12), "?", Types.DECIMAL},
+                {createUnboundedVarcharType(), "?", Types.VARCHAR},
+                {createVarcharType(123), "?", Types.VARCHAR},
+                {TIMESTAMP_SECONDS, "TO_DATE(?, 'SYYYY-MM-DD HH24:MI:SS')", Types.VARCHAR},
+                {TIMESTAMP_MILLIS, "TO_TIMESTAMP(?, 'SYYYY-MM-DD HH24:MI:SS.FF')", Types.VARCHAR},
+                {TIMESTAMP_TZ_MILLIS, "?", OracleTypes.TIMESTAMPTZ},
+                {DATE, "TO_DATE(?, 'SYYYY-MM-DD')", Types.VARCHAR},
+        };
+    }
+}


### PR DESCRIPTION
Use this information when writing NULL values.

Some databases, like Oracle, expect NULLs to be typed,
and without that information, Oracle inserts explicit cast to column type
which slows inserts considerably.

Supersedes https://github.com/trinodb/trino/pull/12383