### PR TITLE
Add argument-less builder methods for boolean values

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/TableArgumentSpecification.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/TableArgumentSpecification.java
@@ -64,21 +64,21 @@ public class TableArgumentSpecification
             return this;
         }
 
-        public Builder rowSemantics(boolean rowSemantics)
+        public Builder rowSemantics()
         {
-            this.rowSemantics = rowSemantics;
+            this.rowSemantics = true;
             return this;
         }
 
-        public Builder pruneWhenEmpty(boolean pruneWhenEmpty)
+        public Builder pruneWhenEmpty()
         {
-            this.pruneWhenEmpty = pruneWhenEmpty;
+            this.pruneWhenEmpty = true;
             return this;
         }
 
-        public Builder passThroughColumns(boolean passThroughColumns)
+        public Builder passThroughColumns()
         {
-            this.passThroughColumns = passThroughColumns;
+            this.passThroughColumns = true;
             return this;
         }
 

--- a/core/trino-spi/src/test/java/io/trino/spi/TestSpiBackwardCompatibility.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/TestSpiBackwardCompatibility.java
@@ -53,6 +53,10 @@ public class TestSpiBackwardCompatibility
                     "Field: public java.util.List<io.trino.spi.predicate.Range> io.trino.spi.predicate.BenchmarkSortedRangeSet$Data.ranges"))
             .put("377", ImmutableSet.of(
                     "Constructor: public io.trino.spi.memory.MemoryPoolInfo(long,long,long,java.util.Map<io.trino.spi.QueryId, java.lang.Long>,java.util.Map<io.trino.spi.QueryId, java.util.List<io.trino.spi.memory.MemoryAllocation>>,java.util.Map<io.trino.spi.QueryId, java.lang.Long>)"))
+            .put("382", ImmutableSet.of(
+                    "Method: public io.trino.spi.ptf.TableArgumentSpecification$Builder io.trino.spi.ptf.TableArgumentSpecification$Builder.rowSemantics(boolean)",
+                    "Method: public io.trino.spi.ptf.TableArgumentSpecification$Builder io.trino.spi.ptf.TableArgumentSpecification$Builder.pruneWhenEmpty(boolean)",
+                    "Method: public io.trino.spi.ptf.TableArgumentSpecification$Builder io.trino.spi.ptf.TableArgumentSpecification$Builder.passThroughColumns(boolean)"))
             .buildOrThrow();
 
     @Test


### PR DESCRIPTION
The TableArgumentSpecification builder is part of SPI for declaring
Table Functions. It assumes default values for boolean table argument
properties, and allows to change them using argument-less methods.
It is meant to provide the easiest and most intuitive way of declaring
Table Functions.

This is a SPI change.

No documentation needed.
