### PR TITLE
Disallow creating view if schema doesn't exist in Accumulo

### DIFF
--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloClient.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloClient.java
@@ -564,6 +564,10 @@ public class AccumuloClient
 
     public void createView(SchemaTableName viewName, String viewData)
     {
+        if (!tableManager.namespaceExists(viewName.getSchemaName())) {
+            throw new SchemaNotFoundException(viewName.getSchemaName());
+        }
+
         if (getSchemaNames().contains(viewName.getSchemaName())) {
             if (getViewNames(viewName.getSchemaName()).contains(viewName.getTableName())) {
                 throw new TrinoException(ALREADY_EXISTS, "View already exists");
@@ -579,6 +583,10 @@ public class AccumuloClient
 
     public void createOrReplaceView(SchemaTableName viewName, String viewData)
     {
+        if (!tableManager.namespaceExists(viewName.getSchemaName())) {
+            throw new SchemaNotFoundException(viewName.getSchemaName());
+        }
+
         if (getView(viewName) != null) {
             metaManager.deleteViewMetadata(viewName);
         }

--- a/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/TestAccumuloConnectorTest.java
+++ b/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/TestAccumuloConnectorTest.java
@@ -316,15 +316,6 @@ public class TestAccumuloConnectorTest
                         ")");
     }
 
-    @Test
-    @Override
-    public void testCreateViewSchemaNotFound()
-    {
-        // TODO (https://github.com/trinodb/trino/issues/12475) Accumulo connector can create new views in a schema where it doesn't exist
-        assertThatThrownBy(super::testCreateViewSchemaNotFound)
-                .hasMessageContaining("Expected query to fail: CREATE VIEW test_schema_");
-    }
-
     @Override
     protected Optional<DataMappingTestSetup> filterDataMappingSmokeTestData(DataMappingTestSetup dataMappingTestSetup)
     {


### PR DESCRIPTION
## Description

Disallow creating view if schema doesn't exist in Accumulo

## Related issues, pull requests, and links

Fixes #12475


## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Accumulo
* Disallow creating views in a schema where it doesn't exist. ({issue}`12475`)
```
