### PR TITLE
Enable Error Prone check: HidingField

### DIFF
--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryTestView.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryTestView.java
@@ -24,14 +24,12 @@ import static java.util.Objects.requireNonNull;
 public class BigQueryTestView
         extends TestTable
 {
-    private final SqlExecutor sqlExecutor;
     private final TestTable table;
     private final String viewName;
 
     public BigQueryTestView(SqlExecutor sqlExecutor, TestTable table)
     {
         super(sqlExecutor, table.getName(), null);
-        this.sqlExecutor = requireNonNull(sqlExecutor, "sqlExecutor is null");
         this.table = requireNonNull(table, "table is null");
         this.viewName = table.getName() + "_view";
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseSharedMetastoreTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseSharedMetastoreTest.java
@@ -16,8 +16,6 @@ package io.trino.plugin.iceberg;
 import io.trino.testing.AbstractTestQueryFramework;
 import org.testng.annotations.Test;
 
-import java.nio.file.Path;
-
 import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -27,7 +25,6 @@ public abstract class BaseSharedMetastoreTest
         extends AbstractTestQueryFramework
 {
     protected final String schema = "test_shared_schema_" + randomTableSuffix();
-    protected Path dataDirectory;
 
     protected abstract String getExpectedHiveCreateSchema(String catalogName);
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestSharedHiveMetastore.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestSharedHiveMetastore.java
@@ -34,6 +34,8 @@ import io.trino.testing.QueryRunner;
 import io.trino.tpch.TpchTable;
 import org.testng.annotations.AfterClass;
 
+import java.nio.file.Path;
+
 import static io.trino.plugin.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
@@ -44,6 +46,7 @@ public class TestSharedHiveMetastore
         extends BaseSharedMetastoreTest
 {
     private static final String HIVE_CATALOG = "hive";
+    private Path dataDirectory;
 
     @Override
     protected QueryRunner createQueryRunner()

--- a/pom.xml
+++ b/pom.xml
@@ -1898,6 +1898,7 @@
                                     -Xep:EqualsIncompatibleType:ERROR \
                                     -Xep:FallThrough:ERROR \
                                     -Xep:GuardedBy:OFF <!-- needs some careful inspection --> \
+                                    -Xep:HidingField:ERROR \
                                     -Xep:ImmutableEnumChecker:OFF <!-- flags enums with List fields even if initialized with ImmutableList, and other false positives --> \
                                     -Xep:ImmutableSetForContains:ERROR \
                                     -Xep:InconsistentCapitalization:ERROR <!-- fields/variables should not differ only in case --> \


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

This warning (now error) triggers when a subclass declares a field with the same name as a non-private (i.e. visible) field in a superclass. Usually this is a simple matter of redundancy, but there's one case where the field in superclass is actually not useful - it is only used in subclasses, and the assignment is trivial, so it's better declared in them instead.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Static analysis improvement.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

All over.

> How would you describe this change to a non-technical end user or system administrator?

It improves code quality.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
