### PR TITLE
Switch from deprecated md5 to murmur3_128 hashing in RowToRowCast

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/RowToRowCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/RowToRowCast.java
@@ -163,13 +163,13 @@ public class RowToRowCast
 
         CallSiteBinder binder = new CallSiteBinder();
 
-        // Embed the MD5 hash code of input and output types into the generated class name instead of the raw type names,
-        // which could prevent the class name from hitting the length limitation and invalid characters.
-        byte[] md5Suffix = Hashing.md5().hashBytes((fromType + "$" + toType).getBytes(UTF_8)).asBytes();
+        // Embed the hash code of input and output types into the generated class name instead of the raw type names,
+        // which ensures the class name does not hit the length limitation or invalid characters.
+        byte[] hashSuffix = Hashing.goodFastHash(128).hashBytes((fromType + "$" + toType).getBytes(UTF_8)).asBytes();
 
         ClassDefinition definition = new ClassDefinition(
                 a(PUBLIC, FINAL),
-                makeClassName(Joiner.on("$").join("RowCast", BaseEncoding.base16().encode(md5Suffix))),
+                makeClassName(Joiner.on("$").join("RowCast", BaseEncoding.base16().encode(hashSuffix))),
                 type(Object.class));
 
         Parameter session = arg("session", ConnectorSession.class);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
Follow-up from https://github.com/trinodb/trino/pull/12631
Switch from deprecated md5 to mumur3_128 hashing in RowToRowCast when generating class names.

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Refactoring

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core

> How would you describe this change to a non-technical end user or system administrator?

Switching usages of deprecated hashing algorithm to preferred alternative

## Related issues, pull requests, and links

https://github.com/trinodb/trino/pull/12631

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(:white_check_mark:) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(:white_check_mark:) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
