### PR TITLE
Rename Iceberg delete_orphan_files to remove_orphan_files

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -216,7 +216,7 @@ The procedure affects all snapshots that are older than the time period configur
 
   ALTER TABLE test_table EXECUTE expire_snapshots(retention_threshold => '7d')
 
-The value for ``retention_threshold`` must be higher than ``iceberg.expire_snapshots.min-retention`` in the catalog
+The value for ``retention_threshold`` must be higher than or equal to ``iceberg.expire_snapshots.min-retention`` in the catalog
 otherwise the procedure will fail with similar message:
 ``Retention specified (1.00d) is shorter than the minimum retention configured in the system (7.00d)``.
 The default value for this property is ``7d``.
@@ -234,7 +234,7 @@ Deleting orphan files from time to time is recommended to keep size of table's d
 
   ALTER TABLE test_table EXECUTE remove_orphan_files(retention_threshold => '7d')
 
-The value for ``retention_threshold`` must be higher than ``iceberg.remove_orphan_files.min-retention`` in the catalog
+The value for ``retention_threshold`` must be higher than or equal to ``iceberg.remove_orphan_files.min-retention`` in the catalog
 otherwise the procedure will fail with similar message:
 ``Retention specified (1.00d) is shorter than the minimum retention configured in the system (7.00d)``.
 The default value for this property is ``7d``.

--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -221,20 +221,20 @@ otherwise the procedure will fail with similar message:
 ``Retention specified (1.00d) is shorter than the minimum retention configured in the system (7.00d)``.
 The default value for this property is ``7d``.
 
-delete_orphan_files
+remove_orphan_files
 ~~~~~~~~~~~~~~~~~~~
 
-The ``delete_orphan_files`` command removes all files from table's data directory which are
+The ``remove_orphan_files`` command removes all files from table's data directory which are
 not linked from metadata files and that are older than the value of ``retention_threshold`` parameter.
 Deleting orphan files from time to time is recommended to keep size of table's data directory under control.
 
-``delete_orphan_files`` can be run as follows:
+``remove_orphan_files`` can be run as follows:
 
 .. code-block:: sql
 
-  ALTER TABLE test_table EXECUTE delete_orphan_files(retention_threshold => '7d')
+  ALTER TABLE test_table EXECUTE remove_orphan_files(retention_threshold => '7d')
 
-The value for ``retention_threshold`` must be higher than ``iceberg.delete_orphan_files.min-retention`` in the catalog
+The value for ``retention_threshold`` must be higher than ``iceberg.remove_orphan_files.min-retention`` in the catalog
 otherwise the procedure will fail with similar message:
 ``Retention specified (1.00d) is shorter than the minimum retention configured in the system (7.00d)``.
 The default value for this property is ``7d``.

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -35,7 +35,7 @@ public class IcebergConfig
     public static final int FORMAT_VERSION_SUPPORT_MIN = 1;
     public static final int FORMAT_VERSION_SUPPORT_MAX = 2;
     public static final String EXPIRE_SNAPSHOTS_MIN_RETENTION = "iceberg.expire_snapshots.min-retention";
-    public static final String DELETE_ORPHAN_FILES_MIN_RETENTION = "iceberg.delete_orphan_files.min-retention";
+    public static final String REMOVE_ORPHAN_FILES_MIN_RETENTION = "iceberg.remove_orphan_files.min-retention";
 
     private IcebergFileFormat fileFormat = ORC;
     private HiveCompressionCodec compressionCodec = ZSTD;
@@ -49,7 +49,7 @@ public class IcebergConfig
     private Optional<String> hiveCatalogName = Optional.empty();
     private int formatVersion = FORMAT_VERSION_SUPPORT_MAX;
     private Duration expireSnapshotsMinRetention = new Duration(7, DAYS);
-    private Duration deleteOrphanFilesMinRetention = new Duration(7, DAYS);
+    private Duration removeOrphanFilesMinRetention = new Duration(7, DAYS);
 
     public CatalogType getCatalogType()
     {
@@ -223,16 +223,16 @@ public class IcebergConfig
     }
 
     @NotNull
-    public Duration getDeleteOrphanFilesMinRetention()
+    public Duration getRemoveOrphanFilesMinRetention()
     {
-        return deleteOrphanFilesMinRetention;
+        return removeOrphanFilesMinRetention;
     }
 
-    @Config(DELETE_ORPHAN_FILES_MIN_RETENTION)
-    @ConfigDescription("Minimal retention period for delete_orphan_files procedure")
-    public IcebergConfig setDeleteOrphanFilesMinRetention(Duration deleteOrphanFilesMinRetention)
+    @Config(REMOVE_ORPHAN_FILES_MIN_RETENTION)
+    @ConfigDescription("Minimal retention period for remove_orphan_files procedure")
+    public IcebergConfig setRemoveOrphanFilesMinRetention(Duration removeOrphanFilesMinRetention)
     {
-        this.deleteOrphanFilesMinRetention = deleteOrphanFilesMinRetention;
+        this.removeOrphanFilesMinRetention = removeOrphanFilesMinRetention;
         return this;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
@@ -25,9 +25,9 @@ import io.trino.plugin.hive.orc.OrcReaderConfig;
 import io.trino.plugin.hive.orc.OrcWriterConfig;
 import io.trino.plugin.hive.parquet.ParquetReaderConfig;
 import io.trino.plugin.hive.parquet.ParquetWriterConfig;
-import io.trino.plugin.iceberg.procedure.DeleteOrphanFilesTableProcedure;
 import io.trino.plugin.iceberg.procedure.ExpireSnapshotsTableProcedure;
 import io.trino.plugin.iceberg.procedure.OptimizeTableProcedure;
+import io.trino.plugin.iceberg.procedure.RemoveOrphanFilesTableProcedure;
 import io.trino.spi.connector.ConnectorNodePartitioningProvider;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorPageSourceProvider;
@@ -83,6 +83,6 @@ public class IcebergModule
         Multibinder<TableProcedureMetadata> tableProcedures = newSetBinder(binder, TableProcedureMetadata.class);
         tableProcedures.addBinding().toProvider(OptimizeTableProcedure.class).in(Scopes.SINGLETON);
         tableProcedures.addBinding().toProvider(ExpireSnapshotsTableProcedure.class).in(Scopes.SINGLETON);
-        tableProcedures.addBinding().toProvider(DeleteOrphanFilesTableProcedure.class).in(Scopes.SINGLETON);
+        tableProcedures.addBinding().toProvider(RemoveOrphanFilesTableProcedure.class).in(Scopes.SINGLETON);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
@@ -125,7 +125,7 @@ public class IcebergPageSinkProvider
                         optimizeHandle.getTableStorageProperties(),
                         maxOpenPartitions);
             case EXPIRE_SNAPSHOTS:
-            case DELETE_ORPHAN_FILES:
+            case REMOVE_ORPHAN_FILES:
                 // handled via ConnectorMetadata.executeTableExecute
         }
         throw new IllegalArgumentException("Unknown procedure: " + executeHandle.getProcedureId());

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -75,7 +75,7 @@ public final class IcebergSessionProperties
     private static final String TARGET_MAX_FILE_SIZE = "target_max_file_size";
     private static final String HIVE_CATALOG_NAME = "hive_catalog_name";
     public static final String EXPIRE_SNAPSHOTS_MIN_RETENTION = "expire_snapshots_min_retention";
-    public static final String DELETE_ORPHAN_FILES_MIN_RETENTION = "delete_orphan_files_min_retention";
+    public static final String REMOVE_ORPHAN_FILES_MIN_RETENTION = "remove_orphan_files_min_retention";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -237,9 +237,9 @@ public final class IcebergSessionProperties
                         icebergConfig.getExpireSnapshotsMinRetention(),
                         false))
                 .add(durationProperty(
-                        DELETE_ORPHAN_FILES_MIN_RETENTION,
-                        "Minimal retention period for delete_orphan_files procedure",
-                        icebergConfig.getDeleteOrphanFilesMinRetention(),
+                        REMOVE_ORPHAN_FILES_MIN_RETENTION,
+                        "Minimal retention period for remove_orphan_files procedure",
+                        icebergConfig.getRemoveOrphanFilesMinRetention(),
                         false))
                 .build();
     }
@@ -392,8 +392,8 @@ public final class IcebergSessionProperties
         return session.getProperty(EXPIRE_SNAPSHOTS_MIN_RETENTION, Duration.class);
     }
 
-    public static Duration getDeleteOrphanFilesMinRetention(ConnectorSession session)
+    public static Duration getRemoveOrphanFilesMinRetention(ConnectorSession session)
     {
-        return session.getProperty(DELETE_ORPHAN_FILES_MIN_RETENTION, Duration.class);
+        return session.getProperty(REMOVE_ORPHAN_FILES_MIN_RETENTION, Duration.class);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergProcedureHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergProcedureHandle.java
@@ -22,6 +22,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonSubTypes({
         @JsonSubTypes.Type(value = IcebergOptimizeHandle.class, name = "optimize"),
         @JsonSubTypes.Type(value = IcebergExpireSnapshotsHandle.class, name = "expire_snapshots"),
-        @JsonSubTypes.Type(value = IcebergDeleteOrphanFilesHandle.class, name = "delete_orphan_files"),
+        @JsonSubTypes.Type(value = IcebergRemoveOrphanFilesHandle.class, name = "remove_orphan_files"),
 })
 public abstract class IcebergProcedureHandle {}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergRemoveOrphanFilesHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergRemoveOrphanFilesHandle.java
@@ -20,13 +20,13 @@ import io.airlift.units.Duration;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
-public class IcebergDeleteOrphanFilesHandle
+public class IcebergRemoveOrphanFilesHandle
         extends IcebergProcedureHandle
 {
     private final Duration retentionThreshold;
 
     @JsonCreator
-    public IcebergDeleteOrphanFilesHandle(Duration retentionThreshold)
+    public IcebergRemoveOrphanFilesHandle(Duration retentionThreshold)
     {
         this.retentionThreshold = requireNonNull(retentionThreshold, "retentionThreshold is null");
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergTableProcedureId.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergTableProcedureId.java
@@ -17,5 +17,5 @@ public enum IcebergTableProcedureId
 {
     OPTIMIZE,
     EXPIRE_SNAPSHOTS,
-    DELETE_ORPHAN_FILES,
+    REMOVE_ORPHAN_FILES,
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/RemoveOrphanFilesTableProcedure.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/RemoveOrphanFilesTableProcedure.java
@@ -20,17 +20,17 @@ import io.trino.spi.connector.TableProcedureMetadata;
 import javax.inject.Provider;
 
 import static io.trino.plugin.base.session.PropertyMetadataUtil.durationProperty;
-import static io.trino.plugin.iceberg.procedure.IcebergTableProcedureId.DELETE_ORPHAN_FILES;
+import static io.trino.plugin.iceberg.procedure.IcebergTableProcedureId.REMOVE_ORPHAN_FILES;
 import static io.trino.spi.connector.TableProcedureExecutionMode.coordinatorOnly;
 
-public class DeleteOrphanFilesTableProcedure
+public class RemoveOrphanFilesTableProcedure
         implements Provider<TableProcedureMetadata>
 {
     @Override
     public TableProcedureMetadata get()
     {
         return new TableProcedureMetadata(
-                DELETE_ORPHAN_FILES.name(),
+                REMOVE_ORPHAN_FILES.name(),
                 coordinatorOnly(),
                 ImmutableList.of(
                         durationProperty(

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
@@ -50,7 +50,7 @@ public class TestIcebergConfig
                 .setHiveCatalogName(null)
                 .setFormatVersion(2)
                 .setExpireSnapshotsMinRetention(new Duration(7, DAYS))
-                .setDeleteOrphanFilesMinRetention(new Duration(7, DAYS)));
+                .setRemoveOrphanFilesMinRetention(new Duration(7, DAYS)));
     }
 
     @Test
@@ -69,7 +69,7 @@ public class TestIcebergConfig
                 .put("iceberg.hive-catalog-name", "hive")
                 .put("iceberg.format-version", "1")
                 .put("iceberg.expire_snapshots.min-retention", "13h")
-                .put("iceberg.delete_orphan_files.min-retention", "14h")
+                .put("iceberg.remove_orphan_files.min-retention", "14h")
                 .buildOrThrow();
 
         IcebergConfig expected = new IcebergConfig()
@@ -85,7 +85,7 @@ public class TestIcebergConfig
                 .setHiveCatalogName("hive")
                 .setFormatVersion(1)
                 .setExpireSnapshotsMinRetention(new Duration(13, HOURS))
-                .setDeleteOrphanFilesMinRetention(new Duration(14, HOURS));
+                .setRemoveOrphanFilesMinRetention(new Duration(14, HOURS));
 
         assertFullMapping(properties, expected);
     }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
@@ -1721,9 +1721,9 @@ public class TestIcebergSparkCompatibility
         int initialNumberOfMetadataFiles = calculateMetadataFilesForPartitionedTable(baseTableName);
 
         onTrino().executeQuery("SET SESSION iceberg.expire_snapshots_min_retention = '0s'");
-        onTrino().executeQuery("SET SESSION iceberg.delete_orphan_files_min_retention = '0s'");
+        onTrino().executeQuery("SET SESSION iceberg.remove_orphan_files_min_retention = '0s'");
         onTrino().executeQuery(format("ALTER TABLE %s EXECUTE EXPIRE_SNAPSHOTS (retention_threshold => '0s')", trinoTableName));
-        onTrino().executeQuery(format("ALTER TABLE %s EXECUTE DELETE_ORPHAN_FILES (retention_threshold => '0s')", trinoTableName));
+        onTrino().executeQuery(format("ALTER TABLE %s EXECUTE REMOVE_ORPHAN_FILES (retention_threshold => '0s')", trinoTableName));
 
         int updatedNumberOfMetadataFiles = calculateMetadataFilesForPartitionedTable(baseTableName);
         Assertions.assertThat(updatedNumberOfMetadataFiles).isLessThan(initialNumberOfMetadataFiles);
@@ -1763,9 +1763,9 @@ public class TestIcebergSparkCompatibility
 
         onTrino().executeQuery(format("ALTER TABLE %s EXECUTE OPTIMIZE", trinoTableName));
         onTrino().executeQuery("SET SESSION iceberg.expire_snapshots_min_retention = '0s'");
-        onTrino().executeQuery("SET SESSION iceberg.delete_orphan_files_min_retention = '0s'");
+        onTrino().executeQuery("SET SESSION iceberg.remove_orphan_files_min_retention = '0s'");
         onTrino().executeQuery(format("ALTER TABLE %s EXECUTE EXPIRE_SNAPSHOTS (retention_threshold => '0s')", trinoTableName));
-        onTrino().executeQuery(format("ALTER TABLE %s EXECUTE DELETE_ORPHAN_FILES (retention_threshold => '0s')", trinoTableName));
+        onTrino().executeQuery(format("ALTER TABLE %s EXECUTE REMOVE_ORPHAN_FILES (retention_threshold => '0s')", trinoTableName));
 
         int updatedNumberOfFiles = onTrino().executeQuery(format("SELECT * FROM iceberg.default.\"%s$files\"", baseTableName)).getRowsCount();
         Assertions.assertThat(updatedNumberOfFiles).isLessThan(initialNumberOfFiles);
@@ -1800,9 +1800,9 @@ public class TestIcebergSparkCompatibility
 
         onTrino().executeQuery(format("ALTER TABLE %s EXECUTE OPTIMIZE", trinoTableName));
         onTrino().executeQuery("SET SESSION iceberg.expire_snapshots_min_retention = '0s'");
-        onTrino().executeQuery("SET SESSION iceberg.delete_orphan_files_min_retention = '0s'");
+        onTrino().executeQuery("SET SESSION iceberg.remove_orphan_files_min_retention = '0s'");
         onTrino().executeQuery(format("ALTER TABLE %s EXECUTE EXPIRE_SNAPSHOTS (retention_threshold => '0s')", trinoTableName));
-        onTrino().executeQuery(format("ALTER TABLE %s EXECUTE DELETE_ORPHAN_FILES (retention_threshold => '0s')", trinoTableName));
+        onTrino().executeQuery(format("ALTER TABLE %s EXECUTE REMOVE_ORPHAN_FILES (retention_threshold => '0s')", trinoTableName));
 
         Row row = row(3008);
         String selectByString = "SELECT SUM(_bigint) FROM %s WHERE _string = 'a'";
@@ -1842,8 +1842,8 @@ public class TestIcebergSparkCompatibility
 
         onTrino().executeQuery("SET SESSION iceberg.expire_snapshots_min_retention = '0s'");
         onTrino().executeQuery(format("ALTER TABLE %s EXECUTE EXPIRE_SNAPSHOTS (retention_threshold => '0s')", trinoTableName));
-        onTrino().executeQuery("SET SESSION iceberg.delete_orphan_files_min_retention = '0s'");
-        onTrino().executeQuery(format("ALTER TABLE %s EXECUTE DELETE_ORPHAN_FILES (retention_threshold => '0s')", trinoTableName));
+        onTrino().executeQuery("SET SESSION iceberg.remove_orphan_files_min_retention = '0s'");
+        onTrino().executeQuery(format("ALTER TABLE %s EXECUTE REMOVE_ORPHAN_FILES (retention_threshold => '0s')", trinoTableName));
 
         assertThat(onTrino().executeQuery(format(selectByString, trinoTableName)))
                 .containsOnly(row);


### PR DESCRIPTION
## Description
REMOVE_ORPHAN_FILES is a name used by iceberg and spark 
## Related issues, pull requests, and links

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:
Renamed Iceberg DELETE_ORPHAN_FILES procedure to REMOVE_ORPHAN_FILES

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
