### PR TITLE
Upgrade Minio image to RELEASE.2022-05-26T05-48-41Z

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Minio.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Minio.java
@@ -40,7 +40,7 @@ public class Minio
 
     private static final String MINIO_ACCESS_KEY = "minio-access-key";
     private static final String MINIO_SECRET_KEY = "minio-secret-key";
-    private static final String MINIO_RELEASE = "RELEASE.2021-07-15T22-27-34Z";
+    private static final String MINIO_RELEASE = "RELEASE.2022-05-26T05-48-41Z";
 
     private static final int MINIO_PORT = 9080; // minio uses 9000 by default, which conflicts with hadoop
     private static final int MINIO_CONSOLE_PORT = 9001;


### PR DESCRIPTION
## Description

Upgrade Minio image to `RELEASE.2022-05-26T05-48-41Z`

Test result using https://github.com/trinodb/docker-images/pull/126
```
testing/trino-product-tests-launcher/bin/run-launcher test run --environment EnvSinglenodeDeltaLakeOss -- -g delta-lake-oss
...

tests               | ===============================================
tests               | tempto-tests
tests               | Total tests run: 39, Failures: 0, Skips: 0
tests               | ===============================================
```

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
