### PR TITLE
Avoid no-op Iceberg table snapshot if DML doesn't change table state

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -565,6 +565,14 @@ public class IcebergMetadata
     @Override
     public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
+        if (fragments.isEmpty()) {
+            // Commit the transaction if the table is being created without data
+            transaction.newFastAppend().commit();
+            transaction.commitTransaction();
+            transaction = null;
+            return Optional.empty();
+        }
+
         return finishInsert(session, (IcebergWritableTableHandle) tableHandle, fragments, computedStatistics);
     }
 
@@ -626,13 +634,17 @@ public class IcebergMetadata
     @Override
     public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
-        IcebergWritableTableHandle table = (IcebergWritableTableHandle) insertHandle;
-        Table icebergTable = transaction.table();
-
         List<CommitTaskData> commitTasks = fragments.stream()
                 .map(slice -> commitTaskCodec.fromJson(slice.getBytes()))
                 .collect(toImmutableList());
 
+        if (commitTasks.isEmpty()) {
+            transaction = null;
+            return Optional.empty();
+        }
+
+        IcebergWritableTableHandle table = (IcebergWritableTableHandle) insertHandle;
+        Table icebergTable = transaction.table();
         Type[] partitionColumnTypes = icebergTable.spec().fields().stream()
                 .map(field -> field.transform().getResultType(
                         icebergTable.schema().findType(field.sourceId())))
@@ -1344,6 +1356,12 @@ public class IcebergMetadata
         List<CommitTaskData> commitTasks = fragments.stream()
                 .map(slice -> commitTaskCodec.fromJson(slice.getBytes()))
                 .collect(toImmutableList());
+
+        if (commitTasks.isEmpty()) {
+            // Avoid recording "empty" write operation
+            transaction = null;
+            return;
+        }
 
         Schema schema = SchemaParser.fromJson(table.getTableSchemaJson());
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -3482,6 +3482,78 @@ public abstract class BaseIcebergConnectorTest
         assertUpdate("DROP TABLE " + tableName);
     }
 
+    @Test
+    public void testEmptyCreateTableAsSelect()
+    {
+        String tableName = "test_empty_ctas_" + randomTableSuffix();
+
+        assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM nation WHERE false", 0);
+        List<Long> initialTableSnapshots = getSnapshotIds(tableName);
+        assertThat(initialTableSnapshots.size())
+                .withFailMessage("CTAS operations must create Iceberg snapshot independently whether the selection is empty or not")
+                .isEqualTo(1);
+        assertQueryReturnsEmptyResult("SELECT * FROM " + tableName);
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testEmptyInsert()
+    {
+        String tableName = "test_empty_insert_" + randomTableSuffix();
+
+        assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM nation", "SELECT count(*) FROM nation");
+        List<Long> initialTableSnapshots = getSnapshotIds(tableName);
+
+        assertUpdate("INSERT INTO " + tableName + " SELECT * FROM nation WHERE false", 0);
+        List<Long> updatedTableSnapshots = getSnapshotIds(tableName);
+
+        assertThat(initialTableSnapshots)
+                .withFailMessage("INSERT operations that are not changing the state of the table must not cause the creation of a new Iceberg snapshot")
+                .hasSize(1)
+                .isEqualTo(updatedTableSnapshots);
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testEmptyUpdate()
+    {
+        String tableName = "test_empty_update_" + randomTableSuffix();
+
+        assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM nation", "SELECT count(*) FROM nation");
+        List<Long> initialTableSnapshots = getSnapshotIds(tableName);
+
+        assertUpdate("UPDATE " + tableName + " SET comment = 'new comment' WHERE nationkey IS NULL", 0);
+        List<Long> updatedTableSnapshots = getSnapshotIds(tableName);
+
+        assertThat(initialTableSnapshots)
+                .withFailMessage("UPDATE operations that are not changing the state of the table must not cause the creation of a new Iceberg snapshot")
+                .hasSize(1)
+                .isEqualTo(updatedTableSnapshots);
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testEmptyDelete()
+    {
+        String tableName = "test_empty_delete_" + randomTableSuffix();
+
+        assertUpdate("CREATE TABLE " + tableName + " WITH (format = '" + format.name() + "') AS SELECT * FROM nation", "SELECT count(*) FROM nation");
+        List<Long> initialTableSnapshots = getSnapshotIds(tableName);
+
+        assertUpdate("DELETE FROM " + tableName + " WHERE nationkey IS NULL", 0);
+        List<Long> updatedTableSnapshots = getSnapshotIds(tableName);
+
+        assertThat(initialTableSnapshots)
+                .withFailMessage("DELETE operations that are not changing the state of the table must not cause the creation of a new Iceberg snapshot")
+                .hasSize(1)
+                .isEqualTo(updatedTableSnapshots);
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
     private Session prepareCleanUpSession()
     {
         return Session.builder(getSession())


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

This PR avoids creating an Iceberg snapshot when dealing with a DML statement that does not affect the contents of the Iceberg table.

e.g. : 

```
INSERT INTO iceberg.default.iceberg_table SELECT * FROM source_table WHERE false
```

NOTE however that a CTAS statement that corresponds to an empty `SELECT` will be obviously recorded as a table snapshot because it creates the table.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Iceberg connector

> How would you describe this change to a non-technical end user or system administrator?

Avoid creating a snapshot for a table when dealing with an empty DML (INSERT, UPDATE, DELETE) statement.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

Fixes #12319

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Iceberg
* Avoid creating a table snapshot for DML statements that do not change the table state
```
