### PR TITLE
Don't truncate min/max for iceberg delete files

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergParquetFileWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergParquetFileWriter.java
@@ -36,11 +36,13 @@ public class IcebergParquetFileWriter
         extends ParquetFileWriter
         implements IcebergFileWriter
 {
+    private final MetricsConfig metricsConfig;
     private final Path outputPath;
     private final HdfsEnvironment hdfsEnvironment;
     private final HdfsContext hdfsContext;
 
     public IcebergParquetFileWriter(
+            MetricsConfig metricsConfig,
             OutputStream outputStream,
             Callable<Void> rollbackAction,
             List<Type> fileColumnTypes,
@@ -63,6 +65,7 @@ public class IcebergParquetFileWriter
                 fileInputColumnIndexes,
                 compressionCodecName,
                 trinoVersion);
+        this.metricsConfig = requireNonNull(metricsConfig, "metricsConfig is null");
         this.outputPath = requireNonNull(outputPath, "outputPath is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.hdfsContext = requireNonNull(hdfsContext, "hdfsContext is null");
@@ -71,6 +74,6 @@ public class IcebergParquetFileWriter
     @Override
     public Metrics getMetrics()
     {
-        return hdfsEnvironment.doAs(hdfsContext.getIdentity(), () -> ParquetUtil.fileMetrics(new HdfsInputFile(outputPath, hdfsEnvironment, hdfsContext), MetricsConfig.getDefault()));
+        return hdfsEnvironment.doAs(hdfsContext.getIdentity(), () -> ParquetUtil.fileMetrics(new HdfsInputFile(outputPath, hdfsEnvironment, hdfsContext), metricsConfig));
     }
 }


### PR DESCRIPTION
## Description

Previously min/max were truncated to very short numbers which may have had very bad impact on performance. 

## Related issues, pull requests, and links

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
