### PR TITLE
Delay converting labels to Block in Prometheus

### DIFF
--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusRecordCursor.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusRecordCursor.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.prometheus;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteSource;
 import com.google.common.io.CountingInputStream;
 import io.airlift.slice.Slice;
@@ -119,7 +118,7 @@ public class PrometheusRecordCursor
         int columnIndex = fieldToColumnIndex[field];
         switch (columnIndex) {
             case 0:
-                return fields.getLabels();
+                return getBlockFromMap(columnHandles.get(columnIndex).getColumnType(), fields.getLabels());
             case 1:
                 return fields.getTimestamp();
             case 2:
@@ -186,7 +185,7 @@ public class PrometheusRecordCursor
     {
         return results.stream().map(result ->
                 result.getTimeSeriesValues().getValues().stream().map(prometheusTimeSeriesValue -> new PrometheusStandardizedRow(
-                        getBlockFromMap(columnHandles.get(0).getColumnType(), ImmutableMap.copyOf(result.getMetricHeader())),
+                        result.getMetricHeader(),
                         prometheusTimeSeriesValue.getTimestamp(),
                         Double.parseDouble(prometheusTimeSeriesValue.getValue())))
                         .collect(Collectors.toList()))

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusStandardizedRow.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusStandardizedRow.java
@@ -13,26 +13,27 @@
  */
 package io.trino.plugin.prometheus;
 
-import io.trino.spi.block.Block;
+import com.google.common.collect.ImmutableMap;
 
 import java.time.Instant;
+import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
 public class PrometheusStandardizedRow
 {
-    private final Block labels;
+    private final Map<String, String> labels;
     private final Instant timestamp;
     private final Double value;
 
-    public PrometheusStandardizedRow(Block labels, Instant timestamp, Double value)
+    public PrometheusStandardizedRow(Map<String, String> labels, Instant timestamp, Double value)
     {
-        this.labels = requireNonNull(labels, "labels is null");
+        this.labels = ImmutableMap.copyOf(requireNonNull(labels, "labels is null"));
         this.timestamp = requireNonNull(timestamp, "timestamp is null");
         this.value = requireNonNull(value, "value is null");
     }
 
-    public Block getLabels()
+    public Map<String, String> getLabels()
     {
         return labels;
     }

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusIntegration.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusIntegration.java
@@ -57,6 +57,13 @@ public class TestPrometheusIntegration
     }
 
     @Test
+    public void testAggregation()
+    {
+        assertQuerySucceeds("SELECT count(*) FROM default.up"); // Don't check value since the row number isn't deterministic
+        assertQuery("SELECT avg(value) FROM default.up", "VALUES ('1.0')");
+    }
+
+    @Test
     public void testPushDown()
     {
         // default interval on the `up` metric that Prometheus records on itself is about 15 seconds, so this should only yield one or two row


### PR DESCRIPTION
## Description

* Fixes #12485

## Documentation

(x) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# Prometheus
* Fix failure when reading tables without specifying a `labels` column. ({issue}`12510`)
```
