### PR TITLE
Add IN operator to the comparison section documentation

### DIFF
--- a/docs/src/main/sphinx/functions/comparison.rst
+++ b/docs/src/main/sphinx/functions/comparison.rst
@@ -227,6 +227,7 @@ It is shorthand of mutiple ``OR`` conditions::
     SELECT * FROM region WHERE name = 'AMERICA' OR name = 'AFRICA';
     
 It will return null if there are no rows matching the ``IN`` condition and hence the query will be null.
+
 It will return null if the left-hand side expression yields null::
 
     SELECT * FROM region WHERE NULL IN ('AMERICA', 'AFRICA');

--- a/docs/src/main/sphinx/functions/comparison.rst
+++ b/docs/src/main/sphinx/functions/comparison.rst
@@ -236,6 +236,8 @@ The below query will return rows containing name as 'AFRICA'::
     SELECT * FROM region WHERE name IN (NULL, 'AFRICA');
     
 The above applies to subqueries also::
+    
     SELECT name FROM nation 
     WHERE regionkey IN ( SELECT regionkey FROM region 
-    WHERE name IN ('AMERICA','AFRICA'));
+    WHERE name IN ('AMERICA', 'AFRICA'));
+    

--- a/docs/src/main/sphinx/functions/comparison.rst
+++ b/docs/src/main/sphinx/functions/comparison.rst
@@ -214,3 +214,28 @@ you need to match the used escape character as well, you can escape it.
 
 If you want to match for the chosen escape character, you simply escape itself.
 For example, you can use ``\\`` to match for ''\''.
+
+Row comparison: IN
+------------------------
+
+The ``IN`` operator can be use to fetch multiple rows according to mutiple values specified in WHERE clause::
+
+    SELECT * FROM region WHERE name IN ('AMERICA', 'AFRICA');
+    
+It is shorthand of mutiple ``OR`` conditions::
+    
+    SELECT * FROM region WHERE name = 'AMERICA' OR name = 'AFRICA';
+    
+It will return null if there are no rows matching the ``IN`` condition and hence the query will be null.
+It will return null if the left-hand side expression yields null::
+
+    SELECT * FROM region WHERE NULL IN ('AMERICA', 'AFRICA');
+    
+The below query will return rows containing name as 'AFRICA'::
+    
+    SELECT * FROM region WHERE name IN (NULL, 'AFRICA');
+    
+The above applies to subqueries also::
+    SELECT name FROM nation 
+    WHERE regionkey IN ( SELECT regionkey FROM region 
+    WHERE name IN ('AMERICA','AFRICA'));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Add IN operator to the comparison section

> Is this change a fix, improvement, new feature, refactoring, or other?
improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
No

> How would you describe this change to a non-technical end user or system administrator?
This change adds documentation about IN operator in the comparison section. It also tells how the query reacts with null.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->
Fixes #4791 

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
