### PR TITLE
Expose partition, file format and compression info of input tables as part of QueryCompletedEvent

### DIFF
--- a/core/trino-main/src/main/java/io/trino/event/QueryMonitor.java
+++ b/core/trino-main/src/main/java/io/trino/event/QueryMonitor.java
@@ -55,6 +55,7 @@ import io.trino.spi.eventlistener.QueryMetadata;
 import io.trino.spi.eventlistener.QueryOutputMetadata;
 import io.trino.spi.eventlistener.QueryStatistics;
 import io.trino.spi.eventlistener.StageCpuDistribution;
+import io.trino.spi.metrics.Metrics;
 import io.trino.spi.resourcegroups.QueryType;
 import io.trino.spi.resourcegroups.ResourceGroupId;
 import io.trino.sql.analyzer.Analysis;
@@ -367,6 +368,9 @@ public class QueryMonitor
                         .mapToLong(OperatorStats::getPhysicalInputPositions)
                         .sum());
             }
+            Metrics connectorMetrics = inputTableOperatorStats.stream()
+                    .map(OperatorStats::getConnectorMetrics)
+                    .reduce(Metrics.EMPTY, Metrics::mergeWith);
 
             inputs.add(new QueryInputMetadata(
                     input.getCatalogName(),
@@ -375,6 +379,7 @@ public class QueryMonitor
                     input.getColumns().stream()
                             .map(Column::getName).collect(Collectors.toList()),
                     input.getConnectorInfo(),
+                    connectorMetrics,
                     physicalInputBytes,
                     physicalInputPositions));
         }

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
@@ -73,6 +73,7 @@ import io.trino.spi.connector.TableScanRedirectApplicationResult;
 import io.trino.spi.connector.TopNApplicationResult;
 import io.trino.spi.eventlistener.EventListener;
 import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.metrics.Metrics;
 import io.trino.spi.procedure.Procedure;
 import io.trino.spi.security.Privilege;
 import io.trino.spi.security.RoleGrant;
@@ -134,6 +135,7 @@ public class MockConnector
     private final Optional<ConnectorNodePartitioningProvider> partitioningProvider;
     private final Optional<ConnectorAccessControl> accessControl;
     private final Function<SchemaTableName, List<List<?>>> data;
+    private final Function<SchemaTableName, Metrics> metrics;
     private final Set<Procedure> procedures;
     private final boolean supportsReportingWrittenBytes;
     private final boolean allowMissingColumnsOnInsert;
@@ -168,6 +170,7 @@ public class MockConnector
             Optional<ConnectorNodePartitioningProvider> partitioningProvider,
             Optional<ConnectorAccessControl> accessControl,
             Function<SchemaTableName, List<List<?>>> data,
+            Function<SchemaTableName, Metrics> metrics,
             Set<Procedure> procedures,
             boolean allowMissingColumnsOnInsert,
             Supplier<List<PropertyMetadata<?>>> schemaProperties,
@@ -200,6 +203,7 @@ public class MockConnector
         this.partitioningProvider = requireNonNull(partitioningProvider, "partitioningProvider is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.data = requireNonNull(data, "data is null");
+        this.metrics = requireNonNull(metrics, "metrics is null");
         this.procedures = requireNonNull(procedures, "procedures is null");
         this.supportsReportingWrittenBytes = supportsReportingWrittenBytes;
         this.allowMissingColumnsOnInsert = allowMissingColumnsOnInsert;
@@ -773,7 +777,7 @@ public class MockConnector
                         return projectedRow.build();
                     })
                     .collect(toImmutableList());
-            return new MockConnectorPageSource(new RecordPageSource(new InMemoryRecordSet(types, records)));
+            return new MockConnectorPageSource(new RecordPageSource(new InMemoryRecordSet(types, records)), metrics.apply(tableName));
         }
 
         private Map<String, Integer> getColumnIndexes(SchemaTableName tableName)

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnectorPageSource.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnectorPageSource.java
@@ -34,10 +34,12 @@ public class MockConnectorPageSource
         implements UpdatablePageSource
 {
     private final ConnectorPageSource delegate;
+    private final Metrics metrics;
 
-    public MockConnectorPageSource(ConnectorPageSource delegate)
+    public MockConnectorPageSource(ConnectorPageSource delegate, Metrics metrics)
     {
         this.delegate = requireNonNull(delegate, "delegate is null");
+        this.metrics = requireNonNull(metrics, "metrics is null");
     }
 
     @Override
@@ -92,7 +94,7 @@ public class MockConnectorPageSource
     @Override
     public Metrics getMetrics()
     {
-        return delegate.getMetrics();
+        return delegate.getMetrics().mergeWith(metrics);
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryInputMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryInputMetadata.java
@@ -15,6 +15,7 @@ package io.trino.spi.eventlistener;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.metrics.Metrics;
 
 import java.util.List;
 import java.util.Optional;
@@ -32,6 +33,7 @@ public class QueryInputMetadata
     private final String table;
     private final List<String> columns;
     private final Optional<Object> connectorInfo;
+    private final Metrics connectorMetrics;
     private final OptionalLong physicalInputBytes;
     private final OptionalLong physicalInputRows;
 
@@ -41,6 +43,7 @@ public class QueryInputMetadata
             String table,
             List<String> columns,
             Optional<Object> connectorInfo,
+            Metrics connectorMetrics,
             OptionalLong physicalInputBytes,
             OptionalLong physicalInputRows)
     {
@@ -49,6 +52,7 @@ public class QueryInputMetadata
         this.table = requireNonNull(table, "table is null");
         this.columns = requireNonNull(columns, "columns is null");
         this.connectorInfo = requireNonNull(connectorInfo, "connectorInfo is null");
+        this.connectorMetrics = requireNonNull(connectorMetrics, "connectorMetrics is null");
         this.physicalInputBytes = requireNonNull(physicalInputBytes, "physicalInputBytes is null");
         this.physicalInputRows = requireNonNull(physicalInputRows, "physicalInputRows is null");
     }
@@ -81,6 +85,12 @@ public class QueryInputMetadata
     public Optional<Object> getConnectorInfo()
     {
         return connectorInfo;
+    }
+
+    @JsonProperty
+    public Metrics getConnectorMetrics()
+    {
+        return connectorMetrics;
     }
 
     @JsonProperty

--- a/core/trino-spi/src/main/java/io/trino/spi/metrics/Metrics.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/metrics/Metrics.java
@@ -19,6 +19,7 @@ import io.trino.spi.Mergeable;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
@@ -50,6 +51,25 @@ public class Metrics
     public static Accumulator accumulator()
     {
         return new Accumulator();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Metrics)) {
+            return false;
+        }
+        Metrics that = (Metrics) o;
+        return metrics.equals(that.metrics);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(metrics);
     }
 
     public static class Accumulator

--- a/core/trino-spi/src/test/java/io/trino/spi/TestSpiBackwardCompatibility.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/TestSpiBackwardCompatibility.java
@@ -66,7 +66,8 @@ public class TestSpiBackwardCompatibility
             .put("383", ImmutableSet.of(
                     "Method: public abstract java.lang.String io.trino.spi.function.AggregationState.value()",
                     "Method: public default void io.trino.spi.security.SystemAccessControl.checkCanExecuteFunction(io.trino.spi.security.SystemSecurityContext,io.trino.spi.connector.CatalogSchemaRoutineName)",
-                    "Method: public default void io.trino.spi.connector.ConnectorAccessControl.checkCanExecuteFunction(io.trino.spi.connector.ConnectorSecurityContext,io.trino.spi.connector.SchemaRoutineName)"))
+                    "Method: public default void io.trino.spi.connector.ConnectorAccessControl.checkCanExecuteFunction(io.trino.spi.connector.ConnectorSecurityContext,io.trino.spi.connector.SchemaRoutineName)",
+                    "Constructor: public io.trino.spi.eventlistener.QueryInputMetadata(java.lang.String,java.lang.String,java.lang.String,java.util.List<java.lang.String>,java.util.Optional<java.lang.Object>,java.util.OptionalLong,java.util.OptionalLong)"))
             .buildOrThrow();
 
     @Test

--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcRecordReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcRecordReader.java
@@ -86,6 +86,7 @@ public class OrcRecordReader
 
     private final long totalRowCount;
     private final long splitLength;
+    private final long totalDataLength;
     private final long maxBlockBytes;
     private final ColumnMetadata<OrcType> orcTypes;
     private long currentPosition;
@@ -190,6 +191,7 @@ public class OrcRecordReader
 
         long totalRowCount = 0;
         long fileRowCount = 0;
+        long totalDataLength = 0;
         ImmutableList.Builder<StripeInformation> stripes = ImmutableList.builder();
         ImmutableList.Builder<Long> stripeFilePositions = ImmutableList.builder();
         if (fileStats.isEmpty() || predicate.matches(numberOfRows, fileStats.get())) {
@@ -200,11 +202,13 @@ public class OrcRecordReader
                     stripes.add(stripe);
                     stripeFilePositions.add(fileRowCount);
                     totalRowCount += stripe.getNumberOfRows();
+                    totalDataLength += stripe.getDataLength();
                 }
                 fileRowCount += stripe.getNumberOfRows();
             }
         }
         this.totalRowCount = totalRowCount;
+        this.totalDataLength = totalDataLength;
         this.stripes = stripes.build();
         this.stripeFilePositions = stripeFilePositions.build();
 
@@ -328,6 +332,11 @@ public class OrcRecordReader
     public long getSplitLength()
     {
         return splitLength;
+    }
+
+    public long getTotalDataLength()
+    {
+        return totalDataLength;
     }
 
     /**

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeInputInfo.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeInputInfo.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+public class DeltaLakeInputInfo
+{
+    private final boolean partitioned;
+
+    @JsonCreator
+    public DeltaLakeInputInfo(@JsonProperty("partitioned") boolean partitioned)
+    {
+        this.partitioned = partitioned;
+    }
+
+    @JsonProperty
+    public boolean isPartitioned()
+    {
+        return partitioned;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof DeltaLakeInputInfo)) {
+            return false;
+        }
+        DeltaLakeInputInfo that = (DeltaLakeInputInfo) o;
+        return partitioned == that.partitioned;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(partitioned);
+    }
+}

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -1619,6 +1619,13 @@ public class DeltaLakeMetadata
     }
 
     @Override
+    public Optional<Object> getInfo(ConnectorTableHandle table)
+    {
+        boolean isPartitioned = !((DeltaLakeTableHandle) table).getMetadataEntry().getCanonicalPartitionColumns().isEmpty();
+        return Optional.of(new DeltaLakeInputInfo(isPartitioned));
+    }
+
+    @Override
     public void dropTable(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         DeltaLakeTableHandle handle = (DeltaLakeTableHandle) tableHandle;

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSource.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSource.java
@@ -18,6 +18,7 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.metrics.Metrics;
 import io.trino.spi.predicate.Utils;
 import io.trino.spi.type.Type;
 
@@ -166,6 +167,12 @@ public class DeltaLakePageSource
     public long getMemoryUsage()
     {
         return delegate.getMemoryUsage();
+    }
+
+    @Override
+    public Metrics getMetrics()
+    {
+        return delegate.getMetrics();
     }
 
     protected void closeWithSuppression(Throwable throwable)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeUpdatablePageSource.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeUpdatablePageSource.java
@@ -32,6 +32,7 @@ import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.UpdatablePageSource;
+import io.trino.spi.metrics.Metrics;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.TypeManager;
 import org.apache.hadoop.conf.Configuration;
@@ -272,6 +273,12 @@ public class DeltaLakeUpdatablePageSource
     public long getMemoryUsage()
     {
         return pageSourceDelegate.getMemoryUsage() + (rowsToDelete.size() / 8);
+    }
+
+    @Override
+    public Metrics getMetrics()
+    {
+        return pageSourceDelegate.getMetrics();
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
@@ -436,6 +436,30 @@ public class TestDeltaLakeMetadata
                 .isEmpty();
     }
 
+    @Test
+    public void testGetInputInfoForPartitionedTable()
+    {
+        DeltaLakeMetadata deltaLakeMetadata = deltaLakeMetadataFactory.create(SESSION.getIdentity());
+        ConnectorTableMetadata tableMetadata = newTableMetadata(
+                ImmutableList.of(BIGINT_COLUMN_1, BIGINT_COLUMN_2),
+                ImmutableList.of(BIGINT_COLUMN_1));
+        deltaLakeMetadata.createTable(SESSION, tableMetadata, false);
+        DeltaLakeTableHandle tableHandle = deltaLakeMetadata.getTableHandle(SESSION, tableMetadata.getTable());
+        assertThat(deltaLakeMetadata.getInfo(tableHandle)).isEqualTo(Optional.of(new DeltaLakeInputInfo(true)));
+    }
+
+    @Test
+    public void testGetInputInfoForUnPartitionedTable()
+    {
+        DeltaLakeMetadata deltaLakeMetadata = deltaLakeMetadataFactory.create(SESSION.getIdentity());
+        ConnectorTableMetadata tableMetadata = newTableMetadata(
+                ImmutableList.of(BIGINT_COLUMN_1, BIGINT_COLUMN_2),
+                ImmutableList.of());
+        deltaLakeMetadata.createTable(SESSION, tableMetadata, false);
+        DeltaLakeTableHandle tableHandle = deltaLakeMetadata.getTableHandle(SESSION, tableMetadata.getTable());
+        assertThat(deltaLakeMetadata.getInfo(tableHandle)).isEqualTo(Optional.of(new DeltaLakeInputInfo(false)));
+    }
+
     private static DeltaLakeTableHandle createDeltaLakeTableHandle(Set<ColumnHandle> projectedColumns, Set<DeltaLakeColumnHandle> constrainedColumns)
     {
         return new DeltaLakeTableHandle(

--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHiveAlluxioMetastore.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHiveAlluxioMetastore.java
@@ -349,6 +349,24 @@ public class TestHiveAlluxioMetastore
     }
 
     @Override
+    public void testInputInfoWhenTableIsPartitioned()
+    {
+        // Alluxio metastore does not support create/delete operations
+    }
+
+    @Override
+    public void testInputInfoWhenTableIsNotPartitioned()
+    {
+        // Alluxio metastore does not support create/delete operations
+    }
+
+    @Override
+    public void testInputInfoWithParquetTableFormat()
+    {
+        // Alluxio metastore does not support create/delete operations
+    }
+
+    @Override
     public void testUpdateTableColumnStatistics()
     {
         // Alluxio metastore does not support create operations

--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHiveAlluxioMetastore.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHiveAlluxioMetastore.java
@@ -264,6 +264,18 @@ public class TestHiveAlluxioMetastore
     }
 
     @Override
+    public void testOrcPageSourceMetrics()
+    {
+        // Alluxio metastore does not support create/insert/delete operations
+    }
+
+    @Override
+    public void testParquetPageSourceMetrics()
+    {
+        // Alluxio metastore does not support create/insert/delete operations
+    }
+
+    @Override
     public void testPreferredInsertLayout()
     {
         // Alluxio metastore does not support insert layout operations

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveInputInfo.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveInputInfo.java
@@ -17,20 +17,64 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
 
 public class HiveInputInfo
 {
     private final List<String> partitionIds;
+    private final boolean partitioned;
+    private final Optional<String> tableDefaultFileFormat;
 
     @JsonCreator
-    public HiveInputInfo(@JsonProperty("partitionIds") List<String> partitionIds)
+    public HiveInputInfo(
+            @JsonProperty("partitionIds") List<String> partitionIds,
+            @JsonProperty("partitioned") boolean partitioned,
+            @JsonProperty("tableDefaultFileFormat") Optional<String> tableDefaultFileFormat)
     {
-        this.partitionIds = partitionIds;
+        this.partitionIds = requireNonNull(partitionIds, "partitionIds is null");
+        this.partitioned = partitioned;
+        this.tableDefaultFileFormat = requireNonNull(tableDefaultFileFormat, "tableDefaultFileFormat is null");
     }
 
     @JsonProperty
     public List<String> getPartitionIds()
     {
         return partitionIds;
+    }
+
+    @JsonProperty
+    public boolean isPartitioned()
+    {
+        return partitioned;
+    }
+
+    @JsonProperty
+    public Optional<String> getTableDefaultFileFormat()
+    {
+        return tableDefaultFileFormat;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof HiveInputInfo)) {
+            return false;
+        }
+        HiveInputInfo that = (HiveInputInfo) o;
+        return partitionIds.equals(that.partitionIds)
+                && partitioned == that.partitioned
+                && tableDefaultFileFormat.equals(that.tableDefaultFileFormat);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(partitionIds, partitioned, tableDefaultFileFormat);
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveInputInfo.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveInputInfo.java
@@ -21,28 +21,16 @@ import java.util.List;
 public class HiveInputInfo
 {
     private final List<String> partitionIds;
-    // Code that serialize HiveInputInfo into log would often need the ability to limit the length of log entries.
-    // This boolean field allows such code to mark the log entry as length limited.
-    private final boolean truncated;
 
     @JsonCreator
-    public HiveInputInfo(
-            @JsonProperty("partitionIds") List<String> partitionIds,
-            @JsonProperty("truncated") boolean truncated)
+    public HiveInputInfo(@JsonProperty("partitionIds") List<String> partitionIds)
     {
         this.partitionIds = partitionIds;
-        this.truncated = truncated;
     }
 
     @JsonProperty
     public List<String> getPartitionIds()
     {
         return partitionIds;
-    }
-
-    @JsonProperty
-    public boolean isTruncated()
-    {
-        return truncated;
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -693,8 +693,7 @@ public class HiveMetadata
                 .map(partitions -> new HiveInputInfo(
                         partitions.stream()
                                 .map(HivePartition::getPartitionId)
-                                .collect(toImmutableList()),
-                        false));
+                                .collect(toImmutableList())));
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSourceFactory.java
@@ -448,7 +448,8 @@ public class OrcPageSourceFactory
                     deletedRows,
                     originalFileRowId,
                     memoryUsage,
-                    stats);
+                    stats,
+                    reader.getCompressionKind());
         }
         catch (Exception e) {
             try {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSource.java
@@ -26,6 +26,7 @@ import io.trino.spi.block.LazyBlockLoader;
 import io.trino.spi.block.LongArrayBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.metrics.Metrics;
 import io.trino.spi.type.Type;
 
 import java.io.IOException;
@@ -229,5 +230,11 @@ public class ParquetPageSource
             rowIndices[position] = baseIndex + position;
         }
         return new LongArrayBlock(size, Optional.empty(), rowIndices);
+    }
+
+    @Override
+    public Metrics getMetrics()
+    {
+        return new Metrics(parquetReader.getCodecMetrics());
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergInputInfo.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergInputInfo.java
@@ -13,8 +13,10 @@
  */
 package io.trino.plugin.iceberg;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
@@ -22,16 +24,56 @@ import static java.util.Objects.requireNonNull;
 public class IcebergInputInfo
 {
     private final Optional<Long> snapshotId;
+    private final boolean partitioned;
+    private final String tableDefaultFileFormat;
 
+    @JsonCreator
     public IcebergInputInfo(
-            @JsonProperty("snapshotId") Optional<Long> snapshotId)
+            @JsonProperty("snapshotId") Optional<Long> snapshotId,
+            @JsonProperty("partitioned") boolean partitioned,
+            @JsonProperty("fileFormat") String tableDefaultFileFormat)
     {
         this.snapshotId = requireNonNull(snapshotId, "snapshotId is null");
+        this.partitioned = partitioned;
+        this.tableDefaultFileFormat = requireNonNull(tableDefaultFileFormat, "tableDefaultFileFormat is null");
     }
 
     @JsonProperty
     public Optional<Long> getSnapshotId()
     {
         return snapshotId;
+    }
+
+    @JsonProperty
+    public boolean isPartitioned()
+    {
+        return partitioned;
+    }
+
+    @JsonProperty
+    public String getTableDefaultFileFormat()
+    {
+        return tableDefaultFileFormat;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof IcebergInputInfo)) {
+            return false;
+        }
+        IcebergInputInfo that = (IcebergInputInfo) o;
+        return partitioned == that.partitioned
+                && snapshotId.equals(that.snapshotId)
+                && tableDefaultFileFormat.equals(that.tableDefaultFileFormat);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(snapshotId, partitioned, tableDefaultFileFormat);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1157,8 +1157,15 @@ public class IcebergMetadata
     @Override
     public Optional<Object> getInfo(ConnectorTableHandle tableHandle)
     {
-        IcebergTableHandle table = (IcebergTableHandle) tableHandle;
-        return Optional.of(new IcebergInputInfo(table.getSnapshotId()));
+        IcebergTableHandle icebergTableHandle = (IcebergTableHandle) tableHandle;
+        PartitionSpec partitionSpec = PartitionSpecParser.fromJson(
+                SchemaParser.fromJson(icebergTableHandle.getTableSchemaJson()),
+                icebergTableHandle.getPartitionSpecJson());
+
+        return Optional.of(new IcebergInputInfo(
+                icebergTableHandle.getSnapshotId(),
+                partitionSpec.isPartitioned(),
+                getFileFormat(icebergTableHandle.getStorageProperties()).name()));
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSource.java
@@ -26,6 +26,7 @@ import io.trino.spi.block.ColumnarRow;
 import io.trino.spi.block.RowBlock;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.UpdatablePageSource;
+import io.trino.spi.metrics.Metrics;
 import io.trino.spi.type.Type;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.DeleteFilter;
@@ -331,6 +332,12 @@ public class IcebergPageSource
             memoryUsage += positionDeleteSink.getMemoryUsage();
         }
         return memoryUsage;
+    }
+
+    @Override
+    public Metrics getMetrics()
+    {
+        return delegate.getMetrics();
     }
 
     protected void closeWithSuppression(Throwable throwable)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -552,7 +552,8 @@ public class IcebergPageSourceProvider
                             Optional.empty(),
                             Optional.empty(),
                             memoryUsage,
-                            stats),
+                            stats,
+                            reader.getCompressionKind()),
                     columnProjections);
         }
         catch (Exception e) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -234,7 +234,12 @@ public final class IcebergUtil
 
     public static IcebergFileFormat getFileFormat(Table table)
     {
-        return IcebergFileFormat.fromIceberg(FileFormat.valueOf(table.properties()
+        return getFileFormat(table.properties());
+    }
+
+    public static IcebergFileFormat getFileFormat(Map<String, String> storageProperties)
+    {
+        return IcebergFileFormat.fromIceberg(FileFormat.valueOf(storageProperties
                 .getOrDefault(DEFAULT_FILE_FORMAT, DEFAULT_FILE_FORMAT_DEFAULT)
                 .toUpperCase(Locale.ENGLISH)));
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergInputInfo.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergInputInfo.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.metadata.Metadata;
+import io.trino.metadata.QualifiedObjectName;
+import io.trino.metadata.TableHandle;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.tpch.TpchTable;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.trino.plugin.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestIcebergInputInfo
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return IcebergQueryRunner.builder()
+                .setInitialTables(ImmutableList.of(TpchTable.NATION))
+                .build();
+    }
+
+    @Test
+    public void testInputWithPartitioning()
+    {
+        String tableName = "test_input_info_with_part_" + randomTableSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " WITH (partitioning = ARRAY['regionkey', 'truncate(name, 1)']) AS SELECT * FROM nation WHERE nationkey < 10", 10);
+        assertInputInfo(tableName, true, "ORC");
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testInputWithoutPartitioning()
+    {
+        String tableName = "test_input_info_without_part_" + randomTableSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM nation WHERE nationkey < 10", 10);
+        assertInputInfo(tableName, false, "ORC");
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testInputWithParquetFileFormat()
+    {
+        String tableName = "test_input_info_with_parquet_file_format_" + randomTableSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " WITH (format = 'PARQUET') AS SELECT * FROM nation WHERE nationkey < 10", 10);
+        assertInputInfo(tableName, false, "PARQUET");
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    private void assertInputInfo(String tableName, boolean expectedPartition, String expectedFileFormat)
+    {
+        inTransaction(session -> {
+            Metadata metadata = getQueryRunner().getMetadata();
+            QualifiedObjectName qualifiedObjectName = new QualifiedObjectName(
+                    session.getCatalog().orElse(ICEBERG_CATALOG),
+                    session.getSchema().orElse("tpch"),
+                    tableName);
+            Optional<TableHandle> tableHandle = metadata.getTableHandle(session, qualifiedObjectName);
+            assertThat(tableHandle).isPresent();
+            Optional<Object> tableInfo = metadata.getInfo(session, tableHandle.get());
+            assertThat(tableInfo).isPresent();
+            IcebergInputInfo icebergInputInfo = (IcebergInputInfo) tableInfo.get();
+            assertThat(icebergInputInfo).isEqualTo(new IcebergInputInfo(
+                    icebergInputInfo.getSnapshotId(),
+                    expectedPartition,
+                    expectedFileFormat));
+        });
+    }
+}

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestMockConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestMockConnector.java
@@ -20,6 +20,7 @@ import io.trino.Session;
 import io.trino.connector.MockConnectorFactory;
 import io.trino.connector.MockConnectorPlugin;
 import io.trino.connector.MockConnectorTableHandle;
+import io.trino.plugin.base.metrics.LongCount;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.procedure.TestProcedure;
 import io.trino.spi.connector.CatalogSchemaTableName;
@@ -27,6 +28,7 @@ import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.spi.connector.ConnectorMaterializedViewDefinition.Column;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.metrics.Metrics;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.DistributedQueryRunner;
@@ -94,6 +96,7 @@ public class TestMockConnector
                                     }
                                     throw new UnsupportedOperationException();
                                 })
+                                .withMetrics(schemaTableName -> new Metrics(ImmutableMap.of("test_metric", new LongCount(1))))
                                 .withProcedures(ImmutableSet.of(new TestProcedure().get()))
                                 .withSchemaProperties(() -> ImmutableList.<PropertyMetadata<?>>builder()
                                         .add(booleanProperty("boolean_schema_property", "description", false, false))


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

> How would you describe this change to a non-technical end user or system administrator?

Expose the following things as part of QueryCompletedEvent which can be later tracked through telemetry.
- Whether the table partitioned?
- What kind of compression input tables are using?
- File format - Parquet/Orc

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
