### PR TITLE
Fix formatting cumulative memory in Web UI

### DIFF
--- a/.github/config/labeler-config.yml
+++ b/.github/config/labeler-config.yml
@@ -16,3 +16,6 @@ docs:
 release-notes:
   - docs/src/main/sphinx/release/**
   - docs/src/main/sphinx/release.rst
+
+ui:
+  - core/trino-main/src/main/resources/webapp/**

--- a/core/trino-main/src/main/resources/webapp/src/components/QueryDetail.jsx
+++ b/core/trino-main/src/main/resources/webapp/src/components/QueryDetail.jsx
@@ -1502,11 +1502,11 @@ export class QueryDetail extends React.Component {
                                             Cumulative User Memory
                                         </td>
                                         <td className="info-text">
-                                            {formatDataSizeBytes(query.queryStats.cumulativeUserMemory / 1000.0) + " seconds"}
+                                            {formatDataSize(query.queryStats.cumulativeUserMemory / 1000.0) + "*seconds"}
                                         </td>
                                         {taskRetriesEnabled &&
                                         <td className="info-failed">
-                                            {formatDataSizeBytes(query.queryStats.failedCumulativeUserMemory / 1000.0) + " seconds"}
+                                            {formatDataSize(query.queryStats.failedCumulativeUserMemory / 1000.0) + "*seconds"}
                                         </td>
                                         }
                                     </tr>


### PR DESCRIPTION
Value for cumulative memory of a query was previously reported using
following format:

"4.33T seconds". It is not obviouls that it represents integer of memory
coinsumption over time.
This commit changes format to:
"4.33TB*seconds"

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Web UI
* Improve readability of Cumulative User Memory on Query Details page. ({issue}`issuenumber`)
```
