### PR TITLE
Attach weights to IcebergSplits

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -20,6 +20,8 @@ import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.plugin.hive.HiveCompressionCodec;
 
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -58,6 +60,7 @@ public class IcebergConfig
     // putting schemas in locations with extraneous files), so default to false
     // to avoid deleting those files if Trino is unable to check.
     private boolean deleteSchemaLocationsFallback;
+    private double minimumAssignedSplitWeight = 0.05;
 
     public CatalogType getCatalogType()
     {
@@ -270,5 +273,20 @@ public class IcebergConfig
     {
         this.deleteSchemaLocationsFallback = deleteSchemaLocationsFallback;
         return this;
+    }
+
+    @Config("iceberg.minimum-assigned-split-weight")
+    @ConfigDescription("Minimum weight that a split can be assigned")
+    public IcebergConfig setMinimumAssignedSplitWeight(double minimumAssignedSplitWeight)
+    {
+        this.minimumAssignedSplitWeight = minimumAssignedSplitWeight;
+        return this;
+    }
+
+    @DecimalMax("1")
+    @DecimalMin(value = "0", inclusive = false)
+    public double getMinimumAssignedSplitWeight()
+    {
+        return minimumAssignedSplitWeight;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -73,6 +73,7 @@ public final class IcebergSessionProperties
     private static final String PROJECTION_PUSHDOWN_ENABLED = "projection_pushdown_enabled";
     private static final String TARGET_MAX_FILE_SIZE = "target_max_file_size";
     private static final String HIVE_CATALOG_NAME = "hive_catalog_name";
+    private static final String MINIMUM_ASSIGNED_SPLIT_WEIGHT = "minimum_assigned_split_weight";
     public static final String EXPIRE_SNAPSHOTS_MIN_RETENTION = "expire_snapshots_min_retention";
     public static final String REMOVE_ORPHAN_FILES_MIN_RETENTION = "remove_orphan_files_min_retention";
 
@@ -229,6 +230,11 @@ public final class IcebergSessionProperties
                         // Session-level redirections configuration does not work well with views, as view body is analyzed in context
                         // of a session with properties stripped off. Thus, this property is more of a test-only, or at most POC usefulness.
                         true))
+                .add(doubleProperty(
+                        MINIMUM_ASSIGNED_SPLIT_WEIGHT,
+                        "Minimum assigned split weight",
+                        icebergConfig.getMinimumAssignedSplitWeight(),
+                        false))
                 .add(durationProperty(
                         EXPIRE_SNAPSHOTS_MIN_RETENTION,
                         "Minimal retention period for expire_snapshot procedure",
@@ -393,5 +399,10 @@ public final class IcebergSessionProperties
     public static Duration getRemoveOrphanFilesMinRetention(ConnectorSession session)
     {
         return session.getProperty(REMOVE_ORPHAN_FILES_MIN_RETENTION, Duration.class);
+    }
+
+    public static double getMinimumAssignedSplitWeight(ConnectorSession session)
+    {
+        return session.getProperty(MINIMUM_ASSIGNED_SPLIT_WEIGHT, Double.class);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplit.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplit.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.iceberg.delete.TrinoDeleteFile;
 import io.trino.spi.HostAddress;
+import io.trino.spi.SplitWeight;
 import io.trino.spi.connector.ConnectorSplit;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -43,6 +44,7 @@ public class IcebergSplit
     private final String partitionSpecJson;
     private final String partitionDataJson;
     private final List<TrinoDeleteFile> deletes;
+    private final SplitWeight splitWeight;
 
     @JsonCreator
     public IcebergSplit(
@@ -55,7 +57,8 @@ public class IcebergSplit
             @JsonProperty("addresses") List<HostAddress> addresses,
             @JsonProperty("partitionSpecJson") String partitionSpecJson,
             @JsonProperty("partitionDataJson") String partitionDataJson,
-            @JsonProperty("deletes") List<TrinoDeleteFile> deletes)
+            @JsonProperty("deletes") List<TrinoDeleteFile> deletes,
+            @JsonProperty("splitWeight") SplitWeight splitWeight)
     {
         this.path = requireNonNull(path, "path is null");
         this.start = start;
@@ -67,6 +70,7 @@ public class IcebergSplit
         this.partitionSpecJson = requireNonNull(partitionSpecJson, "partitionSpecJson is null");
         this.partitionDataJson = requireNonNull(partitionDataJson, "partitionDataJson is null");
         this.deletes = ImmutableList.copyOf(requireNonNull(deletes, "deletes is null"));
+        this.splitWeight = requireNonNull(splitWeight, "splitWeight is null");
     }
 
     @Override
@@ -136,6 +140,13 @@ public class IcebergSplit
         return deletes;
     }
 
+    @JsonProperty
+    @Override
+    public SplitWeight getSplitWeight()
+    {
+        return splitWeight;
+    }
+
     @Override
     public Object getInfo()
     {
@@ -154,7 +165,8 @@ public class IcebergSplit
                 + estimatedSizeOf(addresses, HostAddress::getRetainedSizeInBytes)
                 + estimatedSizeOf(partitionSpecJson)
                 + estimatedSizeOf(partitionDataJson)
-                + estimatedSizeOf(deletes, TrinoDeleteFile::getRetainedSizeInBytes);
+                + estimatedSizeOf(deletes, TrinoDeleteFile::getRetainedSizeInBytes)
+                + splitWeight.getRetainedSizeInBytes();
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitManager.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitManager.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.TableScan;
 import javax.inject.Inject;
 
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getDynamicFilteringWaitTimeout;
+import static io.trino.plugin.iceberg.IcebergSessionProperties.getMinimumAssignedSplitWeight;
 import static java.util.Objects.requireNonNull;
 
 public class IcebergSplitManager
@@ -79,7 +80,8 @@ public class IcebergSplitManager
                 dynamicFilteringWaitTimeout,
                 constraint,
                 typeManager,
-                table.isRecordScannedFiles());
+                table.isRecordScannedFiles(),
+                getMinimumAssignedSplitWeight(session));
 
         return new ClassLoaderSafeConnectorSplitSource(splitSource, Thread.currentThread().getContextClassLoader());
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
@@ -18,7 +18,7 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
-import com.google.common.collect.Streams;
+import com.google.common.io.Closer;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.plugin.iceberg.delete.TrinoDeleteFile;
@@ -36,7 +36,6 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.predicate.ValueSet;
 import io.trino.spi.type.TypeManager;
 import org.apache.hadoop.fs.Path;
-import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.PartitionSpecParser;
@@ -44,7 +43,9 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.TableScanUtil;
 
 import javax.annotation.Nullable;
 
@@ -53,8 +54,6 @@ import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.ByteBuffer;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -100,9 +99,10 @@ public class IcebergSplitSource
     private final Stopwatch dynamicFilterWaitStopwatch;
     private final Constraint constraint;
     private final TypeManager typeManager;
+    private final Closer closer = Closer.create();
 
-    private CloseableIterable<CombinedScanTask> combinedScanIterable;
-    private Iterator<FileScanTask> fileScanIterator;
+    private CloseableIterable<FileScanTask> fileScanTaskIterable;
+    private CloseableIterator<FileScanTask> fileScanTaskIterator;
     private TupleDomain<IcebergColumnHandle> pushedDownDynamicFilterPredicate;
 
     private final boolean recordScannedFiles;
@@ -140,7 +140,7 @@ public class IcebergSplitSource
                     .completeOnTimeout(EMPTY_BATCH, timeLeft, MILLISECONDS);
         }
 
-        if (combinedScanIterable == null) {
+        if (fileScanTaskIterable == null) {
             // Used to avoid duplicating work if the Dynamic Filter was already pushed down to the Iceberg API
             this.pushedDownDynamicFilterPredicate = dynamicFilter.getCurrentPredicate().transformKeys(IcebergColumnHandle.class::cast);
             TupleDomain<IcebergColumnHandle> fullPredicate = tableHandle.getUnenforcedPredicate()
@@ -161,14 +161,14 @@ public class IcebergSplitSource
             }
 
             Expression filterExpression = toIcebergExpression(effectivePredicate);
-            this.combinedScanIterable = tableScan
-                    .filter(filterExpression)
-                    .includeColumnStats()
-                    .planTasks();
-            this.fileScanIterator = Streams.stream(combinedScanIterable)
-                    .map(CombinedScanTask::files)
-                    .flatMap(Collection::stream)
-                    .iterator();
+            this.fileScanTaskIterable = TableScanUtil.splitFiles(
+                    tableScan.filter(filterExpression)
+                            .includeColumnStats()
+                            .planFiles(),
+                    tableScan.targetSplitSize());
+            closer.register(fileScanTaskIterable);
+            this.fileScanTaskIterator = fileScanTaskIterable.iterator();
+            closer.register(fileScanTaskIterator);
         }
 
         TupleDomain<IcebergColumnHandle> dynamicFilterPredicate = dynamicFilter.getCurrentPredicate()
@@ -178,7 +178,7 @@ public class IcebergSplitSource
             return completedFuture(NO_MORE_SPLITS_BATCH);
         }
 
-        Iterator<FileScanTask> fileScanTasks = Iterators.limit(fileScanIterator, maxSize);
+        Iterator<FileScanTask> fileScanTasks = Iterators.limit(fileScanTaskIterator, maxSize);
         ImmutableList.Builder<ConnectorSplit> splits = ImmutableList.builder();
         while (fileScanTasks.hasNext()) {
             FileScanTask scanTask = fileScanTasks.next();
@@ -238,14 +238,14 @@ public class IcebergSplitSource
     private void finish()
     {
         close();
-        this.combinedScanIterable = CloseableIterable.empty();
-        this.fileScanIterator = Collections.emptyIterator();
+        this.fileScanTaskIterable = CloseableIterable.empty();
+        this.fileScanTaskIterator = CloseableIterator.empty();
     }
 
     @Override
     public boolean isFinished()
     {
-        return fileScanIterator != null && !fileScanIterator.hasNext();
+        return fileScanTaskIterator != null && !fileScanTaskIterator.hasNext();
     }
 
     @Override
@@ -261,13 +261,11 @@ public class IcebergSplitSource
     @Override
     public void close()
     {
-        if (combinedScanIterable != null) {
-            try {
-                combinedScanIterable.close();
-            }
-            catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
+        try {
+            closer.close();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
@@ -55,7 +55,8 @@ public class TestIcebergConfig
                 .setExpireSnapshotsMinRetention(new Duration(7, DAYS))
                 .setRemoveOrphanFilesMinRetention(new Duration(7, DAYS))
                 .setDeleteSchemaLocationsFallback(false)
-                .setTargetMaxFileSize(DataSize.of(1, GIGABYTE)));
+                .setTargetMaxFileSize(DataSize.of(1, GIGABYTE))
+                .setMinimumAssignedSplitWeight(0.05));
     }
 
     @Test
@@ -77,6 +78,7 @@ public class TestIcebergConfig
                 .put("iceberg.remove_orphan_files.min-retention", "14h")
                 .put("iceberg.delete-schema-locations-fallback", "true")
                 .put("iceberg.target-max-file-size", "1MB")
+                .put("iceberg.minimum-assigned-split-weight", "0.01")
                 .buildOrThrow();
 
         IcebergConfig expected = new IcebergConfig()
@@ -94,7 +96,8 @@ public class TestIcebergConfig
                 .setExpireSnapshotsMinRetention(new Duration(13, HOURS))
                 .setRemoveOrphanFilesMinRetention(new Duration(14, HOURS))
                 .setDeleteSchemaLocationsFallback(true)
-                .setTargetMaxFileSize(DataSize.of(1, MEGABYTE));
+                .setTargetMaxFileSize(DataSize.of(1, MEGABYTE))
+                .setMinimumAssignedSplitWeight(0.01);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
@@ -35,6 +35,7 @@ import io.trino.plugin.hive.orc.OrcWriterConfig;
 import io.trino.plugin.hive.parquet.ParquetReaderConfig;
 import io.trino.plugin.hive.parquet.ParquetWriterConfig;
 import io.trino.spi.Page;
+import io.trino.spi.SplitWeight;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorPageSource;
@@ -161,7 +162,8 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                 ImmutableList.of(),
                 PartitionSpecParser.toJson(PartitionSpec.unpartitioned()),
                 PartitionData.toJson(new PartitionData(new Object[] {})),
-                ImmutableList.of());
+                ImmutableList.of(),
+                SplitWeight.standard());
 
         TableHandle tableHandle = new TableHandle(
                 new CatalogName(ICEBERG_CATALOG_NAME),

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
@@ -185,7 +185,8 @@ public class TestIcebergSplitSource
                 new Duration(2, SECONDS),
                 alwaysTrue(),
                 new TestingTypeManager(),
-                false);
+                false,
+                new IcebergConfig().getMinimumAssignedSplitWeight());
 
         ImmutableList.Builder<IcebergSplit> splits = ImmutableList.builder();
         while (!splitSource.isFinished()) {


### PR DESCRIPTION
## Description

Performance improvements for queries against Iceberg tables with small files.

> Is this change a fix, improvement, new feature, refactoring, or other?

Performance improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Iceberg connector with all catalogs

> How would you describe this change to a non-technical end user or system administrator?

Improve query execution time when the table contains many small files

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Iceberg
* Use split weights to improve scheduling and query performance on tables with many small files.  ({issue}`12162`)
```
