### PR TITLE
Fix handling of NONE constraint in ElasticsearchMetadata.applyFilter

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -941,9 +941,14 @@ public interface ConnectorMetadata
      * <b>Note</b>: Implementation must not maintain reference to {@code constraint}'s {@link Constraint#predicate()} after the
      * call returns.
      * </p>
+     *
+     * @param constraint constraint to be applied to the table. {@link Constraint#getSummary()} is guaranteed not to be {@link TupleDomain#isNone() none}.
      */
     default Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint constraint)
     {
+        if (constraint.getSummary().getDomains().isEmpty()) {
+            throw new IllegalArgumentException("constraint summary is NONE");
+        }
         return Optional.empty();
     }
 

--- a/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopMetadata.java
+++ b/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopMetadata.java
@@ -160,20 +160,18 @@ public class AtopMetadata
     {
         AtopTableHandle handle = (AtopTableHandle) table;
 
-        Optional<Map<ColumnHandle, Domain>> domains = constraint.getSummary().getDomains();
+        Map<ColumnHandle, Domain> domains = constraint.getSummary().getDomains().orElseThrow(() -> new IllegalArgumentException("constraint summary is NONE"));
 
         Domain oldEndTimeDomain = handle.getEndTimeConstraint();
         Domain oldStartTimeDomain = handle.getStartTimeConstraint();
         Domain newEndTimeDomain = oldEndTimeDomain;
         Domain newStartTimeDomain = oldStartTimeDomain;
 
-        if (domains.isPresent()) {
-            if (domains.get().containsKey(START_TIME_HANDLE)) {
-                newStartTimeDomain = domains.get().get(START_TIME_HANDLE).intersect(oldStartTimeDomain);
-            }
-            if (domains.get().containsKey(END_TIME_HANDLE)) {
-                newEndTimeDomain = domains.get().get(END_TIME_HANDLE).intersect(oldEndTimeDomain);
-            }
+        if (domains.containsKey(START_TIME_HANDLE)) {
+            newStartTimeDomain = domains.get(START_TIME_HANDLE).intersect(oldStartTimeDomain);
+        }
+        if (domains.containsKey(END_TIME_HANDLE)) {
+            newEndTimeDomain = domains.get(END_TIME_HANDLE).intersect(oldEndTimeDomain);
         }
 
         if (oldEndTimeDomain.equals(newEndTimeDomain) && oldStartTimeDomain.equals(newStartTimeDomain)) {

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -1768,8 +1768,7 @@ public class DeltaLakeMetadata
         SchemaTableName tableName = tableHandle.getSchemaTableName();
 
         Set<DeltaLakeColumnHandle> partitionColumns = ImmutableSet.copyOf(extractPartitionColumns(tableHandle.getMetadataEntry(), typeManager));
-        verify(!constraint.getSummary().isNone(), "applyFilter constraint has summary NONE");
-        Map<ColumnHandle, Domain> constraintDomains = constraint.getSummary().getDomains().orElseThrow();
+        Map<ColumnHandle, Domain> constraintDomains = constraint.getSummary().getDomains().orElseThrow(() -> new IllegalArgumentException("constraint summary is NONE"));
 
         ImmutableMap.Builder<DeltaLakeColumnHandle, Domain> enforceableDomains = ImmutableMap.builder();
         ImmutableMap.Builder<DeltaLakeColumnHandle, Domain> unenforceableDomains = ImmutableMap.builder();

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
@@ -525,16 +525,15 @@ public class ElasticsearchMetadata
 
         Map<ColumnHandle, Domain> supported = new HashMap<>();
         Map<ColumnHandle, Domain> unsupported = new HashMap<>();
-        if (constraint.getSummary().getDomains().isPresent()) {
-            for (Map.Entry<ColumnHandle, Domain> entry : constraint.getSummary().getDomains().get().entrySet()) {
-                ElasticsearchColumnHandle column = (ElasticsearchColumnHandle) entry.getKey();
+        Map<ColumnHandle, Domain> domains = constraint.getSummary().getDomains().orElseThrow(() -> new IllegalArgumentException("constraint summary is NONE"));
+        for (Map.Entry<ColumnHandle, Domain> entry : domains.entrySet()) {
+            ElasticsearchColumnHandle column = (ElasticsearchColumnHandle) entry.getKey();
 
-                if (column.isSupportsPredicates()) {
-                    supported.put(column, entry.getValue());
-                }
-                else {
-                    unsupported.put(column, entry.getValue());
-                }
+            if (column.isSupportsPredicates()) {
+                supported.put(column, entry.getValue());
+            }
+            else {
+                unsupported.put(column, entry.getValue());
             }
         }
 

--- a/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxMetadata.java
+++ b/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxMetadata.java
@@ -261,16 +261,13 @@ public class JmxMetadata
     @Override
     public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint constraint)
     {
-        Optional<Map<ColumnHandle, Domain>> domains = constraint.getSummary().getDomains();
-        if (domains.isEmpty()) {
-            return Optional.empty();
-        }
+        Map<ColumnHandle, Domain> domains = constraint.getSummary().getDomains().orElseThrow(() -> new IllegalArgumentException("constraint summary is NONE"));
 
         JmxTableHandle tableHandle = (JmxTableHandle) handle;
 
         Map<ColumnHandle, Domain> nodeDomains = new LinkedHashMap<>();
         Map<ColumnHandle, Domain> otherDomains = new LinkedHashMap<>();
-        domains.get().forEach((column, domain) -> {
+        domains.forEach((column, domain) -> {
             JmxColumnHandle columnHandle = (JmxColumnHandle) column;
             if (columnHandle.getColumnName().equals(NODE_COLUMN_NAME)) {
                 nodeDomains.put(column, domain);


### PR DESCRIPTION
Before the change, the NONE domain was treated the same as ALL domain.
If connector accepted a NONE constraint (while not doing filtering),
this would lead to incorrect results.

Fortunately, the `applyFilter` is never invoked with NONE domain, and
should not be, since the engine knows what to do in such case without
asking the connector.
