### PR TITLE
Document "DROP TABLE IF EXISTS" throws an error if view exists

### DIFF
--- a/docs/src/main/sphinx/sql/drop-table.md
+++ b/docs/src/main/sphinx/sql/drop-table.md
@@ -10,8 +10,9 @@ DROP TABLE  [ IF EXISTS ] table_name
 
 Drops an existing table.
 
-The optional `IF EXISTS` clause causes the error to be suppressed if
-the table does not exist.
+The optional `IF EXISTS` clause causes the error to be suppressed if the table
+does not exist. The error is not suppressed if a Trino view with the same name
+exists.
 
 ## Examples
 


### PR DESCRIPTION
folliowing https://github.com/trinodb/trino/issues/11555

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

documentation

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

no

> How would you describe this change to a non-technical end user or system administrator?

add documentation regarding an error

## Related issues, pull requests, and links


* Follow https://github.com/trinodb/trino/issues/11555

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
