### PR TITLE
Bump Airbase to 126

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>123</version>
+        <version>126</version>
     </parent>
 
     <groupId>io.trino</groupId>
@@ -1678,7 +1678,7 @@
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
-                <version>1.28</version>
+                <version>1.30</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestVerifyTrinoTestsTestSetup.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestVerifyTrinoTestsTestSetup.java
@@ -16,6 +16,7 @@ package io.trino.tests;
 import org.testng.annotations.Test;
 
 import java.time.ZoneId;
+import java.util.Locale;
 
 import static org.testng.Assert.assertEquals;
 
@@ -26,5 +27,12 @@ public class TestVerifyTrinoTestsTestSetup
     {
         // Ensure that the zone defined in the POM is correctly set in the test JVM
         assertEquals(ZoneId.systemDefault().getId(), "America/Bahia_Banderas");
+    }
+
+    @Test
+    public void testJvmLocale()
+    {
+        // Ensure that locale defined in the POM is correctly set in the test JVM
+        assertEquals(Locale.getDefault(), Locale.US);
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

* Version 125 brings (among other things) updated dependency on Jackson, which fixes at least one CVE. Dependency on snakeyaml needs to be bumped to avoid conflicts with transitive dependencies.

* Version 126 brings fixes to how locale information is passed to Maven Surefire plugin. In relation to that, this commit adds a test to verify that the system locale is actually properly configured in the JVM.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Potential security fix, improvements to test stability.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Everything touching JSON

> How would you describe this change to a non-technical end user or system administrator?

Potential security fix, improvements to test stability.

## Related issues, pull requests, and links

airlift/airbase#314

airlift/airbase#315

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
