### PR TITLE
Add user identity to HTTP headers for HiveS3

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/HiveS3Config.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/HiveS3Config.java
@@ -81,6 +81,7 @@ public class HiveS3Config
     private boolean s3preemptiveBasicProxyAuth;
     private String s3StsEndpoint;
     private String s3StsRegion;
+    private boolean s3HttpHeaderUserIdentityEnabled;
 
     public String getS3AwsAccessKey()
     {
@@ -614,6 +615,19 @@ public class HiveS3Config
     public HiveS3Config setS3StsRegion(String s3StsRegion)
     {
         this.s3StsRegion = s3StsRegion;
+        return this;
+    }
+
+    public boolean isS3HttpHeadersUserIdentityEnabled()
+    {
+        return s3HttpHeaderUserIdentityEnabled;
+    }
+
+    @Config("hive.s3.http-headers.user-identity.enabled")
+    @ConfigDescription("User identity for S3 access will be added to http custom headers.")
+    public HiveS3Config setS3HttpHeadersUserIdentityEnabled(boolean s3HttpHeaderUserIdentityEnabled)
+    {
+        this.s3HttpHeaderUserIdentityEnabled = s3HttpHeaderUserIdentityEnabled;
         return this;
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/TrinoS3ConfigurationInitializer.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/TrinoS3ConfigurationInitializer.java
@@ -29,6 +29,7 @@ import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_CONNECT_TIMEOUT;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_ENCRYPTION_MATERIALS_PROVIDER;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_ENDPOINT;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_EXTERNAL_ID;
+import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_HTTP_HEADERS_USER_IDENTITY_ENABLED;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_IAM_ROLE;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_KMS_KEY_ID;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_MAX_BACKOFF_TIME;
@@ -110,6 +111,7 @@ public class TrinoS3ConfigurationInitializer
     private final boolean s3preemptiveBasicProxyAuth;
     private final String s3StsEndpoint;
     private final String s3StsRegion;
+    private final boolean httpHeadersUserIdentityEnabled;
 
     @Inject
     public TrinoS3ConfigurationInitializer(HiveS3Config config)
@@ -155,6 +157,7 @@ public class TrinoS3ConfigurationInitializer
         this.s3preemptiveBasicProxyAuth = config.getS3PreemptiveBasicProxyAuth();
         this.s3StsEndpoint = config.getS3StsEndpoint();
         this.s3StsRegion = config.getS3StsRegion();
+        this.httpHeadersUserIdentityEnabled = config.isS3HttpHeadersUserIdentityEnabled();
     }
 
     @Override
@@ -217,6 +220,7 @@ public class TrinoS3ConfigurationInitializer
         config.setBoolean(S3_REQUESTER_PAYS_ENABLED, requesterPaysEnabled);
         config.setBoolean(S3_STREAMING_UPLOAD_ENABLED, s3StreamingUploadEnabled);
         config.setLong(S3_STREAMING_UPLOAD_PART_SIZE, streamingPartSize.toBytes());
+        config.setBoolean(S3_HTTP_HEADERS_USER_IDENTITY_ENABLED, httpHeadersUserIdentityEnabled);
         if (s3proxyHost != null) {
             config.set(S3_PROXY_HOST, s3proxyHost);
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
When the property **hive.s3.http-headers.user-identity.enabled** is set to true in the Hive catalog file, the user that runs the query will be added to the audit logs as **X-Trino-Session-Name: trino-session=_user_** This can be used for chargeback capability in data sources such as S3 and MinIO.

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

New Feature

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core Engine (trino-hive plugin)

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( x) No release notes entries required.
( ) Release notes entries required with the following suggested text:
