### PR TITLE
Reset MultiChannelGroupByHash.currentPageBuilder to exact position count

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/MultiChannelGroupByHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/MultiChannelGroupByHash.java
@@ -351,8 +351,7 @@ public class MultiChannelGroupByHash
     {
         if (currentPageBuilder != null) {
             completedPagesMemorySize += currentPageBuilder.getRetainedSizeInBytes();
-            // TODO: (https://github.com/trinodb/trino/issues/12484) pre-size new PageBuilder to OUTPUT_PAGE_SIZE
-            currentPageBuilder = currentPageBuilder.newPageBuilderLike();
+            currentPageBuilder.reset(currentPageBuilder.getPositionCount());
         }
         else {
             currentPageBuilder = new PageBuilder(types);

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -185,6 +185,10 @@
                                     <code>java.method.removed</code>
                                     <old>method java.util.Set&lt;io.trino.spi.security.RoleGrant&gt; io.trino.spi.connector.ConnectorMetadata::listAllRoleGrants(io.trino.spi.connector.ConnectorSession, java.util.Optional&lt;java.util.Set&lt;java.lang.String&gt;&gt;, java.util.Optional&lt;java.util.Set&lt;java.lang.String&gt;&gt;, java.util.OptionalLong)</old>
                                 </item>
+                                <item>
+                                    <code>java.method.addedToInterface</code>
+                                    <new>method io.trino.spi.block.BlockBuilder io.trino.spi.block.BlockBuilder::newBlockBuilderLike(int, io.trino.spi.block.BlockBuilderStatus)</new>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/PageBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/PageBuilder.java
@@ -98,6 +98,19 @@ public class PageBuilder
         }
     }
 
+    public void reset(int expectedEntries)
+    {
+        if (isEmpty()) {
+            return;
+        }
+        pageBuilderStatus = new PageBuilderStatus(pageBuilderStatus.getMaxPageSizeInBytes());
+
+        for (int i = 0; i < blockBuilders.length; i++) {
+            blockBuilders[i] = blockBuilders[i].newBlockBuilderLike(expectedEntries, pageBuilderStatus.createBlockBuilderStatus());
+        }
+        declaredPositions = 0;
+    }
+
     public PageBuilder newPageBuilderLike()
     {
         return new PageBuilder(declaredPositions, pageBuilderStatus.getMaxPageSizeInBytes(), types, Optional.of(blockBuilders));

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlockBuilder.java
@@ -23,7 +23,6 @@ import java.util.function.ObjLongConsumer;
 
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.ArrayBlock.createArrayBlockInternal;
-import static io.trino.spi.block.BlockUtil.calculateBlockResetSize;
 import static java.lang.Math.max;
 import static java.util.Objects.requireNonNull;
 
@@ -228,10 +227,9 @@ public class ArrayBlockBuilder
     }
 
     @Override
-    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    public BlockBuilder newBlockBuilderLike(int expectedEntries, BlockBuilderStatus blockBuilderStatus)
     {
-        int newSize = calculateBlockResetSize(getPositionCount());
-        return new ArrayBlockBuilder(blockBuilderStatus, values.newBlockBuilderLike(blockBuilderStatus), newSize);
+        return new ArrayBlockBuilder(blockBuilderStatus, values.newBlockBuilderLike(blockBuilderStatus), expectedEntries);
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/BlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/BlockBuilder.java
@@ -15,6 +15,8 @@ package io.trino.spi.block;
 
 import io.airlift.slice.Slice;
 
+import static io.trino.spi.block.BlockUtil.calculateBlockResetSize;
+
 public interface BlockBuilder
         extends Block
 {
@@ -95,7 +97,12 @@ public interface BlockBuilder
     /**
      * Creates a new block builder of the same type based on the current usage statistics of this block builder.
      */
-    BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus);
+    BlockBuilder newBlockBuilderLike(int expectedEntries, BlockBuilderStatus blockBuilderStatus);
+
+    default BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    {
+        return newBlockBuilderLike(calculateBlockResetSize(getPositionCount()), blockBuilderStatus);
+    }
 
     /**
      * This method is not expected to be implemented for {@code BlockBuilder} implementations, the method

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlockBuilder.java
@@ -24,7 +24,6 @@ import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
 import static io.airlift.slice.SizeOf.sizeOf;
-import static io.trino.spi.block.BlockUtil.calculateBlockResetSize;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkReadablePosition;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
@@ -109,9 +108,9 @@ public class ByteArrayBlockBuilder
     }
 
     @Override
-    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    public BlockBuilder newBlockBuilderLike(int expectedEntries, BlockBuilderStatus blockBuilderStatus)
     {
-        return new ByteArrayBlockBuilder(blockBuilderStatus, calculateBlockResetSize(positionCount));
+        return new ByteArrayBlockBuilder(blockBuilderStatus, expectedEntries);
     }
 
     private void growCapacity()

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlockBuilder.java
@@ -25,7 +25,6 @@ import java.util.function.ObjLongConsumer;
 
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static io.trino.spi.block.BlockUtil.calculateBlockResetSize;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkReadablePosition;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
@@ -123,9 +122,9 @@ public class Int128ArrayBlockBuilder
     }
 
     @Override
-    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    public BlockBuilder newBlockBuilderLike(int expectedEntries, BlockBuilderStatus blockBuilderStatus)
     {
-        return new Int128ArrayBlockBuilder(blockBuilderStatus, calculateBlockResetSize(positionCount));
+        return new Int128ArrayBlockBuilder(blockBuilderStatus, expectedEntries);
     }
 
     private void growCapacity()

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Int96ArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Int96ArrayBlockBuilder.java
@@ -25,7 +25,6 @@ import java.util.function.ObjLongConsumer;
 
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static io.trino.spi.block.BlockUtil.calculateBlockResetSize;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkReadablePosition;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
@@ -145,9 +144,9 @@ public class Int96ArrayBlockBuilder
     }
 
     @Override
-    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    public BlockBuilder newBlockBuilderLike(int expectedEntries, BlockBuilderStatus blockBuilderStatus)
     {
-        return new Int96ArrayBlockBuilder(blockBuilderStatus, calculateBlockResetSize(positionCount));
+        return new Int96ArrayBlockBuilder(blockBuilderStatus, expectedEntries);
     }
 
     private void growCapacity()

--- a/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlockBuilder.java
@@ -24,7 +24,6 @@ import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
 import static io.airlift.slice.SizeOf.sizeOf;
-import static io.trino.spi.block.BlockUtil.calculateBlockResetSize;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkReadablePosition;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
@@ -109,9 +108,9 @@ public class IntArrayBlockBuilder
     }
 
     @Override
-    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    public BlockBuilder newBlockBuilderLike(int expectedEntries, BlockBuilderStatus blockBuilderStatus)
     {
-        return new IntArrayBlockBuilder(blockBuilderStatus, calculateBlockResetSize(positionCount));
+        return new IntArrayBlockBuilder(blockBuilderStatus, expectedEntries);
     }
 
     private void growCapacity()

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlockBuilder.java
@@ -24,7 +24,6 @@ import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
 import static io.airlift.slice.SizeOf.sizeOf;
-import static io.trino.spi.block.BlockUtil.calculateBlockResetSize;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkReadablePosition;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
@@ -110,9 +109,9 @@ public class LongArrayBlockBuilder
     }
 
     @Override
-    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    public BlockBuilder newBlockBuilderLike(int expectedEntries, BlockBuilderStatus blockBuilderStatus)
     {
-        return new LongArrayBlockBuilder(blockBuilderStatus, calculateBlockResetSize(positionCount));
+        return new LongArrayBlockBuilder(blockBuilderStatus, expectedEntries);
     }
 
     private void growCapacity()

--- a/core/trino-spi/src/main/java/io/trino/spi/block/MapBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/MapBlockBuilder.java
@@ -24,7 +24,6 @@ import java.util.Optional;
 import java.util.function.ObjLongConsumer;
 
 import static io.airlift.slice.SizeOf.sizeOf;
-import static io.trino.spi.block.BlockUtil.calculateBlockResetSize;
 import static io.trino.spi.block.BlockUtil.calculateNewArraySize;
 import static io.trino.spi.block.MapBlock.createMapBlockInternal;
 import static io.trino.spi.block.MapHashTables.HASH_MULTIPLIER;
@@ -304,16 +303,15 @@ public class MapBlockBuilder
     }
 
     @Override
-    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    public BlockBuilder newBlockBuilderLike(int expectedEntries, BlockBuilderStatus blockBuilderStatus)
     {
-        int newSize = calculateBlockResetSize(getPositionCount());
         return new MapBlockBuilder(
                 getMapType(),
                 blockBuilderStatus,
                 keyBlockBuilder.newBlockBuilderLike(blockBuilderStatus),
                 valueBlockBuilder.newBlockBuilderLike(blockBuilderStatus),
-                new int[newSize + 1],
-                new boolean[newSize]);
+                new int[expectedEntries + 1],
+                new boolean[expectedEntries]);
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlockBuilder.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.function.ObjLongConsumer;
 
 import static io.airlift.slice.SizeOf.sizeOf;
-import static io.trino.spi.block.BlockUtil.calculateBlockResetSize;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.RowBlock.createRowBlockInternal;
@@ -241,14 +240,13 @@ public class RowBlockBuilder
     }
 
     @Override
-    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    public BlockBuilder newBlockBuilderLike(int expectedEntries, BlockBuilderStatus blockBuilderStatus)
     {
-        int newSize = calculateBlockResetSize(getPositionCount());
         BlockBuilder[] newBlockBuilders = new BlockBuilder[numFields];
         for (int i = 0; i < numFields; i++) {
             newBlockBuilders[i] = fieldBlockBuilders[i].newBlockBuilderLike(blockBuilderStatus);
         }
-        return new RowBlockBuilder(blockBuilderStatus, newBlockBuilders, new int[newSize + 1], new boolean[newSize]);
+        return new RowBlockBuilder(blockBuilderStatus, newBlockBuilders, new int[expectedEntries + 1], new boolean[expectedEntries]);
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlockBuilder.java
@@ -24,7 +24,6 @@ import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
 import static io.airlift.slice.SizeOf.sizeOf;
-import static io.trino.spi.block.BlockUtil.calculateBlockResetSize;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkReadablePosition;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
@@ -109,9 +108,9 @@ public class ShortArrayBlockBuilder
     }
 
     @Override
-    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    public BlockBuilder newBlockBuilderLike(int expectedEntries, BlockBuilderStatus blockBuilderStatus)
     {
-        return new ShortArrayBlockBuilder(blockBuilderStatus, calculateBlockResetSize(positionCount));
+        return new ShortArrayBlockBuilder(blockBuilderStatus, expectedEntries);
     }
 
     private void growCapacity()

--- a/core/trino-spi/src/main/java/io/trino/spi/block/SingleArrayBlockWriter.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/SingleArrayBlockWriter.java
@@ -144,7 +144,7 @@ public class SingleArrayBlockWriter
     }
 
     @Override
-    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    public BlockBuilder newBlockBuilderLike(int expectedEntries, BlockBuilderStatus blockBuilderStatus)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/SingleMapBlockWriter.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/SingleMapBlockWriter.java
@@ -219,7 +219,7 @@ public class SingleMapBlockWriter
     }
 
     @Override
-    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    public BlockBuilder newBlockBuilderLike(int expectedEntries, BlockBuilderStatus blockBuilderStatus)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/SingleRowBlockWriter.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/SingleRowBlockWriter.java
@@ -205,7 +205,7 @@ public class SingleRowBlockWriter
     }
 
     @Override
-    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    public BlockBuilder newBlockBuilderLike(int expectedEntries, BlockBuilderStatus blockBuilderStatus)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlockBuilder.java
@@ -33,7 +33,6 @@ import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static io.trino.spi.block.BlockUtil.MAX_ARRAY_SIZE;
 import static io.trino.spi.block.BlockUtil.calculateBlockResetBytes;
-import static io.trino.spi.block.BlockUtil.calculateBlockResetSize;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkValidPosition;
 import static io.trino.spi.block.BlockUtil.checkValidPositions;
@@ -368,10 +367,10 @@ public class VariableWidthBlockBuilder
     }
 
     @Override
-    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    public BlockBuilder newBlockBuilderLike(int expectedEntries, BlockBuilderStatus blockBuilderStatus)
     {
         int currentSizeInBytes = positions == 0 ? positions : (getOffset(positions) - getOffset(0));
-        return new VariableWidthBlockBuilder(blockBuilderStatus, calculateBlockResetSize(positions), calculateBlockResetBytes(currentSizeInBytes));
+        return new VariableWidthBlockBuilder(blockBuilderStatus, expectedEntries, calculateBlockResetBytes(currentSizeInBytes));
     }
 
     private int getOffset(int position)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

Since `MultiChannelGroupByHash` knows exactly how many
positions `currentPageBuilder` can eventually contain,
there is no need to increase the size with
`calculateBlockResetSize`, wasting memory in the process.

This fixes https://github.com/trinodb/trino/issues/12484
It's based on https://github.com/trinodb/trino/pull/12336. Only last commit matters here.

### tpch/tpcds benchmark
There is a 1-2 % improvement in peak memory consumption.

![image](https://user-images.githubusercontent.com/8080198/169768113-082590b0-209d-4e10-b308-b5eca6405d44.png)

[reset-exeact-orc-part-sf1000.pdf](https://github.com/trinodb/trino/files/8752443/reset-exeact-orc-part-sf1000.pdf)


<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

improvement
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core query engine, spi `BlockBuilder`
> How would you describe this change to a non-technical end user or system administrator?

Lower hash aggregation memory consumption
## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->
* Fixes #12484

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
