### PR TITLE
Rely on noMoreOperators for dynamic filters collection

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/DynamicFilterSourceConsumer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DynamicFilterSourceConsumer.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner;
+
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.sql.planner.plan.DynamicFilterId;
+
+public interface DynamicFilterSourceConsumer
+{
+    void addPartition(TupleDomain<DynamicFilterId> tupleDomain);
+
+    void setPartitionCount(int partitionCount);
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -2553,7 +2553,7 @@ public class LocalExecutionPlanner
             checkArgument(partitionCount == 1, "Expected local execution to not be parallel");
 
             int operatorId = buildContext.getNextOperatorId();
-            Optional<LocalDynamicFilterConsumer> localDynamicFilter = createDynamicFilter(buildSource, node, context, partitionCount, localDynamicFilters);
+            Optional<LocalDynamicFilterConsumer> localDynamicFilter = createDynamicFilter(buildSource, node, context, localDynamicFilters);
             if (localDynamicFilter.isPresent()) {
                 buildSource = createDynamicFilterSourceOperatorFactory(operatorId, localDynamicFilter.get(), node, buildSource, buildContext);
             }
@@ -2817,7 +2817,7 @@ public class LocalExecutionPlanner
                     buildOutputTypes);
 
             int operatorId = buildContext.getNextOperatorId();
-            Optional<LocalDynamicFilterConsumer> localDynamicFilter = createDynamicFilter(buildSource, node, context, partitionCount, localDynamicFilters);
+            Optional<LocalDynamicFilterConsumer> localDynamicFilter = createDynamicFilter(buildSource, node, context, localDynamicFilters);
             if (localDynamicFilter.isPresent()) {
                 buildSource = createDynamicFilterSourceOperatorFactory(operatorId, localDynamicFilter.get(), node, buildSource, buildContext);
             }
@@ -2874,7 +2874,7 @@ public class LocalExecutionPlanner
                     new DynamicFilterSourceOperatorFactory(
                             operatorId,
                             node.getId(),
-                            dynamicFilter.getTupleDomainConsumer(),
+                            dynamicFilter,
                             filterBuildChannels,
                             multipleIf(getDynamicFilteringMaxDistinctValuesPerDriver(session, isReplicatedJoin), taskConcurrency, isBuildSideSingle),
                             multipleIf(getDynamicFilteringMaxSizePerDriver(session, isReplicatedJoin), taskConcurrency, isBuildSideSingle),
@@ -2899,7 +2899,6 @@ public class LocalExecutionPlanner
                 PhysicalOperation buildSource,
                 JoinNode node,
                 LocalExecutionPlanContext context,
-                int partitionCount,
                 Set<DynamicFilterId> localDynamicFilters)
         {
             Set<DynamicFilterId> coordinatorDynamicFilters = getCoordinatorDynamicFilters(node.getDynamicFilters().keySet(), node, context.getTaskId());
@@ -2914,7 +2913,7 @@ public class LocalExecutionPlanner
                     buildSource.getPipelineExecutionStrategy() != GROUPED_EXECUTION,
                     "Dynamic filtering cannot be used with grouped execution");
             log.debug("[Join] Dynamic filters: %s", node.getDynamicFilters());
-            LocalDynamicFilterConsumer filterConsumer = LocalDynamicFilterConsumer.create(node, buildSource.getTypes(), partitionCount, collectedDynamicFilters);
+            LocalDynamicFilterConsumer filterConsumer = LocalDynamicFilterConsumer.create(node, buildSource.getTypes(), collectedDynamicFilters);
             ListenableFuture<Map<DynamicFilterId, Domain>> domainsFuture = filterConsumer.getDynamicFilterDomains();
             if (!localDynamicFilters.isEmpty()) {
                 addSuccessCallback(domainsFuture, context::addLocalDynamicFilters);
@@ -3080,8 +3079,7 @@ public class LocalExecutionPlanner
                 log.debug("[Semi-join] Dynamic filter: %s", filterId);
                 LocalDynamicFilterConsumer filterConsumer = new LocalDynamicFilterConsumer(
                         ImmutableMap.of(filterId, buildChannel),
-                        ImmutableMap.of(filterId, buildSource.getTypes().get(buildChannel)),
-                        partitionCount);
+                        ImmutableMap.of(filterId, buildSource.getTypes().get(buildChannel)));
                 ListenableFuture<Map<DynamicFilterId, Domain>> domainsFuture = filterConsumer.getDynamicFilterDomains();
                 if (isLocalDynamicFilter) {
                     addSuccessCallback(domainsFuture, context::addLocalDynamicFilters);
@@ -3094,7 +3092,7 @@ public class LocalExecutionPlanner
                         new DynamicFilterSourceOperatorFactory(
                                 operatorId,
                                 node.getId(),
-                                filterConsumer.getTupleDomainConsumer(),
+                                filterConsumer,
                                 ImmutableList.of(new DynamicFilterSourceOperator.Channel(filterId, buildSource.getTypes().get(buildChannel), buildChannel)),
                                 getDynamicFilteringMaxDistinctValuesPerDriver(session, isReplicatedJoin),
                                 getDynamicFilteringMaxSizePerDriver(session, isReplicatedJoin),

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkDynamicFilterSourceOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkDynamicFilterSourceOperator.java
@@ -17,7 +17,9 @@ import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
+import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.TypeOperators;
+import io.trino.sql.planner.DynamicFilterSourceConsumer;
 import io.trino.sql.planner.plan.DynamicFilterId;
 import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.testing.TestingTaskContext;
@@ -93,7 +95,13 @@ public class BenchmarkDynamicFilterSourceOperator
             operatorFactory = new DynamicFilterSourceOperator.DynamicFilterSourceOperatorFactory(
                     1,
                     new PlanNodeId("joinNodeId"),
-                    (tupleDomain -> {}),
+                    new DynamicFilterSourceConsumer() {
+                        @Override
+                        public void addPartition(TupleDomain<DynamicFilterId> tupleDomain) {}
+
+                        @Override
+                        public void setPartitionCount(int partitionCount) {}
+                    },
                     ImmutableList.of(new DynamicFilterSourceOperator.Channel(new DynamicFilterId("0"), BIGINT, 0)),
                     maxDistinctValuesCount,
                     DataSize.ofBytes(Long.MAX_VALUE),

--- a/core/trino-main/src/test/java/io/trino/operator/TestDynamicFilterSourceOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestDynamicFilterSourceOperator.java
@@ -24,6 +24,7 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.predicate.ValueSet;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
+import io.trino.sql.planner.DynamicFilterSourceConsumer;
 import io.trino.sql.planner.plan.DynamicFilterId;
 import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.testing.MaterializedResult;
@@ -132,17 +133,21 @@ public class TestDynamicFilterSourceOperator
         return new DynamicFilterSourceOperator.DynamicFilterSourceOperatorFactory(
                 0,
                 new PlanNodeId("PLAN_NODE_ID"),
-                this::consumePredicate,
+                new DynamicFilterSourceConsumer() {
+                    @Override
+                    public void addPartition(TupleDomain<DynamicFilterId> tupleDomain)
+                    {
+                        partitions.add(tupleDomain);
+                    }
+
+                    @Override
+                    public void setPartitionCount(int partitionCount) {}
+                },
                 ImmutableList.copyOf(buildChannels),
                 maxFilterDistinctValues,
                 maxFilterSize,
                 minMaxCollectionLimit,
                 blockTypeOperators);
-    }
-
-    private void consumePredicate(TupleDomain<DynamicFilterId> partitionPredicate)
-    {
-        partitions.add(partitionPredicate);
     }
 
     private Operator createOperator(OperatorFactory operatorFactory)


### PR DESCRIPTION
Relying on noMoreOperators from DynamicFilterSourceOperatorFactory
for detecting completion of dynamic filter collection will simplify
the implementation for fault tolerant execution where the collection
may take place in a source stage.