### PR TITLE
Update docker-images to v59

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <dep.casandra.version>4.14.0</dep.casandra.version>
         <dep.minio.version>7.1.4</dep.minio.version>
 
-        <dep.docker.images.version>57</dep.docker.images.version>
+        <dep.docker.images.version>59</dep.docker.images.version>
 
         <!--
           America/Bahia_Banderas has:


### PR DESCRIPTION
## Description

Update docker-images to v59

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
