### PR TITLE
Remove redundant call to string.format()

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/auth/external/CompositeRedirectHandler.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/external/CompositeRedirectHandler.java
@@ -38,7 +38,7 @@ public class CompositeRedirectHandler
     @Override
     public void redirectTo(URI uri) throws RedirectException
     {
-        RedirectException redirectException = new RedirectException(format("Could not redirect to " + uri));
+        RedirectException redirectException = new RedirectException("Could not redirect to " + uri);
         for (RedirectHandler handler : handlers) {
             try {
                 handler.redirectTo(uri);


### PR DESCRIPTION
**Remove redundant call to 'String.format()'**  

**Class:** 
io.trino.client.auth.external.CompositeRedirectHandler
**Code:**
```
@Override
public void redirectTo(URI uri) throws RedirectException
{
    RedirectException redirectException = new RedirectException(format("Could not redirect to " + uri));
    for (RedirectHandler handler : handlers) {
        try {
            handler.redirectTo(uri);
            return;
        }
        catch (RedirectException e) {
            redirectException.addSuppressed(e);
        }
    }
    throw redirectException;
}
```