### PR TITLE
Disallow null table version

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -4573,6 +4573,7 @@ class StatementAnalyzer
         private void validateVersionPointer(QualifiedObjectName tableName, QueryPeriod queryPeriod, TableVersion extractedVersion)
         {
             Type type = extractedVersion.getObjectType();
+            Object pointer = extractedVersion.getPointer();
             if (extractedVersion.getPointerType() == PointerType.TEMPORAL) {
                 // Before checking if the connector supports the version type, verify that version is a valid time-based type
                 if (!(type instanceof TimestampWithTimeZoneType ||
@@ -4581,6 +4582,14 @@ class StatementAnalyzer
                     throw semanticException(TYPE_MISMATCH, queryPeriod, format(
                             "Type %s invalid. Temporal pointers must be of type Timestamp, Timestamp with Time Zone, or Date.",
                             type.getDisplayName()));
+                }
+                if (pointer == null) {
+                    throw semanticException(INVALID_ARGUMENTS, queryPeriod, "Pointer value cannot be NULL");
+                }
+            }
+            else {
+                if (pointer == null) {
+                    throw semanticException(INVALID_ARGUMENTS, queryPeriod, "Pointer value cannot be NULL");
                 }
             }
 

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -402,14 +402,14 @@ public class TestAnalyzer
 
         // null value with right type
         assertFails("SELECT * FROM t1 FOR TIMESTAMP AS OF CAST(NULL AS date)")
-                .hasErrorCode(NOT_SUPPORTED)
-                .hasMessage("This connector does not support versioned tables");
+                .hasErrorCode(INVALID_ARGUMENTS)
+                .hasMessage("line 1:18: Pointer value cannot be NULL");
         assertFails("SELECT * FROM t1 FOR TIMESTAMP AS OF CAST(NULL AS timestamp(3))")
-                .hasErrorCode(NOT_SUPPORTED)
-                .hasMessage("This connector does not support versioned tables");
+                .hasErrorCode(INVALID_ARGUMENTS)
+                .hasMessage("line 1:18: Pointer value cannot be NULL");
         assertFails("SELECT * FROM t1 FOR TIMESTAMP AS OF CAST(NULL AS timestamp(3) with time zone)")
-                .hasErrorCode(NOT_SUPPORTED)
-                .hasMessage("This connector does not support versioned tables");
+                .hasErrorCode(INVALID_ARGUMENTS)
+                .hasMessage("line 1:18: Pointer value cannot be NULL");
 
         // null value with wrong type
         assertFails("SELECT * FROM t1 FOR TIMESTAMP AS OF NULL")
@@ -448,11 +448,11 @@ public class TestAnalyzer
                 .hasErrorCode(INVALID_ARGUMENTS)
                 .hasMessage("line 1:18: Pointer value cannot be NULL");
         assertFails("SELECT * FROM t1 FOR VERSION AS OF CAST(NULL AS bigint)")
-                .hasErrorCode(NOT_SUPPORTED)
-                .hasMessage("This connector does not support versioned tables");
+                .hasErrorCode(INVALID_ARGUMENTS)
+                .hasMessage("line 1:18: Pointer value cannot be NULL");
         assertFails("SELECT * FROM t1 FOR VERSION AS OF CAST(NULL AS varchar)")
-                .hasErrorCode(NOT_SUPPORTED)
-                .hasMessage("This connector does not support versioned tables");
+                .hasErrorCode(INVALID_ARGUMENTS)
+                .hasMessage("line 1:18: Pointer value cannot be NULL");
     }
 
     @Test


### PR DESCRIPTION
It probably does not have any practical use, so it is safer to just
disallow it, so that connectors do not have to check for (the rather
unexpected) null.

Note that `NULL` version (without a CAST) was not supported anyway.