### PR TITLE
Change type for CumulativeUserMemory to DataSize to avoid overflows

### DIFF
--- a/core/trino-main/src/main/java/io/trino/dispatcher/FailedDispatchQuery.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/FailedDispatchQuery.java
@@ -271,7 +271,7 @@ public class FailedDispatchQuery
                 0,
                 0,
                 0,
-                0,
+                DataSize.ofBytes(0),
                 0,
                 DataSize.ofBytes(0),
                 DataSize.ofBytes(0),

--- a/core/trino-main/src/main/java/io/trino/event/QueryMonitor.java
+++ b/core/trino-main/src/main/java/io/trino/event/QueryMonitor.java
@@ -295,7 +295,7 @@ public class QueryMonitor
                 queryStats.getOutputPositions(),
                 queryStats.getLogicalWrittenDataSize().toBytes(),
                 queryStats.getWrittenPositions(),
-                queryStats.getCumulativeUserMemory(),
+                queryStats.getCumulativeUserMemory().toBytes(),
                 queryStats.getFailedCumulativeUserMemory(),
                 queryStats.getStageGcStatistics(),
                 queryStats.getCompletedDrivers(),

--- a/core/trino-main/src/main/java/io/trino/execution/BasicStageStats.java
+++ b/core/trino-main/src/main/java/io/trino/execution/BasicStageStats.java
@@ -49,7 +49,7 @@ public class BasicStageStats
             DataSize.ofBytes(0),
             0,
 
-            0,
+            DataSize.ofBytes(0),
             0,
             DataSize.ofBytes(0),
             DataSize.ofBytes(0),
@@ -77,7 +77,7 @@ public class BasicStageStats
     private final long internalNetworkInputPositions;
     private final DataSize rawInputDataSize;
     private final long rawInputPositions;
-    private final long cumulativeUserMemory;
+    private final DataSize cumulativeUserMemory;
     private final long failedCumulativeUserMemory;
     private final DataSize userMemoryReservation;
     private final DataSize totalMemoryReservation;
@@ -109,7 +109,7 @@ public class BasicStageStats
             DataSize rawInputDataSize,
             long rawInputPositions,
 
-            long cumulativeUserMemory,
+            DataSize cumulativeUserMemory,
             long failedCumulativeUserMemory,
             DataSize userMemoryReservation,
             DataSize totalMemoryReservation,
@@ -215,7 +215,7 @@ public class BasicStageStats
         return physicalInputReadTime;
     }
 
-    public long getCumulativeUserMemory()
+    public DataSize getCumulativeUserMemory()
     {
         return cumulativeUserMemory;
     }
@@ -312,7 +312,7 @@ public class BasicStageStats
             runningDrivers += stageStats.getRunningDrivers();
             completedDrivers += stageStats.getCompletedDrivers();
 
-            cumulativeUserMemory += stageStats.getCumulativeUserMemory();
+            cumulativeUserMemory += stageStats.getCumulativeUserMemory().toBytes();
             failedCumulativeUserMemory += stageStats.getFailedCumulativeUserMemory();
             userMemoryReservation += stageStats.getUserMemoryReservation().toBytes();
             totalMemoryReservation += stageStats.getTotalMemoryReservation().toBytes();
@@ -363,7 +363,7 @@ public class BasicStageStats
                 succinctBytes(rawInputDataSize),
                 rawInputPositions,
 
-                cumulativeUserMemory,
+                succinctBytes(cumulativeUserMemory),
                 failedCumulativeUserMemory,
                 succinctBytes(userMemoryReservation),
                 succinctBytes(totalMemoryReservation),

--- a/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
@@ -384,8 +384,7 @@ public class QueryStateMachine
                 stageStats.getRawInputDataSize(),
                 stageStats.getRawInputPositions(),
                 stageStats.getPhysicalInputDataSize(),
-
-                stageStats.getCumulativeUserMemory(),
+                succinctBytes(stageStats.getCumulativeUserMemory().toBytes()),
                 stageStats.getFailedCumulativeUserMemory(),
                 stageStats.getUserMemoryReservation(),
                 stageStats.getTotalMemoryReservation(),
@@ -554,7 +553,7 @@ public class QueryStateMachine
             blockedDrivers += stageStats.getBlockedDrivers();
             completedDrivers += stageStats.getCompletedDrivers();
 
-            cumulativeUserMemory += stageStats.getCumulativeUserMemory();
+            cumulativeUserMemory += stageStats.getCumulativeUserMemory().toBytes();
             failedCumulativeUserMemory += stageStats.getFailedCumulativeUserMemory();
             userMemoryReservation += stageStats.getUserMemoryReservation().toBytes();
             revocableMemoryReservation += stageStats.getRevocableMemoryReservation().toBytes();
@@ -646,7 +645,7 @@ public class QueryStateMachine
                 blockedDrivers,
                 completedDrivers,
 
-                cumulativeUserMemory,
+                succinctBytes(cumulativeUserMemory),
                 failedCumulativeUserMemory,
                 succinctBytes(userMemoryReservation),
                 succinctBytes(revocableMemoryReservation),

--- a/core/trino-main/src/main/java/io/trino/execution/QueryStats.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryStats.java
@@ -251,7 +251,6 @@ public class QueryStats
         this.blockedDrivers = blockedDrivers;
         checkArgument(completedDrivers >= 0, "completedDrivers is negative");
         this.completedDrivers = completedDrivers;
-        //checkArgument(cumulativeUserMemory >= 0, "cumulativeUserMemory is negative");
         this.cumulativeUserMemory = requireNonNull(cumulativeUserMemory, "cumulativeUserMemory is null");
         this.failedCumulativeUserMemory = failedCumulativeUserMemory;
         this.userMemoryReservation = requireNonNull(userMemoryReservation, "userMemoryReservation is null");

--- a/core/trino-main/src/main/java/io/trino/execution/QueryStats.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryStats.java
@@ -65,7 +65,7 @@ public class QueryStats
     private final int blockedDrivers;
     private final int completedDrivers;
 
-    private final double cumulativeUserMemory;
+    private final DataSize cumulativeUserMemory;
     private final double failedCumulativeUserMemory;
     private final DataSize userMemoryReservation;
     private final DataSize revocableMemoryReservation;
@@ -155,7 +155,7 @@ public class QueryStats
             @JsonProperty("blockedDrivers") int blockedDrivers,
             @JsonProperty("completedDrivers") int completedDrivers,
 
-            @JsonProperty("cumulativeUserMemory") double cumulativeUserMemory,
+            @JsonProperty("cumulativeUserMemory") DataSize cumulativeUserMemory,
             @JsonProperty("failedCumulativeUserMemory") double failedCumulativeUserMemory,
             @JsonProperty("userMemoryReservation") DataSize userMemoryReservation,
             @JsonProperty("revocableMemoryReservation") DataSize revocableMemoryReservation,
@@ -251,8 +251,8 @@ public class QueryStats
         this.blockedDrivers = blockedDrivers;
         checkArgument(completedDrivers >= 0, "completedDrivers is negative");
         this.completedDrivers = completedDrivers;
-        checkArgument(cumulativeUserMemory >= 0, "cumulativeUserMemory is negative");
-        this.cumulativeUserMemory = cumulativeUserMemory;
+        //checkArgument(cumulativeUserMemory >= 0, "cumulativeUserMemory is negative");
+        this.cumulativeUserMemory = requireNonNull(cumulativeUserMemory, "cumulativeUserMemory is null");
         this.failedCumulativeUserMemory = failedCumulativeUserMemory;
         this.userMemoryReservation = requireNonNull(userMemoryReservation, "userMemoryReservation is null");
         this.revocableMemoryReservation = requireNonNull(revocableMemoryReservation, "revocableMemoryReservation is null");
@@ -453,7 +453,7 @@ public class QueryStats
     }
 
     @JsonProperty
-    public double getCumulativeUserMemory()
+    public DataSize getCumulativeUserMemory()
     {
         return cumulativeUserMemory;
     }

--- a/core/trino-main/src/main/java/io/trino/execution/StageStateMachine.java
+++ b/core/trino-main/src/main/java/io/trino/execution/StageStateMachine.java
@@ -279,9 +279,9 @@ public class StageStateMachine
             runningDrivers += taskStats.getRunningDrivers();
             completedDrivers += taskStats.getCompletedDrivers();
 
-            cumulativeUserMemory += taskStats.getCumulativeUserMemory();
+            cumulativeUserMemory += taskStats.getCumulativeUserMemory().toBytes();
             if (taskState == TaskState.FAILED) {
-                failedCumulativeUserMemory += taskStats.getCumulativeUserMemory();
+                failedCumulativeUserMemory += taskStats.getCumulativeUserMemory().toBytes();
             }
 
             long taskUserMemory = taskStats.getUserMemoryReservation().toBytes();
@@ -338,7 +338,7 @@ public class StageStateMachine
                 succinctBytes(rawInputDataSize),
                 rawInputPositions,
 
-                cumulativeUserMemory,
+                succinctBytes(cumulativeUserMemory),
                 failedCumulativeUserMemory,
                 succinctBytes(userMemoryReservation),
                 succinctBytes(totalMemoryReservation),
@@ -462,9 +462,9 @@ public class StageStateMachine
             blockedDrivers += taskStats.getBlockedDrivers();
             completedDrivers += taskStats.getCompletedDrivers();
 
-            cumulativeUserMemory += taskStats.getCumulativeUserMemory();
+            cumulativeUserMemory += taskStats.getCumulativeUserMemory().toBytes();
             if (taskState == TaskState.FAILED) {
-                failedCumulativeUserMemory += taskStats.getCumulativeUserMemory();
+                failedCumulativeUserMemory += taskStats.getCumulativeUserMemory().toBytes();
             }
 
             totalScheduledTime += taskStats.getTotalScheduledTime().roundTo(NANOSECONDS);
@@ -557,7 +557,7 @@ public class StageStateMachine
                 blockedDrivers,
                 completedDrivers,
 
-                cumulativeUserMemory,
+                succinctBytes(cumulativeUserMemory),
                 failedCumulativeUserMemory,
                 succinctBytes(userMemoryReservation),
                 succinctBytes(revocableMemoryReservation),

--- a/core/trino-main/src/main/java/io/trino/execution/StageStats.java
+++ b/core/trino-main/src/main/java/io/trino/execution/StageStats.java
@@ -54,7 +54,7 @@ public class StageStats
     private final int blockedDrivers;
     private final int completedDrivers;
 
-    private final double cumulativeUserMemory;
+    private final DataSize cumulativeUserMemory;
     private final double failedCumulativeUserMemory;
     private final DataSize userMemoryReservation;
     private final DataSize revocableMemoryReservation;
@@ -128,7 +128,7 @@ public class StageStats
             @JsonProperty("blockedDrivers") int blockedDrivers,
             @JsonProperty("completedDrivers") int completedDrivers,
 
-            @JsonProperty("cumulativeUserMemory") double cumulativeUserMemory,
+            @JsonProperty("cumulativeUserMemory") DataSize cumulativeUserMemory,
             @JsonProperty("failedCumulativeUserMemory") double failedCumulativeUserMemory,
             @JsonProperty("userMemoryReservation") DataSize userMemoryReservation,
             @JsonProperty("revocableMemoryReservation") DataSize revocableMemoryReservation,
@@ -207,8 +207,8 @@ public class StageStats
         this.blockedDrivers = blockedDrivers;
         checkArgument(completedDrivers >= 0, "completedDrivers is negative");
         this.completedDrivers = completedDrivers;
-        checkArgument(cumulativeUserMemory >= 0, "cumulativeUserMemory is negative");
-        this.cumulativeUserMemory = cumulativeUserMemory;
+        //checkArgument(cumulativeUserMemory >= 0, "cumulativeUserMemory is negative");
+        this.cumulativeUserMemory = requireNonNull(cumulativeUserMemory, "cumulativeUserMemory is null");
         this.failedCumulativeUserMemory = failedCumulativeUserMemory;
         this.userMemoryReservation = requireNonNull(userMemoryReservation, "userMemoryReservation is null");
         this.revocableMemoryReservation = requireNonNull(revocableMemoryReservation, "revocableMemoryReservation is null");
@@ -343,7 +343,7 @@ public class StageStats
     }
 
     @JsonProperty
-    public double getCumulativeUserMemory()
+    public DataSize getCumulativeUserMemory()
     {
         return cumulativeUserMemory;
     }
@@ -635,7 +635,7 @@ public class StageStats
                 internalNetworkInputPositions,
                 rawInputDataSize,
                 rawInputPositions,
-                (long) cumulativeUserMemory,
+                cumulativeUserMemory,
                 (long) failedCumulativeUserMemory,
                 userMemoryReservation,
                 totalMemoryReservation,

--- a/core/trino-main/src/main/java/io/trino/execution/StageStats.java
+++ b/core/trino-main/src/main/java/io/trino/execution/StageStats.java
@@ -207,7 +207,6 @@ public class StageStats
         this.blockedDrivers = blockedDrivers;
         checkArgument(completedDrivers >= 0, "completedDrivers is negative");
         this.completedDrivers = completedDrivers;
-        //checkArgument(cumulativeUserMemory >= 0, "cumulativeUserMemory is negative");
         this.cumulativeUserMemory = requireNonNull(cumulativeUserMemory, "cumulativeUserMemory is null");
         this.failedCumulativeUserMemory = failedCumulativeUserMemory;
         this.userMemoryReservation = requireNonNull(userMemoryReservation, "userMemoryReservation is null");

--- a/core/trino-main/src/main/java/io/trino/operator/TaskStats.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TaskStats.java
@@ -51,7 +51,7 @@ public class TaskStats
     private final int blockedDrivers;
     private final int completedDrivers;
 
-    private final double cumulativeUserMemory;
+    private final DataSize cumulativeUserMemory;
     private final DataSize userMemoryReservation;
     private final DataSize peakUserMemoryReservation;
     private final DataSize revocableMemoryReservation;
@@ -107,7 +107,7 @@ public class TaskStats
                 0L,
                 0,
                 0,
-                0.0,
+                DataSize.ofBytes(0),
                 DataSize.ofBytes(0),
                 DataSize.ofBytes(0),
                 DataSize.ofBytes(0),
@@ -155,7 +155,7 @@ public class TaskStats
             @JsonProperty("blockedDrivers") int blockedDrivers,
             @JsonProperty("completedDrivers") int completedDrivers,
 
-            @JsonProperty("cumulativeUserMemory") double cumulativeUserMemory,
+            @JsonProperty("cumulativeUserMemory") DataSize cumulativeUserMemory,
             @JsonProperty("userMemoryReservation") DataSize userMemoryReservation,
             @JsonProperty("peakUserMemoryReservation") DataSize peakUserMemoryReservation,
             @JsonProperty("revocableMemoryReservation") DataSize revocableMemoryReservation,
@@ -345,7 +345,7 @@ public class TaskStats
     }
 
     @JsonProperty
-    public double getCumulativeUserMemory()
+    public DataSize getCumulativeUserMemory()
     {
         return cumulativeUserMemory;
     }

--- a/core/trino-main/src/main/java/io/trino/server/BasicQueryStats.java
+++ b/core/trino-main/src/main/java/io/trino/server/BasicQueryStats.java
@@ -56,7 +56,7 @@ public class BasicQueryStats
     private final long rawInputPositions;
     private final DataSize physicalInputDataSize;
 
-    private final double cumulativeUserMemory;
+    private final DataSize cumulativeUserMemory;
     private final double failedCumulativeUserMemory;
     private final DataSize userMemoryReservation;
     private final DataSize totalMemoryReservation;
@@ -87,7 +87,7 @@ public class BasicQueryStats
             @JsonProperty("rawInputDataSize") DataSize rawInputDataSize,
             @JsonProperty("rawInputPositions") long rawInputPositions,
             @JsonProperty("physicalInputDataSize") DataSize physicalInputDataSize,
-            @JsonProperty("cumulativeUserMemory") double cumulativeUserMemory,
+            @JsonProperty("cumulativeUserMemory") DataSize cumulativeUserMemory,
             @JsonProperty("failedCumulativeUserMemory") double failedCumulativeUserMemory,
             @JsonProperty("userMemoryReservation") DataSize userMemoryReservation,
             @JsonProperty("totalMemoryReservation") DataSize totalMemoryReservation,
@@ -188,7 +188,7 @@ public class BasicQueryStats
                 DataSize.ofBytes(0),
                 0,
                 DataSize.ofBytes(0),
-                0,
+                DataSize.ofBytes(0),
                 0,
                 DataSize.ofBytes(0),
                 DataSize.ofBytes(0),
@@ -282,7 +282,7 @@ public class BasicQueryStats
     }
 
     @JsonProperty
-    public double getCumulativeUserMemory()
+    public DataSize getCumulativeUserMemory()
     {
         return cumulativeUserMemory;
     }

--- a/core/trino-main/src/main/resources/webapp/src/components/QueryDetail.jsx
+++ b/core/trino-main/src/main/resources/webapp/src/components/QueryDetail.jsx
@@ -502,7 +502,7 @@ class StageSummary extends React.Component {
                                             Cumulative
                                         </td>
                                         <td className="stage-table-stat-text">
-                                            {formatDataSizeBytes(stage.stageStats.cumulativeUserMemory / 1000)}
+                                            {parseAndFormatDataSize(stage.stageStats.cumulativeUserMemory)}
                                         </td>
                                     </tr>
                                     <tr>
@@ -1502,7 +1502,7 @@ export class QueryDetail extends React.Component {
                                             Cumulative User Memory
                                         </td>
                                         <td className="info-text">
-                                            {formatDataSize(query.queryStats.cumulativeUserMemory / 1000.0) + "*seconds"}
+                                            {parseAndFormatDataSize(query.queryStats.cumulativeUserMemory) + "*seconds"}
                                         </td>
                                         {taskRetriesEnabled &&
                                         <td className="info-failed">

--- a/core/trino-main/src/main/resources/webapp/src/components/QueryList.jsx
+++ b/core/trino-main/src/main/resources/webapp/src/components/QueryList.jsx
@@ -124,7 +124,7 @@ export class QueryListItem extends React.Component {
                 </span>
                 <span className="tinystat" data-toggle="tooltip" data-placement="top" title="Cumulative user memory">
                     <span className="glyphicon glyphicon-equalizer" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
-                    {formatDataSizeBytes(query.queryStats.cumulativeUserMemory / 1000.0)}
+                    {parseAndFormatDataSize(query.queryStats.cumulativeUserMemory )}
                 </span>
             </div>);
 
@@ -232,7 +232,7 @@ const SORT_TYPE = {
     ELAPSED: function (query) {return parseDuration(query.queryStats.elapsedTime)},
     EXECUTION: function (query) {return parseDuration(query.queryStats.executionTime)},
     CPU: function (query) {return parseDuration(query.queryStats.totalCpuTime)},
-    CUMULATIVE_MEMORY: function (query) {return query.queryStats.cumulativeUserMemory},
+    CUMULATIVE_MEMORY: function (query) {return parseDataSize(query.queryStats.cumulativeUserMemory)},
     CURRENT_MEMORY: function (query) {return parseDataSize(query.queryStats.userMemoryReservation)},
 };
 

--- a/core/trino-main/src/test/java/io/trino/execution/MockManagedQueryExecution.java
+++ b/core/trino-main/src/test/java/io/trino/execution/MockManagedQueryExecution.java
@@ -132,7 +132,7 @@ public class MockManagedQueryExecution
                         DataSize.ofBytes(14),
                         15,
                         DataSize.ofBytes(13),
-                        16.0,
+                        DataSize.ofBytes(16),
                         17.0,
                         memoryUsage,
                         memoryUsage,
@@ -188,7 +188,7 @@ public class MockManagedQueryExecution
                         30,
                         16,
 
-                        17.0,
+                        DataSize.ofBytes(17),
                         0.0,
                         DataSize.ofBytes(18),
                         DataSize.ofBytes(19),

--- a/core/trino-main/src/test/java/io/trino/execution/TestQueryStats.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestQueryStats.java
@@ -187,7 +187,7 @@ public class TestQueryStats
             30,
             16,
 
-            17.0,
+            DataSize.ofBytes(17),
             18.0,
             DataSize.ofBytes(19),
             DataSize.ofBytes(20),

--- a/core/trino-main/src/test/java/io/trino/execution/TestStageStats.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestStageStats.java
@@ -45,7 +45,7 @@ public class TestStageStats
             26,
             11,
 
-            12.0,
+            DataSize.ofBytes(12),
             13.0,
             DataSize.ofBytes(14),
             DataSize.ofBytes(15),

--- a/core/trino-main/src/test/java/io/trino/memory/TestLeastWastedEffortTaskLowMemoryKiller.java
+++ b/core/trino-main/src/test/java/io/trino/memory/TestLeastWastedEffortTaskLowMemoryKiller.java
@@ -266,7 +266,7 @@ public class TestLeastWastedEffortTaskLowMemoryKiller
                         0L,
                         0,
                         0,
-                        0.0,
+                        DataSize.ofBytes(0),
                         DataSize.ofBytes(0),
                         DataSize.ofBytes(0),
                         DataSize.ofBytes(0),

--- a/core/trino-main/src/test/java/io/trino/operator/TestTaskStats.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestTaskStats.java
@@ -47,7 +47,7 @@ public class TestTaskStats
             24,
             10,
 
-            11.0,
+            DataSize.ofBytes(11),
             DataSize.ofBytes(12),
             DataSize.ofBytes(120),
             DataSize.ofBytes(13),

--- a/core/trino-main/src/test/java/io/trino/server/TestBasicQueryInfo.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestBasicQueryInfo.java
@@ -77,7 +77,7 @@ public class TestBasicQueryInfo
                                 19,
                                 34,
                                 20,
-                                21.0,
+                                DataSize.valueOf("21GB"),
                                 22.0,
                                 DataSize.valueOf("23GB"),
                                 DataSize.valueOf("24GB"),

--- a/core/trino-main/src/test/java/io/trino/server/TestQueryStateInfo.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestQueryStateInfo.java
@@ -127,7 +127,7 @@ public class TestQueryStateInfo
                         18,
                         34,
                         19,
-                        20.0,
+                        DataSize.valueOf("20GB"),
                         21.0,
                         DataSize.valueOf("21GB"),
                         DataSize.valueOf("22GB"),

--- a/testing/trino-tests/src/test/java/io/trino/memory/TestClusterMemoryLeakDetector.java
+++ b/testing/trino-tests/src/test/java/io/trino/memory/TestClusterMemoryLeakDetector.java
@@ -92,7 +92,7 @@ public class TestClusterMemoryLeakDetector
                         DataSize.valueOf("21GB"),
                         22,
                         DataSize.valueOf("23GB"),
-                        24,
+                        DataSize.valueOf("24GB"),
                         25,
                         DataSize.valueOf("26GB"),
                         DataSize.valueOf("27GB"),


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
Changed type from double to DataSize as for queries with very large memory consumption, double overflows and negative values are rendered.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other? 
Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific) 
Core query engine

> How would you describe this change to a non-technical end user or system administrator?
CumulativeUserMemory reports negative values for queries with very large memory consumption, this change fixes that.
## Related issues, pull requests, and links

* Fixes #9080

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`9080`)
```
