### PR TITLE
Support `data_size` when analyzing in Delta Lake

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.rst
+++ b/docs/src/main/sphinx/connector/delta-lake.rst
@@ -505,7 +505,7 @@ Table statistics
 ^^^^^^^^^^^^^^^^
 
 You can use :doc:`/sql/analyze` statements in Trino to populate the table
-statistics in Delta Lake. Number of distinct values (NDV)
+statistics in Delta Lake. Data size and number of distinct values (NDV)
 statistics are supported, while Minimum value, maximum value, and null value
 count statistics are not supported. The :doc:`cost-based optimizer
 </optimizer/cost-based-optimizations>` then uses these statistics to improve

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
@@ -352,6 +352,7 @@ public class HiveMetastoreBackedDeltaLakeMetastore
             if (statistics.isPresent()) {
                 DeltaLakeColumnStatistics deltaLakeColumnStatistics = statistics.get().getColumnStatistics().get(column.getName());
                 if (deltaLakeColumnStatistics != null && column.getColumnType() != PARTITION_KEY) {
+                    deltaLakeColumnStatistics.getTotalSizeInBytes().ifPresent(size -> columnStatsBuilder.setDataSize(Estimate.of(size)));
                     columnStatsBuilder.setDistinctValuesCount(Estimate.of(deltaLakeColumnStatistics.getNdvSummary().cardinality()));
                 }
             }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -1155,8 +1155,8 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
                 "VALUES " +
                         "('nationkey', null, 25.0, 0.0, null, 0, 24)," +
                         "('regionkey', null, 5.0, 0.0, null, 0, 4)," +
-                        "('comment', null, 25.0, 0.0, null, null, null)," +
-                        "('name', null, 25.0, 0.0, null, null, null)," +
+                        "('comment', 1857.0, 25.0, 0.0, null, null, null)," +
+                        "('name', 177.0, 25.0, 0.0, null, null, null)," +
                         "(null, null, null, null, 25.0, null, null)");
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAnalyze.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAnalyze.java
@@ -103,8 +103,8 @@ public class TestDeltaLakeAnalyze
                 "VALUES " +
                         "('nationkey', null, 25.0, 0.0, null, 0, 24)," +
                         "('regionkey', null, 5.0, 0.0, null, 0, 4)," +
-                        "('comment', null, 25.0, 0.0, null, null, null)," +
-                        "('name', null, 25.0, 0.0, null, null, null)," +
+                        "('comment', 1857.0, 25.0, 0.0, null, null, null)," +
+                        "('name', 177.0, 25.0, 0.0, null, null, null)," +
                         "(null, null, null, null, 25.0, null, null)");
 
         // reanalyze data (1 split is empty values)
@@ -115,8 +115,8 @@ public class TestDeltaLakeAnalyze
                 "VALUES " +
                         "('nationkey', null, 25.0, 0.0, null, 0, 24)," +
                         "('regionkey', null, 5.0, 0.0, null, 0, 4)," +
-                        "('comment', null, 25.0, 0.0, null, null, null)," +
-                        "('name', null, 25.0, 0.0, null, null, null)," +
+                        "('comment', 1857.0, 25.0, 0.0, null, null, null)," +
+                        "('name', 177.0, 25.0, 0.0, null, null, null)," +
                         "(null, null, null, null, 25.0, null, null)");
 
         // insert one more copy; should not influence stats other than rowcount
@@ -129,24 +129,24 @@ public class TestDeltaLakeAnalyze
                 "VALUES " +
                         "('nationkey', null, 25.0, 0.0, null, 0, 24)," +
                         "('regionkey', null, 5.0, 0.0, null, 0, 4)," +
-                        "('comment', null, 25.0, 0.0, null, null, null)," +
-                        "('name', null, 25.0, 0.0, null, null, null)," +
+                        "('comment', 3714.0, 25.0, 0.0, null, null, null)," +
+                        "('name', 354.0, 25.0, 0.0, null, null, null)," +
                         "(null, null, null, null, 50.0, null, null)");
 
         // insert modified rows
         assertUpdate("INSERT INTO " + tableName + " SELECT nationkey + 25, reverse(name), regionkey + 5, reverse(comment) FROM tpch.sf1.nation", 25);
 
-        // without ANALYZE all stats but NDV should be updated
+        // without ANALYZE all stats but size and NDV should be updated
         assertQuery(
                 "SHOW STATS FOR " + tableName,
                 "VALUES " +
                         "('nationkey', null, 25.0, 0.0, null, 0, 49)," +
                         "('regionkey', null, 5.0, 0.0, null, 0, 9)," +
-                        "('comment', null, 25.0, 0.0, null, null, null)," +
-                        "('name', null, 25.0, 0.0, null, null, null)," +
+                        "('comment', 3714.0, 25.0, 0.0, null, null, null)," +
+                        "('name', 354.0, 25.0, 0.0, null, null, null)," +
                         "(null, null, null, null, 75.0, null, null)");
 
-        // with analyze we should get new NDV
+        // with analyze we should get new size and NDV
         runAnalyzeVerifySplitCount(tableName, 1);
 
         assertQuery(
@@ -154,8 +154,8 @@ public class TestDeltaLakeAnalyze
                 "VALUES " +
                         "('nationkey', null, 50.0, 0.0, null, 0, 49)," +
                         "('regionkey', null, 10.0, 0.0, null, 0, 9)," +
-                        "('comment', null, 50.0, 0.0, null, null, null)," +
-                        "('name', null, 50.0, 0.0, null, null, null)," +
+                        "('comment', 5571.0, 50.0, 0.0, null, null, null)," +
+                        "('name', 531.0, 50.0, 0.0, null, null, null)," +
                         "(null, null, null, null, 75.0, null, null)");
     }
 
@@ -186,8 +186,8 @@ public class TestDeltaLakeAnalyze
                 "VALUES " +
                         "('nationkey', null, 25.0, 0.0, null, 0, 24)," +
                         "('regionkey', null, 5.0, 0.0, null, null, null)," +
-                        "('comment', null, 25.0, 0.0, null, null, null)," +
-                        "('name', null, 25.0, 0.0, null, null, null)," +
+                        "('comment', 1857.0, 25.0, 0.0, null, null, null)," +
+                        "('name', 177.0, 25.0, 0.0, null, null, null)," +
                         "(null, null, null, null, 25.0, null, null)");
 
         // insert one more copy; should not influence stats other than rowcount
@@ -200,32 +200,32 @@ public class TestDeltaLakeAnalyze
                 "VALUES " +
                         "('nationkey', null, 25.0, 0.0, null, 0, 24)," +
                         "('regionkey', null, 5.0, 0.0, null, null, null)," +
-                        "('comment', null, 25.0, 0.0, null, null, null)," +
-                        "('name', null, 25.0, 0.0, null, null, null)," +
+                        "('comment', 3714.0, 25.0, 0.0, null, null, null)," +
+                        "('name', 354.0, 25.0, 0.0, null, null, null)," +
                         "(null, null, null, null, 50.0, null, null)");
 
         // insert modified rows
         assertUpdate("INSERT INTO " + tableName + " SELECT nationkey + 25, reverse(name), regionkey + 5, reverse(comment) FROM tpch.sf1.nation", 25);
 
-        // without ANALYZE all stats but NDV should be updated
+        // without ANALYZE all stats but size and NDV should be updated
         assertQuery(
                 "SHOW STATS FOR " + tableName,
                 "VALUES " +
                         "('nationkey', null, 25.0, 0.0, null, 0, 49)," +
                         "('regionkey', null, 10.0, 0.0, null, null, null)," +
-                        "('comment', null, 25.0, 0.0, null, null, null)," +
-                        "('name', null, 25.0, 0.0, null, null, null)," +
+                        "('comment', 3714.0, 25.0, 0.0, null, null, null)," +
+                        "('name', 354.0, 25.0, 0.0, null, null, null)," +
                         "(null, null, null, null, 75.0, null, null)");
 
-        // with analyze we should get new NDV
+        // with analyze we should get new size and NDV
         runAnalyzeVerifySplitCount(tableName, 5);
         assertQuery(
                 "SHOW STATS FOR " + tableName,
                 "VALUES " +
                         "('nationkey', null, 50.0, 0.0, null, 0, 49)," +
                         "('regionkey', null, 10.0, 0.0, null, null, null)," +
-                        "('comment', null, 50.0, 0.0, null, null, null)," +
-                        "('name', null, 50.0, 0.0, null, null, null)," +
+                        "('comment', 5571.0, 50.0, 0.0, null, null, null)," +
+                        "('name', 531.0, 50.0, 0.0, null, null, null)," +
                         "(null, null, null, null, 75.0, null, null)");
     }
 
@@ -269,8 +269,8 @@ public class TestDeltaLakeAnalyze
                 "VALUES " +
                         "('nationkey', null, 25.0, 0.0, null, 0, 24)," +
                         "('regionkey', null, 5.0, 0.0, null, 0, 4)," +
-                        "('comment', null, 25.0, 0.0, null, null, null)," +
-                        "('name', null, 25.0, 0.0, null, null, null)," +
+                        "('comment', 1857.0, 25.0, 0.0, null, null, null)," +
+                        "('name', 177.0, 25.0, 0.0, null, null, null)," +
                         "(null, null, null, null, 25.0, null, null)");
     }
 
@@ -326,8 +326,8 @@ public class TestDeltaLakeAnalyze
                 "VALUES " +
                         "('nationkey', null, 5.0, 0.0, null, 0, 24)," +
                         "('regionkey', null, 3.0, 0.0, null, 0, 4)," +
-                        "('comment', null, 5.0, 0.0, null, null, null)," +
-                        "('name', null, 5.0, 0.0, null, null, null)," +
+                        "('comment', 434.0, 5.0, 0.0, null, null, null)," +
+                        "('name', 33.0, 5.0, 0.0, null, null, null)," +
                         "(null, null, null, null, 30.0, null, null)");
     }
 
@@ -391,8 +391,8 @@ public class TestDeltaLakeAnalyze
                 "VALUES " +
                         "('nationkey', null, 50.0, 0.0, null, 0, 49)," +
                         "('regionkey', null, 10.0, 0.0, null, 0, 9)," +
-                        "('comment', null, 50.0, 0.0, null, null, null)," +
-                        "('name', null, 50.0, 0.0, null, null, null)," +
+                        "('comment', 3764.0, 50.0, 0.0, null, null, null)," +
+                        "('name', 379.0, 50.0, 0.0, null, null, null)," +
                         "(null, null, null, null, 50.0, null, null)");
 
         // we and we should be able to reanalyze with a subset of columns
@@ -438,8 +438,8 @@ public class TestDeltaLakeAnalyze
             String extendedStats = "VALUES"
                     + "('nationkey', null, 25.0,  0.0, null,    0,   24),"
                     + "('regionkey', null,  5.0,  0.0, null,    0,    4),"
-                    + "('comment',   null, 25.0,  0.0, null, null, null),"
-                    + "('name',      null, 25.0,  0.0, null, null, null),"
+                    + "('comment', 1857.0, 25.0,  0.0, null, null, null),"
+                    + "('name',     177.0, 25.0,  0.0, null, null, null),"
                     + "(null,        null, null, null, 25.0, null, null)";
 
             assertQuery(query, baseStats);

--- a/plugin/trino-delta-lake/src/test/resources/statistics/extended_stats_with_data_size/_delta_log/_trino_meta/extended_stats.json
+++ b/plugin/trino-delta-lake/src/test/resources/statistics/extended_stats_with_data_size/_delta_log/_trino_meta/extended_stats.json
@@ -1,0 +1,1 @@
+{"modelVersion":4,"alreadyAnalyzedModifiedTimeMax":"2022-06-14T00:22:45.832Z","columnStatistics":{"regionkey":{"ndvSummary":"AgwFAMAJpivCask0QBa4hwHLKZ9HPsfq"},"name":{"totalSizeInBytes":34,"ndvSummary":"AgwFAIDfcjhBaBVVQ5jHhcHx/PZAbXX+"},"comment":{"totalSizeInBytes":330,"ndvSummary":"AgwFAIBFHELBdPNTwUY4mQCYOLrBl1fx"}}}

--- a/plugin/trino-delta-lake/src/test/resources/statistics/extended_stats_without_data_size/_delta_log/_trino_meta/extended_stats.json
+++ b/plugin/trino-delta-lake/src/test/resources/statistics/extended_stats_without_data_size/_delta_log/_trino_meta/extended_stats.json
@@ -1,0 +1,1 @@
+{"modelVersion":4,"alreadyAnalyzedModifiedTimeMax":"2022-06-13T05:40:24.561Z","columnStatistics":{"regionkey":{"ndvSummary":"AgwFAMAJpivCask0QBa4hwHLKZ9HPsfq"},"name":{"ndvSummary":"AgwFAIDfcjhBaBVVQ5jHhcHx/PZAbXX+"},"comment":{"ndvSummary":"AgwFAIBFHELBdPNTwUY4mQCYOLrBl1fx"}}}


### PR DESCRIPTION
## Description

Add support for `data_size` when analyzing in Delta Lake

## Documentation

(x) Sufficient documentation is included in this PR.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# Delta Lake
* Add support for `data_size` when analyzing a table. ({issue}`12814`)
```
