### PR TITLE
Support snapshot queries on Iceberg system tables

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/FilesTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/FilesTable.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slices;
 import io.trino.plugin.iceberg.util.PageListBuilder;
 import io.trino.spi.Page;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.ConnectorSession;
@@ -25,7 +26,6 @@ import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.FixedPageSource;
 import io.trino.spi.connector.SchemaTableName;
-import io.trino.spi.connector.SystemTable;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.TypeManager;
@@ -36,25 +36,44 @@ import org.apache.iceberg.TableScan;
 import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Type;
-import org.apache.iceberg.types.Types;
 
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.trino.plugin.iceberg.ColumnIdentity.createColumnIdentity;
+import static io.trino.plugin.iceberg.IcebergUtil.createColumnHandle;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.TypeSignature.mapType;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.util.Objects.requireNonNull;
+import static org.apache.iceberg.DataFile.COLUMN_SIZES;
+import static org.apache.iceberg.DataFile.CONTENT;
+import static org.apache.iceberg.DataFile.EQUALITY_IDS;
+import static org.apache.iceberg.DataFile.FILE_FORMAT;
+import static org.apache.iceberg.DataFile.FILE_PATH;
+import static org.apache.iceberg.DataFile.FILE_SIZE;
+import static org.apache.iceberg.DataFile.KEY_METADATA;
+import static org.apache.iceberg.DataFile.LOWER_BOUNDS;
+import static org.apache.iceberg.DataFile.NAN_VALUE_COUNTS;
+import static org.apache.iceberg.DataFile.NULL_VALUE_COUNTS;
+import static org.apache.iceberg.DataFile.RECORD_COUNT;
+import static org.apache.iceberg.DataFile.SPLIT_OFFSETS;
+import static org.apache.iceberg.DataFile.UPPER_BOUNDS;
+import static org.apache.iceberg.DataFile.VALUE_COUNTS;
+import static org.apache.iceberg.types.Types.NestedField;
 
 public class FilesTable
-        implements SystemTable
+        implements IcebergSystemTable
 {
     private final ConnectorTableMetadata tableMetadata;
+    private final Map<String, ColumnHandle> columnHandles;
     private final Table icebergTable;
     private final Optional<Long> snapshotId;
 
@@ -62,36 +81,42 @@ public class FilesTable
     {
         this.icebergTable = requireNonNull(icebergTable, "icebergTable is null");
 
-        tableMetadata = new ConnectorTableMetadata(requireNonNull(tableName, "tableName is null"),
-                ImmutableList.<ColumnMetadata>builder()
-                        .add(new ColumnMetadata("content", INTEGER))
-                        .add(new ColumnMetadata("file_path", VARCHAR))
-                        .add(new ColumnMetadata("file_format", VARCHAR))
-                        .add(new ColumnMetadata("record_count", BIGINT))
-                        .add(new ColumnMetadata("file_size_in_bytes", BIGINT))
-                        .add(new ColumnMetadata("column_sizes", typeManager.getType(mapType(INTEGER.getTypeSignature(), BIGINT.getTypeSignature()))))
-                        .add(new ColumnMetadata("value_counts", typeManager.getType(mapType(INTEGER.getTypeSignature(), BIGINT.getTypeSignature()))))
-                        .add(new ColumnMetadata("null_value_counts", typeManager.getType(mapType(INTEGER.getTypeSignature(), BIGINT.getTypeSignature()))))
-                        .add(new ColumnMetadata("nan_value_counts", typeManager.getType(mapType(INTEGER.getTypeSignature(), BIGINT.getTypeSignature()))))
-                        .add(new ColumnMetadata("lower_bounds", typeManager.getType(mapType(INTEGER.getTypeSignature(), VARCHAR.getTypeSignature()))))
-                        .add(new ColumnMetadata("upper_bounds", typeManager.getType(mapType(INTEGER.getTypeSignature(), VARCHAR.getTypeSignature()))))
-                        .add(new ColumnMetadata("key_metadata", VARBINARY))
-                        .add(new ColumnMetadata("split_offsets", new ArrayType(BIGINT)))
-                        .add(new ColumnMetadata("equality_ids", new ArrayType(INTEGER)))
-                        .build());
+        List<IcebergColumnHandle> columnHandlesList = ImmutableList.<IcebergColumnHandle>builder()
+                .add(createColumnHandle(createColumnIdentity(CONTENT), INTEGER))
+                .add(createColumnHandle(createColumnIdentity(FILE_PATH), VARCHAR))
+                .add(createColumnHandle(createColumnIdentity(FILE_FORMAT), VARCHAR))
+                .add(createColumnHandle(createColumnIdentity(RECORD_COUNT), BIGINT))
+                .add(createColumnHandle(createColumnIdentity(FILE_SIZE), BIGINT))
+                .add(createColumnHandle(createColumnIdentity(COLUMN_SIZES), typeManager.getType(mapType(INTEGER.getTypeSignature(), BIGINT.getTypeSignature()))))
+                .add(createColumnHandle(createColumnIdentity(VALUE_COUNTS), typeManager.getType(mapType(INTEGER.getTypeSignature(), BIGINT.getTypeSignature()))))
+                .add(createColumnHandle(createColumnIdentity(NULL_VALUE_COUNTS), typeManager.getType(mapType(INTEGER.getTypeSignature(), BIGINT.getTypeSignature()))))
+                .add(createColumnHandle(createColumnIdentity(NAN_VALUE_COUNTS), typeManager.getType(mapType(INTEGER.getTypeSignature(), BIGINT.getTypeSignature()))))
+                .add(createColumnHandle(createColumnIdentity(LOWER_BOUNDS), typeManager.getType(mapType(INTEGER.getTypeSignature(), VARCHAR.getTypeSignature()))))
+                .add(createColumnHandle(createColumnIdentity(UPPER_BOUNDS), typeManager.getType(mapType(INTEGER.getTypeSignature(), VARCHAR.getTypeSignature()))))
+                .add(createColumnHandle(createColumnIdentity(KEY_METADATA), VARBINARY))
+                .add(createColumnHandle(createColumnIdentity(SPLIT_OFFSETS), new ArrayType(BIGINT)))
+                .add(createColumnHandle(createColumnIdentity(EQUALITY_IDS), new ArrayType(INTEGER)))
+                .build();
+        columnHandles = columnHandlesList.stream()
+                .collect(toImmutableMap(IcebergColumnHandle::getName, Function.identity()));
+        tableMetadata = new ConnectorTableMetadata(
+                requireNonNull(tableName, "tableName is null"),
+                columnHandlesList.stream()
+                        .map(icebergColumnHandle -> new ColumnMetadata(icebergColumnHandle.getName(), icebergColumnHandle.getType()))
+                        .collect(Collectors.toUnmodifiableList()));
         this.snapshotId = requireNonNull(snapshotId, "snapshotId is null");
-    }
-
-    @Override
-    public Distribution getDistribution()
-    {
-        return Distribution.SINGLE_COORDINATOR;
     }
 
     @Override
     public ConnectorTableMetadata getTableMetadata()
     {
         return tableMetadata;
+    }
+
+    @Override
+    public Map<String, ColumnHandle> getColumnHandles()
+    {
+        return columnHandles;
     }
 
     @Override
@@ -176,13 +201,13 @@ public class FilesTable
     private static Map<Integer, Type> getIcebergIdToTypeMapping(Schema schema)
     {
         ImmutableMap.Builder<Integer, Type> icebergIdToTypeMapping = ImmutableMap.builder();
-        for (Types.NestedField field : schema.columns()) {
+        for (NestedField field : schema.columns()) {
             populateIcebergIdToTypeMapping(field, icebergIdToTypeMapping);
         }
         return icebergIdToTypeMapping.buildOrThrow();
     }
 
-    private static void populateIcebergIdToTypeMapping(Types.NestedField field, ImmutableMap.Builder<Integer, Type> icebergIdToTypeMapping)
+    private static void populateIcebergIdToTypeMapping(NestedField field, ImmutableMap.Builder<Integer, Type> icebergIdToTypeMapping)
     {
         Type type = field.type();
         icebergIdToTypeMapping.put(field.fieldId(), type);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HistoryTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HistoryTable.java
@@ -15,6 +15,7 @@ package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableMetadata;
@@ -22,17 +23,23 @@ import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.InMemoryRecordSet;
 import io.trino.spi.connector.RecordCursor;
 import io.trino.spi.connector.SchemaTableName;
-import io.trino.spi.connector.SystemTable;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.TimeZoneKey;
 import org.apache.iceberg.HistoryEntry;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.SnapshotUtil;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.trino.plugin.iceberg.ColumnIdentity.createColumnIdentity;
+import static io.trino.plugin.iceberg.IcebergUtil.createColumnHandle;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
@@ -40,17 +47,24 @@ import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static java.util.Objects.requireNonNull;
 
 public class HistoryTable
-        implements SystemTable
+        implements IcebergSystemTable
 {
     private final ConnectorTableMetadata tableMetadata;
     private final Table icebergTable;
 
-    private static final List<ColumnMetadata> COLUMNS = ImmutableList.<ColumnMetadata>builder()
-            .add(new ColumnMetadata("made_current_at", TIMESTAMP_TZ_MILLIS))
-            .add(new ColumnMetadata("snapshot_id", BIGINT))
-            .add(new ColumnMetadata("parent_id", BIGINT))
-            .add(new ColumnMetadata("is_current_ancestor", BOOLEAN))
+    private static final List<IcebergColumnHandle> COLUMNS_HANDLES_LIST = ImmutableList.<IcebergColumnHandle>builder()
+            .add(createColumnHandle(createColumnIdentity(Types.NestedField.required(1, "made_current_at", Types.TimestampType.withZone())), TIMESTAMP_TZ_MILLIS))
+            .add(createColumnHandle(createColumnIdentity(Types.NestedField.required(2, "snapshot_id", Types.LongType.get())), BIGINT))
+            .add(createColumnHandle(createColumnIdentity(Types.NestedField.optional(3, "parent_id", Types.LongType.get())), BIGINT))
+            .add(createColumnHandle(createColumnIdentity(Types.NestedField.required(4, "is_current_ancestor", Types.BooleanType.get())), BOOLEAN))
             .build();
+
+    private static final List<ColumnMetadata> COLUMNS = COLUMNS_HANDLES_LIST.stream()
+            .map(icebergColumnHandle -> new ColumnMetadata(icebergColumnHandle.getName(), icebergColumnHandle.getType()))
+            .collect(Collectors.toUnmodifiableList());
+
+    private static final Map<String, ColumnHandle> COLUMN_HANDLES_MAP = COLUMNS_HANDLES_LIST.stream()
+                .collect(toImmutableMap(IcebergColumnHandle::getName, Function.identity()));
 
     public HistoryTable(SchemaTableName tableName, Table icebergTable)
     {
@@ -59,15 +73,15 @@ public class HistoryTable
     }
 
     @Override
-    public Distribution getDistribution()
-    {
-        return Distribution.SINGLE_COORDINATOR;
-    }
-
-    @Override
     public ConnectorTableMetadata getTableMetadata()
     {
         return tableMetadata;
+    }
+
+    @Override
+    public Map<String, ColumnHandle> getColumnHandles()
+    {
+        return COLUMN_HANDLES_MAP;
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSystemSplit.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSystemSplit.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.HostAddress;
+import io.trino.spi.connector.ConnectorSplit;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.List;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static java.util.Objects.requireNonNull;
+
+public class IcebergSystemSplit
+        implements ConnectorSplit
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(IcebergSystemSplit.class).instanceSize();
+
+    private final List<HostAddress> addresses;
+
+    public IcebergSystemSplit(HostAddress address)
+    {
+        this(ImmutableList.of(requireNonNull(address, "address is null")));
+    }
+
+    @JsonCreator
+    public IcebergSystemSplit(@JsonProperty("addresses") List<HostAddress> addresses)
+    {
+        requireNonNull(addresses, "addresses is null");
+        checkArgument(!addresses.isEmpty(), "addresses is empty");
+        this.addresses = ImmutableList.copyOf(addresses);
+    }
+
+    @Override
+    public boolean isRemotelyAccessible()
+    {
+        return false;
+    }
+
+    @Override
+    @JsonProperty
+    public List<HostAddress> getAddresses()
+    {
+        return addresses;
+    }
+
+    @Override
+    public Object getInfo()
+    {
+        return this;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE
+                + estimatedSizeOf(addresses, HostAddress::getRetainedSizeInBytes);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("addresses", addresses)
+                .toString();
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSystemTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSystemTable.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.RecordCursor;
+import io.trino.spi.predicate.TupleDomain;
+
+import java.util.Map;
+
+/**
+ * Exactly one of {@link #cursor} or {@link #pageSource} must be implemented.
+ */
+public interface IcebergSystemTable
+{
+    ConnectorTableMetadata getTableMetadata();
+
+    Map<String, ColumnHandle> getColumnHandles();
+
+    /**
+     * Create a cursor for the data in this table.
+     *
+     * @param session the session to use for creating the data
+     * @param constraint the constraints for the table columns (indexed from 0)
+     */
+    default RecordCursor cursor(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Create a page source for the data in this table.
+     *
+     * @param session the session to use for creating the data
+     * @param constraint the constraints for the table columns (indexed from 0)
+     */
+    default ConnectorPageSource pageSource(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -653,4 +653,14 @@ public final class IcebergUtil
             throw new TrinoException(INVALID_TABLE_PROPERTY, format("Orc bloom filter columns %s not present in schema", Sets.difference(ImmutableSet.copyOf(orcBloomFilterColumns), allColumns)));
         }
     }
+
+    public static IcebergColumnHandle createColumnHandle(ColumnIdentity columnIdentity, io.trino.spi.type.Type type)
+    {
+        return new IcebergColumnHandle(
+                columnIdentity,
+                type,
+                ImmutableList.of(),
+                type,
+                Optional.empty());
+    }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/SnapshotsTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/SnapshotsTable.java
@@ -16,6 +16,7 @@ package io.trino.plugin.iceberg;
 import com.google.common.collect.ImmutableList;
 import io.trino.plugin.iceberg.util.PageListBuilder;
 import io.trino.spi.Page;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.ConnectorSession;
@@ -23,24 +24,31 @@ import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.FixedPageSource;
 import io.trino.spi.connector.SchemaTableName;
-import io.trino.spi.connector.SystemTable;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.TimeZoneKey;
 import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.TypeSignature;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.types.Types;
 
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.trino.plugin.iceberg.ColumnIdentity.createColumnIdentity;
+import static io.trino.plugin.iceberg.IcebergUtil.createColumnHandle;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.util.Objects.requireNonNull;
 
 public class SnapshotsTable
-        implements SystemTable
+        implements IcebergSystemTable
 {
     private final ConnectorTableMetadata tableMetadata;
+    private final Map<String, ColumnHandle> columnHandles;
     private final Table icebergTable;
 
     public SnapshotsTable(SchemaTableName tableName, TypeManager typeManager, Table icebergTable)
@@ -48,27 +56,37 @@ public class SnapshotsTable
         requireNonNull(typeManager, "typeManager is null");
 
         this.icebergTable = requireNonNull(icebergTable, "icebergTable is null");
+        List<IcebergColumnHandle> columnHandlesList = ImmutableList.<IcebergColumnHandle>builder()
+                .add(createColumnHandle(createColumnIdentity(Types.NestedField.required(1, "committed_at", Types.TimestampType.withZone())), TIMESTAMP_TZ_MILLIS))
+                .add(createColumnHandle(createColumnIdentity(Types.NestedField.required(2, "snapshot_id", Types.LongType.get())), BIGINT))
+                .add(createColumnHandle(createColumnIdentity(Types.NestedField.optional(3, "parent_id", Types.LongType.get())), BIGINT))
+                .add(createColumnHandle(createColumnIdentity(Types.NestedField.optional(4, "operation", Types.StringType.get())), VARCHAR))
+                .add(createColumnHandle(createColumnIdentity(Types.NestedField.optional(5, "manifest_list", Types.StringType.get())), VARCHAR))
+                .add(createColumnHandle(
+                        createColumnIdentity(Types.NestedField.optional(
+                                6,
+                                "summary",
+                                Types.MapType.ofRequired(7, 8, Types.StringType.get(), Types.StringType.get()))),
+                        typeManager.getType(TypeSignature.mapType(VARCHAR.getTypeSignature(), VARCHAR.getTypeSignature()))))
+                .build();
+        columnHandles = columnHandlesList.stream()
+                .collect(toImmutableMap(IcebergColumnHandle::getName, Function.identity()));
         tableMetadata = new ConnectorTableMetadata(requireNonNull(tableName, "tableName is null"),
-                ImmutableList.<ColumnMetadata>builder()
-                        .add(new ColumnMetadata("committed_at", TIMESTAMP_TZ_MILLIS))
-                        .add(new ColumnMetadata("snapshot_id", BIGINT))
-                        .add(new ColumnMetadata("parent_id", BIGINT))
-                        .add(new ColumnMetadata("operation", VARCHAR))
-                        .add(new ColumnMetadata("manifest_list", VARCHAR))
-                        .add(new ColumnMetadata("summary", typeManager.getType(TypeSignature.mapType(VARCHAR.getTypeSignature(), VARCHAR.getTypeSignature()))))
-                        .build());
-    }
-
-    @Override
-    public Distribution getDistribution()
-    {
-        return Distribution.SINGLE_COORDINATOR;
+                columnHandlesList.stream()
+                        .map(icebergColumnHandle -> new ColumnMetadata(icebergColumnHandle.getName(), icebergColumnHandle.getType()))
+                        .collect(Collectors.toUnmodifiableList()));
     }
 
     @Override
     public ConnectorTableMetadata getTableMetadata()
     {
         return tableMetadata;
+    }
+
+    @Override
+    public Map<String, ColumnHandle> getColumnHandles()
+    {
+        return columnHandles;
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -5235,6 +5235,81 @@ public abstract class BaseIcebergConnectorTest
         assertThat(e).hasMessageContaining("Failed to create file");
     }
 
+    @Test
+    public void testVersionedQueriesOnTableWithPartionSpecEvolution()
+    {
+        String tableName = "test_versioned_queries_partition_spec_evolution_" + randomTableSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " (d DATE, b BIGINT) WITH (partitioning = ARRAY['d'])");
+        long v1SnapshotId = getLatestSnapshotId(tableName);
+        assertUpdate("INSERT INTO " + tableName + " VALUES " +
+                "(NULL, 101)," +
+                "(DATE '2021-10-01', 10), " +
+                "(DATE '2021-12-01', 11)", 3);
+        long v2SnapshotId = getLatestSnapshotId(tableName);
+        assertUpdate("ALTER TABLE " + tableName + " SET PROPERTIES partitioning = ARRAY['month(d)']");
+        assertUpdate("INSERT INTO " + tableName + " VALUES " +
+                "(DATE '2022-01-01', 101), " +
+                "(DATE '2022-01-02', 102), " +
+                "(DATE '2022-02-01', 201)", 3);
+        long v3SnapshotId = getLatestSnapshotId(tableName);
+        assertUpdate("ALTER TABLE " + tableName + " SET PROPERTIES partitioning = ARRAY['day(d)']");
+        assertUpdate("INSERT INTO " + tableName + " VALUES " +
+                "(DATE '2022-03-01', 301), " +
+                "(DATE '2022-03-02', 302)", 2);
+        long v4SnapshotId = getLatestSnapshotId(tableName);
+
+        assertQuery("SELECT * FROM " + tableName, "VALUES " +
+                "(NULL, 101)," +
+                "(DATE '2021-10-01', 10), " +
+                "(DATE '2021-12-01', 11), " +
+                "(DATE '2022-01-01', 101), " +
+                "(DATE '2022-01-02', 102), " +
+                "(DATE '2022-02-01', 201), " +
+                "(DATE '2022-03-01', 301), " +
+                "(DATE '2022-03-02', 302)");
+
+        assertQueryReturnsEmptyResult("SELECT partition FROM \"" + tableName + "$partitions\" FOR VERSION AS OF " + v1SnapshotId);
+        assertQueryReturnsEmptyResult("SELECT partitions FROM \"" + tableName + "$manifests\" FOR VERSION AS OF " + v1SnapshotId);
+
+        assertThat(query("SELECT partition FROM \"" + tableName + "$partitions\" FOR VERSION AS OF " + v2SnapshotId))
+                .matches("VALUES " +
+                        "CAST(ROW(ROW(NULL, NULL, NULL)) AS row(row(d date, d_month integer, d_day date))), " +
+                        "CAST(ROW(ROW(DATE '2021-10-01', NULL, NULL)) AS row(row(d date, d_month integer, d_day date))), " +
+                        "CAST(ROW(ROW(DATE '2021-12-01', NULL, NULL)) AS row(row(d date, d_month integer, d_day date)))");
+        assertThat(query("SELECT partitions FROM \"" + tableName + "$manifests\" FOR VERSION AS OF " + v2SnapshotId))
+                .matches("VALUES " +
+                        "CAST(ROW(ARRAY[ROW(true, false, '2021-10-01', '2021-12-01')]) AS row(array(row(contains_null boolean, contains_nan boolean, lower_bound varchar, upper_bound varchar))))");
+
+        assertThat(query("SELECT partition FROM \"" + tableName + "$partitions\" FOR VERSION AS OF " + v3SnapshotId))
+                .matches("VALUES " +
+                        "CAST(ROW(ROW(NULL, NULL, NULL)) AS row(row(d date, d_month integer, d_day date))), " +
+                        "CAST(ROW(ROW(DATE '2021-10-01', NULL, NULL)) AS row(row(d date, d_month integer, d_day date))), " +
+                        "CAST(ROW(ROW(DATE '2021-12-01', NULL, NULL)) AS row(row(d date, d_month integer, d_day date))), " +
+                        "CAST(ROW(ROW(NULL, INTEGER '624', NULL)) AS row(row(d date, d_month integer, d_day date))), " +
+                        "CAST(ROW(ROW(NULL, INTEGER '625', NULL)) AS row(row(d date, d_month integer, d_day date)))");
+        assertThat(query("SELECT partitions FROM \"" + tableName + "$manifests\" FOR VERSION AS OF " + v3SnapshotId))
+                .matches("VALUES " +
+                        "CAST(ROW(ARRAY[ROW(true, false, '2021-10-01', '2021-12-01')]) AS row(array(row(contains_null boolean, contains_nan boolean, lower_bound varchar, upper_bound varchar)))), " +
+                        "CAST(ROW(ARRAY[ROW(false, false, '2022-01', '2022-02')]) AS row(array(row(contains_null boolean, contains_nan boolean, lower_bound varchar, upper_bound varchar))))");
+
+        assertThat(query("SELECT partition FROM \"" + tableName + "$partitions\" FOR VERSION AS OF " + v4SnapshotId))
+                .matches("VALUES " +
+                        "CAST(ROW(ROW(NULL, NULL, NULL)) AS row(row(d date, d_month integer, d_day date))), " +
+                        "CAST(ROW(ROW(DATE '2021-10-01', NULL, NULL)) AS row(row(d date, d_month integer, d_day date))), " +
+                        "CAST(ROW(ROW(DATE '2021-12-01', NULL, NULL)) AS row(row(d date, d_month integer, d_day date))), " +
+                        "CAST(ROW(ROW(NULL, INTEGER '624', NULL)) AS row(row(d date, d_month integer, d_day date))), " +
+                        "CAST(ROW(ROW(NULL, INTEGER '625', NULL)) AS row(row(d date, d_month integer, d_day date))), " +
+                        "CAST(ROW(ROW(NULL, NULL, DATE '2022-03-01')) AS row(row(d date, d_month integer, d_day date))), " +
+                        "CAST(ROW(ROW(NULL, NULL, DATE '2022-03-02')) AS row(row(d date, d_month integer, d_day date)))");
+        assertThat(query("SELECT partitions FROM \"" + tableName + "$manifests\" FOR VERSION AS OF " + v4SnapshotId))
+                .matches("VALUES " +
+                        "CAST(ROW(ARRAY[ROW(true, false, '2021-10-01', '2021-12-01')]) AS row(array(row(contains_null boolean, contains_nan boolean, lower_bound varchar, upper_bound varchar)))), " +
+                        "CAST(ROW(ARRAY[ROW(false, false, '2022-01', '2022-02')]) AS row(array(row(contains_null boolean, contains_nan boolean, lower_bound varchar, upper_bound varchar)))), " +
+                        "CAST(ROW(ARRAY[ROW(false, false, '2022-03-01', '2022-03-02')]) AS row(array(row(contains_null boolean, contains_nan boolean, lower_bound varchar, upper_bound varchar))))");
+
+        dropTable(tableName);
+    }
+
     private Session prepareCleanUpSession()
     {
         return Session.builder(getSession())

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
@@ -263,37 +263,37 @@ public class TestIcebergMetastoreAccessOperations
         // select from $history
         assertMetastoreInvocations("SELECT * FROM \"test_select_snapshots$history\"",
                 ImmutableMultiset.builder()
-                        .addCopies(GET_TABLE, 1)
+                        .addCopies(GET_TABLE, 3)
                         .build());
 
         // select from $snapshots
         assertMetastoreInvocations("SELECT * FROM \"test_select_snapshots$snapshots\"",
                 ImmutableMultiset.builder()
-                        .addCopies(GET_TABLE, 1)
+                        .addCopies(GET_TABLE, 3)
                         .build());
 
         // select from $manifests
         assertMetastoreInvocations("SELECT * FROM \"test_select_snapshots$manifests\"",
                 ImmutableMultiset.builder()
-                        .addCopies(GET_TABLE, 1)
+                        .addCopies(GET_TABLE, 3)
                         .build());
 
         // select from $partitions
         assertMetastoreInvocations("SELECT * FROM \"test_select_snapshots$partitions\"",
                 ImmutableMultiset.builder()
-                        .addCopies(GET_TABLE, 1)
+                        .addCopies(GET_TABLE, 3)
                         .build());
 
         // select from $files
         assertMetastoreInvocations("SELECT * FROM \"test_select_snapshots$files\"",
                 ImmutableMultiset.builder()
-                        .addCopies(GET_TABLE, 1)
+                        .addCopies(GET_TABLE, 3)
                         .build());
 
         // select from $properties
         assertMetastoreInvocations("SELECT * FROM \"test_select_snapshots$properties\"",
                 ImmutableMultiset.builder()
-                        .addCopies(GET_TABLE, 1)
+                        .addCopies(GET_TABLE, 3)
                         .build());
 
         // This test should get updated if a new system table is added.

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergReadVersionedTable.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergReadVersionedTable.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.iceberg;
 
+import io.trino.Session;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.DistributedQueryRunner;
 import org.testng.annotations.BeforeClass;
@@ -25,6 +26,7 @@ import java.time.format.DateTimeFormatter;
 import static io.trino.plugin.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
 import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
+import static org.testng.Assert.assertEquals;
 
 public class TestIcebergReadVersionedTable
         extends AbstractTestQueryFramework
@@ -94,11 +96,18 @@ public class TestIcebergReadVersionedTable
     }
 
     @Test
-    public void testSystemTables()
+    public void testSelectFromSystemTablesWithEndSnapshotId()
     {
-        // TODO https://github.com/trinodb/trino/issues/12920
-        assertQueryFails("SELECT * FROM \"test_iceberg_read_versioned_table$partitions\" FOR VERSION AS OF " + v1SnapshotId,
-                "This connector does not support versioned tables");
+        assertQuery("SELECT * FROM \"test_iceberg_read_versioned_table$data\" FOR VERSION AS OF " + v1SnapshotId, "VALUES ('a', 1)");
+        assertQuerySucceeds("SELECT * FROM \"test_iceberg_read_versioned_table$properties\" FOR VERSION AS OF " + v1SnapshotId);
+        assertQueryFails("SELECT * FROM \"test_iceberg_read_versioned_table$history\" FOR VERSION AS OF " + v1SnapshotId, "Versioning not supported for metadata table\\: tpch.test_iceberg_read_versioned_table\\$history");
+        assertQueryFails("SELECT * FROM \"test_iceberg_read_versioned_table$snapshots\" FOR VERSION AS OF " + v1SnapshotId, "Versioning not supported for metadata table\\: tpch.test_iceberg_read_versioned_table\\$snapshots");
+        Session allowLegacySnapshotSession = Session.builder(getSession())
+                .setCatalogSessionProperty("iceberg", "allow_legacy_snapshot_syntax", "true")
+                .build();
+        assertEquals(computeActual(allowLegacySnapshotSession, "SELECT * FROM \"test_iceberg_read_versioned_table$files@" + v1SnapshotId + "\"").getRowCount(), 1);
+        assertEquals(computeActual("SELECT * FROM \"test_iceberg_read_versioned_table$files\" FOR VERSION AS OF " + v1SnapshotId).getRowCount(), 1);
+        assertEquals(computeActual("SELECT * FROM \"test_iceberg_read_versioned_table$files\" FOR VERSION AS OF " + v2SnapshotId).getRowCount(), 2);
     }
 
     private long getLatestSnapshotId(String tableName)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergHiveTablesCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergHiveTablesCompatibility.java
@@ -48,7 +48,7 @@ public class TestIcebergHiveTablesCompatibility
                 .hasMessageMatching("Query failed \\(#\\w+\\):\\Q Not an Iceberg table: default." + tableName);
 
         assertQueryFailure(() -> onTrino().executeQuery("SELECT * FROM iceberg.default.\"" + tableName + "$files\""))
-                .hasMessageMatching("Query failed \\(#\\w+\\):\\Q line 1:15: Table 'iceberg.default." + tableName + "$files' does not exist");
+                .hasMessageMatching("Query failed \\(#\\w+\\):\\Q Not an Iceberg table: default." + tableName);
 
         onTrino().executeQuery("DROP TABLE hive.default." + tableName);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Use `IcebergTableHandle` for dealing with system tables
because it encodes the snapshot id of the table being queried.


<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Bugfix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Iceberg connector

> How would you describe this change to a non-technical end user or system administrator?

The metadata tables exposed by the Iceberg connector for its tables should support snapshot/versioned queries in the same fashion as the Iceberg tables.

```
SELECT * FROM table1$files FOR VERSION AS OF 1242141
SELECT * FROM table1$files FOR TIMESTAMP AS OF TIMESTAMP '2022-01-01'
```

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

Fixes #12736

This PR could pave the way to the functionality of having distributed `$files` calculation. See https://github.com/trinodb/trino/pull/4840

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

() No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Iceberg
* Support snapshot queries on Iceberg system tables
```
