### PR TITLE
Support commenting on table in ClickHouse

### DIFF
--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseConnectorTest.java
@@ -18,7 +18,6 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.jdbc.BaseJdbcConnectorTest;
 import io.trino.sql.planner.plan.AggregationNode;
 import io.trino.testing.MaterializedResult;
-import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
 import io.trino.testing.sql.SqlExecutor;
 import io.trino.testing.sql.TestTable;
@@ -34,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static io.trino.plugin.clickhouse.ClickHouseQueryRunner.createClickHouseQueryRunner;
 import static io.trino.plugin.clickhouse.ClickHouseTableProperties.ENGINE_PROPERTY;
 import static io.trino.plugin.clickhouse.ClickHouseTableProperties.ORDER_BY_PROPERTY;
 import static io.trino.plugin.clickhouse.ClickHouseTableProperties.PARTITION_BY_PROPERTY;
@@ -51,24 +49,10 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
-public class TestClickHouseConnectorTest
+public abstract class BaseClickHouseConnectorTest
         extends BaseJdbcConnectorTest
 {
-    private TestingClickHouseServer clickhouseServer;
-
-    @Override
-    protected QueryRunner createQueryRunner()
-            throws Exception
-    {
-        this.clickhouseServer = closeAfterClass(new TestingClickHouseServer());
-        return createClickHouseQueryRunner(
-                clickhouseServer,
-                ImmutableMap.of(),
-                ImmutableMap.<String, String>builder()
-                        .put("clickhouse.map-string-as-varchar", "true")
-                        .buildOrThrow(),
-                REQUIRED_TPCH_TABLES);
-    }
+    protected TestingClickHouseServer clickhouseServer;
 
     @Override
     protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseConnectorTest.java
@@ -63,9 +63,6 @@ public abstract class BaseClickHouseConnectorTest
             case SUPPORTS_TOPN_PUSHDOWN:
                 return false;
 
-            case SUPPORTS_COMMENT_ON_TABLE:
-                return false;
-
             case SUPPORTS_ARRAY:
             case SUPPORTS_ROW_TYPE:
                 return false;

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.testing.QueryRunner;
 
 import static io.trino.plugin.clickhouse.ClickHouseQueryRunner.createClickHouseQueryRunner;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestClickHouseConnectorTest
         extends BaseClickHouseConnectorTest
@@ -33,5 +34,12 @@ public class TestClickHouseConnectorTest
                         .put("clickhouse.map-string-as-varchar", "true")
                         .buildOrThrow(),
                 REQUIRED_TPCH_TABLES);
+    }
+
+    @Override
+    public void testCommentTable()
+    {
+        assertThatThrownBy(super::testCommentTable)
+                .hasMessageContaining("Code: 62, e.displayText() = DB::Exception: Syntax error");
     }
 }

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.clickhouse;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.QueryRunner;
+
+import static io.trino.plugin.clickhouse.ClickHouseQueryRunner.createClickHouseQueryRunner;
+
+public class TestClickHouseConnectorTest
+        extends BaseClickHouseConnectorTest
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        this.clickhouseServer = closeAfterClass(new TestingClickHouseServer());
+        return createClickHouseQueryRunner(
+                clickhouseServer,
+                ImmutableMap.of(),
+                ImmutableMap.<String, String>builder()
+                        .put("clickhouse.map-string-as-varchar", "true")
+                        .buildOrThrow(),
+                REQUIRED_TPCH_TABLES);
+    }
+}

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseLatestConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseLatestConnectorTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.clickhouse;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.QueryRunner;
+
+import static io.trino.plugin.clickhouse.ClickHouseQueryRunner.createClickHouseQueryRunner;
+import static io.trino.plugin.clickhouse.TestingClickHouseServer.CLICKHOUSE_LATEST_IMAGE;
+
+public class TestClickHouseLatestConnectorTest
+        extends BaseClickHouseConnectorTest
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        this.clickhouseServer = closeAfterClass(new TestingClickHouseServer(CLICKHOUSE_LATEST_IMAGE));
+        return createClickHouseQueryRunner(
+                clickhouseServer,
+                ImmutableMap.of(),
+                ImmutableMap.<String, String>builder()
+                        .put("clickhouse.map-string-as-varchar", "true")
+                        .buildOrThrow(),
+                REQUIRED_TPCH_TABLES);
+    }
+}


### PR DESCRIPTION
## Description

* Fixes #11216

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# ClickHouse
* Add support for [`COMMENT ON TABLE`](/sql/comment). ({issue}`11216`)
```
