### PR TITLE
Prevent table creation on non-empty location for Iceberg tables (v2)

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -116,6 +116,9 @@ is used.
   * - ``iceberg.target-max-file-size``
     - Target maximum size of written files; the actual size may be larger
     - ``1GB``
+  * - ``iceberg.unique-table-location``
+    - Use randomized, unique table locations
+    - ``false``
   * - ``iceberg.delete-schema-locations-fallback``
     - Whether schema locations should be deleted when Trino can't determine whether they contain external files.
     - ``false``

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergTableWithExternalLocation.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergTableWithExternalLocation.java
@@ -111,6 +111,6 @@ public class TestIcebergTableWithExternalLocation
         assertQuerySucceeds(format("DROP TABLE %s", tableName));
         assertThat(metastore.getTable("tpch", tableName)).as("Table should be dropped").isEmpty();
         assertFalse(fileSystem.exists(new Path(dataFile.getFilePath())), "The data file should have been removed");
-        assertFalse(fileSystem.exists(tableLocation), "The directory corresponding to the dropped Iceberg table should not be removed because it may be shared with other tables");
+        assertFalse(fileSystem.exists(tableLocation), "The directory corresponding to the dropped Iceberg table should be removed as we don't allow shared locations.");
     }
 }


### PR DESCRIPTION
Re-merge https://github.com/trinodb/trino/pull/12626. That PR was backed out for release process-related reasons.

Fixes https://github.com/trinodb/trino/issues/12573 