### PR TITLE
SPI extension to trigger initial refresh on MV creation

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -1220,6 +1220,44 @@ public interface ConnectorMetadata
     }
 
     /**
+     * Begin the creation of a materialized view with data.
+     */
+    default ConnectorInsertTableHandle beginCreateMaterializedView(
+            ConnectorSession session,
+            SchemaTableName viewName,
+            ConnectorMaterializedViewDefinition definition,
+            boolean replace,
+            boolean ignoreExisting,
+            List<ConnectorTableHandle> sourceTableHandles,
+            ConnectorTableMetadata storageTableMetadata,
+            Optional<ConnectorTableLayout> storageTableLayout,
+            RetryMode retryMode)
+    {
+        throw new TrinoException(GENERIC_INTERNAL_ERROR, "This connector does not support creating materialized views");
+    }
+
+    /**
+     * Finish the creation of a materialized view.
+     */
+    default Optional<ConnectorOutputMetadata> finishCreateMaterializedView(
+            ConnectorSession session,
+            ConnectorInsertTableHandle tableHandle,
+            Collection<Slice> fragments,
+            Collection<ComputedStatistics> computedStatistics,
+            List<ConnectorTableHandle> sourceTableHandles)
+    {
+        throw new TrinoException(GENERIC_INTERNAL_ERROR, "This connector does not support creating materialized views");
+    }
+
+    /**
+     * Returns the properties of storage table for materialized view
+     */
+    default Map<String, Object> getMaterializedViewStorageTableProperties(ConnectorSession session, Map<String, Object> materializedViewProperties)
+    {
+        throw new TrinoException(GENERIC_INTERNAL_ERROR, "This connector does not support creating materialized views");
+    }
+
+    /**
      * Drop the specified materialized view.
      */
     default void dropMaterializedView(ConnectorSession session, SchemaTableName viewName)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

New SPIs are introduced to support initial refresh on MV creation.

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

refactoring

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

SPI interface

> How would you describe this change to a non-technical end user or system administrator?

This change is for internal purpose yet.

## Related issues, pull requests, and links
https://github.com/trinodb/trino/issues/12466

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(O) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(O) No release notes entries required.
( ) Release notes entries required with the following suggested text:

