### PR TITLE
Add Ceph support for Delta Lake

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.rst
+++ b/docs/src/main/sphinx/connector/delta-lake.rst
@@ -17,8 +17,9 @@ Requirements
 To connect to Databricks Delta Lake, you need:
 
 * Tables written by Databricks Runtime 7.3 LTS and 9.1 LTS are supported.
-* Deployments using AWS, HDFS, and Azure Storage are fully supported. Google
-  Cloud Storage (GCS) is :ref:`partially supported<delta-lake-gcs-support>`.
+* Deployments using AWS, HDFS, Ceph, and Azure Storage are fully supported.
+  Google Cloud Storage (GCS) is :ref:`partially
+  supported<delta-lake-gcs-support>`.
 * Network access from the coordinator and workers to the Delta Lake storage.
 * Access to the Hive metastore service (HMS) of Delta Lake or a separate HMS.
 * Network access to the HMS from the coordinator and workers. Port 9083 is the

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TransactionLogTail.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TransactionLogTail.java
@@ -148,7 +148,7 @@ public class TransactionLogTail
         if (e instanceof FileNotFoundException) {
             return true;
         }
-        else if (e.getMessage().contains("The specified key does not exist")) {
+        else if (e.getMessage().contains("Error Code: NoSuchKey")) {
             return true;
         }
         else {

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
@@ -34,6 +34,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.units.Duration.nanosSince;
 import static io.trino.plugin.deltalake.DeltaLakeConnectorFactory.CONNECTOR_NAME;
 import static io.trino.plugin.deltalake.DeltaLakeDockerizedMinioDataLake.createDockerizedMinioDataLakeForDeltaLake;
+import static io.trino.plugin.deltalake.util.CephContainer.CEPH_ACCESS_KEY;
+import static io.trino.plugin.deltalake.util.CephContainer.CEPH_SECRET_KEY;
 import static io.trino.plugin.deltalake.util.MinioContainer.MINIO_ACCESS_KEY;
 import static io.trino.plugin.deltalake.util.MinioContainer.MINIO_SECRET_KEY;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
@@ -118,6 +120,30 @@ public final class DeltaLakeQueryRunner
                         .buildOrThrow(),
                 testingHadoop,
                 additionalSetup);
+    }
+
+    public static DistributedQueryRunner createCephDeltaLakeQueryRunner(
+            String catalogName,
+            String schemaName,
+            Map<String, String> connectorProperties,
+            String cephS3Endpoint,
+            TestingHadoop testingHadoop)
+            throws Exception
+    {
+        return createDockerizedDeltaLakeQueryRunner(
+                catalogName,
+                schemaName,
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                ImmutableMap.<String, String>builder()
+                        .put("hive.s3.aws-access-key", CEPH_ACCESS_KEY)
+                        .put("hive.s3.aws-secret-key", CEPH_SECRET_KEY)
+                        .put("hive.s3.endpoint", cephS3Endpoint)
+                        .put("hive.s3.path-style-access", "true")
+                        .putAll(connectorProperties)
+                        .buildOrThrow(),
+                testingHadoop,
+                queryRunner -> {});
     }
 
     public static QueryRunner createAbfsDeltaLakeQueryRunner(

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeCephConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeCephConnectorSmokeTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.deltalake.util.DockerizedCephDataLake;
+import io.trino.plugin.deltalake.util.DockerizedDataLake;
+import io.trino.plugin.hive.parquet.ParquetWriterConfig;
+import io.trino.testing.QueryRunner;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.DELTA_CATALOG;
+import static io.trino.plugin.deltalake.util.CephContainer.CEPH_ACCESS_KEY;
+import static io.trino.plugin.deltalake.util.CephContainer.CEPH_PORT;
+import static io.trino.plugin.deltalake.util.CephContainer.CEPH_SECRET_KEY;
+import static io.trino.plugin.deltalake.util.TestingHadoop.renderHadoopCoreSiteTemplate;
+import static java.lang.String.format;
+
+public class TestDeltaLakeCephConnectorSmokeTest
+        extends BaseDeltaLakeConnectorSmokeTest
+{
+    protected DockerizedCephDataLake dockerizedCephDataLake;
+
+    @Override
+    protected DockerizedDataLake createDockerizedDataLake()
+            throws IOException
+    {
+        Path hadoopCoreSiteXmlTempFile = renderHadoopCoreSiteTemplate(
+                "io/trino/plugin/deltalake/core-site.xml",
+                ImmutableMap.of(
+                        "%S3_ENDPOINT%", format("http://ceph:%s", CEPH_PORT),
+                        "%S3_ACCESS_KEY%", CEPH_ACCESS_KEY,
+                        "%S3_SECRET_KEY%", CEPH_SECRET_KEY));
+
+        dockerizedCephDataLake = new DockerizedCephDataLake(
+                bucketName,
+                getHadoopBaseImage(),
+                ImmutableMap.of(),
+                ImmutableMap.of(hadoopCoreSiteXmlTempFile.normalize().toAbsolutePath().toString(), "/etc/hadoop/conf/core-site.xml"));
+        return dockerizedCephDataLake;
+    }
+
+    @Override
+    protected QueryRunner createDeltaLakeQueryRunner(Map<String, String> connectorProperties)
+            throws Exception
+    {
+        verify(!new ParquetWriterConfig().isParquetOptimizedWriterEnabled(), "This test assumes the optimized Parquet writer is disabled by default");
+        return DeltaLakeQueryRunner.createCephDeltaLakeQueryRunner(
+                DELTA_CATALOG,
+                SCHEMA,
+                ImmutableMap.<String, String>builder()
+                        .putAll(connectorProperties)
+                        .put("delta.enable-non-concurrent-writes", "true")
+                        .buildOrThrow(),
+                dockerizedCephDataLake.getCephEndpoint(),
+                dockerizedCephDataLake.getTestingHadoop());
+    }
+
+    @Override
+    protected void createTableFromResources(String table, String resourcePath, QueryRunner queryRunner)
+    {
+        dockerizedCephDataLake.copyResources(resourcePath, table);
+        queryRunner.execute(format("CREATE TABLE %s (dummy int) WITH (location = '%s')",
+                table,
+                getLocationForTable(bucketName, table)));
+    }
+
+    @Override
+    protected String getLocationForTable(String bucketName, String tableName)
+    {
+        return format("s3://%s/%s", bucketName, tableName);
+    }
+
+    @Override
+    protected List<String> getTableFiles(String tableName)
+    {
+        return dockerizedCephDataLake.listFiles(tableName).stream()
+                .map(path -> format("s3://%s/%s", bucketName, path))
+                .collect(toImmutableList());
+    }
+
+    @Override
+    protected List<String> listCheckpointFiles(String transactionLogDirectory)
+    {
+        return dockerizedCephDataLake.listFiles(transactionLogDirectory)
+                .stream()
+                .filter(path -> path.contains("checkpoint.parquet"))
+                .map(path -> format("s3://%s/%s", bucketName, path))
+                .collect(toImmutableList());
+    }
+
+    @Override
+    protected String bucketUrl()
+    {
+        return format("s3://%s/", bucketName);
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/util/CephContainer.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/util/CephContainer.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake.util;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.containers.wait.strategy.SelectedPortWaitStrategy;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.startupcheck.IsRunningStartupCheckStrategy;
+
+import java.io.Closeable;
+import java.time.Duration;
+
+public final class CephContainer
+        implements Closeable
+{
+    public static final String CEPH_ACCESS_KEY = "ceph-access-key";
+    public static final String CEPH_SECRET_KEY = "ceph-secret-key";
+    public static final int CEPH_PORT = 8000;
+
+    private final DockerContainer ceph;
+
+    public CephContainer(Network network)
+    {
+        ceph = new DockerContainer("ceph/daemon:master-dba849b-pacific-centos-8")
+                .withEnv(ImmutableMap.<String, String>builder()
+                        .put("MON_IP", "127.0.0.1")
+                        .put("OSD_COUNT", "1")
+                        .put("CLUSTER", "ceph")
+                        .put("CEPH_PUBLIC_NETWORK", "0.0.0.0/0")
+                        .put("CEPH_DEMO_UID", "ceph")
+                        .put("CEPH_DEMO_ACCESS_KEY", CEPH_ACCESS_KEY)
+                        .put("CEPH_DEMO_SECRET_KEY", CEPH_SECRET_KEY)
+                        .put("RGW_NAME", "ceph")
+                        .put("RGW_FRONTEND_PORT", String.valueOf(CEPH_PORT))
+                        .buildOrThrow())
+                .withNetwork(network)
+                .withNetworkAliases("ceph")
+                .withCommand("demo")
+                .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
+                .waitingFor(new SelectedPortWaitStrategy(CEPH_PORT))
+                .withStartupTimeout(Duration.ofMinutes(1));
+
+        ceph.addExposedPort(CEPH_PORT);
+    }
+
+    public void start()
+    {
+        ceph.start();
+    }
+
+    @Override
+    public void close()
+    {
+        ceph.close();
+    }
+
+    public String getCephEndpoint()
+    {
+        // Ceph demo container tries to resolve given hostname into a bucket name.
+        // That results in a NoSuchBucket error. Workaround is to use service IP address.
+        return "http://0.0.0.0:" + ceph.getMappedPort(CEPH_PORT);
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/util/DockerizedCephDataLake.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/util/DockerizedCephDataLake.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake.util;
+
+import io.trino.testing.ceph.CephClient;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.plugin.deltalake.util.CephContainer.CEPH_ACCESS_KEY;
+import static io.trino.plugin.deltalake.util.CephContainer.CEPH_SECRET_KEY;
+
+public final class DockerizedCephDataLake
+        extends DockerizedDataLake
+{
+    private final CephContainer cephServer;
+    private final CephClient cephClient;
+    private final String bucketName;
+
+    public DockerizedCephDataLake(
+            String bucketName,
+            Optional<String> hadoopBaseImage,
+            Map<String, String> hadoopImageResourceMap,
+            Map<String, String> hadoopImageFileMap)
+    {
+        super(hadoopBaseImage, hadoopImageResourceMap, hadoopImageFileMap);
+        try {
+            this.bucketName = bucketName;
+            this.cephServer = initCephServer();
+            this.cephClient = initCephClient(this.cephServer.getCephEndpoint(), bucketName);
+        }
+        catch (Exception e) {
+            try {
+                closer.close();
+            }
+            catch (IOException closeException) {
+                if (e != closeException) {
+                    e.addSuppressed(closeException);
+                }
+            }
+            throw e;
+        }
+    }
+
+    private CephContainer initCephServer()
+    {
+        CephContainer container = new CephContainer(network);
+        closer.register(container);
+        container.start();
+        return container;
+    }
+
+    private static CephClient initCephClient(String s3endpoint, String bucketName)
+    {
+        CephClient client = new CephClient(s3endpoint, CEPH_ACCESS_KEY, CEPH_SECRET_KEY);
+        client.makeBucket(bucketName);
+        return client;
+    }
+
+    public void copyResources(String resourcePath, String target)
+    {
+        cephClient.copyResourcePath(bucketName, resourcePath, target);
+    }
+
+    public List<String> listFiles(String targetDirectory)
+    {
+        return cephClient.listObjects(bucketName, targetDirectory);
+    }
+
+    public String getCephEndpoint()
+    {
+        return cephServer.getCephEndpoint();
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/util/MinioContainer.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/util/MinioContainer.java
@@ -28,7 +28,7 @@ public final class MinioContainer
 {
     public static final String MINIO_ACCESS_KEY = "minio-access-key";
     public static final String MINIO_SECRET_KEY = "minio-secret-key";
-    private static final int MINIO_PORT = 9080;
+    public static final int MINIO_PORT = 9080;
 
     private final DockerContainer minio;
 

--- a/plugin/trino-delta-lake/src/test/resources/io/trino/plugin/deltalake/core-site.xml
+++ b/plugin/trino-delta-lake/src/test/resources/io/trino/plugin/deltalake/core-site.xml
@@ -6,15 +6,15 @@
     </property>
     <property>
         <name>fs.s3a.endpoint</name>
-        <value>http://minio:9080</value>
+        <value>%S3_ENDPOINT%</value>
     </property>
     <property>
         <name>fs.s3a.access.key</name>
-        <value>minio-access-key</value>
+        <value>%S3_ACCESS_KEY%</value>
     </property>
     <property>
         <name>fs.s3a.secret.key</name>
-        <value>minio-secret-key</value>
+        <value>%S3_SECRET_KEY%</value>
     </property>
     <property>
         <name>fs.s3a.path.style.access</name>

--- a/plugin/trino-exchange-filesystem/pom.xml
+++ b/plugin/trino-exchange-filesystem/pom.xml
@@ -355,4 +355,28 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.basepom.maven</groupId>
+                        <artifactId>duplicate-finder-maven-plugin</artifactId>
+                        <configuration>
+                            <ignoredResourcePatterns>
+                                <!-- com.amazonaws:aws-java-sdk-core and software.amazon.awssdk:sdk-core MIME type file duplicate-->
+                                <ignoredResourcePattern>mime.types</ignoredResourcePattern>
+                                <ignoredResourcePattern>about.html</ignoredResourcePattern>
+                            </ignoredResourcePatterns>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/testing/trino-testing-containers/pom.xml
+++ b/testing/trino-testing-containers/pom.xml
@@ -23,6 +23,16 @@
         </dependency>
 
         <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.github.docker-java</groupId>
             <artifactId>docker-java-api</artifactId>
             <version>${dep.docker-java.version}</version>

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/ceph/CephClient.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/ceph/CephClient.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing.ceph;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.Protocol;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.iterable.S3Objects;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.google.common.collect.Sets;
+import com.google.common.collect.Streams;
+import com.google.common.io.ByteSource;
+import com.google.common.reflect.ClassPath;
+import io.airlift.log.Logger;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static java.util.regex.Matcher.quoteReplacement;
+
+public class CephClient
+{
+    private static final Logger log = Logger.get(CephClient.class);
+
+    private static final Set<String> createdBuckets = Sets.newConcurrentHashSet();
+
+    private final AmazonS3 client;
+
+    public CephClient(String endpoint, String accessKey, String secretKey)
+    {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        AWSCredentialsProvider credentialsProvider = new AWSStaticCredentialsProvider(credentials);
+        ClientConfiguration clientConfiguration = new ClientConfiguration()
+                .withProtocol(Protocol.HTTP)
+                .withSignerOverride("AWSS3V4SignerType");
+
+        client = AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(credentialsProvider)
+                .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpoint, Regions.US_EAST_1.name()))
+                .withPathStyleAccessEnabled(true)
+                .withClientConfiguration(clientConfiguration)
+                .build();
+    }
+
+    public void copyResourcePath(String bucket, String resourcePath, String target)
+    {
+        ensureBucketExists(bucket);
+
+        try {
+            ClassPath.from(CephClient.class.getClassLoader())
+                    .getResources().stream()
+                    .filter(resourceInfo -> resourceInfo.getResourceName().startsWith(resourcePath))
+                    .forEach(resourceInfo -> {
+                        String fileName = resourceInfo.getResourceName().replaceFirst("^" + Pattern.quote(resourcePath), quoteReplacement(target));
+                        try {
+                            putObject(bucket, fileName, resourceInfo.asByteSource());
+                        }
+                        catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+        }
+        catch (IOException e) {
+            log.warn(e, "Could not copy resources from classpath");
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private void putObject(String bucket, String fileName, ByteSource byteSource)
+            throws IOException
+    {
+        ensureBucketExists(bucket);
+
+        try (InputStream inputStream = byteSource.openStream()) {
+            client.putObject(new PutObjectRequest(bucket, fileName, inputStream, new ObjectMetadata()));
+        }
+    }
+
+    public List<String> listObjects(String bucket, String path)
+    {
+        return Streams
+                .stream(S3Objects.withPrefix(client, bucket, path))
+                .map(S3ObjectSummary::getKey).collect(Collectors.toList());
+    }
+
+    public void makeBucket(String bucket)
+    {
+        if (!createdBuckets.add(bucket)) {
+            // Forbid to create a bucket with given name more than once per class loader.
+            // The reason for that is that bucket name is used as a key in TrinoFileSystemCache which is
+            // managed in static manner. Allowing creating same bucket twice (even for two different ceph environments)
+            // leads to hard to understand problems when one test influences the other via unexpected cache lookups.
+            throw new IllegalArgumentException("Bucket " + bucket + " already created in this classloader");
+        }
+        try {
+            client.createBucket(bucket);
+        }
+        catch (Exception e) {
+            // Revert bucket registration, so we can retry the call on transient errors.
+            createdBuckets.remove(bucket);
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void ensureBucketExists(String bucket)
+    {
+        try {
+            if (!client.doesBucketExistV2(bucket)) {
+                makeBucket(bucket);
+            }
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Trino fails to read the Delta Table snapshot from Ceph Object Gateway S3 API because thrown exception does not contain the expected message. The common part of the exception message for AWS S3, MinIO, and Ceph S3 API is `Error Code: NoSuchKey`.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

It's a fix.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

It's a change to the Delta Lake connector.

> How would you describe this change to a non-technical end user or system administrator?

This change enables Trino to connect to the Delta Lake tables stored on Ceph with S3 API.

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:
