### PR TITLE
Do not extract distinct operator when de-correlating global aggregation

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedGlobalAggregationWithProjection.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedGlobalAggregationWithProjection.java
@@ -185,6 +185,54 @@ public class TestTransformCorrelatedGlobalAggregationWithProjection
     }
 
     @Test
+    public void rewritesOnSubqueryWithDecorrelatableDistinct()
+    {
+        // distinct aggregation can be decorrelated in the subquery by PlanNodeDecorrelator
+        // because the correlated predicate is equality comparison
+        tester().assertThat(new TransformCorrelatedGlobalAggregationWithProjection(tester().getPlannerContext()))
+                .on(p -> p.correlatedJoin(
+                        ImmutableList.of(p.symbol("corr")),
+                        p.values(p.symbol("corr")),
+                        p.project(
+                                Assignments.of(p.symbol("expr_sum"), PlanBuilder.expression("sum + 1"), p.symbol("expr_count"), PlanBuilder.expression("count - 1")),
+                                p.aggregation(outerBuilder -> outerBuilder
+                                        .addAggregation(p.symbol("sum"), PlanBuilder.expression("sum(a)"), ImmutableList.of(BIGINT))
+                                        .addAggregation(p.symbol("count"), PlanBuilder.expression("count()"), ImmutableList.of())
+                                        .globalGrouping()
+                                        .source(p.aggregation(innerBuilder -> innerBuilder
+                                                .singleGroupingSet(p.symbol("a"))
+                                                .source(p.filter(
+                                                        PlanBuilder.expression("b = corr"),
+                                                        p.values(p.symbol("a"), p.symbol("b"))))))))))
+                .matches(
+                        project(ImmutableMap.of("corr", expression("corr"), "expr_sum", expression("(sum_agg + 1)"), "expr_count", expression("count_agg - 1")),
+                                aggregation(
+                                        singleGroupingSet("corr", "unique"),
+                                        ImmutableMap.of(Optional.of("sum_agg"), functionCall("sum", ImmutableList.of("a")), Optional.of("count_agg"), functionCall("count", ImmutableList.of())),
+                                        ImmutableList.of(),
+                                        ImmutableList.of("non_null"),
+                                        Optional.empty(),
+                                        SINGLE,
+                                        join(
+                                                LEFT,
+                                                ImmutableList.of(),
+                                                Optional.of("b = corr"),
+                                                assignUniqueId(
+                                                        "unique",
+                                                        values("corr")),
+                                                project(
+                                                        ImmutableMap.of("non_null", expression("true")),
+                                                        aggregation(
+                                                                singleGroupingSet("a", "b"),
+                                                                ImmutableMap.of(),
+                                                                Optional.empty(),
+                                                                SINGLE,
+                                                                filter(
+                                                                        "true",
+                                                                        values("a", "b"))))))));
+    }
+
+    @Test
     public void testWithPreexistingMask()
     {
         tester().assertThat(new TransformCorrelatedGlobalAggregationWithProjection(tester().getPlannerContext()))


### PR DESCRIPTION
Fixes: https://github.com/trinodb/trino/issues/12564

Credits to @sopel39 for investigating this complicated case.

Before this change, rules
`TestTransformCorrelatedGlobalAggregationWithoutProjection` and
`TestTransformCorrelatedGlobalAggregationWithProjection` extracted
and handled two aggregations in the correlated subquery:
- a global aggregation
- a "distinct operator" - i.e. an aggregation with grouping symbols
  but without any aggregate functions

It is a common case that such two aggregations are present. They
result from a call like: `count(distinct x)`

Before this change, if both aggregations were present in the subquery,
the rules would move them both on top of the de-correlated join.
This behavior was suboptimal in some cases, specifically when the
"distinct operator" could be de-correlated in place. Moving the
"distinct operator" on top of the join blocked other optimizations,
e.g. `PushAggregationThroughOuterJoin`.

After this change, the "distinct operator" is moved on top of the
de-correlated join only if it can't be de-correlated in the
subquery.



This change might need a release notes entry as a perf improvement / regression fix.