### PR TITLE
Allow multiple hosts for elasticsearch connector

### DIFF
--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchConfig.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchConfig.java
@@ -25,6 +25,7 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import java.io.File;
+import java.util.List;
 import java.util.Optional;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -54,7 +55,7 @@ public class ElasticsearchConfig
         PASSWORD,
     }
 
-    private String host;
+    private List<String> hosts;
     private int port = 9200;
     private String defaultSchema = "default";
     private int scrollSize = 1_000;
@@ -79,15 +80,15 @@ public class ElasticsearchConfig
     private Security security;
 
     @NotNull
-    public String getHost()
+    public List<String> getHosts()
     {
-        return host;
+        return hosts;
     }
 
     @Config("elasticsearch.host")
-    public ElasticsearchConfig setHost(String host)
+    public ElasticsearchConfig setHosts(List<String> hosts)
     {
-        this.host = host;
+        this.hosts = hosts;
         return this;
     }
 

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/ElasticsearchClient.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/ElasticsearchClient.java
@@ -202,7 +202,9 @@ public class ElasticsearchClient
             TimeStat backpressureStats)
     {
         RestClientBuilder builder = RestClient.builder(
-                new HttpHost(config.getHost(), config.getPort(), config.isTlsEnabled() ? "https" : "http"))
+                config.getHosts().stream()
+                        .map(httpHost -> new HttpHost(httpHost, config.getPort(), config.isTlsEnabled() ? "https" : "http"))
+                        .toArray(HttpHost[]::new))
                 .setMaxRetryTimeoutMillis(toIntExact(config.getMaxRetryTime().toMillis()));
 
         builder.setHttpClientConfigCallback(ignored -> {

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearchConfig.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearchConfig.java
@@ -20,6 +20,7 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Map;
 
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
@@ -36,7 +37,7 @@ public class TestElasticsearchConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(ElasticsearchConfig.class)
-                .setHost(null)
+                .setHosts(null)
                 .setPort(9200)
                 .setDefaultSchema("default")
                 .setScrollSize(1000)
@@ -91,7 +92,7 @@ public class TestElasticsearchConfig
                 .buildOrThrow();
 
         ElasticsearchConfig expected = new ElasticsearchConfig()
-                .setHost("example.com")
+                .setHosts(Arrays.asList("example.com"))
                 .setPort(9999)
                 .setDefaultSchema("test")
                 .setScrollSize(4000)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

No

> How would you describe this change to a non-technical end user or system administrator?

Allow multiple hosts for elasticsearch connector (elasticsearch.host property)

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->
Fixes [#11889](https://github.com/trinodb/trino/issues/11889)

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
(X) Documentation issue #[12528](https://github.com/trinodb/trino/issues/12528) is filed, and can be handled later.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# Elasticsearch
* Add support for multiple Elasticsearch hosts in `elasticsearch.host` configuration property. ({issue}`12530`)
```
