### PR TITLE
Allow configuring schema for iceberg MV storage tables

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -146,6 +146,12 @@ is used.
   * - ``iceberg.hive-catalog-name``
     - Catalog to redirect to when a Hive table is referenced.
     -
+  * - ``iceberg.materialized-views.storage-schema``
+    - Schema for creating materialized views storage tables. When this property
+      is not configured, storage tables are created in the same schema as the
+      materialized view definition. When the ``storage_schema`` materialized
+      view property is specified, it takes precedence over this catalog property.
+    - Empty
 
 ORC format configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -944,6 +950,11 @@ for the data files and partition the storage per day using the column
 ``_date``::
 
     WITH ( format = 'ORC', partitioning = ARRAY['event_date'] )
+
+By default, the storage table is created in the same schema as the materialized
+view definition. The ``iceberg.materialized-views.storage-schema`` catalog
+configuration property or ``storage_schema`` materialized view property can be
+used to specify the schema where the storage table will be created.
 
 Updating the data in the materialized view with
 :doc:`/sql/refresh-materialized-view` deletes the data from the storage table,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -62,6 +62,7 @@ public class IcebergConfig
     private boolean deleteSchemaLocationsFallback;
     private double minimumAssignedSplitWeight = 0.05;
     private boolean allowLegacySnapshotSyntax;
+    private Optional<String> materializedViewsStorageSchema = Optional.empty();
 
     public CatalogType getCatalogType()
     {
@@ -303,5 +304,19 @@ public class IcebergConfig
     public boolean isAllowLegacySnapshotSyntax()
     {
         return allowLegacySnapshotSyntax;
+    }
+
+    @NotNull
+    public Optional<String> getMaterializedViewsStorageSchema()
+    {
+        return materializedViewsStorageSchema;
+    }
+
+    @Config("iceberg.materialized-views.storage-schema")
+    @ConfigDescription("Schema for creating materialized views storage tables")
+    public IcebergConfig setMaterializedViewsStorageSchema(String materializedViewsStorageSchema)
+    {
+        this.materializedViewsStorageSchema = Optional.ofNullable(materializedViewsStorageSchema);
+        return this;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConnector.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConnector.java
@@ -57,6 +57,7 @@ public class IcebergConnector
     private final List<PropertyMetadata<?>> sessionProperties;
     private final List<PropertyMetadata<?>> schemaProperties;
     private final List<PropertyMetadata<?>> tableProperties;
+    private final List<PropertyMetadata<?>> materializedViewProperties;
     private final Optional<ConnectorAccessControl> accessControl;
     private final Set<Procedure> procedures;
     private final Set<TableProcedureMetadata> tableProcedures;
@@ -71,6 +72,7 @@ public class IcebergConnector
             Set<SessionPropertiesProvider> sessionPropertiesProviders,
             List<PropertyMetadata<?>> schemaProperties,
             List<PropertyMetadata<?>> tableProperties,
+            List<PropertyMetadata<?>> materializedViewProperties,
             Optional<ConnectorAccessControl> accessControl,
             Set<Procedure> procedures,
             Set<TableProcedureMetadata> tableProcedures)
@@ -86,6 +88,7 @@ public class IcebergConnector
                 .collect(toImmutableList());
         this.schemaProperties = ImmutableList.copyOf(requireNonNull(schemaProperties, "schemaProperties is null"));
         this.tableProperties = ImmutableList.copyOf(requireNonNull(tableProperties, "tableProperties is null"));
+        this.materializedViewProperties = ImmutableList.copyOf(requireNonNull(materializedViewProperties, "materializedViewProperties is null"));
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.procedures = ImmutableSet.copyOf(requireNonNull(procedures, "procedures is null"));
         this.tableProcedures = ImmutableSet.copyOf(requireNonNull(tableProcedures, "tableProcedures is null"));
@@ -161,7 +164,7 @@ public class IcebergConnector
     @Override
     public List<PropertyMetadata<?>> getMaterializedViewProperties()
     {
-        return tableProperties;
+        return materializedViewProperties;
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMaterializedViewAdditionalProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMaterializedViewAdditionalProperties.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.session.PropertyMetadata;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.spi.session.PropertyMetadata.stringProperty;
+
+public class IcebergMaterializedViewAdditionalProperties
+{
+    public static final String STORAGE_SCHEMA = "storage_schema";
+
+    private final List<PropertyMetadata<?>> materializedViewProperties;
+
+    @Inject
+    public IcebergMaterializedViewAdditionalProperties(IcebergConfig icebergConfig)
+    {
+        materializedViewProperties = ImmutableList.<PropertyMetadata<?>>builder()
+                .add(stringProperty(
+                        STORAGE_SCHEMA,
+                        "Schema for creating materialized view storage table",
+                        icebergConfig.getMaterializedViewsStorageSchema().orElse(null),
+                        false))
+                .build();
+    }
+
+    public List<PropertyMetadata<?>> getMaterializedViewProperties()
+    {
+        return materializedViewProperties;
+    }
+
+    public static Optional<String> getStorageSchema(Map<String, Object> materializedViewProperties)
+    {
+        return Optional.ofNullable((String) materializedViewProperties.get(STORAGE_SCHEMA));
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
@@ -53,6 +53,7 @@ public class IcebergModule
 
         newSetBinder(binder, SessionPropertiesProvider.class).addBinding().to(IcebergSessionProperties.class).in(Scopes.SINGLETON);
         binder.bind(IcebergTableProperties.class).in(Scopes.SINGLETON);
+        binder.bind(IcebergMaterializedViewAdditionalProperties.class).in(Scopes.SINGLETON);
 
         binder.bind(ConnectorSplitManager.class).to(IcebergSplitManager.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, ConnectorPageSourceProvider.class).setDefault().to(IcebergPageSourceProvider.class).in(Scopes.SINGLETON);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
@@ -60,6 +60,8 @@ import static io.trino.plugin.hive.ViewReaderUtil.PRESTO_VIEW_FLAG;
 import static io.trino.plugin.hive.ViewReaderUtil.isHiveOrPrestoView;
 import static io.trino.plugin.hive.ViewReaderUtil.isPrestoView;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_FILESYSTEM_ERROR;
+import static io.trino.plugin.iceberg.IcebergMaterializedViewAdditionalProperties.STORAGE_SCHEMA;
+import static io.trino.plugin.iceberg.IcebergMaterializedViewAdditionalProperties.getStorageSchema;
 import static io.trino.plugin.iceberg.IcebergMaterializedViewDefinition.decodeMaterializedViewData;
 import static io.trino.plugin.iceberg.IcebergTableProperties.FILE_FORMAT_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergUtil.getIcebergTableProperties;
@@ -262,7 +264,8 @@ public abstract class AbstractTrinoCatalog
         Map<String, Object> storageTableProperties = new HashMap<>(definition.getProperties());
         storageTableProperties.putIfAbsent(FILE_FORMAT_PROPERTY, DEFAULT_FILE_FORMAT_DEFAULT);
 
-        SchemaTableName storageTable = new SchemaTableName(viewName.getSchemaName(), storageTableName);
+        String storageSchema = getStorageSchema(definition.getProperties()).orElse(viewName.getSchemaName());
+        SchemaTableName storageTable = new SchemaTableName(storageSchema, storageTableName);
         List<ColumnMetadata> columns = definition.getColumns().stream()
                 .map(column -> new ColumnMetadata(column.getName(), typeManager.getType(column.getType())))
                 .collect(toImmutableList());
@@ -275,16 +278,15 @@ public abstract class AbstractTrinoCatalog
     }
 
     protected ConnectorMaterializedViewDefinition getMaterializedViewDefinition(
-            SchemaTableName viewName,
             Table icebergTable,
             Optional<String> owner,
             String viewOriginalText,
-            String storageTableName)
+            SchemaTableName storageTableName)
     {
         IcebergMaterializedViewDefinition definition = decodeMaterializedViewData(viewOriginalText);
         return new ConnectorMaterializedViewDefinition(
                 definition.getOriginalSql(),
-                Optional.of(new CatalogSchemaTableName(catalogName.toString(), new SchemaTableName(viewName.getSchemaName(), storageTableName))),
+                Optional.of(new CatalogSchemaTableName(catalogName.toString(), storageTableName)),
                 definition.getCatalog(),
                 definition.getSchema(),
                 definition.getColumns().stream()
@@ -292,14 +294,18 @@ public abstract class AbstractTrinoCatalog
                         .collect(toImmutableList()),
                 definition.getComment(),
                 owner,
-                getIcebergTableProperties(icebergTable));
+                ImmutableMap.<String, Object>builder()
+                        .putAll(getIcebergTableProperties(icebergTable))
+                        .put(STORAGE_SCHEMA, storageTableName.getSchemaName())
+                        .buildOrThrow());
     }
 
-    protected Map<String, String> createMaterializedViewProperties(ConnectorSession session, String storageTableName)
+    protected Map<String, String> createMaterializedViewProperties(ConnectorSession session, SchemaTableName storageTableName)
     {
         return ImmutableMap.<String, String>builder()
                 .put(PRESTO_QUERY_ID_NAME, session.getQueryId())
-                .put(STORAGE_TABLE, storageTableName)
+                .put(STORAGE_SCHEMA, storageTableName.getSchemaName())
+                .put(STORAGE_TABLE, storageTableName.getTableName())
                 .put(PRESTO_VIEW_FLAG, "true")
                 .put(TRINO_CREATED_BY, TRINO_CREATED_BY_VALUE)
                 .put(TABLE_COMMENT, ICEBERG_MATERIALIZED_VIEW_COMMENT)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
@@ -76,6 +76,7 @@ import static io.trino.plugin.hive.metastore.PrincipalPrivileges.NO_PRIVILEGES;
 import static io.trino.plugin.hive.metastore.StorageFormat.VIEW_STORAGE_FORMAT;
 import static io.trino.plugin.hive.util.HiveUtil.isHiveSystemSchema;
 import static io.trino.plugin.hive.util.HiveWriteUtils.getTableDefaultLocation;
+import static io.trino.plugin.iceberg.IcebergMaterializedViewAdditionalProperties.STORAGE_SCHEMA;
 import static io.trino.plugin.iceberg.IcebergMaterializedViewDefinition.encodeMaterializedViewData;
 import static io.trino.plugin.iceberg.IcebergMaterializedViewDefinition.fromConnectorMaterializedViewDefinition;
 import static io.trino.plugin.iceberg.IcebergSchemaProperties.getSchemaLocation;
@@ -455,7 +456,7 @@ public class TrinoHiveCatalog
         SchemaTableName storageTable = createMaterializedViewStorageTable(session, viewName, definition);
 
         // Create a view indicating the storage table
-        Map<String, String> viewProperties = createMaterializedViewProperties(session, storageTable.getTableName());
+        Map<String, String> viewProperties = createMaterializedViewProperties(session, storageTable);
         Column dummyColumn = new Column("dummy", HIVE_STRING, Optional.empty());
 
         io.trino.plugin.hive.metastore.Table.Builder tableBuilder = io.trino.plugin.hive.metastore.Table.builder()
@@ -477,7 +478,9 @@ public class TrinoHiveCatalog
             // drop the current storage table
             String oldStorageTable = existing.get().getParameters().get(STORAGE_TABLE);
             if (oldStorageTable != null) {
-                metastore.dropTable(viewName.getSchemaName(), oldStorageTable, true);
+                String storageSchema = Optional.ofNullable(existing.get().getParameters().get(STORAGE_SCHEMA))
+                        .orElse(viewName.getSchemaName());
+                metastore.dropTable(storageSchema, oldStorageTable, true);
             }
             // Replace the existing view definition
             metastore.replaceTable(viewName.getSchemaName(), viewName.getTableName(), table, principalPrivileges);
@@ -499,11 +502,13 @@ public class TrinoHiveCatalog
 
         String storageTableName = view.getParameters().get(STORAGE_TABLE);
         if (storageTableName != null) {
+            String storageSchema = Optional.ofNullable(view.getParameters().get(STORAGE_SCHEMA))
+                    .orElse(viewName.getSchemaName());
             try {
-                metastore.dropTable(viewName.getSchemaName(), storageTableName, true);
+                metastore.dropTable(storageSchema, storageTableName, true);
             }
             catch (TrinoException e) {
-                log.warn(e, "Failed to drop storage table '%s' for materialized view '%s'", storageTableName, viewName);
+                log.warn(e, "Failed to drop storage table '%s.%s' for materialized view '%s'", storageSchema, storageTableName, viewName);
             }
         }
         metastore.dropTable(viewName.getSchemaName(), viewName.getTableName(), true);
@@ -525,10 +530,13 @@ public class TrinoHiveCatalog
         io.trino.plugin.hive.metastore.Table materializedView = tableOptional.get();
         String storageTable = materializedView.getParameters().get(STORAGE_TABLE);
         checkState(storageTable != null, "Storage table missing in definition of materialized view " + viewName);
+        String storageSchema = Optional.ofNullable(materializedView.getParameters().get(STORAGE_SCHEMA))
+                .orElse(viewName.getSchemaName());
+        SchemaTableName storageTableName = new SchemaTableName(storageSchema, storageTable);
 
         Table icebergTable;
         try {
-            icebergTable = loadTable(session, new SchemaTableName(viewName.getSchemaName(), storageTable));
+            icebergTable = loadTable(session, storageTableName);
         }
         catch (RuntimeException e) {
             // The materialized view could be removed concurrently. This may manifest in a number of ways, e.g.
@@ -537,16 +545,15 @@ public class TrinoHiveCatalog
             // - other failures when reading storage table's metadata files
             // Retry, as we're catching broadly.
             metastore.invalidateTable(viewName.getSchemaName(), viewName.getTableName());
-            metastore.invalidateTable(viewName.getSchemaName(), storageTable);
+            metastore.invalidateTable(storageSchema, storageTable);
             throw new MaterializedViewMayBeBeingRemovedException(e);
         }
         return Optional.of(getMaterializedViewDefinition(
-                viewName,
                 icebergTable,
                 table.getOwner(),
                 materializedView.getViewOriginalText()
                         .orElseThrow(() -> new TrinoException(HIVE_INVALID_METADATA, "No view original text: " + viewName)),
-                storageTable));
+                storageTableName));
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
@@ -51,6 +51,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public abstract class BaseIcebergMaterializedViewTest
         extends AbstractTestQueryFramework
 {
+    protected final String storageSchemaName = "testing_storage_schema_" + randomTableSuffix();
+
     protected abstract String getSchemaName();
 
     protected abstract String getSchemaDirectory();
@@ -169,7 +171,8 @@ public abstract class BaseIcebergMaterializedViewTest
                                 "   location = '" + getSchemaDirectory() + "/st_\\E[0-9a-f]+\\Q',\n" +
                                 "   orc_bloom_filter_columns = ARRAY['_date'],\n" +
                                 "   orc_bloom_filter_fpp = 1E-1,\n" +
-                                "   partitioning = ARRAY['_date']\n" +
+                                "   partitioning = ARRAY['_date'],\n" +
+                                "   storage_schema = 'tpch'\n" +
                                 ") AS\n" +
                                 "SELECT\n" +
                                 "  _bigint\n" +
@@ -441,7 +444,8 @@ public abstract class BaseIcebergMaterializedViewTest
                         "   format = 'ORC',\n" +
                         "   format_version = 2,\n" +
                         "   location = '" + getSchemaDirectory() + "/st_\\E[0-9a-f]+\\Q',\n" +
-                        "   partitioning = ARRAY['_date']\n" +
+                        "   partitioning = ARRAY['_date'],\n" +
+                        "   storage_schema = 'tpch'\n" +
                         ") AS\n" +
                         "SELECT\n" +
                         "  _date\n" +
@@ -546,6 +550,48 @@ public abstract class BaseIcebergMaterializedViewTest
         assertUpdate("DROP TABLE IF EXISTS base_table5");
         assertUpdate("DROP MATERIALIZED VIEW materialized_view_level1");
         assertUpdate("DROP MATERIALIZED VIEW materialized_view_level2");
+    }
+
+    @Test
+    public void testStorageSchemaProperty()
+    {
+        String catalogName = getSession().getCatalog().orElseThrow();
+        String viewName = "storage_schema_property_test";
+        assertUpdate("CREATE SCHEMA IF NOT EXISTS " + catalogName + "." + storageSchemaName);
+        assertUpdate(
+                "CREATE MATERIALIZED VIEW " + viewName + " " +
+                        "WITH (storage_schema = '" + storageSchemaName + "') AS " +
+                        "SELECT * FROM base_table1");
+        SchemaTableName storageTable = getStorageTable(catalogName, viewName);
+        assertThat(storageTable.getSchemaName()).isEqualTo(storageSchemaName);
+
+        assertUpdate("REFRESH MATERIALIZED VIEW " + viewName, 6);
+        assertThat(computeActual("SELECT * FROM " + viewName).getRowCount()).isEqualTo(6);
+        assertThat(getExplainPlan("SELECT * FROM " + viewName, ExplainType.Type.IO))
+                .doesNotContain("base_table1")
+                .contains(storageSchemaName);
+
+        assertThat((String) computeScalar("SHOW CREATE MATERIALIZED VIEW " + viewName))
+                .contains("storage_schema = '" + storageSchemaName + "'");
+
+        Set<String> storageSchemaTables = computeActual("SHOW TABLES IN " + storageSchemaName).getOnlyColumnAsSet().stream()
+                .map(String.class::cast)
+                .collect(toImmutableSet());
+        assertThat(storageSchemaTables).contains(storageTable.getTableName());
+
+        assertUpdate("DROP MATERIALIZED VIEW " + viewName);
+        storageSchemaTables = computeActual("SHOW TABLES IN " + storageSchemaName).getOnlyColumnAsSet().stream()
+                .map(String.class::cast)
+                .collect(toImmutableSet());
+        assertThat(storageSchemaTables).doesNotContain(storageTable.getTableName());
+
+        assertThatThrownBy(() -> query(
+                "CREATE MATERIALIZED VIEW " + viewName + " " +
+                        "WITH (storage_schema = 'non_existent') AS " +
+                        "SELECT * FROM base_table1"))
+                .hasMessageContaining("Schema non_existent not found");
+        assertThatThrownBy(() -> query("DESCRIBE " + viewName))
+                .hasMessageContaining(format("'iceberg.%s.%s' does not exist", getSchemaName(), viewName));
     }
 
     private SchemaTableName getStorageTable(String catalogName, String objectName)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
@@ -57,7 +57,8 @@ public class TestIcebergConfig
                 .setDeleteSchemaLocationsFallback(false)
                 .setTargetMaxFileSize(DataSize.of(1, GIGABYTE))
                 .setMinimumAssignedSplitWeight(0.05)
-                .setAllowLegacySnapshotSyntax(false));
+                .setAllowLegacySnapshotSyntax(false)
+                .setMaterializedViewsStorageSchema(null));
     }
 
     @Test
@@ -81,6 +82,7 @@ public class TestIcebergConfig
                 .put("iceberg.target-max-file-size", "1MB")
                 .put("iceberg.minimum-assigned-split-weight", "0.01")
                 .put("iceberg.allow-legacy-snapshot-syntax", "true")
+                .put("iceberg.materialized-views.storage-schema", "mv_storage_schema")
                 .buildOrThrow();
 
         IcebergConfig expected = new IcebergConfig()
@@ -100,7 +102,8 @@ public class TestIcebergConfig
                 .setDeleteSchemaLocationsFallback(true)
                 .setTargetMaxFileSize(DataSize.of(1, MEGABYTE))
                 .setMinimumAssignedSplitWeight(0.01)
-                .setAllowLegacySnapshotSyntax(true);
+                .setAllowLegacySnapshotSyntax(true)
+                .setMaterializedViewsStorageSchema("mv_storage_schema");
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogMaterializedViewTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogMaterializedViewTest.java
@@ -80,10 +80,16 @@ public class TestIcebergGlueCatalogMaterializedViewTest
     @AfterClass(alwaysRun = true)
     public void cleanup()
     {
+        cleanUpSchema(schemaName);
+        cleanUpSchema(storageSchemaName);
+    }
+
+    private static void cleanUpSchema(String schema)
+    {
         AWSGlueAsync glueClient = AWSGlueAsyncClientBuilder.defaultClient();
         Set<String> tableNames = getPaginatedResults(
                 glueClient::getTables,
-                new GetTablesRequest().withDatabaseName(schemaName),
+                new GetTablesRequest().withDatabaseName(schema),
                 GetTablesRequest::setNextToken,
                 GetTablesResult::getNextToken,
                 new GlueMetastoreApiStats())
@@ -92,9 +98,9 @@ public class TestIcebergGlueCatalogMaterializedViewTest
                 .map(Table::getName)
                 .collect(toImmutableSet());
         glueClient.batchDeleteTable(new BatchDeleteTableRequest()
-                .withDatabaseName(schemaName)
+                .withDatabaseName(schema)
                 .withTablesToDelete(tableNames));
         glueClient.deleteDatabase(new DeleteDatabaseRequest()
-                .withName(schemaName));
+                .withName(schema));
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Adds storage_schema MV property and
iceberg.materialized-views.storage-schema catalog config.
By default, storage table will continue to created in
the same schema as the MV definition.

> Is this change a fix, improvement, new feature, refactoring, or other?

new feature
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

iceberg connector
> How would you describe this change to a non-technical end user or system administrator?

See description
## Related issues, pull requests, and links

https://github.com/trinodb/trino/issues/12503#issuecomment-1139539874

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Section
* Add the ability to configure schema for Iceberg materialized view storage tables. ({issue}`12591`)
```
