### PR TITLE
Allow implicit escape for _ but not % in JDBC metadata calls

### DIFF
--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
@@ -59,6 +59,7 @@ final class ConnectionProperties
     public static final ConnectionProperty<String> APPLICATION_NAME_PREFIX = new ApplicationNamePrefix();
     public static final ConnectionProperty<Boolean> DISABLE_COMPRESSION = new DisableCompression();
     public static final ConnectionProperty<Boolean> ASSUME_LITERAL_NAMES_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS = new AssumeLiteralNamesInMetadataCallsForNonConformingClients();
+    public static final ConnectionProperty<Boolean> ASSUME_LITERAL_UNDERSCORE_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS = new AssumeLiteralUnderscoreInMetadataCallsForNonConformingClients();
     public static final ConnectionProperty<Boolean> SSL = new Ssl();
     public static final ConnectionProperty<SslVerificationMode> SSL_VERIFICATION = new SslVerification();
     public static final ConnectionProperty<String> SSL_KEY_STORE_PATH = new SslKeyStorePath();
@@ -98,6 +99,7 @@ final class ConnectionProperties
             .add(APPLICATION_NAME_PREFIX)
             .add(DISABLE_COMPRESSION)
             .add(ASSUME_LITERAL_NAMES_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS)
+            .add(ASSUME_LITERAL_UNDERSCORE_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS)
             .add(SSL)
             .add(SSL_VERIFICATION)
             .add(SSL_KEY_STORE_PATH)
@@ -289,9 +291,34 @@ final class ConnectionProperties
     private static class AssumeLiteralNamesInMetadataCallsForNonConformingClients
             extends AbstractConnectionProperty<Boolean>
     {
+        private static final Predicate<Properties> IS_ASSUME_LITERAL_NAMES_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS_NOT_ENABLED =
+                checkedPredicate(properties -> !ASSUME_LITERAL_NAMES_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS.getValue(properties).orElse(false));
+
         public AssumeLiteralNamesInMetadataCallsForNonConformingClients()
         {
-            super("assumeLiteralNamesInMetadataCallsForNonConformingClients", NOT_REQUIRED, ALLOWED, BOOLEAN_CONVERTER);
+            super(
+                    "assumeLiteralNamesInMetadataCallsForNonConformingClients",
+                    NOT_REQUIRED,
+                    AssumeLiteralUnderscoreInMetadataCallsForNonConformingClients.IS_ASSUME_LITERAL_UNDERSCORE_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS_NOT_ENABLED
+                            .or(IS_ASSUME_LITERAL_NAMES_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS_NOT_ENABLED),
+                    BOOLEAN_CONVERTER);
+        }
+    }
+
+    private static class AssumeLiteralUnderscoreInMetadataCallsForNonConformingClients
+            extends AbstractConnectionProperty<Boolean>
+    {
+        private static final Predicate<Properties> IS_ASSUME_LITERAL_UNDERSCORE_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS_NOT_ENABLED =
+                checkedPredicate(properties -> !ASSUME_LITERAL_UNDERSCORE_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS.getValue(properties).orElse(false));
+
+        public AssumeLiteralUnderscoreInMetadataCallsForNonConformingClients()
+        {
+            super(
+                    "assumeLiteralUnderscoreInMetadataCallsForNonConformingClients",
+                    NOT_REQUIRED,
+                    AssumeLiteralNamesInMetadataCallsForNonConformingClients.IS_ASSUME_LITERAL_NAMES_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS_NOT_ENABLED
+                            .or(IS_ASSUME_LITERAL_UNDERSCORE_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS_NOT_ENABLED),
+                    BOOLEAN_CONVERTER);
         }
     }
 

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
@@ -97,6 +97,7 @@ public class TrinoConnection
     private final Optional<String> sessionUser;
     private final boolean compressionDisabled;
     private final boolean assumeLiteralNamesInMetadataCallsForNonConformingClients;
+    private final boolean assumeLiteralUnderscoreInMetadataCallsForNonConformingClients;
     private final Map<String, String> extraCredentials;
     private final Optional<String> applicationNamePrefix;
     private final Optional<String> source;
@@ -123,6 +124,7 @@ public class TrinoConnection
         this.extraCredentials = uri.getExtraCredentials();
         this.compressionDisabled = uri.isCompressionDisabled();
         this.assumeLiteralNamesInMetadataCallsForNonConformingClients = uri.isAssumeLiteralNamesInMetadataCallsForNonConformingClients();
+        this.assumeLiteralUnderscoreInMetadataCallsForNonConformingClients = uri.isAssumeLiteralUnderscoreInMetadataCallsForNonConformingClients();
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
         uri.getClientInfo().ifPresent(tags -> clientInfo.put(CLIENT_INFO, tags));
         uri.getClientTags().ifPresent(tags -> clientInfo.put(CLIENT_TAGS, tags));
@@ -271,7 +273,7 @@ public class TrinoConnection
     public DatabaseMetaData getMetaData()
             throws SQLException
     {
-        return new TrinoDatabaseMetaData(this, assumeLiteralNamesInMetadataCallsForNonConformingClients);
+        return new TrinoDatabaseMetaData(this, assumeLiteralNamesInMetadataCallsForNonConformingClients, assumeLiteralUnderscoreInMetadataCallsForNonConformingClients);
     }
 
     @Override

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
@@ -54,6 +54,7 @@ import static io.trino.client.OkHttpUtil.tokenAuth;
 import static io.trino.jdbc.ConnectionProperties.ACCESS_TOKEN;
 import static io.trino.jdbc.ConnectionProperties.APPLICATION_NAME_PREFIX;
 import static io.trino.jdbc.ConnectionProperties.ASSUME_LITERAL_NAMES_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS;
+import static io.trino.jdbc.ConnectionProperties.ASSUME_LITERAL_UNDERSCORE_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS;
 import static io.trino.jdbc.ConnectionProperties.CLIENT_INFO;
 import static io.trino.jdbc.ConnectionProperties.CLIENT_TAGS;
 import static io.trino.jdbc.ConnectionProperties.DISABLE_COMPRESSION;
@@ -249,6 +250,12 @@ public final class TrinoDriverUri
             throws SQLException
     {
         return ASSUME_LITERAL_NAMES_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS.getValue(properties).orElse(false);
+    }
+
+    public boolean isAssumeLiteralUnderscoreInMetadataCallsForNonConformingClients()
+            throws SQLException
+    {
+        return ASSUME_LITERAL_UNDERSCORE_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS.getValue(properties).orElse(false);
     }
 
     public void setupClient(OkHttpClient.Builder builder)

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
@@ -46,6 +46,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.sql.Connection;
@@ -86,6 +87,7 @@ import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -1419,12 +1421,12 @@ public class TestTrinoDatabaseMetaData
                         .withGetColumnsCount(3000));
     }
 
-    @Test
-    public void testAssumeLiteralMetadataCalls()
+    @Test(dataProvider = "escapeLiteralParameters")
+    public void testAssumeLiteralMetadataCalls(String escapeLiteralParameter)
             throws Exception
     {
         try (Connection connection = DriverManager.getConnection(
-                format("jdbc:trino://%s?assumeLiteralNamesInMetadataCallsForNonConformingClients=true", server.getAddress()),
+                format("jdbc:trino://%s?%s", server.getAddress(), escapeLiteralParameter),
                 "admin",
                 null)) {
             // getTables's schema name pattern treated as literal
@@ -1497,22 +1499,52 @@ public class TestTrinoDatabaseMetaData
         }
     }
 
+    @DataProvider
+    public Object[][] escapeLiteralParameters()
+    {
+        return new Object[][]{
+                {"assumeLiteralNamesInMetadataCallsForNonConformingClients=true"},
+                {"assumeLiteralUnderscoreInMetadataCallsForNonConformingClients=true"},
+                {"assumeLiteralNamesInMetadataCallsForNonConformingClients=false&assumeLiteralUnderscoreInMetadataCallsForNonConformingClients=true"},
+                {"assumeLiteralNamesInMetadataCallsForNonConformingClients=true&assumeLiteralUnderscoreInMetadataCallsForNonConformingClients=false"},
+        };
+    }
+
+    @Test
+    public void testFailedBothEscapeLiteralParameters()
+            throws SQLException
+    {
+        assertThatThrownBy(() -> DriverManager.getConnection(
+                format("jdbc:trino://%s?%s", server.getAddress(), "assumeLiteralNamesInMetadataCallsForNonConformingClients=true&assumeLiteralUnderscoreInMetadataCallsForNonConformingClients=true"),
+                "admin",
+                null))
+                .isInstanceOf(SQLException.class)
+                .hasMessage("Connection property 'assumeLiteralNamesInMetadataCallsForNonConformingClients' is not allowed");
+    }
+
     @Test
     public void testEscapeIfNecessary()
+            throws SQLException
     {
-        assertEquals(TrinoDatabaseMetaData.escapeIfNecessary(false, null), null);
-        assertEquals(TrinoDatabaseMetaData.escapeIfNecessary(false, "a"), "a");
-        assertEquals(TrinoDatabaseMetaData.escapeIfNecessary(false, "abc_def"), "abc_def");
-        assertEquals(TrinoDatabaseMetaData.escapeIfNecessary(false, "abc__de_f"), "abc__de_f");
-        assertEquals(TrinoDatabaseMetaData.escapeIfNecessary(false, "abc%def"), "abc%def");
-        assertEquals(TrinoDatabaseMetaData.escapeIfNecessary(false, "abc\\_def"), "abc\\_def");
+        assertEquals(TrinoDatabaseMetaData.escapeIfNecessary(false, false, null), null);
+        assertEquals(TrinoDatabaseMetaData.escapeIfNecessary(false, false, "a"), "a");
+        assertEquals(TrinoDatabaseMetaData.escapeIfNecessary(false, false, "abc_def"), "abc_def");
+        assertEquals(TrinoDatabaseMetaData.escapeIfNecessary(false, false, "abc__de_f"), "abc__de_f");
+        assertEquals(TrinoDatabaseMetaData.escapeIfNecessary(false, false, "abc%def"), "abc%def");
+        assertEquals(TrinoDatabaseMetaData.escapeIfNecessary(false, false, "abc\\_def"), "abc\\_def");
 
-        assertEquals(TrinoDatabaseMetaData.escapeIfNecessary(true, null), null);
-        assertEquals(TrinoDatabaseMetaData.escapeIfNecessary(true, "a"), "a");
-        assertEquals(TrinoDatabaseMetaData.escapeIfNecessary(true, "abc_def"), "abc\\_def");
-        assertEquals(TrinoDatabaseMetaData.escapeIfNecessary(true, "abc__de_f"), "abc\\_\\_de\\_f");
-        assertEquals(TrinoDatabaseMetaData.escapeIfNecessary(true, "abc%def"), "abc\\%def");
-        assertEquals(TrinoDatabaseMetaData.escapeIfNecessary(true, "abc\\_def"), "abc\\\\\\_def");
+        assertEquals(TrinoDatabaseMetaData.escapeIfNecessary(true, false, null), null);
+        assertEquals(TrinoDatabaseMetaData.escapeIfNecessary(true, false, "a"), "a");
+        assertEquals(TrinoDatabaseMetaData.escapeIfNecessary(true, false, "abc_def"), "abc\\_def");
+        assertEquals(TrinoDatabaseMetaData.escapeIfNecessary(true, false, "abc__de_f"), "abc\\_\\_de\\_f");
+        assertEquals(TrinoDatabaseMetaData.escapeIfNecessary(true, false, "abc%def"), "abc\\%def");
+        assertEquals(TrinoDatabaseMetaData.escapeIfNecessary(true, false, "abc\\_def"), "abc\\\\\\_def");
+
+        assertEquals(TrinoDatabaseMetaData.escapeIfNecessary(false, true, null), null);
+        assertEquals(TrinoDatabaseMetaData.escapeIfNecessary(false, true, "a"), "a");
+        assertEquals(TrinoDatabaseMetaData.escapeIfNecessary(false, true, "abc_def"), "abc\\_def");
+        assertEquals(TrinoDatabaseMetaData.escapeIfNecessary(false, true, "abc__de_f"), "abc\\_\\_de\\_f");
+        assertEquals(TrinoDatabaseMetaData.escapeIfNecessary(false, true, "abc\\_def"), "abc\\\\\\_def");
     }
 
     @Test

--- a/docs/src/main/sphinx/installation/jdbc.rst
+++ b/docs/src/main/sphinx/installation/jdbc.rst
@@ -120,92 +120,92 @@ may not be specified using both methods.
 Parameter reference
 -------------------
 
-============================================================ =======================================================================
-Name                                                         Description
-============================================================ =======================================================================
-``user``                                                     Username to use for authentication and authorization.
-``password``                                                 Password to use for LDAP authentication.
-``sessionUser``                                              Session username override, used for impersonation.
-``socksProxy``                                               SOCKS proxy host and port. Example: ``localhost:1080``
-``httpProxy``                                                HTTP proxy host and port. Example: ``localhost:8888``
-``clientInfo``                                               Extra information about the client.
-``clientTags``                                               Client tags for selecting resource groups. Example: ``abc,xyz``
-``traceToken``                                               Trace token for correlating requests across systems.
-``source``                                                   Source name for the Trino query. This parameter should be used in
-                                                             preference to ``ApplicationName``. Thus, it takes precedence
-                                                             over ``ApplicationName`` and/or ``applicationNamePrefix``.
-``applicationNamePrefix``                                    Prefix to append to any specified ``ApplicationName`` client info
-                                                             property, which is used to set the source name for the Trino query
-                                                             if the ``source`` parameter has not been set. If neither this
-                                                             property nor ``ApplicationName`` or ``source`` are set, the source
-                                                             name for the query is ``trino-jdbc``.
-``accessToken``                                              :doc:`JWT </security/jwt>` access token for token based authentication.
-``SSL``                                                      Set ``true`` to specify using TLS/HTTPS for connections.
-``SSLVerification``                                          The method of TLS verification. There are three modes: ``FULL``
-                                                             (default), ``CA`` and ``NONE``. For ``FULL``, the normal TLS
-                                                             verification is performed. For ``CA``, only the CA is verified but
-                                                             hostname mismatch is allowed. For ``NONE``, there is no verification.
-``SSLKeyStorePath``                                          Use only when connecting to a Trino cluster that has :doc:`certificate
-                                                             authentication </security/certificate>` enabled.
-                                                             Specifies the path to a :doc:`PEM </security/inspect-pem>` or :doc:`JKS
-                                                             </security/inspect-jks>` file, which must contain a certificate that
-                                                             is trusted by the Trino cluster you connect to.
-``SSLKeyStorePassword``                                      The password for the KeyStore, if any.
-``SSLKeyStoreType``                                          The type of the KeyStore. The default type is provided by the Java
-                                                             ``keystore.type`` security property or ``jks`` if none exists.
-``SSLTrustStorePath``                                        The location of the Java TrustStore file to use.
-                                                             to validate HTTPS server certificates.
-``SSLTrustStorePassword``                                    The password for the TrustStore.
-``SSLTrustStoreType``                                        The type of the TrustStore. The default type is provided by the Java
-                                                             ``keystore.type`` security property or ``jks`` if none exists.
-``SSLUseSystemTrustStore``                                   Set ``true`` to automatically use the system TrustStore based on the operating system.
-                                                             The supported OSes are Windows and macOS. For Windows, the ``Windows-ROOT``
-                                                             TrustStore is selected. For macOS, the ``KeychainStore`` TrustStore is selected.
-                                                             For other OSes, the default Java TrustStore is loaded.
-                                                             The TrustStore specification can be overridden using ``SSLTrustStoreType``.
-``KerberosRemoteServiceName``                                Trino coordinator Kerberos service name. This parameter is
-                                                             required for Kerberos authentication.
-``KerberosPrincipal``                                        The principal to use when authenticating to the Trino coordinator.
-``KerberosUseCanonicalHostname``                             Use the canonical hostname of the Trino coordinator for the Kerberos
-                                                             service principal by first resolving the hostname to an IP address
-                                                             and then doing a reverse DNS lookup for that IP address.
-                                                             This is enabled by default.
-``KerberosServicePrincipalPattern``                          Trino coordinator Kerberos service principal pattern. The default is
-                                                             ``${SERVICE}@${HOST}``. ``${SERVICE}`` is replaced with the value of
-                                                             ``KerberosRemoteServiceName`` and ``${HOST}`` is replaced with the
-                                                             hostname of the coordinator (after canonicalization if enabled).
-``KerberosConfigPath``                                       Kerberos configuration file.
-``KerberosKeytabPath``                                       Kerberos keytab file.
-``KerberosCredentialCachePath``                              Kerberos credential cache.
-``KerberosDelegation``                                       Set to ``true`` to use the token from an existing Kerberos context.
-                                                             This allows client to use Kerberos authentication without passing
-                                                             the Keytab or credential cache. Defaults to ``false``.
-``extraCredentials``                                         Extra credentials for connecting to external services,
-                                                             specified as a list of key-value pairs. For example,
-                                                             ``foo:bar;abc:xyz`` creates the credential named ``abc``
-                                                             with value ``xyz`` and the credential named ``foo`` with value ``bar``.
-``roles``                                                    Authorization roles to use for catalogs, specified as a list of
-                                                             key-value pairs for the catalog and role. For example,
-                                                             ``catalog1:roleA;catalog2:roleB`` sets ``roleA``
-                                                             for ``catalog1`` and ``roleB`` for ``catalog2``.
-``sessionProperties``                                        Session properties to set for the system and for catalogs,
-                                                             specified as a list of key-value pairs.
-                                                             For example, ``abc:xyz;example.foo:bar`` sets the system property
-                                                             ``abc`` to the value ``xyz`` and the ``foo`` property for
-                                                             catalog ``example`` to the value ``bar``.
-``externalAuthentication``                                   Set to true if you want to use external authentication via
-                                                             :doc:`/security/oauth2`. Use a local web browser to authenticate with an
-                                                             identity provider (IdP) that has been configured for the Trino coordinator.
-``externalAuthenticationTokenCache``                         Allows the sharing of external authentication tokens between different
-                                                             connections for the same authenticated user until the cache is
-                                                             invalidated, such as when a client is restarted or when the classloader
-                                                             reloads the JDBC driver. This is disabled by default, with a value of
-                                                             ``NONE``. To enable, set the value to ``MEMORY``. If the JDBC driver is used
-                                                             in a shared mode by different users, the first registered token is stored
-                                                             and authenticates all users.
-``disableCompression``                                       Whether compression should be enabled.
-``assumeLiteralNamesInMetadataCallsForNonConformingClients`` When enabled, the name patterns passed to ``DatabaseMetaData`` methods
-                                                             are treated as literals. You can use this as a workaround for
-                                                             applications that do not escape schema or table names when passing them
-                                                             to ``DatabaseMetaData`` methods as schema or table name patterns.
-============================================================ =======================================================================
+================================================================= =======================================================================
+Name                                                              Description
+================================================================= =======================================================================
+``user``                                                          Username to use for authentication and authorization.
+``password``                                                      Password to use for LDAP authentication.
+``sessionUser``                                                   Session username override, used for impersonation.
+``socksProxy``                                                    SOCKS proxy host and port. Example: ``localhost:1080``
+``httpProxy``                                                     HTTP proxy host and port. Example: ``localhost:8888``
+``clientInfo``                                                    Extra information about the client.
+``clientTags``                                                    Client tags for selecting resource groups. Example: ``abc,xyz``
+``traceToken``                                                    Trace token for correlating requests across systems.
+``source``                                                        Source name for the Trino query. This parameter should be used in
+                                                                  preference to ``ApplicationName``. Thus, it takes precedence
+                                                                  over ``ApplicationName`` and/or ``applicationNamePrefix``.
+``applicationNamePrefix``                                         Prefix to append to any specified ``ApplicationName`` client info
+                                                                  property, which is used to set the source name for the Trino query
+                                                                  if the ``source`` parameter has not been set. If neither this
+                                                                  property nor ``ApplicationName`` or ``source`` are set, the source
+                                                                  name for the query is ``trino-jdbc``.
+``accessToken``                                                   :doc:`JWT </security/jwt>` access token for token based authentication.
+``SSL``                                                           Set ``true`` to specify using TLS/HTTPS for connections.
+``SSLVerification``                                               The method of TLS verification. There are three modes: ``FULL``
+                                                                  (default), ``CA`` and ``NONE``. For ``FULL``, the normal TLS
+                                                                  verification is performed. For ``CA``, only the CA is verified but
+                                                                  hostname mismatch is allowed. For ``NONE``, there is no verification.
+``SSLKeyStorePath``                                               Use only when connecting to a Trino cluster that has :doc:`certificate
+                                                                  authentication </security/certificate>` enabled.
+                                                                  Specifies the path to a :doc:`PEM </security/inspect-pem>` or :doc:`JKS
+                                                                  </security/inspect-jks>` file, which must contain a certificate that
+                                                                  is trusted by the Trino cluster you connect to.
+``SSLKeyStorePassword``                                           The password for the KeyStore, if any.
+``SSLKeyStoreType``                                               The type of the KeyStore. The default type is provided by the Java
+                                                                  ``keystore.type`` security property or ``jks`` if none exists.
+``SSLTrustStorePath``                                             The location of the Java TrustStore file to use.
+                                                                  to validate HTTPS server certificates.
+``SSLTrustStorePassword``                                         The password for the TrustStore.
+``SSLTrustStoreType``                                             The type of the TrustStore. The default type is provided by the Java
+                                                                  ``keystore.type`` security property or ``jks`` if none exists.
+``SSLUseSystemTrustStore``                                        Set ``true`` to automatically use the system TrustStore based on the operating system.
+                                                                  The supported OSes are Windows and macOS. For Windows, the ``Windows-ROOT``
+                                                                  TrustStore is selected. For macOS, the ``KeychainStore`` TrustStore is selected.
+                                                                  For other OSes, the default Java TrustStore is loaded.
+                                                                  The TrustStore specification can be overridden using ``SSLTrustStoreType``.
+``KerberosRemoteServiceName``                                     Trino coordinator Kerberos service name. This parameter is
+                                                                  required for Kerberos authentication.
+``KerberosPrincipal``                                             The principal to use when authenticating to the Trino coordinator.
+``KerberosUseCanonicalHostname``                                  Use the canonical hostname of the Trino coordinator for the Kerberos
+                                                                  service principal by first resolving the hostname to an IP address
+                                                                  and then doing a reverse DNS lookup for that IP address.
+                                                                  This is enabled by default.
+``KerberosServicePrincipalPattern``                               Trino coordinator Kerberos service principal pattern. The default is
+                                                                  ``${SERVICE}@${HOST}``. ``${SERVICE}`` is replaced with the value of
+                                                                  ``KerberosRemoteServiceName`` and ``${HOST}`` is replaced with the
+                                                                  hostname of the coordinator (after canonicalization if enabled).
+``KerberosConfigPath``                                            Kerberos configuration file.
+``KerberosKeytabPath``                                            Kerberos keytab file.
+``KerberosCredentialCachePath``                                   Kerberos credential cache.
+``KerberosDelegation``                                            Set to ``true`` to use the token from an existing Kerberos context.
+                                                                  This allows client to use Kerberos authentication without passing
+                                                                  the Keytab or credential cache. Defaults to ``false``.
+``extraCredentials``                                              Extra credentials for connecting to external services,
+                                                                  specified as a list of key-value pairs. For example,
+                                                                  ``foo:bar;abc:xyz`` creates the credential named ``abc``
+                                                                  with value ``xyz`` and the credential named ``foo`` with value ``bar``.
+``roles``                                                         Authorization roles to use for catalogs, specified as a list of
+                                                                  key-value pairs for the catalog and role. For example,
+                                                                  ``catalog1:roleA;catalog2:roleB`` sets ``roleA``
+                                                                  for ``catalog1`` and ``roleB`` for ``catalog2``.
+``sessionProperties``                                             Session properties to set for the system and for catalogs,
+                                                                  specified as a list of key-value pairs.
+                                                                  For example, ``abc:xyz;example.foo:bar`` sets the system property
+                                                                  ``abc`` to the value ``xyz`` and the ``foo`` property for
+                                                                  catalog ``example`` to the value ``bar``.
+``externalAuthentication``                                        Set to true if you want to use external authentication via
+                                                                  :doc:`/security/oauth2`. Use a local web browser to authenticate with an
+                                                                  identity provider (IdP) that has been configured for the Trino coordinator.
+``externalAuthenticationTokenCache``                              Allows the sharing of external authentication tokens between different
+                                                                  connections for the same authenticated user until the cache is
+                                                                  invalidated, such as when a client is restarted or when the classloader
+                                                                  reloads the JDBC driver. This is disabled by default, with a value of
+                                                                  ``NONE``. To enable, set the value to ``MEMORY``. If the JDBC driver is used
+                                                                  in a shared mode by different users, the first registered token is stored
+                                                                  and authenticates all users.
+``disableCompression``                                            Whether compression should be enabled.
+``assumeLiteralNamesInMetadataCallsForNonConformingClients``      When enabled, the name patterns passed to ``DatabaseMetaData`` methods
+                                                                  are treated as literals. You can use this as a workaround for
+                                                                  applications that do not escape schema or table names when passing them
+                                                                  to ``DatabaseMetaData`` methods as schema or table name patterns.
+================================================================= =======================================================================

--- a/docs/src/main/sphinx/installation/jdbc.rst
+++ b/docs/src/main/sphinx/installation/jdbc.rst
@@ -208,4 +208,8 @@ Name                                                              Description
                                                                   are treated as literals. You can use this as a workaround for
                                                                   applications that do not escape schema or table names when passing them
                                                                   to ``DatabaseMetaData`` methods as schema or table name patterns.
+``assumeLiteralUnderscoreInMetadataCallsForNonConformingClients`` When enabled, the name patterns passed to ``DatabaseMetaData`` methods
+                                                                  are treated as underscores. You can use this as a workaround for
+                                                                  applications that do not escape schema or table names when passing them
+                                                                  to ``DatabaseMetaData`` methods as schema or table name patterns.
 ================================================================= =======================================================================


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Setting `assumeLiteralNamesInMetadataCallsForNonConformingClients=true` highly improves performance of metadata retrieval in Tableau. However while loading a table to Tableau a following query is being issued which results in no rows returned cause it tries to find a wildcard character in column name `COLUMN_NAME LIKE '\%' ESCAPE '\'`, it turns the query into a search for columns that literally have `%` in them. This PR introduces a new parameter assumeLiteralUnderscoreInMetadataCallsForNonConformingClients to JDBC driver which fixes the issue by not escaping `%`. 

```
SELECT TABLE_CAT, TABLE_SCHEM, TABLE_NAME, COLUMN_NAME, DATA_TYPE,

  TYPE_NAME, COLUMN_SIZE, BUFFER_LENGTH, DECIMAL_DIGITS, NUM_PREC_RADIX,

  NULLABLE, REMARKS, COLUMN_DEF, SQL_DATA_TYPE, SQL_DATETIME_SUB,

  CHAR_OCTET_LENGTH, ORDINAL_POSITION, IS_NULLABLE,

  SCOPE_CATALOG, SCOPE_SCHEMA, SCOPE_TABLE,

  SOURCE_DATA_TYPE, IS_AUTOINCREMENT, IS_GENERATEDCOLUMN

FROM system.jdbc.columns

WHERE TABLE_CAT = 'hive_r' AND TABLE_SCHEM LIKE 'oasis\_db' ESCAPE '\' AND TABLE_NAME LIKE 'account' ESCAPE '\' 

AND COLUMN_NAME LIKE '\%' ESCAPE '\'
```

> Is this change a fix, improvement, new feature, refactoring, or other?

new feature/improvement 

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

jdbc

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
