### PR TITLE
Allow to skip loading unused plugins in Docker container

### DIFF
--- a/core/docker/README.md
+++ b/core/docker/README.md
@@ -19,7 +19,9 @@ To launch it, execute the following:
 docker run -p 8080:8080 --name trino trinodb/trino
 ```
 
-Wait for the following message log line:
+When Trino finishes starting up, the container will report its status as healthy.
+You can check it in the output of `docker ps`, or wait for the following message
+log line:
 ```
 INFO	main	io.trino.server.Server	======== SERVER STARTED ========
 ```
@@ -61,6 +63,15 @@ across all worker nodes if desired. Additionally this has the added benefit of
 The default configuration uses `/data/trino` as the default for
 `node.data-dir`. Thus if using the default configuration and a mounted volume
 is desired for the data directory it should be mounted to `/data/trino`.
+
+## Disabling plugins
+
+On startup, Trino loads all plugins found in `/usr/lib/trino/plugin`. To avoid
+loading unused plugins, set the `TRINO_DISABLE_PLUGINS` to a comma separated
+list of plugin names. Set the `TRINO_ENABLE_PLUGINS` to only enable selected plugins:
+```bash
+docker run -p 8080:8080 --name trino -e TRINO_ENABLE_PLUGINS=hive,jmx trinodb/trino
+```
 
 ## Building a custom Docker image
 

--- a/core/docker/bin/run-trino
+++ b/core/docker/bin/run-trino
@@ -2,14 +2,9 @@
 
 set -xeuo pipefail
 
-set +e
-grep -s -q 'node.id' /etc/trino/node.properties
-NODE_ID_EXISTS=$?
-set -e
-
 NODE_ID=""
-if [[ ${NODE_ID_EXISTS} != 0 ]] ; then
+if ! grep -s -q 'node.id' /etc/trino/node.properties; then
     NODE_ID="-Dnode.id=${HOSTNAME}"
 fi
 
-exec /usr/lib/trino/bin/launcher run --etc-dir /etc/trino ${NODE_ID} "$@"
+exec /usr/lib/trino/bin/launcher run --etc-dir /etc/trino "${NODE_ID}" "$@"

--- a/core/docker/bin/run-trino
+++ b/core/docker/bin/run-trino
@@ -7,4 +7,34 @@ if ! grep -s -q 'node.id' /etc/trino/node.properties; then
     NODE_ID="-Dnode.id=${HOSTNAME}"
 fi
 
+base=/usr/lib/trino
+if [ -n "${TRINO_ENABLE_PLUGINS:-}" ] && [ -n "${TRINO_DISABLE_PLUGINS:-}" ]; then
+    echo >&2 "Cannot set both \$TRINO_DISABLE_PLUGINS and \$TRINO_ENABLE_PLUGINS"
+    exit 1
+elif [ -n "${TRINO_ENABLE_PLUGINS:-}" ]; then
+    if [ -n "${TRINO_DISABLE_PLUGINS:-}" ]; then
+        echo >&2 "Cannot set both \$TRINO_DISABLE_PLUGINS and \$TRINO_ENABLE_PLUGINS"
+        exit 1
+    fi
+    mv "$base/plugin" "$base/plugin.disabled"
+    mv "/etc/trino/catalog" "/etc/trino/catalog.disabled"
+    mkdir -p "$base/plugin" /etc/trino/catalog
+    IFS=, read -ra names <<< "$TRINO_ENABLE_PLUGINS"
+    for name in "${names[@]}"; do
+        mv "$base/plugin.disabled/$name" "$base/plugin/$name"
+        if [ -f "/etc/trino/catalog.disabled/$name.properties" ]; then
+            mv "/etc/trino/catalog.disabled/$name.properties" "/etc/trino/catalog/$name.properties"
+        fi
+    done
+elif [ -n "${TRINO_DISABLE_PLUGINS:-}" ]; then
+    mkdir -p "$base/plugin.disabled" /etc/trino/catalog.disabled
+    IFS=, read -ra names <<< "$TRINO_DISABLE_PLUGINS"
+    for name in "${names[@]}"; do
+        mv "$base/plugin/$name" "$base/plugin.disabled/$name"
+        if [ -f "/etc/trino/catalog/$name.properties" ]; then
+            mv "/etc/trino/catalog/$name.properties" "/etc/trino/catalog.disabled/$name.properties"
+        fi
+    done
+fi
+
 exec /usr/lib/trino/bin/launcher run --etc-dir /etc/trino "${NODE_ID}" "$@"


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

> **Note** This is only a suggestion. I'm fine with closing this PR if this is not the best idea for any reason.

Sometimes users would like to completely avoid loading unused plugins. The best recommendation would be to rebuild the Docker image, but some might struggle with this. This PR introduces two new environmental variables recognized only by the Docker container: `TRINO_ENABLE_PLUGINS` and `TRINO_DISABLE_PLUGINS`, which are inclusive and exclusive comma-separated lists of plugin names. Only one of them can be non-empty.

Removing plugins doesn't affect the startup time much (there's about 1s of variance):
```
Baseline: 8.345482000
With tpch,tpcds only: 7.005982000
Without tpch,tpcds: 9.227644000
```

For curiosity, I checked for `arm64` (with emulation):
```
Baseline: 115.821223000
With tpch,tpcds only: 96.419130000
Without tpch,tpcds: 116.562944000
```

If adding environmental variables like this is not a good idea, maybe it's better to add some support at build time, by defining build args that would do the same. That would also be a chance to document how to build custom images based on the official Trino images.

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
