### PR TITLE
Block update and delete operations from append only Delta Lake tables

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeSchemaSupport.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeSchemaSupport.java
@@ -63,6 +63,7 @@ public final class DeltaLakeSchemaSupport
 {
     private DeltaLakeSchemaSupport() {}
 
+    public static final String APPEND_ONLY_CONFIGURATION_KEY = "delta.appendOnly";
     // only non-parametrized types are stored here
     private static final Map<Type, String> PRIMITIVE_TYPE_MAPPING = ImmutableMap.<Type, String>builder()
             .put(BIGINT, "long")
@@ -77,6 +78,11 @@ public final class DeltaLakeSchemaSupport
             .buildOrThrow();
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapperProvider().get();
+
+    public static boolean isAppendOnly(MetadataEntry metadataEntry)
+    {
+        return Boolean.parseBoolean(metadataEntry.getConfiguration().getOrDefault(APPEND_ONLY_CONFIGURATION_KEY, "false"));
+    }
 
     public static List<DeltaLakeColumnHandle> extractPartitionColumns(MetadataEntry metadataEntry, TypeManager typeManager)
     {

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksDelete.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksDelete.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.deltalake;
+
+import org.testng.annotations.Test;
+
+import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
+import static io.trino.tempto.assertions.QueryAssert.assertThat;
+import static io.trino.tests.product.TestGroups.DELTA_LAKE_DATABRICKS;
+import static io.trino.tests.product.TestGroups.DELTA_LAKE_OSS;
+import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static io.trino.tests.product.hive.util.TemporaryHiveTable.randomTableSuffix;
+import static io.trino.tests.product.utils.QueryExecutors.onDelta;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
+
+public class TestDeltaLakeDatabricksDelete
+        extends BaseTestDeltaLakeS3Storage
+{
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_OSS, PROFILE_SPECIFIC_TESTS})
+    public void testDeleteOnAppendOnlyTableFails()
+    {
+        String tableName = "test_delete_on_append_only_table_fails_" + randomTableSuffix();
+        onDelta().executeQuery("" +
+                "CREATE TABLE default." + tableName +
+                "         (a INT, b INT)" +
+                "         USING delta " +
+                "         LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "' " +
+                "         TBLPROPERTIES ('delta.appendOnly' = true)");
+
+        onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES (1,11), (2, 12)");
+        assertQueryFailure(() -> onDelta().executeQuery("DELETE FROM default." + tableName + " WHERE a = 1"))
+                .hasMessageContaining("This table is configured to only allow appends");
+        assertQueryFailure(() -> onTrino().executeQuery("DELETE FROM default." + tableName + " WHERE a = 1"))
+                .hasMessageContaining("Cannot delete rows from a table with 'delta.appendOnly' set to true");
+
+        assertThat(onDelta().executeQuery("SELECT * FROM default." + tableName))
+                .containsOnly(row(1, 11), row(2, 12));
+        onTrino().executeQuery("DROP TABLE " + tableName);
+    }
+}


### PR DESCRIPTION
## Description

Delta tables have an `appendOnly` option which specified that table data cannot be updated or deleted. Delta Lake documentation for it is here: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#append-only-tables

> Is this change a fix, improvement, new feature, refactoring, or other?

New feature / fix. The connector has allowed writes to tables that require a minimum writer version 2, however this `appendOnly` field is part of the v2 specification: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#append-only-tables

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Delta lake connector

> How would you describe this change to a non-technical end user or system administrator?

Support for append only tables

## Related issues, pull requests, and links

Part of: https://github.com/trinodb/trino/issues/12635

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Delta Lake
* Respect the `appendOnly` field introduced in Delta Lake writer version 2. ({issue}`12635`)
```
