### PR TITLE
Free task descriptor memory for finished tasks

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/FaultTolerantStageScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/FaultTolerantStageScheduler.java
@@ -615,6 +615,11 @@ public class FaultTolerantStageScheduler
                                 delaySchedulingFuture = null;
                             }
 
+                            // Remove taskDescriptor for finished partition to conserve memory
+                            // We may revisit the approach when we support volatile exchanges, for which
+                            // it may be needed to restart already finished task to recreate output it produced.
+                            taskDescriptorStorage.remove(stage.getStageId(), partitionId);
+
                             break;
                         case CANCELED:
                             log.debug("Task cancelled: %s", taskId);

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestTaskDescriptorStorage.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestTaskDescriptorStorage.java
@@ -80,8 +80,17 @@ public class TestTaskDescriptorStorage
                 .flatMap(TestTaskDescriptorStorage::getCatalogName)
                 .contains("catalog6");
 
-        manager.destroy(QUERY_1);
-        manager.destroy(QUERY_2);
+        manager.remove(QUERY_1_STAGE_1, 0);
+        manager.remove(QUERY_2_STAGE_2, 1);
+
+        assertThatThrownBy(() -> manager.get(QUERY_1_STAGE_1, 0))
+                .hasMessageContaining("descriptor not found for key");
+        assertThatThrownBy(() -> manager.get(QUERY_2_STAGE_2, 1))
+                .hasMessageContaining("descriptor not found for key");
+
+        assertThat(manager.getReservedBytes())
+                .isGreaterThanOrEqualTo(toBytes(5, KILOBYTE))
+                .isLessThanOrEqualTo(toBytes(7, KILOBYTE));
     }
 
     @Test
@@ -140,6 +149,12 @@ public class TestTaskDescriptorStorage
                 .matches(TestTaskDescriptorStorage::isStorageCapacityExceededFailure);
         assertThatThrownBy(() -> manager.get(QUERY_1_STAGE_2, 0))
                 .matches(TestTaskDescriptorStorage::isStorageCapacityExceededFailure);
+        assertThatThrownBy(() -> manager.remove(QUERY_1_STAGE_1, 0))
+                .matches(TestTaskDescriptorStorage::isStorageCapacityExceededFailure);
+        assertThatThrownBy(() -> manager.remove(QUERY_1_STAGE_1, 1))
+                .matches(TestTaskDescriptorStorage::isStorageCapacityExceededFailure);
+        assertThatThrownBy(() -> manager.remove(QUERY_1_STAGE_2, 0))
+                .matches(TestTaskDescriptorStorage::isStorageCapacityExceededFailure);
 
         // QUERY_2 is still active
         assertThat(manager.get(QUERY_2_STAGE_1, 0))
@@ -159,6 +174,8 @@ public class TestTaskDescriptorStorage
         assertThatThrownBy(() -> manager.put(QUERY_2_STAGE_2, createTaskDescriptor(3, DataSize.of(1, KILOBYTE))))
                 .matches(TestTaskDescriptorStorage::isStorageCapacityExceededFailure);
         assertThatThrownBy(() -> manager.get(QUERY_2_STAGE_1, 0))
+                .matches(TestTaskDescriptorStorage::isStorageCapacityExceededFailure);
+        assertThatThrownBy(() -> manager.remove(QUERY_2_STAGE_1, 0))
                 .matches(TestTaskDescriptorStorage::isStorageCapacityExceededFailure);
     }
 


### PR DESCRIPTION
## Description

In execution mode with task retries we need to keep task descriptors which
(among other things) wrap set of input split until matching tasks finishe.
It is needed so we can restart a task in case of a failure.
Previously we kept the descriptor in memory even after task successfully
finished which was wasteful. It could result in crossing descriptor
storage size boundary which resulted in query failures with
EXCEEDED_TASK_DESCRIPTOR_STORAGE_CAPACITY error code.

With this commit we drop task descriptor from storage as soon as we
observe matching task complete succesfully.

> Is this change a fix, improvement, new feature, refactoring, or other?

improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core engine

> How would you describe this change to a non-technical end user or system administrator?

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# General
* Improve coordinator memory management for fault-tolerant execution (`retry-mode=TASK`)
  decreasing the chance that some queries may fail with `EXCEEDED_TASK_DESCRIPTOR_STORAGE_CAPACITY` 
  error code. ({issue}`12478`)
```
