### PR TITLE
Refactor `ConnectorTableFunction` into interface

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/AbstractConnectorTableFunction.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/AbstractConnectorTableFunction.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.ptf;
+
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public abstract class AbstractConnectorTableFunction
+        implements ConnectorTableFunction
+{
+    private final String schema;
+    private final String name;
+    private final List<ArgumentSpecification> arguments;
+    private final ReturnTypeSpecification returnTypeSpecification;
+
+    public AbstractConnectorTableFunction(String schema, String name, List<ArgumentSpecification> arguments, ReturnTypeSpecification returnTypeSpecification)
+    {
+        this.schema = requireNonNull(schema, "schema is null");
+        this.name = requireNonNull(name, "name is null");
+        this.arguments = List.copyOf(requireNonNull(arguments, "arguments is null"));
+        this.returnTypeSpecification = requireNonNull(returnTypeSpecification, "returnTypeSpecification is null");
+    }
+
+    @Override
+    public String getSchema()
+    {
+        return schema;
+    }
+
+    @Override
+    public String getName()
+    {
+        return name;
+    }
+
+    @Override
+    public List<ArgumentSpecification> getArguments()
+    {
+        return arguments;
+    }
+
+    @Override
+    public ReturnTypeSpecification getReturnTypeSpecification()
+    {
+        return returnTypeSpecification;
+    }
+
+    @Override
+    public abstract TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments);
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/ArgumentSpecification.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/ArgumentSpecification.java
@@ -15,8 +15,8 @@ package io.trino.spi.ptf;
 
 import javax.annotation.Nullable;
 
-import static io.trino.spi.ptf.ConnectorTableFunction.checkArgument;
-import static io.trino.spi.ptf.ConnectorTableFunction.checkNotNullOrEmpty;
+import static io.trino.spi.ptf.Preconditions.checkArgument;
+import static io.trino.spi.ptf.Preconditions.checkNotNullOrEmpty;
 
 /**
  * Abstract class to capture the three supported argument types for a table function:

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/ConnectorTableFunction.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/ConnectorTableFunction.java
@@ -16,62 +16,18 @@ package io.trino.spi.ptf;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
-import static io.trino.spi.ptf.Preconditions.checkArgument;
-import static io.trino.spi.ptf.Preconditions.checkNotNullOrEmpty;
-import static java.util.Objects.requireNonNull;
-
-public abstract class ConnectorTableFunction
+public interface ConnectorTableFunction
 {
-    private final String schema;
-    private final String name;
-    private final List<ArgumentSpecification> arguments;
-    private final ReturnTypeSpecification returnTypeSpecification;
+    String getSchema();
 
-    public ConnectorTableFunction(String schema, String name, List<ArgumentSpecification> arguments, ReturnTypeSpecification returnTypeSpecification)
-    {
-        this.schema = checkNotNullOrEmpty(schema, "schema");
-        this.name = checkNotNullOrEmpty(name, "name");
-        requireNonNull(arguments, "arguments is null");
-        Set<String> argumentNames = new HashSet<>();
-        for (ArgumentSpecification specification : arguments) {
-            if (!argumentNames.add(specification.getName())) {
-                throw new IllegalArgumentException("duplicate argument name: " + specification.getName());
-            }
-        }
-        long tableArgumentsWithRowSemantics = arguments.stream()
-                .filter(specification -> specification instanceof TableArgumentSpecification)
-                .map(TableArgumentSpecification.class::cast)
-                .filter(TableArgumentSpecification::isRowSemantics)
-                .count();
-        checkArgument(tableArgumentsWithRowSemantics <= 1, "more than one table argument with row semantics");
-        this.arguments = List.copyOf(arguments);
-        this.returnTypeSpecification = requireNonNull(returnTypeSpecification, "returnTypeSpecification is null");
-    }
+    String getName();
 
-    public String getSchema()
-    {
-        return schema;
-    }
+    List<ArgumentSpecification> getArguments();
 
-    public String getName()
-    {
-        return name;
-    }
-
-    public List<ArgumentSpecification> getArguments()
-    {
-        return arguments;
-    }
-
-    public ReturnTypeSpecification getReturnTypeSpecification()
-    {
-        return returnTypeSpecification;
-    }
+    ReturnTypeSpecification getReturnTypeSpecification();
 
     /**
      * This method is called by the Analyzer. Its main purposes are to:
@@ -89,5 +45,5 @@ public abstract class ConnectorTableFunction
      *
      * @param arguments actual invocation arguments, mapped by argument names
      */
-    public abstract TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments);
+    TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments);
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/ConnectorTableFunction.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/ConnectorTableFunction.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static io.trino.spi.ptf.Preconditions.checkArgument;
+import static io.trino.spi.ptf.Preconditions.checkNotNullOrEmpty;
 import static java.util.Objects.requireNonNull;
 
 public abstract class ConnectorTableFunction
@@ -88,18 +90,4 @@ public abstract class ConnectorTableFunction
      * @param arguments actual invocation arguments, mapped by argument names
      */
     public abstract TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments);
-
-    static String checkNotNullOrEmpty(String value, String name)
-    {
-        requireNonNull(value, name + " is null");
-        checkArgument(!value.isEmpty(), name + " is empty");
-        return value;
-    }
-
-    static void checkArgument(boolean assertion, String message)
-    {
-        if (!assertion) {
-            throw new IllegalArgumentException(message);
-        }
-    }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/Descriptor.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/Descriptor.java
@@ -23,8 +23,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static io.trino.spi.ptf.ConnectorTableFunction.checkArgument;
-import static io.trino.spi.ptf.ConnectorTableFunction.checkNotNullOrEmpty;
+import static io.trino.spi.ptf.Preconditions.checkArgument;
+import static io.trino.spi.ptf.Preconditions.checkNotNullOrEmpty;
 import static java.util.Objects.requireNonNull;
 
 public class Descriptor

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/DescriptorMapping.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/DescriptorMapping.java
@@ -18,8 +18,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static io.trino.spi.ptf.ConnectorTableFunction.checkArgument;
-import static io.trino.spi.ptf.ConnectorTableFunction.checkNotNullOrEmpty;
+import static io.trino.spi.ptf.Preconditions.checkArgument;
+import static io.trino.spi.ptf.Preconditions.checkNotNullOrEmpty;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/NameAndPosition.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/NameAndPosition.java
@@ -15,6 +15,9 @@ package io.trino.spi.ptf;
 
 import java.util.Objects;
 
+import static io.trino.spi.ptf.Preconditions.checkArgument;
+import static io.trino.spi.ptf.Preconditions.checkNotNullOrEmpty;
+
 /**
  * This class represents a descriptor field reference.
  * `name` is the descriptor argument name, `position` is the zero-based field index.
@@ -31,8 +34,8 @@ public class NameAndPosition
 
     public NameAndPosition(String name, int position)
     {
-        this.name = ConnectorTableFunction.checkNotNullOrEmpty(name, "name");
-        ConnectorTableFunction.checkArgument(position >= 0, "position in descriptor must not be negative");
+        this.name = checkNotNullOrEmpty(name, "name");
+        checkArgument(position >= 0, "position in descriptor must not be negative");
         this.position = position;
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/Preconditions.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/Preconditions.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.ptf;
+
+import static java.util.Objects.requireNonNull;
+
+final class Preconditions
+{
+    private Preconditions() {}
+
+    public static String checkNotNullOrEmpty(String value, String name)
+    {
+        requireNonNull(value, name + " is null");
+        checkArgument(!value.isEmpty(), name + " is empty");
+        return value;
+    }
+
+    public static void checkArgument(boolean assertion, String message)
+    {
+        if (!assertion) {
+            throw new IllegalArgumentException(message);
+        }
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/ReturnTypeSpecification.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/ReturnTypeSpecification.java
@@ -13,7 +13,7 @@
  */
 package io.trino.spi.ptf;
 
-import static io.trino.spi.ptf.ConnectorTableFunction.checkArgument;
+import static io.trino.spi.ptf.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 /**

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/ScalarArgumentSpecification.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/ScalarArgumentSpecification.java
@@ -15,7 +15,7 @@ package io.trino.spi.ptf;
 
 import io.trino.spi.type.Type;
 
-import static io.trino.spi.ptf.ConnectorTableFunction.checkArgument;
+import static io.trino.spi.ptf.Preconditions.checkArgument;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/TableArgument.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/TableArgument.java
@@ -21,7 +21,7 @@ import io.trino.spi.type.RowType;
 import java.util.List;
 import java.util.Optional;
 
-import static io.trino.spi.ptf.ConnectorTableFunction.checkNotNullOrEmpty;
+import static io.trino.spi.ptf.Preconditions.checkNotNullOrEmpty;
 import static java.util.Objects.requireNonNull;
 
 /**

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionAnalysis.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/TableFunctionAnalysis.java
@@ -15,8 +15,8 @@ package io.trino.spi.ptf;
 
 import java.util.Optional;
 
-import static io.trino.spi.ptf.ConnectorTableFunction.checkArgument;
 import static io.trino.spi.ptf.DescriptorMapping.EMPTY_MAPPING;
+import static io.trino.spi.ptf.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 /**

--- a/core/trino-spi/src/test/java/io/trino/spi/TestSpiBackwardCompatibility.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/TestSpiBackwardCompatibility.java
@@ -56,7 +56,13 @@ public class TestSpiBackwardCompatibility
             .put("382", ImmutableSet.of(
                     "Method: public io.trino.spi.ptf.TableArgumentSpecification$Builder io.trino.spi.ptf.TableArgumentSpecification$Builder.rowSemantics(boolean)",
                     "Method: public io.trino.spi.ptf.TableArgumentSpecification$Builder io.trino.spi.ptf.TableArgumentSpecification$Builder.pruneWhenEmpty(boolean)",
-                    "Method: public io.trino.spi.ptf.TableArgumentSpecification$Builder io.trino.spi.ptf.TableArgumentSpecification$Builder.passThroughColumns(boolean)"))
+                    "Method: public io.trino.spi.ptf.TableArgumentSpecification$Builder io.trino.spi.ptf.TableArgumentSpecification$Builder.passThroughColumns(boolean)",
+                    "Class: public abstract class io.trino.spi.ptf.ConnectorTableFunction",
+                    "Constructor: public io.trino.spi.ptf.ConnectorTableFunction(java.lang.String,java.lang.String,java.util.List<io.trino.spi.ptf.ArgumentSpecification>,io.trino.spi.ptf.ReturnTypeSpecification)",
+                    "Method: public java.util.List<io.trino.spi.ptf.ArgumentSpecification> io.trino.spi.ptf.ConnectorTableFunction.getArguments()",
+                    "Method: public io.trino.spi.ptf.ReturnTypeSpecification io.trino.spi.ptf.ConnectorTableFunction.getReturnTypeSpecification()",
+                    "Method: public java.lang.String io.trino.spi.ptf.ConnectorTableFunction.getName()",
+                    "Method: public java.lang.String io.trino.spi.ptf.ConnectorTableFunction.getSchema()"))
             .buildOrThrow();
 
     @Test

--- a/docs/src/main/sphinx/develop/table-functions.rst
+++ b/docs/src/main/sphinx/develop/table-functions.rst
@@ -14,7 +14,8 @@ through implementing dedicated interfaces.
 Table function declaration
 --------------------------
 
-To declare a table function, you need to subclass ``ConnectorTableFunction``.
+To declare a table function, you need to implement ``ConnectorTableFunction``.
+Subclassing ``AbstractConnectorTableFunction`` is a convenient way to do it.
 The connector's ``getTableFunctions()`` method must return a ``Provider`` of
 your implementation.
 
@@ -24,7 +25,7 @@ The constructor
 .. code-block:: java
 
     public class MyFunction
-            extends ConnectorTableFunction
+            extends AbstractConnectorTableFunction
     {
         public MyFunction()
         {


### PR DESCRIPTION

This change refactors `ConnectorTableFunction` from abstract class into interface. It also adds an abstract class `AbstractConnectorTableFunction`, which is meant to be base for all implementations of `ConnectorTableFunction`.

This is a SPI change.

Related to: https://github.com/trinodb/trino/pull/12325#discussion_r870020934 (an interface is needed to apply a class-loader-safe wrapper)

Docs change included.

```markdown
# SPI
* Change `ConnectorTableFunction` into an interface and add `AbstractConnectorTableFunction` class as the base implementation of table functions.
```
