### PR TITLE
Reduce trino-tests' memory footprint

### DIFF
--- a/testing/trino-tests/pom.xml
+++ b/testing/trino-tests/pom.xml
@@ -14,6 +14,16 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+
+        <!--
+          Project's default for air.test.parallel is 'methods'. By design, 'instances' runs all the methods in the same instance in the same thread,
+          but two methods on two different instances will be running in different threads.
+          As a side effect, it prevents TestNG from initializing multiple test instances upfront, which happens with 'methods'.
+          This reduces tests' memory footprint, which generally allows them to complete faster.
+          A potential downside can be long tail single-threaded execution of a single long test class.
+          TODO (https://github.com/trinodb/trino/issues/11294) remove when we upgrade to surefire with https://issues.apache.org/jira/browse/SUREFIRE-1967
+          -->
+        <air.test.parallel>instances</air.test.parallel>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
On CI it was observed to improve test times, preventing build timeouts.

Verified with https://github.com/trinodb/trino/pull/12727