### PR TITLE
Add multinode product test environment backed by GCS

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteGCS.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteGCS.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.launcher.suite.suites;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.tests.product.launcher.env.EnvironmentConfig;
+import io.trino.tests.product.launcher.env.environment.EnvMultinodeGcs;
+import io.trino.tests.product.launcher.suite.Suite;
+import io.trino.tests.product.launcher.suite.SuiteTestRun;
+
+import java.util.List;
+
+import static io.trino.tests.product.launcher.suite.SuiteTestRun.testOnEnvironment;
+
+public class SuiteGCS
+        extends Suite
+{
+    @Override
+    public List<SuiteTestRun> getTestRuns(EnvironmentConfig config)
+    {
+        return ImmutableList.of(
+                testOnEnvironment(EnvMultinodeGcs.class)
+                        .withGroups("delta_lake_gcs")
+                        .build());
+    }
+}

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-gcs/apply-gcs-config.sh
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-gcs/apply-gcs-config.sh
@@ -3,3 +3,4 @@ set -exuo pipefail
 
 echo "Applying GCS core-site configuration overrides"
 apply-site-xml-override /etc/hadoop/conf/core-site.xml "/docker/presto-product-tests/conf/environment/multinode-gcs/core-site-overrides.xml"
+apply-site-xml-override /etc/hive/conf/hive-site.xml "/docker/presto-product-tests/conf/environment/multinode-gcs/hive-site-overrides.xml"

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-gcs/core-site-overrides-template.xml
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-gcs/core-site-overrides-template.xml
@@ -1,4 +1,10 @@
 <configuration>
+    <property>
+        <!-- Required to enable full schema evolution. See https://github.com/apache/iceberg/issues/1092#issuecomment-638432848 -->
+        <name>hive.metastore.disallow.incompatible.col.type.changes</name>
+        <value>false</value>
+    </property>
+
     <!-- Google Cloud Storage properties -->
     <property>
         <name>fs.gs.impl</name>

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-gcs/hive-site-overrides-template.xml
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-gcs/hive-site-overrides-template.xml
@@ -1,0 +1,8 @@
+<configuration>
+
+    <property>
+        <name>hive.metastore.warehouse.dir</name>
+        <value>gs://%GCP_STORAGE_BUCKET%/%GCP_WAREHOUSE_DIR%/</value>
+    </property>
+
+</configuration>

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-gcs/tempto-configuration.yaml
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-gcs/tempto-configuration.yaml
@@ -1,0 +1,19 @@
+databases:
+    hive:
+        host: hadoop-master
+        jdbc_driver_class: org.apache.hive.jdbc.HiveDriver
+        jdbc_url: jdbc:hive2://${databases.hive.host}:10000
+        jdbc_user: hive
+        jdbc_password: na
+        jdbc_pooling: false
+        schema: default
+        prepare_statement:
+            - USE ${databases.hive.schema}
+        table_manager_type: hive
+        warehouse_directory_path: gs://${GCP_STORAGE_BUCKET}/${GCP_TEST_DIRECTORY}
+        inject_stats_for_immutable_tables: true
+        inject_stats_for_mutable_tables: true
+        enforce_non_transactional_tables: false
+        metastore:
+            host: ${databases.hive.host}
+            port: 9083

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestGroups.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestGroups.java
@@ -75,6 +75,7 @@ public final class TestGroups
     public static final String DELTA_LAKE_OSS = "delta-lake-oss";
     public static final String DELTA_LAKE_HDFS = "delta-lake-hdfs";
     public static final String DELTA_LAKE_MINIO = "delta-lake-minio";
+    public static final String DELTA_LAKE_GCS = "delta_lake_gcs";
     public static final String DELTA_LAKE_DATABRICKS = "delta-lake-databricks";
     public static final String DELTA_LAKE_EXCLUDE_73 = "delta-lake-exclude-73";
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeGcsReads.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeGcsReads.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.deltalake;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import io.trino.tempto.ProductTest;
+import org.testng.annotations.Test;
+
+import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertThat;
+import static io.trino.tests.product.TestGroups.DELTA_LAKE_GCS;
+import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static io.trino.tests.product.hive.util.TemporaryHiveTable.randomTableSuffix;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
+import static java.lang.String.format;
+
+public class TestDeltaLakeGcsReads
+        extends ProductTest
+{
+    @Inject
+    @Named("databases.hive.warehouse_directory_path")
+    private String warehouseDirectory;
+
+    @Test(groups = {DELTA_LAKE_GCS, PROFILE_SPECIFIC_TESTS})
+    public void testReadRegionTable()
+    {
+        String tableName = "nation_" + randomTableSuffix();
+        onTrino().executeQuery(format(
+                "CREATE TABLE delta.default.%1$s WITH (location = '%2$s/%1$s') AS SELECT * FROM tpch.tiny.nation",
+                tableName,
+                warehouseDirectory));
+
+        assertThat(onTrino().executeQuery("SELECT count(*) FROM delta.default." + tableName)).containsOnly(row(25));
+        onTrino().executeQuery("DROP TABLE delta.default." + tableName);
+    }
+}


### PR DESCRIPTION
Targeting test branch only.

includes a Suite running a Delta test against GCS, and a hive-site.xml override that sets the warehouse directory to be in GCS.