### PR TITLE
refactor(docs): Adding Note for Docker Configuration of Connectors

### DIFF
--- a/docs/src/main/sphinx/connector/atop.rst
+++ b/docs/src/main/sphinx/connector/atop.rst
@@ -18,7 +18,7 @@ The connector can read disk utilization statistics on the Trino cluster.
 Create a catalog properties file that specifies the Atop connector by
 setting the ``connector.name`` to ``atop``.
 
-For example, create the file ``etc/catalog/system_monitor.properties``
+For example, create the file ``etc/catalog/system_monitor.properties`` (in ``/etc/trino/catalog`` for Docker)
 and replace the connector properties as appropriate for your setup:
 
 .. code-block:: text

--- a/docs/src/main/sphinx/connector/bigquery.rst
+++ b/docs/src/main/sphinx/connector/bigquery.rst
@@ -65,7 +65,7 @@ Configuration
 -------------
 
 To configure the BigQuery connector, create a catalog properties file in
-``etc/catalog`` named, for example, ``bigquery.properties``, to mount the
+``etc/catalog`` (in ``/etc/trino/catalog`` for Docker) named, for example, ``bigquery.properties``, to mount the
 BigQuery connector as the ``bigquery`` catalog. Create the file with the
 following contents, replacing the connection properties as appropriate for
 your setup:

--- a/docs/src/main/sphinx/connector/blackhole.rst
+++ b/docs/src/main/sphinx/connector/blackhole.rst
@@ -25,7 +25,7 @@ Configuration
 -------------
 
 To configure the Black Hole connector, create a catalog properties file
-``etc/catalog/blackhole.properties`` with the following contents:
+``etc/catalog/blackhole.properties`` (in ``/etc/trino/catalog`` for Docker) with the following contents:
 
 .. code-block:: text
 

--- a/docs/src/main/sphinx/connector/cassandra.rst
+++ b/docs/src/main/sphinx/connector/cassandra.rst
@@ -22,7 +22,7 @@ Configuration
 -------------
 
 To configure the Cassandra connector, create a catalog properties file
-``etc/catalog/cassandra.properties`` with the following contents,
+``etc/catalog/cassandra.properties`` (in ``/etc/trino/catalog`` for Docker) with the following contents,
 replacing ``host1,host2`` with a comma-separated list of the Cassandra
 nodes, used to discovery the cluster topology:
 

--- a/docs/src/main/sphinx/connector/clickhouse.rst
+++ b/docs/src/main/sphinx/connector/clickhouse.rst
@@ -28,7 +28,7 @@ that specifies the ClickHouse connector by setting the ``connector.name`` to
 ``clickhouse``.
 
 For example, to access a server as ``clickhouse``, create the file
-``etc/catalog/clickhouse.properties``. Replace the connection properties as
+``etc/catalog/clickhouse.properties`` (in ``/etc/trino/catalog`` for Docker). Replace the connection properties as
 appropriate for your setup:
 
 .. code-block:: none

--- a/docs/src/main/sphinx/connector/delta-lake.rst
+++ b/docs/src/main/sphinx/connector/delta-lake.rst
@@ -36,7 +36,7 @@ runtime. If non-Delta tables are present in the metastore, as well, they are not
 visible to the connector.
 
 To configure the Delta Lake connector, create a catalog properties file, for
-example ``etc/catalog/delta.properties``, that references the ``delta-lake``
+example ``etc/catalog/delta.properties`` (in ``/etc/trino/catalog`` for Docker), that references the ``delta-lake``
 connector. Update the ``hive.metastore.uri`` with the URI of your Hive metastore
 Thrift service:
 

--- a/docs/src/main/sphinx/connector/druid.rst
+++ b/docs/src/main/sphinx/connector/druid.rst
@@ -26,7 +26,7 @@ the ``connector.name`` to ``druid`` and configuring the ``connection-url`` with
 the JDBC string to connect to Druid.
 
 For example, to access a database as ``druid``, create the file
-``etc/catalog/druid.properties``. Replace ``BROKER:8082`` with the correct
+``etc/catalog/druid.properties`` (in ``/etc/trino/catalog`` for Docker). Replace ``BROKER:8082`` with the correct
 host and port of your Druid broker.
 
 .. code-block:: properties

--- a/docs/src/main/sphinx/connector/elasticsearch.rst
+++ b/docs/src/main/sphinx/connector/elasticsearch.rst
@@ -17,7 +17,7 @@ Configuration
 -------------
 
 To configure the Elasticsearch connector, create a catalog properties file
-``etc/catalog/elasticsearch.properties`` with the following contents,
+``etc/catalog/elasticsearch.properties`` (in ``/etc/trino/catalog`` for Docker) with the following contents,
 replacing the properties as appropriate:
 
 .. code-block:: text

--- a/docs/src/main/sphinx/connector/googlesheets.rst
+++ b/docs/src/main/sphinx/connector/googlesheets.rst
@@ -11,7 +11,7 @@ The Google Sheets connector allows reading `Google Sheets <https://www.google.co
 Configuration
 -------------
 
-Create ``etc/catalog/sheets.properties``
+Create ``etc/catalog/sheets.properties`` (in ``/etc/trino/catalog`` for Docker)
 to mount the Google Sheets connector as the ``sheets`` catalog,
 replacing the properties as appropriate:
 

--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -169,7 +169,7 @@ functionality:
 Configuration
 -------------
 
-Create ``etc/catalog/hive.properties`` with the following contents
+Create ``etc/catalog/hive.properties`` (in ``/etc/trino/catalog`` for Docker) with the following contents
 to mount the ``hive`` connector as the ``hive`` catalog,
 replacing ``example.net:9083`` with the correct host and port
 for your Hive metastore Thrift service:

--- a/docs/src/main/sphinx/connector/jmx.rst
+++ b/docs/src/main/sphinx/connector/jmx.rst
@@ -16,7 +16,7 @@ Configuration
 -------------
 
 To configure the JMX connector, create a catalog properties file
-``etc/catalog/jmx.properties`` with the following contents:
+``etc/catalog/jmx.properties`` (in ``/etc/trino/catalog`` for Docker) with the following contents:
 
 .. code-block:: text
 

--- a/docs/src/main/sphinx/connector/kafka.rst
+++ b/docs/src/main/sphinx/connector/kafka.rst
@@ -39,7 +39,7 @@ Configuration
 -------------
 
 To configure the Kafka connector, create a catalog properties file
-``etc/catalog/kafka.properties`` with the following contents,
+``etc/catalog/kafka.properties`` (in ``/etc/trino/catalog`` for Docker) with the following contents,
 replacing the properties as appropriate.
 
 In some cases, such as when using specialized authentication methods, it is necessary to specify

--- a/docs/src/main/sphinx/connector/kinesis.rst
+++ b/docs/src/main/sphinx/connector/kinesis.rst
@@ -24,7 +24,7 @@ This connector is a **read-only** connector. It can only fetch data from Kinesis
 but cannot create streams or push data into existing streams.
 
 To configure the Kinesis connector, create a catalog properties file ``etc/catalog/kinesis.properties``
-with the following contents, replacing the properties as appropriate:
+(in ``/etc/trino/catalog`` for Docker) with the following contents, replacing the properties as appropriate:
 
 .. code-block:: text
 

--- a/docs/src/main/sphinx/connector/kudu.rst
+++ b/docs/src/main/sphinx/connector/kudu.rst
@@ -23,7 +23,7 @@ Configuration
 -------------
 
 To configure the Kudu connector, create a catalog properties file
-``etc/catalog/kudu.properties`` with the following contents,
+``etc/catalog/kudu.properties`` (in ``/etc/trino/catalog`` for Docker) with the following contents,
 replacing the properties as appropriate:
 
 .. code-block:: properties

--- a/docs/src/main/sphinx/connector/localfile.rst
+++ b/docs/src/main/sphinx/connector/localfile.rst
@@ -9,7 +9,8 @@ Configuration
 -------------
 
 To configure the local file connector, create a catalog properties file
-under ``etc/catalog`` named, for example, ``localfile.properties`` with the following contents:
+under ``etc/catalog`` (in ``/etc/trino/catalog`` for Docker) named, for example,
+``localfile.properties`` with the following contents:
 
 .. code-block:: text
 

--- a/docs/src/main/sphinx/connector/mariadb.rst
+++ b/docs/src/main/sphinx/connector/mariadb.rst
@@ -22,7 +22,8 @@ Configuration
 -------------
 
 To configure the MariaDB connector, create a catalog properties file
-in ``etc/catalog`` named, for example, ``mariadb.properties``, to
+in ``etc/catalog``  (in ``/etc/trino/catalog`` for Docker)named,
+for example, ``mariadb.properties``, to
 mount the MariaDB connector as the ``mariadb`` catalog.
 Create the file with the following contents, replacing the
 connection properties as appropriate for your setup:

--- a/docs/src/main/sphinx/connector/memory.rst
+++ b/docs/src/main/sphinx/connector/memory.rst
@@ -10,7 +10,7 @@ Configuration
 -------------
 
 To configure the Memory connector, create a catalog properties file
-``etc/catalog/memory.properties`` with the following contents:
+``etc/catalog/memory.properties`` (in ``/etc/trino/catalog`` for Docker) with the following contents:
 
 .. code-block:: text
 

--- a/docs/src/main/sphinx/connector/memsql.rst
+++ b/docs/src/main/sphinx/connector/memsql.rst
@@ -24,7 +24,7 @@ Configuration
 -------------
 
 To configure the SingleStore connector, create a catalog properties file
-in ``etc/catalog`` named, for example, ``singlestore.properties``, to
+in ``etc/catalog`` (in ``/etc/trino/catalog`` for Docker) named, for example, ``singlestore.properties``, to
 mount the SingleStore connector as the ``singlestore`` catalog.
 Create the file with the following contents, replacing the
 connection properties as appropriate for your setup:

--- a/docs/src/main/sphinx/connector/mongodb.rst
+++ b/docs/src/main/sphinx/connector/mongodb.rst
@@ -24,8 +24,8 @@ Configuration
 -------------
 
 To configure the MongoDB connector, create a catalog properties file
-``etc/catalog/mongodb.properties`` with the following contents,
-replacing the properties as appropriate:
+``etc/catalog/mongodb.properties`` (in ``/etc/trino/catalog`` for Docker)
+with the following contents, replacing the properties as appropriate:
 
 .. code-block:: text
 

--- a/docs/src/main/sphinx/connector/mysql.rst
+++ b/docs/src/main/sphinx/connector/mysql.rst
@@ -23,8 +23,8 @@ Configuration
 -------------
 
 To configure the MySQL connector, create a catalog properties file
-in ``etc/catalog`` named, for example, ``mysql.properties``, to
-mount the MySQL connector as the ``mysql`` catalog.
+in ``etc/catalog`` (in ``/etc/trino/catalog`` for Docker) named, for example,
+``mysql.properties``, to mount the MySQL connector as the ``mysql`` catalog.
 Create the file with the following contents, replacing the
 connection properties as appropriate for your setup:
 

--- a/docs/src/main/sphinx/connector/oracle.rst
+++ b/docs/src/main/sphinx/connector/oracle.rst
@@ -23,8 +23,8 @@ Configuration
 -------------
 
 To configure the Oracle connector as the ``oracle`` catalog, create a file named
-``oracle.properties`` in ``etc/catalog``. Include the following connection
-properties in the file:
+``oracle.properties`` in ``etc/catalog`` (in ``/etc/trino/catalog`` for Docker).
+Include the following connection properties in the file:
 
 .. code-block:: text
 

--- a/docs/src/main/sphinx/connector/phoenix.rst
+++ b/docs/src/main/sphinx/connector/phoenix.rst
@@ -29,7 +29,7 @@ Configuration
 -------------
 
 To configure the Phoenix connector, create a catalog properties file
-``etc/catalog/phoenix.properties`` with the following contents,
+``etc/catalog/phoenix.properties`` (in ``/etc/trino/catalog`` for Docker) with the following contents,
 replacing ``host1,host2,host3`` with a comma-separated list of the ZooKeeper
 nodes used for discovery of the HBase cluster:
 

--- a/docs/src/main/sphinx/connector/pinot.rst
+++ b/docs/src/main/sphinx/connector/pinot.rst
@@ -22,7 +22,7 @@ Configuration
 -------------
 
 To configure the Pinot connector, create a catalog properties file
-e.g. ``etc/catalog/pinot.properties`` with at least the following contents:
+e.g. ``etc/catalog/pinot.properties`` (in ``/etc/trino/catalog`` for Docker) with at least the following contents:
 
 .. code-block:: text
 

--- a/docs/src/main/sphinx/connector/postgresql.rst
+++ b/docs/src/main/sphinx/connector/postgresql.rst
@@ -28,8 +28,8 @@ properties file that specifies the PostgreSQL connector by setting the
 ``connector.name`` to ``postgresql``.
 
 For example, to access a database as the ``postgresql`` catalog, create the
-file ``etc/catalog/postgresql.properties``. Replace the connection properties
-as appropriate for your setup:
+file ``etc/catalog/postgresql.properties`` (in ``/etc/trino/catalog`` for Docker).
+Replace the connection properties as appropriate for your setup:
 
 .. code-block:: text
 

--- a/docs/src/main/sphinx/connector/prometheus.rst
+++ b/docs/src/main/sphinx/connector/prometheus.rst
@@ -28,7 +28,7 @@ To query Prometheus, you need:
 Configuration
 -------------
 
-Create ``etc/catalog/prometheus.properties``
+Create ``etc/catalog/prometheus.properties`` (in ``/etc/trino/catalog`` for Docker)
 to mount the Prometheus connector as the ``prometheus`` catalog,
 replacing the properties as appropriate:
 

--- a/docs/src/main/sphinx/connector/redis.rst
+++ b/docs/src/main/sphinx/connector/redis.rst
@@ -29,8 +29,8 @@ Configuration
 -------------
 
 To configure the Redis connector, create a catalog properties file
-``etc/catalog/redis.properties`` with the following content,
-replacing the properties as appropriate:
+``etc/catalog/redis.properties`` (in ``/etc/trino/catalog`` for Docker)
+with the following content, replacing the properties as appropriate:
 
 .. code-block:: text
 

--- a/docs/src/main/sphinx/connector/redshift.rst
+++ b/docs/src/main/sphinx/connector/redshift.rst
@@ -23,7 +23,7 @@ Configuration
 -------------
 
 To configure the Redshift connector, create a catalog properties file
-in ``etc/catalog`` named, for example, ``redshift.properties``, to
+in ``etc/catalog``(in ``/etc/trino/catalog`` for Docker)  named, for example, ``redshift.properties``, to
 mount the Redshift connector as the ``redshift`` catalog.
 Create the file with the following contents, replacing the
 connection properties as appropriate for your setup:

--- a/docs/src/main/sphinx/connector/sqlserver.rst
+++ b/docs/src/main/sphinx/connector/sqlserver.rst
@@ -28,8 +28,8 @@ catalog properties file that specifies the SQL server connector by setting the
 ``connector.name`` to ``sqlserver``.
 
 For example, to access a database as ``sqlserver``, create the file
-``etc/catalog/sqlserver.properties``. Replace the connection properties as
-appropriate for your setup:
+``etc/catalog/sqlserver.properties`` (in ``/etc/trino/catalog`` for Docker).
+Replace the connection properties as appropriate for your setup:
 
 .. code-block:: properties
 

--- a/docs/src/main/sphinx/connector/thrift.rst
+++ b/docs/src/main/sphinx/connector/thrift.rst
@@ -28,8 +28,8 @@ Configuration
 -------------
 
 To configure the Thrift connector, create a catalog properties file
-``etc/catalog/thrift.properties`` with the following content,
-replacing the properties as appropriate:
+``etc/catalog/thrift.properties`` (in ``/etc/trino/catalog`` for Docker)
+with the following content, replacing the properties as appropriate:
 
 .. code-block:: text
 

--- a/docs/src/main/sphinx/connector/tpcds.rst
+++ b/docs/src/main/sphinx/connector/tpcds.rst
@@ -15,7 +15,7 @@ Configuration
 -------------
 
 To configure the TPCDS connector, create a catalog properties file
-``etc/catalog/tpcds.properties`` with the following contents:
+``etc/catalog/tpcds.properties`` (in ``/etc/trino/catalog`` for Docker) with the following contents:
 
 .. code-block:: text
 

--- a/docs/src/main/sphinx/connector/tpch.rst
+++ b/docs/src/main/sphinx/connector/tpch.rst
@@ -15,7 +15,7 @@ Configuration
 -------------
 
 To configure the TPCH connector, create a catalog properties file
-``etc/catalog/tpch.properties`` with the following contents:
+``etc/catalog/tpch.properties`` (in ``/etc/trino/catalog`` for Docker) with the following contents:
 
 .. code-block:: text
 


### PR DESCRIPTION
## Description

For issue #12494 .

Adding "(in ``/etc/trino/catalog`` for Docker)" clause in connector pages
to highlight the configuration difference between tarball and Docker.

> Is this change a fix, improvement, new feature, refactoring, or other?

Refactoring of Connector Docs

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

No

> How would you describe this change to a non-technical end user or system administrator?

Adding an extra small note in existing notes to prevent confusions for configuration in different environments.

## Related issues, pull requests, and links

- [Issue](https://github.com/trinodb/trino/issues/12494)
- A related [PR]((https://github.com/trinodb/trino/pull/12340)).
- Initial troubleshooting [Slack discussion](https://trinodb.slack.com/archives/CGB0QHWSW/p1652278657730469).

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
