### PR TITLE
Support Direct Recursive Hive File Listings

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/DirectoryLister.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/DirectoryLister.java
@@ -27,4 +27,7 @@ public interface DirectoryLister
 {
     RemoteIterator<LocatedFileStatus> list(FileSystem fs, Table table, Path path)
             throws IOException;
+
+    RemoteIterator<LocatedFileStatus> listFilesRecursively(FileSystem fs, Table table, Path path)
+            throws IOException;
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/DirectoryListingCacheKey.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/DirectoryListingCacheKey.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.fs;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.plugin.hive.metastore.Table;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A cache key designed for use in {@link CachingDirectoryLister} and {@link TransactionScopeCachingDirectoryLister}
+ * that allows distinct cache entries to be created for both recursive, files-only listings and shallow listings
+ * (that also might contain directories) at the same {@link Path}, ie: {@link DirectoryLister#list(FileSystem, Table, Path)}
+ * and {@link DirectoryLister#listFilesRecursively(FileSystem, Table, Path)} results.
+ */
+final class DirectoryListingCacheKey
+{
+    private final Path path;
+    private final int hashCode; // precomputed hashCode
+    private final boolean recursiveFilesOnly;
+
+    public DirectoryListingCacheKey(Path path, boolean recursiveFilesOnly)
+    {
+        this.path = requireNonNull(path, "path is null");
+        this.recursiveFilesOnly = recursiveFilesOnly;
+        this.hashCode = Objects.hash(path, recursiveFilesOnly);
+    }
+
+    public Path getPath()
+    {
+        return path;
+    }
+
+    public boolean isRecursiveFilesOnly()
+    {
+        return recursiveFilesOnly;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return hashCode;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (o == null || (o.getClass() != this.getClass())) {
+            return false;
+        }
+        DirectoryListingCacheKey other = (DirectoryListingCacheKey) o;
+        return recursiveFilesOnly == other.recursiveFilesOnly
+                && hashCode == other.hashCode
+                && path.equals(other.path);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("path", path)
+                .add("isRecursiveFilesOnly", recursiveFilesOnly)
+                .toString();
+    }
+
+    public static List<DirectoryListingCacheKey> allKeysWithPath(Path path)
+    {
+        return ImmutableList.of(new DirectoryListingCacheKey(path, true), new DirectoryListingCacheKey(path, false));
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/TrinoFileSystemCache.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/TrinoFileSystemCache.java
@@ -25,8 +25,10 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FileSystemCache;
 import org.apache.hadoop.fs.FilterFileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod;
@@ -374,6 +376,14 @@ public class TrinoFileSystemCache
                 throws IOException
         {
             return fs.getFileBlockLocations(p, start, len);
+        }
+
+        // missing in FilterFileSystem
+        @Override
+        public RemoteIterator<LocatedFileStatus> listFiles(Path path, boolean recursive)
+                throws IOException
+        {
+            return fs.listFiles(path, recursive);
         }
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -6168,6 +6168,14 @@ public abstract class AbstractTestHive
             return fs.listLocatedStatus(path);
         }
 
+        @Override
+        public RemoteIterator<LocatedFileStatus> listFilesRecursively(FileSystem fs, Table table, Path path)
+                throws IOException
+        {
+            listCount.incrementAndGet();
+            return fs.listFiles(path, true);
+        }
+
         public int getListCount()
         {
             return listCount.get();

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
@@ -15,6 +15,8 @@ package io.trino.plugin.hive;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
 import com.google.common.net.HostAndPort;
 import io.airlift.concurrent.BoundedExecutor;
 import io.airlift.json.JsonCodec;
@@ -28,6 +30,7 @@ import io.trino.plugin.hive.HdfsEnvironment.HdfsContext;
 import io.trino.plugin.hive.authentication.HiveIdentity;
 import io.trino.plugin.hive.authentication.NoHdfsAuthentication;
 import io.trino.plugin.hive.fs.FileSystemDirectoryLister;
+import io.trino.plugin.hive.fs.HiveFileIterator;
 import io.trino.plugin.hive.metastore.Column;
 import io.trino.plugin.hive.metastore.Database;
 import io.trino.plugin.hive.metastore.ForwardingHiveMetastore;
@@ -35,6 +38,7 @@ import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.HiveMetastoreConfig;
 import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
 import io.trino.plugin.hive.metastore.PrincipalPrivileges;
+import io.trino.plugin.hive.metastore.StorageFormat;
 import io.trino.plugin.hive.metastore.Table;
 import io.trino.plugin.hive.metastore.thrift.BridgingHiveMetastore;
 import io.trino.plugin.hive.metastore.thrift.MetastoreLocator;
@@ -69,6 +73,7 @@ import io.trino.testing.MaterializedRow;
 import io.trino.testing.TestingNodeManager;
 import io.trino.type.BlockTypeOperators;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem;
 import org.testng.annotations.AfterClass;
@@ -102,6 +107,7 @@ import static io.trino.plugin.hive.HiveTestUtils.getDefaultHiveRecordCursorProvi
 import static io.trino.plugin.hive.HiveTestUtils.getHiveSession;
 import static io.trino.plugin.hive.HiveTestUtils.getHiveSessionProperties;
 import static io.trino.plugin.hive.HiveTestUtils.getTypes;
+import static io.trino.plugin.hive.HiveType.HIVE_LONG;
 import static io.trino.plugin.hive.metastore.PrincipalPrivileges.NO_PRIVILEGES;
 import static io.trino.plugin.hive.util.HiveWriteUtils.getRawFileSystem;
 import static io.trino.spi.connector.MetadataProvider.NOOP_METADATA_PROVIDER;
@@ -398,6 +404,81 @@ public abstract class AbstractTestHiveFileSystem
 
         // cleanup
         fs.delete(basePath, true);
+    }
+
+    @Test
+    public void testFileIteratorListing()
+            throws Exception
+    {
+        Table.Builder tableBuilder = Table.builder()
+                .setDatabaseName(table.getSchemaName())
+                .setTableName(table.getTableName())
+                .setDataColumns(ImmutableList.of(new Column("one", HIVE_LONG, Optional.empty())))
+                .setPartitionColumns(ImmutableList.of())
+                .setOwner(Optional.empty())
+                .setTableType("fake");
+        tableBuilder.getStorageBuilder()
+                .setStorageFormat(StorageFormat.fromHiveStorageFormat(HiveStorageFormat.CSV));
+        Table fakeTable = tableBuilder.build();
+
+        // Expected file system tree:
+        // test-file-iterator-listing/
+        //      .hidden/
+        //          nested-file-in-hidden.txt
+        //      parent/
+        //          _nested-hidden-file.txt
+        //          nested-file.txt
+        //      empty-directory/
+        //      .hidden-in-base.txt
+        //      base-path-file.txt
+        Path basePath = new Path(getBasePath(), "test-file-iterator-listing");
+        FileSystem fs = hdfsEnvironment.getFileSystem(TESTING_CONTEXT, basePath);
+        fs.mkdirs(basePath);
+
+        // create file in hidden folder
+        Path fileInHiddenParent = new Path(new Path(basePath, ".hidden"), "nested-file-in-hidden.txt");
+        fs.createNewFile(fileInHiddenParent);
+        // create hidden file in non-hidden folder
+        Path nestedHiddenFile = new Path(new Path(basePath, "parent"), "_nested-hidden-file.txt");
+        fs.createNewFile(nestedHiddenFile);
+        // create file in non-hidden folder
+        Path nestedFile = new Path(new Path(basePath, "parent"), "nested-file.txt");
+        fs.createNewFile(nestedFile);
+        // create file in base path
+        Path baseFile = new Path(basePath, "base-path-file.txt");
+        fs.createNewFile(baseFile);
+        // create hidden file in base path
+        Path hiddenBase = new Path(basePath, ".hidden-in-base.txt");
+        fs.createNewFile(hiddenBase);
+        // create empty subdirectory
+        Path emptyDirectory = new Path(basePath, "empty-directory");
+        fs.mkdirs(emptyDirectory);
+
+        // List recursively through hive file iterator
+        HiveFileIterator recursiveIterator = new HiveFileIterator(
+                fakeTable,
+                basePath,
+                fs,
+                new FileSystemDirectoryLister(),
+                new NamenodeStats(),
+                HiveFileIterator.NestedDirectoryPolicy.RECURSE,
+                false); // ignoreAbsentPartitions
+
+        List<Path> recursiveListing = Lists.newArrayList(Iterators.transform(recursiveIterator, LocatedFileStatus::getPath));
+        // Should not include directories, or files underneath hidden directories
+        assertEqualsIgnoreOrder(recursiveListing, ImmutableList.of(nestedFile, baseFile));
+
+        HiveFileIterator shallowIterator = new HiveFileIterator(
+                fakeTable,
+                basePath,
+                fs,
+                new FileSystemDirectoryLister(),
+                new NamenodeStats(),
+                HiveFileIterator.NestedDirectoryPolicy.IGNORED,
+                false); // ignoreAbsentPartitions
+        List<Path> shallowListing = Lists.newArrayList(Iterators.transform(shallowIterator, LocatedFileStatus::getPath));
+        // Should not include any hidden files, folders, or nested files
+        assertEqualsIgnoreOrder(shallowListing, ImmutableList.of(baseFile));
     }
 
     @Test

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/FileSystemDirectoryLister.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/FileSystemDirectoryLister.java
@@ -33,6 +33,13 @@ public class FileSystemDirectoryLister
     }
 
     @Override
+    public RemoteIterator<LocatedFileStatus> listFilesRecursively(FileSystem fs, Table table, Path path)
+            throws IOException
+    {
+        return fs.listFiles(path, true);
+    }
+
+    @Override
     public void invalidate(Partition partition)
     {
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/TestCachingDirectoryListerRecursiveFilesOnly.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/TestCachingDirectoryListerRecursiveFilesOnly.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.fs;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import io.trino.plugin.hive.metastore.MetastoreUtil;
+import io.trino.plugin.hive.metastore.Table;
+import io.trino.testing.QueryRunner;
+import org.apache.hadoop.fs.Path;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static io.trino.plugin.hive.HiveQueryRunner.TPCH_SCHEMA;
+import static io.trino.plugin.hive.metastore.PrincipalPrivileges.NO_PRIVILEGES;
+import static java.lang.String.format;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+// some tests may invalidate the whole cache affecting therefore other concurrent tests
+@Test(singleThreaded = true)
+public class TestCachingDirectoryListerRecursiveFilesOnly
+        extends BaseCachingDirectoryListerTest<CachingDirectoryLister>
+{
+    @Override
+    protected CachingDirectoryLister createDirectoryLister()
+    {
+        return new CachingDirectoryLister(Duration.valueOf("5m"), 1_000_000L, List.of("tpch.*"));
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return createQueryRunner(ImmutableMap.of(
+                "hive.allow-register-partition-procedure", "true",
+                "hive.recursive-directories", "true"));
+    }
+
+    @Override
+    protected boolean isCached(CachingDirectoryLister directoryLister, Path path)
+    {
+        return directoryLister.isCached(new DirectoryListingCacheKey(path, true));
+    }
+
+    @Test
+    public void testRecursiveDirectories()
+    {
+        // Create partitioned table to force files to be inserted in sub-partition paths
+        assertUpdate("CREATE TABLE recursive_directories (clicks bigint, day date, country varchar) WITH (format = 'ORC', partitioned_by = ARRAY['day', 'country'])");
+        assertUpdate("INSERT INTO recursive_directories VALUES (1000, DATE '2022-02-01', 'US'), (2000, DATE '2022-02-01', 'US'), (4000, DATE '2022-02-02', 'US'), (1500, DATE '2022-02-01', 'AT'), (2500, DATE '2022-02-02', 'AT')", 5);
+
+        // Replace the partitioned table a new unpartitioned table with the same root location, leaving the data in place
+        Table partitionedTable = getTable(TPCH_SCHEMA, "recursive_directories")
+                .orElseThrow(() -> new NoSuchElementException(format("Failed to read table %s.%s", TPCH_SCHEMA, "recursive_directories")));
+        // Must not delete the data files when dropping the partitioned table
+        dropTable(TPCH_SCHEMA, "recursive_directories", false);
+        // Must create the table directly to bypass check that the target directory already exists
+        Table testTable = Table.builder(partitionedTable)
+                .setPartitionColumns(ImmutableList.of())
+                .build();
+        createTable(testTable, testTable.getOwner().map(MetastoreUtil::buildInitialPrivilegeSet).orElse(NO_PRIVILEGES));
+
+        // Execute a query on the new table to pull the listing into the cache
+        assertQuery("SELECT sum(clicks) FROM recursive_directories", "VALUES (11000)");
+
+        Path tableLocation = getTableLocation(TPCH_SCHEMA, "recursive_directories");
+        assertTrue(isCached(tableLocation));
+
+        // Insert should invalidate cache, even at the root directory path
+        assertUpdate("INSERT INTO recursive_directories VALUES (1000)", 1);
+        assertFalse(isCached(tableLocation));
+
+        // Results should include the new insert which is at the table location root for the unpartitioned table
+        assertQuery("SELECT sum(clicks) FROM recursive_directories", "VALUES (12000)");
+
+        assertUpdate("DROP TABLE recursive_directories");
+
+        assertFalse(isCached(tableLocation));
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/TestHiveFileIterator.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/TestHiveFileIterator.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.fs;
+
+import org.apache.hadoop.fs.Path;
+import org.testng.annotations.Test;
+
+import static io.trino.plugin.hive.fs.HiveFileIterator.containsHiddenPathPartAfterIndex;
+import static io.trino.plugin.hive.fs.HiveFileIterator.isHiddenFileOrDirectory;
+import static io.trino.plugin.hive.fs.HiveFileIterator.isHiddenOrWithinHiddenParentDirectory;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestHiveFileIterator
+{
+    @Test
+    public void testRelativeHiddenPathDetection()
+    {
+        String root = new Path("file:///root-path").toUri().getPath();
+        assertTrue(isHiddenOrWithinHiddenParentDirectory(new Path(root, ".hidden/child"), root));
+        assertTrue(isHiddenOrWithinHiddenParentDirectory(new Path(root, "_hidden.txt"), root));
+        String rootWithinHidden = new Path("file:///root/.hidden/listing-root").toUri().getPath();
+        assertFalse(isHiddenOrWithinHiddenParentDirectory(new Path(rootWithinHidden, "file.txt"), rootWithinHidden));
+        String rootHiddenEnding = new Path("file:///root/hidden-ending_").toUri().getPath();
+        assertFalse(isHiddenOrWithinHiddenParentDirectory(new Path(rootHiddenEnding, "file.txt"), rootHiddenEnding));
+    }
+
+    @Test
+    public void testHiddenFileNameDetection()
+    {
+        assertFalse(isHiddenFileOrDirectory(new Path("file:///parent/.hidden/ignore-parent-directories.txt")));
+        assertTrue(isHiddenFileOrDirectory(new Path("file:///parent/visible/_hidden-file.txt")));
+    }
+
+    @Test
+    public void testHiddenDetectionEdgeCases()
+    {
+        assertTrue(containsHiddenPathPartAfterIndex("/.leading-slash-hidden/file.txt", 0));
+        assertTrue(containsHiddenPathPartAfterIndex("/.leading-slash-hidden-directory/", 0));
+        assertTrue(containsHiddenPathPartAfterIndex("_root-hidden/file.txt", 0));
+        assertTrue(containsHiddenPathPartAfterIndex("_root-hidden/directory/", 0));
+        assertFalse(containsHiddenPathPartAfterIndex("root//multi-slash/", 0));
+        assertTrue(containsHiddenPathPartAfterIndex("root/child/.slash-hidden/file.txt", 0));
+        assertTrue(containsHiddenPathPartAfterIndex("root/child/.slash-hidden/parent/file.txt", 0));
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/TestTransactionScopeCachingDirectoryLister.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/TestTransactionScopeCachingDirectoryLister.java
@@ -187,6 +187,14 @@ public class TestTransactionScopeCachingDirectoryLister
             return throwingRemoteIterator(requireNonNull(fileStatuses.get(path)), throwException);
         }
 
+        @Override
+        public RemoteIterator<LocatedFileStatus> listFilesRecursively(FileSystem fs, Table table, Path path)
+                throws IOException
+        {
+            // No specific recursive files-only listing implementation
+            return list(fs, table, path);
+        }
+
         public void setThrowException(boolean throwException)
         {
             this.throwException = throwException;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
This change includes three changes that are designed to improve the efficiency of the hive plugin `DirectoryLister` when used in combination with a `FileSystem` that supports more efficient recursive listing via `FileSystem#listFiles(Path, boolean recursive)` like the `TrinoS3FileSystem`.

1. The first commit extends the `DirectoryLister` interface with an additional method that requests that a full recursive file listing instead of a shallow, "files and directories" listing. This necessarily required altering `CachingDirectoryLister` and `TransactionScopeCachingDirectoryLister` to be able to store both kinds of listings at the same path, which was done by adding `DirectoryListingCacheKey` which distinguishes the two kinds of keys via the sign bit in their precomputed hash code.
2. The second commit modifies `HiveFileIterator` to conditionally call `DirectoryLister.listFilesRecursively` when recursive behaviors are requested instead of `DirectoryLister.list`. This greatly simplifies the the implementation, since now recursion and traversal down into sub-paths are handled by the file system itself, but comes with the cost of attempting to identify "hidden sub-paths" between the top level path and child paths in a slightly more complex fashion.
3. The third and final commit changes the behavior of `HiveFileIterator` to avoid eagerly checking `FileSystem.exists` when `ignoreAbsentPartitions` is `true`, instead waiting for the listing to throw an exception and then checking whether the exception was caused by the path existing. This is especially useful for the `TrinoS3FileSystem` since the implementation of `FileSystem.exists` itself performs an S3 listing operation.

Overall, this greatly reduces the number of S3 listing operations that will be performed when there is a large number of nested "directories" since we can instead fully enumerate all of the leaf S3 object paths when that's the desired behavior. For instance the ELB access log S3 path structure is described [here](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-access-logs.html) will generate a separate "directory" per region, per day- which can quickly result in many hundreds of S3 listing calls to recurse through the hierarchy before reaching the actual data files without this improvement.

This change bridges the gap between the `BackgroundHiveSplitLoader` and the optimized `TrinoS3FileSystem#listFiles(Path, boolean recursive)` implementation originally contributed in https://github.com/trinodb/trino/pull/4825

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

~(x) No release notes entries required.~
( ) Release notes entries required with the following suggested text:
