### PR TITLE
Ensure single task reads single partition in write stage

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -166,6 +166,8 @@ public final class SystemSessionProperties
     public static final String FAULT_TOLERANT_EXECUTION_TASK_MEMORY_GROWTH_FACTOR = "fault_tolerant_execution_task_memory_growth_factor";
     public static final String FAULT_TOLERANT_EXECUTION_TASK_MEMORY_ESTIMATION_QUANTILE = "fault_tolerant_execution_task_memory_estimation_quantile";
     public static final String FAULT_TOLERANT_EXECUTION_PARTITION_COUNT = "fault_tolerant_execution_partition_count";
+
+    public static final String FAULT_TOLERANT_EXECUTION_PRESERVE_INPUT_PARTITIONS_IN_WRITE_STAGE = "fault_tolerant_execution_preserve_input_partitions_in_write_stage";
     public static final String ADAPTIVE_PARTIAL_AGGREGATION_ENABLED = "adaptive_partial_aggregation_enabled";
     public static final String ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS = "adaptive_partial_aggregation_min_rows";
     public static final String ADAPTIVE_PARTIAL_AGGREGATION_UNIQUE_ROWS_RATIO_THRESHOLD = "adaptive_partial_aggregation_unique_rows_ratio_threshold";
@@ -809,6 +811,11 @@ public final class SystemSessionProperties
                         FAULT_TOLERANT_EXECUTION_PARTITION_COUNT,
                         "Number of partitions for distributed joins and aggregations executed with fault tolerant execution enabled",
                         queryManagerConfig.getFaultTolerantExecutionPartitionCount(),
+                        false),
+                booleanProperty(
+                        FAULT_TOLERANT_EXECUTION_PRESERVE_INPUT_PARTITIONS_IN_WRITE_STAGE,
+                        "Ensure single task reads single hash partitioned input partition for stages which write table data",
+                        queryManagerConfig.getFaultTolerantPreserveInputPartitionsInWriteStage(),
                         false),
                 booleanProperty(
                         ADAPTIVE_PARTIAL_AGGREGATION_ENABLED,
@@ -1472,6 +1479,11 @@ public final class SystemSessionProperties
     public static double getFaultTolerantExecutionTaskMemoryEstimationQuantile(Session session)
     {
         return session.getSystemProperty(FAULT_TOLERANT_EXECUTION_TASK_MEMORY_ESTIMATION_QUANTILE, Double.class);
+    }
+
+    public static boolean getFaultTolerantPreserveInputPartitionsInWriteStage(Session session)
+    {
+        return session.getSystemProperty(FAULT_TOLERANT_EXECUTION_PRESERVE_INPUT_PARTITIONS_IN_WRITE_STAGE, Boolean.class);
     }
 
     public static int getFaultTolerantExecutionPartitionCount(Session session)

--- a/core/trino-main/src/main/java/io/trino/execution/QueryManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryManagerConfig.java
@@ -93,6 +93,7 @@ public class QueryManagerConfig
     private int faultTolerantExecutionMaxTaskSplitCount = 256;
     private DataSize faultTolerantExecutionTaskDescriptorStorageMaxMemory = DataSize.ofBytes(Math.round(AVAILABLE_HEAP_MEMORY * 0.15));
     private int faultTolerantExecutionPartitionCount = 50;
+    private boolean faultTolerantPreserveInputPartitionsInWriteStage = true;
 
     @Min(1)
     public int getScheduleSplitBatchSize()
@@ -598,6 +599,19 @@ public class QueryManagerConfig
     public QueryManagerConfig setFaultTolerantExecutionPartitionCount(int faultTolerantExecutionPartitionCount)
     {
         this.faultTolerantExecutionPartitionCount = faultTolerantExecutionPartitionCount;
+        return this;
+    }
+
+    public boolean getFaultTolerantPreserveInputPartitionsInWriteStage()
+    {
+        return faultTolerantPreserveInputPartitionsInWriteStage;
+    }
+
+    @Config("fault-tolerant-execution-preserve-input-partitions-in-write-stage")
+    @ConfigDescription("Ensure single task reads single hash partitioned input partition for stages which write table data")
+    public QueryManagerConfig setFaultTolerantPreserveInputPartitionsInWriteStage(boolean faultTolerantPreserveInputPartitionsInWriteStage)
+    {
+        this.faultTolerantPreserveInputPartitionsInWriteStage = faultTolerantPreserveInputPartitionsInWriteStage;
         return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/StageTaskSourceFactory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/StageTaskSourceFactory.java
@@ -13,6 +13,7 @@
  */
 package io.trino.execution.scheduler;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.VerifyException;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.HashMultimap;
@@ -205,7 +206,8 @@ public class StageTaskSourceFactory
             return new SingleDistributionTaskSource(getInputsForRemoteSources(fragment.getRemoteSourceNodes(), exchangeSourceHandles), getFaultTolerantExecutionDefaultTaskMemory(session));
         }
 
-        public SingleDistributionTaskSource(ListMultimap<PlanNodeId, ExchangeSourceHandle> exchangeSourceHandles, DataSize taskMemory)
+        @VisibleForTesting
+        SingleDistributionTaskSource(ListMultimap<PlanNodeId, ExchangeSourceHandle> exchangeSourceHandles, DataSize taskMemory)
         {
             this.exchangeSourceHandles = ImmutableListMultimap.copyOf(requireNonNull(exchangeSourceHandles, "exchangeSourceHandles is null"));
             this.taskMemory = requireNonNull(taskMemory, "taskMemory is null");
@@ -267,7 +269,8 @@ public class StageTaskSourceFactory
                     getFaultTolerantExecutionDefaultTaskMemory(session));
         }
 
-        public ArbitraryDistributionTaskSource(
+        @VisibleForTesting
+        ArbitraryDistributionTaskSource(
                 IdentityHashMap<ExchangeSourceHandle, Exchange> sourceExchanges,
                 Multimap<PlanNodeId, ExchangeSourceHandle> partitionedExchangeSourceHandles,
                 Multimap<PlanNodeId, ExchangeSourceHandle> replicatedExchangeSourceHandles,
@@ -417,7 +420,8 @@ public class StageTaskSourceFactory
                     executor);
         }
 
-        public HashDistributionTaskSource(
+        @VisibleForTesting
+        HashDistributionTaskSource(
                 Map<PlanNodeId, SplitSource> splitSources,
                 IdentityHashMap<ExchangeSourceHandle, Exchange> exchangeForHandle,
                 Multimap<PlanNodeId, ExchangeSourceHandle> partitionedExchangeSourceHandles,
@@ -712,7 +716,8 @@ public class StageTaskSourceFactory
                     executor);
         }
 
-        public SourceDistributionTaskSource(
+        @VisibleForTesting
+        SourceDistributionTaskSource(
                 QueryId queryId,
                 PlanNodeId partitionedSourceNodeId,
                 TableExecuteContextManager tableExecuteContextManager,

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/StageTaskSourceFactory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/StageTaskSourceFactory.java
@@ -411,7 +411,8 @@ public class StageTaskSourceFactory
                     bucketToPartitionMap,
                     bucketNodeMap,
                     fragment.getPartitioning().getConnectorId(),
-                    targetPartitionSplitWeight, targetPartitionSourceSize,
+                    targetPartitionSplitWeight,
+                    targetPartitionSourceSize,
                     getFaultTolerantExecutionDefaultTaskMemory(session),
                     executor);
         }

--- a/core/trino-main/src/test/java/io/trino/execution/TestQueryManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestQueryManagerConfig.java
@@ -75,7 +75,8 @@ public class TestQueryManagerConfig
                 .setFaultTolerantExecutionTargetTaskSplitCount(16)
                 .setFaultTolerantExecutionMaxTaskSplitCount(256)
                 .setFaultTolerantExecutionTaskDescriptorStorageMaxMemory(DataSize.ofBytes(Math.round(AVAILABLE_HEAP_MEMORY * 0.15)))
-                .setFaultTolerantExecutionPartitionCount(50));
+                .setFaultTolerantExecutionPartitionCount(50)
+                .setFaultTolerantPreserveInputPartitionsInWriteStage(true));
     }
 
     @Test
@@ -119,6 +120,7 @@ public class TestQueryManagerConfig
                 .put("fault-tolerant-execution-max-task-split-count", "22")
                 .put("fault-tolerant-execution-task-descriptor-storage-max-memory", "3GB")
                 .put("fault-tolerant-execution-partition-count", "123")
+                .put("fault-tolerant-execution-preserve-input-partitions-in-write-stage", "false")
                 .buildOrThrow();
 
         QueryManagerConfig expected = new QueryManagerConfig()
@@ -158,7 +160,8 @@ public class TestQueryManagerConfig
                 .setFaultTolerantExecutionTargetTaskSplitCount(3)
                 .setFaultTolerantExecutionMaxTaskSplitCount(22)
                 .setFaultTolerantExecutionTaskDescriptorStorageMaxMemory(DataSize.of(3, GIGABYTE))
-                .setFaultTolerantExecutionPartitionCount(123);
+                .setFaultTolerantExecutionPartitionCount(123)
+                .setFaultTolerantPreserveInputPartitionsInWriteStage(false);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->


## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

The thing which could be documented is config/sessino property, yet I think it is not needed.
I added it merely as a kill switch, and changing default should not be needed.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# General
* Increase high granularity of tasks for stages which are writing table data, when fault-tolerant execution is enabled (`retry-policy` is set to `TASK`).
  That is to reduce chance of hitting `Exceeded limit of N open writers for partitions` errors. ({issue}`12721`)
```
