### PR TITLE
Add a workaround for empty Slice copy SIGSEGV

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/output/SlicePositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/SlicePositionsAppender.java
@@ -196,12 +196,18 @@ public class SlicePositionsAppender
     {
         int length = block.getSliceLength(position);
         int newByteCount = count * length;
-        ensureBytesCapacity(currentOffset + newByteCount);
+        if (length == 0) {
+            // empty Slice, there is no need to copy anything
+            Arrays.fill(offsets, positionCount + 1, positionCount + count + 1, startOffset);
+        }
+        else {
+            ensureBytesCapacity(currentOffset + newByteCount);
 
-        Slice slice = block.getSlice(position, 0, length);
-        for (int i = 0; i < count; i++) {
-            slice.getBytes(0, bytes, startOffset + (i * length), length);
-            offsets[positionCount + i + 1] = startOffset + ((i + 1) * length);
+            Slice slice = block.getSlice(position, 0, length);
+            for (int i = 0; i < count; i++) {
+                slice.getBytes(0, bytes, startOffset + (i * length), length);
+                offsets[positionCount + i + 1] = startOffset + ((i + 1) * length);
+            }
         }
 
         positionCount += count;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
Due to jvm bug, compiled code could fail
with SIGSEGV when copying 0 bytes from an empty Slice.
This change avoids copy attempts altogether, which
additionally increases performance in empty Slice case.

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

fix
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core query engine
> How would you describe this change to a non-technical end user or system administrator?

Avoid worker process crash when using vulnerable JVM version
## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->
* Fixes #12821
<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
