### PR TITLE
Rename caching hive metastore config

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastoreConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastoreConfig.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.hive.metastore.cache;
 
 import io.airlift.configuration.Config;
+import io.airlift.configuration.LegacyConfig;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDuration;
 
@@ -37,7 +38,8 @@ public class CachingHiveMetastoreConfig
         return metastoreCacheTtl;
     }
 
-    @Config("hive.metastore-cache-ttl")
+    @Config("hive.metastore-cache.cache-ttl")
+    @LegacyConfig("hive.metastore-cache-ttl")
     public CachingHiveMetastoreConfig setMetastoreCacheTtl(Duration metastoreCacheTtl)
     {
         this.metastoreCacheTtl = metastoreCacheTtl;
@@ -50,7 +52,8 @@ public class CachingHiveMetastoreConfig
         return metastoreRefreshInterval;
     }
 
-    @Config("hive.metastore-refresh-interval")
+    @Config("hive.metastore-cache.refresh-interval")
+    @LegacyConfig("hive.metastore-refresh-interval")
     public CachingHiveMetastoreConfig setMetastoreRefreshInterval(Duration metastoreRefreshInterval)
     {
         this.metastoreRefreshInterval = Optional.ofNullable(metastoreRefreshInterval);
@@ -63,7 +66,8 @@ public class CachingHiveMetastoreConfig
         return metastoreCacheMaximumSize;
     }
 
-    @Config("hive.metastore-cache-maximum-size")
+    @Config("hive.metastore-cache.cache-maximum-size")
+    @LegacyConfig("hive.metastore-cache-maximum-size")
     public CachingHiveMetastoreConfig setMetastoreCacheMaximumSize(long metastoreCacheMaximumSize)
     {
         this.metastoreCacheMaximumSize = metastoreCacheMaximumSize;
@@ -76,7 +80,8 @@ public class CachingHiveMetastoreConfig
         return maxMetastoreRefreshThreads;
     }
 
-    @Config("hive.metastore-refresh-max-threads")
+    @Config("hive.metastore-cache.refresh-max-threads")
+    @LegacyConfig("hive.metastore-refresh-max-threads")
     public CachingHiveMetastoreConfig setMaxMetastoreRefreshThreads(int maxMetastoreRefreshThreads)
     {
         this.maxMetastoreRefreshThreads = maxMetastoreRefreshThreads;

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastoreConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastoreConfig.java
@@ -41,10 +41,10 @@ public class TestCachingHiveMetastoreConfig
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
-                .put("hive.metastore-cache-ttl", "2h")
-                .put("hive.metastore-refresh-interval", "30m")
-                .put("hive.metastore-cache-maximum-size", "5000")
-                .put("hive.metastore-refresh-max-threads", "2500")
+                .put("hive.metastore-cache.cache-ttl", "2h")
+                .put("hive.metastore-cache.refresh-interval", "30m")
+                .put("hive.metastore-cache.cache-maximum-size", "5000")
+                .put("hive.metastore-cache.refresh-max-threads", "2500")
                 .put("hive.metastore-cache.cache-partitions", "false")
                 .buildOrThrow();
 


### PR DESCRIPTION
## Description

It's a followup to match new naming convention,
that will enable more granullar approach to metastore
caches configs.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->



<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

refactoring

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

hive connector

> How would you describe this change to a non-technical end user or system administrator?

cleans up naming conventions of hive metastore caching config

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
