### PR TITLE
Implementation of new MV SPIs for Iceberg connector

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -1220,6 +1220,44 @@ public interface ConnectorMetadata
     }
 
     /**
+     * Begin the creation of a materialized view with data.
+     */
+    default ConnectorInsertTableHandle beginCreateMaterializedView(
+            ConnectorSession session,
+            SchemaTableName viewName,
+            ConnectorMaterializedViewDefinition definition,
+            boolean replace,
+            boolean ignoreExisting,
+            List<ConnectorTableHandle> sourceTableHandles,
+            ConnectorTableMetadata storageTableMetadata,
+            Optional<ConnectorTableLayout> storageTableLayout,
+            RetryMode retryMode)
+    {
+        throw new TrinoException(GENERIC_INTERNAL_ERROR, "This connector does not support creating materialized views");
+    }
+
+    /**
+     * Finish the creation of a materialized view.
+     */
+    default Optional<ConnectorOutputMetadata> finishCreateMaterializedView(
+            ConnectorSession session,
+            ConnectorInsertTableHandle tableHandle,
+            Collection<Slice> fragments,
+            Collection<ComputedStatistics> computedStatistics,
+            List<ConnectorTableHandle> sourceTableHandles)
+    {
+        throw new TrinoException(GENERIC_INTERNAL_ERROR, "This connector does not support creating materialized views");
+    }
+
+    /**
+     * Returns the properties of storage table for materialized view
+     */
+    default Map<String, Object> getMaterializedViewStorageTableProperties(ConnectorSession session, Map<String, Object> materializedViewProperties)
+    {
+        throw new TrinoException(GENERIC_INTERNAL_ERROR, "This connector does not support creating materialized views");
+    }
+
+    /**
      * Drop the specified materialized view.
      */
     default void dropMaterializedView(ConnectorSession session, SchemaTableName viewName)

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -914,6 +914,44 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public ConnectorInsertTableHandle beginCreateMaterializedView(
+            ConnectorSession session,
+            SchemaTableName viewName,
+            ConnectorMaterializedViewDefinition definition,
+            boolean replace,
+            boolean ignoreExisting,
+            List<ConnectorTableHandle> sourceTableHandles,
+            ConnectorTableMetadata storageTableMetadata,
+            Optional<ConnectorTableLayout> storageTableLayout,
+            RetryMode retryMode)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.beginCreateMaterializedView(session, viewName, definition, replace, ignoreExisting, sourceTableHandles, storageTableMetadata, storageTableLayout, retryMode);
+        }
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishCreateMaterializedView(
+            ConnectorSession session,
+            ConnectorInsertTableHandle tableHandle,
+            Collection<Slice> fragments,
+            Collection<ComputedStatistics> computedStatistics,
+            List<ConnectorTableHandle> sourceTableHandles)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.finishCreateMaterializedView(session, tableHandle, fragments, computedStatistics, sourceTableHandles);
+        }
+    }
+
+    @Override
+    public Map<String, Object> getMaterializedViewStorageTableProperties(ConnectorSession session, Map<String, Object> materializedViewProperties)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getMaterializedViewStorageTableProperties(session, materializedViewProperties);
+        }
+    }
+
+    @Override
     public void dropMaterializedView(ConnectorSession session, SchemaTableName viewName)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -641,7 +641,16 @@ public class IcebergMetadata
     @Override
     public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
-        IcebergWritableTableHandle table = (IcebergWritableTableHandle) insertHandle;
+        return finishInsertInternal(session, (IcebergWritableTableHandle) insertHandle, fragments, ImmutableList.of(), false);
+    }
+
+    private Optional<ConnectorOutputMetadata> finishInsertInternal(
+            ConnectorSession session,
+            IcebergWritableTableHandle table,
+            Collection<Slice> fragments,
+            List<ConnectorTableHandle> sourceTableHandles,
+            boolean useFastAppend)
+    {
         Table icebergTable = transaction.table();
 
         List<CommitTaskData> commitTasks = fragments.stream()
@@ -653,7 +662,7 @@ public class IcebergMetadata
                         icebergTable.schema().findType(field.sourceId())))
                 .toArray(Type[]::new);
 
-        AppendFiles appendFiles = transaction.newAppend();
+        AppendFiles appendFiles = useFastAppend ? transaction.newFastAppend() : transaction.newAppend();
         ImmutableSet.Builder<String> writtenFiles = ImmutableSet.builder();
         for (CommitTaskData task : commitTasks) {
             DataFiles.Builder builder = DataFiles.builder(icebergTable.spec())
@@ -675,6 +684,16 @@ public class IcebergMetadata
         // try to leave as little garbage as possible behind
         if (table.getRetryMode() != NO_RETRIES) {
             cleanExtraOutputFiles(session, writtenFiles.build());
+        }
+
+        String dependencies = sourceTableHandles.stream()
+                .map(handle -> (IcebergTableHandle) handle)
+                .filter(handle -> handle.getSnapshotId().isPresent())
+                .map(handle -> handle.getSchemaTableName() + "=" + handle.getSnapshotId().get())
+                .distinct()
+                .collect(joining(","));
+        if (!dependencies.isEmpty()) {
+            appendFiles.set(DEPENDS_ON_TABLES, dependencies);
         }
 
         appendFiles.commit();
@@ -1820,6 +1839,40 @@ public class IcebergMetadata
     }
 
     @Override
+    public ConnectorInsertTableHandle beginCreateMaterializedView(
+            ConnectorSession session,
+            SchemaTableName viewName,
+            ConnectorMaterializedViewDefinition definition,
+            boolean replace,
+            boolean ignoreExisting,
+            List<ConnectorTableHandle> sourceTableHandles,
+            ConnectorTableMetadata storageTableMetadata,
+            Optional<ConnectorTableLayout> storageTableLayout,
+            RetryMode retryMode)
+    {
+        catalog.createMaterializedViewWithStorageTableMetadata(session, viewName, definition, replace, ignoreExisting, storageTableMetadata);
+        IcebergTableHandle table = getTableHandle(session, storageTableMetadata.getTable());
+        return beginRefreshMaterializedView(session, table, sourceTableHandles, retryMode);
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishCreateMaterializedView(
+            ConnectorSession session,
+            ConnectorInsertTableHandle tableHandle,
+            Collection<Slice> fragments,
+            Collection<ComputedStatistics> computedStatistics,
+            List<ConnectorTableHandle> sourceTableHandles)
+    {
+        return finishInsertInternal(session, (IcebergWritableTableHandle) tableHandle, fragments, sourceTableHandles, true);
+    }
+
+    @Override
+    public Map<String, Object> getMaterializedViewStorageTableProperties(ConnectorSession session, Map<String, Object> materializedViewProperties)
+    {
+        return catalog.getMaterializedViewStorageTableProperties(materializedViewProperties);
+    }
+
+    @Override
     public void dropMaterializedView(ConnectorSession session, SchemaTableName viewName)
     {
         catalog.dropMaterializedView(session, viewName);
@@ -1863,58 +1916,7 @@ public class IcebergMetadata
         // delete before insert .. simulating overwrite
         executeDelete(session, tableHandle);
 
-        IcebergWritableTableHandle table = (IcebergWritableTableHandle) insertHandle;
-
-        Table icebergTable = transaction.table();
-        List<CommitTaskData> commitTasks = fragments.stream()
-                .map(slice -> commitTaskCodec.fromJson(slice.getBytes()))
-                .collect(toImmutableList());
-
-        Type[] partitionColumnTypes = icebergTable.spec().fields().stream()
-                .map(field -> field.transform().getResultType(
-                        icebergTable.schema().findType(field.sourceId())))
-                .toArray(Type[]::new);
-
-        AppendFiles appendFiles = transaction.newFastAppend();
-        ImmutableSet.Builder<String> writtenFiles = ImmutableSet.builder();
-        for (CommitTaskData task : commitTasks) {
-            DataFiles.Builder builder = DataFiles.builder(icebergTable.spec())
-                    .withPath(task.getPath())
-                    .withFileSizeInBytes(task.getFileSizeInBytes())
-                    .withFormat(table.getFileFormat().toIceberg())
-                    .withMetrics(task.getMetrics().metrics());
-
-            if (!icebergTable.spec().fields().isEmpty()) {
-                String partitionDataJson = task.getPartitionDataJson()
-                        .orElseThrow(() -> new VerifyException("No partition data for partitioned table"));
-                builder.withPartition(PartitionData.fromJson(partitionDataJson, partitionColumnTypes));
-            }
-
-            appendFiles.appendFile(builder.build());
-            writtenFiles.add(task.getPath());
-        }
-
-        String dependencies = sourceTableHandles.stream()
-                .map(handle -> (IcebergTableHandle) handle)
-                .filter(handle -> handle.getSnapshotId().isPresent())
-                .map(handle -> handle.getSchemaTableName() + "=" + handle.getSnapshotId().get())
-                .distinct()
-                .collect(joining(","));
-
-        // try to leave as little garbage as possible behind
-        if (table.getRetryMode() != NO_RETRIES) {
-            cleanExtraOutputFiles(session, writtenFiles.build());
-        }
-
-        // Update the 'dependsOnTables' property that tracks tables on which the materialized view depends and the corresponding snapshot ids of the tables
-        appendFiles.set(DEPENDS_ON_TABLES, dependencies);
-        appendFiles.commit();
-
-        transaction.commitTransaction();
-        transaction = null;
-        return Optional.of(new HiveWrittenPartitions(commitTasks.stream()
-                .map(CommitTaskData::getPath)
-                .collect(toImmutableList())));
+        return finishInsertInternal(session, (IcebergWritableTableHandle) insertHandle, fragments, sourceTableHandles, true);
     }
 
     private void cleanExtraOutputFiles(ConnectorSession session, Set<String> writtenFiles)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/TrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/TrinoCatalog.java
@@ -18,6 +18,7 @@ import io.trino.plugin.iceberg.UnknownTableTypeException;
 import io.trino.spi.connector.CatalogSchemaTableName;
 import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.security.TrinoPrincipal;
@@ -112,6 +113,16 @@ public interface TrinoCatalog
             ConnectorMaterializedViewDefinition definition,
             boolean replace,
             boolean ignoreExisting);
+
+    void createMaterializedViewWithStorageTableMetadata(
+            ConnectorSession session,
+            SchemaTableName viewName,
+            ConnectorMaterializedViewDefinition definition,
+            boolean replace,
+            boolean ignoreExisting,
+            ConnectorTableMetadata storageTableMetadata);
+
+    Map<String, Object> getMaterializedViewStorageTableProperties(Map<String, Object> materializedViewProperties);
 
     void dropMaterializedView(ConnectorSession session, SchemaTableName viewName);
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

3 new SPIs to support initial refresh during MV creation are implemented in Iceberg connector.
`beginCreateMaterializedView`
`finishCreateMaterializedView`
`getMaterializedViewStorageTableProperties`

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

refactoring

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Iceberg connector only

> How would you describe this change to a non-technical end user or system administrator?

Not relevant (yet internal changes only)

## Related issues, pull requests, and links

Dependent PR: https://github.com/trinodb/trino/pull/12643
https://github.com/trinodb/trino/issues/12466

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(O) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(O) No release notes entries required.
( ) Release notes entries required with the following suggested text:

