### PR TITLE
Fix missing historical metrics in trino-jmx

### DIFF
--- a/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxRecordSetProvider.java
+++ b/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxRecordSetProvider.java
@@ -41,7 +41,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
 import static java.util.Objects.requireNonNull;
@@ -169,9 +168,7 @@ public class JmxRecordSetProvider
             }
             else {
                 List<Integer> selectedColumns = calculateSelectedColumns(tableHandle.getColumnHandles(), getColumnNames(columns));
-                rows = tableHandle.getObjectNames().stream()
-                        .flatMap(objectName -> jmxHistoricalData.getRows(objectName, selectedColumns).stream())
-                        .collect(toImmutableList());
+                rows = ImmutableList.copyOf(jmxHistoricalData.getRows(tableHandle.getTableName().getTableName(), selectedColumns));
             }
         }
         catch (JMException e) {


### PR DESCRIPTION
## Description

The historical metrics of resource groups in `jmx.history` are missing. 

Here's the reasons:

1) Some mbeans may be registered to MBeanServer after server launch, 
like metrics of resource groups. So that we must refresh the dynamic
mbean tables regularly.

2) It should use table name instead of object name to get records
from JmxHistoricalData, since on mbeans with attribute name and type,
the table name is different from object name.

See: #12781 

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# trino-jmx
* trino-jmx missing resource group metrics ({issue}`https://github.com/trinodb/trino/issues/12781`)
```
