### PR TITLE
Convert connector service managers to pull model

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/CatalogServiceProvider.java
+++ b/core/trino-main/src/main/java/io/trino/connector/CatalogServiceProvider.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.connector;
+
+import javax.validation.constraints.NotNull;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public interface CatalogServiceProvider<T>
+{
+    static <T> CatalogServiceProvider<T> fail()
+    {
+        return fail("Not supported");
+    }
+
+    static <T> CatalogServiceProvider<T> fail(String message)
+    {
+        return catalogName -> {
+            throw new IllegalStateException(message);
+        };
+    }
+
+    static <T> CatalogServiceProvider<T> singleton(CatalogName name, T value)
+    {
+        return catalogName -> {
+            checkArgument(catalogName.equals(name));
+            return value;
+        };
+    }
+
+    @NotNull
+    T getService(CatalogName catalogName);
+}

--- a/core/trino-main/src/main/java/io/trino/connector/CatalogServiceProviderModule.java
+++ b/core/trino-main/src/main/java/io/trino/connector/CatalogServiceProviderModule.java
@@ -17,9 +17,14 @@ import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Provides;
 import io.trino.connector.ConnectorManager.ConnectorServices;
+import io.trino.metadata.AnalyzePropertyManager;
 import io.trino.metadata.CatalogProcedures;
 import io.trino.metadata.CatalogTableFunctions;
 import io.trino.metadata.CatalogTableProcedures;
+import io.trino.metadata.ColumnPropertyManager;
+import io.trino.metadata.MaterializedViewPropertyManager;
+import io.trino.metadata.SchemaPropertyManager;
+import io.trino.metadata.TablePropertyManager;
 import io.trino.spi.connector.ConnectorIndexProvider;
 import io.trino.spi.connector.ConnectorNodePartitioningProvider;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
@@ -88,5 +93,38 @@ public class CatalogServiceProviderModule
     public static CatalogServiceProvider<CatalogTableFunctions> createTableFunctionProvider(ConnectorServicesProvider connectorServicesProvider)
     {
         return new ConnectorCatalogServiceProvider<>("table functions", connectorServicesProvider, ConnectorServices::getTableFunctions);
+    }
+
+    public static SchemaPropertyManager createSchemaPropertyManager(ConnectorServicesProvider connectorServicesProvider)
+    {
+        return new SchemaPropertyManager(new ConnectorCatalogServiceProvider<>("schema properties", connectorServicesProvider, ConnectorServices::getSchemaProperties));
+    }
+
+    @Provides
+    @Singleton
+    public static ColumnPropertyManager createColumnPropertyManager(ConnectorServicesProvider connectorServicesProvider)
+    {
+        return new ColumnPropertyManager(new ConnectorCatalogServiceProvider<>("column properties", connectorServicesProvider, ConnectorServices::getColumnProperties));
+    }
+
+    @Provides
+    @Singleton
+    public static TablePropertyManager createTablePropertyManager(ConnectorServicesProvider connectorServicesProvider)
+    {
+        return new TablePropertyManager(new ConnectorCatalogServiceProvider<>("table properties", connectorServicesProvider, ConnectorServices::getTableProperties));
+    }
+
+    @Provides
+    @Singleton
+    public static MaterializedViewPropertyManager createMaterializedViewPropertyManager(ConnectorServicesProvider connectorServicesProvider)
+    {
+        return new MaterializedViewPropertyManager(new ConnectorCatalogServiceProvider<>("materialized view properties", connectorServicesProvider, ConnectorServices::getMaterializedViewProperties));
+    }
+
+    @Provides
+    @Singleton
+    public static AnalyzePropertyManager createAnalyzePropertyManager(ConnectorServicesProvider connectorServicesProvider)
+    {
+        return new AnalyzePropertyManager(new ConnectorCatalogServiceProvider<>("analyze properties", connectorServicesProvider, ConnectorServices::getAnalyzeProperties));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/connector/CatalogServiceProviderModule.java
+++ b/core/trino-main/src/main/java/io/trino/connector/CatalogServiceProviderModule.java
@@ -18,6 +18,7 @@ import com.google.inject.Module;
 import com.google.inject.Provides;
 import io.trino.connector.ConnectorManager.ConnectorServices;
 import io.trino.metadata.CatalogProcedures;
+import io.trino.metadata.CatalogTableFunctions;
 import io.trino.metadata.CatalogTableProcedures;
 import io.trino.spi.connector.ConnectorIndexProvider;
 import io.trino.spi.connector.ConnectorNodePartitioningProvider;
@@ -80,5 +81,12 @@ public class CatalogServiceProviderModule
     public static CatalogServiceProvider<CatalogTableProcedures> createTableProceduresProvider(ConnectorServicesProvider connectorServicesProvider)
     {
         return new ConnectorCatalogServiceProvider<>("table procedures", connectorServicesProvider, ConnectorServices::getTableProcedures);
+    }
+
+    @Provides
+    @Singleton
+    public static CatalogServiceProvider<CatalogTableFunctions> createTableFunctionProvider(ConnectorServicesProvider connectorServicesProvider)
+    {
+        return new ConnectorCatalogServiceProvider<>("table functions", connectorServicesProvider, ConnectorServices::getTableFunctions);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/connector/CatalogServiceProviderModule.java
+++ b/core/trino-main/src/main/java/io/trino/connector/CatalogServiceProviderModule.java
@@ -16,6 +16,7 @@ package io.trino.connector;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Provides;
+import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorPageSourceProvider;
 import io.trino.spi.connector.ConnectorSplitManager;
 
@@ -39,5 +40,12 @@ public class CatalogServiceProviderModule
     public static CatalogServiceProvider<ConnectorPageSourceProvider> createPageSourceProvider(ConnectorServicesProvider connectorServicesProvider)
     {
         return new ConnectorCatalogServiceProvider<>("page source provider", connectorServicesProvider, connector -> connector.getPageSourceProvider().orElse(null));
+    }
+
+    @Provides
+    @Singleton
+    public static CatalogServiceProvider<ConnectorPageSinkProvider> createPageSinkProvider(ConnectorServicesProvider connectorServicesProvider)
+    {
+        return new ConnectorCatalogServiceProvider<>("page sink provider", connectorServicesProvider, connector -> connector.getPageSinkProvider().orElse(null));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/connector/CatalogServiceProviderModule.java
+++ b/core/trino-main/src/main/java/io/trino/connector/CatalogServiceProviderModule.java
@@ -17,6 +17,7 @@ import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Provides;
 import io.trino.spi.connector.ConnectorIndexProvider;
+import io.trino.spi.connector.ConnectorNodePartitioningProvider;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorPageSourceProvider;
 import io.trino.spi.connector.ConnectorSplitManager;
@@ -55,5 +56,12 @@ public class CatalogServiceProviderModule
     public static CatalogServiceProvider<ConnectorIndexProvider> createIndexProvider(ConnectorServicesProvider connectorServicesProvider)
     {
         return new ConnectorCatalogServiceProvider<>("index provider", connectorServicesProvider, connector -> connector.getIndexProvider().orElse(null));
+    }
+
+    @Provides
+    @Singleton
+    public static CatalogServiceProvider<ConnectorNodePartitioningProvider> createNodePartitioningProvider(ConnectorServicesProvider connectorServicesProvider)
+    {
+        return new ConnectorCatalogServiceProvider<>("node partitioning provider", connectorServicesProvider, connector -> connector.getPartitioningProvider().orElse(null));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/connector/CatalogServiceProviderModule.java
+++ b/core/trino-main/src/main/java/io/trino/connector/CatalogServiceProviderModule.java
@@ -16,6 +16,7 @@ package io.trino.connector;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Provides;
+import io.trino.spi.connector.ConnectorPageSourceProvider;
 import io.trino.spi.connector.ConnectorSplitManager;
 
 import javax.inject.Singleton;
@@ -31,5 +32,12 @@ public class CatalogServiceProviderModule
     public static CatalogServiceProvider<ConnectorSplitManager> createSplitManagerProvider(ConnectorServicesProvider connectorServicesProvider)
     {
         return new ConnectorCatalogServiceProvider<>("split manager", connectorServicesProvider, connector -> connector.getSplitManager().orElse(null));
+    }
+
+    @Provides
+    @Singleton
+    public static CatalogServiceProvider<ConnectorPageSourceProvider> createPageSourceProvider(ConnectorServicesProvider connectorServicesProvider)
+    {
+        return new ConnectorCatalogServiceProvider<>("page source provider", connectorServicesProvider, connector -> connector.getPageSourceProvider().orElse(null));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/connector/CatalogServiceProviderModule.java
+++ b/core/trino-main/src/main/java/io/trino/connector/CatalogServiceProviderModule.java
@@ -16,6 +16,9 @@ package io.trino.connector;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Provides;
+import io.trino.connector.ConnectorManager.ConnectorServices;
+import io.trino.metadata.CatalogProcedures;
+import io.trino.metadata.CatalogTableProcedures;
 import io.trino.spi.connector.ConnectorIndexProvider;
 import io.trino.spi.connector.ConnectorNodePartitioningProvider;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
@@ -63,5 +66,19 @@ public class CatalogServiceProviderModule
     public static CatalogServiceProvider<ConnectorNodePartitioningProvider> createNodePartitioningProvider(ConnectorServicesProvider connectorServicesProvider)
     {
         return new ConnectorCatalogServiceProvider<>("node partitioning provider", connectorServicesProvider, connector -> connector.getPartitioningProvider().orElse(null));
+    }
+
+    @Provides
+    @Singleton
+    public static CatalogServiceProvider<CatalogProcedures> createProceduresProvider(ConnectorServicesProvider connectorServicesProvider)
+    {
+        return new ConnectorCatalogServiceProvider<>("procedures", connectorServicesProvider, ConnectorServices::getProcedures);
+    }
+
+    @Provides
+    @Singleton
+    public static CatalogServiceProvider<CatalogTableProcedures> createTableProceduresProvider(ConnectorServicesProvider connectorServicesProvider)
+    {
+        return new ConnectorCatalogServiceProvider<>("table procedures", connectorServicesProvider, ConnectorServices::getTableProcedures);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/connector/CatalogServiceProviderModule.java
+++ b/core/trino-main/src/main/java/io/trino/connector/CatalogServiceProviderModule.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.connector;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+
+public class CatalogServiceProviderModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder) {}
+}

--- a/core/trino-main/src/main/java/io/trino/connector/CatalogServiceProviderModule.java
+++ b/core/trino-main/src/main/java/io/trino/connector/CatalogServiceProviderModule.java
@@ -26,6 +26,7 @@ import io.trino.metadata.ColumnPropertyManager;
 import io.trino.metadata.MaterializedViewPropertyManager;
 import io.trino.metadata.SchemaPropertyManager;
 import io.trino.metadata.SessionPropertyManager;
+import io.trino.metadata.TableProceduresPropertyManager;
 import io.trino.metadata.TablePropertyManager;
 import io.trino.spi.connector.ConnectorIndexProvider;
 import io.trino.spi.connector.ConnectorNodePartitioningProvider;
@@ -139,5 +140,12 @@ public class CatalogServiceProviderModule
     public static AnalyzePropertyManager createAnalyzePropertyManager(ConnectorServicesProvider connectorServicesProvider)
     {
         return new AnalyzePropertyManager(new ConnectorCatalogServiceProvider<>("analyze properties", connectorServicesProvider, ConnectorServices::getAnalyzeProperties));
+    }
+
+    @Provides
+    @Singleton
+    public static TableProceduresPropertyManager createTableProceduresPropertyManager(ConnectorServicesProvider connectorServicesProvider)
+    {
+        return new TableProceduresPropertyManager(new ConnectorCatalogServiceProvider<>("table procedures", connectorServicesProvider, ConnectorServices::getTableProcedures));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/connector/CatalogServiceProviderModule.java
+++ b/core/trino-main/src/main/java/io/trino/connector/CatalogServiceProviderModule.java
@@ -16,6 +16,7 @@ package io.trino.connector;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Provides;
+import io.trino.SystemSessionPropertiesProvider;
 import io.trino.connector.ConnectorManager.ConnectorServices;
 import io.trino.metadata.AnalyzePropertyManager;
 import io.trino.metadata.CatalogProcedures;
@@ -24,6 +25,7 @@ import io.trino.metadata.CatalogTableProcedures;
 import io.trino.metadata.ColumnPropertyManager;
 import io.trino.metadata.MaterializedViewPropertyManager;
 import io.trino.metadata.SchemaPropertyManager;
+import io.trino.metadata.SessionPropertyManager;
 import io.trino.metadata.TablePropertyManager;
 import io.trino.spi.connector.ConnectorIndexProvider;
 import io.trino.spi.connector.ConnectorNodePartitioningProvider;
@@ -32,6 +34,8 @@ import io.trino.spi.connector.ConnectorPageSourceProvider;
 import io.trino.spi.connector.ConnectorSplitManager;
 
 import javax.inject.Singleton;
+
+import java.util.Set;
 
 public class CatalogServiceProviderModule
         implements Module
@@ -95,6 +99,15 @@ public class CatalogServiceProviderModule
         return new ConnectorCatalogServiceProvider<>("table functions", connectorServicesProvider, ConnectorServices::getTableFunctions);
     }
 
+    @Provides
+    @Singleton
+    public static SessionPropertyManager createSessionPropertyManager(Set<SystemSessionPropertiesProvider> systemSessionProperties, ConnectorServicesProvider connectorServicesProvider)
+    {
+        return new SessionPropertyManager(systemSessionProperties, new ConnectorCatalogServiceProvider<>("session properties", connectorServicesProvider, ConnectorServices::getSessionProperties));
+    }
+
+    @Provides
+    @Singleton
     public static SchemaPropertyManager createSchemaPropertyManager(ConnectorServicesProvider connectorServicesProvider)
     {
         return new SchemaPropertyManager(new ConnectorCatalogServiceProvider<>("schema properties", connectorServicesProvider, ConnectorServices::getSchemaProperties));

--- a/core/trino-main/src/main/java/io/trino/connector/CatalogServiceProviderModule.java
+++ b/core/trino-main/src/main/java/io/trino/connector/CatalogServiceProviderModule.java
@@ -15,10 +15,21 @@ package io.trino.connector;
 
 import com.google.inject.Binder;
 import com.google.inject.Module;
+import com.google.inject.Provides;
+import io.trino.spi.connector.ConnectorSplitManager;
+
+import javax.inject.Singleton;
 
 public class CatalogServiceProviderModule
         implements Module
 {
     @Override
     public void configure(Binder binder) {}
+
+    @Provides
+    @Singleton
+    public static CatalogServiceProvider<ConnectorSplitManager> createSplitManagerProvider(ConnectorServicesProvider connectorServicesProvider)
+    {
+        return new ConnectorCatalogServiceProvider<>("split manager", connectorServicesProvider, connector -> connector.getSplitManager().orElse(null));
+    }
 }

--- a/core/trino-main/src/main/java/io/trino/connector/CatalogServiceProviderModule.java
+++ b/core/trino-main/src/main/java/io/trino/connector/CatalogServiceProviderModule.java
@@ -16,6 +16,7 @@ package io.trino.connector;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Provides;
+import io.trino.spi.connector.ConnectorIndexProvider;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorPageSourceProvider;
 import io.trino.spi.connector.ConnectorSplitManager;
@@ -47,5 +48,12 @@ public class CatalogServiceProviderModule
     public static CatalogServiceProvider<ConnectorPageSinkProvider> createPageSinkProvider(ConnectorServicesProvider connectorServicesProvider)
     {
         return new ConnectorCatalogServiceProvider<>("page sink provider", connectorServicesProvider, connector -> connector.getPageSinkProvider().orElse(null));
+    }
+
+    @Provides
+    @Singleton
+    public static CatalogServiceProvider<ConnectorIndexProvider> createIndexProvider(ConnectorServicesProvider connectorServicesProvider)
+    {
+        return new ConnectorCatalogServiceProvider<>("index provider", connectorServicesProvider, connector -> connector.getIndexProvider().orElse(null));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/connector/ConnectorCatalogServiceProvider.java
+++ b/core/trino-main/src/main/java/io/trino/connector/ConnectorCatalogServiceProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.connector;
+
+import io.trino.connector.ConnectorManager.ConnectorServices;
+
+import java.util.function.Function;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class ConnectorCatalogServiceProvider<T>
+        implements CatalogServiceProvider<T>
+{
+    private final String name;
+    private final ConnectorServicesProvider connectorServicesProvider;
+    private final Function<ConnectorServices, T> serviceGetter;
+
+    public ConnectorCatalogServiceProvider(String name, ConnectorServicesProvider connectorServicesProvider, Function<ConnectorServices, T> serviceGetter)
+    {
+        this.name = requireNonNull(name, "name is null");
+        this.connectorServicesProvider = requireNonNull(connectorServicesProvider, "connectorServicesProvider is null");
+        this.serviceGetter = requireNonNull(serviceGetter, "serviceGetter is null");
+    }
+
+    @Override
+    public T getService(CatalogName catalogName)
+    {
+        ConnectorServices connectorServices = connectorServicesProvider.getConnectorServices(catalogName);
+        T result = serviceGetter.apply(connectorServices);
+        checkArgument(result != null, "Catalog '%s' does not have a %s", catalogName, name);
+        return result;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/connector/ConnectorManager.java
+++ b/core/trino-main/src/main/java/io/trino/connector/ConnectorManager.java
@@ -66,7 +66,6 @@ import io.trino.spi.ptf.ConnectorTableFunction;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.type.TypeManager;
 import io.trino.split.PageSinkManager;
-import io.trino.split.PageSourceManager;
 import io.trino.split.RecordPageSourceProvider;
 import io.trino.sql.planner.NodePartitioningManager;
 import io.trino.transaction.TransactionManager;
@@ -105,7 +104,6 @@ public class ConnectorManager
     private final Metadata metadata;
     private final CatalogManager catalogManager;
     private final AccessControlManager accessControlManager;
-    private final PageSourceManager pageSourceManager;
     private final IndexManager indexManager;
     private final NodePartitioningManager nodePartitioningManager;
 
@@ -145,7 +143,6 @@ public class ConnectorManager
             Metadata metadata,
             CatalogManager catalogManager,
             AccessControlManager accessControlManager,
-            PageSourceManager pageSourceManager,
             IndexManager indexManager,
             NodePartitioningManager nodePartitioningManager,
             PageSinkManager pageSinkManager,
@@ -173,7 +170,6 @@ public class ConnectorManager
         this.metadata = metadata;
         this.catalogManager = catalogManager;
         this.accessControlManager = accessControlManager;
-        this.pageSourceManager = pageSourceManager;
         this.indexManager = indexManager;
         this.nodePartitioningManager = nodePartitioningManager;
         this.pageSinkManager = pageSinkManager;
@@ -322,9 +318,6 @@ public class ConnectorManager
         checkState(!connectors.containsKey(catalogName), "Catalog '%s' already exists", catalogName);
         connectors.put(catalogName, connector);
 
-        connector.getPageSourceProvider()
-                .ifPresent(pageSourceProvider -> pageSourceManager.addConnectorPageSourceProvider(catalogName, pageSourceProvider));
-
         connector.getPageSinkProvider()
                 .ifPresent(pageSinkProvider -> pageSinkManager.addConnectorPageSinkProvider(catalogName, pageSinkProvider));
 
@@ -355,7 +348,6 @@ public class ConnectorManager
 
     private synchronized void removeConnectorInternal(CatalogName catalogName)
     {
-        pageSourceManager.removeConnectorPageSourceProvider(catalogName);
         pageSinkManager.removeConnectorPageSinkProvider(catalogName);
         indexManager.removeIndexProvider(catalogName);
         nodePartitioningManager.removePartitioningProvider(catalogName);

--- a/core/trino-main/src/main/java/io/trino/connector/ConnectorManager.java
+++ b/core/trino-main/src/main/java/io/trino/connector/ConnectorManager.java
@@ -24,7 +24,6 @@ import io.trino.connector.system.SystemConnector;
 import io.trino.connector.system.SystemTablesProvider;
 import io.trino.eventlistener.EventListenerManager;
 import io.trino.execution.scheduler.NodeSchedulerConfig;
-import io.trino.index.IndexManager;
 import io.trino.metadata.AnalyzePropertyManager;
 import io.trino.metadata.Catalog;
 import io.trino.metadata.CatalogManager;
@@ -103,7 +102,6 @@ public class ConnectorManager
     private final Metadata metadata;
     private final CatalogManager catalogManager;
     private final AccessControlManager accessControlManager;
-    private final IndexManager indexManager;
     private final NodePartitioningManager nodePartitioningManager;
 
     private final HandleResolver handleResolver;
@@ -141,7 +139,6 @@ public class ConnectorManager
             Metadata metadata,
             CatalogManager catalogManager,
             AccessControlManager accessControlManager,
-            IndexManager indexManager,
             NodePartitioningManager nodePartitioningManager,
             HandleResolver handleResolver,
             InternalNodeManager nodeManager,
@@ -167,7 +164,6 @@ public class ConnectorManager
         this.metadata = metadata;
         this.catalogManager = catalogManager;
         this.accessControlManager = accessControlManager;
-        this.indexManager = indexManager;
         this.nodePartitioningManager = nodePartitioningManager;
         this.handleResolver = handleResolver;
         this.nodeManager = nodeManager;
@@ -314,9 +310,6 @@ public class ConnectorManager
         checkState(!connectors.containsKey(catalogName), "Catalog '%s' already exists", catalogName);
         connectors.put(catalogName, connector);
 
-        connector.getIndexProvider()
-                .ifPresent(indexProvider -> indexManager.addIndexProvider(catalogName, indexProvider));
-
         connector.getPartitioningProvider()
                 .ifPresent(partitioningProvider -> nodePartitioningManager.addPartitioningProvider(catalogName, partitioningProvider));
 
@@ -341,7 +334,6 @@ public class ConnectorManager
 
     private synchronized void removeConnectorInternal(CatalogName catalogName)
     {
-        indexManager.removeIndexProvider(catalogName);
         nodePartitioningManager.removePartitioningProvider(catalogName);
         procedureRegistry.removeProcedures(catalogName);
         tableProceduresRegistry.removeProcedures(catalogName);

--- a/core/trino-main/src/main/java/io/trino/connector/ConnectorManager.java
+++ b/core/trino-main/src/main/java/io/trino/connector/ConnectorManager.java
@@ -68,7 +68,6 @@ import io.trino.spi.type.TypeManager;
 import io.trino.split.PageSinkManager;
 import io.trino.split.PageSourceManager;
 import io.trino.split.RecordPageSourceProvider;
-import io.trino.split.SplitManager;
 import io.trino.sql.planner.NodePartitioningManager;
 import io.trino.transaction.TransactionManager;
 
@@ -106,7 +105,6 @@ public class ConnectorManager
     private final Metadata metadata;
     private final CatalogManager catalogManager;
     private final AccessControlManager accessControlManager;
-    private final SplitManager splitManager;
     private final PageSourceManager pageSourceManager;
     private final IndexManager indexManager;
     private final NodePartitioningManager nodePartitioningManager;
@@ -147,7 +145,6 @@ public class ConnectorManager
             Metadata metadata,
             CatalogManager catalogManager,
             AccessControlManager accessControlManager,
-            SplitManager splitManager,
             PageSourceManager pageSourceManager,
             IndexManager indexManager,
             NodePartitioningManager nodePartitioningManager,
@@ -176,7 +173,6 @@ public class ConnectorManager
         this.metadata = metadata;
         this.catalogManager = catalogManager;
         this.accessControlManager = accessControlManager;
-        this.splitManager = splitManager;
         this.pageSourceManager = pageSourceManager;
         this.indexManager = indexManager;
         this.nodePartitioningManager = nodePartitioningManager;
@@ -326,9 +322,6 @@ public class ConnectorManager
         checkState(!connectors.containsKey(catalogName), "Catalog '%s' already exists", catalogName);
         connectors.put(catalogName, connector);
 
-        connector.getSplitManager()
-                .ifPresent(connectorSplitManager -> splitManager.addConnectorSplitManager(catalogName, connectorSplitManager));
-
         connector.getPageSourceProvider()
                 .ifPresent(pageSourceProvider -> pageSourceManager.addConnectorPageSourceProvider(catalogName, pageSourceProvider));
 
@@ -362,7 +355,6 @@ public class ConnectorManager
 
     private synchronized void removeConnectorInternal(CatalogName catalogName)
     {
-        splitManager.removeConnectorSplitManager(catalogName);
         pageSourceManager.removeConnectorPageSourceProvider(catalogName);
         pageSinkManager.removeConnectorPageSinkProvider(catalogName);
         indexManager.removeIndexProvider(catalogName);

--- a/core/trino-main/src/main/java/io/trino/connector/ConnectorManager.java
+++ b/core/trino-main/src/main/java/io/trino/connector/ConnectorManager.java
@@ -34,7 +34,6 @@ import io.trino.metadata.CatalogTableProcedures;
 import io.trino.metadata.HandleResolver;
 import io.trino.metadata.InternalNodeManager;
 import io.trino.metadata.Metadata;
-import io.trino.metadata.TableProceduresPropertyManager;
 import io.trino.security.AccessControlManager;
 import io.trino.server.PluginClassLoader;
 import io.trino.spi.PageIndexerFactory;
@@ -109,7 +108,6 @@ public class ConnectorManager
     private final TransactionManager transactionManager;
     private final EventListenerManager eventListenerManager;
     private final TypeManager typeManager;
-    private final TableProceduresPropertyManager tableProceduresPropertyManager;
 
     private final boolean schedulerIncludeCoordinator;
 
@@ -135,7 +133,6 @@ public class ConnectorManager
             TransactionManager transactionManager,
             EventListenerManager eventListenerManager,
             TypeManager typeManager,
-            TableProceduresPropertyManager tableProceduresPropertyManager,
             NodeSchedulerConfig nodeSchedulerConfig)
     {
         this.metadata = metadata;
@@ -150,7 +147,6 @@ public class ConnectorManager
         this.transactionManager = transactionManager;
         this.eventListenerManager = eventListenerManager;
         this.typeManager = typeManager;
-        this.tableProceduresPropertyManager = tableProceduresPropertyManager;
         this.schedulerIncludeCoordinator = nodeSchedulerConfig.isIncludeCoordinator();
     }
 
@@ -279,16 +275,11 @@ public class ConnectorManager
 
         connector.getAccessControl()
                 .ifPresent(accessControl -> accessControlManager.addCatalogAccessControl(catalogName, accessControl));
-
-        for (TableProcedureMetadata tableProcedure : connector.getTableProcedures().getTableProcedures()) {
-            tableProceduresPropertyManager.addProperties(catalogName, tableProcedure.getName(), tableProcedure.getProperties());
-        }
     }
 
     private synchronized void removeConnectorInternal(CatalogName catalogName)
     {
         accessControlManager.removeCatalogAccessControl(catalogName);
-        tableProceduresPropertyManager.removeProperties(catalogName);
 
         ConnectorServices connectorServices = connectors.remove(catalogName);
         if (connectorServices != null) {

--- a/core/trino-main/src/main/java/io/trino/connector/ConnectorManager.java
+++ b/core/trino-main/src/main/java/io/trino/connector/ConnectorManager.java
@@ -65,7 +65,6 @@ import io.trino.spi.ptf.ConnectorTableFunction;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.type.TypeManager;
 import io.trino.split.RecordPageSourceProvider;
-import io.trino.sql.planner.NodePartitioningManager;
 import io.trino.transaction.TransactionManager;
 
 import javax.annotation.PreDestroy;
@@ -102,7 +101,6 @@ public class ConnectorManager
     private final Metadata metadata;
     private final CatalogManager catalogManager;
     private final AccessControlManager accessControlManager;
-    private final NodePartitioningManager nodePartitioningManager;
 
     private final HandleResolver handleResolver;
     private final InternalNodeManager nodeManager;
@@ -139,7 +137,6 @@ public class ConnectorManager
             Metadata metadata,
             CatalogManager catalogManager,
             AccessControlManager accessControlManager,
-            NodePartitioningManager nodePartitioningManager,
             HandleResolver handleResolver,
             InternalNodeManager nodeManager,
             NodeInfo nodeInfo,
@@ -164,7 +161,6 @@ public class ConnectorManager
         this.metadata = metadata;
         this.catalogManager = catalogManager;
         this.accessControlManager = accessControlManager;
-        this.nodePartitioningManager = nodePartitioningManager;
         this.handleResolver = handleResolver;
         this.nodeManager = nodeManager;
         this.pageSorter = pageSorter;
@@ -310,9 +306,6 @@ public class ConnectorManager
         checkState(!connectors.containsKey(catalogName), "Catalog '%s' already exists", catalogName);
         connectors.put(catalogName, connector);
 
-        connector.getPartitioningProvider()
-                .ifPresent(partitioningProvider -> nodePartitioningManager.addPartitioningProvider(catalogName, partitioningProvider));
-
         procedureRegistry.addProcedures(catalogName, connector.getProcedures());
         Set<TableProcedureMetadata> tableProcedures = connector.getTableProcedures();
         tableProceduresRegistry.addTableProcedures(catalogName, tableProcedures);
@@ -334,7 +327,6 @@ public class ConnectorManager
 
     private synchronized void removeConnectorInternal(CatalogName catalogName)
     {
-        nodePartitioningManager.removePartitioningProvider(catalogName);
         procedureRegistry.removeProcedures(catalogName);
         tableProceduresRegistry.removeProcedures(catalogName);
         tableFunctionRegistry.removeTableFunctions(catalogName);

--- a/core/trino-main/src/main/java/io/trino/connector/ConnectorManager.java
+++ b/core/trino-main/src/main/java/io/trino/connector/ConnectorManager.java
@@ -99,6 +99,7 @@ import static java.util.Objects.requireNonNull;
 
 @ThreadSafe
 public class ConnectorManager
+        implements ConnectorServicesProvider
 {
     private static final Logger log = Logger.get(ConnectorManager.class);
 
@@ -224,6 +225,14 @@ public class ConnectorManager
                 connectorFactory.getName(),
                 new InternalConnectorFactory(connectorFactory, duplicatePluginClassLoaderFactory));
         checkArgument(existingConnectorFactory == null, "Connector '%s' is already registered", connectorFactory.getName());
+    }
+
+    @Override
+    public synchronized ConnectorServices getConnectorServices(CatalogName catalogName)
+    {
+        ConnectorServices connectorServices = connectors.get(catalogName);
+        checkArgument(connectorServices != null, "No catalog '%s'", catalogName);
+        return connectorServices;
     }
 
     public synchronized CatalogName createCatalog(String catalogName, String connectorName, Map<String, String> properties)

--- a/core/trino-main/src/main/java/io/trino/connector/ConnectorManager.java
+++ b/core/trino-main/src/main/java/io/trino/connector/ConnectorManager.java
@@ -65,7 +65,6 @@ import io.trino.spi.procedure.Procedure;
 import io.trino.spi.ptf.ConnectorTableFunction;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.type.TypeManager;
-import io.trino.split.PageSinkManager;
 import io.trino.split.RecordPageSourceProvider;
 import io.trino.sql.planner.NodePartitioningManager;
 import io.trino.transaction.TransactionManager;
@@ -107,7 +106,6 @@ public class ConnectorManager
     private final IndexManager indexManager;
     private final NodePartitioningManager nodePartitioningManager;
 
-    private final PageSinkManager pageSinkManager;
     private final HandleResolver handleResolver;
     private final InternalNodeManager nodeManager;
     private final PageSorter pageSorter;
@@ -145,7 +143,6 @@ public class ConnectorManager
             AccessControlManager accessControlManager,
             IndexManager indexManager,
             NodePartitioningManager nodePartitioningManager,
-            PageSinkManager pageSinkManager,
             HandleResolver handleResolver,
             InternalNodeManager nodeManager,
             NodeInfo nodeInfo,
@@ -172,7 +169,6 @@ public class ConnectorManager
         this.accessControlManager = accessControlManager;
         this.indexManager = indexManager;
         this.nodePartitioningManager = nodePartitioningManager;
-        this.pageSinkManager = pageSinkManager;
         this.handleResolver = handleResolver;
         this.nodeManager = nodeManager;
         this.pageSorter = pageSorter;
@@ -318,9 +314,6 @@ public class ConnectorManager
         checkState(!connectors.containsKey(catalogName), "Catalog '%s' already exists", catalogName);
         connectors.put(catalogName, connector);
 
-        connector.getPageSinkProvider()
-                .ifPresent(pageSinkProvider -> pageSinkManager.addConnectorPageSinkProvider(catalogName, pageSinkProvider));
-
         connector.getIndexProvider()
                 .ifPresent(indexProvider -> indexManager.addIndexProvider(catalogName, indexProvider));
 
@@ -348,7 +341,6 @@ public class ConnectorManager
 
     private synchronized void removeConnectorInternal(CatalogName catalogName)
     {
-        pageSinkManager.removeConnectorPageSinkProvider(catalogName);
         indexManager.removeIndexProvider(catalogName);
         nodePartitioningManager.removePartitioningProvider(catalogName);
         procedureRegistry.removeProcedures(catalogName);

--- a/core/trino-main/src/main/java/io/trino/connector/ConnectorServicesProvider.java
+++ b/core/trino-main/src/main/java/io/trino/connector/ConnectorServicesProvider.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.connector;
+
+import io.trino.connector.ConnectorManager.ConnectorServices;
+
+public interface ConnectorServicesProvider
+{
+    ConnectorServices getConnectorServices(CatalogName catalogName);
+}

--- a/core/trino-main/src/main/java/io/trino/index/IndexManager.java
+++ b/core/trino-main/src/main/java/io/trino/index/IndexManager.java
@@ -14,48 +14,33 @@
 package io.trino.index;
 
 import io.trino.Session;
-import io.trino.connector.CatalogName;
+import io.trino.connector.CatalogServiceProvider;
 import io.trino.metadata.IndexHandle;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorIndex;
 import io.trino.spi.connector.ConnectorIndexProvider;
 import io.trino.spi.connector.ConnectorSession;
 
-import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
+import javax.inject.Inject;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
+import java.util.List;
+
 import static java.util.Objects.requireNonNull;
 
 public class IndexManager
 {
-    private final ConcurrentMap<CatalogName, ConnectorIndexProvider> providers = new ConcurrentHashMap<>();
+    private final CatalogServiceProvider<ConnectorIndexProvider> indexProvider;
 
-    public void addIndexProvider(CatalogName catalogName, ConnectorIndexProvider indexProvider)
+    @Inject
+    public IndexManager(CatalogServiceProvider<ConnectorIndexProvider> indexProvider)
     {
-        requireNonNull(catalogName, "catalogName is null");
-        requireNonNull(indexProvider, "indexProvider is null");
-        checkState(providers.putIfAbsent(catalogName, indexProvider) == null, "IndexProvider for connector '%s' is already registered", catalogName);
-    }
-
-    public void removeIndexProvider(CatalogName catalogName)
-    {
-        providers.remove(catalogName);
+        this.indexProvider = requireNonNull(indexProvider, "indexProvider is null");
     }
 
     public ConnectorIndex getIndex(Session session, IndexHandle indexHandle, List<ColumnHandle> lookupSchema, List<ColumnHandle> outputSchema)
     {
         ConnectorSession connectorSession = session.toConnectorSession(indexHandle.getCatalogName());
-        ConnectorIndexProvider provider = getProvider(indexHandle);
+        ConnectorIndexProvider provider = indexProvider.getService(indexHandle.getCatalogName());
         return provider.getIndex(indexHandle.getTransactionHandle(), connectorSession, indexHandle.getConnectorHandle(), lookupSchema, outputSchema);
-    }
-
-    private ConnectorIndexProvider getProvider(IndexHandle handle)
-    {
-        ConnectorIndexProvider result = providers.get(handle.getCatalogName());
-        checkArgument(result != null, "No index provider for connector '%s'", handle.getCatalogName());
-        return result;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/AnalyzePropertyManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/AnalyzePropertyManager.java
@@ -13,13 +13,18 @@
  */
 package io.trino.metadata;
 
+import io.trino.connector.CatalogServiceProvider;
+import io.trino.spi.session.PropertyMetadata;
+
+import java.util.Map;
+
 import static io.trino.spi.StandardErrorCode.INVALID_ANALYZE_PROPERTY;
 
 public class AnalyzePropertyManager
         extends AbstractCatalogPropertyManager
 {
-    public AnalyzePropertyManager()
+    public AnalyzePropertyManager(CatalogServiceProvider<Map<String, PropertyMetadata<?>>> connectorProperties)
     {
-        super("analyze", INVALID_ANALYZE_PROPERTY);
+        super("analyze", INVALID_ANALYZE_PROPERTY, connectorProperties);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/Catalog.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Catalog.java
@@ -14,7 +14,7 @@
 package io.trino.metadata;
 
 import io.trino.connector.CatalogName;
-import io.trino.connector.ConnectorManager.MaterializedConnector;
+import io.trino.connector.ConnectorManager.ConnectorServices;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.transaction.IsolationLevel;
@@ -28,18 +28,18 @@ public class Catalog
 {
     private final CatalogName catalogName;
     private final String connectorName;
-    private final MaterializedConnector catalogConnector;
-    private final MaterializedConnector informationSchemaConnector;
-    private final MaterializedConnector systemConnector;
+    private final ConnectorServices catalogConnector;
+    private final ConnectorServices informationSchemaConnector;
+    private final ConnectorServices systemConnector;
 
     public Catalog(
             CatalogName catalogName,
             String connectorName,
-            MaterializedConnector catalogConnector,
+            ConnectorServices catalogConnector,
             CatalogName informationSchemaName,
-            MaterializedConnector informationSchemaConnector,
+            ConnectorServices informationSchemaConnector,
             CatalogName systemName,
-            MaterializedConnector systemConnector)
+            ConnectorServices systemConnector)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.connectorName = requireNonNull(connectorName, "connectorName is null");
@@ -77,13 +77,13 @@ public class Catalog
     }
 
     private static CatalogTransaction beginTransaction(
-            MaterializedConnector materializedConnector,
+            ConnectorServices connectorServices,
             TransactionId transactionId,
             IsolationLevel isolationLevel,
             boolean readOnly,
             boolean autoCommitContext)
     {
-        Connector connector = materializedConnector.getConnector();
+        Connector connector = connectorServices.getConnector();
         ConnectorTransactionHandle transactionHandle;
         if (connector instanceof InternalConnector) {
             transactionHandle = ((InternalConnector) connector).beginTransaction(transactionId, isolationLevel, readOnly);
@@ -92,7 +92,7 @@ public class Catalog
             transactionHandle = connector.beginTransaction(isolationLevel, readOnly, autoCommitContext);
         }
 
-        return new CatalogTransaction(materializedConnector.getCatalogName(), connector, transactionHandle);
+        return new CatalogTransaction(connectorServices.getCatalogName(), connector, transactionHandle);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/metadata/CatalogProcedures.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/CatalogProcedures.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.metadata;
+
+import com.google.common.collect.Maps;
+import com.google.common.primitives.Primitives;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorAccessControl;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.procedure.Procedure;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.Type;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.spi.StandardErrorCode.PROCEDURE_NOT_FOUND;
+import static io.trino.spi.procedure.Procedure.Argument;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+
+@ThreadSafe
+public class CatalogProcedures
+{
+    private final Map<SchemaTableName, Procedure> procedures;
+
+    public CatalogProcedures(Collection<Procedure> procedures)
+    {
+        requireNonNull(procedures, "procedures is null");
+        procedures.forEach(CatalogProcedures::validateProcedure);
+
+        this.procedures = Maps.uniqueIndex(
+                procedures,
+                procedure -> new SchemaTableName(procedure.getSchema(), procedure.getName()));
+    }
+
+    public Procedure getProcedure(SchemaTableName name)
+    {
+        Procedure procedure = procedures.get(name);
+        if (procedure == null) {
+            throw new TrinoException(PROCEDURE_NOT_FOUND, "Procedure not registered: " + name);
+        }
+        return procedure;
+    }
+
+    private static void validateProcedure(Procedure procedure)
+    {
+        List<Class<?>> parameters = procedure.getMethodHandle().type().parameterList().stream()
+                .filter(type -> !ConnectorSession.class.equals(type))
+                .filter(type -> !ConnectorAccessControl.class.equals(type))
+                .collect(toList());
+
+        for (int i = 0; i < procedure.getArguments().size(); i++) {
+            Argument argument = procedure.getArguments().get(i);
+            Type type = argument.getType();
+
+            Class<?> argumentType = Primitives.unwrap(parameters.get(i));
+            Class<?> expectedType = getObjectType(type);
+            checkArgument(
+                    expectedType.equals(argumentType),
+                    "Argument '%s' has invalid type %s (expected %s)",
+                    argument.getName(),
+                    argumentType.getName(),
+                    expectedType.getName());
+        }
+    }
+
+    private static Class<?> getObjectType(Type type)
+    {
+        if (type.equals(BOOLEAN)) {
+            return boolean.class;
+        }
+        if (type.equals(BIGINT)) {
+            return long.class;
+        }
+        if (type.equals(DOUBLE)) {
+            return double.class;
+        }
+        if (type.equals(VARCHAR)) {
+            return String.class;
+        }
+        if (type instanceof ArrayType) {
+            getObjectType(type.getTypeParameters().get(0));
+            return List.class;
+        }
+        if (type instanceof MapType) {
+            getObjectType(type.getTypeParameters().get(0));
+            getObjectType(type.getTypeParameters().get(1));
+            return Map.class;
+        }
+        throw new IllegalArgumentException("Unsupported argument type: " + type.getDisplayName());
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/metadata/CatalogTableFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/CatalogTableFunctions.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.metadata;
+
+import com.google.common.collect.Maps;
+import io.trino.spi.ptf.ConnectorTableFunction;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+
+@ThreadSafe
+public class CatalogTableFunctions
+{
+    // schema and function name in lowercase
+    private final Map<SchemaFunctionName, ConnectorTableFunction> functions;
+
+    public CatalogTableFunctions(Collection<ConnectorTableFunction> functions)
+    {
+        requireNonNull(functions, "functions is null");
+        this.functions = Maps.uniqueIndex(functions, function -> lowerCaseSchemaFunctionName(new SchemaFunctionName(function.getSchema(), function.getName())));
+    }
+
+    public Optional<ConnectorTableFunction> getTableFunction(SchemaFunctionName schemaFunctionName)
+    {
+        return Optional.ofNullable(functions.get(lowerCaseSchemaFunctionName(schemaFunctionName)));
+    }
+
+    private static SchemaFunctionName lowerCaseSchemaFunctionName(SchemaFunctionName name)
+    {
+        return new SchemaFunctionName(
+                name.getSchemaName().toLowerCase(ENGLISH),
+                name.getFunctionName().toLowerCase(ENGLISH));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/metadata/CatalogTableProcedures.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/CatalogTableProcedures.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.metadata;
+
+import com.google.common.collect.Maps;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.TableProcedureMetadata;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.Collection;
+import java.util.Map;
+
+import static io.trino.spi.StandardErrorCode.PROCEDURE_NOT_FOUND;
+import static java.util.Objects.requireNonNull;
+
+@ThreadSafe
+public class CatalogTableProcedures
+{
+    private final Map<String, TableProcedureMetadata> procedures;
+
+    public CatalogTableProcedures(Collection<TableProcedureMetadata> procedures)
+    {
+        requireNonNull(procedures, "procedures is null");
+        this.procedures = Maps.uniqueIndex(procedures, TableProcedureMetadata::getName);
+    }
+
+    public Collection<TableProcedureMetadata> getTableProcedures()
+    {
+        return procedures.values();
+    }
+
+    public TableProcedureMetadata getTableProcedure(String name)
+    {
+        TableProcedureMetadata procedure = procedures.get(name);
+        if (procedure == null) {
+            throw new TrinoException(PROCEDURE_NOT_FOUND, "Table procedure not registered: " + name);
+        }
+        return procedure;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/metadata/ColumnPropertyManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/ColumnPropertyManager.java
@@ -13,13 +13,18 @@
  */
 package io.trino.metadata;
 
+import io.trino.connector.CatalogServiceProvider;
+import io.trino.spi.session.PropertyMetadata;
+
+import java.util.Map;
+
 import static io.trino.spi.StandardErrorCode.INVALID_COLUMN_PROPERTY;
 
 public class ColumnPropertyManager
         extends AbstractCatalogPropertyManager
 {
-    public ColumnPropertyManager()
+    public ColumnPropertyManager(CatalogServiceProvider<Map<String, PropertyMetadata<?>>> connectorProperties)
     {
-        super("column", INVALID_COLUMN_PROPERTY);
+        super("column", INVALID_COLUMN_PROPERTY, connectorProperties);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/MaterializedViewPropertyManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MaterializedViewPropertyManager.java
@@ -13,13 +13,18 @@
  */
 package io.trino.metadata;
 
+import io.trino.connector.CatalogServiceProvider;
+import io.trino.spi.session.PropertyMetadata;
+
+import java.util.Map;
+
 import static io.trino.spi.StandardErrorCode.INVALID_MATERIALIZED_VIEW_PROPERTY;
 
 public class MaterializedViewPropertyManager
         extends AbstractCatalogPropertyManager
 {
-    public MaterializedViewPropertyManager()
+    public MaterializedViewPropertyManager(CatalogServiceProvider<Map<String, PropertyMetadata<?>>> connectorProperties)
     {
-        super("materialized view", INVALID_MATERIALIZED_VIEW_PROPERTY);
+        super("materialized view", INVALID_MATERIALIZED_VIEW_PROPERTY, connectorProperties);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/ProcedureRegistry.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/ProcedureRegistry.java
@@ -13,116 +13,29 @@
  */
 package io.trino.metadata;
 
-import com.google.common.collect.Maps;
-import com.google.common.primitives.Primitives;
 import io.trino.connector.CatalogName;
-import io.trino.spi.TrinoException;
-import io.trino.spi.connector.ConnectorAccessControl;
-import io.trino.spi.connector.ConnectorSession;
+import io.trino.connector.CatalogServiceProvider;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.procedure.Procedure;
-import io.trino.spi.type.ArrayType;
-import io.trino.spi.type.MapType;
-import io.trino.spi.type.Type;
 
 import javax.annotation.concurrent.ThreadSafe;
+import javax.inject.Inject;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
-import static io.trino.spi.StandardErrorCode.PROCEDURE_NOT_FOUND;
-import static io.trino.spi.procedure.Procedure.Argument;
-import static io.trino.spi.type.BigintType.BIGINT;
-import static io.trino.spi.type.BooleanType.BOOLEAN;
-import static io.trino.spi.type.DoubleType.DOUBLE;
-import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toList;
 
 @ThreadSafe
 public class ProcedureRegistry
 {
-    private final Map<CatalogName, Map<SchemaTableName, Procedure>> connectorProcedures = new ConcurrentHashMap<>();
+    private final CatalogServiceProvider<CatalogProcedures> proceduresProvider;
 
-    public void addProcedures(CatalogName catalogName, Collection<Procedure> procedures)
+    @Inject
+    public ProcedureRegistry(CatalogServiceProvider<CatalogProcedures> proceduresProvider)
     {
-        requireNonNull(catalogName, "catalogName is null");
-        requireNonNull(procedures, "procedures is null");
-
-        procedures.forEach(this::validateProcedure);
-
-        Map<SchemaTableName, Procedure> proceduresByName = Maps.uniqueIndex(
-                procedures,
-                procedure -> new SchemaTableName(procedure.getSchema(), procedure.getName()));
-
-        checkState(connectorProcedures.putIfAbsent(catalogName, proceduresByName) == null, "Procedures already registered for connector: %s", catalogName);
-    }
-
-    public void removeProcedures(CatalogName catalogName)
-    {
-        connectorProcedures.remove(catalogName);
+        this.proceduresProvider = requireNonNull(proceduresProvider, "proceduresProvider is null");
     }
 
     public Procedure resolve(CatalogName catalogName, SchemaTableName name)
     {
-        Map<SchemaTableName, Procedure> procedures = connectorProcedures.get(catalogName);
-        if (procedures != null) {
-            Procedure procedure = procedures.get(name);
-            if (procedure != null) {
-                return procedure;
-            }
-        }
-        throw new TrinoException(PROCEDURE_NOT_FOUND, "Procedure not registered: " + name);
-    }
-
-    private void validateProcedure(Procedure procedure)
-    {
-        List<Class<?>> parameters = procedure.getMethodHandle().type().parameterList().stream()
-                .filter(type -> !ConnectorSession.class.equals(type))
-                .filter(type -> !ConnectorAccessControl.class.equals(type))
-                .collect(toList());
-
-        for (int i = 0; i < procedure.getArguments().size(); i++) {
-            Argument argument = procedure.getArguments().get(i);
-            Type type = argument.getType();
-
-            Class<?> argumentType = Primitives.unwrap(parameters.get(i));
-            Class<?> expectedType = getObjectType(type);
-            checkArgument(expectedType.equals(argumentType),
-                    "Argument '%s' has invalid type %s (expected %s)",
-                    argument.getName(),
-                    argumentType.getName(),
-                    expectedType.getName());
-        }
-    }
-
-    private static Class<?> getObjectType(Type type)
-    {
-        if (type.equals(BOOLEAN)) {
-            return boolean.class;
-        }
-        if (type.equals(BIGINT)) {
-            return long.class;
-        }
-        if (type.equals(DOUBLE)) {
-            return double.class;
-        }
-        if (type.equals(VARCHAR)) {
-            return String.class;
-        }
-        if (type instanceof ArrayType) {
-            getObjectType(type.getTypeParameters().get(0));
-            return List.class;
-        }
-        if (type instanceof MapType) {
-            getObjectType(type.getTypeParameters().get(0));
-            getObjectType(type.getTypeParameters().get(1));
-            return Map.class;
-        }
-        throw new IllegalArgumentException("Unsupported argument type: " + type.getDisplayName());
+        return proceduresProvider.getService(catalogName).getProcedure(name);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/SchemaPropertyManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SchemaPropertyManager.java
@@ -13,13 +13,18 @@
  */
 package io.trino.metadata;
 
+import io.trino.connector.CatalogServiceProvider;
+import io.trino.spi.session.PropertyMetadata;
+
+import java.util.Map;
+
 import static io.trino.spi.StandardErrorCode.INVALID_SCHEMA_PROPERTY;
 
 public class SchemaPropertyManager
         extends AbstractCatalogPropertyManager
 {
-    public SchemaPropertyManager()
+    public SchemaPropertyManager(CatalogServiceProvider<Map<String, PropertyMetadata<?>>> connectorProperties)
     {
-        super("schema", INVALID_SCHEMA_PROPERTY);
+        super("schema", INVALID_SCHEMA_PROPERTY, connectorProperties);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/SessionPropertyManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SessionPropertyManager.java
@@ -14,14 +14,15 @@
 package io.trino.metadata;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
 import io.airlift.json.JsonCodec;
 import io.airlift.json.JsonCodecFactory;
 import io.trino.Session;
 import io.trino.SystemSessionProperties;
 import io.trino.SystemSessionPropertiesProvider;
 import io.trino.connector.CatalogName;
+import io.trino.connector.CatalogServiceProvider;
 import io.trino.security.AccessControl;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.BlockBuilder;
@@ -42,7 +43,6 @@ import io.trino.sql.tree.NodeRef;
 import io.trino.sql.tree.Parameter;
 
 import javax.annotation.Nullable;
-import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Map;
@@ -65,7 +65,7 @@ public final class SessionPropertyManager
 {
     private static final JsonCodecFactory JSON_CODEC_FACTORY = new JsonCodecFactory();
     private final ConcurrentMap<String, PropertyMetadata<?>> systemSessionProperties = new ConcurrentHashMap<>();
-    private final ConcurrentMap<CatalogName, Map<String, PropertyMetadata<?>>> connectorSessionProperties = new ConcurrentHashMap<>();
+    private final CatalogServiceProvider<Map<String, PropertyMetadata<?>>> connectorSessionProperties;
 
     public SessionPropertyManager()
     {
@@ -74,21 +74,16 @@ public final class SessionPropertyManager
 
     public SessionPropertyManager(SystemSessionPropertiesProvider systemSessionPropertiesProvider)
     {
-        this(ImmutableSet.of(systemSessionPropertiesProvider));
+        this(ImmutableSet.of(systemSessionPropertiesProvider), connectorName -> ImmutableMap.of());
     }
 
-    @Inject
-    public SessionPropertyManager(Set<SystemSessionPropertiesProvider> systemSessionProperties)
+    public SessionPropertyManager(Set<SystemSessionPropertiesProvider> systemSessionProperties, CatalogServiceProvider<Map<String, PropertyMetadata<?>>> connectorSessionProperties)
     {
-        this(systemSessionProperties
+        addSystemSessionProperties(requireNonNull(systemSessionProperties, "systemSessionProperties is null")
                 .stream()
                 .flatMap(provider -> provider.getSessionProperties().stream())
                 .collect(toImmutableList()));
-    }
-
-    public SessionPropertyManager(List<PropertyMetadata<?>> systemSessionProperties)
-    {
-        addSystemSessionProperties(systemSessionProperties);
+        this.connectorSessionProperties = requireNonNull(connectorSessionProperties, "connectorSessionProperties is null");
     }
 
     public void addSystemSessionProperties(List<PropertyMetadata<?>> systemSessionProperties)
@@ -104,20 +99,6 @@ public final class SessionPropertyManager
                 "System session property '%s' are already registered", sessionProperty.getName());
     }
 
-    public void addConnectorSessionProperties(CatalogName catalogName, List<PropertyMetadata<?>> properties)
-    {
-        requireNonNull(catalogName, "catalogName is null");
-        requireNonNull(properties, "properties is null");
-
-        Map<String, PropertyMetadata<?>> propertiesByName = Maps.uniqueIndex(properties, PropertyMetadata::getName);
-        checkState(connectorSessionProperties.putIfAbsent(catalogName, propertiesByName) == null, "Session properties for catalog '%s' are already registered", catalogName);
-    }
-
-    public void removeConnectorSessionProperties(CatalogName catalogName)
-    {
-        connectorSessionProperties.remove(catalogName);
-    }
-
     public Optional<PropertyMetadata<?>> getSystemSessionPropertyMetadata(String name)
     {
         requireNonNull(name, "name is null");
@@ -129,14 +110,7 @@ public final class SessionPropertyManager
     {
         requireNonNull(catalogName, "catalogName is null");
         requireNonNull(propertyName, "propertyName is null");
-        Map<String, PropertyMetadata<?>> properties = connectorSessionProperties.get(catalogName);
-        if (properties == null) {
-            throw new TrinoException(INVALID_SESSION_PROPERTY, "Unknown catalog: " + catalogName);
-        }
-        if (properties.isEmpty()) {
-            throw new TrinoException(INVALID_SESSION_PROPERTY, "No session properties found for catalog: " + catalogName);
-        }
-
+        Map<String, PropertyMetadata<?>> properties = connectorSessionProperties.getService(catalogName);
         return Optional.ofNullable(properties.get(propertyName));
     }
 
@@ -164,7 +138,7 @@ public final class SessionPropertyManager
             CatalogName catalogName = catalogInfo.getCatalogName();
             Map<String, String> connectorProperties = session.getCatalogProperties(catalogName.getCatalogName());
 
-            for (PropertyMetadata<?> property : new TreeMap<>(connectorSessionProperties.get(catalogName)).values()) {
+            for (PropertyMetadata<?> property : new TreeMap<>(connectorSessionProperties.getService(catalogName)).values()) {
                 String defaultValue = firstNonNull(property.getDefaultValue(), "").toString();
                 String value = connectorProperties.getOrDefault(property.getName(), defaultValue);
 

--- a/core/trino-main/src/main/java/io/trino/metadata/TableFunctionRegistry.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/TableFunctionRegistry.java
@@ -13,102 +13,35 @@
  */
 package io.trino.metadata;
 
-import com.google.common.collect.ImmutableMap;
-import io.trino.Session;
 import io.trino.connector.CatalogName;
-import io.trino.spi.ptf.ArgumentSpecification;
+import io.trino.connector.CatalogServiceProvider;
 import io.trino.spi.ptf.ConnectorTableFunction;
-import io.trino.spi.ptf.TableArgumentSpecification;
-import io.trino.sql.tree.QualifiedName;
 
 import javax.annotation.concurrent.ThreadSafe;
+import javax.inject.Inject;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
-import static io.trino.metadata.FunctionResolver.toPath;
-import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
 @ThreadSafe
 public class TableFunctionRegistry
 {
-    // catalog name in the original case; schema and function name in lowercase
-    private final Map<CatalogName, Map<SchemaFunctionName, TableFunctionMetadata>> tableFunctions = new ConcurrentHashMap<>();
+    private final CatalogServiceProvider<CatalogTableFunctions> tableFunctionsProvider;
 
-    public void addTableFunctions(CatalogName catalogName, Collection<ConnectorTableFunction> functions)
+    @Inject
+    public TableFunctionRegistry(CatalogServiceProvider<CatalogTableFunctions> tableFunctionsProvider)
     {
-        requireNonNull(catalogName, "catalogName is null");
-        requireNonNull(functions, "functions is null");
-
-        functions.stream()
-                .forEach(TableFunctionRegistry::validateTableFunction);
-
-        ImmutableMap.Builder<SchemaFunctionName, TableFunctionMetadata> builder = ImmutableMap.builder();
-        for (ConnectorTableFunction function : functions) {
-            builder.put(
-                    new SchemaFunctionName(
-                            function.getSchema().toLowerCase(ENGLISH),
-                            function.getName().toLowerCase(ENGLISH)),
-                    new TableFunctionMetadata(catalogName, function));
-        }
-        checkState(tableFunctions.putIfAbsent(catalogName, builder.buildOrThrow()) == null, "Table functions already registered for catalog: " + catalogName);
-    }
-
-    public void removeTableFunctions(CatalogName catalogName)
-    {
-        tableFunctions.remove(catalogName);
+        this.tableFunctionsProvider = requireNonNull(tableFunctionsProvider, "tableFunctionsProvider is null");
     }
 
     /**
      * Resolve table function with given qualified name.
      * Table functions are resolved case-insensitive for consistency with existing scalar function resolution.
      */
-    public TableFunctionMetadata resolve(Session session, QualifiedName qualifiedName)
+    public Optional<ConnectorTableFunction> resolve(CatalogName catalogName, SchemaFunctionName schemaFunctionName)
     {
-        for (CatalogSchemaFunctionName name : toPath(session, qualifiedName)) {
-            CatalogName catalogName = new CatalogName(name.getCatalogName());
-            Map<SchemaFunctionName, TableFunctionMetadata> catalogFunctions = tableFunctions.get(catalogName);
-            if (catalogFunctions != null) {
-                String lowercasedSchemaName = name.getSchemaFunctionName().getSchemaName().toLowerCase(ENGLISH);
-                String lowercasedFunctionName = name.getSchemaFunctionName().getFunctionName().toLowerCase(ENGLISH);
-                TableFunctionMetadata function = catalogFunctions.get(new SchemaFunctionName(lowercasedSchemaName, lowercasedFunctionName));
-                if (function != null) {
-                    return function;
-                }
-            }
-        }
-
-        return null;
-    }
-
-    private static void validateTableFunction(ConnectorTableFunction tableFunction)
-    {
-        requireNonNull(tableFunction, "tableFunction is null");
-        requireNonNull(tableFunction.getName(), "table function name is null");
-        requireNonNull(tableFunction.getSchema(), "table function schema name is null");
-        requireNonNull(tableFunction.getArguments(), "table function arguments is null");
-        requireNonNull(tableFunction.getReturnTypeSpecification(), "table function returnTypeSpecification is null");
-
-        checkArgument(!tableFunction.getName().isEmpty(), "table function name is empty");
-        checkArgument(!tableFunction.getSchema().isEmpty(), "table function schema name is empty");
-
-        Set<String> argumentNames = new HashSet<>();
-        for (ArgumentSpecification specification : tableFunction.getArguments()) {
-            if (!argumentNames.add(specification.getName())) {
-                throw new IllegalArgumentException("duplicate argument name: " + specification.getName());
-            }
-        }
-        long tableArgumentsWithRowSemantics = tableFunction.getArguments().stream()
-                .filter(specification -> specification instanceof TableArgumentSpecification)
-                .map(TableArgumentSpecification.class::cast)
-                .filter(TableArgumentSpecification::isRowSemantics)
-                .count();
-        checkArgument(tableArgumentsWithRowSemantics <= 1, "more than one table argument with row semantics");
+        return tableFunctionsProvider.getService(catalogName)
+                .getTableFunction(schemaFunctionName);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/TableProceduresRegistry.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/TableProceduresRegistry.java
@@ -13,51 +13,26 @@
  */
 package io.trino.metadata;
 
-import com.google.common.collect.Maps;
 import io.trino.connector.CatalogName;
-import io.trino.spi.TrinoException;
+import io.trino.connector.CatalogServiceProvider;
 import io.trino.spi.connector.TableProcedureMetadata;
 
-import java.util.Collection;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import javax.inject.Inject;
 
-import static com.google.common.base.Preconditions.checkState;
-import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
-import static io.trino.spi.StandardErrorCode.PROCEDURE_NOT_FOUND;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class TableProceduresRegistry
 {
-    private final Map<CatalogName, Map<String, TableProcedureMetadata>> tableProcedures = new ConcurrentHashMap<>();
+    private final CatalogServiceProvider<CatalogTableProcedures> tableProceduresProvider;
 
-    public void addTableProcedures(CatalogName catalogName, Collection<TableProcedureMetadata> procedures)
+    @Inject
+    public TableProceduresRegistry(CatalogServiceProvider<CatalogTableProcedures> tableProceduresProvider)
     {
-        requireNonNull(catalogName, "catalogName is null");
-        requireNonNull(procedures, "procedures is null");
-
-        Map<String, TableProcedureMetadata> proceduresByName = Maps.uniqueIndex(procedures, TableProcedureMetadata::getName);
-
-        checkState(tableProcedures.putIfAbsent(catalogName, proceduresByName) == null, "Table procedures already registered for connector: %s", catalogName);
-    }
-
-    public void removeProcedures(CatalogName catalogName)
-    {
-        tableProcedures.remove(catalogName);
+        this.tableProceduresProvider = requireNonNull(tableProceduresProvider, "tableProceduresProvider is null");
     }
 
     public TableProcedureMetadata resolve(CatalogName catalogName, String name)
     {
-        Map<String, TableProcedureMetadata> procedures = tableProcedures.get(catalogName);
-        if (procedures == null) {
-            throw new TrinoException(GENERIC_INTERNAL_ERROR, format("Catalog %s not registered", catalogName));
-        }
-
-        TableProcedureMetadata procedure = procedures.get(name);
-        if (procedure == null) {
-            throw new TrinoException(PROCEDURE_NOT_FOUND, format("Procedure %s not registered for catalog %s", name, catalogName));
-        }
-        return procedure;
+        return tableProceduresProvider.getService(catalogName).getTableProcedure(name);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/TablePropertyManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/TablePropertyManager.java
@@ -13,13 +13,18 @@
  */
 package io.trino.metadata;
 
+import io.trino.connector.CatalogServiceProvider;
+import io.trino.spi.session.PropertyMetadata;
+
+import java.util.Map;
+
 import static io.trino.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
 
 public class TablePropertyManager
         extends AbstractCatalogPropertyManager
 {
-    public TablePropertyManager()
+    public TablePropertyManager(CatalogServiceProvider<Map<String, PropertyMetadata<?>>> connectorProperties)
     {
-        super("table", INVALID_TABLE_PROPERTY);
+        super("table", INVALID_TABLE_PROPERTY, connectorProperties);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableSet;
 import io.airlift.log.Logger;
 import io.airlift.stats.CounterStat;
 import io.trino.connector.CatalogName;
+import io.trino.connector.CatalogServiceProvider;
 import io.trino.eventlistener.EventListenerManager;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.plugin.base.security.AllowAllSystemAccessControl;
@@ -89,7 +90,7 @@ public class AccessControlManager
     private final List<File> configFiles;
     private final String defaultAccessControlName;
     private final Map<String, SystemAccessControlFactory> systemAccessControlFactories = new ConcurrentHashMap<>();
-    private final Map<CatalogName, CatalogAccessControlEntry> connectorAccessControl = new ConcurrentHashMap<>();
+    private final AtomicReference<CatalogServiceProvider<Optional<ConnectorAccessControl>>> connectorAccessControlProvider = new AtomicReference<>();
 
     private final AtomicReference<List<SystemAccessControl>> systemAccessControls = new AtomicReference<>();
 
@@ -122,17 +123,14 @@ public class AccessControlManager
         }
     }
 
-    public void addCatalogAccessControl(CatalogName catalogName, ConnectorAccessControl accessControl)
+    /**
+     * Lazy registry for connector access controls due to circular dependency between access control and connector creation in ConnectorManager.
+     */
+    public void setConnectorAccessControlProvider(CatalogServiceProvider<Optional<ConnectorAccessControl>> connectorAccessControlProvider)
     {
-        requireNonNull(catalogName, "catalogName is null");
-        requireNonNull(accessControl, "accessControl is null");
-        checkState(connectorAccessControl.putIfAbsent(catalogName, new CatalogAccessControlEntry(catalogName, accessControl)) == null,
-                "Access control for connector '%s' is already registered", catalogName);
-    }
-
-    public void removeCatalogAccessControl(CatalogName catalogName)
-    {
-        connectorAccessControl.remove(catalogName);
+        if (!this.connectorAccessControlProvider.compareAndSet(null, connectorAccessControlProvider)) {
+            throw new IllegalStateException("connectorAccessControlProvider already set");
+        }
     }
 
     public void loadSystemAccessControl()
@@ -384,9 +382,9 @@ public class AccessControlManager
             schemaNames = systemAccessControl.filterSchemas(securityContext.toSystemSecurityContext(), catalogName, schemaNames);
         }
 
-        CatalogAccessControlEntry entry = getConnectorAccessControl(securityContext.getTransactionId(), catalogName);
-        if (entry != null) {
-            schemaNames = entry.getAccessControl().filterSchemas(entry.toConnectorSecurityContext(securityContext), schemaNames);
+        ConnectorAccessControl connectorAccessControl = getConnectorAccessControl(securityContext.getTransactionId(), catalogName);
+        if (connectorAccessControl != null) {
+            schemaNames = connectorAccessControl.filterSchemas(toConnectorSecurityContext(catalogName, securityContext), schemaNames);
         }
         return schemaNames;
     }
@@ -525,9 +523,9 @@ public class AccessControlManager
             tableNames = systemAccessControl.filterTables(securityContext.toSystemSecurityContext(), catalogName, tableNames);
         }
 
-        CatalogAccessControlEntry entry = getConnectorAccessControl(securityContext.getTransactionId(), catalogName);
-        if (entry != null) {
-            tableNames = entry.getAccessControl().filterTables(entry.toConnectorSecurityContext(securityContext), tableNames);
+        ConnectorAccessControl connectorAccessControl = getConnectorAccessControl(securityContext.getTransactionId(), catalogName);
+        if (connectorAccessControl != null) {
+            tableNames = connectorAccessControl.filterTables(toConnectorSecurityContext(catalogName, securityContext), tableNames);
         }
         return tableNames;
     }
@@ -559,9 +557,9 @@ public class AccessControlManager
             columns = systemAccessControl.filterColumns(securityContext.toSystemSecurityContext(), table, columns);
         }
 
-        CatalogAccessControlEntry entry = getConnectorAccessControl(securityContext.getTransactionId(), table.getCatalogName());
-        if (entry != null) {
-            columns = entry.getAccessControl().filterColumns(entry.toConnectorSecurityContext(securityContext), table.getSchemaTableName(), columns);
+        ConnectorAccessControl connectorAccessControl = getConnectorAccessControl(securityContext.getTransactionId(), table.getCatalogName());
+        if (connectorAccessControl != null) {
+            columns = connectorAccessControl.filterColumns(toConnectorSecurityContext(table.getCatalogName(), securityContext), table.getSchemaTableName(), columns);
         }
         return columns;
     }
@@ -1183,10 +1181,10 @@ public class AccessControlManager
         requireNonNull(tableName, "tableName is null");
 
         ImmutableList.Builder<ViewExpression> filters = ImmutableList.builder();
-        CatalogAccessControlEntry entry = getConnectorAccessControl(context.getTransactionId(), tableName.getCatalogName());
+        ConnectorAccessControl connectorAccessControl = getConnectorAccessControl(context.getTransactionId(), tableName.getCatalogName());
 
-        if (entry != null) {
-            entry.getAccessControl().getRowFilters(entry.toConnectorSecurityContext(context), tableName.asSchemaTableName())
+        if (connectorAccessControl != null) {
+            connectorAccessControl.getRowFilters(toConnectorSecurityContext(tableName.getCatalogName(), context), tableName.asSchemaTableName())
                     .forEach(filters::add);
         }
 
@@ -1207,9 +1205,9 @@ public class AccessControlManager
         ImmutableList.Builder<ViewExpression> masks = ImmutableList.builder();
 
         // connector-provided masks take precedence over global masks
-        CatalogAccessControlEntry entry = getConnectorAccessControl(context.getTransactionId(), tableName.getCatalogName());
-        if (entry != null) {
-            entry.getAccessControl().getColumnMasks(entry.toConnectorSecurityContext(context), tableName.asSchemaTableName(), columnName, type)
+        ConnectorAccessControl connectorAccessControl = getConnectorAccessControl(context.getTransactionId(), tableName.getCatalogName());
+        if (connectorAccessControl != null) {
+            connectorAccessControl.getColumnMasks(toConnectorSecurityContext(tableName.getCatalogName(), context), tableName.asSchemaTableName(), columnName, type)
                     .forEach(masks::add);
         }
 
@@ -1221,10 +1219,15 @@ public class AccessControlManager
         return masks.build();
     }
 
-    private CatalogAccessControlEntry getConnectorAccessControl(TransactionId transactionId, String catalogName)
+    private ConnectorAccessControl getConnectorAccessControl(TransactionId transactionId, String catalogName)
     {
+        CatalogServiceProvider<Optional<ConnectorAccessControl>> connectorAccessControlProvider = this.connectorAccessControlProvider.get();
+        if (connectorAccessControlProvider == null) {
+            return null;
+        }
+
         return transactionManager.getCatalogName(transactionId, catalogName)
-                .map(connectorAccessControl::get)
+                .flatMap(connectorAccessControlProvider::getService)
                 .orElse(null);
     }
 
@@ -1272,13 +1275,13 @@ public class AccessControlManager
 
     private void catalogAuthorizationCheck(String catalogName, SecurityContext securityContext, BiConsumer<ConnectorAccessControl, ConnectorSecurityContext> check)
     {
-        CatalogAccessControlEntry entry = getConnectorAccessControl(securityContext.getTransactionId(), catalogName);
-        if (entry == null) {
+        ConnectorAccessControl connectorAccessControl = getConnectorAccessControl(securityContext.getTransactionId(), catalogName);
+        if (connectorAccessControl == null) {
             return;
         }
 
         try {
-            check.accept(entry.getAccessControl(), entry.toConnectorSecurityContext(securityContext));
+            check.accept(connectorAccessControl, toConnectorSecurityContext(catalogName, securityContext));
             authorizationSuccess.update(1);
         }
         catch (TrinoException e) {
@@ -1289,8 +1292,8 @@ public class AccessControlManager
 
     private void checkCatalogRoles(SecurityContext securityContext, String catalogName)
     {
-        CatalogAccessControlEntry entry = getConnectorAccessControl(securityContext.getTransactionId(), catalogName);
-        if (entry == null) {
+        ConnectorAccessControl connectorAccessControl = getConnectorAccessControl(securityContext.getTransactionId(), catalogName);
+        if (connectorAccessControl == null) {
             throw new TrinoException(NOT_SUPPORTED, format("Catalog %s does not support catalog roles", catalogName));
         }
     }
@@ -1301,39 +1304,17 @@ public class AccessControlManager
                 .orElse(ImmutableList.of(new InitializingSystemAccessControl()));
     }
 
-    private class CatalogAccessControlEntry
+    private ConnectorSecurityContext toConnectorSecurityContext(String catalogName, SecurityContext securityContext)
     {
-        private final CatalogName catalogName;
-        private final ConnectorAccessControl accessControl;
+        return toConnectorSecurityContext(catalogName, securityContext.getTransactionId(), securityContext.getIdentity(), securityContext.getQueryId());
+    }
 
-        public CatalogAccessControlEntry(CatalogName catalogName, ConnectorAccessControl accessControl)
-        {
-            this.catalogName = requireNonNull(catalogName, "catalogName is null");
-            this.accessControl = requireNonNull(accessControl, "accessControl is null");
-        }
-
-        public CatalogName getCatalogName()
-        {
-            return catalogName;
-        }
-
-        public ConnectorAccessControl getAccessControl()
-        {
-            return accessControl;
-        }
-
-        public ConnectorSecurityContext toConnectorSecurityContext(SecurityContext securityContext)
-        {
-            return toConnectorSecurityContext(securityContext.getTransactionId(), securityContext.getIdentity(), securityContext.getQueryId());
-        }
-
-        public ConnectorSecurityContext toConnectorSecurityContext(TransactionId requiredTransactionId, Identity identity, QueryId queryId)
-        {
-            return new ConnectorSecurityContext(
-                    transactionManager.getConnectorTransaction(requiredTransactionId, catalogName),
-                    identity.toConnectorIdentity(catalogName.getCatalogName()),
-                    queryId);
-        }
+    private ConnectorSecurityContext toConnectorSecurityContext(String catalogName, TransactionId requiredTransactionId, Identity identity, QueryId queryId)
+    {
+        return new ConnectorSecurityContext(
+                transactionManager.getConnectorTransaction(requiredTransactionId, new CatalogName(catalogName)),
+                identity.toConnectorIdentity(catalogName),
+                queryId);
     }
 
     private static class InitializingSystemAccessControl

--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -79,7 +79,6 @@ import io.trino.metadata.LiteralFunction;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.MetadataManager;
 import io.trino.metadata.ProcedureRegistry;
-import io.trino.metadata.SessionPropertyManager;
 import io.trino.metadata.StaticCatalogStore;
 import io.trino.metadata.StaticCatalogStoreConfig;
 import io.trino.metadata.SystemFunctionBundle;
@@ -240,7 +239,6 @@ public class ServerMainModule
 
         // session properties
         newSetBinder(binder, SystemSessionPropertiesProvider.class).addBinding().to(SystemSessionProperties.class);
-        binder.bind(SessionPropertyManager.class).in(Scopes.SINGLETON);
         binder.bind(SystemSessionProperties.class).in(Scopes.SINGLETON);
         binder.bind(SessionPropertyDefaults.class).in(Scopes.SINGLETON);
 

--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -63,10 +63,8 @@ import io.trino.memory.MemoryInfo;
 import io.trino.memory.MemoryManagerConfig;
 import io.trino.memory.MemoryResource;
 import io.trino.memory.NodeMemoryConfig;
-import io.trino.metadata.AnalyzePropertyManager;
 import io.trino.metadata.BlockEncodingManager;
 import io.trino.metadata.CatalogManager;
-import io.trino.metadata.ColumnPropertyManager;
 import io.trino.metadata.DisabledSystemSecurityMetadata;
 import io.trino.metadata.DiscoveryNodeManager;
 import io.trino.metadata.ForNodeManager;
@@ -78,11 +76,9 @@ import io.trino.metadata.InternalBlockEncodingSerde;
 import io.trino.metadata.InternalFunctionBundle;
 import io.trino.metadata.InternalNodeManager;
 import io.trino.metadata.LiteralFunction;
-import io.trino.metadata.MaterializedViewPropertyManager;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.MetadataManager;
 import io.trino.metadata.ProcedureRegistry;
-import io.trino.metadata.SchemaPropertyManager;
 import io.trino.metadata.SessionPropertyManager;
 import io.trino.metadata.StaticCatalogStore;
 import io.trino.metadata.StaticCatalogStoreConfig;
@@ -91,7 +87,6 @@ import io.trino.metadata.SystemSecurityMetadata;
 import io.trino.metadata.TableFunctionRegistry;
 import io.trino.metadata.TableProceduresPropertyManager;
 import io.trino.metadata.TableProceduresRegistry;
-import io.trino.metadata.TablePropertyManager;
 import io.trino.metadata.TypeRegistry;
 import io.trino.operator.DirectExchangeClientConfig;
 import io.trino.operator.DirectExchangeClientFactory;
@@ -248,21 +243,6 @@ public class ServerMainModule
         binder.bind(SessionPropertyManager.class).in(Scopes.SINGLETON);
         binder.bind(SystemSessionProperties.class).in(Scopes.SINGLETON);
         binder.bind(SessionPropertyDefaults.class).in(Scopes.SINGLETON);
-
-        // schema properties
-        binder.bind(SchemaPropertyManager.class).in(Scopes.SINGLETON);
-
-        // table properties
-        binder.bind(TablePropertyManager.class).in(Scopes.SINGLETON);
-
-        // materialized view properties
-        binder.bind(MaterializedViewPropertyManager.class).in(Scopes.SINGLETON);
-
-        // column properties
-        binder.bind(ColumnPropertyManager.class).in(Scopes.SINGLETON);
-
-        // analyze properties
-        binder.bind(AnalyzePropertyManager.class).in(Scopes.SINGLETON);
 
         // table procedures properties
         binder.bind(TableProceduresPropertyManager.class).in(Scopes.SINGLETON);

--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -32,7 +32,9 @@ import io.trino.SystemSessionProperties;
 import io.trino.SystemSessionPropertiesProvider;
 import io.trino.block.BlockJsonSerde;
 import io.trino.client.NodeVersion;
+import io.trino.connector.CatalogServiceProviderModule;
 import io.trino.connector.ConnectorManager;
+import io.trino.connector.ConnectorServicesProvider;
 import io.trino.connector.system.SystemConnectorModule;
 import io.trino.dispatcher.DispatchManager;
 import io.trino.event.SplitMonitor;
@@ -424,6 +426,8 @@ public class ServerMainModule
 
         // connector
         binder.bind(ConnectorManager.class).in(Scopes.SINGLETON);
+        binder.bind(ConnectorServicesProvider.class).to(ConnectorManager.class).in(Scopes.SINGLETON);
+        binder.install(new CatalogServiceProviderModule());
 
         // system connector
         binder.install(new SystemConnectorModule());

--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -84,7 +84,6 @@ import io.trino.metadata.StaticCatalogStoreConfig;
 import io.trino.metadata.SystemFunctionBundle;
 import io.trino.metadata.SystemSecurityMetadata;
 import io.trino.metadata.TableFunctionRegistry;
-import io.trino.metadata.TableProceduresPropertyManager;
 import io.trino.metadata.TableProceduresRegistry;
 import io.trino.metadata.TypeRegistry;
 import io.trino.operator.DirectExchangeClientConfig;
@@ -241,9 +240,6 @@ public class ServerMainModule
         newSetBinder(binder, SystemSessionPropertiesProvider.class).addBinding().to(SystemSessionProperties.class);
         binder.bind(SystemSessionProperties.class).in(Scopes.SINGLETON);
         binder.bind(SessionPropertyDefaults.class).in(Scopes.SINGLETON);
-
-        // table procedures properties
-        binder.bind(TableProceduresPropertyManager.class).in(Scopes.SINGLETON);
 
         // node manager
         discoveryBinder(binder).bindSelector("trino");

--- a/core/trino-main/src/main/java/io/trino/split/PageSinkManager.java
+++ b/core/trino-main/src/main/java/io/trino/split/PageSinkManager.java
@@ -15,6 +15,7 @@ package io.trino.split;
 
 import io.trino.Session;
 import io.trino.connector.CatalogName;
+import io.trino.connector.CatalogServiceProvider;
 import io.trino.metadata.InsertTableHandle;
 import io.trino.metadata.OutputTableHandle;
 import io.trino.metadata.TableExecuteHandle;
@@ -22,28 +23,19 @@ import io.trino.spi.connector.ConnectorPageSink;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorSession;
 
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
+import javax.inject.Inject;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 public class PageSinkManager
         implements PageSinkProvider
 {
-    private final ConcurrentMap<CatalogName, ConnectorPageSinkProvider> pageSinkProviders = new ConcurrentHashMap<>();
+    private final CatalogServiceProvider<ConnectorPageSinkProvider> pageSinkProvider;
 
-    public void addConnectorPageSinkProvider(CatalogName catalogName, ConnectorPageSinkProvider pageSinkProvider)
+    @Inject
+    public PageSinkManager(CatalogServiceProvider<ConnectorPageSinkProvider> pageSinkProvider)
     {
-        requireNonNull(catalogName, "catalogName is null");
-        requireNonNull(pageSinkProvider, "pageSinkProvider is null");
-        checkState(pageSinkProviders.put(catalogName, pageSinkProvider) == null, "PageSinkProvider for connector '%s' is already registered", catalogName);
-    }
-
-    public void removeConnectorPageSinkProvider(CatalogName catalogName)
-    {
-        pageSinkProviders.remove(catalogName);
+        this.pageSinkProvider = requireNonNull(pageSinkProvider, "pageSinkProvider is null");
     }
 
     @Override
@@ -72,8 +64,6 @@ public class PageSinkManager
 
     private ConnectorPageSinkProvider providerFor(CatalogName catalogName)
     {
-        ConnectorPageSinkProvider provider = pageSinkProviders.get(catalogName);
-        checkArgument(provider != null, "No page sink provider for catalog '%s'", catalogName.getCatalogName());
-        return provider;
+        return pageSinkProvider.getService(catalogName);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/split/PageSourceManager.java
+++ b/core/trino-main/src/main/java/io/trino/split/PageSourceManager.java
@@ -15,6 +15,7 @@ package io.trino.split;
 
 import io.trino.Session;
 import io.trino.connector.CatalogName;
+import io.trino.connector.CatalogServiceProvider;
 import io.trino.metadata.Split;
 import io.trino.metadata.TableHandle;
 import io.trino.spi.connector.ColumnHandle;
@@ -24,30 +25,23 @@ import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.connector.EmptyPageSource;
 import io.trino.spi.predicate.TupleDomain;
 
+import javax.inject.Inject;
+
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 import static io.trino.SystemSessionProperties.isAllowPushdownIntoConnectors;
 import static java.util.Objects.requireNonNull;
 
 public class PageSourceManager
         implements PageSourceProvider
 {
-    private final ConcurrentMap<CatalogName, ConnectorPageSourceProvider> pageSourceProviders = new ConcurrentHashMap<>();
+    private final CatalogServiceProvider<ConnectorPageSourceProvider> pageSourceProvider;
 
-    public void addConnectorPageSourceProvider(CatalogName catalogName, ConnectorPageSourceProvider pageSourceProvider)
+    @Inject
+    public PageSourceManager(CatalogServiceProvider<ConnectorPageSourceProvider> pageSourceProvider)
     {
-        requireNonNull(catalogName, "catalogName is null");
-        requireNonNull(pageSourceProvider, "pageSourceProvider is null");
-        checkState(pageSourceProviders.put(catalogName, pageSourceProvider) == null, "PageSourceProvider for connector '%s' is already registered", catalogName);
-    }
-
-    public void removeConnectorPageSourceProvider(CatalogName catalogName)
-    {
-        pageSourceProviders.remove(catalogName);
+        this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
     }
 
     @Override
@@ -57,7 +51,7 @@ public class PageSourceManager
         checkArgument(split.getCatalogName().equals(table.getCatalogName()), "mismatched split and table");
         CatalogName catalogName = split.getCatalogName();
 
-        ConnectorPageSourceProvider provider = getPageSourceProvider(catalogName);
+        ConnectorPageSourceProvider provider = pageSourceProvider.getService(catalogName);
         TupleDomain<ColumnHandle> constraint = dynamicFilter.getCurrentPredicate();
         if (constraint.isNone()) {
             return new EmptyPageSource();
@@ -72,12 +66,5 @@ public class PageSourceManager
                 table.getConnectorHandle(),
                 columns,
                 dynamicFilter);
-    }
-
-    private ConnectorPageSourceProvider getPageSourceProvider(CatalogName catalogName)
-    {
-        ConnectorPageSourceProvider provider = pageSourceProviders.get(catalogName);
-        checkArgument(provider != null, "No page source provider for connector: %s", catalogName);
-        return provider;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzerFactory.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzerFactory.java
@@ -133,6 +133,6 @@ public class StatementAnalyzerFactory
                 new SessionPropertyManager(),
                 tablePropertyManager,
                 analyzePropertyManager,
-                new TableProceduresPropertyManager());
+                new TableProceduresPropertyManager(CatalogServiceProvider.fail("procedures are not supported in testing analyzer")));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzerFactory.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzerFactory.java
@@ -15,6 +15,7 @@ package io.trino.sql.analyzer;
 
 import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
+import io.trino.connector.CatalogServiceProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.AnalyzePropertyManager;
 import io.trino.metadata.SessionPropertyManager;
@@ -127,7 +128,7 @@ public class StatementAnalyzerFactory
                 accessControl,
                 new NoOpTransactionManager(),
                 user -> ImmutableSet.of(),
-                new TableProceduresRegistry(),
+                new TableProceduresRegistry(CatalogServiceProvider.fail("procedures are not supported in testing analyzer")),
                 new TableFunctionRegistry(),
                 new SessionPropertyManager(),
                 tablePropertyManager,

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzerFactory.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzerFactory.java
@@ -129,7 +129,7 @@ public class StatementAnalyzerFactory
                 new NoOpTransactionManager(),
                 user -> ImmutableSet.of(),
                 new TableProceduresRegistry(CatalogServiceProvider.fail("procedures are not supported in testing analyzer")),
-                new TableFunctionRegistry(),
+                new TableFunctionRegistry(CatalogServiceProvider.fail("table functions are not supported in testing analyzer")),
                 new SessionPropertyManager(),
                 tablePropertyManager,
                 analyzePropertyManager,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
@@ -316,7 +316,7 @@ public final class DomainTranslator
                         new NoOpTransactionManager(),
                         user -> ImmutableSet.of(),
                         new TableProceduresRegistry(CatalogServiceProvider.fail("procedures are not supported in domain translator")),
-                        new TableFunctionRegistry(),
+                        new TableFunctionRegistry(CatalogServiceProvider.fail("table functions are not supported in domain translator")),
                         new SessionPropertyManager(),
                         new TablePropertyManager(),
                         new AnalyzePropertyManager(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
@@ -318,8 +318,8 @@ public final class DomainTranslator
                         new TableProceduresRegistry(CatalogServiceProvider.fail("procedures are not supported in domain translator")),
                         new TableFunctionRegistry(CatalogServiceProvider.fail("table functions are not supported in domain translator")),
                         new SessionPropertyManager(),
-                        new TablePropertyManager(),
-                        new AnalyzePropertyManager(),
+                        new TablePropertyManager(CatalogServiceProvider.fail("table properties not supported in domain translator")),
+                        new AnalyzePropertyManager(CatalogServiceProvider.fail("analyze properties not supported in domain translator")),
                         new TableProceduresPropertyManager()));
         return new Visitor(plannerContext, session, types, typeAnalyzer).process(predicate, false);
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
@@ -21,6 +21,7 @@ import com.google.common.collect.PeekingIterator;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.trino.Session;
+import io.trino.connector.CatalogServiceProvider;
 import io.trino.metadata.AnalyzePropertyManager;
 import io.trino.metadata.OperatorNotFoundException;
 import io.trino.metadata.ResolvedFunction;
@@ -314,7 +315,7 @@ public final class DomainTranslator
                         new AllowAllAccessControl(),
                         new NoOpTransactionManager(),
                         user -> ImmutableSet.of(),
-                        new TableProceduresRegistry(),
+                        new TableProceduresRegistry(CatalogServiceProvider.fail("procedures are not supported in domain translator")),
                         new TableFunctionRegistry(),
                         new SessionPropertyManager(),
                         new TablePropertyManager(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
@@ -320,7 +320,7 @@ public final class DomainTranslator
                         new SessionPropertyManager(),
                         new TablePropertyManager(CatalogServiceProvider.fail("table properties not supported in domain translator")),
                         new AnalyzePropertyManager(CatalogServiceProvider.fail("analyze properties not supported in domain translator")),
-                        new TableProceduresPropertyManager()));
+                        new TableProceduresPropertyManager(CatalogServiceProvider.fail("procedures are not supported in domain translator"))));
         return new Visitor(plannerContext, session, types, typeAnalyzer).process(predicate, false);
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/TypeAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/TypeAnalyzer.java
@@ -16,6 +16,7 @@ package io.trino.sql.planner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
+import io.trino.connector.CatalogServiceProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.AnalyzePropertyManager;
 import io.trino.metadata.TablePropertyManager;
@@ -84,7 +85,7 @@ public class TypeAnalyzer
                 createTestingStatementAnalyzerFactory(
                         plannerContext,
                         new AllowAllAccessControl(),
-                        new TablePropertyManager(),
-                        new AnalyzePropertyManager()));
+                        new TablePropertyManager(CatalogServiceProvider.fail("table properties not supported in testing type analyzer")),
+                        new AnalyzePropertyManager(CatalogServiceProvider.fail("analyze properties not supported in testing type analyzer"))));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveUnsupportedDynamicFilters.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveUnsupportedDynamicFilters.java
@@ -105,7 +105,7 @@ public class RemoveUnsupportedDynamicFilters
                         new SessionPropertyManager(),
                         new TablePropertyManager(CatalogServiceProvider.fail("table properties not supported in testing analyzer")),
                         new AnalyzePropertyManager(CatalogServiceProvider.fail("analyze properties not supported in testing analyzer")),
-                        new TableProceduresPropertyManager()));
+                        new TableProceduresPropertyManager(CatalogServiceProvider.fail("procedures are not supported in testing analyzer"))));
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveUnsupportedDynamicFilters.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveUnsupportedDynamicFilters.java
@@ -103,8 +103,8 @@ public class RemoveUnsupportedDynamicFilters
                         new TableProceduresRegistry(CatalogServiceProvider.fail("procedures are not supported in testing analyzer")),
                         new TableFunctionRegistry(CatalogServiceProvider.fail("table functions are not supported in testing analyzer")),
                         new SessionPropertyManager(),
-                        new TablePropertyManager(),
-                        new AnalyzePropertyManager(),
+                        new TablePropertyManager(CatalogServiceProvider.fail("table properties not supported in testing analyzer")),
+                        new AnalyzePropertyManager(CatalogServiceProvider.fail("analyze properties not supported in testing analyzer")),
                         new TableProceduresPropertyManager()));
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveUnsupportedDynamicFilters.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveUnsupportedDynamicFilters.java
@@ -16,6 +16,7 @@ package io.trino.sql.planner.iterative.rule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
+import io.trino.connector.CatalogServiceProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.AnalyzePropertyManager;
 import io.trino.metadata.OperatorNotFoundException;
@@ -99,7 +100,7 @@ public class RemoveUnsupportedDynamicFilters
                         new AllowAllAccessControl(),
                         new NoOpTransactionManager(),
                         user -> ImmutableSet.of(),
-                        new TableProceduresRegistry(),
+                        new TableProceduresRegistry(CatalogServiceProvider.fail("procedures are not supported in testing analyzer")),
                         new TableFunctionRegistry(),
                         new SessionPropertyManager(),
                         new TablePropertyManager(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveUnsupportedDynamicFilters.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveUnsupportedDynamicFilters.java
@@ -101,7 +101,7 @@ public class RemoveUnsupportedDynamicFilters
                         new NoOpTransactionManager(),
                         user -> ImmutableSet.of(),
                         new TableProceduresRegistry(CatalogServiceProvider.fail("procedures are not supported in testing analyzer")),
-                        new TableFunctionRegistry(),
+                        new TableFunctionRegistry(CatalogServiceProvider.fail("table functions are not supported in testing analyzer")),
                         new SessionPropertyManager(),
                         new TablePropertyManager(),
                         new AnalyzePropertyManager(),

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -218,6 +218,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.trino.connector.CatalogServiceProviderModule.createSplitManagerProvider;
 import static io.trino.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.GROUPED_SCHEDULING;
 import static io.trino.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.UNGROUPED_SCHEDULING;
 import static io.trino.spi.connector.Constraint.alwaysTrue;
@@ -371,7 +372,6 @@ public class LocalQueryRunner
                 new JsonQueryFunction(functionManager, metadata, typeManager)));
         typeRegistry.addType(new JsonPath2016Type(new TypeDeserializer(typeManager), blockEncodingSerde));
         this.plannerContext = new PlannerContext(metadata, typeOperators, blockEncodingSerde, typeManager, functionManager);
-        this.splitManager = new SplitManager(new QueryManagerConfig());
         this.planFragmenter = new PlanFragmenter(metadata, functionManager, this.nodePartitioningManager, new QueryManagerConfig());
         this.joinCompiler = new JoinCompiler(typeOperators);
         PageIndexerFactory pageIndexerFactory = new GroupByHashPageIndexerFactory(joinCompiler, blockTypeOperators);
@@ -419,7 +419,6 @@ public class LocalQueryRunner
                 metadata,
                 catalogManager,
                 accessControl,
-                splitManager,
                 pageSourceManager,
                 indexManager,
                 nodePartitioningManager,
@@ -444,6 +443,7 @@ public class LocalQueryRunner
                 analyzePropertyManager,
                 tableProceduresPropertyManager,
                 nodeSchedulerConfig);
+        this.splitManager = new SplitManager(createSplitManagerProvider(connectorManager), new QueryManagerConfig());
 
         GlobalSystemConnectorFactory globalSystemConnectorFactory = new GlobalSystemConnectorFactory(ImmutableSet.of(
                 new NodeSystemTable(nodeManager),

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -218,6 +218,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.trino.connector.CatalogServiceProviderModule.createPageSinkProvider;
 import static io.trino.connector.CatalogServiceProviderModule.createPageSourceProvider;
 import static io.trino.connector.CatalogServiceProviderModule.createSplitManagerProvider;
 import static io.trino.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.GROUPED_SCHEDULING;
@@ -344,7 +345,6 @@ public class LocalQueryRunner
         NodeScheduler nodeScheduler = new NodeScheduler(new UniformNodeSelectorFactory(nodeManager, nodeSchedulerConfig, new NodeTaskMap(finalizerService)));
         requireNonNull(featuresConfig, "featuresConfig is null");
         this.optimizerConfig = new OptimizerConfig();
-        this.pageSinkManager = new PageSinkManager();
         CatalogManager catalogManager = new CatalogManager();
         this.transactionManager = InMemoryTransactionManager.create(
                 new TransactionManagerConfig().setIdleTimeout(new Duration(1, TimeUnit.DAYS)),
@@ -421,7 +421,6 @@ public class LocalQueryRunner
                 accessControl,
                 indexManager,
                 nodePartitioningManager,
-                pageSinkManager,
                 handleResolver,
                 nodeManager,
                 nodeInfo,
@@ -444,6 +443,7 @@ public class LocalQueryRunner
                 nodeSchedulerConfig);
         this.splitManager = new SplitManager(createSplitManagerProvider(connectorManager), new QueryManagerConfig());
         this.pageSourceManager = new PageSourceManager(createPageSourceProvider(connectorManager));
+        this.pageSinkManager = new PageSinkManager(createPageSinkProvider(connectorManager));
 
         GlobalSystemConnectorFactory globalSystemConnectorFactory = new GlobalSystemConnectorFactory(ImmutableSet.of(
                 new NodeSystemTable(nodeManager),

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -229,6 +229,7 @@ import static io.trino.connector.CatalogServiceProviderModule.createPageSourcePr
 import static io.trino.connector.CatalogServiceProviderModule.createSchemaPropertyManager;
 import static io.trino.connector.CatalogServiceProviderModule.createSplitManagerProvider;
 import static io.trino.connector.CatalogServiceProviderModule.createTableFunctionProvider;
+import static io.trino.connector.CatalogServiceProviderModule.createTableProceduresPropertyManager;
 import static io.trino.connector.CatalogServiceProviderModule.createTableProceduresProvider;
 import static io.trino.connector.CatalogServiceProviderModule.createTablePropertyManager;
 import static io.trino.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.GROUPED_SCHEDULING;
@@ -386,8 +387,6 @@ public class LocalQueryRunner
         this.accessControl = new TestingAccessControlManager(transactionManager, eventListenerManager);
         accessControl.loadSystemAccessControl(AllowAllSystemAccessControl.NAME, ImmutableMap.of());
 
-        TableProceduresPropertyManager tableProceduresPropertyManager = new TableProceduresPropertyManager();
-
         this.pageFunctionCompiler = new PageFunctionCompiler(functionManager, 0);
         this.expressionCompiler = new ExpressionCompiler(functionManager, pageFunctionCompiler);
         this.joinFilterFunctionCompiler = new JoinFilterFunctionCompiler(functionManager);
@@ -408,7 +407,6 @@ public class LocalQueryRunner
                 transactionManager,
                 eventListenerManager,
                 typeManager,
-                tableProceduresPropertyManager,
                 nodeSchedulerConfig);
         this.splitManager = new SplitManager(createSplitManagerProvider(connectorManager), new QueryManagerConfig());
         this.pageSourceManager = new PageSourceManager(createPageSourceProvider(connectorManager));
@@ -424,6 +422,7 @@ public class LocalQueryRunner
         this.tablePropertyManager = createTablePropertyManager(connectorManager);
         this.materializedViewPropertyManager = createMaterializedViewPropertyManager(connectorManager);
         this.analyzePropertyManager = createAnalyzePropertyManager(connectorManager);
+        TableProceduresPropertyManager tableProceduresPropertyManager = createTableProceduresPropertyManager(connectorManager);
 
         this.statementAnalyzerFactory = new StatementAnalyzerFactory(
                 plannerContext,

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -217,13 +217,18 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.trino.connector.CatalogServiceProviderModule.createAnalyzePropertyManager;
+import static io.trino.connector.CatalogServiceProviderModule.createColumnPropertyManager;
 import static io.trino.connector.CatalogServiceProviderModule.createIndexProvider;
+import static io.trino.connector.CatalogServiceProviderModule.createMaterializedViewPropertyManager;
 import static io.trino.connector.CatalogServiceProviderModule.createNodePartitioningProvider;
 import static io.trino.connector.CatalogServiceProviderModule.createPageSinkProvider;
 import static io.trino.connector.CatalogServiceProviderModule.createPageSourceProvider;
+import static io.trino.connector.CatalogServiceProviderModule.createSchemaPropertyManager;
 import static io.trino.connector.CatalogServiceProviderModule.createSplitManagerProvider;
 import static io.trino.connector.CatalogServiceProviderModule.createTableFunctionProvider;
 import static io.trino.connector.CatalogServiceProviderModule.createTableProceduresProvider;
+import static io.trino.connector.CatalogServiceProviderModule.createTablePropertyManager;
 import static io.trino.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.GROUPED_SCHEDULING;
 import static io.trino.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.UNGROUPED_SCHEDULING;
 import static io.trino.spi.connector.Constraint.alwaysTrue;
@@ -380,11 +385,6 @@ public class LocalQueryRunner
         accessControl.loadSystemAccessControl(AllowAllSystemAccessControl.NAME, ImmutableMap.of());
 
         this.sessionPropertyManager = createSessionPropertyManager(extraSessionProperties, taskManagerConfig, featuresConfig, optimizerConfig);
-        this.schemaPropertyManager = new SchemaPropertyManager();
-        this.columnPropertyManager = new ColumnPropertyManager();
-        this.tablePropertyManager = new TablePropertyManager();
-        this.materializedViewPropertyManager = new MaterializedViewPropertyManager();
-        this.analyzePropertyManager = new AnalyzePropertyManager();
         TableProceduresPropertyManager tableProceduresPropertyManager = new TableProceduresPropertyManager();
 
         this.pageFunctionCompiler = new PageFunctionCompiler(functionManager, 0);
@@ -408,11 +408,6 @@ public class LocalQueryRunner
                 eventListenerManager,
                 typeManager,
                 sessionPropertyManager,
-                schemaPropertyManager,
-                columnPropertyManager,
-                tablePropertyManager,
-                materializedViewPropertyManager,
-                analyzePropertyManager,
                 tableProceduresPropertyManager,
                 nodeSchedulerConfig);
         this.splitManager = new SplitManager(createSplitManagerProvider(connectorManager), new QueryManagerConfig());
@@ -423,6 +418,11 @@ public class LocalQueryRunner
         this.nodePartitioningManager = new NodePartitioningManager(nodeScheduler, blockTypeOperators, createNodePartitioningProvider(connectorManager));
         TableProceduresRegistry tableProceduresRegistry = new TableProceduresRegistry(createTableProceduresProvider(connectorManager));
         TableFunctionRegistry tableFunctionRegistry = new TableFunctionRegistry(createTableFunctionProvider(connectorManager));
+        this.schemaPropertyManager = createSchemaPropertyManager(connectorManager);
+        this.columnPropertyManager = createColumnPropertyManager(connectorManager);
+        this.tablePropertyManager = createTablePropertyManager(connectorManager);
+        this.materializedViewPropertyManager = createMaterializedViewPropertyManager(connectorManager);
+        this.analyzePropertyManager = createAnalyzePropertyManager(connectorManager);
 
         this.statementAnalyzerFactory = new StatementAnalyzerFactory(
                 plannerContext,

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -218,6 +218,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.trino.connector.CatalogServiceProviderModule.createPageSourceProvider;
 import static io.trino.connector.CatalogServiceProviderModule.createSplitManagerProvider;
 import static io.trino.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.GROUPED_SCHEDULING;
 import static io.trino.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.UNGROUPED_SCHEDULING;
@@ -406,7 +407,6 @@ public class LocalQueryRunner
         this.taskCountEstimator = new TaskCountEstimator(() -> nodeCountForStats);
         this.costCalculator = new CostCalculatorUsingExchanges(taskCountEstimator);
         this.estimatedExchangesCostCalculator = new CostCalculatorWithEstimatedExchanges(costCalculator, taskCountEstimator);
-        this.pageSourceManager = new PageSourceManager();
 
         this.pageFunctionCompiler = new PageFunctionCompiler(functionManager, 0);
         this.expressionCompiler = new ExpressionCompiler(functionManager, pageFunctionCompiler);
@@ -419,7 +419,6 @@ public class LocalQueryRunner
                 metadata,
                 catalogManager,
                 accessControl,
-                pageSourceManager,
                 indexManager,
                 nodePartitioningManager,
                 pageSinkManager,
@@ -444,6 +443,7 @@ public class LocalQueryRunner
                 tableProceduresPropertyManager,
                 nodeSchedulerConfig);
         this.splitManager = new SplitManager(createSplitManagerProvider(connectorManager), new QueryManagerConfig());
+        this.pageSourceManager = new PageSourceManager(createPageSourceProvider(connectorManager));
 
         GlobalSystemConnectorFactory globalSystemConnectorFactory = new GlobalSystemConnectorFactory(ImmutableSet.of(
                 new NodeSystemTable(nodeManager),

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -218,6 +218,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.trino.connector.CatalogServiceProviderModule.createIndexProvider;
 import static io.trino.connector.CatalogServiceProviderModule.createPageSinkProvider;
 import static io.trino.connector.CatalogServiceProviderModule.createPageSourceProvider;
 import static io.trino.connector.CatalogServiceProviderModule.createSplitManagerProvider;
@@ -340,7 +341,6 @@ public class LocalQueryRunner
         this.sqlParser = new SqlParser();
         this.nodeManager = new InMemoryNodeManager();
         PageSorter pageSorter = new PagesIndexPageSorter(new PagesIndex.TestingFactory(false));
-        this.indexManager = new IndexManager();
         NodeSchedulerConfig nodeSchedulerConfig = new NodeSchedulerConfig().setIncludeCoordinator(true);
         NodeScheduler nodeScheduler = new NodeScheduler(new UniformNodeSelectorFactory(nodeManager, nodeSchedulerConfig, new NodeTaskMap(finalizerService)));
         requireNonNull(featuresConfig, "featuresConfig is null");
@@ -419,7 +419,6 @@ public class LocalQueryRunner
                 metadata,
                 catalogManager,
                 accessControl,
-                indexManager,
                 nodePartitioningManager,
                 handleResolver,
                 nodeManager,
@@ -444,6 +443,7 @@ public class LocalQueryRunner
         this.splitManager = new SplitManager(createSplitManagerProvider(connectorManager), new QueryManagerConfig());
         this.pageSourceManager = new PageSourceManager(createPageSourceProvider(connectorManager));
         this.pageSinkManager = new PageSinkManager(createPageSinkProvider(connectorManager));
+        this.indexManager = new IndexManager(createIndexProvider(connectorManager));
 
         GlobalSystemConnectorFactory globalSystemConnectorFactory = new GlobalSystemConnectorFactory(ImmutableSet.of(
                 new NodeSystemTable(nodeManager),

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -222,6 +222,7 @@ import static io.trino.connector.CatalogServiceProviderModule.createNodePartitio
 import static io.trino.connector.CatalogServiceProviderModule.createPageSinkProvider;
 import static io.trino.connector.CatalogServiceProviderModule.createPageSourceProvider;
 import static io.trino.connector.CatalogServiceProviderModule.createSplitManagerProvider;
+import static io.trino.connector.CatalogServiceProviderModule.createTableFunctionProvider;
 import static io.trino.connector.CatalogServiceProviderModule.createTableProceduresProvider;
 import static io.trino.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.GROUPED_SCHEDULING;
 import static io.trino.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.UNGROUPED_SCHEDULING;
@@ -406,7 +407,6 @@ public class LocalQueryRunner
                 transactionManager,
                 eventListenerManager,
                 typeManager,
-                new TableFunctionRegistry(),
                 sessionPropertyManager,
                 schemaPropertyManager,
                 columnPropertyManager,
@@ -422,6 +422,7 @@ public class LocalQueryRunner
         NodeScheduler nodeScheduler = new NodeScheduler(new UniformNodeSelectorFactory(nodeManager, nodeSchedulerConfig, new NodeTaskMap(finalizerService)));
         this.nodePartitioningManager = new NodePartitioningManager(nodeScheduler, blockTypeOperators, createNodePartitioningProvider(connectorManager));
         TableProceduresRegistry tableProceduresRegistry = new TableProceduresRegistry(createTableProceduresProvider(connectorManager));
+        TableFunctionRegistry tableFunctionRegistry = new TableFunctionRegistry(createTableFunctionProvider(connectorManager));
 
         this.statementAnalyzerFactory = new StatementAnalyzerFactory(
                 plannerContext,
@@ -430,7 +431,7 @@ public class LocalQueryRunner
                 transactionManager,
                 groupProvider,
                 tableProceduresRegistry,
-                new TableFunctionRegistry(),
+                tableFunctionRegistry,
                 sessionPropertyManager,
                 tablePropertyManager,
                 analyzePropertyManager,

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -219,6 +219,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.trino.connector.CatalogServiceProviderModule.createAccessControlProvider;
 import static io.trino.connector.CatalogServiceProviderModule.createAnalyzePropertyManager;
 import static io.trino.connector.CatalogServiceProviderModule.createColumnPropertyManager;
 import static io.trino.connector.CatalogServiceProviderModule.createIndexProvider;
@@ -423,6 +424,8 @@ public class LocalQueryRunner
         this.materializedViewPropertyManager = createMaterializedViewPropertyManager(connectorManager);
         this.analyzePropertyManager = createAnalyzePropertyManager(connectorManager);
         TableProceduresPropertyManager tableProceduresPropertyManager = createTableProceduresPropertyManager(connectorManager);
+
+        accessControl.setConnectorAccessControlProvider(createAccessControlProvider(connectorManager));
 
         this.statementAnalyzerFactory = new StatementAnalyzerFactory(
                 plannerContext,

--- a/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
+++ b/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.connector.CatalogName;
+import io.trino.connector.CatalogServiceProvider;
 import io.trino.connector.MockConnectorFactory;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.AbstractMockMetadata;
@@ -44,6 +45,7 @@ import io.trino.spi.function.OperatorType;
 import io.trino.spi.resourcegroups.ResourceGroupId;
 import io.trino.spi.security.Identity;
 import io.trino.spi.security.TrinoPrincipal;
+import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.type.Type;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.planner.TestingConnectorTransactionHandle;
@@ -110,12 +112,10 @@ public abstract class BaseDataDefinitionTaskTest
         testSession = testSessionBuilder().build();
         metadata = new MockMetadata(new CatalogName(CATALOG_NAME));
         plannerContext = plannerContextBuilder().withMetadata(metadata).build();
-        materializedViewPropertyManager = new MaterializedViewPropertyManager();
-        materializedViewPropertyManager.addProperties(
-                new CatalogName(CATALOG_NAME),
-                ImmutableList.of(
-                        longProperty(MATERIALIZED_VIEW_PROPERTY_1_NAME, "property 1", MATERIALIZED_VIEW_PROPERTY_1_DEFAULT_VALUE, false),
-                        stringProperty(MATERIALIZED_VIEW_PROPERTY_2_NAME, "property 2", MATERIALIZED_VIEW_PROPERTY_2_DEFAULT_VALUE, false)));
+        Map<String, PropertyMetadata<?>> properties = ImmutableMap.of(
+                MATERIALIZED_VIEW_PROPERTY_1_NAME, longProperty(MATERIALIZED_VIEW_PROPERTY_1_NAME, "property 1", MATERIALIZED_VIEW_PROPERTY_1_DEFAULT_VALUE, false),
+                MATERIALIZED_VIEW_PROPERTY_2_NAME, stringProperty(MATERIALIZED_VIEW_PROPERTY_2_NAME, "property 2", MATERIALIZED_VIEW_PROPERTY_2_DEFAULT_VALUE, false));
+        materializedViewPropertyManager = new MaterializedViewPropertyManager(CatalogServiceProvider.singleton(new CatalogName(CATALOG_NAME), properties));
         queryStateMachine = stateMachine(transactionManager, createTestMetadataManager(), new AllowAllAccessControl(), testSession);
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
@@ -122,7 +122,7 @@ public final class TaskTestUtils
                 createTestingTypeAnalyzer(PLANNER_CONTEXT),
                 Optional.empty(),
                 pageSourceManager,
-                new IndexManager(),
+                new IndexManager(CatalogServiceProvider.fail()),
                 nodePartitioningManager,
                 new PageSinkManager(CatalogServiceProvider.fail()),
                 new MockDirectExchangeClientSupplier(),

--- a/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
@@ -114,7 +114,10 @@ public final class TaskTestUtils
                 new InMemoryNodeManager(),
                 new NodeSchedulerConfig().setIncludeCoordinator(true),
                 new NodeTaskMap(finalizerService)));
-        NodePartitioningManager nodePartitioningManager = new NodePartitioningManager(nodeScheduler, blockTypeOperators);
+        NodePartitioningManager nodePartitioningManager = new NodePartitioningManager(
+                nodeScheduler,
+                blockTypeOperators,
+                CatalogServiceProvider.fail());
 
         PageFunctionCompiler pageFunctionCompiler = new PageFunctionCompiler(PLANNER_CONTEXT.getFunctionManager(), 0);
         return new LocalExecutionPlanner(

--- a/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.json.ObjectMapperProvider;
 import io.trino.connector.CatalogName;
+import io.trino.connector.CatalogServiceProvider;
 import io.trino.cost.StatsAndCosts;
 import io.trino.event.SplitMonitor;
 import io.trino.eventlistener.EventListenerConfig;
@@ -103,8 +104,7 @@ public final class TaskTestUtils
 
     public static LocalExecutionPlanner createTestingPlanner()
     {
-        PageSourceManager pageSourceManager = new PageSourceManager();
-        pageSourceManager.addConnectorPageSourceProvider(CONNECTOR_ID, new TestingPageSourceProvider());
+        PageSourceManager pageSourceManager = new PageSourceManager(CatalogServiceProvider.singleton(CONNECTOR_ID, new TestingPageSourceProvider()));
 
         // we don't start the finalizer so nothing will be collected, which is ok for a test
         FinalizerService finalizerService = new FinalizerService();

--- a/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
@@ -124,7 +124,7 @@ public final class TaskTestUtils
                 pageSourceManager,
                 new IndexManager(),
                 nodePartitioningManager,
-                new PageSinkManager(),
+                new PageSinkManager(CatalogServiceProvider.fail()),
                 new MockDirectExchangeClientSupplier(),
                 new ExpressionCompiler(PLANNER_CONTEXT.getFunctionManager(), pageFunctionCompiler),
                 pageFunctionCompiler,

--- a/core/trino-main/src/test/java/io/trino/execution/TestCallTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCallTask.java
@@ -16,8 +16,10 @@ package io.trino.execution;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.connector.CatalogName;
+import io.trino.connector.CatalogServiceProvider;
 import io.trino.connector.MockConnectorFactory;
 import io.trino.execution.warnings.WarningCollector;
+import io.trino.metadata.CatalogProcedures;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.ProcedureRegistry;
 import io.trino.plugin.base.security.AllowAllSystemAccessControl;
@@ -148,9 +150,8 @@ public class TestCallTask
 
     private static ProcedureRegistry createProcedureRegistry(Procedure procedure)
     {
-        ProcedureRegistry procedureRegistry = new ProcedureRegistry();
-        procedureRegistry.addProcedures(new CatalogName("test"), ImmutableList.of(procedure));
-        return procedureRegistry;
+        CatalogName catalogName = new CatalogName("test");
+        return new ProcedureRegistry(CatalogServiceProvider.singleton(catalogName, new CatalogProcedures(ImmutableList.of(procedure))));
     }
 
     private QueryStateMachine stateMachine(TransactionManager transactionManager, Metadata metadata, AccessControl accessControl)

--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateSchemaTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateSchemaTask.java
@@ -14,7 +14,9 @@
 package io.trino.execution;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.trino.connector.CatalogName;
+import io.trino.connector.CatalogServiceProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.SchemaPropertyManager;
 import io.trino.security.AllowAllAccessControl;
@@ -81,8 +83,7 @@ public class TestCreateSchemaTask
 
     private CreateSchemaTask getCreateSchemaTask()
     {
-        SchemaPropertyManager schemaPropertyManager = new SchemaPropertyManager();
-        schemaPropertyManager.addProperties(new CatalogName(CATALOG_NAME), ImmutableList.of());
+        SchemaPropertyManager schemaPropertyManager = new SchemaPropertyManager(CatalogServiceProvider.singleton(new CatalogName(CATALOG_NAME), ImmutableMap.of()));
         return new CreateSchemaTask(plannerContext, new AllowAllAccessControl(), schemaPropertyManager);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateViewTask.java
@@ -16,6 +16,7 @@ package io.trino.execution;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
+import io.trino.connector.CatalogServiceProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.AnalyzePropertyManager;
 import io.trino.metadata.QualifiedObjectName;
@@ -56,7 +57,13 @@ public class TestCreateViewTask
     {
         super.setUp();
         parser = new SqlParser();
-        analyzerFactory = new AnalyzerFactory(createTestingStatementAnalyzerFactory(plannerContext, new AllowAllAccessControl(), new TablePropertyManager(), new AnalyzePropertyManager()), new StatementRewrite(ImmutableSet.of()));
+        analyzerFactory = new AnalyzerFactory(
+                createTestingStatementAnalyzerFactory(
+                        plannerContext,
+                        new AllowAllAccessControl(),
+                        new TablePropertyManager(CatalogServiceProvider.fail()),
+                        new AnalyzePropertyManager(CatalogServiceProvider.fail())),
+                new StatementRewrite(ImmutableSet.of()));
         QualifiedObjectName tableName = qualifiedObjectName("mock_table");
         metadata.createTable(testSession, CATALOG_NAME, someTable(tableName), false);
     }

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetPropertiesTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetPropertiesTask.java
@@ -15,6 +15,7 @@ package io.trino.execution;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.trino.connector.CatalogServiceProvider;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.TablePropertyManager;
@@ -68,7 +69,7 @@ public class TestSetPropertiesTask
 
     private void executeSetProperties(SetProperties statement)
     {
-        new SetPropertiesTask(plannerContext, new AllowAllAccessControl(), new TablePropertyManager(), materializedViewPropertyManager)
+        new SetPropertiesTask(plannerContext, new AllowAllAccessControl(), new TablePropertyManager(CatalogServiceProvider.fail()), materializedViewPropertyManager)
                 .execute(statement, queryStateMachine, ImmutableList.of(), WarningCollector.NOOP);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/TestTableWriterOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestTableWriterOperator.java
@@ -18,6 +18,7 @@ import io.airlift.slice.Slice;
 import io.trino.RowPagesBuilder;
 import io.trino.Session;
 import io.trino.connector.CatalogName;
+import io.trino.connector.CatalogServiceProvider;
 import io.trino.memory.context.MemoryTrackingContext;
 import io.trino.metadata.OutputTableHandle;
 import io.trino.metadata.TestingFunctionResolution;
@@ -164,8 +165,7 @@ public class TestTableWriterOperator
     @Test
     public void testTableWriterInfo()
     {
-        PageSinkManager pageSinkManager = new PageSinkManager();
-        pageSinkManager.addConnectorPageSinkProvider(CONNECTOR_ID, new ConstantPageSinkProvider(new TableWriteInfoTestPageSink()));
+        PageSinkManager pageSinkManager = new PageSinkManager(CatalogServiceProvider.singleton(CONNECTOR_ID, new ConstantPageSinkProvider(new TableWriteInfoTestPageSink())));
         TableWriterOperator tableWriterOperator = (TableWriterOperator) createTableWriterOperator(
                 pageSinkManager,
                 new DevNullOperatorFactory(1, new PlanNodeId("test")),
@@ -194,8 +194,7 @@ public class TestTableWriterOperator
     public void testStatisticsAggregation()
             throws Exception
     {
-        PageSinkManager pageSinkManager = new PageSinkManager();
-        pageSinkManager.addConnectorPageSinkProvider(CONNECTOR_ID, new ConstantPageSinkProvider(new TableWriteInfoTestPageSink()));
+        PageSinkManager pageSinkManager = new PageSinkManager(CatalogServiceProvider.singleton(CONNECTOR_ID, new ConstantPageSinkProvider(new TableWriteInfoTestPageSink())));
         ImmutableList<Type> outputTypes = ImmutableList.of(BIGINT, VARBINARY, BIGINT);
         Session session = testSessionBuilder()
                 .setSystemProperty("statistics_cpu_timer_enabled", "true")
@@ -262,8 +261,7 @@ public class TestTableWriterOperator
 
     private Operator createTableWriterOperator(BlockingPageSink blockingPageSink)
     {
-        PageSinkManager pageSinkManager = new PageSinkManager();
-        pageSinkManager.addConnectorPageSinkProvider(CONNECTOR_ID, new ConstantPageSinkProvider(blockingPageSink));
+        PageSinkManager pageSinkManager = new PageSinkManager(CatalogServiceProvider.singleton(CONNECTOR_ID, new ConstantPageSinkProvider(blockingPageSink)));
         return createTableWriterOperator(pageSinkManager, new DevNullOperatorFactory(1, new PlanNodeId("test")), ImmutableList.of(BIGINT, VARBINARY));
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/join/TestHashJoinOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/TestHashJoinOperator.java
@@ -23,6 +23,7 @@ import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.ExceededMemoryLimitException;
 import io.trino.RowPagesBuilder;
+import io.trino.connector.CatalogServiceProvider;
 import io.trino.execution.Lifespan;
 import io.trino.execution.NodeTaskMap;
 import io.trino.execution.StageId;
@@ -167,7 +168,10 @@ public class TestHashJoinOperator
                 new InMemoryNodeManager(),
                 new NodeSchedulerConfig().setIncludeCoordinator(true),
                 new NodeTaskMap(new FinalizerService())));
-        nodePartitioningManager = new NodePartitioningManager(nodeScheduler, new BlockTypeOperators(new TypeOperators()));
+        nodePartitioningManager = new NodePartitioningManager(
+                nodeScheduler,
+                new BlockTypeOperators(new TypeOperators()),
+                CatalogServiceProvider.fail());
     }
 
     @AfterMethod(alwaysRun = true)

--- a/core/trino-main/src/test/java/io/trino/server/TestSessionPropertyDefaults.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestSessionPropertyDefaults.java
@@ -15,9 +15,13 @@ package io.trino.server;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import io.airlift.node.NodeInfo;
 import io.trino.Session;
+import io.trino.SystemSessionProperties;
 import io.trino.connector.CatalogName;
+import io.trino.connector.CatalogServiceProvider;
 import io.trino.metadata.SessionPropertyManager;
 import io.trino.spi.QueryId;
 import io.trino.spi.resourcegroups.ResourceGroupId;
@@ -46,10 +50,12 @@ public class TestSessionPropertyDefaults
     {
         SessionPropertyDefaults sessionPropertyDefaults = new SessionPropertyDefaults(TEST_NODE_INFO, new AllowAllAccessControlManager());
 
-        SessionPropertyManager sessionPropertyManager = new SessionPropertyManager();
-        sessionPropertyManager.addConnectorSessionProperties(new CatalogName("testCatalog"), ImmutableList.of(
+        ImmutableList<PropertyMetadata<?>> catalogProperties = ImmutableList.of(
                 PropertyMetadata.stringProperty("explicit_set", "Test property", null, false),
-                PropertyMetadata.stringProperty("catalog_default", "Test property", null, false)));
+                PropertyMetadata.stringProperty("catalog_default", "Test property", null, false));
+        SessionPropertyManager sessionPropertyManager = new SessionPropertyManager(
+                ImmutableSet.of(new SystemSessionProperties()),
+                CatalogServiceProvider.singleton(new CatalogName("testCatalog"), Maps.uniqueIndex(catalogProperties, PropertyMetadata::getName)));
 
         SessionPropertyConfigurationManagerFactory factory = new TestingSessionPropertyConfigurationManagerFactory(
                 ImmutableMap.<String, String>builder()

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -21,6 +21,7 @@ import com.google.common.io.Closer;
 import io.trino.FeaturesConfig;
 import io.trino.Session;
 import io.trino.SystemSessionProperties;
+import io.trino.connector.CatalogServiceProvider;
 import io.trino.connector.MockConnectorFactory;
 import io.trino.connector.StaticConnectorFactory;
 import io.trino.execution.DynamicFilterConfig;
@@ -6257,10 +6258,10 @@ public class TestAnalyzer
                 SQL_PARSER,
                 accessControl,
                 new SessionPropertyManager(),
-                new SchemaPropertyManager(),
-                new ColumnPropertyManager(),
+                new SchemaPropertyManager(CatalogServiceProvider.fail()),
+                new ColumnPropertyManager(CatalogServiceProvider.fail()),
                 tablePropertyManager,
-                new MaterializedViewPropertyManager())));
+                new MaterializedViewPropertyManager(catalogName -> ImmutableMap.of()))));
         StatementAnalyzerFactory statementAnalyzerFactory = createTestingStatementAnalyzerFactory(plannerContext, accessControl, tablePropertyManager, analyzePropertyManager);
         AnalyzerFactory analyzerFactory = new AnalyzerFactory(statementAnalyzerFactory, statementRewrite);
         return analyzerFactory.createAnalyzer(

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestTableScanNodePartitioning.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestTableScanNodePartitioning.java
@@ -131,9 +131,6 @@ public class TestTableScanNodePartitioning
                 .withNodeCountForStats(10)
                 .build();
         queryRunner.createCatalog(MOCK_CATALOG, createMockFactory(), ImmutableMap.of());
-        queryRunner.getNodePartitioningManager().addPartitioningProvider(
-                new CatalogName(MOCK_CATALOG),
-                new TestPartitioningProvider(new InMemoryNodeManager()));
         return queryRunner;
     }
 
@@ -201,6 +198,7 @@ public class TestTableScanNodePartitioning
     public static MockConnectorFactory createMockFactory()
     {
         return MockConnectorFactory.builder()
+                .withPartitionProvider(new TestPartitioningProvider(new InMemoryNodeManager()))
                 .withGetColumns(schemaTableName -> ImmutableList.of(
                         new ColumnMetadata(COLUMN_A, BIGINT),
                         new ColumnMetadata(COLUMN_B, VARCHAR)))

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestDetermineTableScanNodePartitioning.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestDetermineTableScanNodePartitioning.java
@@ -16,16 +16,13 @@ package io.trino.sql.planner.iterative.rule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
-import io.trino.connector.CatalogName;
 import io.trino.cost.StatsProvider;
 import io.trino.cost.TaskCountEstimator;
-import io.trino.metadata.InMemoryNodeManager;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.TableHandle;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.sql.planner.Symbol;
-import io.trino.sql.planner.TestTableScanNodePartitioning.TestPartitioningProvider;
 import io.trino.sql.planner.assertions.MatchResult;
 import io.trino.sql.planner.assertions.Matcher;
 import io.trino.sql.planner.assertions.SymbolAliases;
@@ -67,9 +64,6 @@ public class TestDetermineTableScanNodePartitioning
     {
         tester = defaultRuleTester();
         tester.getQueryRunner().createCatalog(MOCK_CATALOG, createMockFactory(), ImmutableMap.of());
-        tester.getQueryRunner().getNodePartitioningManager().addPartitioningProvider(
-                new CatalogName(MOCK_CATALOG),
-                new TestPartitioningProvider(new InMemoryNodeManager()));
     }
 
     @AfterClass(alwaysRun = true)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -7979,7 +7979,7 @@ public abstract class BaseHiveConnectorTest
         assertThat(getTableFiles(tableName)).hasSameElementsAs(compactedFiles);
 
         // optimize with delimited procedure name
-        assertQueryFails(optimizeEnabledSession, "ALTER TABLE " + tableName + " EXECUTE \"optimize\"", "Procedure optimize not registered for catalog hive");
+        assertQueryFails(optimizeEnabledSession, "ALTER TABLE " + tableName + " EXECUTE \"optimize\"", "Table procedure not registered: optimize");
         assertUpdate(optimizeEnabledSession, "ALTER TABLE " + tableName + " EXECUTE \"OPTIMIZE\"");
         // optimize with delimited parameter name (and procedure name)
         assertUpdate(optimizeEnabledSession, "ALTER TABLE " + tableName + " EXECUTE \"OPTIMIZE\" (\"file_size_threshold\" => '10B')"); // TODO (https://github.com/trinodb/trino/issues/11326) this should fail

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -3615,7 +3615,7 @@ public abstract class BaseIcebergConnectorTest
                 .containsExactlyInAnyOrderElementsOf(concat(initialFiles, updatedFiles));
 
         // optimize with delimited procedure name
-        assertQueryFails("ALTER TABLE " + tableName + " EXECUTE \"optimize\"", "Procedure optimize not registered for catalog iceberg");
+        assertQueryFails("ALTER TABLE " + tableName + " EXECUTE \"optimize\"", "Table procedure not registered: optimize");
         assertUpdate("ALTER TABLE " + tableName + " EXECUTE \"OPTIMIZE\"");
         // optimize with delimited parameter name (and procedure name)
         assertUpdate("ALTER TABLE " + tableName + " EXECUTE \"OPTIMIZE\" (\"file_size_threshold\" => '33B')"); // TODO (https://github.com/trinodb/trino/issues/11326) this should fail

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/PinotQueryRunner.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/PinotQueryRunner.java
@@ -14,11 +14,16 @@
 package io.trino.plugin.pinot;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.google.inject.Module;
 import io.airlift.log.Logger;
 import io.trino.Session;
+import io.trino.SystemSessionProperties;
 import io.trino.connector.CatalogName;
+import io.trino.connector.CatalogServiceProvider;
 import io.trino.metadata.SessionPropertyManager;
+import io.trino.spi.session.PropertyMetadata;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.kafka.TestingKafka;
 
@@ -53,9 +58,10 @@ public class PinotQueryRunner
 
     public static Session createSession(String schema, PinotConfig config)
     {
-        SessionPropertyManager sessionPropertyManager = new SessionPropertyManager();
         PinotSessionProperties pinotSessionProperties = new PinotSessionProperties(config);
-        sessionPropertyManager.addConnectorSessionProperties(new CatalogName(PINOT_CATALOG), pinotSessionProperties.getSessionProperties());
+        SessionPropertyManager sessionPropertyManager = new SessionPropertyManager(
+                ImmutableSet.of(new SystemSessionProperties()),
+                CatalogServiceProvider.singleton(new CatalogName(PINOT_CATALOG), Maps.uniqueIndex(pinotSessionProperties.getSessionProperties(), PropertyMetadata::getName)));
         return testSessionBuilder(sessionPropertyManager)
                 .setCatalog(PINOT_CATALOG)
                 .setSchema(schema)

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/RaptorQueryRunner.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/RaptorQueryRunner.java
@@ -15,13 +15,18 @@ package io.trino.plugin.raptor.legacy;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import io.airlift.log.Logger;
 import io.trino.Session;
+import io.trino.SystemSessionProperties;
 import io.trino.connector.CatalogName;
+import io.trino.connector.CatalogServiceProvider;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.SessionPropertyManager;
 import io.trino.plugin.raptor.legacy.storage.StorageManagerConfig;
 import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.spi.session.PropertyMetadata;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
 import io.trino.tpch.TpchTable;
@@ -146,8 +151,11 @@ public final class RaptorQueryRunner
 
     public static Session createSession(String schema)
     {
-        SessionPropertyManager sessionPropertyManager = new SessionPropertyManager();
-        sessionPropertyManager.addConnectorSessionProperties(new CatalogName("raptor"), new RaptorSessionProperties(new StorageManagerConfig()).getSessionProperties());
+        SessionPropertyManager sessionPropertyManager = new SessionPropertyManager(
+                ImmutableSet.of(new SystemSessionProperties()),
+                CatalogServiceProvider.singleton(
+                        new CatalogName("raptor"),
+                        Maps.uniqueIndex(new RaptorSessionProperties(new StorageManagerConfig()).getSessionProperties(), PropertyMetadata::getName)));
         return testSessionBuilder(sessionPropertyManager)
                 .setCatalog("raptor")
                 .setSchema(schema)


### PR DESCRIPTION
## Description

Change connector service managers (e.g.`SplitManager`, `PageSourceManager`) to pull connector services from `ConnectorManager` instead of `ConnectorManager` pushing services into the manger.  This makes it possible to cleanly add and remove connector instances at runtime.

## Related issues, pull requests, and links

This is a base refactorings for [Dynamic Catalogs](https://github.com/trinodb/trino/issues/12709) 

## Documentation

(X) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(X) No release notes entries required.
( ) Release notes entries required with the following suggested text:
