### PR TITLE
Add RowPositionsAppender

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppenderFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppenderFactory.java
@@ -16,6 +16,7 @@ package io.trino.operator.output;
 import io.trino.spi.block.Int128ArrayBlock;
 import io.trino.spi.block.Int96ArrayBlock;
 import io.trino.spi.type.FixedWidthType;
+import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VariableWidthType;
 import io.trino.type.BlockTypeOperators;
@@ -65,6 +66,9 @@ public class PositionsAppenderFactory
         }
         else if (type instanceof VariableWidthType) {
             return new SlicePositionsAppender(expectedPositions, maxPageSizeInBytes);
+        }
+        else if (type instanceof RowType) {
+            return RowPositionsAppender.createRowAppender(this, (RowType) type, expectedPositions, maxPageSizeInBytes);
         }
 
         return new TypedPositionsAppender(type, expectedPositions);

--- a/core/trino-main/src/main/java/io/trino/operator/output/RowPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/RowPositionsAppender.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.output;
+
+import io.trino.spi.block.Block;
+import io.trino.spi.block.RowBlock;
+import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.spi.type.RowType;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static io.airlift.slice.SizeOf.sizeOf;
+import static io.trino.operator.output.PositionsAppenderUtil.calculateBlockResetSize;
+import static io.trino.operator.output.PositionsAppenderUtil.calculateNewArraySize;
+import static io.trino.spi.block.RowBlock.fromFieldBlocks;
+import static java.util.Objects.requireNonNull;
+
+public class RowPositionsAppender
+        implements PositionsAppender
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(RowPositionsAppender.class).instanceSize();
+    private final PositionsAppender[] fieldAppenders;
+    private int initialEntryCount;
+    private boolean initialized;
+
+    private int positionCount;
+    private boolean hasNullRow;
+    private boolean hasNonNullRow;
+    private boolean[] rowIsNull = new boolean[0];
+    private long retainedSizeInBytes;
+    private long sizeInBytes;
+
+    public static RowPositionsAppender createRowAppender(
+            PositionsAppenderFactory positionsAppenderFactory,
+            RowType type,
+            int expectedPositions,
+            long maxPageSizeInBytes)
+    {
+        PositionsAppender[] fields = new PositionsAppender[type.getFields().size()];
+        for (int i = 0; i < fields.length; i++) {
+            fields[i] = positionsAppenderFactory.create(type.getFields().get(i).getType(), expectedPositions, maxPageSizeInBytes);
+        }
+        return new RowPositionsAppender(fields, expectedPositions);
+    }
+
+    private RowPositionsAppender(PositionsAppender[] fieldAppenders, int expectedPositions)
+    {
+        this.fieldAppenders = requireNonNull(fieldAppenders, "fields is null");
+        this.initialEntryCount = expectedPositions;
+        updateRetainedSize();
+    }
+
+    @Override
+    public void append(IntArrayList positions, Block block)
+    {
+        if (positions.isEmpty()) {
+            return;
+        }
+        ensureCapacity(positions.size());
+        RowBlock sourceRowBlock = (RowBlock) block;
+        IntArrayList nonNullPositions;
+        if (sourceRowBlock.mayHaveNull()) {
+            nonNullPositions = processNullablePositions(positions, sourceRowBlock);
+            hasNullRow |= nonNullPositions.size() < positions.size();
+            hasNonNullRow |= nonNullPositions.size() > 0;
+        }
+        else {
+            // the source Block does not have nulls
+            nonNullPositions = processNonNullablePositions(positions, sourceRowBlock);
+            hasNonNullRow = true;
+        }
+
+        List<Block> fieldBlocks = sourceRowBlock.getChildren();
+        for (int i = 0; i < fieldAppenders.length; i++) {
+            fieldAppenders[i].append(nonNullPositions, fieldBlocks.get(i));
+        }
+
+        positionCount += positions.size();
+        updateSize();
+    }
+
+    @Override
+    public void appendRle(RunLengthEncodedBlock rleBlock)
+    {
+        int rlePositionCount = rleBlock.getPositionCount();
+        ensureCapacity(rlePositionCount);
+        RowBlock sourceRowBlock = (RowBlock) rleBlock.getValue();
+        if (sourceRowBlock.isNull(0)) {
+            // append rlePositionCount nulls
+            Arrays.fill(rowIsNull, positionCount, positionCount + rlePositionCount, true);
+            hasNullRow = true;
+        }
+        else {
+            // append not null row value
+            List<Block> fieldBlocks = sourceRowBlock.getChildren();
+            int fieldPosition = sourceRowBlock.getFieldBlockOffset(0);
+            for (int i = 0; i < fieldAppenders.length; i++) {
+                fieldAppenders[i].appendRle(new RunLengthEncodedBlock(fieldBlocks.get(i).getSingleValueBlock(fieldPosition), rlePositionCount));
+            }
+            hasNonNullRow = true;
+        }
+        positionCount += rlePositionCount;
+        updateSize();
+    }
+
+    @Override
+    public Block build()
+    {
+        Block[] fieldBlocks = new Block[fieldAppenders.length];
+        for (int i = 0; i < fieldAppenders.length; i++) {
+            fieldBlocks[i] = fieldAppenders[i].build();
+        }
+        Block result;
+        if (hasNonNullRow) {
+            result = fromFieldBlocks(positionCount, hasNullRow ? Optional.of(rowIsNull) : Optional.empty(), fieldBlocks);
+        }
+        else {
+            Block nullRowBlock = fromFieldBlocks(1, Optional.of(new boolean[] {true}), fieldBlocks);
+            result = new RunLengthEncodedBlock(nullRowBlock, positionCount);
+        }
+
+        reset();
+        return result;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        long size = retainedSizeInBytes;
+        for (PositionsAppender field : fieldAppenders) {
+            size += field.getRetainedSizeInBytes();
+        }
+        return size;
+    }
+
+    @Override
+    public long getSizeInBytes()
+    {
+        return sizeInBytes;
+    }
+
+    private void reset()
+    {
+        initialEntryCount = calculateBlockResetSize(positionCount);
+        initialized = false;
+        rowIsNull = new boolean[0];
+        positionCount = 0;
+        sizeInBytes = 0;
+        hasNonNullRow = false;
+        hasNullRow = false;
+        updateRetainedSize();
+    }
+
+    private IntArrayList processNullablePositions(IntArrayList positions, RowBlock sourceRowBlock)
+    {
+        int[] nonNullPositions = new int[positions.size()];
+        int nonNullPositionsCount = 0;
+
+        for (int i = 0; i < positions.size(); i++) {
+            int position = positions.getInt(i);
+            boolean positionIsNull = sourceRowBlock.isNull(position);
+            nonNullPositions[nonNullPositionsCount] = sourceRowBlock.getFieldBlockOffset(position);
+            nonNullPositionsCount += positionIsNull ? 0 : 1;
+            rowIsNull[positionCount + i] = positionIsNull;
+        }
+
+        return IntArrayList.wrap(nonNullPositions, nonNullPositionsCount);
+    }
+
+    private IntArrayList processNonNullablePositions(IntArrayList positions, RowBlock sourceRowBlock)
+    {
+        int[] nonNullPositions = new int[positions.size()];
+        for (int i = 0; i < positions.size(); i++) {
+            nonNullPositions[i] = sourceRowBlock.getFieldBlockOffset(positions.getInt(i));
+        }
+        return IntArrayList.wrap(nonNullPositions);
+    }
+
+    private void ensureCapacity(int additionalCapacity)
+    {
+        if (rowIsNull.length <= positionCount + additionalCapacity) {
+            int newSize;
+            if (initialized) {
+                newSize = calculateNewArraySize(rowIsNull.length);
+            }
+            else {
+                newSize = initialEntryCount;
+                initialized = true;
+            }
+
+            int newCapacity = Math.max(newSize, positionCount + additionalCapacity);
+            rowIsNull = Arrays.copyOf(rowIsNull, newCapacity);
+            updateRetainedSize();
+        }
+    }
+
+    private void updateSize()
+    {
+        long size = (Integer.BYTES + Byte.BYTES) * (long) positionCount;
+        for (PositionsAppender field : fieldAppenders) {
+            size += field.getSizeInBytes();
+        }
+        sizeInBytes = size;
+    }
+
+    private void updateRetainedSize()
+    {
+        retainedSizeInBytes = INSTANCE_SIZE + sizeOf(rowIsNull);
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/block/AbstractRowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/AbstractRowBlock.java
@@ -51,7 +51,7 @@ public abstract class AbstractRowBlock
     protected abstract boolean[] getRowIsNull();
 
     // the offset in each field block, it can also be viewed as the "entry-based" offset in the RowBlock
-    protected final int getFieldBlockOffset(int position)
+    public final int getFieldBlockOffset(int position)
     {
         int[] offsets = getFieldBlockOffsets();
         return offsets != null ? offsets[position + getOffsetBase()] : position + getOffsetBase();


### PR DESCRIPTION
Optimize partitioned exchange for RowType channels
with batch oriented RowPositionsAppender

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

performance improvement
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core query engine and spi
> How would you describe this change to a non-technical end user or system administrator?



### Benchmarks
#### tpch/tpcds orc sf1000 partitioned
There is a slight (1.5%) CPU improvement. This is expected as `PartitindOutputOperator` is about 5% of the overall CPU.
![image](https://user-images.githubusercontent.com/8080198/172877960-78830427-f649-4635-9ceb-557f7da049ee.png)

[poo-row-type-sf1000-orc-part.pdf](https://github.com/trinodb/trino/files/8871530/poo-row-type-sf1000-orc-part.pdf)

#### jmh
There is 2x to 4x improvement.
before
```
Benchmark                                   (channelCount)  (enableCompression)  (nullRate)  (partitionCount)  (positionCount)                 (type)  Mode  Cnt    Score    Error  Units
BenchmarkPartitionedOutputOperator.addPage               1                false           0                16             8192      ROW_BIGINT_BIGINT  avgt   20  625.371 ± 12.527  ms/op
BenchmarkPartitionedOutputOperator.addPage               1                false           0                16             8192  ROW_RLE_BIGINT_BIGINT  avgt   20  518.245 ± 82.994  ms/op
BenchmarkPartitionedOutputOperator.addPage               1                false         0.2                16             8192      ROW_BIGINT_BIGINT  avgt   20  557.170 ± 65.907  ms/op
BenchmarkPartitionedOutputOperator.addPage               1                false         0.2                16             8192  ROW_RLE_BIGINT_BIGINT  avgt   20  473.040 ± 64.605  ms/o
```
after
```
Benchmark                                   (channelCount)  (enableCompression)  (nullRate)  (partitionCount)  (positionCount)                 (type)  Mode  Cnt    Score   Error  Units
BenchmarkPartitionedOutputOperator.addPage               1                false           0                16             8192      ROW_BIGINT_BIGINT  avgt   20  144.102 ± 5.855  ms/op
BenchmarkPartitionedOutputOperator.addPage               1                false           0                16             8192  ROW_RLE_BIGINT_BIGINT  avgt   20  109.074 ± 1.223  ms/op
BenchmarkPartitionedOutputOperator.addPage               1                false         0.2                16             8192      ROW_BIGINT_BIGINT  avgt   20  281.255 ± 4.728  ms/op
BenchmarkPartitionedOutputOperator.addPage               1                false         0.2                16             8192  ROW_RLE_BIGINT_BIGINT  avgt   20  162.054 ± 2.670  ms/op
```

This also brings big improvements for queries with a large number of aggregations that use `RowType` as an intermediate state e.g. `sum`.
This sample query sees about a 30% improvement.
```
trino:tpch_sf1000_dec_orc_part> explain analyze select cast ((orderkey+partkey) %1300000 as int), sum(suppkey), sum(suppkey + 1), sum(suppkey + 2), sum(suppkey + 3),
                             -> sum(suppkey + 4), sum(suppkey + 5), sum(suppkey + 6), sum(suppkey + 7), 
                             -> sum(suppkey + 8), sum(suppkey + 9), sum(suppkey + 10), sum(suppkey + 11)
                             -> from lineitem group by cast ((orderkey + partkey) % 1300000  as int);

```

before
```
Query 20220610_101803_00005_8baqg, FINISHED, 7 nodes
http://localhost:8082/ui/query.html?20220610_101803_00005_8baqg
Splits: 3,081 total, 3,081 done (100.00%)
CPU Time: 32273.5s total,  186K rows/s, 1.88MB/s, 68% active
Per Node: 20.1 parallelism, 3.73M rows/s, 37.6MB/s
Parallelism: 140.5
Peak Memory: 9.59GB
3:50 [6B rows, 59.1GB] [26.1M rows/s, 263MB/s]
```
after
```
Query 20220610_090149_00009_b42pz, FINISHED, 7 nodes
http://localhost:8081/ui/query.html?20220610_090149_00009_b42pz
Splits: 3,081 total, 3,081 done (100.00%)
CPU Time: 22725.7s total,  264K rows/s, 2.66MB/s, 75% active
Per Node: 16.7 parallelism,  4.4M rows/s, 44.4MB/s
Parallelism: 116.7
Peak Memory: 9.87GB
3:15 [6B rows, 59.1GB] [30.8M rows/s, 311MB/s]
```
<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( X) Release notes entries required with the following suggested text:

```markdown
# Section
* Improve performance of queries with a large number of aggregations that use `RowType` as an intermediate state (e.g. `sum`).
```
