### PR TITLE
User Identity HTTP Headers for HiveS3

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/HiveS3Config.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/HiveS3Config.java
@@ -81,6 +81,7 @@ public class HiveS3Config
     private boolean s3preemptiveBasicProxyAuth;
     private String s3StsEndpoint;
     private String s3StsRegion;
+    private boolean s3HttpHeaderUserIdentityEnabled;
 
     public String getS3AwsAccessKey()
     {
@@ -614,6 +615,19 @@ public class HiveS3Config
     public HiveS3Config setS3StsRegion(String s3StsRegion)
     {
         this.s3StsRegion = s3StsRegion;
+        return this;
+    }
+
+    public boolean isS3HttpHeadersUserIdentityEnabled()
+    {
+        return s3HttpHeaderUserIdentityEnabled;
+    }
+
+    @Config("hive.s3.http-headers.user-identity.enabled")
+    @ConfigDescription("User identity for S3 access will be added to http custom headers.")
+    public HiveS3Config setS3HttpHeadersUserIdentityEnabled(boolean s3HttpHeaderUserIdentityEnabled)
+    {
+        this.s3HttpHeaderUserIdentityEnabled = s3HttpHeaderUserIdentityEnabled;
         return this;
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/TrinoS3ConfigurationInitializer.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/TrinoS3ConfigurationInitializer.java
@@ -63,6 +63,7 @@ import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_STREAMING_UPLOAD_ENAB
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_STREAMING_UPLOAD_PART_SIZE;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_STS_ENDPOINT;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_STS_REGION;
+import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_HTTP_HEADERS_USER_IDENTITY_ENABLED;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_USER_AGENT_PREFIX;
 import static java.util.stream.Collectors.joining;
 
@@ -110,6 +111,7 @@ public class TrinoS3ConfigurationInitializer
     private final boolean s3preemptiveBasicProxyAuth;
     private final String s3StsEndpoint;
     private final String s3StsRegion;
+    private final boolean httpHeadersUserIdentityEnabled;
 
     @Inject
     public TrinoS3ConfigurationInitializer(HiveS3Config config)
@@ -155,6 +157,7 @@ public class TrinoS3ConfigurationInitializer
         this.s3preemptiveBasicProxyAuth = config.getS3PreemptiveBasicProxyAuth();
         this.s3StsEndpoint = config.getS3StsEndpoint();
         this.s3StsRegion = config.getS3StsRegion();
+        this.httpHeadersUserIdentityEnabled = config.isS3HttpHeadersUserIdentityEnabled();
     }
 
     @Override
@@ -217,6 +220,7 @@ public class TrinoS3ConfigurationInitializer
         config.setBoolean(S3_REQUESTER_PAYS_ENABLED, requesterPaysEnabled);
         config.setBoolean(S3_STREAMING_UPLOAD_ENABLED, s3StreamingUploadEnabled);
         config.setLong(S3_STREAMING_UPLOAD_PART_SIZE, streamingPartSize.toBytes());
+        config.setBoolean(S3_HTTP_HEADERS_USER_IDENTITY_ENABLED, httpHeadersUserIdentityEnabled);
         if (s3proxyHost != null) {
             config.set(S3_PROXY_HOST, s3proxyHost);
         }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/TrinoS3ConfigurationInitializer.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/TrinoS3ConfigurationInitializer.java
@@ -29,6 +29,7 @@ import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_CONNECT_TIMEOUT;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_ENCRYPTION_MATERIALS_PROVIDER;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_ENDPOINT;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_EXTERNAL_ID;
+import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_HTTP_HEADERS_USER_IDENTITY_ENABLED;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_IAM_ROLE;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_KMS_KEY_ID;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_MAX_BACKOFF_TIME;
@@ -63,7 +64,6 @@ import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_STREAMING_UPLOAD_ENAB
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_STREAMING_UPLOAD_PART_SIZE;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_STS_ENDPOINT;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_STS_REGION;
-import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_HTTP_HEADERS_USER_IDENTITY_ENABLED;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_USER_AGENT_PREFIX;
 import static java.util.stream.Collectors.joining;
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/TrinoS3FileSystem.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/TrinoS3FileSystem.java
@@ -224,7 +224,7 @@ public class TrinoS3FileSystem
     private static final Set<String> GLACIER_STORAGE_CLASSES = ImmutableSet.of(Glacier.toString(), DeepArchive.toString());
     private static final MediaType DIRECTORY_MEDIA_TYPE = MediaType.create("application", "x-directory");
     private static final String S3_DEFAULT_ROLE_SESSION_NAME = "trino-session";
-    public static final String TRINO_HEADER_SESSION_NAME = "x-trino-session-name";
+    public static final String TRINO_HEADER_SESSION_NAME = "X-Trino-Session-Name";
     public static final String S3_HTTP_HEADERS_USER_IDENTITY_ENABLED = "trino.s3.http.headers.user.identity.enabled";
 
     private URI uri;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/TrinoS3FileSystem.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/TrinoS3FileSystem.java
@@ -224,6 +224,7 @@ public class TrinoS3FileSystem
     private static final Set<String> GLACIER_STORAGE_CLASSES = ImmutableSet.of(Glacier.toString(), DeepArchive.toString());
     private static final MediaType DIRECTORY_MEDIA_TYPE = MediaType.create("application", "x-directory");
     private static final String S3_DEFAULT_ROLE_SESSION_NAME = "trino-session";
+    public static final String TRINO_HEADER_SESSION_NAME = "x-trino-session-name";
     public static final String S3_HTTP_HEADERS_USER_IDENTITY_ENABLED = "trino.s3.http.headers.user.identity.enabled";
 
     private URI uri;
@@ -1181,7 +1182,7 @@ public class TrinoS3FileSystem
                                         .withRange(position, (position + length) - 1)
                                         .withRequesterPays(requesterPaysEnabled);
                                 if (s3HttpHeadersUserIdentityEnabled) {
-                                    request.putCustomRequestHeader("x-trino-session-name", s3RoleSessionName);
+                                    request.putCustomRequestHeader(TRINO_HEADER_SESSION_NAME, s3RoleSessionName);
                                 }
                                 stream = s3.getObject(request).getObjectContent();
                             }
@@ -1358,7 +1359,7 @@ public class TrinoS3FileSystem
                                         .withRange(start)
                                         .withRequesterPays(requesterPaysEnabled);
                                 if (s3HttpHeadersUserIdentityEnabled) {
-                                    request.putCustomRequestHeader("x-trino-session-name", s3RoleSessionName);
+                                    request.putCustomRequestHeader(TRINO_HEADER_SESSION_NAME, s3RoleSessionName);
                                 }
                                 return s3.getObject(request).getObjectContent();
                             }
@@ -1507,7 +1508,7 @@ public class TrinoS3FileSystem
 
                 PutObjectRequest request = new PutObjectRequest(bucket, key, tempFile);
                 if (s3HttpHeadersUserIdentityEnabled) {
-                    request.putCustomRequestHeader("x-trino-session-name", s3RoleSessionName);
+                    request.putCustomRequestHeader(TRINO_HEADER_SESSION_NAME, s3RoleSessionName);
                 }
                 requestCustomizer.accept(request);
 
@@ -1692,7 +1693,7 @@ public class TrinoS3FileSystem
 
                 PutObjectRequest request = new PutObjectRequest(bucketName, key, in, metadata);
                 if (s3HttpHeadersUserIdentityEnabled) {
-                    request.putCustomRequestHeader("x-trino-session-name", s3RoleSessionName);
+                    request.putCustomRequestHeader(TRINO_HEADER_SESSION_NAME, s3RoleSessionName);
                 }
                 requestCustomizer.accept(request);
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/TrinoS3FileSystem.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/TrinoS3FileSystem.java
@@ -224,6 +224,7 @@ public class TrinoS3FileSystem
     private static final Set<String> GLACIER_STORAGE_CLASSES = ImmutableSet.of(Glacier.toString(), DeepArchive.toString());
     private static final MediaType DIRECTORY_MEDIA_TYPE = MediaType.create("application", "x-directory");
     private static final String S3_DEFAULT_ROLE_SESSION_NAME = "trino-session";
+    public static final String S3_HTTP_HEADERS_USER_IDENTITY_ENABLED = "trino.s3.http.headers.user.identity.enabled";
 
     private URI uri;
     private Path workingDirectory;
@@ -249,6 +250,7 @@ public class TrinoS3FileSystem
     private int streamingUploadPartSize;
     private TrinoS3StorageClass s3StorageClass;
     private String s3RoleSessionName;
+    private boolean s3HttpHeadersUserIdentityEnabled;
 
     private final ExecutorService uploadExecutor = newCachedThreadPool(threadsNamed("s3-upload-%s"));
 
@@ -298,6 +300,7 @@ public class TrinoS3FileSystem
         this.streamingUploadPartSize = toIntExact(conf.getLong(S3_STREAMING_UPLOAD_PART_SIZE, defaults.getS3StreamingPartSize().toBytes()));
         this.s3StorageClass = conf.getEnum(S3_STORAGE_CLASS, defaults.getS3StorageClass());
         this.s3RoleSessionName = conf.get(S3_ROLE_SESSION_NAME, S3_DEFAULT_ROLE_SESSION_NAME);
+        this.s3HttpHeadersUserIdentityEnabled = conf.getBoolean(S3_HTTP_HEADERS_USER_IDENTITY_ENABLED, defaults.isS3HttpHeadersUserIdentityEnabled());
 
         ClientConfiguration configuration = new ClientConfiguration()
                 .withMaxErrorRetry(maxErrorRetries)
@@ -499,7 +502,7 @@ public class TrinoS3FileSystem
     {
         return new FSDataInputStream(
                 new BufferedFSInputStream(
-                        new TrinoS3InputStream(s3, getBucketName(uri), path, requesterPaysEnabled, maxAttempts, maxBackoffTime, maxRetryTime),
+                        new TrinoS3InputStream(s3, getBucketName(uri), path, requesterPaysEnabled, maxAttempts, maxBackoffTime, maxRetryTime, s3HttpHeadersUserIdentityEnabled, s3RoleSessionName),
                         bufferSize));
     }
 
@@ -520,7 +523,7 @@ public class TrinoS3FileSystem
 
         if (streamingUploadEnabled) {
             Supplier<String> uploadIdFactory = () -> initMultipartUpload(bucketName, key).getUploadId();
-            return new TrinoS3StreamingOutputStream(s3, bucketName, key, this::customizePutObjectRequest, uploadIdFactory, uploadExecutor, streamingUploadPartSize);
+            return new TrinoS3StreamingOutputStream(s3, bucketName, key, this::customizePutObjectRequest, uploadIdFactory, uploadExecutor, streamingUploadPartSize, s3HttpHeadersUserIdentityEnabled, s3RoleSessionName);
         }
 
         if (!stagingDirectory.exists()) {
@@ -530,7 +533,7 @@ public class TrinoS3FileSystem
             throw new IOException("Configured staging path is not a directory: " + stagingDirectory);
         }
         File tempFile = createTempFile(stagingDirectory.toPath(), "trino-s3-", ".tmp").toFile();
-        return new TrinoS3StagingOutputStream(s3, bucketName, key, tempFile, this::customizePutObjectRequest, multiPartUploadMinFileSize, multiPartUploadMinPartSize);
+        return new TrinoS3StagingOutputStream(s3, bucketName, key, tempFile, this::customizePutObjectRequest, multiPartUploadMinFileSize, multiPartUploadMinPartSize, s3HttpHeadersUserIdentityEnabled, s3RoleSessionName);
     }
 
     @Override
@@ -1121,6 +1124,8 @@ public class TrinoS3FileSystem
         private final int maxAttempts;
         private final Duration maxBackoffTime;
         private final Duration maxRetryTime;
+        private final boolean s3HttpHeadersUserIdentityEnabled;
+        private final String s3RoleSessionName;
 
         private final AtomicBoolean closed = new AtomicBoolean();
 
@@ -1128,7 +1133,7 @@ public class TrinoS3FileSystem
         private long streamPosition;
         private long nextReadPosition;
 
-        public TrinoS3InputStream(AmazonS3 s3, String bucket, Path path, boolean requesterPaysEnabled, int maxAttempts, Duration maxBackoffTime, Duration maxRetryTime)
+        public TrinoS3InputStream(AmazonS3 s3, String bucket, Path path, boolean requesterPaysEnabled, int maxAttempts, Duration maxBackoffTime, Duration maxRetryTime, boolean s3HttpHeadersUserIdentityEnabled, String s3RoleSessionName)
         {
             this.s3 = requireNonNull(s3, "s3 is null");
             this.bucket = requireNonNull(bucket, "bucket is null");
@@ -1139,6 +1144,8 @@ public class TrinoS3FileSystem
             this.maxAttempts = maxAttempts;
             this.maxBackoffTime = requireNonNull(maxBackoffTime, "maxBackoffTime is null");
             this.maxRetryTime = requireNonNull(maxRetryTime, "maxRetryTime is null");
+            this.s3HttpHeadersUserIdentityEnabled = s3HttpHeadersUserIdentityEnabled;
+            this.s3RoleSessionName = s3RoleSessionName;
         }
 
         @Override
@@ -1173,6 +1180,9 @@ public class TrinoS3FileSystem
                                 GetObjectRequest request = new GetObjectRequest(bucket, keyFromPath(path))
                                         .withRange(position, (position + length) - 1)
                                         .withRequesterPays(requesterPaysEnabled);
+                                if (s3HttpHeadersUserIdentityEnabled) {
+                                    request.putCustomRequestHeader("x-trino-session-name", s3RoleSessionName);
+                                }
                                 stream = s3.getObject(request).getObjectContent();
                             }
                             catch (RuntimeException e) {
@@ -1347,6 +1357,9 @@ public class TrinoS3FileSystem
                                 GetObjectRequest request = new GetObjectRequest(bucket, keyFromPath(path))
                                         .withRange(start)
                                         .withRequesterPays(requesterPaysEnabled);
+                                if (s3HttpHeadersUserIdentityEnabled) {
+                                    request.putCustomRequestHeader("x-trino-session-name", s3RoleSessionName);
+                                }
                                 return s3.getObject(request).getObjectContent();
                             }
                             catch (RuntimeException e) {
@@ -1429,6 +1442,8 @@ public class TrinoS3FileSystem
         private final String key;
         private final File tempFile;
         private final Consumer<PutObjectRequest> requestCustomizer;
+        private final boolean s3HttpHeadersUserIdentityEnabled;
+        private final String s3RoleSessionName;
 
         private boolean closed;
 
@@ -1439,7 +1454,9 @@ public class TrinoS3FileSystem
                 File tempFile,
                 Consumer<PutObjectRequest> requestCustomizer,
                 long multiPartUploadMinFileSize,
-                long multiPartUploadMinPartSize)
+                long multiPartUploadMinPartSize,
+                boolean s3HttpHeadersUserIdentityEnabled,
+                String s3RoleSessionName)
                 throws IOException
         {
             super(new BufferedOutputStream(new FileOutputStream(requireNonNull(tempFile, "tempFile is null"))));
@@ -1453,6 +1470,8 @@ public class TrinoS3FileSystem
             this.key = requireNonNull(key, "key is null");
             this.tempFile = tempFile;
             this.requestCustomizer = requireNonNull(requestCustomizer, "requestCustomizer is null");
+            this.s3HttpHeadersUserIdentityEnabled = s3HttpHeadersUserIdentityEnabled;
+            this.s3RoleSessionName = s3RoleSessionName;
 
             log.debug("OutputStream for key '%s' using file: %s", key, tempFile);
         }
@@ -1487,6 +1506,9 @@ public class TrinoS3FileSystem
                 STATS.uploadStarted();
 
                 PutObjectRequest request = new PutObjectRequest(bucket, key, tempFile);
+                if (s3HttpHeadersUserIdentityEnabled) {
+                    request.putCustomRequestHeader("x-trino-session-name", s3RoleSessionName);
+                }
                 requestCustomizer.accept(request);
 
                 Upload upload = transferManager.upload(request);
@@ -1545,6 +1567,8 @@ public class TrinoS3FileSystem
         private final Consumer<PutObjectRequest> requestCustomizer;
         private final Supplier<String> uploadIdFactory;
         private final ExecutorService uploadExecutor;
+        private final boolean s3HttpHeadersUserIdentityEnabled;
+        private final String s3RoleSessionName;
 
         private int currentPartNumber;
         private byte[] buffer;
@@ -1567,7 +1591,9 @@ public class TrinoS3FileSystem
                 Consumer<PutObjectRequest> requestCustomizer,
                 Supplier<String> uploadIdFactory,
                 ExecutorService uploadExecutor,
-                int partSize)
+                int partSize,
+                boolean s3HttpHeadersUserIdentityEnabled,
+                String s3RoleSessionName)
         {
             STATS.uploadStarted();
 
@@ -1580,6 +1606,8 @@ public class TrinoS3FileSystem
             this.requestCustomizer = requireNonNull(requestCustomizer, "requestCustomizer is null");
             this.uploadIdFactory = requireNonNull(uploadIdFactory, "uploadIdFactory is null");
             this.uploadExecutor = requireNonNull(uploadExecutor, "uploadExecutor is null");
+            this.s3HttpHeadersUserIdentityEnabled = s3HttpHeadersUserIdentityEnabled;
+            this.s3RoleSessionName = s3RoleSessionName;
         }
 
         @Override
@@ -1663,6 +1691,9 @@ public class TrinoS3FileSystem
                 metadata.setContentMD5(getMd5AsBase64(buffer, 0, bufferSize));
 
                 PutObjectRequest request = new PutObjectRequest(bucketName, key, in, metadata);
+                if (s3HttpHeadersUserIdentityEnabled) {
+                    request.putCustomRequestHeader("x-trino-session-name", s3RoleSessionName);
+                }
                 requestCustomizer.accept(request);
 
                 try {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
When the property **hive.s3.http-headers.user-identity.enabled** is set to true in the Hive catalog file, the user that runs the query will be added to the audit logs as **X-Trino-Session-Name: trino-session=_user_** This can be used for chargeback capability in data sources such as S3 and MinIO.

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

New Feature

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core Query Engine (trino-hive plugin)

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
