### PR TITLE
Defer initialization of Hive metastore modules

### DIFF
--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHivePlugin.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHivePlugin.java
@@ -127,6 +127,20 @@ public class TestHivePlugin
     }
 
     @Test
+    public void testAlluxioMetastore()
+    {
+        ConnectorFactory factory = getHiveConnectorFactory();
+
+        factory.create(
+                "test",
+                ImmutableMap.of(
+                        "hive.metastore", "alluxio",
+                        "hive.metastore.alluxio.master.address", "dummy:1234"),
+                new TestingConnectorContext())
+                .shutdown();
+    }
+
+    @Test
     public void testRecordingMetastore()
     {
         ConnectorFactory factory = getHiveConnectorFactory();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastoreModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastoreModule.java
@@ -16,7 +16,6 @@ package io.trino.plugin.hive.metastore;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
-import io.trino.plugin.hive.metastore.alluxio.AlluxioMetastoreModule;
 import io.trino.plugin.hive.metastore.file.FileMetastoreModule;
 import io.trino.plugin.hive.metastore.glue.GlueMetastoreModule;
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreModule;
@@ -45,7 +44,10 @@ public class HiveMetastoreModule
             bindMetastoreModule("thrift", new ThriftMetastoreModule());
             bindMetastoreModule("file", new FileMetastoreModule());
             bindMetastoreModule("glue", new GlueMetastoreModule());
-            bindMetastoreModule("alluxio", new AlluxioMetastoreModule());
+            // Load Alluxio metastore support through reflection. This makes Alluxio effectively an optional dependency
+            // and allows deploying Trino without the Alluxio jar. Can be useful if the integration is unused and is flagged
+            // by a security scanner.
+            bindMetastoreModule("alluxio", deferredModule("io.trino.plugin.hive.metastore.alluxio.AlluxioMetastoreModule"));
         }
 
         install(new DecoratedHiveMetastoreModule());
@@ -57,5 +59,25 @@ public class HiveMetastoreModule
                 MetastoreTypeConfig.class,
                 metastore -> name.equalsIgnoreCase(metastore.getMetastoreType()),
                 module));
+    }
+
+    private static Module deferredModule(String moduleClassName)
+    {
+        return new AbstractConfigurationAwareModule()
+        {
+            @Override
+            protected void setup(Binder binder)
+            {
+                try {
+                    install(Class.forName(moduleClassName)
+                            .asSubclass(Module.class)
+                            .getConstructor()
+                            .newInstance());
+                }
+                catch (ReflectiveOperationException e) {
+                    throw new RuntimeException("Problem loading module class: " + moduleClassName, e);
+                }
+            }
+        };
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

Some of these modules are depending on third-party libraries (e.g. Alluxio), which may have some security vulnerabilities; they should be benign if the particular module is not enabled, but instantiation of the module class may trigger loading and initialization of some code from these libraries anyway. For this particular module we want to make some preemptive action, because it is unmaintained (though still used).

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Something between a fix and improvement...

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Plugins (Hive Hadoop2).

> How would you describe this change to a non-technical end user or system administrator?

Makes it harder to exploit vulnerabilities in unused libraries.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
