### PR TITLE
Batch delete requests for exchange spooling on S3 and Azure

### DIFF
--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeFutures.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeFutures.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.exchange.filesystem;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.io.IOException;
+
+import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static io.airlift.concurrent.MoreFutures.asVoid;
+
+public final class FileSystemExchangeFutures
+{
+    private FileSystemExchangeFutures() {}
+
+    // Helper function that translates exception and transform future type to avoid abstraction leak
+    public static ListenableFuture<Void> translateFailures(ListenableFuture<?> listenableFuture)
+    {
+        return asVoid(Futures.catchingAsync(listenableFuture, Throwable.class, throwable -> {
+            if (throwable instanceof Error || throwable instanceof IOException) {
+                return immediateFailedFuture(throwable);
+            }
+            else {
+                return immediateFailedFuture(new IOException(throwable));
+            }
+        }, directExecutor()));
+    }
+}

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/s3/S3FileSystemExchangeStorage.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/s3/S3FileSystemExchangeStorage.java
@@ -21,7 +21,9 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageBatch;
 import com.google.cloud.storage.StorageOptions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
 import com.google.common.io.Closer;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
@@ -89,6 +91,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Queue;
@@ -254,14 +257,32 @@ public class S3FileSystemExchangeStorage
             })));
         }
         else {
-            return stats.getDeleteRecursively().record(asVoid(Futures.allAsList(directories.stream().map(dir -> {
+            ImmutableMultimap.Builder<String, ListenableFuture<List<String>>> bucketToListObjectsFuturesBuilder = ImmutableMultimap.builder();
+            for (URI dir : directories) {
                 ImmutableList.Builder<String> keys = ImmutableList.builder();
-                return transformFuture(Futures.transformAsync(
-                        toListenableFuture((listObjectsRecursively(dir).subscribe(listObjectsV2Response ->
-                                listObjectsV2Response.contents().stream().map(S3Object::key).forEach(keys::add)))),
-                        ignored -> deleteObjects(getBucketName(dir), keys.build()),
+                ListenableFuture<List<String>> listObjectsFuture = Futures.transform(
+                        toListenableFuture((listObjectsRecursively(dir)
+                                .subscribe(listObjectsV2Response -> listObjectsV2Response.contents().stream()
+                                        .map(S3Object::key)
+                                        .forEach(keys::add)))),
+                        ignored -> keys.build(),
+                        directExecutor());
+                bucketToListObjectsFuturesBuilder.put(getBucketName(dir), listObjectsFuture);
+            }
+            Multimap<String, ListenableFuture<List<String>>> bucketToListObjectsFutures = bucketToListObjectsFuturesBuilder.build();
+
+            ImmutableList.Builder<ListenableFuture<List<DeleteObjectsResponse>>> deleteObjectsFutures = ImmutableList.builder();
+            for (String bucketName : bucketToListObjectsFutures.keySet()) {
+                deleteObjectsFutures.add(Futures.transformAsync(
+                        Futures.allAsList(bucketToListObjectsFutures.get(bucketName)),
+                        keys -> deleteObjects(
+                                bucketName,
+                                keys.stream()
+                                        .flatMap(Collection::stream)
+                                        .collect(toImmutableList())),
                         directExecutor()));
-            }).collect(toImmutableList()))));
+            }
+            return transformFuture(Futures.allAsList(deleteObjectsFutures.build()));
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

trino-filesystem-exchange

> How would you describe this change to a non-technical end user or system administrator?

This will help reduce the number of delete request sent to S3/Azure by batching them.

## Related issues, pull requests, and links

Depend on https://github.com/trinodb/trino/pull/12360

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
