### PR TITLE
Prune empty global aggregation

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -188,6 +188,7 @@ import io.trino.sql.planner.iterative.rule.RemoveAggregationInSemiJoin;
 import io.trino.sql.planner.iterative.rule.RemoveDuplicateConditions;
 import io.trino.sql.planner.iterative.rule.RemoveEmptyDeleteRuleSet;
 import io.trino.sql.planner.iterative.rule.RemoveEmptyExceptBranches;
+import io.trino.sql.planner.iterative.rule.RemoveEmptyGlobalAggregation;
 import io.trino.sql.planner.iterative.rule.RemoveEmptyTableExecute;
 import io.trino.sql.planner.iterative.rule.RemoveEmptyUnionBranches;
 import io.trino.sql.planner.iterative.rule.RemoveFullSample;
@@ -983,6 +984,7 @@ public class PlanOptimizers
     {
         return ImmutableSet.of(
                 new PruneAggregationColumns(),
+                new RemoveEmptyGlobalAggregation(), // aggregation can become empty after pruning its output columns
                 new PruneAggregationSourceColumns(),
                 new PruneApplyColumns(),
                 new PruneApplyCorrelation(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushAggregationIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushAggregationIntoTableScan.java
@@ -45,7 +45,6 @@ import io.trino.sql.planner.plan.Assignments;
 import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.ProjectNode;
 import io.trino.sql.planner.plan.TableScanNode;
-import io.trino.sql.planner.plan.ValuesNode;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.NodeRef;
 import io.trino.sql.tree.SymbolReference;
@@ -140,8 +139,8 @@ public class PushAggregationIntoTableScan
         Session session = context.getSession();
 
         if (groupingKeys.isEmpty() && aggregations.isEmpty()) {
-            // Global aggregation with no aggregation functions
-            return Optional.of(new ValuesNode(aggregationNode.getId(), 1));
+            // Global aggregation with no aggregate functions. No point to push this down into connector.
+            return Optional.empty();
         }
 
         Map<String, ColumnHandle> assignments = tableScan.getAssignments()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveEmptyGlobalAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveEmptyGlobalAggregation.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.plan.AggregationNode;
+import io.trino.sql.planner.plan.ValuesNode;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.sql.planner.plan.Patterns.Aggregation.step;
+import static io.trino.sql.planner.plan.Patterns.aggregation;
+
+public class RemoveEmptyGlobalAggregation
+        implements Rule<AggregationNode>
+{
+    private static final Pattern<AggregationNode> PATTERN =
+            aggregation()
+                    .with(step().equalTo(AggregationNode.Step.SINGLE))
+                    .matching(node ->
+                            // no aggregate functions
+                            node.getAggregations().isEmpty() &&
+                                    // global aggregation
+                                    node.hasEmptyGroupingSet() && node.getGroupingSetCount() == 1);
+
+    @Override
+    public Pattern<AggregationNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(AggregationNode node, Captures captures, Context context)
+    {
+        // There should be no hash symbol in a global aggregation
+        checkArgument(node.getHashSymbol().isEmpty(), "Unexpected hash symbol: %s", node.getHashSymbol());
+        // There should be no output symbols, since there is no information the aggregation could return
+        checkArgument(node.getOutputSymbols().isEmpty(), "Unexpected output symbols: %s", node.getOutputSymbols());
+
+        return Result.ofPlanNode(new ValuesNode(node.getId(), 1));
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestHaving.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestHaving.java
@@ -13,17 +13,14 @@
  */
 package io.trino.sql.planner;
 
-import com.google.common.collect.ImmutableMap;
 import io.trino.sql.planner.assertions.BasePlanTest;
-import io.trino.sql.planner.plan.AggregationNode;
 import org.testng.annotations.Test;
 
-import java.util.Optional;
+import java.util.List;
 
-import static io.trino.sql.planner.assertions.PlanMatchPattern.aggregation;
-import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
-import static io.trino.sql.planner.assertions.PlanMatchPattern.globalAggregation;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.output;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expression;
 
 public class TestHaving
         extends BasePlanTest
@@ -33,12 +30,6 @@ public class TestHaving
     {
         assertPlan(
                 "SELECT 'a' FROM (VALUES 1, 1, 2) t(a) HAVING true",
-                anyTree(
-                        aggregation(
-                                globalAggregation(),
-                                ImmutableMap.of(),
-                                Optional.empty(),
-                                AggregationNode.Step.SINGLE,
-                                values())));
+                output(values(List.of("a_symbol"), List.of(List.of(expression("'a'"))))));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveEmptyGlobalAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveEmptyGlobalAggregation.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import org.testng.annotations.Test;
+
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestRemoveEmptyGlobalAggregation
+        extends BaseRuleTest
+{
+    @Test
+    public void testDoesNotFire()
+    {
+        tester().assertThat(new RemoveEmptyGlobalAggregation())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    return p.aggregation(aggregation ->
+                            aggregation.singleGroupingSet(a)
+                                    .source(p.values(a)));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void test()
+    {
+        tester().assertThat(new RemoveEmptyGlobalAggregation())
+                .on(p -> p.aggregation(aggregation ->
+                        aggregation
+                                .globalGrouping()
+                                .source(p.values(p.symbol("a")))))
+                .matches(values(1));
+    }
+}

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
@@ -253,7 +253,7 @@ public abstract class BaseJdbcConnectorTest
         // pruned away aggregation
         assertThat(query("SELECT -13 FROM (SELECT count(*) FROM nation)"))
                 .matches("VALUES -13")
-                .hasPlan(node(OutputNode.class, node(ProjectNode.class, node(ValuesNode.class))));
+                .hasPlan(node(OutputNode.class, node(ValuesNode.class)));
         // aggregation over aggregation
         assertThat(query("SELECT count(*) FROM (SELECT count(*) FROM nation)"))
                 .matches("VALUES BIGINT '1'")


### PR DESCRIPTION
A global aggregation that has no aggregation expressions can be replaced
with VALUES. Before the change, this was done in
`PushAggregationIntoTableScan`, so happened only when aggregation was
directly above table scan. With this change, it's applied more broadly.