### PR TITLE
Increase page size when listing GitHub milestones

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -37,7 +37,7 @@ jobs:
             const { MILESTONE_NUMBER } = process.env
 
             // Find milestone
-            const response = await github.issues.listMilestones(context.repo)
+            const response = await github.issues.listMilestones({ owner: context.repo.owner, repo: context.repo.repo, per_page: 100, })
             let milestone = response.data.find(milestoneResponse => milestoneResponse.title === MILESTONE_NUMBER)
 
             // Create new milestone if it doesn't exist


### PR DESCRIPTION
Fixes: https://github.com/trinodb/trino/issues/10652

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other? 

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

CI only

> How would you describe this change to a non-technical end user or system administrator?

GitHub list_milestones API requires paging which we currently do not support. Default page size is 30, so if we have more than 30 open milestones, searching for a matching milestone may fail. This PR increases page size to the maximum allowed value of 100.

If we expect to have more than 100 open milestones, we should properly support paging to fetch all the milestones.


## Related issues, pull requests, and links

* Fixes #10652


<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# CI
* Fix GitHub milestone workflow flakiness. ({issue}`10652`)
```
