### PR TITLE
Fix inaccurate references to prepared statement header

### DIFF
--- a/docs/src/main/sphinx/develop/client-protocol.rst
+++ b/docs/src/main/sphinx/develop/client-protocol.rst
@@ -244,13 +244,13 @@ subsequent requests to be consistent with the response headers received.
       in subsequent client requests.
   * - ``X-Trino-Added-Prepare``
     - Instructs the client to add the name=value pair to the set of
-      prepared statements in the ``X-Trino-Prepared-Statements``
+      prepared statements in the ``X-Trino-Prepared-Statement``
       request header in subsequent client requests.
   * - ``X-Trino-Deallocated-Prepare``
     - Instructs the client to remove the prepared statement whose name
       is the value of the ``X-Trino-Deallocated-Prepare`` header from
       the client's list of prepared statements sent in the
-      ``X-Trino-Prepared-Statements`` request header in subsequent client
+      ``X-Trino-Prepared-Statement`` request header in subsequent client
       requests.
   * - ``X-Trino-Started-Transaction-Id``
     - Provides the transaction ID that the client should pass back in the


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

The header here is X-Trino-Prepared-Statement, but a couple references say that it is X-Trino-Prepared-Statements, which is wrong. This fixes that.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Docs

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:
