### PR TITLE
Use byte arrays for encoding short decimals in native hive parquet writer

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetSchemaConverter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetSchemaConverter.java
@@ -50,6 +50,7 @@ import static io.trino.spi.type.StandardTypes.ROW;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.decimalType;
 import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
 
 public class ParquetSchemaConverter
@@ -104,22 +105,19 @@ public class ParquetSchemaConverter
             DecimalType decimalType = (DecimalType) type;
             if (decimalType.getPrecision() <= 9) {
                 return Types.optional(PrimitiveType.PrimitiveTypeName.INT32)
-                        .as(OriginalType.DECIMAL)
-                        .precision(decimalType.getPrecision())
-                        .scale(decimalType.getScale()).named(name);
+                        .as(decimalType(decimalType.getScale(), decimalType.getPrecision()))
+                        .named(name);
             }
             else if (decimalType.isShort()) {
                 return Types.optional(PrimitiveType.PrimitiveTypeName.INT64)
-                        .as(OriginalType.DECIMAL)
-                        .precision(decimalType.getPrecision())
-                        .scale(decimalType.getScale()).named(name);
+                        .as(decimalType(decimalType.getScale(), decimalType.getPrecision()))
+                        .named(name);
             }
             else {
                 return Types.optional(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
                         .length(16)
-                        .as(OriginalType.DECIMAL)
-                        .precision(decimalType.getPrecision())
-                        .scale(decimalType.getScale()).named(name);
+                        .as(decimalType(decimalType.getScale(), decimalType.getPrecision()))
+                        .named(name);
             }
         }
         if (DATE.equals(type)) {

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriters.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriters.java
@@ -18,8 +18,11 @@ import io.trino.parquet.writer.valuewriter.BigintValueWriter;
 import io.trino.parquet.writer.valuewriter.BinaryValueWriter;
 import io.trino.parquet.writer.valuewriter.BooleanValueWriter;
 import io.trino.parquet.writer.valuewriter.DateValueWriter;
-import io.trino.parquet.writer.valuewriter.DecimalValueWriter;
 import io.trino.parquet.writer.valuewriter.DoubleValueWriter;
+import io.trino.parquet.writer.valuewriter.FixedLenByteArrayLongDecimalValueWriter;
+import io.trino.parquet.writer.valuewriter.FixedLenByteArrayShortDecimalValueWriter;
+import io.trino.parquet.writer.valuewriter.Int32ShortDecimalValueWriter;
+import io.trino.parquet.writer.valuewriter.Int64ShortDecimalValueWriter;
 import io.trino.parquet.writer.valuewriter.IntegerValueWriter;
 import io.trino.parquet.writer.valuewriter.PrimitiveValueWriter;
 import io.trino.parquet.writer.valuewriter.RealValueWriter;
@@ -70,6 +73,8 @@ import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 
 final class ParquetWriters
 {
@@ -179,7 +184,16 @@ final class ParquetWriters
             return new BigintValueWriter(valuesWriter, type, parquetType);
         }
         if (type instanceof DecimalType) {
-            return new DecimalValueWriter(valuesWriter, type, parquetType);
+            if (parquetType.getPrimitiveTypeName() == INT32) {
+                return new Int32ShortDecimalValueWriter(valuesWriter, type, parquetType);
+            }
+            if (parquetType.getPrimitiveTypeName() == INT64) {
+                return new Int64ShortDecimalValueWriter(valuesWriter, type, parquetType);
+            }
+            if (((DecimalType) type).isShort()) {
+                return new FixedLenByteArrayShortDecimalValueWriter(valuesWriter, type, parquetType);
+            }
+            return new FixedLenByteArrayLongDecimalValueWriter(valuesWriter, type, parquetType);
         }
         if (DATE.equals(type)) {
             return new DateValueWriter(valuesWriter, parquetType);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/DecimalValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/DecimalValueWriter.java
@@ -73,14 +73,16 @@ public class DecimalValueWriter
 
     private byte[] paddingBigInteger(BigInteger bigInteger)
     {
-        byte[] result = new byte[getTypeLength()];
-        if (bigInteger.signum() < 0) {
-            Arrays.fill(result, (byte) 0xFF);
-        }
+        int numBytes = getTypeLength();
         byte[] bytes = bigInteger.toByteArray();
-        for (int i = bytes.length - 1, j = result.length - 1; i >= 0; --i, --j) {
-            result[j] = bytes[i];
+        if (bytes.length == numBytes) {
+            return bytes;
         }
+        byte[] result = new byte[numBytes];
+        if (bigInteger.signum() < 0) {
+            Arrays.fill(result, 0, numBytes - bytes.length, (byte) 0xFF);
+        }
+        System.arraycopy(bytes, 0, result, numBytes - bytes.length, bytes.length);
         return result;
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/FixedLenByteArrayShortDecimalValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/FixedLenByteArrayShortDecimalValueWriter.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.writer.valuewriter;
+
+import io.trino.spi.block.Block;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Type;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.PrimitiveType;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class FixedLenByteArrayShortDecimalValueWriter
+        extends PrimitiveValueWriter
+{
+    private final DecimalType decimalType;
+
+    public FixedLenByteArrayShortDecimalValueWriter(ValuesWriter valuesWriter, Type type, PrimitiveType parquetType)
+    {
+        super(parquetType, valuesWriter);
+        this.decimalType = (DecimalType) requireNonNull(type, "type is null");
+        checkArgument(this.decimalType.isShort(), "type is not a short decimal");
+        checkArgument(
+                parquetType.getTypeLength() > 0 && parquetType.getTypeLength() <= Long.BYTES,
+                "Type length %s must be in range 1-%s",
+                parquetType.getTypeLength(),
+                Long.BYTES);
+    }
+
+    @Override
+    public void write(Block block)
+    {
+        for (int i = 0; i < block.getPositionCount(); i++) {
+            if (!block.isNull(i)) {
+                long value = decimalType.getLong(block, i);
+                Binary binary = Binary.fromConstantByteArray(paddingLong(value));
+                getValueWriter().writeBytes(binary);
+                getStatistics().updateStats(binary);
+            }
+        }
+    }
+
+    private byte[] paddingLong(long unscaledValue)
+    {
+        int numBytes = getTypeLength();
+        byte[] result = new byte[numBytes];
+        switch (numBytes) {
+            case 1:
+                result[0] = (byte) unscaledValue;
+                break;
+            case 2:
+                result[0] = (byte) (unscaledValue >> 8);
+                result[1] = (byte) unscaledValue;
+                break;
+            case 3:
+                result[0] = (byte) (unscaledValue >> 16);
+                result[1] = (byte) (unscaledValue >> 8);
+                result[2] = (byte) unscaledValue;
+                break;
+            case 4:
+                result[0] = (byte) (unscaledValue >> 24);
+                result[1] = (byte) (unscaledValue >> 16);
+                result[2] = (byte) (unscaledValue >> 8);
+                result[3] = (byte) unscaledValue;
+                break;
+            case 5:
+                result[0] = (byte) (unscaledValue >> 32);
+                result[1] = (byte) (unscaledValue >> 24);
+                result[2] = (byte) (unscaledValue >> 16);
+                result[3] = (byte) (unscaledValue >> 8);
+                result[4] = (byte) unscaledValue;
+                break;
+            case 6:
+                result[0] = (byte) (unscaledValue >> 40);
+                result[1] = (byte) (unscaledValue >> 32);
+                result[2] = (byte) (unscaledValue >> 24);
+                result[3] = (byte) (unscaledValue >> 16);
+                result[4] = (byte) (unscaledValue >> 8);
+                result[5] = (byte) unscaledValue;
+                break;
+            case 7:
+                result[0] = (byte) (unscaledValue >> 48);
+                result[1] = (byte) (unscaledValue >> 40);
+                result[2] = (byte) (unscaledValue >> 32);
+                result[3] = (byte) (unscaledValue >> 24);
+                result[4] = (byte) (unscaledValue >> 16);
+                result[5] = (byte) (unscaledValue >> 8);
+                result[6] = (byte) unscaledValue;
+                break;
+            case 8:
+                result[0] = (byte) (unscaledValue >> 56);
+                result[1] = (byte) (unscaledValue >> 48);
+                result[2] = (byte) (unscaledValue >> 40);
+                result[3] = (byte) (unscaledValue >> 32);
+                result[4] = (byte) (unscaledValue >> 24);
+                result[5] = (byte) (unscaledValue >> 16);
+                result[6] = (byte) (unscaledValue >> 8);
+                result[7] = (byte) unscaledValue;
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid number of bytes: " + numBytes);
+        }
+        return result;
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/Int32ShortDecimalValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/Int32ShortDecimalValueWriter.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.writer.valuewriter;
+
+import io.trino.spi.block.Block;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Type;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.schema.PrimitiveType;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+
+public class Int32ShortDecimalValueWriter
+        extends PrimitiveValueWriter
+{
+    private final DecimalType decimalType;
+
+    public Int32ShortDecimalValueWriter(ValuesWriter valuesWriter, Type type, PrimitiveType parquetType)
+    {
+        super(parquetType, valuesWriter);
+        this.decimalType = (DecimalType) requireNonNull(type, "type is null");
+        checkArgument(this.decimalType.getPrecision() <= 9, "decimalType precision %s must be <= 9", this.decimalType.getPrecision());
+    }
+
+    @Override
+    public void write(Block block)
+    {
+        for (int i = 0; i < block.getPositionCount(); i++) {
+            if (!block.isNull(i)) {
+                int value = toIntExact(decimalType.getLong(block, i));
+                getValueWriter().writeInteger(value);
+                getStatistics().updateStats(value);
+            }
+        }
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/Int64ShortDecimalValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/Int64ShortDecimalValueWriter.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.writer.valuewriter;
+
+import io.trino.spi.block.Block;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Type;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.schema.PrimitiveType;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class Int64ShortDecimalValueWriter
+        extends PrimitiveValueWriter
+{
+    private final DecimalType decimalType;
+
+    public Int64ShortDecimalValueWriter(ValuesWriter valuesWriter, Type type, PrimitiveType parquetType)
+    {
+        super(parquetType, valuesWriter);
+        this.decimalType = (DecimalType) requireNonNull(type, "type is null");
+        checkArgument(this.decimalType.isShort(), "type is not a short decimal");
+    }
+
+    @Override
+    public void write(Block block)
+    {
+        for (int i = 0; i < block.getPositionCount(); i++) {
+            if (!block.isNull(i)) {
+                long value = decimalType.getLong(block, i);
+                getValueWriter().writeLong(value);
+                getStatistics().updateStats(value);
+            }
+        }
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetSchemaConverter.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetSchemaConverter.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.writer;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.parquet.schema.PrimitiveType;
+import org.testng.annotations.Test;
+
+import java.math.BigInteger;
+
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.Decimals.MAX_PRECISION;
+import static io.trino.spi.type.Decimals.MAX_SHORT_PRECISION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestParquetSchemaConverter
+{
+    @Test
+    public void testDecimalTypeLength()
+    {
+        for (int precision = 1; precision <= MAX_PRECISION; precision++) {
+            ParquetSchemaConverter schemaConverter = new ParquetSchemaConverter(
+                    ImmutableList.of(createDecimalType(precision)),
+                    ImmutableList.of("test"));
+            PrimitiveType primitiveType = schemaConverter.getMessageType().getType(0).asPrimitiveType();
+            if (precision <= 9) {
+                assertThat(primitiveType.getPrimitiveTypeName())
+                        .isEqualTo(PrimitiveType.PrimitiveTypeName.INT32);
+            }
+            else if (precision <= MAX_SHORT_PRECISION) {
+                assertThat(primitiveType.getPrimitiveTypeName())
+                        .isEqualTo(PrimitiveType.PrimitiveTypeName.INT64);
+            }
+            else {
+                assertThat(primitiveType.getPrimitiveTypeName())
+                        .isEqualTo(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY);
+                assertThat(primitiveType.getTypeLength()).isBetween(9, 16);
+                BigInteger bigInteger = new BigInteger("9".repeat(precision));
+                assertThat(bigInteger.toByteArray().length).isEqualTo(primitiveType.getTypeLength());
+            }
+        }
+    }
+}

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSink.java
@@ -468,7 +468,7 @@ public class DeltaLakePageSink
                 identityMapping[i] = i;
             }
 
-            ParquetSchemaConverter schemaConverter = new ParquetSchemaConverter(parquetTypes, dataColumnNames);
+            ParquetSchemaConverter schemaConverter = new ParquetSchemaConverter(parquetTypes, dataColumnNames, false);
             return new ParquetFileWriter(
                     fileSystem.create(path),
                     rollbackAction,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriterFactory.java
@@ -43,6 +43,7 @@ import java.util.OptionalInt;
 import java.util.Properties;
 import java.util.concurrent.Callable;
 
+import static io.trino.parquet.writer.ParquetSchemaConverter.HIVE_PARQUET_USE_LEGACY_DECIMAL_ENCODING;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITER_OPEN_ERROR;
 import static io.trino.plugin.hive.HiveSessionProperties.getTimestampPrecision;
 import static io.trino.plugin.hive.util.HiveUtil.getColumnNames;
@@ -114,7 +115,7 @@ public class ParquetFileWriterFactory
                 return null;
             };
 
-            ParquetSchemaConverter schemaConverter = new ParquetSchemaConverter(fileColumnTypes, fileColumnNames);
+            ParquetSchemaConverter schemaConverter = new ParquetSchemaConverter(fileColumnTypes, fileColumnNames, HIVE_PARQUET_USE_LEGACY_DECIMAL_ENCODING);
 
             return Optional.of(new ParquetFileWriter(
                     fileSystem.create(path, false),

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetWriterConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetWriterConfig.java
@@ -68,15 +68,6 @@ public class ParquetWriterConfig
         return this;
     }
 
-    public ParquetWriterOptions toParquetWriterOptions()
-    {
-        return ParquetWriterOptions.builder()
-                .setMaxBlockSize(getBlockSize())
-                .setMaxPageSize(getPageSize())
-                .setBatchSize(getBatchSize())
-                .build();
-    }
-
     @Config("parquet.writer.batch-size")
     @ConfigDescription("Maximum number of rows passed to the writer in each batch")
     public ParquetWriterConfig setBatchSize(int batchSize)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/StandardFileFormats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/StandardFileFormats.java
@@ -55,6 +55,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static io.trino.orc.OrcWriteValidation.OrcWriteValidationMode.BOTH;
+import static io.trino.parquet.writer.ParquetSchemaConverter.HIVE_PARQUET_USE_LEGACY_DECIMAL_ENCODING;
 import static io.trino.plugin.hive.HiveTestUtils.createGenericHiveRecordCursorProvider;
 import static io.trino.plugin.hive.benchmark.AbstractFileFormat.createSchema;
 import static io.trino.plugin.hive.metastore.StorageFormat.fromHiveStorageFormat;
@@ -298,7 +299,7 @@ public final class StandardFileFormats
         public PrestoParquetFormatWriter(File targetFile, List<String> columnNames, List<Type> types, HiveCompressionCodec compressionCodec)
                 throws IOException
         {
-            ParquetSchemaConverter schemaConverter = new ParquetSchemaConverter(types, columnNames);
+            ParquetSchemaConverter schemaConverter = new ParquetSchemaConverter(types, columnNames, HIVE_PARQUET_USE_LEGACY_DECIMAL_ENCODING);
 
             writer = new ParquetWriter(
                     new FileOutputStream(targetFile),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetTester.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetTester.java
@@ -98,6 +98,7 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.Iterables.transform;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
+import static io.trino.parquet.writer.ParquetSchemaConverter.HIVE_PARQUET_USE_LEGACY_DECIMAL_ENCODING;
 import static io.trino.plugin.hive.AbstractTestHiveFileFormats.getFieldFromCursor;
 import static io.trino.plugin.hive.HiveSessionProperties.getParquetMaxReadBlockSize;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
@@ -722,7 +723,7 @@ public class ParquetTester
             throws Exception
     {
         checkArgument(types.size() == columnNames.size() && types.size() == values.length);
-        ParquetSchemaConverter schemaConverter = new ParquetSchemaConverter(types, columnNames);
+        ParquetSchemaConverter schemaConverter = new ParquetSchemaConverter(types, columnNames, HIVE_PARQUET_USE_LEGACY_DECIMAL_ENCODING);
         ParquetWriter writer = new ParquetWriter(
                 new FileOutputStream(outputFile),
                 schemaConverter.getMessageType(),


### PR DESCRIPTION
## Description

Apache Hive fails to read short decimals encoded as INT32/INT64 by the optimized parquet hive writer in Trino.
This PR changes the native writer to use fixed length byte arrays for encoding short decimals when writing parquet files in hive connector. This makes the output readable by Apache Hive.

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Parquet writer
> How would you describe this change to a non-technical end user or system administrator?

Makes output of optimized parquet writer for short decimals compatible with Apache Hive.

## Related issues, pull requests, and links

https://github.com/trinodb/trino/issues/6377
https://github.com/trinodb/trino/issues/10486

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Section
* Fixes compatibility of files produced by optimized parquet writer for short decimal columns in Trino hive connnector with Apache Hive. ({issue}`12658`)
```
