### PR TITLE
Move assertion back to the right test

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -1689,9 +1689,9 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testApplyFilterWithNonEmptyConstraintPredicate()
     {
-        assertUpdate("CREATE TABLE test_bucket_transform (d VARCHAR, b BIGINT) WITH (partitioning = ARRAY['bucket(d, 2)'])");
+        assertUpdate("CREATE TABLE test_apply_functional_constraint (d VARCHAR, b BIGINT) WITH (partitioning = ARRAY['bucket(d, 2)'])");
         assertUpdate(
-                "INSERT INTO test_bucket_transform VALUES" +
+                "INSERT INTO test_apply_functional_constraint VALUES" +
                         "('abcd', 1)," +
                         "('abxy', 2)," +
                         "('ab598', 3)," +
@@ -1702,8 +1702,10 @@ public abstract class BaseIcebergConnectorTest
                 7);
 
         assertQuery(
-                "SELECT * FROM test_bucket_transform WHERE length(d) = 4 AND b % 7 = 2",
+                "SELECT * FROM test_apply_functional_constraint WHERE length(d) = 4 AND b % 7 = 2",
                 "VALUES ('abxy', 2)");
+
+        assertUpdate("DROP TABLE test_apply_functional_constraint");
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -1675,6 +1675,14 @@ public abstract class BaseIcebergConnectorTest
             assertQuery(selectFromPartitions + " WHERE partition.d_bucket = 0", format("VALUES(0, %d, null, null)", 2));
             assertQuery(selectFromPartitions + " WHERE partition.d_bucket = 1", format("VALUES(1, %d, null, null)", 1));
         }
+
+        assertThat(query("SHOW STATS FOR " + tableName))
+                .skippingTypesCheck()
+                .projected(0, 2, 3, 4) // data size, min and max may vary between types
+                .matches("VALUES " +
+                        "  ('d', NULL, 0e0, NULL), " +
+                        "  (NULL, NULL, NULL, 3e0)");
+
         dropTable(tableName);
     }
 
@@ -1696,13 +1704,6 @@ public abstract class BaseIcebergConnectorTest
         assertQuery(
                 "SELECT * FROM test_bucket_transform WHERE length(d) = 4 AND b % 7 = 2",
                 "VALUES ('abxy', 2)");
-
-        assertThat(query("SHOW STATS FOR test_bucket_transform"))
-                .skippingTypesCheck()
-                .matches("VALUES " +
-                        "  ('d', " + (format == PARQUET ? "136e0" : "NULL") + ", NULL, 0e0, NULL, NULL, NULL), " +
-                        "  ('b', NULL, NULL, 0e0, NULL, '1', '7'), " +
-                        "  (NULL, NULL, NULL, NULL, 7e0, NULL, NULL)");
     }
 
     @Test


### PR DESCRIPTION
The SHOW STATS related assertion was initially added in
`testBucketTransform`. It seemed to have "floated" to
`testApplyFilterWithNonEmptyConstraintPredicate` when this new focused
test was extracted.

Extracted from https://github.com/trinodb/trino/pull/12795