### PR TITLE
fix bug of push agg into tablescan

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
@@ -289,6 +289,10 @@ public class DefaultJdbcMetadata
             return Optional.empty();
         }
 
+        if (aggregates.isEmpty() && groupingSets.stream().allMatch(List::isEmpty)) {
+            return Optional.empty();
+        }
+
         JdbcTableHandle handle = (JdbcTableHandle) table;
 
         // Global aggregation is represented by [[]]


### PR DESCRIPTION
## Description

Prevent AggregationPushdown for the jdbc connector when the aggrationNode do have the aggration and grouppingset,
in this case the jdbc connect can not applyAggration correctly, and may case wrong sql calculate result in the case, till now, we just prevent it

## Related issues, pull requests, and links

issue : https://github.com/trinodb/trino/issues/12598

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

```markdown
# Section
* Fix some things. ({}`12598`)
```
