### PR TITLE
Disallow creating views when schema doesn't exist in File HMS

### DIFF
--- a/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/TestAccumuloConnectorTest.java
+++ b/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/TestAccumuloConnectorTest.java
@@ -296,6 +296,15 @@ public class TestAccumuloConnectorTest
                         ")");
     }
 
+    @Test
+    @Override
+    public void testCreateViewSchemaNotFound()
+    {
+        // TODO (https://github.com/trinodb/trino/issues/12475) Accumulo connector can create new views in a schema where it doesn't exist
+        assertThatThrownBy(super::testCreateViewSchemaNotFound)
+                .hasMessageContaining("Expected query to fail: CREATE VIEW test_schema_");
+    }
+
     @Override
     protected Optional<DataMappingTestSetup> filterDataMappingSmokeTestData(DataMappingTestSetup dataMappingTestSetup)
     {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -298,6 +298,7 @@ public class FileHiveMetastore
     @Override
     public synchronized void createTable(Table table, PrincipalPrivileges principalPrivileges)
     {
+        verifyDatabaseExists(table.getDatabaseName());
         verifyTableNotExists(table.getDatabaseName(), table.getTableName());
 
         Path tableMetadataDirectory = getTableMetadataDirectory(table);
@@ -411,6 +412,13 @@ public class FileHiveMetastore
     {
         return getTable(databaseName, tableName)
                 .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(databaseName, tableName)));
+    }
+
+    private void verifyDatabaseExists(String databaseName)
+    {
+        if (getDatabase(databaseName).isEmpty()) {
+            throw new SchemaNotFoundException(databaseName);
+        }
     }
 
     private void verifyTableNotExists(String newDatabaseName, String newTableName)

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/BaseRaptorConnectorTest.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/BaseRaptorConnectorTest.java
@@ -170,6 +170,15 @@ public abstract class BaseRaptorConnectorTest
     }
 
     @Test
+    @Override
+    public void testCreateViewSchemaNotFound()
+    {
+        // TODO (https://github.com/trinodb/trino/issues/11110) Raptor connector can create new views in a schema where it doesn't exist
+        assertThatThrownBy(super::testCreateViewSchemaNotFound)
+                .hasMessageContaining("Expected query to fail: CREATE VIEW test_schema_");
+    }
+
+    @Test
     public void testCreateTableViewAlreadyExists()
     {
         assertUpdate("CREATE VIEW view_already_exists AS SELECT 1 a");

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -737,6 +737,26 @@ public abstract class BaseConnectorTest
     }
 
     @Test
+    public void testCreateViewSchemaNotFound()
+    {
+        skipTestUnless(hasBehavior(SUPPORTS_CREATE_VIEW));
+
+        String schemaName = "test_schema_" + randomTableSuffix();
+        String viewName = "test_view_create_no_schema_" + randomTableSuffix();
+        try {
+            assertQueryFails(
+                    format("CREATE VIEW %s.%s AS SELECT 1 AS c1", schemaName, viewName),
+                    format("Schema %s not found", schemaName));
+            assertQueryFails(
+                    format("CREATE OR REPLACE VIEW %s.%s AS SELECT 1 AS c1", schemaName, viewName),
+                    format("Schema %s not found", schemaName));
+        }
+        finally {
+            assertUpdate(format("DROP VIEW IF EXISTS %s.%s", schemaName, viewName));
+        }
+    }
+
+    @Test
     public void testViewCaseSensitivity()
     {
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_VIEW));


### PR DESCRIPTION
## Description

Fix file-metastore allows creating views in a schema where it doesn't exist

## Related issues, pull requests, and links
Fixes https://github.com/trinodb/trino/issues/10857
