### PR TITLE
Improve CLI query time rendering

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/FormatUtils.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/FormatUtils.java
@@ -25,7 +25,7 @@ import static com.google.common.base.Strings.repeat;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.String.format;
-import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 public final class FormatUtils
@@ -163,18 +163,17 @@ public final class FormatUtils
         int minutes = totalSeconds / 60;
         int seconds = totalSeconds % 60;
 
-        return format("%s:%02d", minutes, seconds);
+        return format("%02d:%02d", minutes, seconds);
     }
 
     public static String formatFinalTime(Duration duration)
     {
-        long totalMillis = duration.toMillis();
+        int totalMillis = Ints.saturatedCast(duration.roundTo(MILLISECONDS));
+        int minutes = totalMillis / 60_000;
+        int seconds = (totalMillis % 60_000) / 1000;
+        int hundredsOfSecond = ceil(totalMillis % 1000, 10);
 
-        if (totalMillis >= MINUTES.toMillis(1)) {
-            return formatTime(duration);
-        }
-
-        return format("%.2f", (totalMillis / 1000.0));
+        return format("%02d:%02d.%02d", minutes, seconds, hundredsOfSecond);
     }
 
     /**


### PR DESCRIPTION
This PR improves sub-minute query time rendering:

<img width="528" alt="Screenshot 2022-05-23 at 15 32 55" src="https://user-images.githubusercontent.com/66972/169831086-09427e1a-2cd8-4b80-8dae-61783c4c08fc.png">

<img width="486" alt="Screenshot 2022-05-23 at 15 32 38" src="https://user-images.githubusercontent.com/66972/169831073-bff32649-e732-4d2b-a55d-5a95cb7e9cab.png">

