### PR TITLE
Refactor class loader safety in Iceberg and Delta split managers

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
@@ -114,7 +114,7 @@ public class DeltaLakeSplitManager
                 getDynamicFilteringWaitTimeout(session),
                 deltaLakeTableHandle.isRecordScannedFiles());
 
-        return new ClassLoaderSafeConnectorSplitSource(splitSource, Thread.currentThread().getContextClassLoader());
+        return new ClassLoaderSafeConnectorSplitSource(splitSource, DeltaLakeSplitManager.class.getClassLoader());
     }
 
     private Stream<DeltaLakeSplit> getSplits(

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitManager.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitManager.java
@@ -81,6 +81,6 @@ public class IcebergSplitManager
                 typeManager,
                 table.isRecordScannedFiles());
 
-        return new ClassLoaderSafeConnectorSplitSource(splitSource, Thread.currentThread().getContextClassLoader());
+        return new ClassLoaderSafeConnectorSplitSource(splitSource, IcebergSplitManager.class.getClassLoader());
     }
 }


### PR DESCRIPTION
Instantiating `ClassLoaderSafeConnectorSplitSource` with TCCL was OK,
because the split manager itself is wrapped in
`ClassLoaderSafeConnectorSplitManager`, so the TCCL is the plugin class
loader. However, the code could be more explicit.