### PR TITLE
Upgrade Coral dependency to v2.0.77

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <dep.testcontainers.version>1.16.3</dep.testcontainers.version>
         <dep.duct-tape.version>1.0.8</dep.duct-tape.version>
         <dep.docker-java.version>3.2.12</dep.docker-java.version>
-        <dep.coral.version>2.0.55</dep.coral.version>
+        <dep.coral.version>2.0.77</dep.coral.version>
         <dep.confluent.version>5.5.2</dep.confluent.version>
         <dep.casandra.version>4.14.0</dep.casandra.version>
 


### PR DESCRIPTION
## Description

This version includes an updated gson dependency to mitigate
CVE-2022-25647.

> Is this change a fix, improvement, new feature, refactoring, or other?

Dependency upgrade

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Hive and Iceberg connectors

> How would you describe this change to a non-technical end user or system administrator?

Does not have any user impact.

## Related issues, pull requests, and links

Part of https://github.com/trinodb/trino/issues/12450

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
