### PR TITLE
Remove redundant `@LegacyConfig` in Delta Lake

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConfig.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConfig.java
@@ -337,7 +337,6 @@ public class DeltaLakeConfig
         return this.deleteSchemaLocationsFallback;
     }
 
-    @LegacyConfig("hive.per-transaction-metastore-cache-maximum-size")
     @Config("delta.delete-schema-locations-fallback")
     @ConfigDescription("Whether schema locations should be deleted when Trino can't determine whether they contain external files.")
     public DeltaLakeConfig setDeleteSchemaLocationsFallback(boolean deleteSchemaLocationsFallback)


### PR DESCRIPTION
## Description

Remove redundant `@LegacyConfig` in Delta Lake

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
