### PR TITLE
Remove @Flaky annotation and disable testNotAnalzyed for MySql 8

### DIFF
--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseTestMySqlTableStatisticsTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseTestMySqlTableStatisticsTest.java
@@ -19,7 +19,6 @@ import io.trino.testing.MaterializedResult;
 import io.trino.testing.MaterializedRow;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.sql.TestTable;
-import io.trino.testng.services.Flaky;
 import org.assertj.core.api.AbstractDoubleAssert;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
@@ -82,10 +81,6 @@ public abstract class BaseTestMySqlTableStatisticsTest
 
     @Override
     @Test
-    @Flaky(
-            // TODO replace @Flaky with assertEventually or @Flaky-like annotation for same purpose
-            issue = "TODO",
-            match = "Expecting.*to be close to|ComparisonFailure.*NDV for")
     public void testNotAnalyzed()
     {
         String tableName = "test_not_analyzed_" + randomTableSuffix();

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseTestMySqlTableStatisticsTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseTestMySqlTableStatisticsTest.java
@@ -38,6 +38,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Streams.stream;
 import static io.trino.plugin.mysql.MySqlQueryRunner.createMySqlQueryRunner;
 import static io.trino.testing.sql.TestTable.fromColumns;
+import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static io.trino.tpch.TpchTable.ORDERS;
 import static java.lang.Math.min;
 import static java.lang.String.format;
@@ -87,7 +88,7 @@ public abstract class BaseTestMySqlTableStatisticsTest
             match = "Expecting.*to be close to|ComparisonFailure.*NDV for")
     public void testNotAnalyzed()
     {
-        String tableName = "test_not_analyzed";
+        String tableName = "test_not_analyzed_" + randomTableSuffix();
         assertUpdate("DROP TABLE IF EXISTS " + tableName);
         computeActual(format("CREATE TABLE %s AS SELECT * FROM tpch.tiny.orders", tableName));
         try {
@@ -119,7 +120,7 @@ public abstract class BaseTestMySqlTableStatisticsTest
     @Test
     public void testBasic()
     {
-        String tableName = "test_stats_orders";
+        String tableName = "test_stats_orders_" + randomTableSuffix();
         assertUpdate("DROP TABLE IF EXISTS " + tableName);
         computeActual(format("CREATE TABLE %s AS SELECT * FROM tpch.tiny.orders", tableName));
         try {
@@ -147,7 +148,7 @@ public abstract class BaseTestMySqlTableStatisticsTest
     @Test
     public void testAllNulls()
     {
-        String tableName = "test_stats_table_all_nulls";
+        String tableName = "test_stats_table_all_nulls_" + randomTableSuffix();
         assertUpdate("DROP TABLE IF EXISTS " + tableName);
         computeActual(format("CREATE TABLE %s AS SELECT orderkey, custkey, orderpriority, comment FROM tpch.tiny.orders WHERE false", tableName));
         try {
@@ -196,7 +197,7 @@ public abstract class BaseTestMySqlTableStatisticsTest
     @Test
     public void testNullsFraction()
     {
-        String tableName = "test_stats_table_with_nulls";
+        String tableName = "test_stats_table_with_nulls_" + randomTableSuffix();
         assertUpdate("DROP TABLE IF EXISTS " + tableName);
         assertUpdate("" +
                         "CREATE TABLE " + tableName + " AS " +
@@ -246,7 +247,7 @@ public abstract class BaseTestMySqlTableStatisticsTest
     @Test
     public void testView()
     {
-        String tableName = "test_stats_view";
+        String tableName = "test_stats_view_" + randomTableSuffix();
         executeInMysql("CREATE OR REPLACE VIEW " + tableName + " AS SELECT orderkey, custkey, orderpriority, comment FROM orders");
         try {
             assertQuery(

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTableStatisticsMySql8Histograms.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTableStatisticsMySql8Histograms.java
@@ -15,6 +15,7 @@ package io.trino.plugin.mysql;
 
 import com.google.common.collect.ImmutableMap;
 import io.trino.testing.sql.TestTable;
+import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -79,6 +80,12 @@ public class TestMySqlTableStatisticsMySql8Histograms
                             "('long_decimals_big_integral', null, 2.0, 0.0, null, null, null)," +
                             "(null, null, null, null, 2, null, null)");
         }
+    }
+
+    @Override
+    public void testNotAnalyzed()
+    {
+        throw new SkipException("MySql8 automatically calculates stats - https://dev.mysql.com/doc/refman/8.0/en/innodb-parameters.html#sysvar_innodb_stats_auto_recalc");
     }
 
     @Override

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTableStatisticsMySql8IndexStatistics.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTableStatisticsMySql8IndexStatistics.java
@@ -13,11 +13,19 @@
  */
 package io.trino.plugin.mysql;
 
+import org.testng.SkipException;
+
 public class TestMySqlTableStatisticsMySql8IndexStatistics
         extends BaseMySqlTableStatisticsIndexStatisticsTest
 {
     public TestMySqlTableStatisticsMySql8IndexStatistics()
     {
         super("mysql:8.0.15");
+    }
+
+    @Override
+    public void testNotAnalyzed()
+    {
+        throw new SkipException("MySql8 automatically calculates stats - https://dev.mysql.com/doc/refman/8.0/en/innodb-parameters.html#sysvar_innodb_stats_auto_recalc");
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
```
    Remove @Flaky annotation and disable testNotAnalzyed for MySql 8

    See https://dev.mysql.com/doc/refman/8.0/en/innodb-parameters.html#sysvar_innodb_stats_auto_recalc
    MySql automatically analyzes tables under certain circumstances, so testNotAnalyzed is not
    deterministic
```

```
 Use randomTableSuffix() in BaseTestMySqlTableStatisticsTest tests

When increasing @test(invocationCount = X) to reproduce @flaky tests,
having a unique table name is important for test isolation.
```


<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Test fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Test

> How would you describe this change to a non-technical end user or system administrator?

Skip a test which cannot be run deterministically due to MySql8's stats guarantees.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```


Fixes https://github.com/trinodb/trino/issues/12413