### PR TITLE
Resolve all com.google.common.io.Files deprecation warnings

### DIFF
--- a/lib/trino-orc/src/test/java/io/trino/orc/TestSliceDictionaryColumnReader.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestSliceDictionaryColumnReader.java
@@ -23,12 +23,12 @@ import io.trino.orc.reader.SliceDictionaryColumnReader;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 
-import static com.google.common.io.Files.createTempDir;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.orc.OrcTester.writeOrcColumnTrino;
 import static io.trino.orc.metadata.CompressionKind.NONE;
@@ -52,7 +52,7 @@ public class TestSliceDictionaryColumnReader
     {
         // create orc file
         List<String> values = createValues();
-        File temporaryDirectory = createTempDir();
+        File temporaryDirectory = Files.createTempDirectory(null).toFile();
         File orcFile = new File(temporaryDirectory, randomUUID().toString());
         writeOrcColumnTrino(orcFile, NONE, VARCHAR, values.iterator(), new OrcWriterStats());
 

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraServer.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraServer.java
@@ -38,13 +38,13 @@ import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.CONTRO
 import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.METADATA_SCHEMA_REFRESHED_KEYSPACES;
 import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.PROTOCOL_VERSION;
 import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.REQUEST_TIMEOUT;
-import static com.google.common.io.Files.write;
 import static com.google.common.io.Resources.getResource;
 import static io.trino.plugin.cassandra.CassandraTestingUtils.CASSANDRA_TYPE_MANAGER;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.createDirectory;
 import static java.nio.file.Files.createTempDirectory;
+import static java.nio.file.Files.writeString;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -124,7 +124,7 @@ public class CassandraServer
 
         File yamlFile = tmpDirPath.resolve("cu-cassandra.yaml").toFile();
         yamlFile.deleteOnExit();
-        write(modified, yamlFile, UTF_8);
+        writeString(yamlFile.toPath(), modified, UTF_8);
 
         return yamlFile.getAbsolutePath();
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.deltalake;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.io.Files;
 import io.airlift.json.JsonCodec;
 import io.airlift.json.JsonCodecFactory;
 import io.airlift.slice.Slice;
@@ -39,6 +38,7 @@ import org.apache.hadoop.fs.Path;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
@@ -72,7 +72,7 @@ public class TestDeltaLakePageSink
     public void testPageSinkStats()
             throws Exception
     {
-        File tempDir = Files.createTempDir();
+        File tempDir = Files.createTempDirectory(null).toFile();
         try {
             DeltaLakeWriterStats stats = new DeltaLakeWriterStats();
             String tablePath = tempDir.getAbsolutePath() + "/test_table";

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestTransactionLogAccess.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestTransactionLogAccess.java
@@ -16,7 +16,6 @@ package io.trino.plugin.deltalake;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.io.Files;
 import io.airlift.units.Duration;
 import io.trino.plugin.deltalake.transactionlog.AddFileEntry;
 import io.trino.plugin.deltalake.transactionlog.CommitInfoEntry;
@@ -48,6 +47,7 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.nio.file.Files;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -410,7 +410,7 @@ public class TestTransactionLogAccess
     {
         String tableName = "person";
         // setupTransactionLogAccess(tableName, new Path(getClass().getClassLoader().getResource("databricks/" + tableName).toURI()));
-        File tempDir = Files.createTempDir();
+        File tempDir = Files.createTempDirectory(null).toFile();
         File tableDir = new File(tempDir, tableName);
         File transactionLogDir = new File(tableDir, TRANSACTION_LOG_DIRECTORY);
         transactionLogDir.mkdirs();
@@ -419,15 +419,15 @@ public class TestTransactionLogAccess
         for (int i = 0; i < 12; i++) {
             String extension = i == 10 ? ".checkpoint.parquet" : ".json";
             String fileName = format("%020d%s", i, extension);
-            Files.copy(resourceDir.resolve(fileName).toFile(), new File(transactionLogDir, fileName));
+            Files.copy(resourceDir.resolve(fileName), new File(transactionLogDir, fileName).toPath());
         }
-        Files.copy(resourceDir.resolve(LAST_CHECKPOINT_FILENAME).toFile(), new File(transactionLogDir, LAST_CHECKPOINT_FILENAME));
+        Files.copy(resourceDir.resolve(LAST_CHECKPOINT_FILENAME), new File(transactionLogDir, LAST_CHECKPOINT_FILENAME).toPath());
 
         setupTransactionLogAccess(tableName, new Path(tableDir.toURI()));
         assertEquals(tableSnapshot.getVersion(), 11L);
 
         String lastTransactionName = format("%020d.json", 12);
-        Files.copy(resourceDir.resolve(lastTransactionName).toFile(), new File(transactionLogDir, lastTransactionName));
+        Files.copy(resourceDir.resolve(lastTransactionName), new File(transactionLogDir, lastTransactionName).toPath());
         TableSnapshot updatedSnapshot = transactionLogAccess.loadSnapshot(new SchemaTableName("schema", tableName), new Path(tableDir.toURI()), SESSION);
         assertEquals(updatedSnapshot.getVersion(), 12);
     }
@@ -437,7 +437,7 @@ public class TestTransactionLogAccess
             throws Exception
     {
         String tableName = "person";
-        File tempDir = Files.createTempDir();
+        File tempDir = Files.createTempDirectory(null).toFile();
         File tableDir = new File(tempDir, tableName);
         File transactionLogDir = new File(tableDir, TRANSACTION_LOG_DIRECTORY);
         transactionLogDir.mkdirs();
@@ -479,7 +479,7 @@ public class TestTransactionLogAccess
             throws Exception
     {
         String tableName = "person";
-        File tempDir = Files.createTempDir();
+        File tempDir = Files.createTempDirectory(null).toFile();
         File tableDir = new File(tempDir, tableName);
         File transactionLogDir = new File(tableDir, TRANSACTION_LOG_DIRECTORY);
         transactionLogDir.mkdirs();
@@ -501,7 +501,7 @@ public class TestTransactionLogAccess
         assertEqualsIgnoreOrder(activeDataFiles.stream().map(AddFileEntry::getPath).collect(Collectors.toSet()), dataFiles);
 
         copyTransactionLogEntry(8, 12, resourceDir, transactionLogDir);
-        Files.copy(new File(resourceDir, LAST_CHECKPOINT_FILENAME), new File(transactionLogDir, LAST_CHECKPOINT_FILENAME));
+        Files.copy(new File(resourceDir, LAST_CHECKPOINT_FILENAME).toPath(), new File(transactionLogDir, LAST_CHECKPOINT_FILENAME).toPath());
         TableSnapshot updatedSnapshot = transactionLogAccess.loadSnapshot(new SchemaTableName("schema", tableName), new Path(tableDir.toURI()), SESSION);
         activeDataFiles = transactionLogAccess.getActiveFiles(updatedSnapshot, SESSION);
 
@@ -525,14 +525,14 @@ public class TestTransactionLogAccess
             throws Exception
     {
         String tableName = "person";
-        File tempDir = Files.createTempDir();
+        File tempDir = Files.createTempDirectory(null).toFile();
         File tableDir = new File(tempDir, tableName);
         File transactionLogDir = new File(tableDir, TRANSACTION_LOG_DIRECTORY);
         transactionLogDir.mkdirs();
 
         File resourceDir = new File(getClass().getClassLoader().getResource("databricks/person/_delta_log").toURI());
         copyTransactionLogEntry(0, 12, resourceDir, transactionLogDir);
-        Files.copy(new File(resourceDir, LAST_CHECKPOINT_FILENAME), new File(transactionLogDir, LAST_CHECKPOINT_FILENAME));
+        Files.copy(new File(resourceDir, LAST_CHECKPOINT_FILENAME).toPath(), new File(transactionLogDir, LAST_CHECKPOINT_FILENAME).toPath());
 
         setupTransactionLogAccess(tableName, new Path(tableDir.toURI()));
         List<AddFileEntry> activeDataFiles = transactionLogAccess.getActiveFiles(tableSnapshot, SESSION);
@@ -582,14 +582,14 @@ public class TestTransactionLogAccess
             throws Exception
     {
         String tableName = "person";
-        File tempDir = Files.createTempDir();
+        File tempDir = Files.createTempDirectory(null).toFile();
         File tableDir = new File(tempDir, tableName);
         File transactionLogDir = new File(tableDir, TRANSACTION_LOG_DIRECTORY);
         transactionLogDir.mkdirs();
 
         File resourceDir = new File(getClass().getClassLoader().getResource("databricks/person/_delta_log").toURI());
         copyTransactionLogEntry(0, 12, resourceDir, transactionLogDir);
-        Files.copy(new File(resourceDir, LAST_CHECKPOINT_FILENAME), new File(transactionLogDir, LAST_CHECKPOINT_FILENAME));
+        Files.copy(new File(resourceDir, LAST_CHECKPOINT_FILENAME).toPath(), new File(transactionLogDir, LAST_CHECKPOINT_FILENAME).toPath());
 
         setupTransactionLogAccess(tableName, new Path(tableDir.toURI()));
         List<AddFileEntry> expectedDataFiles = transactionLogAccess.getActiveFiles(tableSnapshot, SESSION);
@@ -637,7 +637,7 @@ public class TestTransactionLogAccess
             throws Exception
     {
         String tableName = "person";
-        File tempDir = Files.createTempDir();
+        File tempDir = Files.createTempDirectory(null).toFile();
         File tableDir = new File(tempDir, tableName);
         File transactionLogDir = new File(tableDir, TRANSACTION_LOG_DIRECTORY);
         transactionLogDir.mkdirs();
@@ -800,10 +800,10 @@ public class TestTransactionLogAccess
         for (int i = startVersion; i < endVersion; i++) {
             if (i % 10 == 0 && i != 0) {
                 String checkpointFileName = format("%020d.checkpoint.parquet", i);
-                Files.copy(new File(sourceDir, checkpointFileName), new File(targetDir, checkpointFileName));
+                Files.copy(new File(sourceDir, checkpointFileName).toPath(), new File(targetDir, checkpointFileName).toPath());
             }
             String lastTransactionName = format("%020d.json", i);
-            Files.copy(new File(sourceDir, lastTransactionName), new File(targetDir, lastTransactionName));
+            Files.copy(new File(sourceDir, lastTransactionName).toPath(), new File(targetDir, lastTransactionName).toPath());
         }
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreStatistics.java
@@ -16,7 +16,6 @@ package io.trino.plugin.deltalake.metastore;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.io.Files;
 import com.google.common.io.Resources;
 import io.airlift.json.JsonCodecFactory;
 import io.trino.plugin.deltalake.DeltaLakeColumnHandle;
@@ -63,6 +62,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.time.LocalDate;
 import java.util.Map;
 import java.util.Optional;
@@ -95,6 +95,7 @@ public class TestDeltaLakeMetastoreStatistics
 
     @BeforeClass
     public void setupMetastore()
+            throws Exception
     {
         TestingConnectorContext context = new TestingConnectorContext();
         TypeManager typeManager = context.getTypeManager();
@@ -113,7 +114,7 @@ public class TestDeltaLakeMetastoreStatistics
                 hdfsEnvironment,
                 new ParquetReaderConfig());
 
-        File tmpDir = Files.createTempDir();
+        File tmpDir = Files.createTempDirectory(null).toFile();
         File metastoreDir = new File(tmpDir, "metastore");
         hiveMetastore = new FileHiveMetastore(
                 new NodeVersion("test_version"),

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaLakeGlueMetastore.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaLakeGlueMetastore.java
@@ -16,7 +16,6 @@ package io.trino.plugin.deltalake.metastore.glue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
-import com.google.common.io.Files;
 import com.google.common.io.Resources;
 import com.google.inject.Injector;
 import com.google.inject.Key;
@@ -56,6 +55,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -97,8 +97,9 @@ public class TestDeltaLakeGlueMetastore
 
     @BeforeClass
     public void setUp()
+            throws Exception
     {
-        tempDir = Files.createTempDir();
+        tempDir = Files.createTempDirectory(null).toFile();
         String temporaryLocation = tempDir.toURI().toString();
 
         Map<String, String> config = ImmutableMap.<String, String>builder()
@@ -265,8 +266,7 @@ public class TestDeltaLakeGlueMetastore
         File deltaTableLogLocation = new File(new File(new URI(deltaLakeTableLocation)), "_delta_log");
         verify(deltaTableLogLocation.mkdirs(), "mkdirs() on '%s' failed", deltaTableLogLocation);
         byte[] entry = Resources.toByteArray(Resources.getResource("deltalake/person/_delta_log/00000000000000000000.json"));
-        Files.asByteSink(new File(deltaTableLogLocation, "00000000000000000000.json"))
-                .write(entry);
+        Files.write(new File(deltaTableLogLocation, "00000000000000000000.json").toPath(), entry);
     }
 
     private String tableLocation(SchemaTableName tableName)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveLocal.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveLocal.java
@@ -15,7 +15,6 @@ package io.trino.plugin.hive;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.io.Files;
 import com.google.common.io.RecursiveDeleteOption;
 import com.google.common.reflect.ClassPath;
 import io.airlift.log.Logger;
@@ -46,6 +45,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -87,8 +87,9 @@ public abstract class AbstractTestHiveLocal
 
     @BeforeClass(alwaysRun = true)
     public void initialize()
+            throws Exception
     {
-        tempDir = Files.createTempDir();
+        tempDir = Files.createTempDirectory(null).toFile();
 
         HiveMetastore metastore = createMetastore(tempDir);
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -16,7 +16,6 @@ package io.trino.plugin.hive;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.io.Files;
 import io.airlift.json.JsonCodec;
 import io.airlift.json.JsonCodecFactory;
 import io.airlift.json.ObjectMapperProvider;
@@ -95,7 +94,6 @@ import static com.google.common.base.Throwables.getStackTraceAsString;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Sets.intersection;
-import static com.google.common.io.Files.asCharSink;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.trino.SystemSessionProperties.COLOCATED_JOIN;
@@ -151,6 +149,7 @@ import static java.lang.String.format;
 import static java.lang.String.join;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.createTempDirectory;
+import static java.nio.file.Files.writeString;
 import static java.util.Collections.nCopies;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
@@ -3856,7 +3855,7 @@ public abstract class BaseHiveConnectorTest
     {
         java.nio.file.Path tempDir = createTempDirectory(null);
         File dataFile = tempDir.resolve("test.txt").toFile();
-        Files.asCharSink(dataFile, UTF_8).write(fileContents);
+        writeString(dataFile.toPath(), fileContents);
 
         // Table properties
         StringJoiner propertiesSql = new StringJoiner(",\n   ");
@@ -7264,7 +7263,7 @@ public abstract class BaseHiveConnectorTest
                 "  \"fields\": [\n" +
                 "    { \"name\":\"string_col\", \"type\":\"string\" }\n" +
                 "]}";
-        asCharSink(schemaFile, UTF_8).write(schema);
+        writeString(schemaFile.toPath(), schema);
         return schemaFile;
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveBenchmarkQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveBenchmarkQueryRunner.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.hive;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.io.Files;
 import io.trino.Session;
 import io.trino.benchmark.BenchmarkSuite;
 import io.trino.plugin.hive.metastore.Database;
@@ -25,6 +24,7 @@ import io.trino.testing.LocalQueryRunner;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Map;
 import java.util.Optional;
 
@@ -42,7 +42,7 @@ public final class HiveBenchmarkQueryRunner
             throws IOException
     {
         String outputDirectory = requireNonNull(System.getProperty("outputDirectory"), "Must specify -DoutputDirectory=...");
-        File tempDir = Files.createTempDir();
+        File tempDir = Files.createTempDirectory(null).toFile();
         try (LocalQueryRunner localQueryRunner = createLocalQueryRunner(tempDir)) {
             new BenchmarkSuite(localQueryRunner, outputDirectory).runAllBenchmarks();
         }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSink.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSink.java
@@ -16,7 +16,6 @@ package io.trino.plugin.hive;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.io.Files;
 import io.airlift.json.JsonCodec;
 import io.airlift.slice.Slices;
 import io.trino.operator.GroupByHashPageIndexerFactory;
@@ -48,6 +47,7 @@ import org.apache.hadoop.fs.Path;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -106,7 +106,7 @@ public class TestHivePageSink
             throws Exception
     {
         HiveConfig config = new HiveConfig();
-        File tempDir = Files.createTempDir();
+        File tempDir = Files.createTempDirectory(null).toFile();
         try {
             HiveMetastore metastore = createTestingFileHiveMetastore(new File(tempDir, "metastore"));
             for (HiveStorageFormat format : HiveStorageFormat.values()) {

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
@@ -200,6 +200,7 @@ public class TestHiveGlueMetastore
     @BeforeClass(alwaysRun = true)
     @Override
     public void initialize()
+            throws Exception
     {
         super.initialize();
         // uncomment to get extra AWS debug information

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
@@ -16,7 +16,6 @@ package io.trino.plugin.hive.optimizer;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.io.Files;
 import io.trino.Session;
 import io.trino.cost.ScalarStatsCalculator;
 import io.trino.metadata.TableHandle;
@@ -61,6 +60,8 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.util.Optional;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
@@ -103,7 +104,13 @@ public class TestConnectorPushdownRulesWithHive
     @Override
     protected Optional<LocalQueryRunner> createLocalQueryRunner()
     {
-        baseDir = Files.createTempDir();
+        try {
+            baseDir = Files.createTempDirectory(null).toFile();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
         HdfsConfig config = new HdfsConfig();
         HdfsConfiguration configuration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(config), ImmutableSet.of());
         HdfsEnvironment environment = new HdfsEnvironment(configuration, config, new NoHdfsAuthentication());

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestHivePlans.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestHivePlans.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.hive.optimizer;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.io.Files;
 import io.trino.Session;
 import io.trino.plugin.hive.HdfsConfig;
 import io.trino.plugin.hive.HdfsConfiguration;
@@ -41,6 +40,9 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -80,7 +82,12 @@ public class TestHivePlans
     @Override
     protected LocalQueryRunner createLocalQueryRunner()
     {
-        baseDir = Files.createTempDir();
+        try {
+            baseDir = Files.createTempDirectory(null).toFile();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
         HdfsConfig config = new HdfsConfig();
         HdfsConfiguration configuration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(config), ImmutableSet.of());
         HdfsEnvironment environment = new HdfsEnvironment(configuration, config, new NoHdfsAuthentication());

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestHiveProjectionPushdownIntoTableScan.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestHiveProjectionPushdownIntoTableScan.java
@@ -16,7 +16,6 @@ package io.trino.plugin.hive.optimizer;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.io.Files;
 import io.trino.Session;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.TableHandle;
@@ -45,6 +44,9 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.util.Map;
 import java.util.Optional;
 
@@ -81,7 +83,12 @@ public class TestHiveProjectionPushdownIntoTableScan
     @Override
     protected LocalQueryRunner createLocalQueryRunner()
     {
-        baseDir = Files.createTempDir();
+        try {
+            baseDir = Files.createTempDirectory(null).toFile();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
         HdfsConfig config = new HdfsConfig();
         HdfsConfiguration configuration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(config), ImmutableSet.of());
         HdfsEnvironment environment = new HdfsEnvironment(configuration, config, new NoHdfsAuthentication());

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergProjectionPushdownPlans.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergProjectionPushdownPlans.java
@@ -16,7 +16,6 @@ package io.trino.plugin.iceberg;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.io.Files;
 import io.trino.Session;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.TableHandle;
@@ -32,6 +31,9 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -71,7 +73,12 @@ public class TestIcebergProjectionPushdownPlans
                 .setSchema(SCHEMA)
                 .build();
 
-        metastoreDir = Files.createTempDir();
+        try {
+            metastoreDir = Files.createTempDirectory(null).toFile();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
         HiveMetastore metastore = createTestingFileHiveMetastore(metastoreDir);
         LocalQueryRunner queryRunner = LocalQueryRunner.create(session);
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestMetadataQueryOptimization.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestMetadataQueryOptimization.java
@@ -15,7 +15,6 @@ package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.io.Files;
 import io.trino.Session;
 import io.trino.plugin.hive.metastore.Database;
 import io.trino.plugin.hive.metastore.HiveMetastore;
@@ -27,6 +26,9 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.util.Optional;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
@@ -53,7 +55,12 @@ public class TestMetadataQueryOptimization
                 .setSchema(SCHEMA_NAME)
                 .build();
 
-        baseDir = Files.createTempDir();
+        try {
+            baseDir = Files.createTempDirectory(null).toFile();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
         HiveMetastore metastore = createTestingFileHiveMetastore(baseDir);
         LocalQueryRunner queryRunner = LocalQueryRunner.create(session);
 

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/TestRaptorConnector.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/TestRaptorConnector.java
@@ -16,7 +16,6 @@ package io.trino.plugin.raptor.legacy;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.io.Files;
 import io.airlift.bootstrap.LifeCycleManager;
 import io.airlift.slice.Slice;
 import io.trino.operator.PagesIndex;
@@ -50,6 +49,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.Optional;
 
@@ -83,12 +83,13 @@ public class TestRaptorConnector
 
     @BeforeMethod
     public void setup()
+            throws Exception
     {
         Jdbi dbi = createTestingJdbi();
         dummyHandle = dbi.open();
         metadataDao = dbi.onDemand(MetadataDao.class);
         createTablesWithRetry(dbi);
-        dataDir = Files.createTempDir();
+        dataDir = Files.createTempDirectory(null).toFile();
 
         CatalogName connectorId = new CatalogName("test");
         NodeManager nodeManager = new TestingNodeManager();

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/TestRaptorPlugin.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/TestRaptorPlugin.java
@@ -14,13 +14,13 @@
 package io.trino.plugin.raptor.legacy;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.io.Files;
 import io.trino.spi.Plugin;
 import io.trino.spi.connector.ConnectorFactory;
 import io.trino.testing.TestingConnectorContext;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.Map;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
@@ -38,7 +38,7 @@ public class TestRaptorPlugin
         ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
         assertInstanceOf(factory, RaptorConnectorFactory.class);
 
-        File tmpDir = Files.createTempDir();
+        File tmpDir = Files.createTempDirectory(null).toFile();
         try {
             Map<String, String> config = ImmutableMap.<String, String>builder()
                     .put("metadata.db.type", "h2")

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/backup/AbstractTestBackupStore.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/backup/AbstractTestBackupStore.java
@@ -13,15 +13,14 @@
  */
 package io.trino.plugin.raptor.legacy.backup;
 
-import com.google.common.io.Files;
 import org.testng.annotations.Test;
 
 import java.io.File;
 import java.nio.file.Path;
 import java.util.UUID;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.readAllBytes;
+import static java.nio.file.Files.writeString;
 import static java.util.UUID.randomUUID;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -38,7 +37,7 @@ public abstract class AbstractTestBackupStore<T extends BackupStore>
     {
         // backup first file
         File file1 = temporary.resolve("file1").toFile();
-        Files.write("hello world", file1, UTF_8);
+        writeString(file1.toPath(), "hello world");
         UUID uuid1 = randomUUID();
 
         assertFalse(store.shardExists(uuid1));
@@ -47,7 +46,7 @@ public abstract class AbstractTestBackupStore<T extends BackupStore>
 
         // backup second file
         File file2 = temporary.resolve("file2").toFile();
-        Files.write("bye bye", file2, UTF_8);
+        writeString(file2.toPath(), "bye bye");
         UUID uuid2 = randomUUID();
 
         assertFalse(store.shardExists(uuid2));

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/backup/TestBackupManager.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/backup/TestBackupManager.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.raptor.legacy.backup;
 
-import com.google.common.io.Files;
 import io.trino.plugin.raptor.legacy.storage.BackupStats;
 import io.trino.plugin.raptor.legacy.storage.FileStorageService;
 import io.trino.spi.TrinoException;
@@ -37,8 +36,8 @@ import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.trino.plugin.raptor.legacy.RaptorErrorCode.RAPTOR_BACKUP_CORRUPTION;
 import static io.trino.plugin.raptor.legacy.RaptorErrorCode.RAPTOR_BACKUP_ERROR;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.createTempDirectory;
+import static java.nio.file.Files.writeString;
 import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -93,7 +92,7 @@ public class TestBackupManager
         List<UUID> uuids = new ArrayList<>(5);
         for (int i = 0; i < 5; i++) {
             File file = temporary.resolve("file" + i).toFile();
-            Files.write("hello world", file, UTF_8);
+            writeString(file.toPath(), "hello world");
             uuids.add(randomUUID());
 
             futures.add(backupManager.submit(uuids.get(i), file));
@@ -115,7 +114,7 @@ public class TestBackupManager
         assertBackupStats(0, 0, 0);
 
         File file = temporary.resolve("failure").toFile();
-        Files.write("hello world", file, UTF_8);
+        writeString(file.toPath(), "hello world");
 
         assertThatThrownBy(() -> backupManager.submit(FAILURE_UUID, file).get(10, SECONDS))
                 .isInstanceOfSatisfying(ExecutionException.class, wrapper -> {
@@ -136,7 +135,7 @@ public class TestBackupManager
         assertBackupStats(0, 0, 0);
 
         File file = temporary.resolve("corrupt").toFile();
-        Files.write("hello world", file, UTF_8);
+        writeString(file.toPath(), "hello world");
 
         assertThatThrownBy(() -> backupManager.submit(CORRUPTION_UUID, file).get(10, SECONDS))
                 .isInstanceOfSatisfying(ExecutionException.class, wrapper -> {

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/metadata/TestDatabaseShardManager.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/metadata/TestDatabaseShardManager.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
-import com.google.common.io.Files;
 import io.airlift.slice.Slice;
 import io.airlift.testing.TestingTicker;
 import io.airlift.units.Duration;
@@ -44,6 +43,7 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -103,11 +103,12 @@ public class TestDatabaseShardManager
 
     @BeforeMethod
     public void setup()
+            throws Exception
     {
         dbi = createTestingJdbi();
         dummyHandle = dbi.open();
         createTablesWithRetry(dbi);
-        dataDir = Files.createTempDir();
+        dataDir = Files.createTempDirectory(null).toFile();
         shardManager = createShardManager(dbi);
     }
 

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/TestShardRecovery.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/TestShardRecovery.java
@@ -44,9 +44,9 @@ import static io.trino.plugin.raptor.legacy.metadata.SchemaDaoUtil.createTablesW
 import static io.trino.plugin.raptor.legacy.metadata.TestDatabaseShardManager.createShardManager;
 import static io.trino.plugin.raptor.legacy.storage.RaptorStorageManager.xxhash64;
 import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.createTempDirectory;
 import static java.nio.file.Files.createTempFile;
+import static java.nio.file.Files.writeString;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -92,7 +92,6 @@ public class TestShardRecovery
         deleteRecursively(temporary, ALLOW_INSECURE);
     }
 
-    @SuppressWarnings("EmptyTryBlock")
     @Test
     public void testShardRecovery()
             throws Exception
@@ -101,7 +100,7 @@ public class TestShardRecovery
         File file = storageService.getStorageFile(shardUuid);
         File tempFile = createTempFile(temporary, "tmp", null).toFile();
 
-        Files.write("test data", tempFile, UTF_8);
+        writeString(tempFile.toPath(), "test data");
 
         backupStore.backupShard(shardUuid, tempFile);
         assertTrue(backupStore.shardExists(shardUuid));
@@ -123,7 +122,7 @@ public class TestShardRecovery
 
         // write data and backup
         File tempFile = createTempFile(temporary, "tmp", null).toFile();
-        Files.write("test data", tempFile, UTF_8);
+        writeString(tempFile.toPath(), "test data");
 
         backupStore.backupShard(shardUuid, tempFile);
         assertTrue(backupStore.shardExists(shardUuid));
@@ -135,7 +134,7 @@ public class TestShardRecovery
         File storageFile = storageService.getStorageFile(shardUuid);
         storageService.createParents(storageFile);
 
-        Files.write("bad data", storageFile, UTF_8);
+        writeString(storageFile.toPath(), "bad data");
 
         assertTrue(storageFile.exists());
         assertNotEquals(storageFile.length(), tempFile.length());
@@ -161,7 +160,7 @@ public class TestShardRecovery
 
         // write data and backup
         File tempFile = createTempFile(temporary, "tmp", null).toFile();
-        Files.write("test data", tempFile, UTF_8);
+        writeString(tempFile.toPath(), "test data");
 
         backupStore.backupShard(shardUuid, tempFile);
         assertTrue(backupStore.shardExists(shardUuid));
@@ -173,7 +172,7 @@ public class TestShardRecovery
         File storageFile = storageService.getStorageFile(shardUuid);
         storageService.createParents(storageFile);
 
-        Files.write("test xata", storageFile, UTF_8);
+        writeString(storageFile.toPath(), "test xata");
 
         assertTrue(storageFile.exists());
         assertEquals(storageFile.length(), tempFile.length());
@@ -201,7 +200,7 @@ public class TestShardRecovery
         File storageFile = storageService.getStorageFile(shardUuid);
         storageService.createParents(storageFile);
 
-        Files.write("test data", storageFile, UTF_8);
+        writeString(storageFile.toPath(), "test data");
 
         long size = storageFile.length();
         long xxhash64 = xxhash64(storageFile);
@@ -214,7 +213,7 @@ public class TestShardRecovery
         assertTrue(Files.equal(storageFile, backupFile));
 
         // corrupt backup file
-        Files.write("test xata", backupFile, UTF_8);
+        writeString(backupFile.toPath(), "test xata");
 
         assertTrue(backupFile.exists());
         assertEquals(storageFile.length(), backupFile.length());

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/organization/TestShardOrganizerUtil.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/organization/TestShardOrganizerUtil.java
@@ -16,7 +16,6 @@ package io.trino.plugin.raptor.legacy.storage.organization;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
-import com.google.common.io.Files;
 import io.trino.plugin.raptor.legacy.RaptorMetadata;
 import io.trino.plugin.raptor.legacy.metadata.ColumnInfo;
 import io.trino.plugin.raptor.legacy.metadata.ColumnStats;
@@ -36,6 +35,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -76,11 +76,12 @@ public class TestShardOrganizerUtil
 
     @BeforeMethod
     public void setup()
+            throws Exception
     {
         dbi = createTestingJdbi();
         dummyHandle = dbi.open();
         createTablesWithRetry(dbi);
-        dataDir = Files.createTempDir();
+        dataDir = Files.createTempDirectory(null).toFile();
 
         metadata = new RaptorMetadata(dbi, createShardManager(dbi));
 

--- a/testing/trino-plugin-reader/src/main/java/io/trino/server/PluginReader.java
+++ b/testing/trino-plugin-reader/src/main/java/io/trino/server/PluginReader.java
@@ -15,7 +15,6 @@ package io.trino.server;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteStreams;
-import com.google.common.io.Files;
 import io.airlift.log.Logger;
 import io.trino.spi.Plugin;
 import io.trino.spi.classloader.ThreadContextClassLoader;
@@ -31,6 +30,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
@@ -219,7 +219,7 @@ public class PluginReader
     private static Optional<List<String>> readImpactedModules(File gibImpactedModules)
     {
         try {
-            return Optional.of(Files.asCharSource(gibImpactedModules, UTF_8).readLines());
+            return Optional.of(Files.readAllLines(gibImpactedModules.toPath()));
         }
         catch (IOException e) {
             log.warn(e, "Couldn't read file %s", gibImpactedModules);

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/cli/TestTrinoCli.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/cli/TestTrinoCli.java
@@ -16,7 +16,6 @@ package io.trino.tests.product.cli;
 import com.google.common.base.CharMatcher;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.io.Files;
 import com.google.common.io.Resources;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
@@ -43,6 +42,7 @@ import static io.trino.tests.product.TestGroups.CLI;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.Files.writeString;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
@@ -151,7 +151,7 @@ public class TestTrinoCli
             throws Exception
     {
         try (TempFile file = new TempFile()) {
-            Files.write("select * from hive.default.nation;", file.file(), UTF_8);
+            writeString(file.path(), "select * from hive.default.nation;");
 
             launchTrinoCliWithRedirectedStdin(file.file());
             assertThat(trimLines(trino.readRemainingOutputLines())).containsAll(nationTableBatchLines);
@@ -164,7 +164,7 @@ public class TestTrinoCli
             throws Exception
     {
         try (TempFile file = new TempFile()) {
-            Files.write("select * from hive.default.nation;select 1;select 2", file.file(), UTF_8);
+            writeString(file.path(), "select * from hive.default.nation;select 1;select 2");
 
             launchTrinoCliWithRedirectedStdin(file.file());
 
@@ -239,7 +239,7 @@ public class TestTrinoCli
             throws Exception
     {
         try (TempFile file = new TempFile()) {
-            Files.write("select * from hive.default.nation;\n", file.file(), UTF_8);
+            writeString(file.path(), "select * from hive.default.nation;\n");
 
             launchTrinoCliWithServerArgument("--file", file.file().getAbsolutePath());
             assertThat(trimLines(trino.readRemainingOutputLines())).containsAll(nationTableBatchLines);
@@ -264,7 +264,7 @@ public class TestTrinoCli
             throws IOException
     {
         try (TempFile file = new TempFile()) {
-            Files.write("select * from hive.default.nations;\nselect * from hive.default.nation;\n", file.file(), UTF_8);
+            writeString(file.path(), "select * from hive.default.nations;\nselect * from hive.default.nation;\n");
 
             launchTrinoCliWithServerArgument("--file", file.file().getAbsolutePath());
             assertThat(trimLines(trino.readRemainingOutputLines())).isEmpty();
@@ -289,7 +289,7 @@ public class TestTrinoCli
             throws IOException
     {
         try (TempFile file = new TempFile()) {
-            Files.write("select * from hive.default.nations;\nselect * from hive.default.nation;\n", file.file(), UTF_8);
+            writeString(file.path(), "select * from hive.default.nations;\nselect * from hive.default.nation;\n");
 
             launchTrinoCliWithServerArgument("--file", file.file().getAbsolutePath(), "--ignore-errors", "true");
             assertThat(trimLines(trino.readRemainingOutputLines())).containsAll(nationTableBatchLines);
@@ -422,7 +422,7 @@ public class TestTrinoCli
 
         File tempFile = File.createTempFile(".trino_config", "");
         tempFile.deleteOnExit();
-        Files.write(fileContent.getBytes(UTF_8), tempFile);
+        writeString(tempFile.toPath(), fileContent);
 
         processBuilder.environment().put("TRINO_CONFIG", tempFile.getAbsolutePath());
         trino = new TrinoCliProcess(processBuilder.start());

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/cli/TestTrinoLdapCli.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/cli/TestTrinoLdapCli.java
@@ -14,7 +14,6 @@
 package io.trino.tests.product.cli;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.io.Files;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import io.trino.tempto.AfterTestWithContext;
@@ -26,6 +25,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
 
 import static io.trino.tempto.Requirements.compose;
@@ -52,7 +52,6 @@ import static io.trino.tests.product.TestGroups.LDAP_CLI;
 import static io.trino.tests.product.TestGroups.LDAP_MULTIPLE_BINDS;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static java.lang.String.format;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -137,7 +136,7 @@ public class TestTrinoLdapCli
     {
         File temporayFile = File.createTempFile("test-sql", null);
         temporayFile.deleteOnExit();
-        Files.write(SELECT_FROM_NATION + "\n", temporayFile, UTF_8);
+        Files.writeString(temporayFile.toPath(), SELECT_FROM_NATION + "\n");
 
         launchTrinoCliWithServerArgument("--file", temporayFile.getAbsolutePath());
         assertThat(trimLines(trino.readRemainingOutputLines())).containsAll(nationTableBatchLines);

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestQuerySpillLimits.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestQuerySpillLimits.java
@@ -14,7 +14,6 @@
 package io.trino.tests;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.io.Files;
 import io.airlift.units.DataSize;
 import io.trino.FeaturesConfig;
 import io.trino.Session;
@@ -27,6 +26,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.nio.file.Files;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
@@ -44,8 +44,9 @@ public class TestQuerySpillLimits
 
     @BeforeMethod
     public void setUp()
+            throws Exception
     {
-        this.spillPath = Files.createTempDir();
+        this.spillPath = Files.createTempDirectory(null).toFile();
     }
 
     @AfterMethod(alwaysRun = true)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
Google's Guava's `Files#createTempDir` and `Files.copy` and `Files.write` are all deprecated. This PR removes all usages of these deprecated methods.

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Refactoring

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Removal of deprecated method usages with appropriate replacements. No functional changes should manifest.

> How would you describe this change to a non-technical end user or system administrator?

Spring-cleaning ;-) 

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(:white_check_mark:) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(:white_check_mark:) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
