### PR TITLE
File-metastore do not allow createing view when schema is not exist

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -169,6 +169,7 @@ public final class SystemSessionProperties
     public static final String ADAPTIVE_PARTIAL_AGGREGATION_ENABLED = "adaptive_partial_aggregation_enabled";
     public static final String ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS = "adaptive_partial_aggregation_min_rows";
     public static final String ADAPTIVE_PARTIAL_AGGREGATION_UNIQUE_ROWS_RATIO_THRESHOLD = "adaptive_partial_aggregation_unique_rows_ratio_threshold";
+    public static final String JOIN_PARTITIONED_BUILD_MIN_ROW_COUNT = "join_partitioned_build_min_row_count";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -823,6 +824,12 @@ public final class SystemSessionProperties
                         ADAPTIVE_PARTIAL_AGGREGATION_UNIQUE_ROWS_RATIO_THRESHOLD,
                         "Ratio between aggregation output and input rows above which partial aggregation might be adaptively turned off",
                         optimizerConfig.getAdaptivePartialAggregationUniqueRowsRatioThreshold(),
+                        false),
+                longProperty(
+                        JOIN_PARTITIONED_BUILD_MIN_ROW_COUNT,
+                        "Minimum number of join build side rows required to use partitioned join lookup",
+                        optimizerConfig.getJoinPartitionedBuildMinRowCount(),
+                        value -> validateNonNegativeLongValue(value, JOIN_PARTITIONED_BUILD_MIN_ROW_COUNT),
                         false));
     }
 
@@ -1204,6 +1211,13 @@ public final class SystemSessionProperties
         return intValue;
     }
 
+    private static void validateNonNegativeLongValue(Long value, String property)
+    {
+        if (value < 0) {
+            throw new TrinoException(INVALID_SESSION_PROPERTY, format("%s must be equal or greater than 0", property));
+        }
+    }
+
     private static double validateDoubleRange(Object value, String property, double lowerBoundIncluded, double upperBoundIncluded)
     {
         double doubleValue = (double) value;
@@ -1478,5 +1492,10 @@ public final class SystemSessionProperties
     public static double getAdaptivePartialAggregationUniqueRowsRatioThreshold(Session session)
     {
         return session.getSystemProperty(ADAPTIVE_PARTIAL_AGGREGATION_UNIQUE_ROWS_RATIO_THRESHOLD, Double.class);
+    }
+
+    public static long getJoinPartitionedBuildMinRowCount(Session session)
+    {
+        return session.getSystemProperty(JOIN_PARTITIONED_BUILD_MIN_ROW_COUNT, Long.class);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/BinPackingNodeAllocatorService.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/BinPackingNodeAllocatorService.java
@@ -15,10 +15,11 @@ package io.trino.execution.scheduler;
 
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Ticker;
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Ordering;
+import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Streams;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -47,7 +48,6 @@ import javax.inject.Inject;
 import java.time.Duration;
 import java.util.Deque;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -456,16 +456,10 @@ public class BinPackingNodeAllocatorService
                 realtimeTasksMemoryPerNode.put(node.getNodeIdentifier(), memoryPoolInfo.getTaskMemoryReservations());
             }
 
-            Map<String, Set<BinPackingNodeLease>> fulfilledAcquiresByNode = new HashMap<>();
+            SetMultimap<String, BinPackingNodeLease> fulfilledAcquiresByNode = HashMultimap.create();
             for (BinPackingNodeLease fulfilledAcquire : fulfilledAcquires) {
                 InternalNode node = fulfilledAcquire.getAssignedNode();
-                fulfilledAcquiresByNode.compute(node.getNodeIdentifier(), (key, set) -> {
-                    if (set == null) {
-                        set = new HashSet<>();
-                    }
-                    set.add(fulfilledAcquire);
-                    return set;
-                });
+                fulfilledAcquiresByNode.put(node.getNodeIdentifier(), fulfilledAcquire);
             }
 
             nodesRemainingMemory = new HashMap<>();
@@ -488,7 +482,7 @@ public class BinPackingNodeAllocatorService
                 }
 
                 Map<String, Long> realtimeNodeMemory = realtimeTasksMemoryPerNode.get(node.getNodeIdentifier());
-                Set<BinPackingNodeLease> nodeFulfilledAcquires = fulfilledAcquiresByNode.getOrDefault(node.getNodeIdentifier(), ImmutableSet.of());
+                Set<BinPackingNodeLease> nodeFulfilledAcquires = fulfilledAcquiresByNode.get(node.getNodeIdentifier());
 
                 long nodeUsedMemoryRuntimeAdjusted = 0;
                 for (BinPackingNodeLease lease : nodeFulfilledAcquires) {

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/BinPackingNodeAllocatorService.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/BinPackingNodeAllocatorService.java
@@ -399,8 +399,8 @@ public class BinPackingNodeAllocatorService
                 node.cancel(true);
                 if (node.isDone() && !node.isCancelled()) {
                     deallocateMemory(getFutureValue(node));
-                    wakeupProcessPendingAcquires();
                     checkState(fulfilledAcquires.remove(this), "node lease %s not found in fulfilledAcquires %s", this, fulfilledAcquires);
+                    wakeupProcessPendingAcquires();
                 }
             }
             else {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/OptimizerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/OptimizerConfig.java
@@ -85,6 +85,7 @@ public class OptimizerConfig
     private boolean adaptivePartialAggregationEnabled = true;
     private long adaptivePartialAggregationMinRows = 100_000;
     private double adaptivePartialAggregationUniqueRowsRatioThreshold = 0.8;
+    private long joinPartitionedBuildMinRowCount = 1_000_000L;
 
     public enum JoinReorderingStrategy
     {
@@ -711,6 +712,20 @@ public class OptimizerConfig
     public OptimizerConfig setAdaptivePartialAggregationUniqueRowsRatioThreshold(double adaptivePartialAggregationUniqueRowsRatioThreshold)
     {
         this.adaptivePartialAggregationUniqueRowsRatioThreshold = adaptivePartialAggregationUniqueRowsRatioThreshold;
+        return this;
+    }
+
+    @Min(0)
+    public long getJoinPartitionedBuildMinRowCount()
+    {
+        return joinPartitionedBuildMinRowCount;
+    }
+
+    @Config("optimizer.join-partitioned-build-min-row-count")
+    @ConfigDescription("Minimum number of join build side rows required to use partitioned join lookup")
+    public OptimizerConfig setJoinPartitionedBuildMinRowCount(long joinPartitionedBuildMinRowCount)
+    {
+        this.joinPartitionedBuildMinRowCount = joinPartitionedBuildMinRowCount;
         return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -235,6 +235,7 @@ import io.trino.sql.planner.iterative.rule.UnwrapCastInComparison;
 import io.trino.sql.planner.iterative.rule.UnwrapRowSubscript;
 import io.trino.sql.planner.iterative.rule.UnwrapSingleColumnRowInApply;
 import io.trino.sql.planner.iterative.rule.UnwrapTimestampToDateCastInComparison;
+import io.trino.sql.planner.iterative.rule.UseNonPartitionedJoinLookupSource;
 import io.trino.sql.planner.optimizations.AddExchanges;
 import io.trino.sql.planner.optimizations.AddLocalExchanges;
 import io.trino.sql.planner.optimizations.BeginTableWrite;
@@ -919,6 +920,13 @@ public class PlanOptimizers
 
         // Optimizers above this don't understand local exchanges, so be careful moving this.
         builder.add(new AddLocalExchanges(plannerContext, typeAnalyzer));
+        // UseNonPartitionedJoinLookupSource needs to run after AddLocalExchanges since it operates on ExchangeNodes added by this optimizer.
+        builder.add(new IterativeOptimizer(
+                plannerContext,
+                ruleStats,
+                statsCalculator,
+                costCalculator,
+                ImmutableSet.of(new UseNonPartitionedJoinLookupSource())));
 
         // Optimizers above this do not need to care about aggregations with the type other than SINGLE
         // This optimizer must be run after all exchange-related optimizers

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UseNonPartitionedJoinLookupSource.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UseNonPartitionedJoinLookupSource.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import io.trino.Session;
+import io.trino.cost.StatsProvider;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.operator.join.LookupJoinOperator;
+import io.trino.sql.planner.Partitioning;
+import io.trino.sql.planner.PartitioningScheme;
+import io.trino.sql.planner.iterative.Lookup;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.optimizations.PlanNodeSearcher;
+import io.trino.sql.planner.plan.ExchangeNode;
+import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.TableScanNode;
+import io.trino.sql.planner.plan.UnnestNode;
+import io.trino.sql.planner.plan.ValuesNode;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.SystemSessionProperties.getJoinPartitionedBuildMinRowCount;
+import static io.trino.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
+import static io.trino.sql.planner.plan.ExchangeNode.Scope.LOCAL;
+import static io.trino.sql.planner.plan.ExchangeNode.Type.GATHER;
+import static io.trino.sql.planner.plan.Patterns.Join.right;
+import static io.trino.sql.planner.plan.Patterns.exchange;
+import static io.trino.sql.planner.plan.Patterns.join;
+
+/**
+ * Rule that transforms
+ * <pre>
+ *     join
+ *       probe
+ *       build
+ *         localExchange(partitioned)
+ * </pre>
+ * into:
+ * <pre>
+ *     join
+ *       probe
+ *       build
+ *         localExchange(gather)
+ * </pre>
+ * for small build sides.
+ * Avoiding partitioned exchange on the probe side improves {@link LookupJoinOperator} performance.
+ */
+public class UseNonPartitionedJoinLookupSource
+        implements Rule<JoinNode>
+{
+    private static final Capture<ExchangeNode> RIGHT_EXCHANGE_NODE = Capture.newCapture();
+    private static final Pattern<JoinNode> JOIN_PATTERN = join()
+            .with(right().matching(exchange()
+                    .matching(UseNonPartitionedJoinLookupSource::canBeTranslatedToLocalGather)
+                    .capturedAs(RIGHT_EXCHANGE_NODE)));
+
+    @Override
+    public Pattern<JoinNode> getPattern()
+    {
+        return JOIN_PATTERN;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return getJoinPartitionedBuildMinRowCount(session) > 0;
+    }
+
+    @Override
+    public Result apply(JoinNode node, Captures captures, Context context)
+    {
+        double buildSideRowCount = getSourceTablesRowCount(node.getRight(), context);
+        if (Double.isNaN(buildSideRowCount)) {
+            // buildSideRowCount = NaN means stats are not available or build side contains join
+            return Result.empty();
+        }
+        if (buildSideRowCount >= getJoinPartitionedBuildMinRowCount(context.getSession())) {
+            // build side has too many rows
+            return Result.empty();
+        }
+
+        ExchangeNode rightSideExchange = captures.get(RIGHT_EXCHANGE_NODE);
+        ExchangeNode singleThreadedExchange = toGatheringExchange(rightSideExchange);
+        return Result.ofPlanNode(node.replaceChildren(ImmutableList.of(node.getLeft(), singleThreadedExchange)));
+    }
+
+    private static ExchangeNode toGatheringExchange(ExchangeNode exchangeNode)
+    {
+        return new ExchangeNode(
+                exchangeNode.getId(),
+                GATHER,
+                LOCAL,
+                new PartitioningScheme(
+                        Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()),
+                        exchangeNode.getPartitioningScheme().getOutputLayout()),
+                exchangeNode.getSources(),
+                exchangeNode.getInputs(),
+                Optional.empty());
+    }
+
+    private static boolean canBeTranslatedToLocalGather(ExchangeNode exchangeNode)
+    {
+        return exchangeNode.getScope() == LOCAL
+                && !isSingleGather(exchangeNode)
+                && exchangeNode.getOrderingScheme().isEmpty()
+                && exchangeNode.getPartitioningScheme().getBucketToPartition().isEmpty()
+                && !exchangeNode.getPartitioningScheme().isReplicateNullsAndAny();
+    }
+
+    private static boolean isSingleGather(ExchangeNode exchangeNode)
+    {
+        return exchangeNode.getType() == GATHER
+                && exchangeNode.getPartitioningScheme().getPartitioning().getHandle() == SINGLE_DISTRIBUTION;
+    }
+
+    private static double getSourceTablesRowCount(PlanNode node, Context context)
+    {
+        return getSourceTablesRowCount(node, context.getLookup(), context.getStatsProvider());
+    }
+
+    @VisibleForTesting
+    static double getSourceTablesRowCount(PlanNode node, Lookup lookup, StatsProvider statsProvider)
+    {
+        boolean hasExpandingNodes = PlanNodeSearcher.searchFrom(node, lookup)
+                .whereIsInstanceOfAny(JoinNode.class, UnnestNode.class)
+                .matches();
+        if (hasExpandingNodes) {
+            return Double.NaN;
+        }
+
+        List<PlanNode> sourceNodes = PlanNodeSearcher.searchFrom(node, lookup)
+                .whereIsInstanceOfAny(TableScanNode.class, ValuesNode.class)
+                .findAll();
+
+        return sourceNodes.stream()
+                .mapToDouble(sourceNode -> statsProvider.getStats(sourceNode).getOutputRowCount())
+                .sum();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/cost/TestOptimizerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/cost/TestOptimizerConfig.java
@@ -86,7 +86,8 @@ public class TestOptimizerConfig
                 .setForceSingleNodeOutput(true)
                 .setAdaptivePartialAggregationEnabled(true)
                 .setAdaptivePartialAggregationMinRows(100_000)
-                .setAdaptivePartialAggregationUniqueRowsRatioThreshold(0.8));
+                .setAdaptivePartialAggregationUniqueRowsRatioThreshold(0.8)
+                .setJoinPartitionedBuildMinRowCount(1_000_000));
     }
 
     @Test
@@ -141,6 +142,7 @@ public class TestOptimizerConfig
                 .put("adaptive-partial-aggregation.enabled", "false")
                 .put("adaptive-partial-aggregation.min-rows", "1")
                 .put("adaptive-partial-aggregation.unique-rows-ratio-threshold", "0.99")
+                .put("optimizer.join-partitioned-build-min-row-count", "1")
                 .buildOrThrow();
 
         OptimizerConfig expected = new OptimizerConfig()
@@ -191,7 +193,8 @@ public class TestOptimizerConfig
                 .setForceSingleNodeOutput(false)
                 .setAdaptivePartialAggregationEnabled(false)
                 .setAdaptivePartialAggregationMinRows(1)
-                .setAdaptivePartialAggregationUniqueRowsRatioThreshold(0.99);
+                .setAdaptivePartialAggregationUniqueRowsRatioThreshold(0.99)
+                .setJoinPartitionedBuildMinRowCount(1);
         assertFullMapping(properties, expected);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestBinPackingNodeAllocator.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestBinPackingNodeAllocator.java
@@ -692,14 +692,17 @@ public class TestBinPackingNodeAllocator
 
     private static void assertEventually(ThrowingRunnable assertion)
     {
-        Assert.assertEventually(() -> {
-            try {
-                assertion.run();
-            }
-            catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
+        Assert.assertEventually(
+                new io.airlift.units.Duration(TEST_TIMEOUT, TimeUnit.MILLISECONDS),
+                new io.airlift.units.Duration(10, TimeUnit.MILLISECONDS),
+                () -> {
+                    try {
+                        assertion.run();
+                    }
+                    catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                });
     }
 
     interface ThrowingRunnable

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestGetSourceTablesRowCount.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestGetSourceTablesRowCount.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+import io.trino.cost.PlanNodeStatsEstimate;
+import io.trino.cost.StatsProvider;
+import io.trino.sql.planner.PlanNodeIdAllocator;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.PlanNodeId;
+import io.trino.sql.planner.plan.TableScanNode;
+import io.trino.sql.planner.plan.ValuesNode;
+import io.trino.testing.TestingMetadata.TestingColumnHandle;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.trino.cost.PlanNodeStatsEstimate.unknown;
+import static io.trino.metadata.AbstractMockMetadata.dummyMetadata;
+import static io.trino.sql.planner.iterative.Lookup.noLookup;
+import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.lang.Double.NaN;
+import static org.testng.Assert.assertEquals;
+
+public class TestGetSourceTablesRowCount
+{
+    @Test
+    public void testMissingSourceStats()
+    {
+        PlanBuilder planBuilder = planBuilder();
+        Symbol symbol = planBuilder.symbol("col");
+
+        assertEquals(
+                getSourceTablesRowCount(
+                        planBuilder.tableScan(
+                                tableScan -> tableScan
+                                        .setSymbols(ImmutableList.of(symbol))
+                                        .setAssignments(ImmutableMap.of(symbol, new TestingColumnHandle("col")))
+                                        .setStatistics(Optional.of(unknown())))),
+                NaN);
+    }
+
+    @Test
+    public void testTwoSourcePlanNodes()
+    {
+        PlanBuilder planBuilder = planBuilder();
+        Symbol symbol = planBuilder.symbol("col");
+        Symbol sourceSymbol1 = planBuilder.symbol("source1");
+        Symbol sourceSymbol2 = planBuilder.symbol("soruce2");
+
+        assertEquals(
+                getSourceTablesRowCount(
+                        planBuilder.union(
+                                ImmutableListMultimap.<Symbol, Symbol>builder()
+                                        .put(symbol, sourceSymbol1)
+                                        .put(symbol, sourceSymbol2)
+                                        .build(),
+                                ImmutableList.of(
+                                        planBuilder.tableScan(
+                                                tableScan -> tableScan
+                                                        .setSymbols(ImmutableList.of(sourceSymbol1))
+                                                        .setAssignments(ImmutableMap.of(sourceSymbol1, new TestingColumnHandle("col")))
+                                                        .setStatistics(Optional.of(stats(10)))),
+                                        planBuilder.values(new PlanNodeId("valuesNode"), 20, sourceSymbol2)))),
+                30.0);
+    }
+
+    @Test
+    public void testJoinNode()
+    {
+        PlanBuilder planBuilder = planBuilder();
+        Symbol sourceSymbol1 = planBuilder.symbol("source1");
+        Symbol sourceSymbol2 = planBuilder.symbol("soruce2");
+
+        assertEquals(
+                getSourceTablesRowCount(
+                        planBuilder.join(
+                                INNER,
+                                planBuilder.values(sourceSymbol1),
+                                planBuilder.values(sourceSymbol2))),
+                NaN);
+    }
+
+    private double getSourceTablesRowCount(PlanNode planNode)
+    {
+        return UseNonPartitionedJoinLookupSource.getSourceTablesRowCount(
+                planNode,
+                noLookup(),
+                testStatsProvider());
+    }
+
+    private PlanBuilder planBuilder()
+    {
+        return new PlanBuilder(new PlanNodeIdAllocator(), dummyMetadata(), testSessionBuilder().build());
+    }
+
+    private static StatsProvider testStatsProvider()
+    {
+        return node -> {
+            if (node instanceof TableScanNode) {
+                return ((TableScanNode) node).getStatistics().orElse(unknown());
+            }
+
+            if (node instanceof ValuesNode) {
+                return stats(((ValuesNode) node).getRowCount());
+            }
+
+            return unknown();
+        };
+    }
+
+    private static PlanNodeStatsEstimate stats(int rowCount)
+    {
+        return PlanNodeStatsEstimate.builder()
+                .setOutputRowCount(rowCount)
+                .build();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestUseNonPartitionedJoinLookupSource.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestUseNonPartitionedJoinLookupSource.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.cost.PlanNodeStatsEstimate;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
+import io.trino.sql.planner.plan.ExchangeNode;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.PlanNodeId;
+import io.trino.sql.planner.plan.UnnestNode;
+import org.testng.annotations.Test;
+
+import static io.trino.SystemSessionProperties.JOIN_PARTITIONED_BUILD_MIN_ROW_COUNT;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.exchange;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.sql.planner.plan.ExchangeNode.Scope.LOCAL;
+import static io.trino.sql.planner.plan.ExchangeNode.Type.GATHER;
+import static io.trino.sql.planner.plan.ExchangeNode.Type.REPARTITION;
+import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
+import static java.lang.Double.NaN;
+
+public class TestUseNonPartitionedJoinLookupSource
+        extends BaseRuleTest
+{
+    @Test
+    public void testLocalGatheringExchangeNotChanged()
+    {
+        tester().assertThat(new UseNonPartitionedJoinLookupSource())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    return p.join(
+                            INNER,
+                            p.values(a),
+                            p.gatheringExchange(LOCAL, p.values(b)));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testLocalRepartitioningExchangeChangedToGather()
+    {
+        tester().assertThat(new UseNonPartitionedJoinLookupSource())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    return p.join(
+                            INNER,
+                            p.values(a),
+                            repartitioningExchange(p, b, p.values(b)));
+                })
+                .matches(
+                        join(
+                                INNER,
+                                ImmutableList.of(),
+                                values("a"),
+                                exchange(LOCAL, GATHER, values("b"))));
+    }
+
+    @Test
+    public void testLeftRepartitionNotChanged()
+    {
+        tester().assertThat(new UseNonPartitionedJoinLookupSource())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    return p.join(
+                            INNER,
+                            repartitioningExchange(p, a, p.values(a)),
+                            p.values(b));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testRepartitioningExchangeNotChangedIfBuildSideTooBig()
+    {
+        tester()
+                .assertThat(new UseNonPartitionedJoinLookupSource())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    return p.join(
+                            INNER,
+                            p.values(a),
+                            repartitioningExchange(p, b, p.values(new PlanNodeId("source"), b)));
+                })
+                .overrideStats("source", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(5_000_001)
+                        .build())
+                .doesNotFire();
+    }
+
+    @Test
+    public void testRepartitioningExchangeNotChangedIfRuleDisabled()
+    {
+        tester().assertThat(new UseNonPartitionedJoinLookupSource())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    return p.join(
+                            INNER,
+                            p.values(a),
+                            repartitioningExchange(p, b, p.values(b)));
+                })
+                .setSystemProperty(JOIN_PARTITIONED_BUILD_MIN_ROW_COUNT, "0")
+                .doesNotFire();
+    }
+
+    @Test
+    public void testRepartitioningExchangeNotChangedIfBuildSideContainsJoin()
+    {
+        tester()
+                .assertThat(new UseNonPartitionedJoinLookupSource())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    Symbol c = p.symbol("c");
+                    return p.join(
+                            INNER,
+                            p.values(a),
+                            repartitioningExchange(p, b, p.join(INNER, p.values(c), p.values(b))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testRepartitioningExchangeNotChangedIfBuildSideContainsUnnest()
+    {
+        tester()
+                .assertThat(new UseNonPartitionedJoinLookupSource())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    Symbol c = p.symbol("c");
+                    return p.join(
+                            INNER,
+                            p.values(a),
+                            repartitioningExchange(p, b, p.unnest(
+                                    ImmutableList.of(),
+                                    ImmutableList.of(new UnnestNode.Mapping(c, ImmutableList.of(b))),
+                                    p.values(c))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testRepartitioningExchangeNotChangedIfBuildSideRowCountUnknown()
+    {
+        tester()
+                .assertThat(new UseNonPartitionedJoinLookupSource())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    return p.join(
+                            INNER,
+                            p.values(a),
+                            repartitioningExchange(p, b, p.values(new PlanNodeId("source"), b)));
+                })
+                .overrideStats("source", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(NaN)
+                        .build())
+                .doesNotFire();
+    }
+
+    private ExchangeNode repartitioningExchange(PlanBuilder p, Symbol symbol, PlanNode source)
+    {
+        return p.exchange(builder -> builder
+                .type(REPARTITION)
+                .scope(LOCAL)
+                .fixedHashDistributionPartitioningScheme(ImmutableList.of(symbol), ImmutableList.of(symbol))
+                .addSource(source)
+                .addInputsSet(symbol));
+    }
+}

--- a/docs/src/main/sphinx/admin/properties-optimizer.rst
+++ b/docs/src/main/sphinx/admin/properties-optimizer.rst
@@ -187,3 +187,15 @@ Enables approximation of the output row count of filters whose costs cannot be
 accurately estimated even with complete statistics. This allows the optimizer to
 produce more efficient plans in the presence of filters which were previously
 not estimated.
+
+``optimizer.join-partitioned-build-min-row-count``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** :ref:`prop-type-integer`
+* **Default value:** ``1000000``
+* **Min allowed value:** ``0``
+
+The minimum number of join build side rows required to use partitioned join lookup.
+If the build side of a join is estimated to be smaller than the configured threshold,
+single threaded join lookup is used to improve join performance.
+A value of ``0`` disables this optimization.

--- a/docs/src/main/sphinx/connector/bigquery.rst
+++ b/docs/src/main/sphinx/connector/bigquery.rst
@@ -137,6 +137,8 @@ Property                                              Description               
 ``bigquery.credentials-key``                          The base64 encoded credentials key                             None. See the `requirements <#requirements>`_ section.
 ``bigquery.credentials-file``                         The path to the JSON credentials file                          None. See the `requirements <#requirements>`_ section.
 ``bigquery.case-insensitive-name-matching``           Match dataset and table names case-insensitively               ``false``
+``bigquery.query-results-cache.enabled``              Enable `query results cache
+                                                      <https://cloud.google.com/bigquery/docs/cached-results>`_      ``false``
 ===================================================== ============================================================== ======================================================
 
 Data types

--- a/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/TestAccumuloConnectorTest.java
+++ b/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/TestAccumuloConnectorTest.java
@@ -296,6 +296,13 @@ public class TestAccumuloConnectorTest
                         ")");
     }
 
+    @Test
+    @Override
+    public void testCreateViewSchemaNotFound()
+    {
+        // TODO (https://github.com/trinodb/trino/issues/12475) Accumulo connector can create new views in a schema where it doesn't exist
+    }
+
     @Override
     protected Optional<DataMappingTestSetup> filterDataMappingSmokeTestData(DataMappingTestSetup dataMappingTestSetup)
     {

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ColumnMapping.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ColumnMapping.java
@@ -22,74 +22,74 @@ import static java.util.Objects.requireNonNull;
 
 public final class ColumnMapping
 {
-    public static ColumnMapping booleanMapping(Type prestoType, BooleanReadFunction readFunction, BooleanWriteFunction writeFunction)
+    public static ColumnMapping booleanMapping(Type trinoType, BooleanReadFunction readFunction, BooleanWriteFunction writeFunction)
     {
-        return booleanMapping(prestoType, readFunction, writeFunction, FULL_PUSHDOWN);
+        return booleanMapping(trinoType, readFunction, writeFunction, FULL_PUSHDOWN);
     }
 
     public static ColumnMapping booleanMapping(
-            Type prestoType,
+            Type trinoType,
             BooleanReadFunction readFunction,
             BooleanWriteFunction writeFunction,
             PredicatePushdownController predicatePushdownController)
     {
-        return new ColumnMapping(prestoType, readFunction, writeFunction, predicatePushdownController);
+        return new ColumnMapping(trinoType, readFunction, writeFunction, predicatePushdownController);
     }
 
-    public static ColumnMapping longMapping(Type prestoType, LongReadFunction readFunction, LongWriteFunction writeFunction)
+    public static ColumnMapping longMapping(Type trinoType, LongReadFunction readFunction, LongWriteFunction writeFunction)
     {
-        return longMapping(prestoType, readFunction, writeFunction, FULL_PUSHDOWN);
+        return longMapping(trinoType, readFunction, writeFunction, FULL_PUSHDOWN);
     }
 
     public static ColumnMapping longMapping(
-            Type prestoType,
+            Type trinoType,
             LongReadFunction readFunction,
             LongWriteFunction writeFunction,
             PredicatePushdownController predicatePushdownController)
     {
-        return new ColumnMapping(prestoType, readFunction, writeFunction, predicatePushdownController);
+        return new ColumnMapping(trinoType, readFunction, writeFunction, predicatePushdownController);
     }
 
-    public static ColumnMapping doubleMapping(Type prestoType, DoubleReadFunction readFunction, DoubleWriteFunction writeFunction)
+    public static ColumnMapping doubleMapping(Type trinoType, DoubleReadFunction readFunction, DoubleWriteFunction writeFunction)
     {
-        return doubleMapping(prestoType, readFunction, writeFunction, FULL_PUSHDOWN);
+        return doubleMapping(trinoType, readFunction, writeFunction, FULL_PUSHDOWN);
     }
 
     public static ColumnMapping doubleMapping(
-            Type prestoType,
+            Type trinoType,
             DoubleReadFunction readFunction,
             DoubleWriteFunction writeFunction,
             PredicatePushdownController predicatePushdownController)
     {
-        return new ColumnMapping(prestoType, readFunction, writeFunction, predicatePushdownController);
+        return new ColumnMapping(trinoType, readFunction, writeFunction, predicatePushdownController);
     }
 
-    public static ColumnMapping sliceMapping(Type prestoType, SliceReadFunction readFunction, SliceWriteFunction writeFunction)
+    public static ColumnMapping sliceMapping(Type trinoType, SliceReadFunction readFunction, SliceWriteFunction writeFunction)
     {
-        return sliceMapping(prestoType, readFunction, writeFunction, FULL_PUSHDOWN);
+        return sliceMapping(trinoType, readFunction, writeFunction, FULL_PUSHDOWN);
     }
 
     public static ColumnMapping sliceMapping(
-            Type prestoType,
+            Type trinoType,
             SliceReadFunction readFunction,
             SliceWriteFunction writeFunction,
             PredicatePushdownController predicatePushdownController)
     {
-        return new ColumnMapping(prestoType, readFunction, writeFunction, predicatePushdownController);
+        return new ColumnMapping(trinoType, readFunction, writeFunction, predicatePushdownController);
     }
 
-    public static <T> ColumnMapping objectMapping(Type prestoType, ObjectReadFunction readFunction, ObjectWriteFunction writeFunction)
+    public static <T> ColumnMapping objectMapping(Type trinoType, ObjectReadFunction readFunction, ObjectWriteFunction writeFunction)
     {
-        return objectMapping(prestoType, readFunction, writeFunction, FULL_PUSHDOWN);
+        return objectMapping(trinoType, readFunction, writeFunction, FULL_PUSHDOWN);
     }
 
     public static <T> ColumnMapping objectMapping(
-            Type prestoType,
+            Type trinoType,
             ObjectReadFunction readFunction,
             ObjectWriteFunction writeFunction,
             PredicatePushdownController predicatePushdownController)
     {
-        return new ColumnMapping(prestoType, readFunction, writeFunction, predicatePushdownController);
+        return new ColumnMapping(trinoType, readFunction, writeFunction, predicatePushdownController);
     }
 
     private final Type type;

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/JdbcClientStats.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/JdbcClientStats.java
@@ -51,7 +51,7 @@ public final class JdbcClientStats
     private final JdbcApiStats setTableProperties = new JdbcApiStats();
     private final JdbcApiStats rollbackCreateTable = new JdbcApiStats();
     private final JdbcApiStats schemaExists = new JdbcApiStats();
-    private final JdbcApiStats toPrestoType = new JdbcApiStats();
+    private final JdbcApiStats toTrinoType = new JdbcApiStats();
     private final JdbcApiStats getColumnMappings = new JdbcApiStats();
     private final JdbcApiStats toWriteMapping = new JdbcApiStats();
     private final JdbcApiStats implementAggregation = new JdbcApiStats();
@@ -293,9 +293,9 @@ public final class JdbcClientStats
 
     @Managed
     @Nested
-    public JdbcApiStats getToPrestoType()
+    public JdbcApiStats getToTrinoType()
     {
-        return toPrestoType;
+        return toTrinoType;
     }
 
     @Managed

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
@@ -113,7 +113,7 @@ public final class StatisticsAwareJdbcClient
     @Override
     public Optional<ColumnMapping> toColumnMapping(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
     {
-        return stats.getToPrestoType().wrap(() -> delegate().toColumnMapping(session, connection, typeHandle));
+        return stats.getToTrinoType().wrap(() -> delegate().toColumnMapping(session, connection, typeHandle));
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcQueryBuilder.java
@@ -457,9 +457,9 @@ public class TestDefaultJdbcQueryBuilder
         TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(ImmutableMap.of(
                 columns.get(6), Domain.create(SortedRangeSet.copyOf(TIMESTAMP_MILLIS,
                         ImmutableList.of(
-                                Range.equal(TIMESTAMP_MILLIS, toPrestoTimestamp(2016, 6, 3, 0, 23, 37)),
-                                Range.equal(TIMESTAMP_MILLIS, toPrestoTimestamp(2016, 10, 19, 16, 23, 37)),
-                                Range.range(TIMESTAMP_MILLIS, toPrestoTimestamp(2016, 6, 7, 8, 23, 37), false, toPrestoTimestamp(2016, 6, 9, 12, 23, 37), true))),
+                                Range.equal(TIMESTAMP_MILLIS, toTrinoTimestamp(2016, 6, 3, 0, 23, 37)),
+                                Range.equal(TIMESTAMP_MILLIS, toTrinoTimestamp(2016, 10, 19, 16, 23, 37)),
+                                Range.range(TIMESTAMP_MILLIS, toTrinoTimestamp(2016, 6, 7, 8, 23, 37), false, toTrinoTimestamp(2016, 6, 9, 12, 23, 37), true))),
                         false)));
 
         Connection connection = database.getConnection();
@@ -654,7 +654,7 @@ public class TestDefaultJdbcQueryBuilder
         }
     }
 
-    private static long toPrestoTimestamp(int year, int month, int day, int hour, int minute, int second)
+    private static long toTrinoTimestamp(int year, int month, int day, int hour, int minute, int second)
     {
         return sqlTimestampOf(3, year, month, day, hour, minute, second, 0).getMillis() * MICROSECONDS_PER_MILLISECOND;
     }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
@@ -20,6 +20,7 @@ import com.google.cloud.bigquery.DatasetId;
 import com.google.cloud.bigquery.DatasetInfo;
 import com.google.cloud.bigquery.Job;
 import com.google.cloud.bigquery.JobInfo;
+import com.google.cloud.bigquery.JobInfo.CreateDisposition;
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.Table;
@@ -208,10 +209,13 @@ public class BigQueryClient
         return bigQuery.create(jobInfo);
     }
 
-    public TableResult query(String sql)
+    public TableResult query(String sql, boolean useQueryResultsCache, CreateDisposition createDisposition)
     {
         try {
-            return bigQuery.query(QueryJobConfiguration.of(sql));
+            return bigQuery.query(QueryJobConfiguration.newBuilder(sql)
+                    .setUseQueryCache(useQueryResultsCache)
+                    .setCreateDisposition(createDisposition)
+                    .build());
         }
         catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -219,12 +223,15 @@ public class BigQueryClient
         }
     }
 
-    public TableResult query(TableId table, List<String> requiredColumns, Optional<String> filter)
+    public TableResult query(TableId table, List<String> requiredColumns, Optional<String> filter, boolean useQueryResultsCache, CreateDisposition createDisposition)
     {
         String sql = selectSql(table, requiredColumns, filter);
         log.debug("Execute query: %s", sql);
         try {
-            return bigQuery.query(QueryJobConfiguration.of(sql));
+            return bigQuery.query(QueryJobConfiguration.newBuilder(sql)
+                    .setUseQueryCache(useQueryResultsCache)
+                    .setCreateDisposition(createDisposition)
+                    .build());
         }
         catch (InterruptedException e) {
             Thread.currentThread().interrupt();

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConfig.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConfig.java
@@ -48,6 +48,7 @@ public class BigQueryConfig
     private boolean caseInsensitiveNameMatching;
     private Duration viewsCacheTtl = new Duration(15, MINUTES);
     private Duration serviceCacheTtl = new Duration(3, MINUTES);
+    private boolean queryResultsCacheEnabled;
 
     public Optional<String> getProjectId()
     {
@@ -209,6 +210,18 @@ public class BigQueryConfig
     public BigQueryConfig setServiceCacheTtl(Duration serviceCacheTtl)
     {
         this.serviceCacheTtl = serviceCacheTtl;
+        return this;
+    }
+
+    public boolean isQueryResultsCacheEnabled()
+    {
+        return queryResultsCacheEnabled;
+    }
+
+    @Config("bigquery.query-results-cache.enabled")
+    public BigQueryConfig setQueryResultsCacheEnabled(boolean queryResultsCacheEnabled)
+    {
+        this.queryResultsCacheEnabled = queryResultsCacheEnabled;
         return this;
     }
 

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnector.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnector.java
@@ -14,16 +14,22 @@
 package io.trino.plugin.bigquery;
 
 import io.airlift.log.Logger;
+import io.trino.plugin.base.session.SessionPropertiesProvider;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.ConnectorPageSourceProvider;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.transaction.IsolationLevel;
 
 import javax.inject.Inject;
 
+import java.util.List;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.spi.transaction.IsolationLevel.READ_COMMITTED;
 import static io.trino.spi.transaction.IsolationLevel.checkConnectorSupports;
 import static java.util.Objects.requireNonNull;
@@ -36,16 +42,21 @@ public class BigQueryConnector
     private final BigQueryMetadata metadata;
     private final BigQuerySplitManager splitManager;
     private final BigQueryPageSourceProvider pageSourceProvider;
+    private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
     public BigQueryConnector(
             BigQueryMetadata metadata,
             BigQuerySplitManager splitManager,
-            BigQueryPageSourceProvider pageSourceProvider)
+            BigQueryPageSourceProvider pageSourceProvider,
+            Set<SessionPropertiesProvider> sessionPropertiesProviders)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
+        this.sessionProperties = requireNonNull(sessionPropertiesProviders, "sessionPropertiesProviders is null").stream()
+                .flatMap(sessionPropertiesProvider -> sessionPropertiesProvider.getSessionProperties().stream())
+                .collect(toImmutableList());
     }
 
     @Override
@@ -72,5 +83,11 @@ public class BigQueryConnector
     public ConnectorPageSourceProvider getPageSourceProvider()
     {
         return pageSourceProvider;
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getSessionProperties()
+    {
+        return sessionProperties;
     }
 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorModule.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorModule.java
@@ -20,8 +20,10 @@ import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.plugin.base.session.SessionPropertiesProvider;
 import io.trino.spi.NodeManager;
 
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 
@@ -52,6 +54,7 @@ public class BigQueryConnectorModule
             binder.bind(BigQueryPageSourceProvider.class).in(Scopes.SINGLETON);
             binder.bind(ViewMaterializationCache.class).in(Scopes.SINGLETON);
             configBinder(binder).bindConfig(BigQueryConfig.class);
+            newSetBinder(binder, SessionPropertiesProvider.class).addBinding().to(BigQuerySessionProperties.class).in(Scopes.SINGLETON);
         }
 
         @Provides

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryPageSourceProvider.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryPageSourceProvider.java
@@ -30,6 +30,8 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.bigquery.BigQuerySessionProperties.createDisposition;
+import static io.trino.plugin.bigquery.BigQuerySessionProperties.isQueryResultsCacheEnabled;
 import static java.util.Objects.requireNonNull;
 
 public class BigQueryPageSourceProvider
@@ -104,6 +106,8 @@ public class BigQueryPageSourceProvider
                 table,
                 columnHandles.stream().map(BigQueryColumnHandle::getName).collect(toImmutableList()),
                 columnHandles.stream().map(BigQueryColumnHandle::getTrinoType).collect(toImmutableList()),
-                filter);
+                filter,
+                isQueryResultsCacheEnabled(session),
+                createDisposition(session));
     }
 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryQueryPageSource.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryQueryPageSource.java
@@ -15,6 +15,7 @@ package io.trino.plugin.bigquery;
 
 import com.google.cloud.bigquery.FieldValue;
 import com.google.cloud.bigquery.FieldValueList;
+import com.google.cloud.bigquery.JobInfo.CreateDisposition;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableResult;
 import com.google.common.collect.ImmutableList;
@@ -83,7 +84,9 @@ public class BigQueryQueryPageSource
             BigQueryTableHandle table,
             List<String> columnNames,
             List<Type> columnTypes,
-            Optional<String> filter)
+            Optional<String> filter,
+            boolean useQueryResultsCache,
+            CreateDisposition createDisposition)
     {
         requireNonNull(client, "client is null");
         requireNonNull(table, "table is null");
@@ -94,7 +97,7 @@ public class BigQueryQueryPageSource
         this.columnTypes = ImmutableList.copyOf(columnTypes);
         this.pageBuilder = new PageBuilder(columnTypes);
         TableId tableId = TableId.of(client.getProjectId(), table.getRemoteTableName().getDatasetName(), table.getRemoteTableName().getTableName());
-        this.tableResult = client.query(tableId, ImmutableList.copyOf(columnNames), filter);
+        this.tableResult = client.query(tableId, ImmutableList.copyOf(columnNames), filter, useQueryResultsCache, createDisposition);
     }
 
     @Override

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySessionProperties.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySessionProperties.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.plugin.base.session.SessionPropertiesProvider;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.session.PropertyMetadata;
+
+import javax.inject.Inject;
+
+import java.util.List;
+
+import static io.trino.spi.session.PropertyMetadata.booleanProperty;
+
+public final class BigQuerySessionProperties
+        implements SessionPropertiesProvider
+{
+    private static final String SKIP_VIEW_MATERIALIZATION = "skip_view_materialization";
+
+    private final List<PropertyMetadata<?>> sessionProperties;
+
+    @Inject
+    public BigQuerySessionProperties(BigQueryConfig config)
+    {
+        sessionProperties = ImmutableList.<PropertyMetadata<?>>builder()
+                .add(booleanProperty(
+                        SKIP_VIEW_MATERIALIZATION,
+                        "Skip materializing views",
+                        config.isSkipViewMaterialization(),
+                        false))
+                .build();
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getSessionProperties()
+    {
+        return sessionProperties;
+    }
+
+    public static boolean isSkipViewMaterialization(ConnectorSession session)
+    {
+        return session.getProperty(SKIP_VIEW_MATERIALIZATION, Boolean.class);
+    }
+}

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySessionProperties.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySessionProperties.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.bigquery;
 
+import com.google.cloud.bigquery.JobInfo.CreateDisposition;
 import com.google.common.collect.ImmutableList;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
 import io.trino.spi.connector.ConnectorSession;
@@ -23,11 +24,14 @@ import javax.inject.Inject;
 import java.util.List;
 
 import static io.trino.spi.session.PropertyMetadata.booleanProperty;
+import static io.trino.spi.session.PropertyMetadata.enumProperty;
 
 public final class BigQuerySessionProperties
         implements SessionPropertiesProvider
 {
     private static final String SKIP_VIEW_MATERIALIZATION = "skip_view_materialization";
+    private static final String QUERY_RESULTS_CACHE_ENABLED = "query_results_cache_enabled";
+    private static final String CREATE_DISPOSITION_TYPE = "create_disposition_type";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -40,6 +44,17 @@ public final class BigQuerySessionProperties
                         "Skip materializing views",
                         config.isSkipViewMaterialization(),
                         false))
+                .add(booleanProperty(
+                        QUERY_RESULTS_CACHE_ENABLED,
+                        "Enable query results cache",
+                        config.isQueryResultsCacheEnabled(),
+                        false))
+                .add(enumProperty(
+                        CREATE_DISPOSITION_TYPE,
+                        "Create disposition type",
+                        CreateDisposition.class,
+                        CreateDisposition.CREATE_IF_NEEDED, // https://cloud.google.com/bigquery/docs/cached-results
+                        true))
                 .build();
     }
 
@@ -52,5 +67,15 @@ public final class BigQuerySessionProperties
     public static boolean isSkipViewMaterialization(ConnectorSession session)
     {
         return session.getProperty(SKIP_VIEW_MATERIALIZATION, Boolean.class);
+    }
+
+    public static boolean isQueryResultsCacheEnabled(ConnectorSession session)
+    {
+        return session.getProperty(QUERY_RESULTS_CACHE_ENABLED, Boolean.class);
+    }
+
+    public static CreateDisposition createDisposition(ConnectorSession session)
+    {
+        return session.getProperty(CREATE_DISPOSITION_TYPE, CreateDisposition.class);
     }
 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitManager.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitManager.java
@@ -46,6 +46,8 @@ import static com.google.cloud.bigquery.TableDefinition.Type.TABLE;
 import static com.google.cloud.bigquery.TableDefinition.Type.VIEW;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.bigquery.BigQueryErrorCode.BIGQUERY_FAILED_TO_EXECUTE_QUERY;
+import static io.trino.plugin.bigquery.BigQuerySessionProperties.createDisposition;
+import static io.trino.plugin.bigquery.BigQuerySessionProperties.isQueryResultsCacheEnabled;
 import static io.trino.plugin.bigquery.BigQuerySessionProperties.isSkipViewMaterialization;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.util.Objects.requireNonNull;
@@ -139,7 +141,7 @@ public class BigQuerySplitManager
             if (filter.isPresent()) {
                 // count the rows based on the filter
                 String sql = client.selectSql(remoteTableId, "COUNT(*)");
-                TableResult result = client.query(sql);
+                TableResult result = client.query(sql, isQueryResultsCacheEnabled(session), createDisposition(session));
                 numberOfRows = result.iterateAll().iterator().next().get(0).getLongValue();
             }
             else {
@@ -151,7 +153,7 @@ public class BigQuerySplitManager
                 }
                 else if (tableInfo.getDefinition().getType() == VIEW) {
                     String sql = client.selectSql(remoteTableId, "COUNT(*)");
-                    TableResult result = client.query(sql);
+                    TableResult result = client.query(sql, isQueryResultsCacheEnabled(session), createDisposition(session));
                     numberOfRows = result.iterateAll().iterator().next().get(0).getLongValue();
                 }
                 else {

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConfig.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConfig.java
@@ -44,7 +44,8 @@ public class TestBigQueryConfig
                 .setCaseInsensitiveNameMatching(false)
                 .setViewsCacheTtl(new Duration(15, MINUTES))
                 .setServiceCacheTtl(new Duration(3, MINUTES))
-                .setViewsEnabled(false));
+                .setViewsEnabled(false)
+                .setQueryResultsCacheEnabled(false));
     }
 
     @Test
@@ -63,6 +64,7 @@ public class TestBigQueryConfig
                 .put("bigquery.case-insensitive-name-matching", "true")
                 .put("bigquery.views-cache-ttl", "1m")
                 .put("bigquery.service-cache-ttl", "10d")
+                .put("bigquery.query-results-cache.enabled", "true")
                 .buildOrThrow();
 
         BigQueryConfig expected = new BigQueryConfig()
@@ -77,7 +79,8 @@ public class TestBigQueryConfig
                 .setMaxReadRowsRetries(10)
                 .setCaseInsensitiveNameMatching(true)
                 .setViewsCacheTtl(new Duration(1, MINUTES))
-                .setServiceCacheTtl(new Duration(10, DAYS));
+                .setServiceCacheTtl(new Duration(10, DAYS))
+                .setQueryResultsCacheEnabled(true);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSession.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSession.java
@@ -489,7 +489,7 @@ public class CassandraSession
 
             log.debug("Execute cql for partition keys with multiple queries: %s", partitionKeys);
             List<Row> resultRows = execute(partitionKeys.build()).all();
-            if (resultRows != null && !resultRows.isEmpty()) {
+            if (!resultRows.isEmpty()) {
                 rowList.addAll(resultRows);
             }
         }

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSession.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSession.java
@@ -395,11 +395,6 @@ public class CassandraSession
             rows = queryPartitionKeysLegacyWithMultipleQueries(table, filterPrefixes);
         }
 
-        if (rows == null) {
-            // just split the whole partition range
-            return ImmutableList.of(CassandraPartition.UNPARTITIONED);
-        }
-
         ByteBuffer buffer = ByteBuffer.allocate(1000);
         HashMap<ColumnHandle, NullableValue> map = new HashMap<>();
         Set<String> uniquePartitionIds = new HashSet<>();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -286,6 +286,13 @@ public class FileHiveMetastore
         }
     }
 
+    private void verifyDatabaseExists(String databaseName)
+    {
+        if (getDatabase(databaseName).isEmpty()) {
+            throw new SchemaNotFoundException(databaseName);
+        }
+    }
+
     @Override
     public synchronized List<String> getAllDatabases()
     {
@@ -298,6 +305,7 @@ public class FileHiveMetastore
     @Override
     public synchronized void createTable(Table table, PrincipalPrivileges principalPrivileges)
     {
+        verifyDatabaseExists(table.getDatabaseName());
         verifyTableNotExists(table.getDatabaseName(), table.getTableName());
 
         Path tableMetadataDirectory = getTableMetadataDirectory(table);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -4642,16 +4642,16 @@ public abstract class BaseHiveConnectorTest
     @Test
     public void testMismatchedBucketWithBucketPredicate()
     {
-        assertUpdate("DROP TABLE IF EXISTS test_mismatch_bucketing8");
-        assertUpdate("DROP TABLE IF EXISTS test_mismatch_bucketing32");
+        assertUpdate("DROP TABLE IF EXISTS test_mismatch_bucketing_with_bucket_predicate8");
+        assertUpdate("DROP TABLE IF EXISTS test_mismatch_bucketing_with_bucket_predicate32");
 
         assertUpdate(
-                "CREATE TABLE test_mismatch_bucketing8 " +
+                "CREATE TABLE test_mismatch_bucketing_with_bucket_predicate8 " +
                         "WITH (bucket_count = 8, bucketed_by = ARRAY['key8']) AS " +
                         "SELECT nationkey key8, comment value8 FROM nation",
                 25);
         assertUpdate(
-                "CREATE TABLE test_mismatch_bucketing32 " +
+                "CREATE TABLE test_mismatch_bucketing_with_bucket_predicate32 " +
                         "WITH (bucket_count = 32, bucketed_by = ARRAY['key32']) AS " +
                         "SELECT nationkey key32, comment value32 FROM nation",
                 25);
@@ -4666,17 +4666,17 @@ public abstract class BaseHiveConnectorTest
         @Language("SQL") String query = "SELECT count(*) AS count " +
                 "FROM (" +
                 "  SELECT key32" +
-                "  FROM test_mismatch_bucketing32" +
+                "  FROM test_mismatch_bucketing_with_bucket_predicate32" +
                 "  WHERE \"$bucket\" between 16 AND 31" +
                 ") a " +
-                "JOIN test_mismatch_bucketing8 b " +
+                "JOIN test_mismatch_bucketing_with_bucket_predicate8 b " +
                 "ON a.key32 = b.key8";
 
         assertQuery(withMismatchOptimization, query, "SELECT 9");
         assertQuery(withoutMismatchOptimization, query, "SELECT 9");
 
-        assertUpdate("DROP TABLE IF EXISTS test_mismatch_bucketing8");
-        assertUpdate("DROP TABLE IF EXISTS test_mismatch_bucketing32");
+        assertUpdate("DROP TABLE IF EXISTS test_mismatch_bucketing_with_bucket_predicate8");
+        assertUpdate("DROP TABLE IF EXISTS test_mismatch_bucketing_with_bucket_predicate32");
     }
 
     @DataProvider

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
@@ -473,7 +473,7 @@ public class TrinoHiveCatalog
                 .setViewExpandedText(Optional.of("/* " + ICEBERG_MATERIALIZED_VIEW_COMMENT + " */"));
         io.trino.plugin.hive.metastore.Table table = tableBuilder.build();
         PrincipalPrivileges principalPrivileges = isUsingSystemSecurity ? NO_PRIVILEGES : buildInitialPrivilegeSet(session.getUser());
-        if (existing.isPresent() && replace) {
+        if (existing.isPresent()) {
             // drop the current storage table
             String oldStorageTable = existing.get().getParameters().get(STORAGE_TABLE);
             if (oldStorageTable != null) {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGetTableStatisticsOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGetTableStatisticsOperations.java
@@ -107,7 +107,7 @@ public class TestIcebergGetTableStatisticsOperations
                 "WHERE o.orderkey = l.orderkey");
         assertThat(metadata.getMethodInvocations()).containsExactlyInAnyOrderElementsOf(
                 ImmutableMultiset.<CountingAccessMetadata.Methods>builder()
-                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 4)
+                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 5)
                         .build());
     }
 
@@ -119,7 +119,7 @@ public class TestIcebergGetTableStatisticsOperations
                 "WHERE o.orderkey = l.orderkey AND c.custkey = o.custkey");
         assertThat(metadata.getMethodInvocations()).containsExactlyInAnyOrderElementsOf(
                 ImmutableMultiset.<CountingAccessMetadata.Methods>builder()
-                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 7)
+                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 9)
                         .build());
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
@@ -159,8 +159,8 @@ public class TestIcebergMetadataFileOperations
 
         assertFileSystemAccesses("SELECT name, age FROM test_join_t1 JOIN test_join_t2 ON test_join_t2.id = test_join_t1.id",
                 ImmutableMultiset.builder()
-                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 8)
-                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 8)
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 10)
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 10)
                         .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM), 2)
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH), 2)
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM), 2)
@@ -177,8 +177,8 @@ public class TestIcebergMetadataFileOperations
 
         assertFileSystemAccesses("SELECT count(*) FROM test_join_partitioned_t1 t1 join test_join_partitioned_t2 t2 on t1.a = t2.foo",
                 ImmutableMultiset.builder()
-                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 8)
-                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 8)
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 10)
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 10)
                         .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM), 2)
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH), 2)
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM), 2)

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/BaseRaptorConnectorTest.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/BaseRaptorConnectorTest.java
@@ -170,6 +170,13 @@ public abstract class BaseRaptorConnectorTest
     }
 
     @Test
+    @Override
+    public void testCreateViewSchemaNotFound()
+    {
+        // TODO (https://github.com/trinodb/trino/issues/11110) Raptor connector can create new views in a schema where it doesn't exist
+    }
+    
+    @Test
     public void testCreateTableViewAlreadyExists()
     {
         assertUpdate("CREATE VIEW view_already_exists AS SELECT 1 a");

--- a/service/trino-verifier/src/main/java/io/trino/verifier/Validator.java
+++ b/service/trino-verifier/src/main/java/io/trino/verifier/Validator.java
@@ -716,7 +716,7 @@ public class Validator
             if (a.getClass() != b.getClass()) {
                 throw new TypesDoNotMatchException(format("item types do not match: %s vs %s", a.getClass().getName(), b.getClass().getName()));
             }
-            if ((a.getClass().isArray() && b.getClass().isArray())) {
+            if (a.getClass().isArray()) {
                 Object[] aArray = (Object[]) a;
                 Object[] bArray = (Object[]) b;
 

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -737,6 +737,23 @@ public abstract class BaseConnectorTest
     }
 
     @Test
+    public void testCreateViewSchemaNotFound()
+    {
+        skipTestUnless(hasBehavior(SUPPORTS_CREATE_VIEW));
+
+        String schemaName = "test_schema_" + randomTableSuffix();
+        String viewName = "test_view_create_no_schema_" + randomTableSuffix();
+        try {
+            assertQueryFails(
+                    format("CREATE VIEW %s.%s AS SELECT 1 AS c1", schemaName, viewName),
+                    format("Schema %s not found", schemaName));
+        }
+        finally {
+            assertUpdate(format("DROP VIEW IF EXISTS %s.%s", schemaName, viewName));
+        }
+    }
+
+    @Test
     public void testViewCaseSensitivity()
     {
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_VIEW));

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestGetTableStatisticsOperations.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestGetTableStatisticsOperations.java
@@ -66,7 +66,7 @@ public class TestGetTableStatisticsOperations
                 "WHERE o.orderkey = l.orderkey");
         assertThat(metadata.getMethodInvocations()).containsExactlyInAnyOrderElementsOf(
                 ImmutableMultiset.<CountingAccessMetadata.Methods>builder()
-                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 2)
+                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 3)
                         .build());
     }
 
@@ -78,7 +78,7 @@ public class TestGetTableStatisticsOperations
                 "WHERE o.orderkey = l.orderkey AND c.custkey = o.custkey");
         assertThat(metadata.getMethodInvocations()).containsExactlyInAnyOrderElementsOf(
                 ImmutableMultiset.<CountingAccessMetadata.Methods>builder()
-                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 3)
+                        .addCopies(CountingAccessMetadata.Methods.GET_TABLE_STATISTICS, 5)
                         .build());
     }
 


### PR DESCRIPTION
## Description
Fix file-metastore allows creating views in a schema where it doesn't exist
## Related issues, pull requests, and links
Fixes https://github.com/trinodb/trino/issues/10857
## Documentation
No documentation is needed.
## Release notes
No release notes entries required.
