### PR TITLE
Inform engine about oversized Hive, Iceberg, Delta splits

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
@@ -57,6 +57,7 @@ import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getMaxInitial
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getMaxSplitSize;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.extractSchema;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogParser.deserializePartitionValue;
+import static java.lang.Math.max;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
@@ -262,7 +263,7 @@ public class DeltaLakeSplitManager
                     fileSize,
                     addFileEntry.getModificationTime(),
                     ImmutableList.of(),
-                    SplitWeight.fromProportion(Math.min(Math.max((double) splitSize / maxSplitSize, minimumAssignedSplitWeight), 1.0)),
+                    SplitWeight.fromProportion(max((double) splitSize / maxSplitSize, minimumAssignedSplitWeight)),
                     statisticsPredicate,
                     partitionKeys));
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/SizeBasedSplitWeightProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/SizeBasedSplitWeightProvider.java
@@ -18,6 +18,7 @@ import io.trino.plugin.hive.HiveSplitWeightProvider;
 import io.trino.spi.SplitWeight;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Math.max;
 import static java.util.Objects.requireNonNull;
 
 public class SizeBasedSplitWeightProvider
@@ -40,6 +41,6 @@ public class SizeBasedSplitWeightProvider
     {
         double computedWeight = splitSizeInBytes / targetSplitSizeInBytes;
         // Clamp the value be between the minimum weight and 1.0 (standard weight)
-        return SplitWeight.fromProportion(Math.min(Math.max(computedWeight, minimumWeight), 1.0));
+        return SplitWeight.fromProportion(max(computedWeight, minimumWeight));
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestSizeBasedSplitWeightProvider.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestSizeBasedSplitWeightProvider.java
@@ -40,7 +40,7 @@ public class TestSizeBasedSplitWeightProvider
         assertEquals(provider.weightForSplitSizeInBytes(1), SplitWeight.fromProportion(minimumWeight));
 
         DataSize largerThanTarget = DataSize.of(128, MEGABYTE);
-        assertEquals(provider.weightForSplitSizeInBytes(largerThanTarget.toBytes()), SplitWeight.standard());
+        assertEquals(provider.weightForSplitSizeInBytes(largerThanTarget.toBytes()), SplitWeight.fromProportion(2));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "^minimumWeight must be > 0 and <= 1, found: 1\\.01$")

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
@@ -79,6 +79,7 @@ import static io.trino.plugin.iceberg.IcebergUtil.getColumnHandle;
 import static io.trino.plugin.iceberg.IcebergUtil.getPartitionKeys;
 import static io.trino.plugin.iceberg.IcebergUtil.primitiveFieldTypes;
 import static io.trino.plugin.iceberg.TypeConverter.toIcebergType;
+import static java.lang.Math.max;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -393,7 +394,7 @@ public class IcebergSplitSource
                 task.deletes().stream()
                         .map(TrinoDeleteFile::copyOf)
                         .collect(toImmutableList()),
-                SplitWeight.fromProportion(Math.min(Math.max((double) task.length() / tableScan.targetSplitSize(), minimumAssignedSplitWeight), 1.0)));
+                SplitWeight.fromProportion(max((double) task.length() / tableScan.targetSplitSize(), minimumAssignedSplitWeight)));
     }
 
     private static String hadoopPath(String path)


### PR DESCRIPTION
There is no technical requirement for a split weight to be between 0 and
1. In fact, values >1 are allowed by the engine and indicate oversized
splits, i.e. splits with size bigger than the expected max split size.

