### PR TITLE
Add `iceberg.table-statistics-enabled` property in Iceberg doc

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -83,7 +83,7 @@ General configuration
 These configuration properties are independent of which catalog implementation
 is used.
 
-.. list-table:: Iceberg configuration properties
+.. list-table:: Iceberg general configuration properties
   :widths: 30, 58, 12
   :header-rows: 1
 
@@ -110,6 +110,20 @@ is used.
   * - ``iceberg.max-partitions-per-writer``
     - Maximum number of partitions handled per writer.
     - 100
+
+ORC format configuration
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following properties are used to configure the read and write operations
+with ORC files performed by the Iceberg connector.
+
+.. list-table:: ORC format configuration properties
+  :widths: 30, 58, 12
+  :header-rows: 1
+
+  * - Property name
+    - Description
+    - Default
   * - ``hive.orc.bloom-filters.enabled``
     - Enable bloom filters for predicate pushdown.
     - ``false``

--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -110,6 +110,14 @@ is used.
   * - ``iceberg.max-partitions-per-writer``
     - Maximum number of partitions handled per writer.
     - 100
+  * - ``iceberg.table-statistics-enabled``
+    - Enables :doc:`/optimizer/statistics`. The equivalent
+      :doc:`catalog session property </sql/set-session>`
+      is ``statistics_enabled`` for session specific use.
+      Set to ``false`` to disable statistics. Disabling statistics
+      means that :doc:`/optimizer/cost-based-optimizations` can
+      not make smart decisions about the query plan.
+    - ``true``
 
 ORC format configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description
Add `iceberg.table-statistics-enabled` property in Iceberg doc.

Refer to `hive.table-statistics-enabled` in Hive: 
https://trino.io/docs/current/connector/hive.html#hive-configuration-properties

This RR also adds `ORC format configuration properties` module, refer to: https://trino.io/docs/current/connector/hive.html#orc-format-configuration-properties. Because `hive.orc.bloom-filters.enabled` in Iceberg is specific to orc format.

## Related issues, pull requests, and links
 Fixes #12589 

## Documentation
(x) Sufficient documentation is included in this PR.

## Release notes
(x) No release notes entries required.
