### PR TITLE
Update kafka smoke tests to use Confluent docker image version 7.1.1

### DIFF
--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaLatestConnectorSmokeTest.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaLatestConnectorSmokeTest.java
@@ -28,7 +28,7 @@ public class TestKafkaLatestConnectorSmokeTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        TestingKafka testingKafka = closeAfterClass(TestingKafka.create("6.0.1"));
+        TestingKafka testingKafka = closeAfterClass(TestingKafka.create("7.1.1"));
         return KafkaQueryRunner.builder(testingKafka)
                 .setTables(REQUIRED_TPCH_TABLES)
                 .build();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
This PR is to advance the Confluent platform docker images version used by trino kafka plugin in the kafka smoke tests.

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->
This is an improvement as new confluent platform docker images utilize improved, more efficient kafka versions

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
This change relates only to the kafka connector smoke tests

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

> How would you describe this change to a non-technical end user or system administrator?
Confluent docker images are being used as part of the testing environment for the trino kafka plugin. This change is about "catching up" with the latest version of these images, which utilize higher versions of kafka / zookeeper and schema registry - taking advantage mostly of more efficient code base.


## Related issues, pull requests, and links
* Fixes #12740

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
