### PR TITLE
Ensure Iceberg test waits for dynamic filtering

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -2575,8 +2575,8 @@ public abstract class BaseIcebergConnectorTest
         assertUpdate("DROP TABLE test_all_types");
     }
 
-    @Test
-    public void testLocalDynamicFilteringWithSelectiveBuildSizeJoin()
+    @Test(timeOut = 25_000)
+    public void testLocalDynamicFilteringWithSelectiveBuildSideJoin()
     {
         // We need to prepare tables for this test. The test is required to use tables that are backed by at lest two files
         Session session = Session.builder(getSession())
@@ -2597,6 +2597,7 @@ public abstract class BaseIcebergConnectorTest
 
         session = Session.builder(getSession())
                 .setSystemProperty(JOIN_DISTRIBUTION_TYPE, BROADCAST.name())
+                .setCatalogSessionProperty(ICEBERG_CATALOG, "dynamic_filtering_wait_timeout", "1h")
                 .build();
 
         ResultWithQueryId<MaterializedResult> result = getDistributedQueryRunner().executeWithQueryId(


### PR DESCRIPTION
## Description

`testLocalDynamicFilteringWithSelectiveBuildSizeJoin` tests that a local Dynamic Filter is applied, so it should have a wait time set to ensure the filter is available.

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Test change only

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Test change only

> How would you describe this change to a non-technical end user or system administrator?

Test change only

## Related issues, pull requests, and links

Fixes: https://github.com/trinodb/trino/issues/10932

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text: