### PR TITLE
Support reading Delta Lake tables having delta.columnMapping.mode=name

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeColumnMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeColumnMetadata.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.type.Type;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+
+public class DeltaLakeColumnMetadata
+{
+    private final ColumnMetadata columnMetadata;
+    private final String physicalName;
+    private final Type physicalColumnType;
+
+    public DeltaLakeColumnMetadata(ColumnMetadata columnMetadata, String physicalName, Type physicalColumnType)
+    {
+        this.columnMetadata = requireNonNull(columnMetadata, "columnMetadata is null");
+        this.physicalName = requireNonNull(physicalName, "physicalName is null").toLowerCase(ENGLISH);
+        this.physicalColumnType = requireNonNull(physicalColumnType, "physicalColumnType is null");
+    }
+
+    public ColumnMetadata getColumnMetadata()
+    {
+        return columnMetadata;
+    }
+
+    public String getName()
+    {
+        return columnMetadata.getName();
+    }
+
+    public Type getType()
+    {
+        return columnMetadata.getType();
+    }
+
+    public String getPhysicalName()
+    {
+        return physicalName;
+    }
+
+    public Type getPhysicalColumnType()
+    {
+        return physicalColumnType;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("columnMetadata", columnMetadata)
+                .add("physicalName", physicalName)
+                .add("physicalColumnType", physicalColumnType)
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DeltaLakeColumnMetadata that = (DeltaLakeColumnMetadata) o;
+        return Objects.equals(columnMetadata, that.columnMetadata) &&
+                Objects.equals(physicalName, that.physicalName) &&
+                Objects.equals(physicalColumnType, that.physicalColumnType);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(columnMetadata, physicalName, physicalColumnType);
+    }
+}

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
@@ -21,7 +21,6 @@ import io.trino.plugin.deltalake.transactionlog.AddFileEntry;
 import io.trino.plugin.hive.HiveTransactionHandle;
 import io.trino.spi.SplitWeight;
 import io.trino.spi.connector.ColumnHandle;
-import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorSplitSource;
@@ -147,9 +146,9 @@ public class DeltaLakeSplitManager
                         .map(DeltaLakeColumnHandle.class::cast))
                 .map(column -> column.getName().toLowerCase(ENGLISH)) // TODO is DeltaLakeColumnHandle.name normalized?
                 .collect(toImmutableSet());
-        List<ColumnMetadata> schema = extractSchema(tableHandle.getMetadataEntry(), typeManager);
-        List<ColumnMetadata> predicatedColumns = schema.stream()
-                .filter(column -> predicatedColumnNames.contains(column.getName())) // ColumnMetadata.name is lowercase
+        List<DeltaLakeColumnMetadata> schema = extractSchema(tableHandle.getMetadataEntry(), typeManager);
+        List<DeltaLakeColumnMetadata> predicatedColumns = schema.stream()
+                .filter(column -> predicatedColumnNames.contains(column.getName())) // DeltaLakeColumnMetadata.name is lowercase
                 .collect(toImmutableList());
 
         return validDataFiles.stream()

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeUpdatablePageSource.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeUpdatablePageSource.java
@@ -28,7 +28,6 @@ import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.RowBlock;
-import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.UpdatablePageSource;
@@ -149,9 +148,9 @@ public class DeltaLakeUpdatablePageSource
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.updateResultJsonCodec = requireNonNull(updateResultJsonCodec, "deleteResultJsonCodec is null");
 
-        List<ColumnMetadata> columnMetadata = extractSchema(tableHandle.getMetadataEntry(), typeManager);
+        List<DeltaLakeColumnMetadata> columnMetadata = extractSchema(tableHandle.getMetadataEntry(), typeManager);
         List<DeltaLakeColumnHandle> allColumns = columnMetadata.stream()
-                .map(metadata -> new DeltaLakeColumnHandle(metadata.getName(), metadata.getType(), partitionKeys.containsKey(metadata.getName()) ? PARTITION_KEY : REGULAR))
+                .map(metadata -> new DeltaLakeColumnHandle(metadata.getName(), metadata.getType(), metadata.getPhysicalName(), metadata.getPhysicalColumnType(), partitionKeys.containsKey(metadata.getName()) ? PARTITION_KEY : REGULAR))
                 .collect(toImmutableList());
         this.allDataColumns = allColumns.stream()
                 .filter(columnHandle -> columnHandle.getColumnType() == REGULAR)
@@ -319,7 +318,7 @@ public class DeltaLakeUpdatablePageSource
      */
     private static DeltaLakeColumnHandle rowIndexColumn()
     {
-        return new DeltaLakeColumnHandle("$delta$dummy_row_index", BIGINT, DeltaLakeColumnType.SYNTHESIZED)
+        return new DeltaLakeColumnHandle("$delta$dummy_row_index", BIGINT, "$delta$dummy_row_index", BIGINT, DeltaLakeColumnType.SYNTHESIZED)
         {
             @Override
             public HiveColumnHandle toHiveColumnHandle()
@@ -572,7 +571,7 @@ public class DeltaLakeUpdatablePageSource
                         .withUseColumnIndex(isParquetUseColumnIndex(this.session)));
     }
 
-    private DeltaLakeWriter createWriter(Path targetFile, List<ColumnMetadata> allColumns, List<DeltaLakeColumnHandle> dataColumns)
+    private DeltaLakeWriter createWriter(Path targetFile, List<DeltaLakeColumnMetadata> allColumns, List<DeltaLakeColumnHandle> dataColumns)
             throws IOException
     {
         Configuration conf = hdfsEnvironment.getConfiguration(new HdfsEnvironment.HdfsContext(session), targetFile);
@@ -610,19 +609,19 @@ public class DeltaLakeUpdatablePageSource
                 dataColumns);
     }
 
-    private List<String> getPartitionValues(List<ColumnMetadata> partitionColumns)
+    private List<String> getPartitionValues(List<DeltaLakeColumnMetadata> partitionColumns)
     {
         Block[] partitionValues = new Block[partitionColumns.size()];
         for (int i = 0; i < partitionValues.length; i++) {
-            ColumnMetadata columnMetadata = partitionColumns.get(i);
+            DeltaLakeColumnMetadata columnMetadata = partitionColumns.get(i);
             partitionValues[i] = nativeValueToBlock(
                     columnMetadata.getType(),
                     deserializePartitionValue(
-                            new DeltaLakeColumnHandle(columnMetadata.getName(), columnMetadata.getType(), PARTITION_KEY),
+                            new DeltaLakeColumnHandle(columnMetadata.getName(), columnMetadata.getType(), columnMetadata.getPhysicalName(), columnMetadata.getPhysicalColumnType(), PARTITION_KEY),
                             partitionKeys.get(columnMetadata.getName())));
         }
         return createPartitionValues(
-                partitionColumns.stream().map(ColumnMetadata::getType).collect(toImmutableList()),
+                partitionColumns.stream().map(DeltaLakeColumnMetadata::getType).collect(toImmutableList()),
                 new Page(1, partitionValues),
                 0);
     }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogAccess.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogAccess.java
@@ -23,6 +23,7 @@ import io.airlift.jmx.CacheStatsMBean;
 import io.airlift.log.Logger;
 import io.trino.collect.cache.EvictableCacheBuilder;
 import io.trino.parquet.ParquetReaderOptions;
+import io.trino.plugin.deltalake.DeltaLakeColumnMetadata;
 import io.trino.plugin.deltalake.DeltaLakeConfig;
 import io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointEntryIterator;
 import io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointSchemaManager;
@@ -31,7 +32,6 @@ import io.trino.plugin.hive.FileFormatDataSourceStats;
 import io.trino.plugin.hive.HdfsEnvironment;
 import io.trino.plugin.hive.parquet.ParquetReaderConfig;
 import io.trino.spi.TrinoException;
-import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.type.ArrayType;
@@ -243,12 +243,12 @@ public class TransactionLogAccess
         }
     }
 
-    public static List<ColumnMetadata> columnsWithStats(MetadataEntry metadataEntry, TypeManager typeManager)
+    public static List<DeltaLakeColumnMetadata> columnsWithStats(MetadataEntry metadataEntry, TypeManager typeManager)
     {
         return columnsWithStats(DeltaLakeSchemaSupport.extractSchema(metadataEntry, typeManager), metadataEntry.getCanonicalPartitionColumns());
     }
 
-    public static ImmutableList<ColumnMetadata> columnsWithStats(List<ColumnMetadata> schema, List<String> partitionColumns)
+    public static ImmutableList<DeltaLakeColumnMetadata> columnsWithStats(List<DeltaLakeColumnMetadata> schema, List<String> partitionColumns)
     {
         return schema.stream()
                 .filter(column -> !partitionColumns.contains(column.getName()))

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/statistics/DeltaLakeJsonFileStatistics.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/statistics/DeltaLakeJsonFileStatistics.java
@@ -108,14 +108,14 @@ public class DeltaLakeJsonFileStatistics
     @Override
     public Optional<Object> getMaxColumnValue(DeltaLakeColumnHandle columnHandle)
     {
-        Optional<Object> value = getStat(columnHandle.getName(), maxValues);
+        Optional<Object> value = getStat(columnHandle.getPhysicalName(), maxValues);
         return value.flatMap(o -> deserializeStatisticsValue(columnHandle, String.valueOf(o)));
     }
 
     @Override
     public Optional<Object> getMinColumnValue(DeltaLakeColumnHandle columnHandle)
     {
-        Optional<Object> value = getStat(columnHandle.getName(), minValues);
+        Optional<Object> value = getStat(columnHandle.getPhysicalName(), minValues);
         return value.flatMap(o -> deserializeStatisticsValue(columnHandle, String.valueOf(o)));
     }
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/statistics/DeltaLakeParquetFileStatistics.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/statistics/DeltaLakeParquetFileStatistics.java
@@ -79,13 +79,13 @@ public class DeltaLakeParquetFileStatistics
     @Override
     public Optional<Object> getMaxColumnValue(DeltaLakeColumnHandle columnHandle)
     {
-        return getStat(columnHandle.getName(), maxValues);
+        return getStat(columnHandle.getPhysicalName(), maxValues);
     }
 
     @Override
     public Optional<Object> getMinColumnValue(DeltaLakeColumnHandle columnHandle)
     {
-        return getStat(columnHandle.getName(), minValues);
+        return getStat(columnHandle.getPhysicalName(), minValues);
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/AbstractTestDeltaLakeCreateTableStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/AbstractTestDeltaLakeCreateTableStatistics.java
@@ -112,14 +112,14 @@ public abstract class AbstractTestDeltaLakeCreateTableStatistics
             assertThat(entry.getStats()).isPresent();
             DeltaLakeFileStatistics fileStatistics = entry.getStats().get();
 
-            DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle("d", createUnboundedVarcharType(), REGULAR);
+            DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle("d", createUnboundedVarcharType(), "d", createUnboundedVarcharType(), REGULAR);
             assertEquals(fileStatistics.getNumRecords(), Optional.of(2L));
             assertEquals(fileStatistics.getMinColumnValue(columnHandle), Optional.of(utf8Slice("foo")));
             assertEquals(fileStatistics.getMaxColumnValue(columnHandle), Optional.of(utf8Slice("moo")));
             assertEquals(fileStatistics.getNullCount("d"), Optional.of(0L));
 
             for (String complexColumn : ImmutableList.of("a", "b", "c")) {
-                columnHandle = new DeltaLakeColumnHandle(complexColumn, createUnboundedVarcharType(), REGULAR);
+                columnHandle = new DeltaLakeColumnHandle(complexColumn, createUnboundedVarcharType(), complexColumn, createUnboundedVarcharType(), REGULAR);
                 assertThat(fileStatistics.getMaxColumnValue(columnHandle)).isEmpty();
                 assertThat(fileStatistics.getMinColumnValue(columnHandle)).isEmpty();
                 assertThat(fileStatistics.getNullCount(complexColumn)).isEmpty();
@@ -138,7 +138,7 @@ public abstract class AbstractTestDeltaLakeCreateTableStatistics
             throws Exception
     {
         String columnName = "t_double";
-        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, REGULAR);
+        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, columnName, DoubleType.DOUBLE, REGULAR);
         try (TestTable table = new TestTable("test_nan_", ImmutableList.of(columnName), format("VALUES CAST(nan() AS %1$s), CAST(0.0 AS %1$s)", type))) {
             List<AddFileEntry> addFileEntries = getAddFileEntries(table.getName());
             AddFileEntry entry = getOnlyElement(addFileEntries);
@@ -157,7 +157,7 @@ public abstract class AbstractTestDeltaLakeCreateTableStatistics
             throws Exception
     {
         String columnName = "t_double";
-        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, REGULAR);
+        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, columnName, DoubleType.DOUBLE, REGULAR);
         try (TestTable table = new TestTable(
                 "test_inf_",
                 ImmutableList.of(columnName),
@@ -179,7 +179,7 @@ public abstract class AbstractTestDeltaLakeCreateTableStatistics
             throws Exception
     {
         String columnName = "t_double";
-        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, REGULAR);
+        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, columnName, DoubleType.DOUBLE, REGULAR);
         try (TestTable table = new TestTable(
                 "test_inf_nan_",
                 ImmutableList.of(columnName),
@@ -201,7 +201,7 @@ public abstract class AbstractTestDeltaLakeCreateTableStatistics
             throws Exception
     {
         String columnName = "t_double";
-        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, REGULAR);
+        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, columnName, DoubleType.DOUBLE, REGULAR);
         try (TestTable table = new TestTable(
                 "test_nan_positive_",
                 ImmutableList.of(columnName),
@@ -223,7 +223,7 @@ public abstract class AbstractTestDeltaLakeCreateTableStatistics
             throws Exception
     {
         String columnName = "t_double";
-        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, REGULAR);
+        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, columnName, DoubleType.DOUBLE, REGULAR);
         try (TestTable table = new TestTable(
                 "test_nan_positive_",
                 ImmutableList.of(columnName),
@@ -269,7 +269,7 @@ public abstract class AbstractTestDeltaLakeCreateTableStatistics
         String negative = "-1" + "0".repeat(precision - scale) + "." + "0".repeat(scale - 1) + "1";
 
         String columnName = "t_decimal";
-        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DecimalType.createDecimalType(precision, scale), REGULAR);
+        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DecimalType.createDecimalType(precision, scale), columnName, DecimalType.createDecimalType(precision, scale), REGULAR);
         try (TestTable table = new TestTable(
                 "test_decimal_records_",
                 ImmutableList.of(columnName),
@@ -301,7 +301,7 @@ public abstract class AbstractTestDeltaLakeCreateTableStatistics
             throws Exception
     {
         String columnName = "t_double";
-        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, REGULAR);
+        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, columnName, DoubleType.DOUBLE, REGULAR);
         try (TestTable table = new TestTable("test_null_records_", ImmutableList.of(columnName), "VALUES null, 0, null, 1")) {
             List<AddFileEntry> addFileEntries = getAddFileEntries(table.getName());
             AddFileEntry entry = getOnlyElement(addFileEntries);
@@ -320,7 +320,7 @@ public abstract class AbstractTestDeltaLakeCreateTableStatistics
             throws Exception
     {
         String columnName = "t_varchar";
-        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, createUnboundedVarcharType(), REGULAR);
+        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, createUnboundedVarcharType(), columnName, createUnboundedVarcharType(), REGULAR);
         try (TestTable table = new TestTable(
                 "test_only_null_records_",
                 ImmutableList.of(columnName),
@@ -342,7 +342,7 @@ public abstract class AbstractTestDeltaLakeCreateTableStatistics
             throws Exception
     {
         String columnName = "t_date";
-        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DateType.DATE, REGULAR);
+        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DateType.DATE, columnName, DateType.DATE, REGULAR);
         try (TestTable table = new TestTable(
                 "test_date_records_",
                 ImmutableList.of(columnName),
@@ -364,7 +364,7 @@ public abstract class AbstractTestDeltaLakeCreateTableStatistics
             throws Exception
     {
         String columnName = "t_timestamp";
-        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, TIMESTAMP_TZ_MILLIS, REGULAR);
+        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, TIMESTAMP_TZ_MILLIS, columnName, TIMESTAMP_TZ_MILLIS, REGULAR);
         try (TestTable table = new TestTable(
                 "test_timestamp_records_",
                 ImmutableList.of(columnName),
@@ -390,7 +390,7 @@ public abstract class AbstractTestDeltaLakeCreateTableStatistics
             throws Exception
     {
         String columnName = "t_string";
-        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, createUnboundedVarcharType(), REGULAR);
+        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, createUnboundedVarcharType(), columnName, createUnboundedVarcharType(), REGULAR);
         try (TestTable table = new TestTable("test_unicode_", ImmutableList.of(columnName), "VALUES 'ab\uFAD8', 'ab\uD83D\uDD74'")) {
             List<AddFileEntry> addFileEntries = getAddFileEntries(table.getName());
             AddFileEntry entry = getOnlyElement(addFileEntries);
@@ -409,7 +409,7 @@ public abstract class AbstractTestDeltaLakeCreateTableStatistics
             throws Exception
     {
         String columnName = "t_string";
-        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, createUnboundedVarcharType(), REGULAR);
+        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, createUnboundedVarcharType(), columnName, createUnboundedVarcharType(), REGULAR);
         String partitionColumn = "t_int";
 
         try (TestTable table = new TestTable(
@@ -443,7 +443,7 @@ public abstract class AbstractTestDeltaLakeCreateTableStatistics
     public void testMultiFileTable()
             throws Exception
     {
-        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle("name", createUnboundedVarcharType(), REGULAR);
+        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle("name", createUnboundedVarcharType(), "name", createUnboundedVarcharType(), REGULAR);
         Session session = testSessionBuilder()
                 .setCatalog(DELTA_CATALOG)
                 .setSystemProperty("scale_writers", "false")
@@ -476,7 +476,7 @@ public abstract class AbstractTestDeltaLakeCreateTableStatistics
         // assertEventually because sometimes write from tpch.tiny.orders creates one file only and the test requires at least two files
         assertEventually(() -> {
             String columnName = "orderkey";
-            DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, REGULAR);
+            DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, columnName, DoubleType.DOUBLE, REGULAR);
             Session session = testSessionBuilder()
                     .setCatalog(DELTA_CATALOG)
                     .setSchema(SCHEMA)

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeCreateTableStatisticsLegacyWriter.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeCreateTableStatisticsLegacyWriter.java
@@ -49,7 +49,7 @@ public class TestDeltaLakeCreateTableStatisticsLegacyWriter
             throws Exception
     {
         String columnName = "t_timestamp";
-        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, TIMESTAMP_TZ_MILLIS, REGULAR);
+        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, TIMESTAMP_TZ_MILLIS, columnName, TIMESTAMP_TZ_MILLIS, REGULAR);
         try (TestTable table = new TestTable(
                 "test_timestamp_records_",
                 ImmutableList.of(columnName),
@@ -72,7 +72,7 @@ public class TestDeltaLakeCreateTableStatisticsLegacyWriter
             throws Exception
     {
         String columnName = "t_timestamp";
-        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, TIMESTAMP_TZ_MILLIS, REGULAR);
+        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, TIMESTAMP_TZ_MILLIS, columnName, TIMESTAMP_TZ_MILLIS, REGULAR);
         try (TestTable table = new TestTable(
                 "test_timestamp_single_record_",
                 ImmutableList.of(columnName),

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
@@ -99,15 +99,15 @@ public class TestDeltaLakeMetadata
     private static final ColumnMetadata MISSING_COLUMN = new ColumnMetadata("missing_column", BIGINT);
 
     private static final DeltaLakeColumnHandle BOOLEAN_COLUMN_HANDLE =
-            new DeltaLakeColumnHandle("boolean_column_name", BooleanType.BOOLEAN, REGULAR);
+            new DeltaLakeColumnHandle("boolean_column_name", BooleanType.BOOLEAN, "boolean_column_name", BooleanType.BOOLEAN, REGULAR);
     private static final DeltaLakeColumnHandle DOUBLE_COLUMN_HANDLE =
-            new DeltaLakeColumnHandle("double_column_name", DoubleType.DOUBLE, REGULAR);
+            new DeltaLakeColumnHandle("double_column_name", DoubleType.DOUBLE, "double_column_name", DoubleType.DOUBLE, REGULAR);
     private static final DeltaLakeColumnHandle BOGUS_COLUMN_HANDLE =
-            new DeltaLakeColumnHandle("bogus_column_name", BogusType.BOGUS, REGULAR);
+            new DeltaLakeColumnHandle("bogus_column_name", BogusType.BOGUS, "bogus_column_name", BogusType.BOGUS, REGULAR);
     private static final DeltaLakeColumnHandle VARCHAR_COLUMN_HANDLE =
-            new DeltaLakeColumnHandle("varchar_column_name", VarcharType.VARCHAR, REGULAR);
+            new DeltaLakeColumnHandle("varchar_column_name", VarcharType.VARCHAR, "varchar_column_name", VarcharType.VARCHAR, REGULAR);
     private static final DeltaLakeColumnHandle DATE_COLUMN_HANDLE =
-            new DeltaLakeColumnHandle("date_column_name", DateType.DATE, REGULAR);
+            new DeltaLakeColumnHandle("date_column_name", DateType.DATE, "date_column_name", DateType.DATE, REGULAR);
 
     private static final Map<String, ColumnHandle> SYNTHETIC_COLUMN_ASSIGNMENTS = ImmutableMap.of(
             "test_synthetic_column_name_1", BOGUS_COLUMN_HANDLE,

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
@@ -187,6 +187,8 @@ public class TestDeltaLakePageSink
             handles.add(new DeltaLakeColumnHandle(
                     column.getColumnName(),
                     getTrinoType(column.getType()),
+                    column.getColumnName(),
+                    getTrinoType(column.getType()),
                     REGULAR));
         }
         return handles.build();

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeWriter.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeWriter.java
@@ -57,7 +57,7 @@ public class TestDeltaLakeWriter
                         Statistics.getBuilderForReading(intType).withMin(getIntByteArray(-100)).withMax(getIntByteArray(250)).withNumNulls(6).build()),
                 createMetaData(columnName, intType, 10,
                         Statistics.getBuilderForReading(intType).withMin(getIntByteArray(-200)).withMax(getIntByteArray(150)).withNumNulls(7).build()));
-        DeltaLakeColumnHandle intColumn = new DeltaLakeColumnHandle(columnName, INTEGER, REGULAR);
+        DeltaLakeColumnHandle intColumn = new DeltaLakeColumnHandle(columnName, INTEGER, columnName, INTEGER, REGULAR);
 
         DeltaLakeFileStatistics fileStats = mergeStats(buildMultimap(columnName, metadata), ImmutableMap.of(columnName, INTEGER), 20);
         assertEquals(fileStats.getNumRecords(), Optional.of(20L));
@@ -76,7 +76,7 @@ public class TestDeltaLakeWriter
                         Statistics.getBuilderForReading(type).withMin(getFloatByteArray(0.01f)).withMax(getFloatByteArray(1.0f)).withNumNulls(6).build()),
                 createMetaData(columnName, type, 10,
                         Statistics.getBuilderForReading(type).withMin(getFloatByteArray(-2.001f)).withMax(getFloatByteArray(0.0f)).withNumNulls(7).build()));
-        DeltaLakeColumnHandle floatColumn = new DeltaLakeColumnHandle(columnName, REAL, REGULAR);
+        DeltaLakeColumnHandle floatColumn = new DeltaLakeColumnHandle(columnName, REAL, columnName, REAL, REGULAR);
 
         DeltaLakeFileStatistics fileStats = mergeStats(buildMultimap(columnName, metadata), ImmutableMap.of(columnName, REAL), 20);
         assertEquals(fileStats.getNumRecords(), Optional.of(20L));
@@ -97,7 +97,7 @@ public class TestDeltaLakeWriter
                         Statistics.getBuilderForReading(type).withMin(getFloatByteArray(Float.NaN)).withMax(getFloatByteArray(1.0f)).withNumNulls(6).build()),
                 createMetaData(columnName, type, 10,
                         Statistics.getBuilderForReading(type).withMin(getFloatByteArray(-2.001f)).withMax(getFloatByteArray(0.0f)).withNumNulls(7).build()));
-        DeltaLakeColumnHandle floatColumn = new DeltaLakeColumnHandle(columnName, REAL, REGULAR);
+        DeltaLakeColumnHandle floatColumn = new DeltaLakeColumnHandle(columnName, REAL, columnName, REAL, REGULAR);
 
         DeltaLakeFileStatistics fileStats = mergeStats(buildMultimap(columnName, metadata), ImmutableMap.of(columnName, REAL), 20);
         assertEquals(fileStats.getNumRecords(), Optional.of(20L));
@@ -118,7 +118,7 @@ public class TestDeltaLakeWriter
                         Statistics.getBuilderForReading(type).withMin(getDoubleByteArray(Double.NaN)).withMax(getDoubleByteArray(1.0f)).withNumNulls(6).build()),
                 createMetaData(columnName, type, 10,
                         Statistics.getBuilderForReading(type).withMin(getDoubleByteArray(-2.001f)).withMax(getDoubleByteArray(0.0f)).withNumNulls(7).build()));
-        DeltaLakeColumnHandle doubleColumn = new DeltaLakeColumnHandle(columnName, DOUBLE, REGULAR);
+        DeltaLakeColumnHandle doubleColumn = new DeltaLakeColumnHandle(columnName, DOUBLE, columnName, DOUBLE, REGULAR);
 
         DeltaLakeFileStatistics fileStats = mergeStats(buildMultimap(columnName, metadata), ImmutableMap.of(columnName, DOUBLE), 20);
         assertEquals(fileStats.getNumRecords(), Optional.of(20L));
@@ -137,7 +137,7 @@ public class TestDeltaLakeWriter
                         Statistics.getBuilderForReading(type).withMin("aba".getBytes(UTF_8)).withMax("ab⌘".getBytes(UTF_8)).withNumNulls(6).build()),
                 createMetaData(columnName, type, 10,
                         Statistics.getBuilderForReading(type).withMin("aba".getBytes(UTF_8)).withMax("abc".getBytes(UTF_8)).withNumNulls(6).build()));
-        DeltaLakeColumnHandle varcharColumn = new DeltaLakeColumnHandle(columnName, VarcharType.createUnboundedVarcharType(), REGULAR);
+        DeltaLakeColumnHandle varcharColumn = new DeltaLakeColumnHandle(columnName, VarcharType.createUnboundedVarcharType(), columnName, VarcharType.createUnboundedVarcharType(), REGULAR);
 
         DeltaLakeFileStatistics fileStats = mergeStats(buildMultimap(columnName, metadata), ImmutableMap.of(columnName, createUnboundedVarcharType()), 20);
         assertEquals(fileStats.getNumRecords(), Optional.of(20L));
@@ -156,7 +156,7 @@ public class TestDeltaLakeWriter
                         Statistics.getBuilderForReading(type).withMin("aba".getBytes(UTF_8)).withMax("ab\uFAD8".getBytes(UTF_8)).withNumNulls(6).build()),
                 createMetaData(columnName, type, 10,
                         Statistics.getBuilderForReading(type).withMin("aba".getBytes(UTF_8)).withMax("ab\uD83D\uDD74".getBytes(UTF_8)).withNumNulls(6).build()));
-        DeltaLakeColumnHandle varcharColumn = new DeltaLakeColumnHandle(columnName, VarcharType.createUnboundedVarcharType(), REGULAR);
+        DeltaLakeColumnHandle varcharColumn = new DeltaLakeColumnHandle(columnName, VarcharType.createUnboundedVarcharType(), columnName, VarcharType.createUnboundedVarcharType(), REGULAR);
 
         DeltaLakeFileStatistics fileStats = mergeStats(buildMultimap(columnName, metadata), ImmutableMap.of(columnName, createUnboundedVarcharType()), 20);
         assertEquals(fileStats.getNumRecords(), Optional.of(20L));

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestTransactionLogAccess.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestTransactionLogAccess.java
@@ -61,7 +61,7 @@ import static com.google.common.collect.Sets.union;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.testing.Assertions.assertEqualsIgnoreOrder;
 import static io.trino.plugin.deltalake.DeltaLakeColumnType.REGULAR;
-import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.extractSchema;
+import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.extractColumnMetadata;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogParser.LAST_CHECKPOINT_FILENAME;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogUtil.TRANSACTION_LOG_DIRECTORY;
 import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
@@ -598,7 +598,7 @@ public class TestTransactionLogAccess
         }
 
         assertEquals(expectedDataFiles.size(), dataFilesWithFixedVersion.size());
-        List<ColumnMetadata> columns = extractSchema(transactionLogAccess.getMetadataEntry(tableSnapshot, SESSION).get(), TESTING_TYPE_MANAGER);
+        List<ColumnMetadata> columns = extractColumnMetadata(transactionLogAccess.getMetadataEntry(tableSnapshot, SESSION).get(), TESTING_TYPE_MANAGER);
         for (int i = 0; i < expectedDataFiles.size(); i++) {
             AddFileEntry expected = expectedDataFiles.get(i);
             AddFileEntry actual = dataFilesWithFixedVersion.get(i);
@@ -614,7 +614,7 @@ public class TestTransactionLogAccess
             assertTrue(actual.getStats().isPresent());
 
             for (ColumnMetadata column : columns) {
-                DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(column.getName(), column.getType(), REGULAR);
+                DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(column.getName(), column.getType(), column.getName(), column.getType(), REGULAR);
                 assertEquals(expected.getStats().get().getMinColumnValue(columnHandle), actual.getStats().get().getMinColumnValue(columnHandle));
                 assertEquals(expected.getStats().get().getMaxColumnValue(columnHandle), actual.getStats().get().getMaxColumnValue(columnHandle));
                 assertEquals(expected.getStats().get().getNullCount(columnHandle.getName()), actual.getStats().get().getNullCount(columnHandle.getName()));
@@ -688,11 +688,11 @@ public class TestTransactionLogAccess
             // Types would need to be specified properly if stats were being read from JSON but are not can be ignored when reading parsed stats from parquet,
             // so it is safe to use INTEGER as a placeholder
             assertEquals(
-                    fileStats.getMinColumnValue(new DeltaLakeColumnHandle(columnName, IntegerType.INTEGER, REGULAR)),
+                    fileStats.getMinColumnValue(new DeltaLakeColumnHandle(columnName, IntegerType.INTEGER, columnName, IntegerType.INTEGER, REGULAR)),
                     Optional.of(statsValues.get(columnName)));
 
             assertEquals(
-                    fileStats.getMaxColumnValue(new DeltaLakeColumnHandle(columnName, IntegerType.INTEGER, REGULAR)),
+                    fileStats.getMaxColumnValue(new DeltaLakeColumnHandle(columnName, IntegerType.INTEGER, columnName, IntegerType.INTEGER, REGULAR)),
                     Optional.of(statsValues.get(columnName)));
         }
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreStatistics.java
@@ -87,7 +87,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestDeltaLakeMetastoreStatistics
 {
-    private static final ColumnHandle COLUMN_HANDLE = new DeltaLakeColumnHandle("val", DoubleType.DOUBLE, REGULAR);
+    private static final ColumnHandle COLUMN_HANDLE = new DeltaLakeColumnHandle("val", DoubleType.DOUBLE, "val", DoubleType.DOUBLE, REGULAR);
 
     private DeltaLakeMetastore deltaLakeMetastore;
     private HiveMetastore hiveMetastore;
@@ -364,47 +364,47 @@ public class TestDeltaLakeMetastoreStatistics
         assertEquals(stats.getRowCount(), Estimate.of(9));
 
         Map<ColumnHandle, ColumnStatistics> statisticsMap = stats.getColumnStatistics();
-        ColumnStatistics columnStats = statisticsMap.get(new DeltaLakeColumnHandle("dec_short", DecimalType.createDecimalType(5, 1), REGULAR));
+        ColumnStatistics columnStats = statisticsMap.get(new DeltaLakeColumnHandle("dec_short", DecimalType.createDecimalType(5, 1), "dec_short", DecimalType.createDecimalType(5, 1), REGULAR));
         assertEquals(columnStats.getNullsFraction(), Estimate.zero());
         assertEquals(columnStats.getRange().get().getMin(), -10.1);
         assertEquals(columnStats.getRange().get().getMax(), 10.1);
 
-        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("dec_long", DecimalType.createDecimalType(25, 3), REGULAR));
+        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("dec_long", DecimalType.createDecimalType(25, 3), "dec_long", DecimalType.createDecimalType(25, 3), REGULAR));
         assertEquals(columnStats.getNullsFraction(), Estimate.zero());
         assertEquals(columnStats.getRange().get().getMin(), -999999999999.123);
         assertEquals(columnStats.getRange().get().getMax(), 999999999999.123);
 
-        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("l", BIGINT, REGULAR));
+        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("l", BIGINT, "l", BIGINT, REGULAR));
         assertEquals(columnStats.getNullsFraction(), Estimate.zero());
         assertEquals(columnStats.getRange().get().getMin(), -10000000.0);
         assertEquals(columnStats.getRange().get().getMax(), 10000000.0);
 
-        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("in", INTEGER, REGULAR));
+        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("in", INTEGER, "in", INTEGER, REGULAR));
         assertEquals(columnStats.getNullsFraction(), Estimate.zero());
         assertEquals(columnStats.getRange().get().getMin(), -20000000.0);
         assertEquals(columnStats.getRange().get().getMax(), 20000000.0);
 
-        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("sh", SMALLINT, REGULAR));
+        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("sh", SMALLINT, "sh", SMALLINT, REGULAR));
         assertEquals(columnStats.getNullsFraction(), Estimate.zero());
         assertEquals(columnStats.getRange().get().getMin(), -123.0);
         assertEquals(columnStats.getRange().get().getMax(), 123.0);
 
-        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("byt", TINYINT, REGULAR));
+        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("byt", TINYINT, "byt", TINYINT, REGULAR));
         assertEquals(columnStats.getNullsFraction(), Estimate.zero());
         assertEquals(columnStats.getRange().get().getMin(), -42.0);
         assertEquals(columnStats.getRange().get().getMax(), 42.0);
 
-        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("fl", REAL, REGULAR));
+        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("fl", REAL, "fl", REAL, REGULAR));
         assertEquals(columnStats.getNullsFraction(), Estimate.zero());
         assertEquals((float) columnStats.getRange().get().getMin(), -0.123f);
         assertEquals((float) columnStats.getRange().get().getMax(), 0.123f);
 
-        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("dou", DOUBLE, REGULAR));
+        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("dou", DOUBLE, "dou", DOUBLE, REGULAR));
         assertEquals(columnStats.getNullsFraction(), Estimate.zero());
         assertEquals(columnStats.getRange().get().getMin(), -0.321);
         assertEquals(columnStats.getRange().get().getMax(), 0.321);
 
-        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("dat", DATE, REGULAR));
+        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("dat", DATE, "dat", DATE, REGULAR));
         assertEquals(columnStats.getNullsFraction(), Estimate.zero());
         assertEquals(columnStats.getRange().get().getMin(), (double) LocalDate.parse("1900-01-01").toEpochDay());
         assertEquals(columnStats.getRange().get().getMax(), (double) LocalDate.parse("5000-01-01").toEpochDay());
@@ -420,11 +420,11 @@ public class TestDeltaLakeMetastoreStatistics
         assertEquals(stats.getRowCount(), Estimate.of(9));
 
         Map<ColumnHandle, ColumnStatistics> statisticsMap = stats.getColumnStatistics();
-        ColumnStatistics columnStats = statisticsMap.get(new DeltaLakeColumnHandle("fl", REAL, REGULAR));
+        ColumnStatistics columnStats = statisticsMap.get(new DeltaLakeColumnHandle("fl", REAL, "fl", REAL, REGULAR));
         assertEquals(columnStats.getNullsFraction(), Estimate.zero());
         assertThat(columnStats.getRange()).isEmpty();
 
-        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("dou", DOUBLE, REGULAR));
+        columnStats = statisticsMap.get(new DeltaLakeColumnHandle("dou", DOUBLE, "dou", DOUBLE, REGULAR));
         assertEquals(columnStats.getNullsFraction(), Estimate.zero());
         assertThat(columnStats.getRange()).isEmpty();
     }
@@ -439,7 +439,7 @@ public class TestDeltaLakeMetastoreStatistics
         assertEquals(stats.getRowCount(), Estimate.of(9));
 
         Map<ColumnHandle, ColumnStatistics> statisticsMap = stats.getColumnStatistics();
-        ColumnStatistics columnStats = statisticsMap.get(new DeltaLakeColumnHandle("i", INTEGER, REGULAR));
+        ColumnStatistics columnStats = statisticsMap.get(new DeltaLakeColumnHandle("i", INTEGER, "i", INTEGER, REGULAR));
         assertEquals(columnStats.getNullsFraction(), Estimate.of(3.0 / 9.0));
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/statistics/BenchmarkExtendedStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/statistics/BenchmarkExtendedStatistics.java
@@ -79,7 +79,7 @@ public class BenchmarkExtendedStatistics
         {
             columns = new ArrayList<>(columnsCount);
             for (int i = 0; i < columnsCount; i++) {
-                columns.add(new DeltaLakeColumnHandle("column_" + i, BigintType.BIGINT, REGULAR));
+                columns.add(new DeltaLakeColumnHandle("column_" + i, BigintType.BIGINT, "column_" + i, BigintType.BIGINT, REGULAR));
             }
 
             fileStatistics = new ArrayList<>(filesCount);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/statistics/TestDeltaLakeFileStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/statistics/TestDeltaLakeFileStatistics.java
@@ -144,53 +144,53 @@ public class TestDeltaLakeFileStatistics
     {
         assertEquals(fileStatistics.getNumRecords(), Optional.of(1L));
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("byt", TINYINT, REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("byt", TINYINT, "byt", TINYINT, REGULAR)),
                 Optional.of(42L));
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("dat", DATE, REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("dat", DATE, "dat", DATE, REGULAR)),
                 Optional.of(LocalDate.parse("5000-01-01").toEpochDay()));
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("dec_long", DecimalType.createDecimalType(25, 3), REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("dec_long", DecimalType.createDecimalType(25, 3), "dec_long", DecimalType.createDecimalType(25, 3), REGULAR)),
                 Optional.of(encodeScaledValue(new BigDecimal("999999999999.123"), 3)));
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("dec_short", DecimalType.createDecimalType(5, 1), REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("dec_short", DecimalType.createDecimalType(5, 1), "dec_short", DecimalType.createDecimalType(5, 1), REGULAR)),
                 Optional.of(new BigDecimal("10.1").unscaledValue().longValueExact()));
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("dou", DoubleType.DOUBLE, REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("dou", DoubleType.DOUBLE, "dou", DoubleType.DOUBLE, REGULAR)),
                 Optional.of(0.321));
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("fl", REAL, REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("fl", REAL, "fl", REAL, REGULAR)),
                 Optional.of((long) floatToIntBits(0.123f)));
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("in", INTEGER, REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("in", INTEGER, "in", INTEGER, REGULAR)),
                 Optional.of(20000000L));
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("l", BIGINT, REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("l", BIGINT, "l", BIGINT, REGULAR)),
                 Optional.of(10000000L));
         Type rowType = RowType.rowType(RowType.field("s1", INTEGER), RowType.field("s3", VarcharType.createUnboundedVarcharType()));
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("row", rowType, REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("row", rowType, "row", rowType, REGULAR)),
                 Optional.empty());
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("arr", new ArrayType(INTEGER), REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("arr", new ArrayType(INTEGER), "arr", new ArrayType(INTEGER), REGULAR)),
                 Optional.empty());
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("m", new MapType(INTEGER, VarcharType.createUnboundedVarcharType(), new TypeOperators()), REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("m", new MapType(INTEGER, VarcharType.createUnboundedVarcharType(), new TypeOperators()), "m", new MapType(INTEGER, VarcharType.createUnboundedVarcharType(), new TypeOperators()), REGULAR)),
                 Optional.empty());
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("sh", SMALLINT, REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("sh", SMALLINT, "sh", SMALLINT, REGULAR)),
                 Optional.of(123L));
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("str", VarcharType.createUnboundedVarcharType(), REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("str", VarcharType.createUnboundedVarcharType(), "str", VarcharType.createUnboundedVarcharType(), REGULAR)),
                 Optional.of(utf8Slice("a")));
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("ts", TIMESTAMP_TZ_MILLIS, REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("ts", TIMESTAMP_TZ_MILLIS, "ts", TIMESTAMP_TZ_MILLIS, REGULAR)),
                 Optional.of(packDateTimeWithZone(LocalDateTime.parse("2960-10-31T01:00:00.000").toInstant(UTC).toEpochMilli(), UTC_KEY)));
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("bool", BOOLEAN, REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("bool", BOOLEAN, "bool", BOOLEAN, REGULAR)),
                 Optional.empty());
         assertEquals(
-                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("bin", VARBINARY, REGULAR)),
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("bin", VARBINARY, "bin", VARBINARY, REGULAR)),
                 Optional.empty());
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeColumnMappingMode.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeColumnMappingMode.java
@@ -65,11 +65,11 @@ public class TestDeltaLakeColumnMappingMode
     @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_OSS, PROFILE_SPECIFIC_TESTS})
     public void testColumnMappingModeName()
     {
-        String tableName = "test_dl_column_mapping_mode_name" + randomTableSuffix();
+        String tableName = "test_dl_column_mapping_mode_name_" + randomTableSuffix();
 
         onDelta().executeQuery("" +
                 "CREATE TABLE default." + tableName +
-                " (a_number INT)" +
+                " (a_number INT, array_col ARRAY<STRUCT<array_struct_element: STRING>>, nested STRUCT<field1: STRING>, a_string STRING)" +
                 " USING delta " +
                 " LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "'" +
                 " TBLPROPERTIES (" +
@@ -78,21 +78,209 @@ public class TestDeltaLakeColumnMappingMode
                 " 'delta.minWriterVersion'='5')");
 
         try {
+            onDelta().executeQuery("" +
+                    "INSERT INTO default." + tableName + " VALUES " +
+                    "(1, array(struct('nested 1')), struct('databricks 1'),'ala'), " +
+                    "(2, array(struct('nested 2')), struct('databricks 2'), 'kota')");
+
+            List<Row> expectedRows = ImmutableList.of(
+                    row(1, "nested 1", "databricks 1", "ala"),
+                    row(2, "nested 2", "databricks 2", "kota"));
+
+            assertThat(onDelta().executeQuery("SELECT a_number, array_col[0].array_struct_element, nested.field1, a_string FROM default." + tableName))
+                    .containsOnly(expectedRows);
+            assertThat(onTrino().executeQuery("SELECT a_number, array_col[1].array_struct_element, nested.field1, a_string FROM delta.default." + tableName))
+                    .containsOnly(expectedRows);
+            assertThat(onTrino().executeQuery("SELECT a_string FROM delta.default." + tableName + " WHERE a_number = 1"))
+                    .containsOnly(ImmutableList.of(row("ala")));
+            assertThat(onTrino().executeQuery("SELECT a_number FROM delta.default." + tableName + " WHERE nested.field1 = 'databricks 1'"))
+                    .containsOnly(ImmutableList.of(row(1)));
+
+            // Verify the connector can read renamed columns correctly
+            onDelta().executeQuery("ALTER TABLE default." + tableName + " RENAME COLUMN a_number TO new_a_column");
+            onDelta().executeQuery("ALTER TABLE default." + tableName + " RENAME COLUMN nested.field1 TO field2");
+
+            assertThat(onTrino().executeQuery("DESCRIBE delta.default." + tableName))
+                    .containsOnly(ImmutableList.of(
+                            row("new_a_column", "integer", "", ""),
+                            row("array_col", "array(row(array_struct_element varchar))", "", ""),
+                            row("nested", "row(field2 varchar)", "", ""),
+                            row("a_string", "varchar", "", "")));
+
+            assertThat(onDelta().executeQuery("SELECT new_a_column, array_col[0].array_struct_element, nested.field2, a_string FROM default." + tableName))
+                    .containsOnly(expectedRows);
+            assertThat(onTrino().executeQuery("SELECT new_a_column, array_col[1].array_struct_element, nested.field2, a_string FROM delta.default." + tableName))
+                    .containsOnly(expectedRows);
+        }
+        finally {
+            onDelta().executeQuery("DROP TABLE default." + tableName);
+        }
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_OSS, PROFILE_SPECIFIC_TESTS})
+    public void testColumnMappingModeNameWithNonLowerCaseColumnName()
+    {
+        String tableName = "test_dl_column_mapping_mode_name_non_loewr_case_" + randomTableSuffix();
+
+        onDelta().executeQuery("" +
+                "CREATE TABLE default." + tableName +
+                " (`mIxEd_CaSe` INT)" +
+                " USING delta " +
+                " LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "'" +
+                " TBLPROPERTIES (" +
+                " 'delta.columnMapping.mode'='name'," +
+                " 'delta.minReaderVersion'='2'," +
+                " 'delta.minWriterVersion'='5')");
+
+        try {
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES (0), (9)");
+
+            List<Row> expectedRows = ImmutableList.of(row(0), row(9));
+
+            assertThat(onDelta().executeQuery("SELECT * FROM default." + tableName))
+                    .containsOnly(expectedRows);
+            assertThat(onTrino().executeQuery("SELECT * FROM delta.default." + tableName))
+                    .containsOnly(expectedRows);
+
+            assertThat(onTrino().executeQuery("SHOW STATS FOR delta.default." + tableName))
+                    .containsOnly(ImmutableList.of(
+                            row("mixed_case", null, null, 0.0, null, "0", "9"),
+                            row(null, null, null, null, 2.0, null, null)));
+        }
+        finally {
+            onDelta().executeQuery("DROP TABLE default." + tableName);
+        }
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_OSS, PROFILE_SPECIFIC_TESTS})
+    public void testShowStatsFromJsonForColumnMappingModeName()
+    {
+        String tableName = "test_dl_show_stats_json_for_column_mapping_mode_" + randomTableSuffix();
+
+        onDelta().executeQuery("" +
+                "CREATE TABLE default." + tableName +
+                " (a_number INT)" +
+                " USING delta " +
+                " LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "'" +
+                " TBLPROPERTIES (" +
+                " 'delta.columnMapping.mode' = 'name'" +
+                ")");
+
+        try {
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES (1), (2), (null)");
+            assertThat(onTrino().executeQuery("SHOW STATS FOR delta.default." + tableName))
+                    .containsOnly(ImmutableList.of(
+                            row("a_number", null, null, 0.33333333333, null, "1", "2"),
+                            row(null, null, null, null, 3.0, null, null)));
+
+            onTrino().executeQuery("ANALYZE delta.default." + tableName);
+            assertThat(onTrino().executeQuery("SHOW STATS FOR delta.default." + tableName))
+                    .containsOnly(ImmutableList.of(
+                            row("a_number", null, 2.00000000000, 0.33333333333, null, "1", "2"),
+                            row(null, null, null, null, 3.0, null, null)));
+        }
+        finally {
+            onDelta().executeQuery("DROP TABLE default." + tableName);
+        }
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, PROFILE_SPECIFIC_TESTS})
+    public void testShowStatsFromParquetForColumnMappingModeName()
+    {
+        String tableName = "test_dl_show_parquet_stats_parquet_for_column_mapping_mode_" + randomTableSuffix();
+
+        onDelta().executeQuery("" +
+                "CREATE TABLE default." + tableName +
+                " (a_number INT)" +
+                " USING delta " +
+                " LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "'" +
+                " TBLPROPERTIES (" +
+                " 'delta.columnMapping.mode' = 'name'," +
+                " 'delta.checkpointInterval' = 3" +
+                ")");
+
+        try {
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES (0)");
             onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES (1)");
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES (null)");
+            assertThat(onTrino().executeQuery("SHOW STATS FOR delta.default." + tableName))
+                    .containsOnly(ImmutableList.of(
+                            row("a_number", null, null, 0.33333333333, null, "0", "1"),
+                            row(null, null, null, null, 3.0, null, null)));
 
-            assertQueryFailure(() -> onTrino().executeQuery("DESCRIBE delta.default." + tableName))
-                    .hasMessageContaining("Only 'none' is supported for 'delta.columnMapping.mode' table property");
+            onTrino().executeQuery("ANALYZE delta.default." + tableName);
+            assertThat(onTrino().executeQuery("SHOW STATS FOR delta.default." + tableName))
+                    .containsOnly(ImmutableList.of(
+                            row("a_number", null, 2.00000000000, 0.33333333333, null, "0", "1"),
+                            row(null, null, null, null, 3.0, null, null)));
+        }
+        finally {
+            onDelta().executeQuery("DROP TABLE default." + tableName);
+        }
+    }
 
-            assertQueryFailure(() -> onTrino().executeQuery("SELECT * FROM delta.default." + tableName))
-                    .hasMessageContaining("Only 'none' is supported for 'delta.columnMapping.mode' table property");
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_OSS, PROFILE_SPECIFIC_TESTS})
+    public void testShowStatsOnPartitionedForColumnMappingModeName()
+    {
+        String tableName = "test_dl_show_stats_partitioned_for_column_mapping_mode_" + randomTableSuffix();
 
-            assertQueryFailure(() -> onTrino().executeQuery("SHOW STATS FOR delta.default." + tableName))
-                    .hasMessageContaining("Only 'none' is supported for 'delta.columnMapping.mode' table property");
+        onDelta().executeQuery("" +
+                "CREATE TABLE default." + tableName +
+                " (a_number INT, part STRING)" +
+                " USING delta " +
+                " PARTITIONED BY (part) " +
+                " LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "'" +
+                " TBLPROPERTIES (" +
+                " 'delta.columnMapping.mode' = 'name'," +
+                " 'checkpointInterval' = 3" +
+                ")");
 
-            assertQueryFailure(() -> onTrino().executeQuery("INSERT INTO delta.default." + tableName + " VALUES (1)"))
-                    .hasMessageContaining("Only 'none' is supported for 'delta.columnMapping.mode' table property");
+        try {
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES (0, 'a')");
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES (1, 'b')");
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES (null, null)");
 
-            // Note that changing delta.columnMapping.mode from 'name' or unsetting the property is unsupported in Delta Lake
+            assertThat(onTrino().executeQuery("SHOW STATS FOR delta.default." + tableName))
+                    .containsOnly(ImmutableList.of(
+                            row("a_number", null, null, 0.33333333333, null, "0", "1"),
+                            row("part", null, 2.00000000000, 0.33333333333, null, null, null),
+                            row(null, null, null, null, 3.0, null, null)));
+        }
+        finally {
+            onDelta().executeQuery("DROP TABLE default." + tableName);
+        }
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_OSS, PROFILE_SPECIFIC_TESTS})
+    public void testUnsupportedOperationsColumnMappingModeName()
+    {
+        String tableName = "test_dl_unsupported_column_mapping_mode_" + randomTableSuffix();
+
+        onDelta().executeQuery("" +
+                "CREATE TABLE default." + tableName +
+                " (a_number INT, a_string STRING)" +
+                " USING delta " +
+                " LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "'" +
+                " TBLPROPERTIES (" +
+                " 'delta.columnMapping.mode'='name'," +
+                " 'delta.minReaderVersion'='2'," +
+                " 'delta.minWriterVersion'='5')");
+
+        try {
+            assertQueryFailure(() -> onTrino().executeQuery("INSERT INTO default." + tableName + " VALUES (1, 'one'), (2, 'two')"))
+                    .hasMessageContaining("Delta Lake writer version 5 which is not supported");
+            assertQueryFailure(() -> onTrino().executeQuery("DELETE FROM default." + tableName))
+                    .hasMessageContaining("Delta Lake writer version 5 which is not supported");
+            assertQueryFailure(() -> onTrino().executeQuery("UPDATE default." + tableName + " SET a_string = 'test'"))
+                    .hasMessageContaining("Delta Lake writer version 5 which is not supported");
+            assertQueryFailure(() -> onTrino().executeQuery("ALTER TABLE default." + tableName + " EXECUTE OPTIMIZE"))
+                    .hasMessageContaining("Delta Lake writer version 5 which is not supported");
+            assertQueryFailure(() -> onTrino().executeQuery("ALTER TABLE default." + tableName + " ADD COLUMN new_col varchar"))
+                    .hasMessageContaining("Delta Lake writer version 5 which is not supported");
+            assertQueryFailure(() -> onTrino().executeQuery("ALTER TABLE default." + tableName + " RENAME COLUMN a_number TO renamed_column"))
+                    .hasMessageContaining("This connector does not support renaming columns");
+            assertQueryFailure(() -> onTrino().executeQuery("ALTER TABLE default." + tableName + " DROP COLUMN a_number"))
+                    .hasMessageContaining("This connector does not support dropping columns");
         }
         finally {
             onDelta().executeQuery("DROP TABLE default." + tableName);


### PR DESCRIPTION
## Description

Support reading Delta Lake tables having `delta.columnMapping.mode=name`
https://github.com/delta-io/delta/blob/master/PROTOCOL.md#reader-requirements-for-column-mapping
Relates to #12592

## Documentation

(x) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# Delta Lake
* Support reading tables having `delta.columnMapping.mode=name`. ({issue}`12675`)
```
