### PR TITLE
Ignore owner if translating Hive view in INVOKER mode

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -2443,20 +2443,8 @@ public class HiveMetadata
                         throw new HiveViewNotSupportedException(viewName);
                     }
 
-                    ConnectorViewDefinition definition = createViewReader(metastore, session, view, typeManager, this::redirectTable, metadataProvider, hiveViewsRunAsInvoker)
+                    return createViewReader(metastore, session, view, typeManager, this::redirectTable, metadataProvider, hiveViewsRunAsInvoker)
                             .decodeViewData(view.getViewOriginalText().get(), view, catalogName);
-                    // use owner from table metadata if it exists
-                    if (view.getOwner().isPresent() && !definition.isRunAsInvoker()) {
-                        definition = new ConnectorViewDefinition(
-                                definition.getOriginalSql(),
-                                definition.getCatalog(),
-                                definition.getSchema(),
-                                definition.getColumns(),
-                                definition.getComment(),
-                                view.getOwner(),
-                                false);
-                    }
-                    return definition;
                 });
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/LegacyHiveViewReader.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/LegacyHiveViewReader.java
@@ -49,7 +49,7 @@ public class LegacyHiveViewReader
                         .map(column -> new ConnectorViewDefinition.ViewColumn(column.getName(), TypeId.of(column.getType().getTypeSignature().toString())))
                         .collect(toImmutableList()),
                 Optional.ofNullable(table.getParameters().get(TABLE_COMMENT)),
-                table.getOwner(),
+                hiveViewsRunAsInvoker ? Optional.empty() : table.getOwner(),
                 hiveViewsRunAsInvoker);
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
@@ -226,7 +226,7 @@ public final class ViewReaderUtil
                         Optional.of(table.getDatabaseName()),
                         columns,
                         Optional.ofNullable(table.getParameters().get(TABLE_COMMENT)),
-                        Optional.empty(),
+                        hiveViewsRunAsInvoker ? Optional.empty() : table.getOwner(),
                         hiveViewsRunAsInvoker);
             }
             catch (RuntimeException e) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->
#12221 added the option to set the security mode for querying Hive views to either DEFINER OR INVOKER, where previously Hive views were hardcoded to run in DEFINER mode only. This option was needed because the way Hive views are defined for many organizations did not require setting an owner for the view, which prevents the DEFINER security mode from working.

This PR addresses a bug that appears as a result of that change for a specific code path, where if using the legacy Hive view logic in INVOKER mode with a Hive view that has an owner, queries will fail with the error:
`Query 20220919_184230_00013_9ndxr failed: owner cannot be present with runAsInvoker`

The bug comes from not taking into account that a [ConnectorViewDefinition](https://github.com/trinodb/trino/blob/dff92cf8a3ef8e1523a50c05e3cb4674acf3f465/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorViewDefinition.java#L56) cannot be created if running as invoker and an owner is set.

This change will avoid passing along the Hive view owner (if there is one) when creating a ConnectorViewDefinition to access a Hive view in INVOKER mode with the legacy code.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Hive connector

> How would you describe this change to a non-technical end user or system administrator?

This change prevents an error when querying a Hive view using a specific set of configuration values

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->
* Related PR #12221

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
