### PR TITLE
Fix failure when accessing without labels column in Prometheus

### DIFF
--- a/plugin/trino-prometheus/pom.xml
+++ b/plugin/trino-prometheus/pom.xml
@@ -63,6 +63,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusStandardizedRow.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusStandardizedRow.java
@@ -15,6 +15,8 @@ package io.trino.plugin.prometheus;
 
 import io.trino.spi.block.Block;
 
+import javax.annotation.Nullable;
+
 import java.time.Instant;
 
 import static java.util.Objects.requireNonNull;
@@ -25,13 +27,14 @@ public class PrometheusStandardizedRow
     private final Instant timestamp;
     private final Double value;
 
-    public PrometheusStandardizedRow(Block labels, Instant timestamp, Double value)
+    public PrometheusStandardizedRow(@Nullable Block labels, Instant timestamp, Double value)
     {
-        this.labels = requireNonNull(labels, "labels is null");
+        this.labels = labels;
         this.timestamp = requireNonNull(timestamp, "timestamp is null");
         this.value = requireNonNull(value, "value is null");
     }
 
+    @Nullable
     public Block getLabels()
     {
         return labels;

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusIntegrationMetrics.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusIntegrationMetrics.java
@@ -71,4 +71,11 @@ public class TestPrometheusIntegrationMetrics
                         "('timestamp', 'timestamp(3) with time zone', '', '')," +
                         "('value', 'double', '', '')");
     }
+
+    @Test
+    public void testSelectWithoutLabels()
+    {
+        assertQuerySucceeds("SELECT timestamp, value FROM prometheus.default.up");
+        assertQuery("SELECT value FROM prometheus.default.up LIMIT 1", "VALUES ('1.0')");
+    }
 }


### PR DESCRIPTION
## Description

Fix Prometheus connector always requires labels column

## Related issues, pull requests, and links
Fixes https://github.com/trinodb/trino/issues/12301
## Documentation

## Release notes

