### PR TITLE
Support push partial aggreation into tablescan

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -254,6 +254,7 @@ import io.trino.sql.planner.optimizations.TransformQuantifiedComparisonApplyToCo
 import io.trino.sql.planner.optimizations.UnaliasSymbolReferences;
 import io.trino.sql.planner.optimizations.WindowFilterPushDown;
 
+import io.trino.sql.planner.plan.AggregationNode.Step;
 import javax.inject.Inject;
 
 import java.util.List;
@@ -938,6 +939,7 @@ public class PlanOptimizers
                 ImmutableSet.of(
                         new PushPartialAggregationThroughJoin(),
                         new PushPartialAggregationThroughExchange(plannerContext),
+                        new PushAggregationIntoTableScan(plannerContext, typeAnalyzer),
                         new PruneJoinColumns(),
                         new PruneJoinChildrenColumns())));
         builder.add(new IterativeOptimizer(

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushAggregationIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushAggregationIntoTableScan.java
@@ -41,6 +41,7 @@ import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.TypeAnalyzer;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.plan.AggregationNode;
+import io.trino.sql.planner.plan.AggregationNode.Step;
 import io.trino.sql.planner.plan.Assignments;
 import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.ProjectNode;
@@ -76,6 +77,8 @@ public class PushAggregationIntoTableScan
 
     private static final Pattern<AggregationNode> PATTERN =
             aggregation()
+                    .matching(node -> node.getStep().equals(Step.SINGLE)
+                        || node.getStep().equals(Step.PARTIAL))
                     // skip arguments that are, for instance, lambda expressions
                     .matching(PushAggregationIntoTableScan::allArgumentsAreSimpleReferences)
                     .matching(node -> node.getGroupingSets().getGroupingSetCount() <= 1)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushAggregationIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushAggregationIntoTableScan.java
@@ -76,7 +76,6 @@ public class PushAggregationIntoTableScan
 
     private static final Pattern<AggregationNode> PATTERN =
             aggregation()
-                    .with(step().equalTo(AggregationNode.Step.SINGLE))
                     // skip arguments that are, for instance, lambda expressions
                     .matching(PushAggregationIntoTableScan::allArgumentsAreSimpleReferences)
                     .matching(node -> node.getGroupingSets().getGroupingSetCount() <= 1)


### PR DESCRIPTION
## Support push partial aggreation into tablescan


> improvement,

> change to the core query engine

> Support push partial aggreation into tablescan

## Related issues, pull requests, and links

> issue: [12547](https://github.com/trinodb/trino/issues/12547)

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation
for this sql:

```
select t, count(*) from (
                    select count(*) t  from mysql.test.userdata union all
                     select count(*) t from mysql.test.userdata1 union all
                     select count(*) t from mysql.test.userdata2
                     ) group by t;
```
before push single and patial agg, this logistic plan is as below:
![Uploading image.png…]()

after push single and patial agg, this logistic plan is as below:
<img width="761" alt="image" src="https://user-images.githubusercontent.com/8596901/172293631-b49d7d1d-d832-4636-896c-405784436c61.png">

as we can see the partial agg also push into source which will reduce the load of execution engine
## Release notes

(1) Support push partial aggreation into tablescan
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Support push partial aggreation into tablescan. ({[12547](https://github.com/trinodb/trino/issues/12547)})
```
