### PR TITLE
Remove json deserializer when pluginClassLoader unregister in HandleResolver

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/HandleJsonModule.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/HandleJsonModule.java
@@ -29,6 +29,8 @@ import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.exchange.ExchangeSinkInstanceHandle;
 import io.trino.spi.exchange.ExchangeSourceHandle;
 
+import java.util.Optional;
+
 public class HandleJsonModule
         implements Module
 {
@@ -42,55 +44,55 @@ public class HandleJsonModule
     @ProvidesIntoSet
     public static com.fasterxml.jackson.databind.Module tableHandleModule(HandleResolver resolver)
     {
-        return new AbstractTypedJacksonModule<>(ConnectorTableHandle.class, resolver::getId, resolver::getHandleClass) {};
+        return new AbstractTypedJacksonModule<>(ConnectorTableHandle.class, resolver::getId, resolver::getHandleClass, Optional.of(resolver::registerDeserializer)) {};
     }
 
     @ProvidesIntoSet
     public static com.fasterxml.jackson.databind.Module columnHandleModule(HandleResolver resolver)
     {
-        return new AbstractTypedJacksonModule<>(ColumnHandle.class, resolver::getId, resolver::getHandleClass) {};
+        return new AbstractTypedJacksonModule<>(ColumnHandle.class, resolver::getId, resolver::getHandleClass, Optional.of(resolver::registerDeserializer)) {};
     }
 
     @ProvidesIntoSet
     public static com.fasterxml.jackson.databind.Module splitModule(HandleResolver resolver)
     {
-        return new AbstractTypedJacksonModule<>(ConnectorSplit.class, resolver::getId, resolver::getHandleClass) {};
+        return new AbstractTypedJacksonModule<>(ConnectorSplit.class, resolver::getId, resolver::getHandleClass, Optional.of(resolver::registerDeserializer)) {};
     }
 
     @ProvidesIntoSet
     public static com.fasterxml.jackson.databind.Module outputTableHandleModule(HandleResolver resolver)
     {
-        return new AbstractTypedJacksonModule<>(ConnectorOutputTableHandle.class, resolver::getId, resolver::getHandleClass) {};
+        return new AbstractTypedJacksonModule<>(ConnectorOutputTableHandle.class, resolver::getId, resolver::getHandleClass, Optional.of(resolver::registerDeserializer)) {};
     }
 
     @ProvidesIntoSet
     public static com.fasterxml.jackson.databind.Module insertTableHandleModule(HandleResolver resolver)
     {
-        return new AbstractTypedJacksonModule<>(ConnectorInsertTableHandle.class, resolver::getId, resolver::getHandleClass) {};
+        return new AbstractTypedJacksonModule<>(ConnectorInsertTableHandle.class, resolver::getId, resolver::getHandleClass, Optional.of(resolver::registerDeserializer)) {};
     }
 
     @ProvidesIntoSet
     public static com.fasterxml.jackson.databind.Module tableExecuteHandleModule(HandleResolver resolver)
     {
-        return new AbstractTypedJacksonModule<>(ConnectorTableExecuteHandle.class, resolver::getId, resolver::getHandleClass) {};
+        return new AbstractTypedJacksonModule<>(ConnectorTableExecuteHandle.class, resolver::getId, resolver::getHandleClass, Optional.of(resolver::registerDeserializer)) {};
     }
 
     @ProvidesIntoSet
     public static com.fasterxml.jackson.databind.Module indexHandleModule(HandleResolver resolver)
     {
-        return new AbstractTypedJacksonModule<>(ConnectorIndexHandle.class, resolver::getId, resolver::getHandleClass) {};
+        return new AbstractTypedJacksonModule<>(ConnectorIndexHandle.class, resolver::getId, resolver::getHandleClass, Optional.of(resolver::registerDeserializer)) {};
     }
 
     @ProvidesIntoSet
     public static com.fasterxml.jackson.databind.Module transactionHandleModule(HandleResolver resolver)
     {
-        return new AbstractTypedJacksonModule<>(ConnectorTransactionHandle.class, resolver::getId, resolver::getHandleClass) {};
+        return new AbstractTypedJacksonModule<>(ConnectorTransactionHandle.class, resolver::getId, resolver::getHandleClass, Optional.of(resolver::registerDeserializer)) {};
     }
 
     @ProvidesIntoSet
     public static com.fasterxml.jackson.databind.Module partitioningHandleModule(HandleResolver resolver)
     {
-        return new AbstractTypedJacksonModule<>(ConnectorPartitioningHandle.class, resolver::getId, resolver::getHandleClass) {};
+        return new AbstractTypedJacksonModule<>(ConnectorPartitioningHandle.class, resolver::getId, resolver::getHandleClass, Optional.of(resolver::registerDeserializer)) {};
     }
 
     @ProvidesIntoSet


### PR DESCRIPTION
## Description

> Is this change a fix, improvement, new feature, refactoring, or other?
other
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
HandleResolver
> How would you describe this change to a non-technical end user or system administrator?
Remove the class deserializer in ``io.trino.metadata.AbstractTypedJacksonModule.InternalTypeDeserializer#InternalTypeDeserializer``  which is contain the tableHandle class instance when we call ``HandleResolver#unregisterClassLoader``  to unregister the pluginClassLoader of catalog.
## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
