### PR TITLE
Suppress warnings for MD5 and SHA1 hashing function usages

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/VarbinaryFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/VarbinaryFunctions.java
@@ -13,6 +13,7 @@
  */
 package io.trino.operator.scalar;
 
+import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import com.google.common.io.BaseEncoding;
 import com.google.common.primitives.Ints;
@@ -300,7 +301,9 @@ public final class VarbinaryFunctions
     @SqlType(StandardTypes.VARBINARY)
     public static Slice md5(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
-        return computeHash(Hashing.md5(), slice);
+        @SuppressWarnings("deprecation")
+        HashFunction md5 = Hashing.md5();
+        return computeHash(md5, slice);
     }
 
     @Description("Compute sha1 hash")
@@ -308,7 +311,9 @@ public final class VarbinaryFunctions
     @SqlType(StandardTypes.VARBINARY)
     public static Slice sha1(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
-        return computeHash(Hashing.sha1(), slice);
+        @SuppressWarnings("deprecation")
+        HashFunction sha1 = Hashing.sha1();
+        return computeHash(sha1, slice);
     }
 
     @Description("Compute sha256 hash")

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/TestRaptorStorageManager.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/TestRaptorStorageManager.java
@@ -66,8 +66,6 @@ import java.util.OptionalLong;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import static com.google.common.hash.Hashing.md5;
-import static com.google.common.io.Files.hash;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
@@ -97,6 +95,7 @@ import static io.trino.testing.assertions.Assert.assertEquals;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static java.lang.String.format;
 import static java.nio.file.Files.createTempDirectory;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
@@ -626,9 +625,8 @@ public class TestRaptorStorageManager
     }
 
     private static void assertFileEquals(File actual, File expected)
-            throws IOException
     {
-        assertEquals(hash(actual, md5()), hash(expected, md5()));
+        assertThat(actual).hasSameBinaryContentAs(expected);
     }
 
     private static void assertColumnStats(List<ColumnStats> list, long columnId, Object min, Object max)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
Google Guava's `Hashing.md5()` and `Hashing.sha1()` are deprecated as insecure.
We use them to provide md5/sha1 functions, and therefore the usage is merited. 
This PR adds `@SuppressWarnings("deprecation")` to the necessary usages to avoid spurious deprecation warnings.

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Refactoring


> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Code change to suppress build warnings / no functional changes (apart from 1 test)

> How would you describe this change to a non-technical end user or system administrator?

Resolve build warnings

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(:white_check_mark:) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(:white_check_mark:) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
