### PR TITLE
Allow creating tables like tables from other catalogs excluding properties

### DIFF
--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateTableTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateTableTask.java
@@ -259,7 +259,7 @@ public class TestCreateTableTask
     }
 
     @Test
-    public void testCreateLikeWithProperties()
+    public void testCreateLikeIncludingProperties()
     {
         CreateTable statement = getCreateLikeStatement(true);
 
@@ -312,7 +312,7 @@ public class TestCreateTableTask
     }
 
     @Test
-    public void testCreateLikeWithPropertiesDenyPermission()
+    public void testCreateLikeIncludingPropertiesDenyPermission()
     {
         CreateTable statement = getCreateLikeStatement(true);
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->
Relax the restriction for creating tables like others in a different catalog when properties are explicitly excluded.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
core

> How would you describe this change to a non-technical end user or system administrator?
It's now possible to run `CREATE TABLE catalog.table (LIKE other_catalog.other_table EXCLUDING PROPERTIES)` 

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->
* Fixes #3171

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# General
* Allow to create table like table from other catalog when excluding properties. ({issue}`issuenumber`)
```
