### PR TITLE
Adjust trino-exchange-filesystem excludes

### DIFF
--- a/plugin/trino-delta-lake/pom.xml
+++ b/plugin/trino-delta-lake/pom.xml
@@ -206,29 +206,23 @@
             <artifactId>trino-exchange-filesystem</artifactId>
             <scope>test</scope>
             <exclusions>
+                <!-- without GCS exclusions the transitive dependencies of com.google.cloud.bigdataoss:gcs-connector:jar:hadoop2-2.0.0 (which is dependency of trino-hive)
+                     or rescoped to "test" from "compile" -->
                 <exclusion>
-                    <groupId>com.google.apis</groupId>
-                    <artifactId>google-api-services-storage</artifactId>
+                    <groupId>com.google.cloud</groupId>
+                    <artifactId>google-cloud-storage</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.google.api-client</groupId>
-                    <artifactId>google-api-client</artifactId>
+                    <groupId>com.google.auth</groupId>
+                    <artifactId>google-auth-library-oauth2-http</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.google.auto.value</groupId>
-                    <artifactId>auto-value-annotations</artifactId>
+                    <groupId>com.google.cloud</groupId>
+                    <artifactId>google-cloud-core</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.google.code.gson</groupId>
-                    <artifactId>gson</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.http-client</groupId>
-                    <artifactId>google-http-client</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.http-client</groupId>
-                    <artifactId>google-http-client-jackson2</artifactId>
+                    <groupId>com.google.api</groupId>
+                    <artifactId>gax</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -238,6 +232,26 @@
             <artifactId>trino-exchange-filesystem</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
+            <exclusions>
+                <!-- without GCS exclusions the transitive dependencies of com.google.cloud.bigdataoss:gcs-connector:jar:hadoop2-2.0.0 (which is dependency of trino-hive)
+                     or rescoped to "test" from "compile" -->
+                <exclusion>
+                    <groupId>com.google.cloud</groupId>
+                    <artifactId>google-cloud-storage</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.auth</groupId>
+                    <artifactId>google-auth-library-oauth2-http</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.cloud</groupId>
+                    <artifactId>google-cloud-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.api</groupId>
+                    <artifactId>gax</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/plugin/trino-hive/pom.xml
+++ b/plugin/trino-hive/pom.xml
@@ -324,29 +324,23 @@
             <artifactId>trino-exchange-filesystem</artifactId>
             <scope>test</scope>
             <exclusions>
+                <!-- without GCS exclusions the transitive dependencies of com.google.cloud.bigdataoss:gcs-connector:jar:hadoop2-2.0.0 (which is dependency of trino-hive)
+                     or rescoped to "test" from "compile" -->
                 <exclusion>
-                    <groupId>com.google.apis</groupId>
-                    <artifactId>google-api-services-storage</artifactId>
+                    <groupId>com.google.cloud</groupId>
+                    <artifactId>google-cloud-storage</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.google.api-client</groupId>
-                    <artifactId>google-api-client</artifactId>
+                    <groupId>com.google.auth</groupId>
+                    <artifactId>google-auth-library-oauth2-http</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.google.auto.value</groupId>
-                    <artifactId>auto-value-annotations</artifactId>
+                    <groupId>com.google.cloud</groupId>
+                    <artifactId>google-cloud-core</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.google.code.gson</groupId>
-                    <artifactId>gson</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.http-client</groupId>
-                    <artifactId>google-http-client</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.http-client</groupId>
-                    <artifactId>google-http-client-jackson2</artifactId>
+                    <groupId>com.google.api</groupId>
+                    <artifactId>gax</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -356,6 +350,26 @@
             <artifactId>trino-exchange-filesystem</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
+            <exclusions>
+                <!-- without GCS exclusions the transitive dependencies of com.google.cloud.bigdataoss:gcs-connector:jar:hadoop2-2.0.0 (which is dependency of trino-hive)
+                     or rescoped to "test" from "compile" -->
+                <exclusion>
+                    <groupId>com.google.cloud</groupId>
+                    <artifactId>google-cloud-storage</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.auth</groupId>
+                    <artifactId>google-auth-library-oauth2-http</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.cloud</groupId>
+                    <artifactId>google-cloud-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.api</groupId>
+                    <artifactId>gax</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -278,29 +278,23 @@
             <artifactId>trino-exchange-filesystem</artifactId>
             <scope>test</scope>
             <exclusions>
+                <!-- without GCS exclusions the transitive dependencies of com.google.cloud.bigdataoss:gcs-connector:jar:hadoop2-2.0.0 (which is dependency of trino-hive)
+                     or rescoped to "test" from "compile" -->
                 <exclusion>
-                    <groupId>com.google.apis</groupId>
-                    <artifactId>google-api-services-storage</artifactId>
+                    <groupId>com.google.cloud</groupId>
+                    <artifactId>google-cloud-storage</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.google.api-client</groupId>
-                    <artifactId>google-api-client</artifactId>
+                    <groupId>com.google.auth</groupId>
+                    <artifactId>google-auth-library-oauth2-http</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.google.auto.value</groupId>
-                    <artifactId>auto-value-annotations</artifactId>
+                    <groupId>com.google.cloud</groupId>
+                    <artifactId>google-cloud-core</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.google.code.gson</groupId>
-                    <artifactId>gson</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.http-client</groupId>
-                    <artifactId>google-http-client</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.http-client</groupId>
-                    <artifactId>google-http-client-jackson2</artifactId>
+                    <groupId>com.google.api</groupId>
+                    <artifactId>gax</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -310,6 +304,26 @@
             <artifactId>trino-exchange-filesystem</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
+            <exclusions>
+                <!-- without GCS exclusions the transitive dependencies of com.google.cloud.bigdataoss:gcs-connector:jar:hadoop2-2.0.0 (which is dependency of trino-hive)
+                     or rescoped to "test" from "compile" -->
+                <exclusion>
+                    <groupId>com.google.cloud</groupId>
+                    <artifactId>google-cloud-storage</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.auth</groupId>
+                    <artifactId>google-auth-library-oauth2-http</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.cloud</groupId>
+                    <artifactId>google-cloud-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.api</groupId>
+                    <artifactId>gax</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This commit excludes GCS related dependecies of
trino-exchange-filesystem used as test dependency more aggresively.

Previously the transitive dependencies of trino-exchange-filesystem
creeped into compile scope of modules which included it as test
dependency (trino-hive, trino-iceberg, trino-delta). Some dependencies
were rescoped from `compile` to `test` and as result queries were
failing at runtime with NoClassDefFoundError.

See https://github.com/trinodb/trino/issues/12674

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->


## Related issues, pull requests, and links

Bandaid fix for https://github.com/trinodb/trino/issues/12674.

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
