### PR TITLE
Improve some default config values of fault-tolerant execution

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/QueryManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryManagerConfig.java
@@ -86,10 +86,10 @@ public class QueryManagerConfig
 
     private int maxTasksWaitingForNodePerStage = 5;
 
-    private DataSize faultTolerantExecutionTargetTaskInputSize = DataSize.of(1, GIGABYTE);
+    private DataSize faultTolerantExecutionTargetTaskInputSize = DataSize.of(4, GIGABYTE);
 
     private int faultTolerantExecutionMinTaskSplitCount = 16;
-    private int faultTolerantExecutionTargetTaskSplitCount = 16;
+    private int faultTolerantExecutionTargetTaskSplitCount = 64;
     private int faultTolerantExecutionMaxTaskSplitCount = 256;
     private DataSize faultTolerantExecutionTaskDescriptorStorageMaxMemory = DataSize.ofBytes(Math.round(AVAILABLE_HEAP_MEMORY * 0.15));
     private int faultTolerantExecutionPartitionCount = 50;

--- a/core/trino-main/src/main/java/io/trino/memory/MemoryManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/memory/MemoryManagerConfig.java
@@ -41,7 +41,7 @@ public class MemoryManagerConfig
     private DataSize maxQueryMemory = DataSize.of(20, GIGABYTE);
     // enforced against user + system memory allocations (default is maxQueryMemory * 2)
     private DataSize maxQueryTotalMemory;
-    private DataSize faultTolerantExecutionTaskMemory = DataSize.of(4, GIGABYTE);
+    private DataSize faultTolerantExecutionTaskMemory = DataSize.of(5, GIGABYTE);
     private double faultTolerantExecutionTaskMemoryGrowthFactor = 3.0;
     private double faultTolerantExecutionTaskMemoryEstimationQuantile = 0.9;
     private DataSize faultTolerantExecutionTaskRuntimeMemoryEstimationOverhead = DataSize.of(1, GIGABYTE);

--- a/core/trino-main/src/test/java/io/trino/execution/TestQueryManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestQueryManagerConfig.java
@@ -70,9 +70,9 @@ public class TestQueryManagerConfig
                 .setRetryMaxDelay(new Duration(1, MINUTES))
                 .setRetryDelayScaleFactor(2.0)
                 .setMaxTasksWaitingForNodePerStage(5)
-                .setFaultTolerantExecutionTargetTaskInputSize(DataSize.of(1, GIGABYTE))
+                .setFaultTolerantExecutionTargetTaskInputSize(DataSize.of(4, GIGABYTE))
                 .setFaultTolerantExecutionMinTaskSplitCount(16)
-                .setFaultTolerantExecutionTargetTaskSplitCount(16)
+                .setFaultTolerantExecutionTargetTaskSplitCount(64)
                 .setFaultTolerantExecutionMaxTaskSplitCount(256)
                 .setFaultTolerantExecutionTaskDescriptorStorageMaxMemory(DataSize.ofBytes(Math.round(AVAILABLE_HEAP_MEMORY * 0.15)))
                 .setFaultTolerantExecutionPartitionCount(50));

--- a/core/trino-main/src/test/java/io/trino/memory/TestMemoryManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/memory/TestMemoryManagerConfig.java
@@ -41,7 +41,7 @@ public class TestMemoryManagerConfig
                 .setKillOnOutOfMemoryDelay(new Duration(5, MINUTES))
                 .setMaxQueryMemory(DataSize.of(20, GIGABYTE))
                 .setMaxQueryTotalMemory(DataSize.of(40, GIGABYTE))
-                .setFaultTolerantExecutionTaskMemory(DataSize.of(4, GIGABYTE))
+                .setFaultTolerantExecutionTaskMemory(DataSize.of(5, GIGABYTE))
                 .setFaultTolerantExecutionTaskRuntimeMemoryEstimationOverhead(DataSize.of(1, GIGABYTE))
                 .setFaultTolerantExecutionTaskMemoryGrowthFactor(3.0)
                 .setFaultTolerantExecutionTaskMemoryEstimationQuantile(0.9));

--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
@@ -206,7 +206,7 @@ properties only apply to a ``TASK`` retry policy.
        May be overridden for the current session with the
        ``fault_tolerant_execution_target_task_input_size``
        :ref:`session property <session-properties-definition>`.
-     - ``1GB``
+     - ``4GB``
    * - ``fault-tolerant-execution-target-task-split-count``
      - Target number of standard :ref:`splits <trino-concept-splits>` processed
        by a single task that reads data from source tables. Value is interpreted
@@ -218,7 +218,7 @@ properties only apply to a ``TASK`` retry policy.
        May be overridden for the current session with the
        ``fault_tolerant_execution_target_task_split_count``
        :ref:`session property <session-properties-definition>`.
-     - ``16``
+     - ``64``
    * - ``fault-tolerant-execution-min-task-split-count``
      - Minimum number of :ref:`splits <trino-concept-splits>` processed by
        a single task. This value is not split weight-adjusted and serves as
@@ -264,7 +264,7 @@ applies to a ``TASK`` retry policy.
        for tasks. May be overridden for the current session with the
        ``fault_tolerant_execution_task_memory``
        :ref:`session property <session-properties-definition>`.
-     - ``4GB``
+     - ``5GB``
 
 Other tuning
 ^^^^^^^^^^^^


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Configs

> How would you describe this change to a non-technical end user or system administrator?

The new values were found better during our testing of batch workloads.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

() No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Section
* Improve execution performance by updating default values for configuration options related to task sizing 
when fault-tolerant execution is used (`retry_mode` is set to `TASK`).
```
