### PR TITLE
Replace `var` usages with explciit type

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/QueryExecutionFactoryModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/QueryExecutionFactoryModule.java
@@ -115,7 +115,8 @@ public class QueryExecutionFactoryModule
     @Override
     public void configure(Binder binder)
     {
-        var executionBinder = newMapBinder(binder, new TypeLiteral<Class<? extends Statement>>() {}, new TypeLiteral<QueryExecutionFactory<?>>() {});
+        MapBinder<Class<? extends Statement>, QueryExecutionFactory<?>> executionBinder =
+                newMapBinder(binder, new TypeLiteral<Class<? extends Statement>>() {}, new TypeLiteral<QueryExecutionFactory<?>>() {});
 
         binder.bind(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
         for (Class<? extends Statement> statement : getNonDataDefinitionStatements()) {
@@ -172,7 +173,8 @@ public class QueryExecutionFactoryModule
             Class<? extends DataDefinitionTask<T>> task)
     {
         checkArgument(isDataDefinitionStatement(statement));
-        var taskBinder = newMapBinder(binder, new TypeLiteral<Class<? extends Statement>>() {}, new TypeLiteral<DataDefinitionTask<?>>() {});
+        MapBinder<Class<? extends Statement>, DataDefinitionTask<?>> taskBinder =
+                newMapBinder(binder, new TypeLiteral<Class<? extends Statement>>() {}, new TypeLiteral<DataDefinitionTask<?>>() {});
         taskBinder.addBinding(statement).to(task).in(Scopes.SINGLETON);
         executionBinder.addBinding(statement).to(DataDefinitionExecutionFactory.class).in(Scopes.SINGLETON);
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/azure/TestTrinoAzureConfigurationInitializer.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/azure/TestTrinoAzureConfigurationInitializer.java
@@ -86,7 +86,7 @@ public class TestTrinoAzureConfigurationInitializer
         testProperties(setters);
 
         // Dropping any one property fails
-        for (var setter : setters) {
+        for (BiConsumer<HiveAzureConfig, String> setter : setters) {
             assertThatThrownBy(() -> testProperties(difference(setters, Set.of(setter))))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage(expectedErrorMessage);
@@ -101,8 +101,8 @@ public class TestTrinoAzureConfigurationInitializer
 
     private static void testProperties(Set<BiConsumer<HiveAzureConfig, String>> setters)
     {
-        var config = new HiveAzureConfig();
-        for (var setter : setters) {
+        HiveAzureConfig config = new HiveAzureConfig();
+        for (BiConsumer<HiveAzureConfig, String> setter : setters) {
             setter.accept(config, "test value");
         }
         new TrinoAzureConfigurationInitializer(config);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastoreWithQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastoreWithQueryRunner.java
@@ -143,8 +143,8 @@ public class TestCachingHiveMetastoreWithQueryRunner
     @Test
     public void testIllegalFlushHiveMetastoreCacheProcedureCalls()
     {
-        var illegalParameterMessage = "Illegal parameter set passed. ";
-        var validUsageExample = "Valid usages:\n - 'flush_metadata_cache()'\n - flush_metadata_cache(schema_name => ..., table_name => ..., partition_column => ARRAY['...'], partition_value => ARRAY['...'])";
+        String illegalParameterMessage = "Illegal parameter set passed. ";
+        String validUsageExample = "Valid usages:\n - 'flush_metadata_cache()'\n - flush_metadata_cache(schema_name => ..., table_name => ..., partition_column => ARRAY['...'], partition_value => ARRAY['...'])";
 
         assertThatThrownBy(() -> getQueryRunner().execute("CALL system.flush_metadata_cache('dummy_schema')"))
                 .hasMessage("Procedure should only be invoked with named parameters. " + validUsageExample);


### PR DESCRIPTION
Per development guidelines, `var` is discouraged.

References
- development guidelines https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md#avoid-var
- old slack thread https://trinodb.slack.com/archives/CP1MUNEUX/p1596193971338400 