### PR TITLE
Fix decoding Float to REAL in Kafka Avro

### DIFF
--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/avro/AvroColumnDecoder.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/avro/AvroColumnDecoder.java
@@ -187,6 +187,9 @@ public class AvroColumnDecoder
             if (value instanceof Long || value instanceof Integer) {
                 return ((Number) value).longValue();
             }
+            if (value instanceof Float && columnType == RealType.REAL) {
+                return floatToIntBits((float) value);
+            }
             throw new TrinoException(DECODER_CONVERSION_NOT_SUPPORTED, format("cannot decode object of '%s' as '%s' for column '%s'", value.getClass(), columnType, columnName));
         }
 

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaConnectorTest.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaConnectorTest.java
@@ -742,10 +742,10 @@ public class TestKafkaConnectorTest
         return ImmutableList.<RoundTripTestCase>builder()
                 .add(new RoundTripTestCase(
                         "all_datatypes_avro",
-                        ImmutableList.of("f_bigint", "f_double", "f_boolean", "f_varchar"),
+                        ImmutableList.of("f_bigint", "f_float", "f_double", "f_boolean", "f_varchar"),
                         ImmutableList.of(
-                                ImmutableList.of(100000, 1000.001, true, "'test'"),
-                                ImmutableList.of(123456, 1234.123, false, "'abcd'"))))
+                                ImmutableList.of(100000, 999.999f, 1000.001, true, "'test'"),
+                                ImmutableList.of(123456, -123.456f, 1234.123, false, "'abcd'"))))
                 .add(new RoundTripTestCase(
                         "all_datatypes_csv",
                         ImmutableList.of("f_bigint", "f_int", "f_smallint", "f_tinyint", "f_double", "f_boolean", "f_varchar"),

--- a/plugin/trino-kafka/src/test/resources/write_test/all_datatypes_avro.json
+++ b/plugin/trino-kafka/src/test/resources/write_test/all_datatypes_avro.json
@@ -23,6 +23,11 @@
             "mapping": "f_bigint"
             },
             {
+            "name": "f_float",
+            "type": "REAL",
+            "mapping": "f_float"
+            },
+            {
             "name": "f_double",
             "type": "DOUBLE",
             "mapping": "f_double"

--- a/plugin/trino-kafka/src/test/resources/write_test/all_datatypes_avro_message_schema.avsc
+++ b/plugin/trino-kafka/src/test/resources/write_test/all_datatypes_avro_message_schema.avsc
@@ -10,6 +10,11 @@
                   "default": null
               },
               {
+                  "name": "f_float",
+                  "type":["null", "float"],
+                  "default": null
+              },
+              {
                   "name": "f_double",
                   "type":["null", "double"],
                   "default": null


### PR DESCRIPTION
## Description

Fix decoding Float to REAL in Kafka Avro
Supersedes #12669

## Documentation

(x) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# Kafka
* Fix failure when decoding `float` value to `real` type. ({issue}`issuenumber`)
```
