### PR TITLE
predicateOnlyColumns pushdown

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPredicateIntoTableScanWithProjection.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPredicateIntoTableScanWithProjection.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.planner.DomainTranslator;
+import io.trino.sql.planner.TypeAnalyzer;
+import io.trino.sql.planner.plan.FilterNode;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.ProjectNode;
+import io.trino.sql.planner.plan.TableScanNode;
+
+import java.util.Optional;
+
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.sql.planner.plan.Patterns.filter;
+import static io.trino.sql.planner.plan.Patterns.project;
+import static io.trino.sql.planner.plan.Patterns.source;
+import static io.trino.sql.planner.plan.Patterns.tableScan;
+
+/**
+ * These rules should not be run after AddExchanges so as not to overwrite the TableLayout
+ * chosen by AddExchanges
+ */
+public class PushPredicateIntoTableScanWithProjection
+        extends PushPredicateIntoTableScan<ProjectNode>
+{
+    private static final Capture<FilterNode> FILTER = newCapture();
+
+    private static final Pattern<ProjectNode> PATTERN = project()
+            .with(source().matching(
+                    filter().capturedAs(FILTER)
+                            .with(source().matching(
+                                    tableScan().capturedAs(TABLE_SCAN)))));
+
+    public PushPredicateIntoTableScanWithProjection(PlannerContext plannerContext, TypeAnalyzer typeAnalyzer)
+    {
+        super(plannerContext, typeAnalyzer);
+    }
+
+    @Override
+    public Pattern<ProjectNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(ProjectNode projectNode, Captures captures, Context context)
+    {
+        FilterNode filterNode = captures.get(FILTER);
+        TableScanNode tableScan = captures.get(TABLE_SCAN);
+
+        Optional<PlanNode> rewritten = pushFilterIntoTableScan(
+                Optional.of(projectNode),
+                filterNode,
+                tableScan,
+                false,
+                context.getSession(),
+                context.getSymbolAllocator(),
+                plannerContext,
+                typeAnalyzer,
+                context.getStatsProvider(),
+                new DomainTranslator(plannerContext));
+
+        if (rewritten.isEmpty() || rewritten.get().getSources().size() != 1 || arePlansSame(filterNode, tableScan, rewritten.get().getSources().get(0))) {
+            return Result.empty();
+        }
+
+        return Result.ofPlanNode(rewritten.get());
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPredicateIntoTableScanWithoutProjection.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPredicateIntoTableScanWithoutProjection.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.planner.DomainTranslator;
+import io.trino.sql.planner.TypeAnalyzer;
+import io.trino.sql.planner.plan.FilterNode;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.TableScanNode;
+
+import java.util.Optional;
+
+import static io.trino.sql.planner.plan.Patterns.filter;
+import static io.trino.sql.planner.plan.Patterns.source;
+import static io.trino.sql.planner.plan.Patterns.tableScan;
+
+/**
+ * These rules should not be run after AddExchanges so as not to overwrite the TableLayout
+ * chosen by AddExchanges
+ */
+public class PushPredicateIntoTableScanWithoutProjection
+        extends PushPredicateIntoTableScan<FilterNode>
+{
+    private static final Pattern<FilterNode> PATTERN = filter().with(source().matching(
+            tableScan().capturedAs(TABLE_SCAN)));
+
+    public PushPredicateIntoTableScanWithoutProjection(PlannerContext plannerContext, TypeAnalyzer typeAnalyzer)
+    {
+        super(plannerContext, typeAnalyzer);
+    }
+
+    @Override
+    public Pattern<FilterNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(FilterNode filterNode, Captures captures, Context context)
+    {
+        TableScanNode tableScan = captures.get(TABLE_SCAN);
+
+        Optional<PlanNode> rewritten = pushFilterIntoTableScan(
+                Optional.empty(),
+                filterNode,
+                tableScan,
+                false,
+                context.getSession(),
+                context.getSymbolAllocator(),
+                plannerContext,
+                typeAnalyzer,
+                context.getStatsProvider(),
+                new DomainTranslator(plannerContext));
+
+        if (rewritten.isEmpty() || arePlansSame(filterNode, tableScan, rewritten.get())) {
+            return Result.empty();
+        }
+
+        return Result.ofPlanNode(rewritten.get());
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveRedundantPredicateAboveTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveRedundantPredicateAboveTableScan.java
@@ -46,7 +46,7 @@ import static io.trino.sql.ExpressionUtils.combineConjuncts;
 import static io.trino.sql.ExpressionUtils.extractConjuncts;
 import static io.trino.sql.ExpressionUtils.filterDeterministicConjuncts;
 import static io.trino.sql.ExpressionUtils.filterNonDeterministicConjuncts;
-import static io.trino.sql.planner.iterative.rule.PushPredicateIntoTableScan.createResultingPredicate;
+import static io.trino.sql.planner.iterative.rule.PushPredicateIntoTableScanWithoutProjection.createResultingPredicate;
 import static io.trino.sql.planner.plan.Patterns.filter;
 import static io.trino.sql.planner.plan.Patterns.source;
 import static io.trino.sql.planner.plan.Patterns.tableScan;

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
@@ -177,6 +177,7 @@ public class AddExchanges
         @Override
         public PlanWithProperties visitProject(ProjectNode node, PreferredProperties preferredProperties)
         {
+            // TODO: Support pushFilterIntoTableScan with projection?
             Map<Symbol, Symbol> identities = computeIdentityTranslations(node.getAssignments());
             PreferredProperties translatedPreferred = preferredProperties.translate(symbol -> Optional.ofNullable(identities.get(symbol)));
 
@@ -567,6 +568,7 @@ public class AddExchanges
         {
             if (node.getSource() instanceof TableScanNode) {
                 Optional<PlanNode> plan = PushPredicateIntoTableScan.pushFilterIntoTableScan(
+                        Optional.empty(),
                         node,
                         (TableScanNode) node.getSource(),
                         true,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
@@ -45,7 +45,7 @@ import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.rule.PruneTableScanColumns;
-import io.trino.sql.planner.iterative.rule.PushPredicateIntoTableScan;
+import io.trino.sql.planner.iterative.rule.PushPredicateIntoTableScanWithoutProjection;
 import io.trino.sql.planner.iterative.rule.PushProjectionIntoTableScan;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
@@ -220,14 +220,14 @@ public class TestConnectorPushdownRulesWithHive
         String tableName = "predicate_test";
         tester().getQueryRunner().execute(format("CREATE TABLE %s (a, b) AS SELECT 5, 6", tableName));
 
-        PushPredicateIntoTableScan pushPredicateIntoTableScan = new PushPredicateIntoTableScan(tester().getPlannerContext(), tester().getTypeAnalyzer());
+        PushPredicateIntoTableScanWithoutProjection pushPredicateIntoTableScanWithoutProjection = new PushPredicateIntoTableScanWithoutProjection(tester().getPlannerContext(), tester().getTypeAnalyzer());
 
         HiveTableHandle hiveTable = new HiveTableHandle(SCHEMA_NAME, tableName, ImmutableMap.of(), ImmutableList.of(), ImmutableList.of(), Optional.empty());
         TableHandle table = new TableHandle(new CatalogName(HIVE_CATALOG_NAME), hiveTable, new HiveTransactionHandle(false));
 
         HiveColumnHandle column = createBaseColumn("a", 0, HIVE_INT, INTEGER, REGULAR, Optional.empty());
 
-        tester().assertThat(pushPredicateIntoTableScan)
+        tester().assertThat(pushPredicateIntoTableScanWithoutProjection)
                 .on(p ->
                         p.filter(
                                 PlanBuilder.expression("a = 5"),

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/optimizer/TestConnectorPushdownRulesWithIceberg.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/optimizer/TestConnectorPushdownRulesWithIceberg.java
@@ -44,7 +44,7 @@ import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.rule.PruneTableScanColumns;
-import io.trino.sql.planner.iterative.rule.PushPredicateIntoTableScan;
+import io.trino.sql.planner.iterative.rule.PushPredicateIntoTableScanWithoutProjection;
 import io.trino.sql.planner.iterative.rule.PushProjectionIntoTableScan;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
@@ -228,7 +228,7 @@ public class TestConnectorPushdownRulesWithIceberg
         String tableName = "predicate_test";
         tester().getQueryRunner().execute(format("CREATE TABLE %s (a, b) AS SELECT 5, 6", tableName));
 
-        PushPredicateIntoTableScan pushPredicateIntoTableScan = new PushPredicateIntoTableScan(tester().getPlannerContext(), tester().getTypeAnalyzer());
+        PushPredicateIntoTableScanWithoutProjection pushPredicateIntoTableScanWithoutProjection = new PushPredicateIntoTableScanWithoutProjection(tester().getPlannerContext(), tester().getTypeAnalyzer());
 
         IcebergTableHandle icebergTable = new IcebergTableHandle(SCHEMA_NAME, tableName, DATA, Optional.of(1L), "", "", 1,
                 TupleDomain.all(), TupleDomain.all(), ImmutableSet.of(), Optional.empty(), "", ImmutableMap.of(), NO_RETRIES, ImmutableList.of());
@@ -236,7 +236,7 @@ public class TestConnectorPushdownRulesWithIceberg
 
         IcebergColumnHandle column = new IcebergColumnHandle(primitiveColumnIdentity(1, "a"), INTEGER, ImmutableList.of(), INTEGER, Optional.empty());
 
-        tester().assertThat(pushPredicateIntoTableScan)
+        tester().assertThat(pushPredicateIntoTableScanWithoutProjection)
                 .on(p ->
                         p.filter(
                                 PlanBuilder.expression("a = 5"),


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
In our use case, for some splits, certain predicate domains can be fully handled and for other splits, they can’t be.
Currently, there's no way for connectors to declare which splits can handle the predicate, so the entire predicate has to be returned as `remainingFilter` \ `remainingExpression` (at `ConstraintApplicationResult`).
This PR adds a new piece of information to `Constraint` which is passed via `applyFilter()` - `predicateOnlyColumns`.
With this information, the connectors would be able to distinguish between columns that are required for projection\non-pushdown filtering and columns that are only needed for filtering the connector's data.
If the connector finds out that the predicate of a `predicateOnlyColumn` can be fully handled in a certain split, it can return a `RunLengthEncodedBlock` with a random value that complies with the predicate and spare the cost of data fetching and transferring.
We believe that this can be helpful for other connectors as well, for example- in the case of `parquet` \ `orc` file, the Reader can tell if the entire RowGroup/Stripe complies with the predicate by looking at the minimum and maximum statistics. So instead of utilizing the statistics just to return an empty result when the predicate doesn't match, the Reader would be able to return a pre-filled result (same as for partitioned columns) when the predicate contains the entire RowGroup/Stripe.
<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

A new feature. This is an alternative implementation for https://github.com/trinodb/trino/pull/11596

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Add information to `Constraint` which is pushed down via `applyFilter` SPI.

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation
( ) No documentation is needed.
(? ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes
(?) No release notes entries required.
( ) Release notes entries required with the following suggested text:
