### PR TITLE
Allow drop materialized view without storage table

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -179,6 +179,10 @@ public final class IcebergUtil
     public static Map<String, Object> getIcebergTableProperties(Table icebergTable)
     {
         ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
+        if (icebergTable == null) {
+            return properties.buildOrThrow();
+        }
+
         properties.put(FILE_FORMAT_PROPERTY, getFileFormat(icebergTable));
         if (!icebergTable.spec().fields().isEmpty()) {
             properties.put(PARTITIONING_PROPERTY, toPartitionFields(icebergTable.spec()));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
@@ -81,6 +81,7 @@ public abstract class AbstractTrinoCatalog
     protected static final String PRESTO_VERSION_NAME = HiveMetadata.PRESTO_VERSION_NAME;
     protected static final String PRESTO_QUERY_ID_NAME = HiveMetadata.PRESTO_QUERY_ID_NAME;
     protected static final String PRESTO_VIEW_EXPANDED_TEXT_MARKER = HiveMetadata.PRESTO_VIEW_EXPANDED_TEXT_MARKER;
+    protected static final String STORAGE_TABLE_PREFIX = "st_";
 
     private final CatalogName catalogName;
     private final TypeManager typeManager;
@@ -258,7 +259,7 @@ public abstract class AbstractTrinoCatalog
     {
         // Generate a storage table name and create a storage table. The properties in the definition are table properties for the
         // storage table as indicated in the materialized view definition.
-        String storageTableName = "st_" + randomUUID().toString().replace("-", "");
+        String storageTableName = STORAGE_TABLE_PREFIX + randomUUID().toString().replace("-", "");
         Map<String, Object> storageTableProperties = new HashMap<>(definition.getProperties());
         storageTableProperties.putIfAbsent(FILE_FORMAT_PROPERTY, DEFAULT_FILE_FORMAT_DEFAULT);
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
@@ -506,6 +506,16 @@ public abstract class BaseIcebergMaterializedViewTest
     }
 
     @Test
+    public void testDropMaterializedViewWithoutStorageTable()
+    {
+        assertUpdate("CREATE MATERIALIZED VIEW test_drop_materialized_view_without_storage_table AS SELECT * FROM base_table1");
+        String catalogName = getSession().getCatalog().orElseThrow();
+        SchemaTableName storageTable = getStorageTable(catalogName, "test_drop_materialized_view_without_storage_table");
+        assertUpdate(format("DROP TABLE %s", storageTable.getTableName()));
+        assertUpdate("DROP MATERIALIZED VIEW test_drop_materialized_view_without_storage_table");
+    }
+
+    @Test
     public void testRenameMaterializedViewCannotRenameTable()
     {
         assertUpdate("CREATE TABLE test_rename_materialized_view_cannot_rename_table (a INT, b INT)");


### PR DESCRIPTION
allowing user to drop the materialized view instead of
failing after storage table externally dropped
and logging the missing storage table

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
fix
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
iceberg connector
> How would you describe this change to a non-technical end user or system administrator?
allowing user to drop the materialized view instead of failing after storage table externally dropped and logging the missing storage table
## Related issues, pull requests, and links
fixes [12503](https://github.com/trinodb/trino/issues/12503)

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(X) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Allow drop materialized view without storage table. ({issue}`12503`)
```
