### PR TITLE
Fix filesystem implementation loading in Iceberg

### DIFF
--- a/.mvn/modernizer/violations.xml
+++ b/.mvn/modernizer/violations.xml
@@ -143,7 +143,14 @@
     <violation>
         <name>org/apache/hadoop/conf/Configuration."&lt;init&gt;":()V</name>
         <version>1.1</version>
-        <comment>Prefer new Configuration(false)</comment>
+        <!-- retain mention of `new Configuration(false)` as it describes why this constructor is discouraged for the first place -->
+        <comment>Prefer new Configuration(false), actually use ConfigurationInstantiator.newEmptyConfiguration()</comment>
+    </violation>
+
+    <violation>
+        <name>org/apache/hadoop/conf/Configuration."&lt;init&gt;":(Z)V</name>
+        <version>1.1</version>
+        <comment>Prefer ConfigurationInstantiator.newEmptyConfiguration()</comment>
     </violation>
 
     <violation>

--- a/lib/trino-hadoop-toolkit/pom.xml
+++ b/lib/trino-hadoop-toolkit/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.trino</groupId>
+        <artifactId>trino-root</artifactId>
+        <version>384-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>trino-hadoop-toolkit</artifactId>
+    <name>trino-hadoop-toolkit</name>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.trino.hadoop</groupId>
+            <artifactId>hadoop-apache</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.gaul</groupId>
+            <artifactId>modernizer-maven-annotations</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/lib/trino-hadoop-toolkit/src/main/java/io/trino/hadoop/ConfigurationInstantiator.java
+++ b/lib/trino-hadoop-toolkit/src/main/java/io/trino/hadoop/ConfigurationInstantiator.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hadoop;
+
+import org.apache.hadoop.conf.Configuration;
+import org.gaul.modernizer_maven_annotations.SuppressModernizer;
+
+import static com.google.common.base.Preconditions.checkState;
+
+public final class ConfigurationInstantiator
+{
+    private ConfigurationInstantiator() {}
+
+    public static Configuration newEmptyConfiguration()
+    {
+        return newConfiguration(false);
+    }
+
+    /**
+     * @see Configuration#Configuration(boolean)
+     */
+    public static Configuration newConfigurationWithDefaultResources()
+    {
+        return newConfiguration(true);
+    }
+
+    private static Configuration newConfiguration(boolean loadDefaults)
+    {
+        // Configuration captures TCCL and it may used later e.g. to load filesystem implementation class
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        ClassLoader expectedClassLoader = ConfigurationInstantiator.class.getClassLoader();
+        checkState(
+                tccl == expectedClassLoader,
+                "During instantiation, the Configuration object captures the TCCL and uses it to resolve classes by name. " +
+                        "For this reason, the current TCCL %s should be same as this class's classloader %s. " +
+                        "Otherwise the constructed Configuration will use *some* classloader to resolve classes",
+                tccl,
+                expectedClassLoader);
+        return newConfigurationWithTccl(loadDefaults);
+    }
+
+    // new Configuration(boolean) is prohibited asking to use newEmptyConfiguration(). Only ConfigurationInstantiator can instantiate Configuration directly.
+    @SuppressModernizer
+    private static Configuration newConfigurationWithTccl(boolean loadDefaults)
+    {
+        // Note: the Configuration captures current thread context class loader (TCCL), so it may or may not be generally usable.
+        return new Configuration(loadDefaults);
+    }
+}

--- a/lib/trino-orc/pom.xml
+++ b/lib/trino-orc/pom.xml
@@ -103,6 +103,12 @@
         <!-- for testing -->
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-hadoop-toolkit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-main</artifactId>
             <scope>test</scope>
         </dependency>

--- a/lib/trino-orc/src/test/java/io/trino/orc/OrcTester.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/OrcTester.java
@@ -50,7 +50,6 @@ import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeSignatureParameter;
 import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.type.Date;
 import org.apache.hadoop.hive.common.type.HiveChar;
@@ -113,6 +112,7 @@ import static com.google.common.collect.Lists.newArrayList;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.airlift.units.DataSize.succinctBytes;
+import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.orc.OrcReader.MAX_BATCH_SIZE;
 import static io.trino.orc.OrcTester.Format.ORC_11;
@@ -770,7 +770,7 @@ public class OrcTester
             Iterable<?> expectedValues)
             throws Exception
     {
-        JobConf configuration = new JobConf(new Configuration(false));
+        JobConf configuration = new JobConf(newEmptyConfiguration());
         configuration.set(READ_COLUMN_IDS_CONF_STR, "0");
         configuration.setBoolean(READ_ALL_COLUMNS, false);
 

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestOrcReaderPositions.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestOrcReaderPositions.java
@@ -43,6 +43,7 @@ import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.util.Map;
 
+import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.orc.OrcReader.BATCH_SIZE_GROWTH_FACTOR;
 import static io.trino.orc.OrcReader.INITIAL_BATCH_SIZE;
 import static io.trino.orc.OrcReader.MAX_BATCH_SIZE;
@@ -412,7 +413,7 @@ public class TestOrcReaderPositions
     private static void createFileWithOnlyUserMetadata(File file, Map<String, String> metadata)
             throws IOException
     {
-        Configuration conf = new Configuration(false);
+        Configuration conf = newEmptyConfiguration();
         OrcFile.WriterOptions writerOptions = OrcFile.writerOptions(conf)
                 .memory(new NullMemoryManager())
                 .inspector(createSettableStructObjectInspector("test", BIGINT))

--- a/lib/trino-rcfile/pom.xml
+++ b/lib/trino-rcfile/pom.xml
@@ -20,6 +20,11 @@
     <dependencies>
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-hadoop-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-plugin-toolkit</artifactId>
         </dependency>
 

--- a/lib/trino-rcfile/src/main/java/io/trino/rcfile/HadoopCodecFactory.java
+++ b/lib/trino-rcfile/src/main/java/io/trino/rcfile/HadoopCodecFactory.java
@@ -14,10 +14,11 @@
 package io.trino.rcfile;
 
 import org.apache.hadoop.conf.Configurable;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.compress.CompressionCodec;
 
 import java.lang.reflect.Constructor;
+
+import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 
 public class HadoopCodecFactory
         implements RcFileCodecFactory
@@ -54,7 +55,7 @@ public class HadoopCodecFactory
                 // Hadoop is crazy... you have to give codecs an empty configuration or they throw NPEs
                 // but you need to make sure the configuration doesn't "load" defaults or it spends
                 // forever loading XML with no useful information
-                ((Configurable) codec).setConf(new Configuration(false));
+                ((Configurable) codec).setConf(newEmptyConfiguration());
             }
             return codec;
         }

--- a/lib/trino-rcfile/src/test/java/io/trino/rcfile/RcFileTester.java
+++ b/lib/trino-rcfile/src/test/java/io/trino/rcfile/RcFileTester.java
@@ -42,7 +42,6 @@ import io.trino.spi.type.SqlVarbinary;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeSignatureParameter;
 import io.trino.spi.type.VarcharType;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.type.Date;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
@@ -122,6 +121,7 @@ import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.rcfile.RcFileDecoderUtils.findFirstSyncPosition;
 import static io.trino.rcfile.RcFileTester.Compression.BZIP2;
 import static io.trino.rcfile.RcFileTester.Compression.LZ4;
@@ -749,7 +749,7 @@ public class RcFileTester
             Iterable<?> expectedValues)
             throws Exception
     {
-        JobConf configuration = new JobConf(new Configuration(false));
+        JobConf configuration = new JobConf(newEmptyConfiguration());
         configuration.set(READ_COLUMN_IDS_CONF_STR, "0");
         configuration.setBoolean(READ_ALL_COLUMNS, false);
 

--- a/plugin/trino-delta-lake/pom.xml
+++ b/plugin/trino-delta-lake/pom.xml
@@ -170,6 +170,12 @@
 
         <!-- used by tests but also needed transitively -->
         <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-hadoop-toolkit</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>log-manager</artifactId>
             <scope>runtime</scope>

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/FileTestingTransactionLogSynchronizer.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/FileTestingTransactionLogSynchronizer.java
@@ -15,13 +15,14 @@ package io.trino.plugin.deltalake;
 
 import io.trino.plugin.deltalake.transactionlog.writer.TransactionLogSynchronizer;
 import io.trino.spi.connector.ConnectorSession;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+
+import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 
 public class FileTestingTransactionLogSynchronizer
         implements TransactionLogSynchronizer
@@ -36,7 +37,7 @@ public class FileTestingTransactionLogSynchronizer
     public void write(ConnectorSession session, String clusterId, Path newLogEntryPath, byte[] entryContents)
     {
         try {
-            FileSystem fileSystem = newLogEntryPath.getFileSystem(new Configuration(false));
+            FileSystem fileSystem = newLogEntryPath.getFileSystem(newEmptyConfiguration());
             try (FSDataOutputStream outputStream = fileSystem.createFile(newLogEntryPath).build()) {
                 outputStream.write(entryContents);
             }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestTableSnapshot.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestTableSnapshot.java
@@ -47,6 +47,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointEntryIterator.EntryType.ADD;
 import static io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointEntryIterator.EntryType.PROTOCOL;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
@@ -73,7 +74,7 @@ public class TestTableSnapshot
         URI deltaLogPath = getClass().getClassLoader().getResource("databricks/person").toURI();
         tableLocation = new Path(deltaLogPath);
 
-        Configuration conf = new Configuration(false);
+        Configuration conf = newEmptyConfiguration();
         FileSystem filesystem = tableLocation.getFileSystem(conf);
         accessTrackingFileSystem = new AccessTrackingFileSystem(filesystem);
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestTransactionLogParser.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestTransactionLogParser.java
@@ -19,6 +19,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.testng.annotations.Test;
 
+import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogParser.getMandatoryCurrentVersion;
 import static org.testng.Assert.assertEquals;
 
@@ -28,7 +29,7 @@ public class TestTransactionLogParser
     public void testGetCurrentVersion()
             throws Exception
     {
-        Configuration conf = new Configuration(false);
+        Configuration conf = newEmptyConfiguration();
         Path basePath = new Path(getClass().getClassLoader().getResource("databricks").toURI());
         FileSystem filesystem = basePath.getFileSystem(conf);
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestTransactionLogTail.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestTransactionLogTail.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 
+import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -53,7 +54,7 @@ public class TestTransactionLogTail
     {
         URI resource = getClass().getClassLoader().getResource(tableLocation).toURI();
         Path tablePath = new Path(resource);
-        Configuration config = new Configuration(false);
+        Configuration config = newEmptyConfiguration();
         FileSystem fileSystem = tablePath.getFileSystem(config);
         TransactionLogTail transactionLogTail = TransactionLogTail.loadNewTail(fileSystem, tablePath, Optional.of(10L), Optional.of(12L));
         Optional<TransactionLogTail> updatedLogTail = transactionLogTail.getUpdatedTail(fileSystem, tablePath);
@@ -66,7 +67,7 @@ public class TestTransactionLogTail
     {
         URI resource = getClass().getClassLoader().getResource(tableLocation).toURI();
         Path tablePath = new Path(resource);
-        Configuration config = new Configuration(false);
+        Configuration config = newEmptyConfiguration();
         FileSystem filesystem = tablePath.getFileSystem(config);
         TransactionLogTail transactionLogTail = TransactionLogTail.loadNewTail(filesystem, tablePath, Optional.of(10L));
         return transactionLogTail.getFileEntries();

--- a/plugin/trino-hive/pom.xml
+++ b/plugin/trino-hive/pom.xml
@@ -25,6 +25,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-hadoop-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-memory-context</artifactId>
         </dependency>
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveHdfsConfiguration.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveHdfsConfiguration.java
@@ -22,6 +22,7 @@ import javax.inject.Inject;
 import java.net.URI;
 import java.util.Set;
 
+import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.plugin.hive.util.ConfigurationUtils.copy;
 import static io.trino.plugin.hive.util.ConfigurationUtils.getInitialConfiguration;
 import static java.util.Objects.requireNonNull;
@@ -37,7 +38,7 @@ public class HiveHdfsConfiguration
         @Override
         protected Configuration initialValue()
         {
-            Configuration configuration = new Configuration(false);
+            Configuration configuration = newEmptyConfiguration();
             copy(INITIAL_CONFIGURATION, configuration);
             initializer.initializeConfiguration(configuration);
             return configuration;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -94,6 +94,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
+import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_CORRUPTED_COLUMN_STATISTICS;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
@@ -1341,7 +1342,7 @@ public class SemiTransactionalHiveMetastore
     private long getServerExpectedHeartbeatIntervalMillis()
     {
         String hiveServerTransactionTimeout = delegate.getConfigValue(TXN_TIMEOUT.getVarname()).orElseGet(() -> TXN_TIMEOUT.getDefaultVal().toString());
-        Configuration configuration = new Configuration(false);
+        Configuration configuration = newEmptyConfiguration();
         configuration.set(TXN_TIMEOUT.toString(), hiveServerTransactionTimeout);
         return getTimeVar(configuration, TXN_TIMEOUT, MILLISECONDS) / 2;
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/ConfigurationUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/ConfigurationUtils.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.hadoop.ConfigurationInstantiator.newConfigurationWithDefaultResources;
+import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 
 public final class ConfigurationUtils
 {
@@ -33,8 +35,8 @@ public final class ConfigurationUtils
 
         // must not be transitively reloaded during the future loading of various Hadoop modules
         // all the required default resources must be declared above
-        INITIAL_CONFIGURATION = new Configuration(false);
-        Configuration defaultConfiguration = new Configuration(true);
+        INITIAL_CONFIGURATION = newEmptyConfiguration();
+        Configuration defaultConfiguration = newConfigurationWithDefaultResources();
         copy(defaultConfiguration, INITIAL_CONFIGURATION);
     }
 
@@ -47,7 +49,7 @@ public final class ConfigurationUtils
 
     public static Configuration copy(Configuration configuration)
     {
-        Configuration copy = new Configuration(false);
+        Configuration copy = newEmptyConfiguration();
         copy(configuration, copy);
         return copy;
     }
@@ -69,12 +71,12 @@ public final class ConfigurationUtils
 
     public static Configuration readConfiguration(List<File> resourcePaths)
     {
-        Configuration result = new Configuration(false);
+        Configuration result = newEmptyConfiguration();
 
         for (File resourcePath : resourcePaths) {
             checkArgument(resourcePath.exists(), "File does not exist: %s", resourcePath);
 
-            Configuration resourceProperties = new Configuration(false);
+            Configuration resourceProperties = newEmptyConfiguration();
             // We need to call `getPath` instead of `toURI` because Hadoop library can not handle a configuration file with relative Xinclude files in case of passing URI.
             // In details, see https://issues.apache.org/jira/browse/HADOOP-17088.
             resourceProperties.addResource(new Path(resourcePath.getPath()));

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileFormats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileFormats.java
@@ -40,7 +40,6 @@ import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 import io.trino.testing.MaterializedResult;
 import io.trino.testing.MaterializedRow;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.type.Date;
 import org.apache.hadoop.hive.common.type.HiveChar;
@@ -85,6 +84,7 @@ import java.util.stream.Collectors;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
 import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static io.trino.plugin.hive.HiveColumnHandle.createBaseColumn;
@@ -626,7 +626,7 @@ public abstract class AbstractTestHiveFileFormats
                 testColumns.stream()
                         .map(TestColumn::getType)
                         .collect(Collectors.joining(",")));
-        serializer.initialize(new Configuration(false), tableProperties);
+        serializer.initialize(newEmptyConfiguration(), tableProperties);
 
         JobConf jobConf = new JobConf();
         configureCompression(jobConf, compressionCodec);
@@ -640,7 +640,7 @@ public abstract class AbstractTestHiveFileFormats
                 () -> {});
 
         try {
-            serializer.initialize(new Configuration(false), tableProperties);
+            serializer.initialize(newEmptyConfiguration(), tableProperties);
 
             SettableStructObjectInspector objectInspector = getStandardStructObjectInspector(
                     testColumns.stream()
@@ -673,7 +673,7 @@ public abstract class AbstractTestHiveFileFormats
 
         // todo to test with compression, the file must be renamed with the compression extension
         Path path = new Path(filePath);
-        path.getFileSystem(new Configuration(false)).setVerifyChecksum(true);
+        path.getFileSystem(newEmptyConfiguration()).setVerifyChecksum(true);
         File file = new File(filePath);
         return new FileSplit(path, 0, file.length(), new String[0]);
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestFileSystemCache.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestFileSystemCache.java
@@ -18,13 +18,13 @@ import io.trino.plugin.hive.authentication.ImpersonatingHdfsAuthentication;
 import io.trino.plugin.hive.authentication.SimpleHadoopAuthentication;
 import io.trino.plugin.hive.authentication.SimpleUserNameProvider;
 import io.trino.spi.security.ConnectorIdentity;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
 
+import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertSame;
 
@@ -59,6 +59,6 @@ public class TestFileSystemCache
     private FileSystem getFileSystem(HdfsEnvironment environment, ConnectorIdentity identity)
             throws IOException
     {
-        return environment.getFileSystem(identity, new Path("/"), new Configuration(false));
+        return environment.getFileSystem(identity, new Path("/"), newEmptyConfiguration());
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
@@ -69,6 +69,7 @@ import java.util.stream.Collectors;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.plugin.hive.HivePageSourceProvider.ColumnMapping.buildColumnMappings;
 import static io.trino.plugin.hive.HiveStorageFormat.AVRO;
 import static io.trino.plugin.hive.HiveStorageFormat.CSV;
@@ -921,7 +922,7 @@ public class TestHiveFileFormats
                 .map(partitionKey -> format("%s=%s", partitionKey.getName(), partitionKey.getValue()))
                 .collect(toImmutableList()));
 
-        Configuration configuration = new Configuration(false);
+        Configuration configuration = newEmptyConfiguration();
         configuration.set("io.compression.codecs", LzoCodec.class.getName() + "," + LzopCodec.class.getName());
 
         List<HiveColumnHandle> columnHandles = getColumnHandles(testReadColumns);
@@ -1017,7 +1018,7 @@ public class TestHiveFileFormats
         Optional<ConnectorPageSource> pageSource = HivePageSourceProvider.createHivePageSource(
                 ImmutableSet.of(sourceFactory),
                 ImmutableSet.of(),
-                new Configuration(false),
+                newEmptyConfiguration(),
                 session,
                 split.getPath(),
                 OptionalInt.empty(),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOrcPageSourceMemoryTracking.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOrcPageSourceMemoryTracking.java
@@ -97,6 +97,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.testing.Assertions.assertBetweenInclusive;
 import static io.airlift.units.DataSize.Unit.BYTE;
+import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.metadata.FunctionManager.createTestingFunctionManager;
 import static io.trino.orc.OrcReader.MAX_BATCH_SIZE;
 import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
@@ -135,7 +136,7 @@ public class TestOrcPageSourceMemoryTracking
 {
     private static final String ORC_RECORD_WRITER = OrcOutputFormat.class.getName() + "$OrcRecordWriter";
     private static final Constructor<? extends RecordWriter> WRITER_CONSTRUCTOR = getOrcWriterConstructor();
-    private static final Configuration CONFIGURATION = new Configuration(false);
+    private static final Configuration CONFIGURATION = newEmptyConfiguration();
     private static final int NUM_ROWS = 50000;
     private static final int STRIPE_ROWS = 20000;
     private static final FunctionManager functionManager = createTestingFunctionManager();
@@ -567,7 +568,7 @@ public class TestOrcPageSourceMemoryTracking
             return HivePageSourceProvider.createHivePageSource(
                     ImmutableSet.of(orcPageSourceFactory),
                     ImmutableSet.of(),
-                    new Configuration(false),
+                    newEmptyConfiguration(),
                     session,
                     fileSplit.getPath(),
                     OptionalInt.empty(),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOriginalFilesUtils.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOriginalFilesUtils.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.plugin.hive.AcidInfo.OriginalFileInfo;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static io.trino.testing.TestingConnectorSession.SESSION;
@@ -41,7 +42,7 @@ public class TestOriginalFilesUtils
             throws Exception
     {
         tablePath = new File(Resources.getResource(("dummy_id_data_orc")).toURI()).getPath();
-        config = new JobConf(new Configuration(false));
+        config = new JobConf(newEmptyConfiguration());
     }
 
     @Test

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/AbstractFileFormat.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/AbstractFileFormat.java
@@ -40,7 +40,6 @@ import io.trino.spi.connector.RecordPageSource;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.Type;
 import io.trino.sql.planner.TestingConnectorTransactionHandle;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.JobConf;
 
@@ -54,6 +53,7 @@ import java.util.stream.IntStream;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static io.trino.plugin.hive.HiveColumnHandle.createBaseColumn;
 import static io.trino.plugin.hive.HiveType.toHiveType;
@@ -72,7 +72,7 @@ public abstract class AbstractFileFormat
     static final JobConf conf;
 
     static {
-        conf = new JobConf(new Configuration(false));
+        conf = new JobConf(newEmptyConfiguration());
         conf.set("fs.file.impl", "org.apache.hadoop.fs.RawLocalFileSystem");
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcDeleteDeltaPageSource.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcDeleteDeltaPageSource.java
@@ -21,7 +21,6 @@ import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.security.ConnectorIdentity;
 import io.trino.testing.MaterializedResult;
 import io.trino.testing.MaterializedRow;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.io.AcidOutputFormat;
 import org.apache.hadoop.hive.ql.io.BucketCodec;
@@ -30,6 +29,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 
+import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static io.trino.plugin.hive.HiveTestUtils.SESSION;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -46,7 +46,7 @@ public class TestOrcDeleteDeltaPageSource
         OrcDeleteDeltaPageSourceFactory pageSourceFactory = new OrcDeleteDeltaPageSourceFactory(
                 new OrcReaderOptions(),
                 ConnectorIdentity.ofUser("test"),
-                new JobConf(new Configuration(false)),
+                new JobConf(newEmptyConfiguration()),
                 HDFS_ENVIRONMENT,
                 new FileFormatDataSourceStats());
 
@@ -55,7 +55,7 @@ public class TestOrcDeleteDeltaPageSource
 
         assertEquals(materializedRows.getRowCount(), 1);
 
-        AcidOutputFormat.Options bucketOptions = new AcidOutputFormat.Options(new Configuration(false)).bucket(0);
+        AcidOutputFormat.Options bucketOptions = new AcidOutputFormat.Options(newEmptyConfiguration()).bucket(0);
         assertEquals(materializedRows.getMaterializedRows().get(0), new MaterializedRow(5, 2L, BucketCodec.V1.encode(bucketOptions), 0L));
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcDeletedRows.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcDeletedRows.java
@@ -22,7 +22,6 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.security.ConnectorIdentity;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.apache.hadoop.mapred.JobConf;
@@ -33,6 +32,7 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
 
+import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static io.trino.plugin.hive.HiveTestUtils.SESSION;
@@ -153,7 +153,7 @@ public class TestOrcDeletedRows
 
     private static OrcDeletedRows createOrcDeletedRows(AcidInfo acidInfo, String sourceFileName)
     {
-        JobConf configuration = new JobConf(new Configuration(false));
+        JobConf configuration = new JobConf(newEmptyConfiguration());
         OrcDeleteDeltaPageSourceFactory pageSourceFactory = new OrcDeleteDeltaPageSourceFactory(
                 new OrcReaderOptions(),
                 ConnectorIdentity.ofUser("test"),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcPageSourceFactory.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcPageSourceFactory.java
@@ -29,7 +29,6 @@ import io.trino.spi.type.Type;
 import io.trino.tpch.Nation;
 import io.trino.tpch.NationColumn;
 import io.trino.tpch.NationGenerator;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.JobConf;
 import org.assertj.core.api.Assertions;
@@ -50,6 +49,7 @@ import java.util.function.LongPredicate;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.io.Resources.getResource;
+import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static io.trino.plugin.hive.HiveColumnHandle.createBaseColumn;
 import static io.trino.plugin.hive.HiveStorageFormat.ORC;
@@ -230,7 +230,7 @@ public class TestOrcPageSourceFactory
                 .collect(toImmutableList());
 
         Optional<ReaderPageSource> pageSourceWithProjections = PAGE_SOURCE_FACTORY.createPageSource(
-                new JobConf(new Configuration(false)),
+                new JobConf(newEmptyConfiguration()),
                 SESSION,
                 new Path(filePath),
                 0,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcPredicates.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcPredicates.java
@@ -32,7 +32,6 @@ import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.FileSplit;
 import org.testng.annotations.Test;
 
@@ -48,6 +47,7 @@ import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.plugin.hive.HivePageSourceProvider.ColumnMapping.buildColumnMappings;
 import static io.trino.plugin.hive.HiveStorageFormat.ORC;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
@@ -219,7 +219,7 @@ public class TestOrcPredicates
         Optional<ConnectorPageSource> pageSource = HivePageSourceProvider.createHivePageSource(
                 ImmutableSet.of(readerFactory),
                 ImmutableSet.of(),
-                new Configuration(false),
+                newEmptyConfiguration(),
                 session,
                 split.getPath(),
                 OptionalInt.empty(),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestTimestampMicros.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestTimestampMicros.java
@@ -28,7 +28,6 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.Type;
 import io.trino.testing.MaterializedResult;
 import io.trino.testing.MaterializedRow;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -41,6 +40,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Properties;
 
+import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static io.trino.plugin.hive.HiveColumnHandle.createBaseColumn;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
@@ -109,7 +109,7 @@ public class TestTimestampMicros
         schema.setProperty(SERIALIZATION_LIB, HiveStorageFormat.PARQUET.getSerde());
 
         ReaderPageSource pageSourceWithProjections = pageSourceFactory.createPageSource(
-                new Configuration(false),
+                        newEmptyConfiguration(),
                 session,
                 new Path(parquetFile.toURI()),
                 0,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/TestS3SecurityMapping.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/TestS3SecurityMapping.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.io.Resources.getResource;
+import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.plugin.hive.HiveTestUtils.getHiveSessionProperties;
 import static io.trino.plugin.hive.s3.TestS3SecurityMapping.MappingResult.clusterDefaultRole;
 import static io.trino.plugin.hive.s3.TestS3SecurityMapping.MappingResult.credentials;
@@ -339,7 +340,7 @@ public class TestS3SecurityMapping
 
     private static void assertMapping(DynamicConfigurationProvider provider, MappingSelector selector, MappingResult mappingResult)
     {
-        Configuration configuration = new Configuration(false);
+        Configuration configuration = newEmptyConfiguration();
 
         assertNull(configuration.get(S3_ACCESS_KEY));
         assertNull(configuration.get(S3_SECRET_KEY));
@@ -358,7 +359,7 @@ public class TestS3SecurityMapping
 
     private static void assertMappingFails(DynamicConfigurationProvider provider, MappingSelector selector, String message)
     {
-        Configuration configuration = new Configuration(false);
+        Configuration configuration = newEmptyConfiguration();
 
         assertThatThrownBy(() -> applyMapping(provider, selector, configuration))
                 .isInstanceOf(AccessDeniedException.class)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/TestTrinoS3FileSystem.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/TestTrinoS3FileSystem.java
@@ -73,6 +73,7 @@ import static com.google.common.io.ByteStreams.toByteArray;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.airlift.testing.Assertions.assertInstanceOf;
+import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_ACCESS_KEY;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_ACL_TYPE;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_CREDENTIALS_PROVIDER;
@@ -115,7 +116,7 @@ public class TestTrinoS3FileSystem
     public void testEmbeddedCredentials()
             throws Exception
     {
-        Configuration config = new Configuration(false);
+        Configuration config = newEmptyConfiguration();
         try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
             AWSCredentials credentials = getStaticCredentials(config, fs, "s3n://testAccess:testSecret@test-bucket/");
             assertEquals(credentials.getAWSAccessKeyId(), "testAccess");
@@ -128,7 +129,7 @@ public class TestTrinoS3FileSystem
     public void testStaticCredentials()
             throws Exception
     {
-        Configuration config = new Configuration(false);
+        Configuration config = newEmptyConfiguration();
         config.set(S3_ACCESS_KEY, "test_access_key");
         config.set(S3_SECRET_KEY, "test_secret_key");
 
@@ -162,7 +163,7 @@ public class TestTrinoS3FileSystem
     public void testEndpointWithPinToCurrentRegionConfiguration()
             throws Exception
     {
-        Configuration config = new Configuration(false);
+        Configuration config = newEmptyConfiguration();
         config.set(S3_ENDPOINT, "test.example.endpoint.com");
         config.set(S3_PIN_CLIENT_TO_CURRENT_REGION, "true");
         try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
@@ -174,7 +175,7 @@ public class TestTrinoS3FileSystem
     public void testAssumeRoleDefaultCredentials()
             throws Exception
     {
-        Configuration config = new Configuration(false);
+        Configuration config = newEmptyConfiguration();
         config.set(S3_IAM_ROLE, "test_role");
 
         try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
@@ -188,7 +189,7 @@ public class TestTrinoS3FileSystem
     public void testAssumeRoleStaticCredentials()
             throws Exception
     {
-        Configuration config = new Configuration(false);
+        Configuration config = newEmptyConfiguration();
         config.set(S3_ACCESS_KEY, "test_access_key");
         config.set(S3_SECRET_KEY, "test_secret_key");
         config.set(S3_IAM_ROLE, "test_role");
@@ -220,7 +221,7 @@ public class TestTrinoS3FileSystem
     public void testAssumeRoleCredentialsWithExternalId()
             throws Exception
     {
-        Configuration config = new Configuration(false);
+        Configuration config = newEmptyConfiguration();
         config.set(S3_IAM_ROLE, "role");
         config.set(S3_EXTERNAL_ID, "externalId");
 
@@ -237,7 +238,7 @@ public class TestTrinoS3FileSystem
     public void testDefaultCredentials()
             throws Exception
     {
-        Configuration config = new Configuration(false);
+        Configuration config = newEmptyConfiguration();
 
         try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
             fs.initialize(new URI("s3n://test-bucket/"), config);
@@ -249,7 +250,7 @@ public class TestTrinoS3FileSystem
     public void testPathStyleAccess()
             throws Exception
     {
-        Configuration config = new Configuration(false);
+        Configuration config = newEmptyConfiguration();
         config.setBoolean(S3_PATH_STYLE_ACCESS, true);
 
         try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
@@ -263,7 +264,7 @@ public class TestTrinoS3FileSystem
     public void testUnderscoreBucket()
             throws Exception
     {
-        Configuration config = new Configuration(false);
+        Configuration config = newEmptyConfiguration();
         config.setBoolean(S3_PATH_STYLE_ACCESS, true);
 
         try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
@@ -287,7 +288,7 @@ public class TestTrinoS3FileSystem
             int maxRetries = 2;
             MockAmazonS3 s3 = new MockAmazonS3();
             s3.setGetObjectHttpErrorCode(HTTP_INTERNAL_ERROR);
-            Configuration configuration = new Configuration(false);
+            Configuration configuration = newEmptyConfiguration();
             configuration.set(S3_MAX_BACKOFF_TIME, "1ms");
             configuration.set(S3_MAX_RETRY_TIME, "5s");
             configuration.setInt(S3_MAX_CLIENT_RETRIES, maxRetries);
@@ -313,7 +314,7 @@ public class TestTrinoS3FileSystem
         try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
             MockAmazonS3 s3 = new MockAmazonS3();
             s3.setGetObjectMetadataHttpCode(HTTP_INTERNAL_ERROR);
-            Configuration configuration = new Configuration(false);
+            Configuration configuration = newEmptyConfiguration();
             configuration.set(S3_MAX_BACKOFF_TIME, "1ms");
             configuration.set(S3_MAX_RETRY_TIME, "5s");
             configuration.setInt(S3_MAX_CLIENT_RETRIES, maxRetries);
@@ -336,7 +337,7 @@ public class TestTrinoS3FileSystem
         try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
             MockAmazonS3 s3 = new MockAmazonS3();
             s3.setGetObjectHttpErrorCode(HTTP_NOT_FOUND);
-            fs.initialize(new URI("s3n://test-bucket/"), new Configuration(false));
+            fs.initialize(new URI("s3n://test-bucket/"), newEmptyConfiguration());
             fs.setS3Client(s3);
             try (FSDataInputStream inputStream = fs.open(new Path("s3n://test-bucket/test"))) {
                 assertThatThrownBy(() -> inputStream.read())
@@ -354,7 +355,7 @@ public class TestTrinoS3FileSystem
         try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
             MockAmazonS3 s3 = new MockAmazonS3();
             s3.setGetObjectHttpErrorCode(HTTP_FORBIDDEN);
-            fs.initialize(new URI("s3n://test-bucket/"), new Configuration(false));
+            fs.initialize(new URI("s3n://test-bucket/"), newEmptyConfiguration());
             fs.setS3Client(s3);
             try (FSDataInputStream inputStream = fs.open(new Path("s3n://test-bucket/test"))) {
                 assertThatThrownBy(inputStream::read)
@@ -375,7 +376,7 @@ public class TestTrinoS3FileSystem
 
         try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
             MockAmazonS3 s3 = new MockAmazonS3();
-            Configuration conf = new Configuration(false);
+            Configuration conf = newEmptyConfiguration();
             conf.set(S3_STAGING_DIRECTORY, staging.toString());
             conf.set(S3_STREAMING_UPLOAD_ENABLED, "false");
             fs.initialize(new URI("s3n://test-bucket/"), conf);
@@ -398,7 +399,7 @@ public class TestTrinoS3FileSystem
 
         try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
             MockAmazonS3 s3 = new MockAmazonS3();
-            Configuration conf = new Configuration(false);
+            Configuration conf = newEmptyConfiguration();
             conf.set(S3_STAGING_DIRECTORY, staging.toString());
             conf.set(S3_STREAMING_UPLOAD_ENABLED, "false");
             fs.initialize(new URI("s3n://test-bucket/"), conf);
@@ -431,7 +432,7 @@ public class TestTrinoS3FileSystem
 
             try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
                 MockAmazonS3 s3 = new MockAmazonS3();
-                Configuration conf = new Configuration(false);
+                Configuration conf = newEmptyConfiguration();
                 conf.set(S3_STAGING_DIRECTORY, link.toString());
                 fs.initialize(new URI("s3n://test-bucket/"), conf);
                 fs.setS3Client(s3);
@@ -453,7 +454,7 @@ public class TestTrinoS3FileSystem
         try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
             MockAmazonS3 s3 = new MockAmazonS3();
             s3.setGetObjectHttpErrorCode(HTTP_RANGE_NOT_SATISFIABLE);
-            fs.initialize(new URI("s3n://test-bucket/"), new Configuration(false));
+            fs.initialize(new URI("s3n://test-bucket/"), newEmptyConfiguration());
             fs.setS3Client(s3);
             try (FSDataInputStream inputStream = fs.open(new Path("s3n://test-bucket/test"))) {
                 assertEquals(inputStream.read(), -1);
@@ -468,7 +469,7 @@ public class TestTrinoS3FileSystem
         try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
             MockAmazonS3 s3 = new MockAmazonS3();
             s3.setGetObjectMetadataHttpCode(HTTP_FORBIDDEN);
-            fs.initialize(new URI("s3n://test-bucket/"), new Configuration(false));
+            fs.initialize(new URI("s3n://test-bucket/"), newEmptyConfiguration());
             fs.setS3Client(s3);
             assertThatThrownBy(() -> fs.getS3ObjectMetadata(new Path("s3n://test-bucket/test")))
                     .isInstanceOf(IOException.class)
@@ -483,7 +484,7 @@ public class TestTrinoS3FileSystem
         try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
             MockAmazonS3 s3 = new MockAmazonS3();
             s3.setGetObjectMetadataHttpCode(HTTP_NOT_FOUND);
-            fs.initialize(new URI("s3n://test-bucket/"), new Configuration(false));
+            fs.initialize(new URI("s3n://test-bucket/"), newEmptyConfiguration());
             fs.setS3Client(s3);
             assertNull(fs.getS3ObjectMetadata(new Path("s3n://test-bucket/test")));
         }
@@ -493,7 +494,7 @@ public class TestTrinoS3FileSystem
     public void testEncryptionMaterialsProvider()
             throws Exception
     {
-        Configuration config = new Configuration(false);
+        Configuration config = newEmptyConfiguration();
         config.set(S3_ENCRYPTION_MATERIALS_PROVIDER, TestEncryptionMaterialsProvider.class.getName());
 
         try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
@@ -506,7 +507,7 @@ public class TestTrinoS3FileSystem
     public void testKMSEncryptionMaterialsProvider()
             throws Exception
     {
-        Configuration config = new Configuration(false);
+        Configuration config = newEmptyConfiguration();
         config.set(S3_KMS_KEY_ID, "test-key-id");
 
         try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
@@ -526,7 +527,7 @@ public class TestTrinoS3FileSystem
     public void testCustomCredentialsProvider()
             throws Exception
     {
-        Configuration config = new Configuration(false);
+        Configuration config = newEmptyConfiguration();
         config.set(S3_CREDENTIALS_PROVIDER, TestCredentialsProvider.class.getName());
         try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
             fs.initialize(new URI("s3n://test-bucket/"), config);
@@ -538,7 +539,7 @@ public class TestTrinoS3FileSystem
     public void testCustomCredentialsClassCannotBeFound()
             throws Exception
     {
-        Configuration config = new Configuration(false);
+        Configuration config = newEmptyConfiguration();
         config.set(S3_CREDENTIALS_PROVIDER, "com.example.DoesNotExist");
         try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
             fs.initialize(new URI("s3n://test-bucket/"), config);
@@ -550,7 +551,7 @@ public class TestTrinoS3FileSystem
             throws Exception
     {
         String userAgentPrefix = "agent_prefix";
-        Configuration config = new Configuration(false);
+        Configuration config = newEmptyConfiguration();
         config.set(S3_USER_AGENT_PREFIX, userAgentPrefix);
         try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
             fs.initialize(new URI("s3n://test-bucket/"), config);
@@ -566,7 +567,7 @@ public class TestTrinoS3FileSystem
     {
         HiveS3Config defaults = new HiveS3Config();
         try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
-            fs.initialize(new URI("s3n://test-bucket/"), new Configuration(false));
+            fs.initialize(new URI("s3n://test-bucket/"), newEmptyConfiguration());
             ClientConfiguration config = getFieldValue(fs.getS3Client(), AmazonWebServiceClient.class, "clientConfiguration", ClientConfiguration.class);
             assertEquals(config.getMaxErrorRetry(), defaults.getS3MaxErrorRetries());
             assertEquals(config.getConnectionTimeout(), defaults.getS3ConnectTimeout().toMillis());
@@ -592,7 +593,7 @@ public class TestTrinoS3FileSystem
         HiveS3Config hiveS3Config = new HiveS3Config();
 
         TrinoS3ConfigurationInitializer configurationInitializer = new TrinoS3ConfigurationInitializer(hiveS3Config);
-        Configuration trinoFsConfiguration = new Configuration(false);
+        Configuration trinoFsConfiguration = newEmptyConfiguration();
         configurationInitializer.initializeConfiguration(trinoFsConfiguration);
 
         try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
@@ -622,7 +623,7 @@ public class TestTrinoS3FileSystem
         hiveS3Config.setS3PreemptiveBasicProxyAuth(true);
 
         TrinoS3ConfigurationInitializer configurationInitializer = new TrinoS3ConfigurationInitializer(hiveS3Config);
-        Configuration trinoFsConfiguration = new Configuration(false);
+        Configuration trinoFsConfiguration = newEmptyConfiguration();
         configurationInitializer.initializeConfiguration(trinoFsConfiguration);
 
         try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
@@ -652,7 +653,7 @@ public class TestTrinoS3FileSystem
         hiveS3Config.setS3PreemptiveBasicProxyAuth(true);
 
         TrinoS3ConfigurationInitializer configurationInitializer = new TrinoS3ConfigurationInitializer(hiveS3Config);
-        Configuration trinoFsConfiguration = new Configuration(false);
+        Configuration trinoFsConfiguration = newEmptyConfiguration();
         configurationInitializer.initializeConfiguration(trinoFsConfiguration);
 
         try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
@@ -671,7 +672,7 @@ public class TestTrinoS3FileSystem
     private static void assertSkipGlacierObjects(boolean skipGlacierObjects)
             throws Exception
     {
-        Configuration config = new Configuration(false);
+        Configuration config = newEmptyConfiguration();
         config.set(S3_SKIP_GLACIER_OBJECTS, String.valueOf(skipGlacierObjects));
 
         try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
@@ -688,7 +689,7 @@ public class TestTrinoS3FileSystem
     public void testSkipHadoopFolderMarkerObjectsEnabled()
             throws Exception
     {
-        Configuration config = new Configuration(false);
+        Configuration config = newEmptyConfiguration();
 
         try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
             MockAmazonS3 s3 = new MockAmazonS3();
@@ -772,7 +773,7 @@ public class TestTrinoS3FileSystem
     public void testDefaultAcl()
             throws Exception
     {
-        Configuration config = new Configuration(false);
+        Configuration config = newEmptyConfiguration();
 
         try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
             MockAmazonS3 s3 = new MockAmazonS3();
@@ -790,7 +791,7 @@ public class TestTrinoS3FileSystem
     public void testFullBucketOwnerControlAcl()
             throws Exception
     {
-        Configuration config = new Configuration(false);
+        Configuration config = newEmptyConfiguration();
         config.set(S3_ACL_TYPE, "BUCKET_OWNER_FULL_CONTROL");
 
         try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
@@ -809,7 +810,7 @@ public class TestTrinoS3FileSystem
     public void testStreamingUpload()
             throws Exception
     {
-        Configuration config = new Configuration(false);
+        Configuration config = newEmptyConfiguration();
         config.set(S3_STREAMING_UPLOAD_ENABLED, "true");
         config.set(S3_STREAMING_UPLOAD_PART_SIZE, "10");
 
@@ -854,7 +855,7 @@ public class TestTrinoS3FileSystem
                     return super.getObjectMetadata(getObjectMetadataRequest);
                 }
             };
-            fs.initialize(new URI("s3n://test-bucket/"), new Configuration(false));
+            fs.initialize(new URI("s3n://test-bucket/"), newEmptyConfiguration());
             fs.setS3Client(s3);
 
             FileStatus fileStatus = fs.getFileStatus(new Path("s3n://test-bucket/empty-dir/"));
@@ -898,7 +899,7 @@ public class TestTrinoS3FileSystem
                 }
             };
             Path rootPath = new Path("s3n://test-bucket/");
-            fs.initialize(rootPath.toUri(), new Configuration(false));
+            fs.initialize(rootPath.toUri(), newEmptyConfiguration());
             fs.setS3Client(s3);
 
             List<LocatedFileStatus> shallowAll = remoteIteratorToList(fs.listLocatedStatus(rootPath));

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestFSDataInputStreamTail.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestFSDataInputStreamTail.java
@@ -17,7 +17,6 @@ package io.trino.plugin.hive.util;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.trino.spi.TrinoException;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
@@ -34,6 +33,7 @@ import java.nio.file.Files;
 import java.util.Arrays;
 
 import static io.airlift.testing.Closeables.closeAll;
+import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertSame;
@@ -52,7 +52,7 @@ public class TestFSDataInputStreamTail
             throws Exception
     {
         fs = new RawLocalFileSystem();
-        fs.initialize(fs.getUri(), new Configuration(false));
+        fs.initialize(fs.getUri(), newEmptyConfiguration());
         tempRoot = Files.createTempDirectory("test_fsdatainputstream_tail").toFile();
         tempFile = new Path(Files.createTempFile(tempRoot.toPath(), "tempfile", "txt").toUri());
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestHiveUtil.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestHiveUtil.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Properties;
 
 import static io.airlift.testing.Assertions.assertInstanceOf;
+import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.plugin.hive.HiveStorageFormat.AVRO;
 import static io.trino.plugin.hive.HiveStorageFormat.PARQUET;
 import static io.trino.plugin.hive.HiveStorageFormat.SEQUENCEFILE;
@@ -69,7 +70,7 @@ public class TestHiveUtil
         schema.setProperty(SERIALIZATION_CLASS, IntString.class.getName());
         schema.setProperty(SERIALIZATION_FORMAT, TBinaryProtocol.class.getName());
 
-        assertInstanceOf(getDeserializer(new Configuration(false), schema), ThriftDeserializer.class);
+        assertInstanceOf(getDeserializer(newEmptyConfiguration(), schema), ThriftDeserializer.class);
     }
 
     @Test
@@ -87,7 +88,7 @@ public class TestHiveUtil
     @Test
     public void testGetInputFormat()
     {
-        Configuration configuration = new Configuration(false);
+        Configuration configuration = newEmptyConfiguration();
 
         // LazySimpleSerDe is used by TEXTFILE and SEQUENCEFILE. getInputFormat should default to TEXTFILE
         // per Hive spec.

--- a/plugin/trino-phoenix/pom.xml
+++ b/plugin/trino-phoenix/pom.xml
@@ -91,6 +91,11 @@
             <classifier>embedded</classifier>
         </dependency>
 
+        <dependency>
+            <groupId>org.gaul</groupId>
+            <artifactId>modernizer-maven-annotations</artifactId>
+        </dependency>
+
         <!-- used by tests but also needed transitively -->
         <dependency>
             <groupId>io.airlift</groupId>

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/ConfigurationInstantiator.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/ConfigurationInstantiator.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.phoenix;
+
+import org.apache.hadoop.conf.Configuration;
+import org.gaul.modernizer_maven_annotations.SuppressModernizer;
+
+import static com.google.common.base.Preconditions.checkState;
+
+final class ConfigurationInstantiator
+{
+    private ConfigurationInstantiator() {}
+
+    public static Configuration newEmptyConfiguration()
+    {
+        // Configuration captures TCCL and it may used later e.g. to load filesystem implementation class
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        ClassLoader expectedClassLoader = ConfigurationInstantiator.class.getClassLoader();
+        checkState(
+                tccl == expectedClassLoader,
+                "During instantiation, the Configuration object captures the TCCL and uses it to resolve classes by name. " +
+                        "For this reason, the current TCCL %s should be same as this class's classloader %s. " +
+                        "Otherwise the constructed Configuration will use *some* classloader to resolve classes",
+                tccl,
+                expectedClassLoader);
+        return newConfigurationWithTccl();
+    }
+
+    // new Configuration(boolean) is prohibited asking to use newEmptyConfiguration(). Only ConfigurationInstantiator can instantiate Configuration directly.
+    @SuppressModernizer
+    private static Configuration newConfigurationWithTccl()
+    {
+        // Note: the Configuration captures current thread context class loader (TCCL), so it may or may not be generally usable.
+        return new Configuration(false);
+    }
+}

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
@@ -146,6 +146,7 @@ import static io.trino.plugin.jdbc.StandardColumnMappings.varcharColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.varcharWriteFunction;
 import static io.trino.plugin.jdbc.TypeHandlingJdbcSessionProperties.getUnsupportedTypeHandling;
 import static io.trino.plugin.jdbc.UnsupportedTypeHandling.CONVERT_TO_VARCHAR;
+import static io.trino.plugin.phoenix.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.plugin.phoenix.MetadataUtil.getEscapedTableName;
 import static io.trino.plugin.phoenix.MetadataUtil.toPhoenixSchemaName;
 import static io.trino.plugin.phoenix.PhoenixClientModule.getConnectionProperties;
@@ -216,7 +217,7 @@ public class PhoenixClient
                 queryBuilder,
                 ImmutableSet.of(),
                 identifierMapping);
-        this.configuration = new Configuration(false);
+        this.configuration = newEmptyConfiguration();
         getConnectionProperties(config).forEach((k, v) -> configuration.set((String) k, (String) v));
     }
 

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClientModule.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClientModule.java
@@ -71,6 +71,7 @@ import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.trino.plugin.jdbc.JdbcModule.bindSessionPropertiesProvider;
 import static io.trino.plugin.jdbc.JdbcModule.bindTablePropertiesProvider;
+import static io.trino.plugin.phoenix.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.plugin.phoenix.PhoenixErrorCode.PHOENIX_CONFIG_ERROR;
 
 public class PhoenixClientModule
@@ -167,7 +168,7 @@ public class PhoenixClientModule
 
     private static Configuration readConfig(PhoenixConfig config)
     {
-        Configuration result = new Configuration(false);
+        Configuration result = newEmptyConfiguration();
         for (String resourcePath : config.getResourceConfigFiles()) {
             result.addResource(new Path(resourcePath));
         }

--- a/plugin/trino-phoenix5/pom.xml
+++ b/plugin/trino-phoenix5/pom.xml
@@ -90,6 +90,11 @@
             <version>5.1.2</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.gaul</groupId>
+            <artifactId>modernizer-maven-annotations</artifactId>
+        </dependency>
+
         <!-- used by tests but also needed transitively -->
         <dependency>
             <groupId>io.airlift</groupId>

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/ConfigurationInstantiator.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/ConfigurationInstantiator.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.phoenix5;
+
+import org.apache.hadoop.conf.Configuration;
+import org.gaul.modernizer_maven_annotations.SuppressModernizer;
+
+import static com.google.common.base.Preconditions.checkState;
+
+final class ConfigurationInstantiator
+{
+    private ConfigurationInstantiator() {}
+
+    public static Configuration newEmptyConfiguration()
+    {
+        // Configuration captures TCCL and it may used later e.g. to load filesystem implementation class
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        ClassLoader expectedClassLoader = ConfigurationInstantiator.class.getClassLoader();
+        checkState(
+                tccl == expectedClassLoader,
+                "During instantiation, the Configuration object captures the TCCL and uses it to resolve classes by name. " +
+                        "For this reason, the current TCCL %s should be same as this class's classloader %s. " +
+                        "Otherwise the constructed Configuration will use *some* classloader to resolve classes",
+                tccl,
+                expectedClassLoader);
+        return newConfigurationWithTccl();
+    }
+
+    // new Configuration(boolean) is prohibited asking to use newEmptyConfiguration(). Only ConfigurationInstantiator can instantiate Configuration directly.
+    @SuppressModernizer
+    private static Configuration newConfigurationWithTccl()
+    {
+        // Note: the Configuration captures current thread context class loader (TCCL), so it may or may not be generally usable.
+        return new Configuration(false);
+    }
+}

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
@@ -147,6 +147,7 @@ import static io.trino.plugin.jdbc.StandardColumnMappings.varcharColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.varcharWriteFunction;
 import static io.trino.plugin.jdbc.TypeHandlingJdbcSessionProperties.getUnsupportedTypeHandling;
 import static io.trino.plugin.jdbc.UnsupportedTypeHandling.CONVERT_TO_VARCHAR;
+import static io.trino.plugin.phoenix5.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.plugin.phoenix5.MetadataUtil.getEscapedTableName;
 import static io.trino.plugin.phoenix5.MetadataUtil.toPhoenixSchemaName;
 import static io.trino.plugin.phoenix5.PhoenixClientModule.getConnectionProperties;
@@ -216,7 +217,7 @@ public class PhoenixClient
                 queryBuilder,
                 ImmutableSet.of(),
                 identifierMapping);
-        this.configuration = new Configuration(false);
+        this.configuration = newEmptyConfiguration();
         getConnectionProperties(config).forEach((k, v) -> configuration.set((String) k, (String) v));
     }
 

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClientModule.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClientModule.java
@@ -71,6 +71,7 @@ import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.trino.plugin.jdbc.JdbcModule.bindSessionPropertiesProvider;
 import static io.trino.plugin.jdbc.JdbcModule.bindTablePropertiesProvider;
+import static io.trino.plugin.phoenix5.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.plugin.phoenix5.PhoenixErrorCode.PHOENIX_CONFIG_ERROR;
 
 public class PhoenixClientModule
@@ -167,7 +168,7 @@ public class PhoenixClientModule
 
     private static Configuration readConfig(PhoenixConfig config)
     {
-        Configuration result = new Configuration(false);
+        Configuration result = newEmptyConfiguration();
         for (String resourcePath : config.getResourceConfigFiles()) {
             result.addResource(new Path(resourcePath));
         }

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/storage/OrcFileRewriter.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/storage/OrcFileRewriter.java
@@ -45,6 +45,7 @@ import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
 import static io.airlift.slice.SizeOf.SIZE_OF_DOUBLE;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.units.Duration.nanosSince;
+import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.plugin.raptor.legacy.util.Closer.closer;
 import static java.lang.Math.toIntExact;
 import static org.apache.hadoop.hive.ql.io.orc.OrcFile.createReader;
@@ -54,7 +55,7 @@ import static org.apache.hadoop.hive.ql.io.orc.OrcUtil.getFieldValue;
 public final class OrcFileRewriter
 {
     private static final Logger log = Logger.get(OrcFileRewriter.class);
-    private static final Configuration CONFIGURATION = new Configuration(false);
+    private static final Configuration CONFIGURATION = newEmptyConfiguration();
 
     private OrcFileRewriter() {}
 

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/storage/OrcFileWriter.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/storage/OrcFileWriter.java
@@ -61,6 +61,7 @@ import java.util.Properties;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.json.JsonCodec.jsonCodec;
+import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.plugin.raptor.legacy.RaptorErrorCode.RAPTOR_ERROR;
 import static io.trino.plugin.raptor.legacy.storage.Row.extractRow;
 import static io.trino.plugin.raptor.legacy.storage.StorageType.arrayOf;
@@ -92,7 +93,7 @@ public class OrcFileWriter
         }
     }
 
-    private static final Configuration CONFIGURATION = new Configuration(false);
+    private static final Configuration CONFIGURATION = newEmptyConfiguration();
     private static final Constructor<? extends RecordWriter> WRITER_CONSTRUCTOR = getOrcWriterConstructor();
     private static final JsonCodec<OrcFileMetadata> METADATA_CODEC = jsonCodec(OrcFileMetadata.class);
 

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
         <module>lib/trino-array</module>
         <module>lib/trino-collect</module>
         <module>lib/trino-geospatial-toolkit</module>
+        <module>lib/trino-hadoop-toolkit</module>
         <module>lib/trino-matching</module>
         <module>lib/trino-memory-context</module>
         <module>lib/trino-orc</module>
@@ -287,6 +288,12 @@
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-geospatial-toolkit</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.trino</groupId>
+                <artifactId>trino-hadoop-toolkit</artifactId>
                 <version>${project.version}</version>
             </dependency>
 


### PR DESCRIPTION
`TrinoFileSystemCache` usually has an implementation for given file
system. When it doesn't have it, it loads it. The loading involves
Hadoop `Configuration` object and its `Configuration.getClassByName`.
`Configuration.classLoader` is the Class Loader used to find the class by
name. It is initialized on `Configuration` instantiation. Therefore,
`Configuration` instantiation-time TCCL matters.

This commit alleviates the problem by ensuring the `Configuration`
always gets instantiated with TCCL being the Class Loader of the
`ConfigurationUtils` class. Since a plugin has just one flat classpath,
it effectively is its classpath.


Fixes https://github.com/trinodb/trino/issues/12676