### PR TITLE
Support inline '=' in session properties

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/HttpRequestSessionContextFactory.java
+++ b/core/trino-main/src/main/java/io/trino/server/HttpRequestSessionContextFactory.java
@@ -324,7 +324,7 @@ public class HttpRequestSessionContextFactory
     {
         Map<String, String> properties = new HashMap<>();
         for (String header : splitHttpHeader(headers, headerName)) {
-            List<String> nameValue = Splitter.on('=').trimResults().splitToList(header);
+            List<String> nameValue = Splitter.on('=').limit(2).trimResults().splitToList(header);
             assertRequest(nameValue.size() == 2, "Invalid %s header", headerName);
             try {
                 properties.put(nameValue.get(0), urlDecode(nameValue.get(1)));


### PR DESCRIPTION
Co-authored-by: jitheshtr <jitheshtr@users.noreply.github.com>

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

For headers may contain "=" in session properties like: 
_linkedin.azkaxxx_job_attempt_url=https://ltx1-holdemxxxxx.grid.linkedin.com:8443/executor?execid=16364327&job=audit-log-parse&attempt=0, linkedin.azkxxx_project_name=holdem_log_parser_

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

It’s a fix for Bad Request for error parsing the session property.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Change in core server.

> How would you describe this change to a non-technical end user or system administrator?

Updated the way to parse property so header with inline "=" sign won't cause a problem.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
