### PR TITLE
Fix potential failure or incorrect result of JSON_QUERY function

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJsonQueryFunction.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJsonQueryFunction.java
@@ -250,6 +250,11 @@ public class TestJsonQueryFunction
         assertThat(assertions.query(
                 "SELECT json_query('" + INPUT + "', 'lax $[$number]' PASSING 5 AS \"number\")"))
                 .matches("VALUES cast(null AS varchar)");
+
+        // parameter cannot be converted to JSON -- returns null, because NULL ON ERROR is implicit
+        assertThat(assertions.query(
+                "SELECT json_query('" + INPUT + "', 'lax $parameter' PASSING DATE '2001-01-31' AS \"parameter\")"))
+                .matches("VALUES cast(null AS varchar)");
     }
 
     @Test


### PR DESCRIPTION
The error handling method was incorrectly placed in a lambda.
That could cause:
- NPE in case of `NULL ON ERROR`
- incorrect result in case of `EMPTY ARRAY ON ERROR` or `EMPTY OBJECT ON ERROR`
when some item in the returned sequence could not be converted to JSON.


```markdown
# General
* Fix potential failure or incorrect result of json_query function.
```
