### PR TITLE
Improve exchange spooling file listing speed

### DIFF
--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeConfig.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeConfig.java
@@ -43,6 +43,7 @@ public class FileSystemExchangeConfig
     private DataSize exchangeSinkMaxFileSize = DataSize.of(1, GIGABYTE);
     private int exchangeSourceConcurrentReaders = 4;
     private int maxOutputPartitionCount = 50;
+    private int exchangeFileListingParallelism = 50;
 
     @NotNull
     @NotEmpty(message = "At least one base directory needs to be configured")
@@ -159,6 +160,20 @@ public class FileSystemExchangeConfig
     public FileSystemExchangeConfig setMaxOutputPartitionCount(int maxOutputPartitionCount)
     {
         this.maxOutputPartitionCount = maxOutputPartitionCount;
+        return this;
+    }
+
+    @Min(1)
+    public int getExchangeFileListingParallelism()
+    {
+        return exchangeFileListingParallelism;
+    }
+
+    @Config("exchange.file-listing-parallelism")
+    @ConfigDescription("Max parallelism of file listing calls when enumerating spooling files. The actual parallelism will depend on implementation")
+    public FileSystemExchangeConfig setExchangeFileListingParallelism(int exchangeFileListingParallelism)
+    {
+        this.exchangeFileListingParallelism = exchangeFileListingParallelism;
         return this;
     }
 }

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeManager.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeManager.java
@@ -61,6 +61,7 @@ public class FileSystemExchangeManager
     private final long exchangeSinkMaxFileSizeInBytes;
     private final int exchangeSourceConcurrentReaders;
     private final int maxOutputPartitionCount;
+    private final int exchangeFileListingParallelism;
     private final ExecutorService executor;
 
     @Inject
@@ -81,6 +82,7 @@ public class FileSystemExchangeManager
         this.exchangeSinkMaxFileSizeInBytes = fileSystemExchangeConfig.getExchangeSinkMaxFileSize().toBytes();
         this.exchangeSourceConcurrentReaders = fileSystemExchangeConfig.getExchangeSourceConcurrentReaders();
         this.maxOutputPartitionCount = fileSystemExchangeConfig.getMaxOutputPartitionCount();
+        this.exchangeFileListingParallelism = fileSystemExchangeConfig.getExchangeFileListingParallelism();
         this.executor = newCachedThreadPool(daemonThreadsNamed("exchange-source-handles-creation-%s"));
     }
 
@@ -110,6 +112,7 @@ public class FileSystemExchangeManager
                 stats,
                 context,
                 outputPartitionCount,
+                exchangeFileListingParallelism,
                 secretKey,
                 executor);
     }

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeStats.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeStats.java
@@ -20,7 +20,6 @@ import org.weakref.jmx.Nested;
 public class FileSystemExchangeStats
 {
     private final ExecutionStats createExchangeSourceHandles = new ExecutionStats();
-    private final ExecutionStats getCommittedAttemptPath = new ExecutionStats();
     private final ExecutionStats getCommittedPartitions = new ExecutionStats();
     private final ExecutionStats closeExchange = new ExecutionStats();
     private final ExecutionStats exchangeSinkBlocked = new ExecutionStats();
@@ -34,13 +33,6 @@ public class FileSystemExchangeStats
     public ExecutionStats getCreateExchangeSourceHandles()
     {
         return createExchangeSourceHandles;
-    }
-
-    @Managed
-    @Nested
-    public ExecutionStats getGetCommittedAttemptPath()
-    {
-        return getCommittedAttemptPath;
     }
 
     @Managed

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeStorage.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeStorage.java
@@ -32,15 +32,11 @@ public interface FileSystemExchangeStorage
 
     ExchangeStorageWriter createExchangeStorageWriter(URI file, Optional<SecretKey> secretKey);
 
-    boolean exists(URI file) throws IOException;
-
     ListenableFuture<Void> createEmptyFile(URI file);
 
     ListenableFuture<Void> deleteRecursively(List<URI> directories);
 
-    List<FileStatus> listFiles(URI dir) throws IOException;
-
-    List<URI> listDirectories(URI dir) throws IOException;
+    ListenableFuture<List<FileStatus>> listFilesRecursively(URI dir);
 
     int getWriteBufferSize();
 

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/s3/S3FileSystemExchangeStorageStats.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/s3/S3FileSystemExchangeStorageStats.java
@@ -20,11 +20,9 @@ import org.weakref.jmx.Nested;
 
 public class S3FileSystemExchangeStorageStats
 {
-    private final ExecutionStats headObject = new ExecutionStats();
     private final ExecutionStats createEmptyFile = new ExecutionStats();
+    private final ExecutionStats listFilesRecursively = new ExecutionStats();
     private final ExecutionStats deleteRecursively = new ExecutionStats();
-    private final ExecutionStats listFiles = new ExecutionStats();
-    private final ExecutionStats listDirectories = new ExecutionStats();
     private final ExecutionStats deleteObjects = new ExecutionStats();
     private final DistributionStat deleteObjectsEntriesCount = new DistributionStat();
     private final ExecutionStats getObject = new ExecutionStats();
@@ -40,13 +38,6 @@ public class S3FileSystemExchangeStorageStats
 
     @Managed
     @Nested
-    public ExecutionStats getHeadObject()
-    {
-        return headObject;
-    }
-
-    @Managed
-    @Nested
     public ExecutionStats getCreateEmptyFile()
     {
         return createEmptyFile;
@@ -54,23 +45,16 @@ public class S3FileSystemExchangeStorageStats
 
     @Managed
     @Nested
+    public ExecutionStats getListFilesRecursively()
+    {
+        return listFilesRecursively;
+    }
+
+    @Managed
+    @Nested
     public ExecutionStats getDeleteRecursively()
     {
         return deleteRecursively;
-    }
-
-    @Managed
-    @Nested
-    public ExecutionStats getListFiles()
-    {
-        return listFiles;
-    }
-
-    @Managed
-    @Nested
-    public ExecutionStats getListDirectories()
-    {
-        return listDirectories;
     }
 
     @Managed

--- a/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/TestFileSystemExchangeConfig.java
+++ b/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/TestFileSystemExchangeConfig.java
@@ -38,7 +38,8 @@ public class TestFileSystemExchangeConfig
                 .setExchangeSinkBuffersPerPartition(2)
                 .setExchangeSinkMaxFileSize(DataSize.of(1, GIGABYTE))
                 .setExchangeSourceConcurrentReaders(4)
-                .setMaxOutputPartitionCount(50));
+                .setMaxOutputPartitionCount(50)
+                .setExchangeFileListingParallelism(50));
     }
 
     @Test
@@ -53,6 +54,7 @@ public class TestFileSystemExchangeConfig
                 .put("exchange.sink-max-file-size", "2GB")
                 .put("exchange.source-concurrent-readers", "10")
                 .put("exchange.max-output-partition-count", "53")
+                .put("exchange.file-listing-parallelism", "20")
                 .buildOrThrow();
 
         FileSystemExchangeConfig expected = new FileSystemExchangeConfig()
@@ -63,7 +65,8 @@ public class TestFileSystemExchangeConfig
                 .setExchangeSinkBuffersPerPartition(3)
                 .setExchangeSinkMaxFileSize(DataSize.of(2, GIGABYTE))
                 .setExchangeSourceConcurrentReaders(10)
-                .setMaxOutputPartitionCount(53);
+                .setMaxOutputPartitionCount(53)
+                .setExchangeFileListingParallelism(20);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
1. Issue a single API call to list output files of all attempts instead of 3
2. Issue list commands concurrently (configurable)

Tested the new version on GCS. With 25 directories (and parallelism = 100), there is 12.5x improvement, file listing time improved from 1s to 0.08s

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

trino-exchange-filesystem

> How would you describe this change to a non-technical end user or system administrator?

This improves Trino's speed on enumeration of spooling files

## Related issues, pull requests, and links

https://github.com/trinodb/trino/issues/12615

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

() No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Section
* Improved exchange spooling file enumeration speed via reducing API calls and issuing API calls concurrently. ({issue}`12615`)
```
