### PR TITLE
Support implicit conversion

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -37,11 +37,14 @@ import io.trino.spi.ErrorCodeSupplier;
 import io.trino.spi.TrinoException;
 import io.trino.spi.TrinoWarning;
 import io.trino.spi.function.OperatorType;
+import io.trino.spi.type.BigintType;
 import io.trino.spi.type.CharType;
 import io.trino.spi.type.DateType;
 import io.trino.spi.type.DecimalParseResult;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Decimals;
+import io.trino.spi.type.DoubleType;
+import io.trino.spi.type.IntegerType;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.TimeType;
 import io.trino.spi.type.TimeWithTimeZoneType;
@@ -86,6 +89,7 @@ import io.trino.sql.tree.FieldReference;
 import io.trino.sql.tree.Format;
 import io.trino.sql.tree.FrameBound;
 import io.trino.sql.tree.FunctionCall;
+import io.trino.sql.tree.GenericDataType;
 import io.trino.sql.tree.GenericLiteral;
 import io.trino.sql.tree.GroupingOperation;
 import io.trino.sql.tree.Identifier;
@@ -102,6 +106,7 @@ import io.trino.sql.tree.LogicalExpression;
 import io.trino.sql.tree.LongLiteral;
 import io.trino.sql.tree.MeasureDefinition;
 import io.trino.sql.tree.Node;
+import io.trino.sql.tree.NodeLocation;
 import io.trino.sql.tree.NodeRef;
 import io.trino.sql.tree.NotExpression;
 import io.trino.sql.tree.NullIfExpression;
@@ -758,6 +763,9 @@ public class ExpressionAnalyzer
                 default:
                     throw new UnsupportedOperationException("Unsupported comparison operator: " + node.getOperator());
             }
+            Optional<String> convertedDataType = getConvertedDateType(node.getLeft(), node.getRight(), context);
+            Optional<Expression> convertedExpression = getConvertedExpression(node.getRight(), convertedDataType);
+            convertedExpression.ifPresent(exp -> node.setRight(exp));
             return getOperator(context, node, operatorType, node.getLeft(), node.getRight());
         }
 
@@ -920,6 +928,9 @@ public class ExpressionAnalyzer
         @Override
         protected Type visitArithmeticBinary(ArithmeticBinaryExpression node, StackableAstVisitorContext<Context> context)
         {
+            Optional<String> convertedDataType = getConvertedDateType(node.getLeft(), node.getRight(), context);
+            Optional<Expression> convertedExpression = getConvertedExpression(node.getRight(), convertedDataType);
+            convertedExpression.ifPresent(exp -> node.setRight(exp));
             return getOperator(context, node, OperatorType.valueOf(node.getOperator().name()), node.getLeft(), node.getRight());
         }
 
@@ -2129,6 +2140,10 @@ public class ExpressionAnalyzer
         protected Type visitBetweenPredicate(BetweenPredicate node, StackableAstVisitorContext<Context> context)
         {
             Type valueType = process(node.getValue(), context);
+            Optional<Expression> convertedMinExpression = getConvertedExpression(node.getMin(), getConvertedDateType(node.getValue(), node.getMin(), context));
+            convertedMinExpression.ifPresent(exp -> node.setMin(exp));
+            Optional<Expression> convertedMaxExpression = getConvertedExpression(node.getMax(), getConvertedDateType(node.getValue(), node.getMax(), context));
+            convertedMaxExpression.ifPresent(exp -> node.setMax(exp));
             Type minType = process(node.getMin(), context);
             Type maxType = process(node.getMax(), context);
 
@@ -2234,6 +2249,12 @@ public class ExpressionAnalyzer
 
             if (valueList instanceof InListExpression) {
                 InListExpression inListExpression = (InListExpression) valueList;
+                List<Expression> replacedValueList = new ArrayList<>();
+                for (Expression listValue : inListExpression.getValues()) {
+                    final Optional<Expression> convertedExpression = getConvertedExpression(listValue, getConvertedDateType(value, listValue, context));
+                    convertedExpression.ifPresentOrElse(exp -> replacedValueList.add(exp), () -> replacedValueList.add(listValue));
+                }
+                inListExpression.setValues(replacedValueList);
                 Type type = coerceToSingleType(context,
                         "IN value and list items must be the same type: %s",
                         ImmutableList.<Expression>builder().add(value).addAll(inListExpression.getValues()).build());
@@ -2494,6 +2515,71 @@ public class ExpressionAnalyzer
             else {
                 return setExpressionType(node, BIGINT);
             }
+        }
+
+        private Optional<Expression> getConvertedExpression(Expression expression, Optional<String> dataType)
+        {
+            if (dataType.isPresent()) {
+                return Optional.of(new TryExpression(new Cast(expression, new GenericDataType(new NodeLocation(1, 1), new Identifier(dataType.get()), new ArrayList<>()))));
+            }
+            else {
+                return Optional.ofNullable(null);
+            }
+        }
+
+        private Optional<String> getConvertedDateType(Expression left, Expression right, StackableAstVisitorContext<Context> context)
+        {
+            Type leftType = process(left, context);
+            Type rightType = process(right, context);
+            if (leftType == rightType) {
+                return Optional.ofNullable(null);
+            }
+            Optional<String> typeIntAndVarchar = getDataTypeIntAndVarchar(leftType, rightType);
+            if (typeIntAndVarchar.isPresent()) {
+                return typeIntAndVarchar;
+            }
+            Optional<String> typeBigintAndVarchar = getDataTypeBigintAndVarchar(leftType, rightType);
+            if (typeBigintAndVarchar.isPresent()) {
+                return typeBigintAndVarchar;
+            }
+            Optional<String> typeDoubleAndVarchar = getDataTypeDoubleAndVarchar(leftType, rightType);
+            if (typeDoubleAndVarchar.isPresent()) {
+                return typeDoubleAndVarchar;
+            }
+            return Optional.ofNullable(null);
+        }
+
+        private Optional<String> getDataTypeBigintAndVarchar(Type leftType, Type rightType)
+        {
+            if (leftType instanceof BigintType && rightType instanceof VarcharType) {
+                return Optional.of("bigint");
+            }
+            if (leftType instanceof VarcharType && rightType instanceof BigintType) {
+                return Optional.of("varchar");
+            }
+            return Optional.ofNullable(null);
+        }
+
+        private Optional<String> getDataTypeIntAndVarchar(Type leftType, Type rightType)
+        {
+            if (leftType instanceof IntegerType && rightType instanceof VarcharType) {
+                return Optional.of("integer");
+            }
+            if (leftType instanceof VarcharType && rightType instanceof IntegerType) {
+                return Optional.of("varchar");
+            }
+            return Optional.ofNullable(null);
+        }
+
+        private Optional<String> getDataTypeDoubleAndVarchar(Type leftType, Type rightType)
+        {
+            if (leftType instanceof DoubleType && rightType instanceof VarcharType) {
+                return Optional.of("double");
+            }
+            if (leftType instanceof VarcharType && rightType instanceof DoubleType) {
+                return Optional.of("varchar");
+            }
+            return Optional.ofNullable(null);
         }
 
         private Type getOperator(StackableAstVisitorContext<Context> context, Expression node, OperatorType operatorType, Expression... arguments)

--- a/core/trino-main/src/test/java/io/trino/sql/TestDataTypeImplicitConvert.java
+++ b/core/trino-main/src/test/java/io/trino/sql/TestDataTypeImplicitConvert.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql;
+
+import io.trino.metadata.Metadata;
+import io.trino.sql.tree.Expression;
+import org.testng.annotations.Test;
+
+import static io.trino.metadata.MetadataManager.createTestMetadataManager;
+import static io.trino.sql.ExpressionTestUtils.analyzeExpression;
+import static io.trino.sql.ExpressionTestUtils.assertExpressionEquals;
+import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expression;
+
+public class TestDataTypeImplicitConvert
+{
+    private final Metadata metadata = createTestMetadataManager();
+
+    @Test
+    public void testIntVarcharComparisonExp()
+    {
+        Expression exp1 = expression("1='1'");
+        analyzeExpression(metadata, exp1);
+        assertExpressionEquals(expression(exp1.toString()), expression("(1 = TRY(CAST('1' AS integer)))"));
+
+        Expression exp2 = expression("1!='1'");
+        analyzeExpression(metadata, exp2);
+        assertExpressionEquals(expression(exp2.toString()), expression("(1 <> TRY(CAST('1' AS integer)))"));
+
+        Expression exp3 = expression("1>'1'");
+        analyzeExpression(metadata, exp3);
+        assertExpressionEquals(expression(exp3.toString()), expression("(1 > TRY(CAST('1' AS integer)))"));
+
+        Expression exp4 = expression("1>='1'");
+        analyzeExpression(metadata, exp4);
+        assertExpressionEquals(expression(exp4.toString()), expression("(1 >= TRY(CAST('1' AS integer)))"));
+
+        Expression exp5 = expression("1<'1'");
+        analyzeExpression(metadata, exp5);
+        assertExpressionEquals(expression(exp5.toString()), expression("(1 < TRY(CAST('1' AS integer)))"));
+
+        Expression exp6 = expression("1<='1'");
+        analyzeExpression(metadata, exp6);
+        assertExpressionEquals(expression(exp6.toString()), expression("(1 <= TRY(CAST('1' AS integer)))"));
+    }
+
+    @Test
+    public void testBigIntVarcharComparisonExp()
+    {
+        Expression exp1 = expression("100000000000000='1'");
+        analyzeExpression(metadata, exp1);
+        assertExpressionEquals(expression(exp1.toString()), expression("(100000000000000 = TRY(CAST('1' AS bigint)))"));
+
+        Expression exp2 = expression("100000000000000!='1'");
+        analyzeExpression(metadata, exp2);
+        assertExpressionEquals(expression(exp2.toString()), expression("(100000000000000 <> TRY(CAST('1' AS bigint)))"));
+
+        Expression exp3 = expression("100000000000000>'1'");
+        analyzeExpression(metadata, exp3);
+        assertExpressionEquals(expression(exp3.toString()), expression("(100000000000000 > TRY(CAST('1' AS bigint)))"));
+
+        Expression exp4 = expression("100000000000000>='1'");
+        analyzeExpression(metadata, exp4);
+        assertExpressionEquals(expression(exp4.toString()), expression("(100000000000000 >= TRY(CAST('1' AS bigint)))"));
+
+        Expression exp5 = expression("100000000000000<'1'");
+        analyzeExpression(metadata, exp5);
+        assertExpressionEquals(expression(exp5.toString()), expression("(100000000000000 < TRY(CAST('1' AS bigint)))"));
+
+        Expression exp6 = expression("100000000000000<='1'");
+        analyzeExpression(metadata, exp6);
+        assertExpressionEquals(expression(exp6.toString()), expression("(100000000000000 <= TRY(CAST('1' AS bigint)))"));
+    }
+
+    @Test
+    public void testDoubleVarcharComparisonExp()
+    {
+        Expression exp1 = expression("1.12e0 ='1'");
+        analyzeExpression(metadata, exp1);
+        assertExpressionEquals(expression(exp1.toString()), expression("(1.12E0 = TRY(CAST('1' AS double)))"));
+
+        Expression exp2 = expression("1.12e0!='1'");
+        analyzeExpression(metadata, exp2);
+        assertExpressionEquals(expression(exp2.toString()), expression("(1.12E0 <> TRY(CAST('1' AS double)))"));
+
+        Expression exp3 = expression("1.12e0>'1'");
+        analyzeExpression(metadata, exp3);
+        assertExpressionEquals(expression(exp3.toString()), expression("(1.12E0 > TRY(CAST('1' AS double)))"));
+
+        Expression exp4 = expression("1.12e0>='1'");
+        analyzeExpression(metadata, exp4);
+        assertExpressionEquals(expression(exp4.toString()), expression("(1.12E0 >= TRY(CAST('1' AS double)))"));
+
+        Expression exp5 = expression("1.12e0<'1'");
+        analyzeExpression(metadata, exp5);
+        assertExpressionEquals(expression(exp5.toString()), expression("(1.12E0 < TRY(CAST('1' AS double)))"));
+
+        Expression exp6 = expression("1.12e0<='1'");
+        analyzeExpression(metadata, exp6);
+        assertExpressionEquals(expression(exp6.toString()), expression("(1.12E0 <= TRY(CAST('1' AS double)))"));
+    }
+
+    @Test
+    public void testIntVarcharArithmeticBinaryExp()
+    {
+        Expression exp1 = expression("1+'1'");
+        analyzeExpression(metadata, exp1);
+        assertExpressionEquals(expression(exp1.toString()), expression("(1 + TRY(CAST('1' AS integer)))"));
+
+        Expression exp2 = expression("1-'1'");
+        analyzeExpression(metadata, exp2);
+        assertExpressionEquals(expression(exp2.toString()), expression("(1 - TRY(CAST('1' AS integer)))"));
+
+        Expression exp3 = expression("1*'1'");
+        analyzeExpression(metadata, exp3);
+        assertExpressionEquals(expression(exp3.toString()), expression("(1 * TRY(CAST('1' AS integer)))"));
+
+        Expression exp4 = expression("1/'1'");
+        analyzeExpression(metadata, exp4);
+        assertExpressionEquals(expression(exp4.toString()), expression("(1 / TRY(CAST('1' AS integer)))"));
+
+        Expression exp5 = expression("1%'1'");
+        analyzeExpression(metadata, exp5);
+        assertExpressionEquals(expression(exp5.toString()), expression("(1 % TRY(CAST('1' AS integer)))"));
+    }
+
+    @Test
+    public void testBigintVarcharArithmeticBinaryExp()
+    {
+        Expression exp1 = expression("100000000000000+'1'");
+        analyzeExpression(metadata, exp1);
+        assertExpressionEquals(expression(exp1.toString()), expression("(100000000000000 + TRY(CAST('1' AS bigint)))"));
+
+        Expression exp2 = expression("100000000000000-'1'");
+        analyzeExpression(metadata, exp2);
+        assertExpressionEquals(expression(exp2.toString()), expression("(100000000000000 - TRY(CAST('1' AS bigint)))"));
+
+        Expression exp3 = expression("100000000000000*'1'");
+        analyzeExpression(metadata, exp3);
+        assertExpressionEquals(expression(exp3.toString()), expression("(100000000000000 * TRY(CAST('1' AS bigint)))"));
+
+        Expression exp4 = expression("100000000000000/'1'");
+        analyzeExpression(metadata, exp4);
+        assertExpressionEquals(expression(exp4.toString()), expression("(100000000000000 / TRY(CAST('1' AS bigint)))"));
+
+        Expression exp5 = expression("100000000000000%'1'");
+        analyzeExpression(metadata, exp5);
+        assertExpressionEquals(expression(exp5.toString()), expression("(100000000000000 % TRY(CAST('1' AS bigint)))"));
+    }
+
+    @Test
+    public void testDoubleVarcharArithmeticBinaryExp()
+    {
+        Expression exp1 = expression("1.12E0 + '1'");
+        analyzeExpression(metadata, exp1);
+        assertExpressionEquals(expression(exp1.toString()), expression("(1.12E0 + TRY(CAST('1' AS double)))"));
+
+        Expression exp2 = expression("1.12E0 - '1'");
+        analyzeExpression(metadata, exp2);
+        assertExpressionEquals(expression(exp2.toString()), expression("(1.12E0 - TRY(CAST('1' AS double)))"));
+
+        Expression exp3 = expression("1.12E0 * '1'");
+        analyzeExpression(metadata, exp3);
+        assertExpressionEquals(expression(exp3.toString()), expression("(1.12E0 * TRY(CAST('1' AS double)))"));
+
+        Expression exp4 = expression("1.12E0 / '1'");
+        analyzeExpression(metadata, exp4);
+        assertExpressionEquals(expression(exp4.toString()), expression("(1.12E0 / TRY(CAST('1' AS double)))"));
+
+        Expression exp5 = expression("1.12E0 %'1'");
+        analyzeExpression(metadata, exp5);
+        assertExpressionEquals(expression(exp5.toString()), expression("(1.12E0 % TRY(CAST('1' AS double)))"));
+    }
+
+    @Test
+    public void testIntVarcharInExp()
+    {
+        Expression exp1 = expression("1 in('1','2','3')");
+        analyzeExpression(metadata, exp1);
+        assertExpressionEquals(expression(exp1.toString()), expression("(1 IN (TRY(CAST('1' AS integer)), TRY(CAST('2' AS integer)), TRY(CAST('3' AS integer))))"));
+
+        Expression exp2 = expression("'1' in(1,2,3)");
+        analyzeExpression(metadata, exp2);
+        assertExpressionEquals(expression(exp2.toString()), expression("('1' IN (TRY(CAST(1 AS varchar)), TRY(CAST(2 AS varchar)), TRY(CAST(3 AS varchar))))"));
+
+        Expression exp3 = expression("1 in(1,'2',3)");
+        analyzeExpression(metadata, exp3);
+        assertExpressionEquals(expression(exp3.toString()), expression("(1 IN (1, TRY(CAST('2' AS integer)), 3))"));
+    }
+
+    @Test
+    public void testBigintVarcharInExp()
+    {
+        Expression exp1 = expression("100000000000000 in('1','2','3')");
+        analyzeExpression(metadata, exp1);
+        assertExpressionEquals(expression(exp1.toString()), expression("(100000000000000 IN (TRY(CAST('1' AS bigint)), TRY(CAST('2' AS bigint)), TRY(CAST('3' AS bigint))))"));
+
+        Expression exp2 = expression("'1' in(100000000000000,200000000000000,300000000000000)");
+        analyzeExpression(metadata, exp2);
+        assertExpressionEquals(expression(exp2.toString()), expression("('1' IN (TRY(CAST(100000000000000 AS varchar)), TRY(CAST(200000000000000 AS varchar)), TRY(CAST(300000000000000 AS varchar))))"));
+
+        Expression exp3 = expression("100000000000000 in(100000000000000,'2',200000000000000)");
+        analyzeExpression(metadata, exp3);
+        assertExpressionEquals(expression(exp3.toString()), expression("(100000000000000 IN (100000000000000, TRY(CAST('2' AS bigint)), 200000000000000))"));
+    }
+
+    @Test
+    public void testDoubleVarcharInExp()
+    {
+        Expression exp1 = expression("1.12E0 in('1','2','3')");
+        analyzeExpression(metadata, exp1);
+        assertExpressionEquals(expression(exp1.toString()), expression("(1.12E0 IN (TRY(CAST('1' AS double)), TRY(CAST('2' AS double)), TRY(CAST('3' AS double))))"));
+
+        Expression exp2 = expression("'1.12' in(1.1E0, 1.2E0, 1.3E0)");
+        analyzeExpression(metadata, exp2);
+        assertExpressionEquals(expression(exp2.toString()), expression("('1.12' IN (TRY(CAST(1.1E0 AS varchar)), TRY(CAST(1.2E0 AS varchar)), TRY(CAST(1.3E0 AS varchar))))"));
+
+        Expression exp3 = expression("1.1E0 in(1.1E0,'2', 1.2E0)");
+        analyzeExpression(metadata, exp3);
+        assertExpressionEquals(expression(exp3.toString()), expression("(1.1E0 IN (1.1E0, TRY(CAST('2' AS double)), 1.2E0))"));
+    }
+
+    @Test
+    public void testIntVarcharBetweenExp()
+    {
+        Expression exp1 = expression("1 between '1' and '2'");
+        analyzeExpression(metadata, exp1);
+        assertExpressionEquals(expression(exp1.toString()), expression("(1 BETWEEN TRY(CAST('1' AS integer)) AND TRY(CAST('2' AS integer)))"));
+
+        Expression exp2 = expression("'1' between 1 and 2");
+        analyzeExpression(metadata, exp2);
+        assertExpressionEquals(expression(exp2.toString()), expression("('1' BETWEEN TRY(CAST(1 AS varchar)) AND TRY(CAST(2 AS varchar)))"));
+
+        Expression exp3 = expression("1 between '1' and 2");
+        analyzeExpression(metadata, exp3);
+        assertExpressionEquals(expression(exp3.toString()), expression("(1 BETWEEN TRY(CAST('1' AS integer)) AND 2)"));
+    }
+
+    @Test
+    public void testBigintVarcharBetweenExp()
+    {
+        Expression exp1 = expression("100000000000000 between '1' and '2'");
+        analyzeExpression(metadata, exp1);
+        assertExpressionEquals(expression(exp1.toString()), expression("(100000000000000 BETWEEN TRY(CAST('1' AS bigint)) AND TRY(CAST('2' AS bigint)))"));
+
+        Expression exp2 = expression("'1' between 100000000000000 and 200000000000000");
+        analyzeExpression(metadata, exp2);
+        assertExpressionEquals(expression(exp2.toString()), expression("('1' BETWEEN TRY(CAST(100000000000000 AS varchar)) AND TRY(CAST(200000000000000 AS varchar)))"));
+
+        Expression exp3 = expression("100000000000000 between '1' and 200000000000000");
+        analyzeExpression(metadata, exp3);
+        assertExpressionEquals(expression(exp3.toString()), expression("(100000000000000 BETWEEN TRY(CAST('1' AS bigint)) AND 200000000000000)"));
+    }
+
+    @Test
+    public void testDoubleVarcharBetweenExp()
+    {
+        Expression exp1 = expression("1.12E0 between '1' and '2'");
+        analyzeExpression(metadata, exp1);
+        assertExpressionEquals(expression(exp1.toString()), expression("(1.12E0 BETWEEN TRY(CAST('1' AS double)) AND TRY(CAST('2' AS double)))"));
+
+        Expression exp2 = expression("'1.12' between 100000000000000 and 200000000000000");
+        analyzeExpression(metadata, exp2);
+        assertExpressionEquals(expression(exp2.toString()), expression("('1.12' BETWEEN TRY(CAST(100000000000000 AS varchar)) AND TRY(CAST(200000000000000 AS varchar)))"));
+
+        Expression exp3 = expression("1.12E0 between '1' and 1.13E0");
+        analyzeExpression(metadata, exp3);
+        assertExpressionEquals(expression(exp3.toString()), expression("(1.12E0 BETWEEN TRY(CAST('1' AS double)) AND 1.13E0)"));
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ArithmeticBinaryExpression.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ArithmeticBinaryExpression.java
@@ -43,8 +43,8 @@ public class ArithmeticBinaryExpression
     }
 
     private final Operator operator;
-    private final Expression left;
-    private final Expression right;
+    private Expression left;
+    private Expression right;
 
     public ArithmeticBinaryExpression(Operator operator, Expression left, Expression right)
     {
@@ -74,9 +74,19 @@ public class ArithmeticBinaryExpression
         return left;
     }
 
+    public void setLeft(Expression left)
+    {
+        this.left = left;
+    }
+
     public Expression getRight()
     {
         return right;
+    }
+
+    public void setRight(Expression right)
+    {
+        this.right = right;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/BetweenPredicate.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/BetweenPredicate.java
@@ -25,8 +25,8 @@ public class BetweenPredicate
         extends Expression
 {
     private final Expression value;
-    private final Expression min;
-    private final Expression max;
+    private Expression min;
+    private Expression max;
 
     public BetweenPredicate(Expression value, Expression min, Expression max)
     {
@@ -60,9 +60,19 @@ public class BetweenPredicate
         return min;
     }
 
+    public void setMin(Expression min)
+    {
+        this.min = min;
+    }
+
     public Expression getMax()
     {
         return max;
+    }
+
+    public void setMax(Expression max)
+    {
+        this.max = max;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ComparisonExpression.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ComparisonExpression.java
@@ -25,8 +25,8 @@ public class ComparisonExpression
         extends Expression
 {
     private final Operator operator;
-    private final Expression left;
-    private final Expression right;
+    private Expression left;
+    private Expression right;
 
     public ComparisonExpression(Operator operator, Expression left, Expression right)
     {
@@ -60,9 +60,19 @@ public class ComparisonExpression
         return left;
     }
 
+    public void setLeft(Expression left)
+    {
+        this.left = left;
+    }
+
     public Expression getRight()
     {
         return right;
+    }
+
+    public void setRight(Expression right)
+    {
+        this.right = right;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/InListExpression.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/InListExpression.java
@@ -25,7 +25,7 @@ import static java.util.Objects.requireNonNull;
 public class InListExpression
         extends Expression
 {
-    private final List<Expression> values;
+    private List<Expression> values;
 
     public InListExpression(List<Expression> values)
     {
@@ -48,6 +48,11 @@ public class InListExpression
     public List<Expression> getValues()
     {
         return values;
+    }
+
+    public void setValues(List<Expression> values)
+    {
+        this.values = values;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/InPredicate.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/InPredicate.java
@@ -22,8 +22,8 @@ import java.util.Optional;
 public class InPredicate
         extends Expression
 {
-    private final Expression value;
-    private final Expression valueList;
+    private Expression value;
+    private Expression valueList;
 
     public InPredicate(Expression value, Expression valueList)
     {
@@ -47,9 +47,19 @@ public class InPredicate
         return value;
     }
 
+    public void setValue(Expression value)
+    {
+        this.value = value;
+    }
+
     public Expression getValueList()
     {
         return valueList;
+    }
+
+    public void setValueList(Expression valueList)
+    {
+        this.valueList = valueList;
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
Supports implicit conversions between the following types in comparison expressions, arithmetic expressions, in expressions, and between expressions
1. int and varchar
2. bigint and varchar
3. double and varchar
<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

## Related issues, pull requests, and links
* Fixes #12430

## Documentation

(x) No documentation is needed.

## Release notes

(x ) No release notes entries required.

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
