### PR TITLE
Fix PositionsAppender#build for null Block

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/output/BytePositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/BytePositionsAppender.java
@@ -121,10 +121,13 @@ public class BytePositionsAppender
     @Override
     public Block build()
     {
-        if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+        Block result;
+        if (hasNonNullValue) {
+            result = new ByteArrayBlock(positionCount, hasNullValue ? Optional.of(valueIsNull) : Optional.empty(), values);
         }
-        ByteArrayBlock result = new ByteArrayBlock(positionCount, hasNullValue ? Optional.of(valueIsNull) : Optional.empty(), values);
+        else {
+            result = new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+        }
         reset();
         return result;
     }

--- a/core/trino-main/src/main/java/io/trino/operator/output/Int128PositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/Int128PositionsAppender.java
@@ -134,10 +134,13 @@ public class Int128PositionsAppender
     @Override
     public Block build()
     {
-        if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+        Block result;
+        if (hasNonNullValue) {
+            result = new Int128ArrayBlock(positionCount, hasNullValue ? Optional.of(valueIsNull) : Optional.empty(), values);
         }
-        Int128ArrayBlock result = new Int128ArrayBlock(positionCount, hasNullValue ? Optional.of(valueIsNull) : Optional.empty(), values);
+        else {
+            result = new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+        }
         reset();
         return result;
     }

--- a/core/trino-main/src/main/java/io/trino/operator/output/Int96PositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/Int96PositionsAppender.java
@@ -129,10 +129,13 @@ public class Int96PositionsAppender
     @Override
     public Block build()
     {
-        if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+        Block result;
+        if (hasNonNullValue) {
+            result = new Int96ArrayBlock(positionCount, hasNullValue ? Optional.of(valueIsNull) : Optional.empty(), high, low);
         }
-        Int96ArrayBlock result = new Int96ArrayBlock(positionCount, hasNullValue ? Optional.of(valueIsNull) : Optional.empty(), high, low);
+        else {
+            result = new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+        }
         reset();
         return result;
     }

--- a/core/trino-main/src/main/java/io/trino/operator/output/IntPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/IntPositionsAppender.java
@@ -121,10 +121,13 @@ public class IntPositionsAppender
     @Override
     public Block build()
     {
-        if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+        Block result;
+        if (hasNonNullValue) {
+            result = new IntArrayBlock(positionCount, hasNullValue ? Optional.of(valueIsNull) : Optional.empty(), values);
         }
-        IntArrayBlock result = new IntArrayBlock(positionCount, hasNullValue ? Optional.of(valueIsNull) : Optional.empty(), values);
+        else {
+            result = new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+        }
         reset();
         return result;
     }

--- a/core/trino-main/src/main/java/io/trino/operator/output/LongPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/LongPositionsAppender.java
@@ -121,10 +121,13 @@ public class LongPositionsAppender
     @Override
     public Block build()
     {
-        if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+        Block result;
+        if (hasNonNullValue) {
+            result = new LongArrayBlock(positionCount, hasNullValue ? Optional.of(valueIsNull) : Optional.empty(), values);
         }
-        LongArrayBlock result = new LongArrayBlock(positionCount, hasNullValue ? Optional.of(valueIsNull) : Optional.empty(), values);
+        else {
+            result = new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+        }
         reset();
         return result;
     }

--- a/core/trino-main/src/main/java/io/trino/operator/output/ShortPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/ShortPositionsAppender.java
@@ -121,10 +121,13 @@ public class ShortPositionsAppender
     @Override
     public Block build()
     {
-        if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+        Block result;
+        if (hasNonNullValue) {
+            result = new ShortArrayBlock(positionCount, hasNullValue ? Optional.of(valueIsNull) : Optional.empty(), values);
         }
-        ShortArrayBlock result = new ShortArrayBlock(positionCount, hasNullValue ? Optional.of(valueIsNull) : Optional.empty(), values);
+        else {
+            result = new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+        }
         reset();
         return result;
     }

--- a/core/trino-main/src/main/java/io/trino/operator/output/SlicePositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/SlicePositionsAppender.java
@@ -144,14 +144,17 @@ public class SlicePositionsAppender
     @Override
     public Block build()
     {
-        if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+        Block result;
+        if (hasNonNullValue) {
+            result = new VariableWidthBlock(
+                    positionCount,
+                    Slices.wrappedBuffer(bytes, 0, currentOffset),
+                    offsets,
+                    hasNullValue ? Optional.of(valueIsNull) : Optional.empty());
         }
-        VariableWidthBlock result = new VariableWidthBlock(
-                positionCount,
-                Slices.wrappedBuffer(bytes, 0, currentOffset),
-                offsets,
-                hasNullValue ? Optional.of(valueIsNull) : Optional.empty());
+        else {
+            result = new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+        }
         reset();
         return result;
     }


### PR DESCRIPTION


<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
If the created block had only null positions
the dedicated PositionAppender's were
not correctly reset.

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
core query engine, PartitionedOutputOperator
> How would you describe this change to a non-technical end user or system administrator?

bug fix
## Related issues, pull requests, and links

Fixes https://github.com/trinodb/trino/issues/12667

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
