### PR TITLE
Support more types of parameters to JSON path

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -2791,17 +2791,17 @@ public class ExpressionAnalyzer
                     else if (isNumericType(parameterType) || parameterType.equals(BOOLEAN)) {
                         passedType = parameterType;
                     }
-                    else if (isDateTimeType(parameterType)) {
-                        if (parameterType.equals(INTERVAL_DAY_TIME) || parameterType.equals(INTERVAL_YEAR_MONTH)) {
-                            throw semanticException(INVALID_FUNCTION_ARGUMENT, parameter, "Invalid type of JSON path parameter: %s", parameterType.getDisplayName());
-                        }
+                    else if (isDateTimeType(parameterType) && !parameterType.equals(INTERVAL_DAY_TIME) && !parameterType.equals(INTERVAL_YEAR_MONTH)) {
                         passedType = parameterType;
                     }
                     else {
-                        if (!typeCoercion.canCoerce(parameterType, VARCHAR)) {
-                            throw semanticException(INVALID_FUNCTION_ARGUMENT, parameter, "Invalid type of JSON path parameter: %s", parameterType.getDisplayName());
+                        try {
+                            plannerContext.getMetadata().getCoercion(session, parameterType, VARCHAR);
                         }
-                        coerceType(parameter, parameterType, VARCHAR, "JSON path parameter");
+                        catch (OperatorNotFoundException e) {
+                            throw semanticException(NOT_SUPPORTED, node, "Unsupported type of JSON path parameter: %s", parameterType.getDisplayName());
+                        }
+                        addOrReplaceExpressionCoercion(parameter, parameterType, VARCHAR);
                         passedType = VARCHAR;
                     }
                 }

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -5417,12 +5417,18 @@ public class TestAnalyzer
     @Test
     public void testJsonPathParameterTypes()
     {
-        assertFails("SELECT JSON_EXISTS( " +
+        analyze("SELECT JSON_EXISTS( " +
                 "                           json_column, " +
                 "                           'lax $.abs()' PASSING INTERVAL '2' DAY AS parameter_1) " +
-                "       FROM (VALUES '-1', 'ala') t(json_column)")
-                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
-                .hasMessage("line 1:110: Invalid type of JSON path parameter: interval day to second");
+                "       FROM (VALUES '-1', 'ala') t(json_column)");
+
+        analyze("SELECT JSON_EXISTS('[]', 'lax $[2]' PASSING INTERVAL '2' DAY AS parameter_interval)");
+
+        analyze("SELECT JSON_EXISTS('[]', 'lax $[2]' PASSING UUID '12151fd2-7586-11e9-8f9e-2a86e4085a59' AS parameter_uuid)");
+
+        assertFails("SELECT JSON_EXISTS('[]', 'lax $[2]' PASSING approx_set(1) AS parameter_hll)")
+                .hasErrorCode(NOT_SUPPORTED)
+                .hasMessage("line 1:8: Unsupported type of JSON path parameter: HyperLogLog");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJsonQueryFunction.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJsonQueryFunction.java
@@ -255,6 +255,15 @@ public class TestJsonQueryFunction
         assertThat(assertions.query(
                 "SELECT json_query('" + INPUT + "', 'lax $parameter' PASSING DATE '2001-01-31' AS \"parameter\")"))
                 .matches("VALUES cast(null AS varchar)");
+
+        // parameter cast to varchar
+        assertThat(assertions.query(
+                "SELECT json_query('" + INPUT + "', 'lax $parameter' PASSING INTERVAL '2' DAY AS \"parameter\")"))
+                .matches("VALUES cast('\"2 00:00:00.000\"' AS varchar)");
+
+        assertThat(assertions.query(
+                "SELECT json_query('" + INPUT + "', 'lax $parameter' PASSING UUID '12151fd2-7586-11e9-8f9e-2a86e4085a59' AS \"parameter\")"))
+                .matches("VALUES cast('\"12151fd2-7586-11e9-8f9e-2a86e4085a59\"' AS varchar)");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJsonValueFunction.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJsonValueFunction.java
@@ -238,6 +238,15 @@ public class TestJsonValueFunction
         assertThat(assertions.query(
                 "SELECT json_value('" + INPUT + "', 'lax $[$number]' PASSING 5 AS \"number\")"))
                 .matches("VALUES cast(null AS varchar)");
+
+        // parameter cast to varchar
+        assertThat(assertions.query(
+                "SELECT json_value('" + INPUT + "', 'lax $parameter' PASSING INTERVAL '2' DAY AS \"parameter\")"))
+                .matches("VALUES cast('2 00:00:00.000' AS varchar)");
+
+        assertThat(assertions.query(
+                "SELECT json_value('" + INPUT + "', 'lax $parameter' PASSING UUID '12151fd2-7586-11e9-8f9e-2a86e4085a59' AS \"parameter\")"))
+                .matches("VALUES cast('12151fd2-7586-11e9-8f9e-2a86e4085a59' AS varchar)");
     }
 
     @Test


### PR DESCRIPTION
Before this change, path parameters could be only: numeric, boolean, datetime
and string values, and other values that could be implicitly coerced to varchar.

After this change, any values are accepted which can be coerced
to varchar. It is no more required that an implicit coercion is defined.

```markdown
# General
* Support all types that can be cast to `varchar` as parameters to JSON path.
```
