### PR TITLE
Require Java 11.0.15+

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/TrinoSystemRequirements.java
+++ b/core/trino-main/src/main/java/io/trino/server/TrinoSystemRequirements.java
@@ -93,7 +93,7 @@ final class TrinoSystemRequirements
 
     private static void verifyJavaVersion()
     {
-        Version required = Version.parse("11.0.11");
+        Version required = Version.parse("11.0.15");
         if (Runtime.version().compareTo(required) < 0) {
             failRequirement("Trino requires Java %s at minimum (found %s)", required, Runtime.version());
         }

--- a/docs/src/main/sphinx/installation/deployment.rst
+++ b/docs/src/main/sphinx/installation/deployment.rst
@@ -34,7 +34,7 @@ Linux operating system
 Java runtime environment
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Trino requires a 64-bit version of Java 11, with a minimum required version of 11.0.11.
+Trino requires a 64-bit version of Java 11, with a minimum required version of 11.0.15.
 Earlier patch versions such as 11.0.2 do not work, nor will earlier major versions such as Java 8.
 Newer major versions such as Java 12 or 13, including Java 17, are not supported -- they may work, but are not tested.
 


### PR DESCRIPTION
## Description

There's a bug in earlier versions that causes a segfault: https://github.com/trinodb/trino/issues/12821

## Documentation

(x) Sufficient documentation is included in this PR.

## Release notes

```markdown
# General
* Update minimum required Java version to 11.0.15. ({issue}`12841`)
```
