### PR TITLE
Improve partitioned output operator performance for strings

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/output/SlicePositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/SlicePositionsAppender.java
@@ -13,6 +13,7 @@
  */
 package io.trino.operator.output;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.trino.spi.block.Block;
@@ -80,38 +81,43 @@ public class SlicePositionsAppender
             return;
         }
         ensurePositionCapacity(positionCount + positions.size());
-        int[] positionArray = positions.elements();
-        int newByteCount = 0;
-        int[] lengths = new int[positions.size()];
+        if (block instanceof VariableWidthBlock) {
+            VariableWidthBlock variableWidthBlock = (VariableWidthBlock) block;
+            int newByteCount = 0;
+            int[] lengths = new int[positions.size()];
+            int[] sourceOffsets = new int[positions.size()];
+            int[] positionArray = positions.elements();
 
-        if (block.mayHaveNull()) {
-            for (int i = 0; i < positions.size(); i++) {
-                int position = positionArray[i];
-                if (block.isNull(position)) {
-                    offsets[positionCount + i + 1] = offsets[positionCount + i];
-                    valueIsNull[positionCount + i] = true;
-                    hasNullValue = true;
-                }
-                else {
-                    int length = block.getSliceLength(position);
+            if (block.mayHaveNull()) {
+                for (int i = 0; i < positions.size(); i++) {
+                    int position = positionArray[i];
+                    int length = variableWidthBlock.getSliceLength(position);
                     lengths[i] = length;
+                    sourceOffsets[i] = variableWidthBlock.getRawSliceOffset(position);
+                    newByteCount += length;
+                    boolean isNull = block.isNull(position);
+                    valueIsNull[positionCount + i] = isNull;
+                    offsets[positionCount + i + 1] = offsets[positionCount + i] + length;
+                    hasNullValue |= isNull;
+                    hasNonNullValue |= !isNull;
+                }
+            }
+            else {
+                for (int i = 0; i < positions.size(); i++) {
+                    int position = positionArray[i];
+                    int length = variableWidthBlock.getSliceLength(position);
+                    lengths[i] = length;
+                    sourceOffsets[i] = variableWidthBlock.getRawSliceOffset(position);
                     newByteCount += length;
                     offsets[positionCount + i + 1] = offsets[positionCount + i] + length;
-                    hasNonNullValue = true;
                 }
+                hasNonNullValue = true;
             }
+            copyBytes(variableWidthBlock.getRawSlice(), lengths, sourceOffsets, positions.size(), newByteCount);
         }
         else {
-            for (int i = 0; i < positions.size(); i++) {
-                int position = positionArray[i];
-                int length = block.getSliceLength(position);
-                lengths[i] = length;
-                newByteCount += length;
-                offsets[positionCount + i + 1] = offsets[positionCount + i] + length;
-            }
-            hasNonNullValue = true;
+            appendGenericBlock(positions, block);
         }
-        copyBytes(block, lengths, positionArray, positions.size(), offsets, positionCount, newByteCount);
     }
 
     @Override
@@ -132,7 +138,7 @@ public class SlicePositionsAppender
         }
         else {
             hasNonNullValue = true;
-            duplicateBytes(block.getValue(), 0, rlePositionCount);
+            duplicateBytes(block.getSlice(0, 0, block.getSliceLength(0)), rlePositionCount);
         }
     }
 
@@ -166,16 +172,20 @@ public class SlicePositionsAppender
         return sizeInBytes;
     }
 
-    private void copyBytes(Block block, int[] lengths, int[] positions, int count, int[] targetOffsets, int targetOffsetsIndex, int newByteCount)
+    private void copyBytes(Slice rawSlice, int[] lengths, int[] sourceOffsets, int count, int newByteCount)
     {
-        ensureBytesCapacity(getCurrentOffset() + newByteCount);
+        ensureExtraBytesCapacity(newByteCount);
 
-        for (int i = 0; i < count; i++) {
-            int position = positions[i];
-            if (!block.isNull(position)) {
-                int length = lengths[i];
-                Slice slice = block.getSlice(position, 0, length);
-                slice.getBytes(0, bytes, targetOffsets[targetOffsetsIndex + i], length);
+        if (rawSlice.hasByteArray()) {
+            byte[] base = rawSlice.byteArray();
+            int byteArrayOffset = rawSlice.byteArrayOffset();
+            for (int i = 0; i < count; i++) {
+                System.arraycopy(base, byteArrayOffset + sourceOffsets[i], bytes, offsets[positionCount + i], lengths[i]);
+            }
+        }
+        else {
+            for (int i = 0; i < count; i++) {
+                rawSlice.getBytes(sourceOffsets[i], bytes, offsets[positionCount + i], lengths[i]);
             }
         }
 
@@ -184,23 +194,73 @@ public class SlicePositionsAppender
     }
 
     /**
-     * Copy {@code length} bytes from {@code block}, at position {@code position} to {@code count} consecutive positions in the {@link #bytes} array.
+     * Copy all bytes from {@code slice} to {@code count} consecutive positions in the {@link #bytes} array.
      */
-    private void duplicateBytes(Block block, int position, int count)
+    private void duplicateBytes(Slice slice, int count)
     {
-        int length = block.getSliceLength(position);
+        int length = slice.length();
         int newByteCount = toIntExact((long) count * length);
         int startOffset = getCurrentOffset();
-        ensureBytesCapacity(startOffset + newByteCount);
+        ensureExtraBytesCapacity(newByteCount);
 
-        Slice slice = block.getSlice(position, 0, length);
+        duplicateBytes(slice, bytes, startOffset, count);
+
+        int currentStartOffset = startOffset + length;
         for (int i = 0; i < count; i++) {
-            slice.getBytes(0, bytes, startOffset + (i * length), length);
-            offsets[positionCount + i + 1] = startOffset + ((i + 1) * length);
+            offsets[positionCount + i + 1] = currentStartOffset;
+            currentStartOffset += length;
         }
 
         positionCount += count;
         updateSize(count, newByteCount);
+    }
+
+    /**
+     * Copy {@code length} bytes from {@code slice}, starting at offset {@code sourceOffset} to {@code count} consecutive positions in the {@link #bytes} array.
+     */
+    @VisibleForTesting
+    static void duplicateBytes(Slice slice, byte[] bytes, int startOffset, int count)
+    {
+        int length = slice.length();
+        if (length == 0) {
+            // nothing to copy
+            return;
+        }
+        // copy slice to the first position
+        slice.getBytes(0, bytes, startOffset, length);
+        int totalDuplicatedBytes = count * length;
+        int duplicatedBytes = length;
+        // copy every byte copied so far, doubling the number of bytes copied on evey iteration
+        while (duplicatedBytes * 2 <= totalDuplicatedBytes) {
+            System.arraycopy(bytes, startOffset, bytes, startOffset + duplicatedBytes, duplicatedBytes);
+            duplicatedBytes = duplicatedBytes * 2;
+        }
+        // copy the leftover
+        System.arraycopy(bytes, startOffset, bytes, startOffset + duplicatedBytes, totalDuplicatedBytes - duplicatedBytes);
+    }
+
+    private void appendGenericBlock(IntArrayList positions, Block block)
+    {
+        int newByteCount = 0;
+        for (int i = 0; i < positions.size(); i++) {
+            int position = positions.getInt(i);
+            if (block.isNull(position)) {
+                offsets[positionCount + 1] = offsets[positionCount];
+                valueIsNull[positionCount] = true;
+                hasNullValue = true;
+            }
+            else {
+                int length = block.getSliceLength(position);
+                ensureExtraBytesCapacity(length);
+                Slice slice = block.getSlice(position, 0, length);
+                slice.getBytes(0, bytes, offsets[positionCount], length);
+                offsets[positionCount + 1] = offsets[positionCount] + length;
+                hasNonNullValue = true;
+                newByteCount += length;
+            }
+            positionCount++;
+        }
+        updateSize(positions.size(), newByteCount);
     }
 
     private void reset()
@@ -228,12 +288,13 @@ public class SlicePositionsAppender
         sizeInBytes += (SIZE_OF_BYTE + SIZE_OF_INT) * positionsSize + bytesWritten;
     }
 
-    private void ensureBytesCapacity(int bytesCapacity)
+    private void ensureExtraBytesCapacity(int extraBytesCapacity)
     {
-        if (bytes.length < bytesCapacity) {
+        int totalBytesCapacity = getCurrentOffset() + extraBytesCapacity;
+        if (bytes.length < totalBytesCapacity) {
             int newBytesLength = Math.max(bytes.length, initialBytesSize);
-            if (bytesCapacity > newBytesLength) {
-                newBytesLength = Math.max(bytesCapacity, calculateNewArraySize(newBytesLength));
+            if (totalBytesCapacity > newBytesLength) {
+                newBytesLength = Math.max(totalBytesCapacity, calculateNewArraySize(newBytesLength));
             }
             bytes = Arrays.copyOf(bytes, newBytesLength);
             updateRetainedSize();

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppender.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppender.java
@@ -14,7 +14,10 @@
 package io.trino.operator.output;
 
 import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import io.trino.block.BlockAssertions;
+import io.trino.spi.block.AbstractVariableWidthBlock;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.BlockBuilderStatus;
@@ -22,20 +25,37 @@ import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.block.PageBuilderStatus;
 import io.trino.spi.block.RowBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.spi.block.VariableWidthBlock;
 import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.BigintType;
+import io.trino.spi.type.BooleanType;
 import io.trino.spi.type.Decimals;
+import io.trino.spi.type.DoubleType;
+import io.trino.spi.type.IntegerType;
 import io.trino.spi.type.LongTimestamp;
 import io.trino.spi.type.RowType;
+import io.trino.spi.type.SmallintType;
+import io.trino.spi.type.TinyintType;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.VarbinaryType;
+import io.trino.spi.type.VarcharType;
 import io.trino.type.BlockTypeOperators;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.function.Function;
+import java.util.function.ObjLongConsumer;
 import java.util.stream.IntStream;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static io.airlift.testing.Assertions.assertGreaterThanOrEqual;
 import static io.airlift.testing.Assertions.assertInstanceOf;
 import static io.trino.block.BlockAssertions.assertBlockEquals;
@@ -46,7 +66,6 @@ import static io.trino.block.BlockAssertions.createIntsBlock;
 import static io.trino.block.BlockAssertions.createLongDecimalsBlock;
 import static io.trino.block.BlockAssertions.createLongTimestampBlock;
 import static io.trino.block.BlockAssertions.createLongsBlock;
-import static io.trino.block.BlockAssertions.createRandomBlockForType;
 import static io.trino.block.BlockAssertions.createRandomDictionaryBlock;
 import static io.trino.block.BlockAssertions.createSlicesBlock;
 import static io.trino.block.BlockAssertions.createSmallintsBlock;
@@ -55,16 +74,10 @@ import static io.trino.block.BlockAssertions.createTinyintsBlock;
 import static io.trino.spi.block.DictionaryId.randomDictionaryId;
 import static io.trino.spi.block.PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
 import static io.trino.spi.type.BigintType.BIGINT;
-import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.CharType.createCharType;
 import static io.trino.spi.type.DecimalType.createDecimalType;
-import static io.trino.spi.type.DoubleType.DOUBLE;
-import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RowType.anonymousRow;
-import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimestampType.createTimestampType;
-import static io.trino.spi.type.TinyintType.TINYINT;
-import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.util.Objects.requireNonNull;
@@ -76,7 +89,7 @@ public class TestPositionsAppender
     private static final PositionsAppenderFactory POSITIONS_APPENDER_FACTORY = new PositionsAppenderFactory(new BlockTypeOperators());
 
     @Test(dataProvider = "types")
-    public void testMixedBlockTypes(Type type)
+    public void testMixedBlockTypes(TestType type)
     {
         List<BlockView> input = ImmutableList.of(
                 input(emptyBlock(type)),
@@ -103,16 +116,16 @@ public class TestPositionsAppender
         testAppend(type, input);
     }
 
-    @Test(dataProvider = "nullRleTypes")
-    public void testNullRle(Type type)
+    @Test(dataProvider = "types")
+    public void testNullRle(TestType type)
     {
-        testNullRle(type, nullBlock(type, 2));
-        testNullRle(type, nullRleBlock(type, 2));
-        testNullRle(type, createRandomBlockForType(type, 4, 0.5f));
+        testNullRle(type.getType(), nullBlock(type, 2));
+        testNullRle(type.getType(), nullRleBlock(type, 2));
+        testNullRle(type.getType(), createRandomBlockForType(type, 4, 0.5f));
     }
 
     @Test(dataProvider = "types")
-    public void testRleSwitchToFlat(Type type)
+    public void testRleSwitchToFlat(TestType type)
     {
         List<BlockView> inputs = ImmutableList.of(
                 input(rleBlock(type, 3), 0, 1),
@@ -126,7 +139,7 @@ public class TestPositionsAppender
     }
 
     @Test(dataProvider = "types")
-    public void testFlatAppendRle(Type type)
+    public void testFlatAppendRle(TestType type)
     {
         List<BlockView> inputs = ImmutableList.of(
                 input(notNullBlock(type, 2), 0, 1),
@@ -140,7 +153,7 @@ public class TestPositionsAppender
     }
 
     @Test(dataProvider = "differentValues")
-    public void testMultipleRleBlocksWithDifferentValues(Type type, Block value1, Block value2)
+    public void testMultipleRleBlocksWithDifferentValues(TestType type, Block value1, Block value2)
     {
         List<BlockView> input = ImmutableList.of(
                 input(rleBlock(value1, 3), 0, 1),
@@ -153,28 +166,27 @@ public class TestPositionsAppender
     {
         return new Object[][]
                 {
-                        {BIGINT, createLongsBlock(0), createLongsBlock(1)},
-                        {BOOLEAN, createBooleansBlock(true), createBooleansBlock(false)},
-                        {INTEGER, createIntsBlock(0), createIntsBlock(1)},
-                        {createCharType(10), createStringsBlock("0"), createStringsBlock("1")},
-                        {createUnboundedVarcharType(), createStringsBlock("0"), createStringsBlock("1")},
-                        {DOUBLE, createDoublesBlock(0D), createDoublesBlock(1D)},
-                        {SMALLINT, createSmallintsBlock(0), createSmallintsBlock(1)},
-                        {TINYINT, createTinyintsBlock(0), createTinyintsBlock(1)},
-                        {VARBINARY, createSlicesBlock(Slices.wrappedLongArray(0)), createSlicesBlock(Slices.wrappedLongArray(1))},
-                        {createDecimalType(Decimals.MAX_SHORT_PRECISION + 1), createLongDecimalsBlock("0"), createLongDecimalsBlock("1")},
-                        {new ArrayType(BIGINT), createArrayBigintBlock(ImmutableList.of(ImmutableList.of(0L))), createArrayBigintBlock(ImmutableList.of(ImmutableList.of(1L)))},
-                        {
-                                createTimestampType(9),
-                                createLongTimestampBlock(createTimestampType(9), new LongTimestamp(0, 0)),
-                                createLongTimestampBlock(createTimestampType(9), new LongTimestamp(1, 0))}
+                        {TestType.BIGINT, createLongsBlock(0), createLongsBlock(1)},
+                        {TestType.BOOLEAN, createBooleansBlock(true), createBooleansBlock(false)},
+                        {TestType.INTEGER, createIntsBlock(0), createIntsBlock(1)},
+                        {TestType.CHAR_10, createStringsBlock("0"), createStringsBlock("1")},
+                        {TestType.VARCHAR, createStringsBlock("0"), createStringsBlock("1")},
+                        {TestType.DOUBLE, createDoublesBlock(0D), createDoublesBlock(1D)},
+                        {TestType.SMALLINT, createSmallintsBlock(0), createSmallintsBlock(1)},
+                        {TestType.TINYINT, createTinyintsBlock(0), createTinyintsBlock(1)},
+                        {TestType.VARBINARY, createSlicesBlock(Slices.wrappedLongArray(0)), createSlicesBlock(Slices.wrappedLongArray(1))},
+                        {TestType.LONG_DECIMAL, createLongDecimalsBlock("0"), createLongDecimalsBlock("1")},
+                        {TestType.ARRAY_BIGINT, createArrayBigintBlock(ImmutableList.of(ImmutableList.of(0L))), createArrayBigintBlock(ImmutableList.of(ImmutableList.of(1L)))},
+                        {TestType.LONG_TIMESTAMP, createLongTimestampBlock(createTimestampType(9), new LongTimestamp(0, 0)),
+                                createLongTimestampBlock(createTimestampType(9), new LongTimestamp(1, 0))},
+                        {TestType.VARCHAR_WITH_TEST_BLOCK, TestVariableWidthBlock.adapt(createStringsBlock("0")), TestVariableWidthBlock.adapt(createStringsBlock("1"))}
                 };
     }
 
     @Test(dataProvider = "types")
-    public void testMultipleRleWithTheSameValueProduceRle(Type type)
+    public void testMultipleRleWithTheSameValueProduceRle(TestType type)
     {
-        PositionsAppender positionsAppender = POSITIONS_APPENDER_FACTORY.create(type, 10, DEFAULT_MAX_PAGE_SIZE_IN_BYTES);
+        PositionsAppender positionsAppender = POSITIONS_APPENDER_FACTORY.create(type.getType(), 10, DEFAULT_MAX_PAGE_SIZE_IN_BYTES);
 
         Block value = notNullBlock(type, 1);
         positionsAppender.append(allPositions(3), rleBlock(value, 3));
@@ -186,9 +198,9 @@ public class TestPositionsAppender
     }
 
     @Test(dataProvider = "types")
-    public void testConsecutiveBuilds(Type type)
+    public void testConsecutiveBuilds(TestType type)
     {
-        PositionsAppender positionsAppender = POSITIONS_APPENDER_FACTORY.create(type, 10, DEFAULT_MAX_PAGE_SIZE_IN_BYTES);
+        PositionsAppender positionsAppender = POSITIONS_APPENDER_FACTORY.create(type.getType(), 10, DEFAULT_MAX_PAGE_SIZE_IN_BYTES);
 
         // empty block
         positionsAppender.append(positions(), emptyBlock(type));
@@ -204,12 +216,12 @@ public class TestPositionsAppender
 
         // append null and not null position
         positionsAppender.append(allPositions(2), block);
-        assertBlockEquals(type, positionsAppender.build(), block);
+        assertBlockEquals(type.getType(), positionsAppender.build(), block);
 
         // append not null rle
         Block rleBlock = rleBlock(type, 1);
         positionsAppender.append(allPositions(1), rleBlock);
-        assertBlockEquals(type, positionsAppender.build(), rleBlock);
+        assertBlockEquals(type.getType(), positionsAppender.build(), rleBlock);
 
         // append empty rle
         positionsAppender.append(positions(), rleBlock(type, 0));
@@ -218,7 +230,7 @@ public class TestPositionsAppender
         // append null rle
         Block nullRleBlock = nullRleBlock(type, 1);
         positionsAppender.append(allPositions(1), nullRleBlock);
-        assertBlockEquals(type, positionsAppender.build(), nullRleBlock);
+        assertBlockEquals(type.getType(), positionsAppender.build(), nullRleBlock);
 
         // just build to confirm appender was reset
         assertEquals(positionsAppender.build().getPositionCount(), 0);
@@ -246,9 +258,9 @@ public class TestPositionsAppender
     {
         RowType type = anonymousRow(BIGINT, BIGINT, VARCHAR);
         Block rowBLock = RowBlock.fromFieldBlocks(2, Optional.empty(), new Block[] {
-                notNullBlock(BIGINT, 2),
-                dictionaryBlock(BIGINT, 2, 2, 0.5F),
-                rleBlock(VARCHAR, 2)
+                notNullBlock(TestType.BIGINT, 2),
+                dictionaryBlock(TestType.BIGINT, 2, 2, 0.5F),
+                rleBlock(TestType.VARCHAR, 2)
         });
 
         PositionsAppender positionsAppender = POSITIONS_APPENDER_FACTORY.create(type, 10, DEFAULT_MAX_PAGE_SIZE_IN_BYTES);
@@ -259,45 +271,12 @@ public class TestPositionsAppender
         assertBlockEquals(type, actual, rowBLock);
     }
 
-    @DataProvider(name = "nullRleTypes")
-    public static Object[][] nullRleTypes()
-    {
-        return new Object[][]
-                {
-                        {BIGINT},
-                        {BOOLEAN},
-                        {INTEGER},
-                        {createCharType(10)},
-                        {createUnboundedVarcharType()},
-                        {DOUBLE},
-                        {SMALLINT},
-                        {TINYINT},
-                        {VARBINARY},
-                        {createDecimalType(Decimals.MAX_SHORT_PRECISION + 1)},
-                        {createTimestampType(9)},
-                        {anonymousRow(BIGINT, VARCHAR)}
-                };
-    }
-
     @DataProvider(name = "types")
     public static Object[][] types()
     {
-        return new Object[][]
-                {
-                        {BIGINT},
-                        {BOOLEAN},
-                        {INTEGER},
-                        {createCharType(10)},
-                        {createUnboundedVarcharType()},
-                        {DOUBLE},
-                        {SMALLINT},
-                        {TINYINT},
-                        {VARBINARY},
-                        {createDecimalType(Decimals.MAX_SHORT_PRECISION + 1)},
-                        {new ArrayType(BIGINT)},
-                        {createTimestampType(9)},
-                        {anonymousRow(BIGINT, VARCHAR)}
-                };
+        return Arrays.stream(TestType.values())
+                .map(type -> new Object[] {type})
+                .toArray(Object[][]::new);
     }
 
     private static Block singleValueBlock(String value)
@@ -332,7 +311,7 @@ public class TestPositionsAppender
         return new DictionaryBlock(0, ids.length, dictionary, ids, false, randomDictionaryId());
     }
 
-    private DictionaryBlock dictionaryBlock(Type type, int positionCount, int dictionarySize, float nullRate)
+    private DictionaryBlock dictionaryBlock(TestType type, int positionCount, int dictionarySize, float nullRate)
     {
         Block dictionary = createRandomBlockForType(type, dictionarySize, nullRate);
         return createRandomDictionaryBlock(dictionary, positionCount);
@@ -343,40 +322,45 @@ public class TestPositionsAppender
         return new RunLengthEncodedBlock(value, positionCount);
     }
 
-    private RunLengthEncodedBlock rleBlock(Type type, int positionCount)
+    private RunLengthEncodedBlock rleBlock(TestType type, int positionCount)
     {
         Block rleValue = createRandomBlockForType(type, 1, 0);
         return new RunLengthEncodedBlock(rleValue, positionCount);
     }
 
-    private RunLengthEncodedBlock nullRleBlock(Type type, int positionCount)
+    private RunLengthEncodedBlock nullRleBlock(TestType type, int positionCount)
     {
         Block rleValue = nullBlock(type, 1);
         return new RunLengthEncodedBlock(rleValue, positionCount);
     }
 
-    private Block partiallyNullBlock(Type type, int positionCount)
+    private Block partiallyNullBlock(TestType type, int positionCount)
     {
         return createRandomBlockForType(type, positionCount, 0.5F);
     }
 
-    private Block notNullBlock(Type type, int positionCount)
+    private Block notNullBlock(TestType type, int positionCount)
     {
         return createRandomBlockForType(type, positionCount, 0);
     }
 
-    private Block nullBlock(Type type, int positionCount)
+    private Block nullBlock(TestType type, int positionCount)
     {
-        BlockBuilder blockBuilder = type.createBlockBuilder(null, positionCount);
+        BlockBuilder blockBuilder = type.getType().createBlockBuilder(null, positionCount);
         for (int i = 0; i < positionCount; i++) {
             blockBuilder.appendNull();
         }
-        return blockBuilder.build();
+        return type.adapt(blockBuilder.build());
     }
 
-    private Block emptyBlock(Type type)
+    private Block emptyBlock(TestType type)
     {
-        return type.createBlockBuilder(null, 0).build();
+        return type.adapt(type.getType().createBlockBuilder(null, 0).build());
+    }
+
+    private Block createRandomBlockForType(TestType type, int positionCount, float nullRate)
+    {
+        return type.adapt(BlockAssertions.createRandomBlockForType(type.getType(), positionCount, nullRate));
     }
 
     private void testNullRle(Type type, Block source)
@@ -398,9 +382,9 @@ public class TestPositionsAppender
         assertInstanceOf(actual, RunLengthEncodedBlock.class);
     }
 
-    private void testAppend(Type type, List<BlockView> inputs)
+    private void testAppend(TestType type, List<BlockView> inputs)
     {
-        PositionsAppender positionsAppender = POSITIONS_APPENDER_FACTORY.create(type, 10, DEFAULT_MAX_PAGE_SIZE_IN_BYTES);
+        PositionsAppender positionsAppender = POSITIONS_APPENDER_FACTORY.create(type.getType(), 10, DEFAULT_MAX_PAGE_SIZE_IN_BYTES);
         long initialRetainedSize = positionsAppender.getRetainedSizeInBytes();
 
         inputs.forEach(input -> positionsAppender.append(input.getPositions(), input.getBlock()));
@@ -408,7 +392,7 @@ public class TestPositionsAppender
         assertGreaterThanOrEqual(positionsAppender.getRetainedSizeInBytes(), sizeInBytes);
         Block actual = positionsAppender.build();
 
-        assertBlockIsValid(actual, sizeInBytes, type, inputs);
+        assertBlockIsValid(actual, sizeInBytes, type.getType(), inputs);
         // verify positionsAppender reset
         assertEquals(positionsAppender.getSizeInBytes(), 0);
         assertEquals(positionsAppender.getRetainedSizeInBytes(), initialRetainedSize);
@@ -437,6 +421,48 @@ public class TestPositionsAppender
         return blockBuilder.build();
     }
 
+    private enum TestType
+    {
+        BIGINT(BigintType.BIGINT),
+        BOOLEAN(BooleanType.BOOLEAN),
+        INTEGER(IntegerType.INTEGER),
+        CHAR_10(createCharType(10)),
+        VARCHAR(createUnboundedVarcharType()),
+        DOUBLE(DoubleType.DOUBLE),
+        SMALLINT(SmallintType.SMALLINT),
+        TINYINT(TinyintType.TINYINT),
+        VARBINARY(VarbinaryType.VARBINARY),
+        LONG_DECIMAL(createDecimalType(Decimals.MAX_SHORT_PRECISION + 1)),
+        LONG_TIMESTAMP(createTimestampType(9)),
+        ROW_BIGINT_VARCHAR(anonymousRow(BigintType.BIGINT, VarcharType.VARCHAR)),
+        ARRAY_BIGINT(new ArrayType(BigintType.BIGINT)),
+        VARCHAR_WITH_TEST_BLOCK(VarcharType.VARCHAR, TestVariableWidthBlock.adaptation());
+
+        private final Type type;
+        private final Function<Block, Block> blockAdaptation;
+
+        TestType(Type type)
+        {
+            this(type, Function.identity());
+        }
+
+        TestType(Type type, Function<Block, Block> blockAdaptation)
+        {
+            this.type = requireNonNull(type, "type is null");
+            this.blockAdaptation = requireNonNull(blockAdaptation, "blockAdaptation is null");
+        }
+
+        public Block adapt(Block block)
+        {
+            return blockAdaptation.apply(block);
+        }
+
+        public Type getType()
+        {
+            return type;
+        }
+    }
+
     private static class BlockView
     {
         private final Block block;
@@ -461,6 +487,162 @@ public class TestPositionsAppender
         public void appendTo(PositionsAppender positionsAppender)
         {
             positionsAppender.append(getPositions(), getBlock());
+        }
+    }
+
+    private static class TestVariableWidthBlock
+            extends AbstractVariableWidthBlock
+    {
+        private final int arrayOffset;
+        private final int positionCount;
+        private final Slice slice;
+        private final int[] offsets;
+        @Nullable
+        private final boolean[] valueIsNull;
+
+        private static Function<Block, Block> adaptation()
+        {
+            return TestVariableWidthBlock::adapt;
+        }
+
+        private static Block adapt(Block block)
+        {
+            if (block instanceof RunLengthEncodedBlock) {
+                checkArgument(block.getPositionCount() == 0 || block.isNull(0));
+                return new RunLengthEncodedBlock(new TestVariableWidthBlock(0, 1, EMPTY_SLICE, new int[] {0, 0}, new boolean[] {true}), block.getPositionCount());
+            }
+
+            int[] offsets = new int[block.getPositionCount() + 1];
+            boolean[] valueIsNull = new boolean[block.getPositionCount()];
+            boolean hasNullValue = false;
+            for (int i = 0; i < block.getPositionCount(); i++) {
+                if (block.isNull(i)) {
+                    valueIsNull[i] = true;
+                    hasNullValue = true;
+                    offsets[i + 1] = offsets[i];
+                }
+                else {
+                    offsets[i + 1] = offsets[i] + block.getSliceLength(i);
+                }
+            }
+
+            return new TestVariableWidthBlock(0, block.getPositionCount(), ((VariableWidthBlock) block).getRawSlice(), offsets, hasNullValue ? valueIsNull : null);
+        }
+
+        private TestVariableWidthBlock(int arrayOffset, int positionCount, Slice slice, int[] offsets, boolean[] valueIsNull)
+        {
+            checkArgument(arrayOffset >= 0);
+            this.arrayOffset = arrayOffset;
+            checkArgument(positionCount >= 0);
+            this.positionCount = positionCount;
+            this.slice = requireNonNull(slice, "slice is null");
+            this.offsets = offsets;
+            this.valueIsNull = valueIsNull;
+        }
+
+        @Override
+        protected Slice getRawSlice(int position)
+        {
+            return slice;
+        }
+
+        @Override
+        protected int getPositionOffset(int position)
+        {
+            return offsets[position + arrayOffset];
+        }
+
+        @Override
+        public int getSliceLength(int position)
+        {
+            return getPositionOffset(position + 1) - getPositionOffset(position);
+        }
+
+        @Override
+        protected boolean isEntryNull(int position)
+        {
+            return valueIsNull != null && valueIsNull[position + arrayOffset];
+        }
+
+        @Override
+        public int getPositionCount()
+        {
+            return positionCount;
+        }
+
+        @Override
+        public Block getRegion(int positionOffset, int length)
+        {
+            return new TestVariableWidthBlock(positionOffset + arrayOffset, length, slice, offsets, valueIsNull);
+        }
+
+        @Override
+        public Block getSingleValueBlock(int position)
+        {
+            if (isNull(position)) {
+                return new TestVariableWidthBlock(0, 1, EMPTY_SLICE, new int[] {0, 0}, new boolean[] {true});
+            }
+
+            int offset = getPositionOffset(position);
+            int entrySize = getSliceLength(position);
+
+            Slice copy = Slices.copyOf(getRawSlice(position), offset, entrySize);
+
+            return new TestVariableWidthBlock(0, 1, copy, new int[] {0, copy.length()}, null);
+        }
+
+        @Override
+        public long getSizeInBytes()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long getRegionSizeInBytes(int position, int length)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public OptionalInt fixedSizeInBytesPerPosition()
+        {
+            return OptionalInt.empty();
+        }
+
+        @Override
+        public long getPositionsSizeInBytes(boolean[] positions, int selectedPositionsCount)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long getRetainedSizeInBytes()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Block copyPositions(int[] positions, int offset, int length)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Block copyRegion(int position, int length)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Block copyWithAppendedNull()
+        {
+            throw new UnsupportedOperationException();
         }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestSlicePositionsAppender.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestSlicePositionsAppender.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.output;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.spi.block.VariableWidthBlock;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static io.trino.block.BlockAssertions.assertBlockEquals;
+import static io.trino.block.BlockAssertions.createStringsBlock;
+import static io.trino.operator.output.SlicePositionsAppender.duplicateBytes;
+import static io.trino.spi.block.PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static org.testng.internal.junit.ArrayAsserts.assertArrayEquals;
+
+public class TestSlicePositionsAppender
+{
+    @Test
+    public void testAppendEmptySliceRle()
+    {
+        // test SlicePositionAppender.appendRle with empty value (Slice with length 0)
+        PositionsAppender positionsAppender = new SlicePositionsAppender(1, 100);
+        RunLengthEncodedBlock rleBlock = new RunLengthEncodedBlock(createStringsBlock(""), 10);
+        positionsAppender.appendRle(rleBlock);
+
+        Block actualBlock = positionsAppender.build();
+
+        assertBlockEquals(VARCHAR, actualBlock, rleBlock);
+    }
+
+    // test append with VariableWidthBlock using Slice not backed by byte array
+    // to test special handling in SlicePositionsAppender.copyBytes
+    @Test
+    public void testAppendSliceNotBackedByByteArray()
+    {
+        PositionsAppender positionsAppender = new SlicePositionsAppender(1, DEFAULT_MAX_PAGE_SIZE_IN_BYTES);
+        Block block = new VariableWidthBlock(3, Slices.wrappedLongArray(257, 2), new int[] {0, 1, Long.BYTES, 2 * Long.BYTES}, Optional.empty());
+        positionsAppender.append(IntArrayList.wrap(new int[] {0, 2}), block);
+
+        Block actual = positionsAppender.build();
+
+        Block expected = new VariableWidthBlock(
+                2,
+                Slices.wrappedBuffer(new byte[] {1, 2, 0, 0, 0, 0, 0, 0, 0}),
+                new int[] {0, 1, Long.BYTES + 1},
+                Optional.empty());
+        assertBlockEquals(VARCHAR, actual, expected);
+    }
+
+    @Test
+    public void testDuplicateZeroLength()
+    {
+        Slice slice = Slices.wrappedBuffer();
+        byte[] target = new byte[] {-1};
+        duplicateBytes(slice, target, 0, 100);
+        assertArrayEquals(new byte[] {-1}, target);
+    }
+
+    @Test
+    public void testDuplicate1Byte()
+    {
+        Slice slice = Slices.wrappedBuffer(new byte[] {2});
+        byte[] target = new byte[5];
+        Arrays.fill(target, (byte) -1);
+        duplicateBytes(slice, target, 3, 2);
+        assertArrayEquals(new byte[] {-1, -1, -1, 2, 2}, target);
+    }
+
+    @Test
+    public void testDuplicate2Bytes()
+    {
+        Slice slice = Slices.wrappedBuffer(new byte[] {1, 2});
+        byte[] target = new byte[8];
+        Arrays.fill(target, (byte) -1);
+        duplicateBytes(slice, target, 1, 3);
+        assertArrayEquals(new byte[] {-1, 1, 2, 1, 2, 1, 2, -1}, target);
+    }
+
+    @Test
+    public void testDuplicate1Time()
+    {
+        Slice slice = Slices.wrappedBuffer(new byte[] {1, 2});
+        byte[] target = new byte[8];
+        Arrays.fill(target, (byte) -1);
+
+        duplicateBytes(slice, target, 1, 1);
+
+        assertArrayEquals(new byte[] {-1, 1, 2, -1, -1, -1, -1, -1}, target);
+    }
+
+    @Test
+    public void testDuplicateMultipleBytesOffNumberOfTimes()
+    {
+        Slice slice = Slices.wrappedBuffer(new byte[] {5, 3, 1});
+        byte[] target = new byte[17];
+        Arrays.fill(target, (byte) -1);
+
+        duplicateBytes(slice, target, 1, 5);
+
+        assertArrayEquals(new byte[] {-1, 5, 3, 1, 5, 3, 1, 5, 3, 1, 5, 3, 1, 5, 3, 1, -1}, target);
+    }
+
+    @Test
+    public void testDuplicateMultipleBytesEvenNumberOfTimes()
+    {
+        Slice slice = Slices.wrappedBuffer(new byte[] {5, 3, 1});
+        byte[] target = new byte[20];
+        Arrays.fill(target, (byte) -1);
+
+        duplicateBytes(slice, target, 1, 6);
+
+        assertArrayEquals(new byte[] {-1, 5, 3, 1, 5, 3, 1, 5, 3, 1, 5, 3, 1, 5, 3, 1, 5, 3, 1, -1}, target);
+    }
+
+    @Test
+    public void testDuplicateMultipleBytesPowerOfTwoNumberOfTimes()
+    {
+        Slice slice = Slices.wrappedBuffer(new byte[] {5, 3, 1});
+        byte[] target = new byte[14];
+        Arrays.fill(target, (byte) -1);
+
+        duplicateBytes(slice, target, 1, 4);
+
+        assertArrayEquals(new byte[] {-1, 5, 3, 1, 5, 3, 1, 5, 3, 1, 5, 3, 1, -1}, target);
+    }
+}

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -193,6 +193,10 @@
                                     <code>java.field.removed</code>
                                     <old>field io.trino.spi.expression.StandardFunctions.LIKE_PATTERN_FUNCTION_NAME</old>
                                 </item>
+                                <item>
+                                    <code>java.method.returnTypeChanged</code>
+                                    <new>method io.trino.spi.block.Block io.trino.spi.block.ArrayBlockBuilder::build()</new>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlock.java
@@ -85,6 +85,23 @@ public class VariableWidthBlock
         retainedSizeInBytes = INSTANCE_SIZE + slice.getRetainedSize() + sizeOf(valueIsNull) + sizeOf(offsets);
     }
 
+    /**
+     * Gets the raw {@link Slice} that keeps the actual data bytes.
+     */
+    public Slice getRawSlice()
+    {
+        return slice;
+    }
+
+    /**
+     * Gets the offset of the value at the {@code position} in the {@link Slice} returned by {@link #getRawSlice())}.
+     */
+    public int getRawSliceOffset(int position)
+    {
+        checkReadablePosition(this, position);
+        return getPositionOffset(position);
+    }
+
     @Override
     protected final int getPositionOffset(int position)
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
Improve performance of `SlicePositionsAppender`.
The improvement comes from not allocating `Slice` per position + using `System.arrayCopy` directly instead of `Slice.getBytes`

> Is this change a fix, improvement, new feature, refactoring, or other?

performance improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core query engine (partitioned exchange) and SPI extension

> How would you describe this change to a non-technical end user or system administrator?

Improve performance of remote partitioned exchange

### Benchamrks
#### jmh
about 30% improvement
```
Before
Benchmark                                   (channelCount)  (enableCompression)  (nullRate)  (partitionCount)  (positionCount)   (type)  Mode  Cnt     Score     Error  Units
BenchmarkPartitionedOutputOperator.addPage               1                false           0                16             8192  VARCHAR  avgt   20  2137.367 ± 166.834  ms/op
BenchmarkPartitionedOutputOperator.addPage               1                false         0.2                16             8192  VARCHAR  avgt   20  1660.550 ±  24.274  ms/op

After
BenchmarkPartitionedOutputOperator.addPage               1                false           0                16             8192  VARCHAR  avgt   20  1399.476 ± 181.301  ms/op
BenchmarkPartitionedOutputOperator.addPage               1                false         0.2                16             8192  VARCHAR  avgt   20  1194.077 ± 160.496  ms/op
```

#### tpch/tpcds
![image](https://user-images.githubusercontent.com/8080198/173786440-1a0ba4f7-9266-4f0b-b15e-73369f2bc682.png)
Overall there is a small improvement. This is expected as `PartitionedOutputOperator` is only around 5% of total CPU time and this pr only improves varchars.
When looking at the `PartitionedOutputOperator` stats only, the improvement is ~10%.
```
Before
Total: 980917.6656576941
PartitionedOutputOperator: 43522.99081258998, 0.044369667645253706%
After
Total: 974919.225831081
PartitionedOutputOperator: 38515.177167889924, 0.03950601870124904%
```
[poo-slice-orc-part-sf1K.pdf](https://github.com/trinodb/trino/files/8907614/poo-slice-orc-part-sf1K.pdf)

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Section
* Improve performance of remote partitioned exchange on string data types. ({issue}`12798`)
```
