### PR TITLE
Remove unused parameter in `MetadataManager`

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -178,7 +178,6 @@ public final class MetadataManager
 
     @Inject
     public MetadataManager(
-            FeaturesConfig featuresConfig,
             SystemSecurityMetadata systemSecurityMetadata,
             TransactionManager transactionManager,
             GlobalFunctionCatalog globalFunctionCatalog,
@@ -2544,7 +2543,6 @@ public final class MetadataManager
 
     public static class TestMetadataManagerBuilder
     {
-        private FeaturesConfig featuresConfig;
         private TransactionManager transactionManager;
         private TypeManager typeManager = TESTING_TYPE_MANAGER;
         private GlobalFunctionCatalog globalFunctionCatalog;
@@ -2554,12 +2552,6 @@ public final class MetadataManager
         public TestMetadataManagerBuilder withCatalogManager(CatalogManager catalogManager)
         {
             this.transactionManager = createTestTransactionManager(catalogManager);
-            return this;
-        }
-
-        public TestMetadataManagerBuilder withFeaturesConfig(FeaturesConfig featuresConfig)
-        {
-            this.featuresConfig = featuresConfig;
             return this;
         }
 
@@ -2583,11 +2575,6 @@ public final class MetadataManager
 
         public MetadataManager build()
         {
-            FeaturesConfig featuresConfig = this.featuresConfig;
-            if (featuresConfig == null) {
-                featuresConfig = new FeaturesConfig();
-            }
-
             TransactionManager transactionManager = this.transactionManager;
             if (transactionManager == null) {
                 transactionManager = createTestTransactionManager();
@@ -2597,12 +2584,11 @@ public final class MetadataManager
             if (globalFunctionCatalog == null) {
                 globalFunctionCatalog = new GlobalFunctionCatalog();
                 TypeOperators typeOperators = new TypeOperators();
-                globalFunctionCatalog.addFunctions(SystemFunctionBundle.create(featuresConfig, typeOperators, new BlockTypeOperators(typeOperators), UNKNOWN));
+                globalFunctionCatalog.addFunctions(SystemFunctionBundle.create(new FeaturesConfig(), typeOperators, new BlockTypeOperators(typeOperators), UNKNOWN));
                 globalFunctionCatalog.addFunctions(new InternalFunctionBundle(new LiteralFunction(new InternalBlockEncodingSerde(new BlockEncodingManager(), typeManager))));
             }
 
             return new MetadataManager(
-                    featuresConfig,
                     new DisabledSystemSecurityMetadata(),
                     transactionManager,
                     globalFunctionCatalog,

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -356,7 +356,6 @@ public class LocalQueryRunner
         globalFunctionCatalog.addFunctions(SystemFunctionBundle.create(featuresConfig, typeOperators, blockTypeOperators, nodeManager.getCurrentNode().getNodeVersion()));
         this.functionManager = new FunctionManager(globalFunctionCatalog);
         Metadata metadata = metadataProvider.getMetadata(
-                featuresConfig,
                 new DisabledSystemSecurityMetadata(),
                 transactionManager,
                 globalFunctionCatalog,
@@ -1148,7 +1147,6 @@ public class LocalQueryRunner
     public interface MetadataProvider
     {
         Metadata getMetadata(
-                FeaturesConfig featuresConfig,
                 SystemSecurityMetadata systemSecurityMetadata,
                 TransactionManager transactionManager,
                 GlobalFunctionCatalog globalFunctionCatalog,

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestingPlannerContext.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestingPlannerContext.java
@@ -118,7 +118,6 @@ public final class TestingPlannerContext
             Metadata metadata = this.metadata;
             if (metadata == null) {
                 TestMetadataManagerBuilder builder = MetadataManager.testMetadataManagerBuilder()
-                        .withFeaturesConfig(featuresConfig)
                         .withTypeManager(typeManager)
                         .withGlobalFunctionCatalog(globalFunctionCatalog);
                 if (transactionManager != null) {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGetTableStatisticsOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGetTableStatisticsOperations.java
@@ -59,8 +59,8 @@ public class TestIcebergGetTableStatisticsOperations
             throws Exception
     {
         localQueryRunner = LocalQueryRunner.builder(testSessionBuilder().build())
-                .withMetadataProvider((featuresConfig, systemSecurityMetadata, transactionManager, globalFunctionCatalog, typeManager)
-                        -> new CountingAccessMetadata(new MetadataManager(featuresConfig, systemSecurityMetadata, transactionManager, globalFunctionCatalog, typeManager)))
+                .withMetadataProvider((systemSecurityMetadata, transactionManager, globalFunctionCatalog, typeManager)
+                        -> new CountingAccessMetadata(new MetadataManager(systemSecurityMetadata, transactionManager, globalFunctionCatalog, typeManager)))
                 .build();
         metadata = (CountingAccessMetadata) localQueryRunner.getMetadata();
         localQueryRunner.installPlugin(new TpchPlugin());

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestGetTableStatisticsOperations.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestGetTableStatisticsOperations.java
@@ -43,8 +43,8 @@ public class TestGetTableStatisticsOperations
             throws Exception
     {
         localQueryRunner = LocalQueryRunner.builder(testSessionBuilder().build())
-                .withMetadataProvider((featuresConfig, systemSecurityMetadata, transactionManager, globalFunctionCatalog, typeManager)
-                        -> new CountingAccessMetadata(new MetadataManager(featuresConfig, systemSecurityMetadata, transactionManager, globalFunctionCatalog, typeManager)))
+                .withMetadataProvider((systemSecurityMetadata, transactionManager, globalFunctionCatalog, typeManager)
+                        -> new CountingAccessMetadata(new MetadataManager(systemSecurityMetadata, transactionManager, globalFunctionCatalog, typeManager)))
                 .build();
         metadata = (CountingAccessMetadata) localQueryRunner.getMetadata();
         localQueryRunner.installPlugin(new TpchPlugin());


### PR DESCRIPTION
## Description

After the following two commits were merged, the `featuresConfig` parameter was no longer used in `MetadataManager`, so I removed it.
https://github.com/trinodb/trino/commit/309efbbae91aaf89107db149d908dd179d58c950
https://github.com/trinodb/trino/commit/0ec20cce411447400f9955bf043e72043a9f6d54

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.