### PR TITLE
Remove outdated if branch in timezone test

### DIFF
--- a/core/trino-main/src/test/java/io/trino/util/TestTimeZoneUtils.java
+++ b/core/trino-main/src/test/java/io/trino/util/TestTimeZoneUtils.java
@@ -43,11 +43,6 @@ public class TestTimeZoneUtils
                 continue;
             }
 
-            // Remove when minimal Java version is raised to 11.0.10: https://github.com/trinodb/trino/issues/6662
-            if (zoneId.equals("US/Pacific-New")) {
-                continue;
-            }
-
             DateTimeZone dateTimeZone = DateTimeZone.forID(zoneId);
             DateTimeZone indexedZone = getDateTimeZone(TimeZoneKey.getTimeZoneKey(zoneId));
 


### PR DESCRIPTION
Fixes #12848 , tested with the following JDK
```
openjdk version "11.0.12" 2021-07-20
OpenJDK Runtime Environment Homebrew (build 11.0.12+0)
OpenJDK 64-Bit Server VM Homebrew (build 11.0.12+0, mixed mode)
```

