### PR TITLE
Add accelerated-repartitioning.enabled property

### DIFF
--- a/core/trino-main/src/main/java/io/trino/FeaturesConfig.java
+++ b/core/trino-main/src/main/java/io/trino/FeaturesConfig.java
@@ -103,6 +103,7 @@ public class FeaturesConfig
     private boolean allowSetViewAuthorization;
 
     private boolean hideInaccessibleColumns;
+    private boolean acceleratedRepartitioningEnabled = true;
 
     public enum DataIntegrityVerification
     {
@@ -519,6 +520,19 @@ public class FeaturesConfig
     public FeaturesConfig setAllowSetViewAuthorization(boolean allowSetViewAuthorization)
     {
         this.allowSetViewAuthorization = allowSetViewAuthorization;
+        return this;
+    }
+
+    public boolean isAcceleratedRepartitioningEnabled()
+    {
+        return acceleratedRepartitioningEnabled;
+    }
+
+    @Config("accelerated-repartitioning.enabled")
+    @ConfigDescription("Use accelerated repartitioning")
+    public FeaturesConfig setAcceleratedRepartitioningEnabled(boolean acceleratedRepartitioningEnabled)
+    {
+        this.acceleratedRepartitioningEnabled = acceleratedRepartitioningEnabled;
         return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -172,6 +172,7 @@ public final class SystemSessionProperties
     public static final String ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS = "adaptive_partial_aggregation_min_rows";
     public static final String ADAPTIVE_PARTIAL_AGGREGATION_UNIQUE_ROWS_RATIO_THRESHOLD = "adaptive_partial_aggregation_unique_rows_ratio_threshold";
     public static final String JOIN_PARTITIONED_BUILD_MIN_ROW_COUNT = "join_partitioned_build_min_row_count";
+    public static final String ACCELERATED_REPARTITIONING_ENABLED = "accelerated_repartitioning_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -837,6 +838,11 @@ public final class SystemSessionProperties
                         "Minimum number of join build side rows required to use partitioned join lookup",
                         optimizerConfig.getJoinPartitionedBuildMinRowCount(),
                         value -> validateNonNegativeLongValue(value, JOIN_PARTITIONED_BUILD_MIN_ROW_COUNT),
+                        false),
+                booleanProperty(
+                        ACCELERATED_REPARTITIONING_ENABLED,
+                        "Use accelerated repartitioning",
+                        featuresConfig.isAcceleratedRepartitioningEnabled(),
                         false));
     }
 
@@ -1509,5 +1515,10 @@ public final class SystemSessionProperties
     public static long getJoinPartitionedBuildMinRowCount(Session session)
     {
         return session.getSystemProperty(JOIN_PARTITIONED_BUILD_MIN_ROW_COUNT, Long.class);
+    }
+
+    public static boolean isAcceleratedRepartitioningEnabled(Session session)
+    {
+        return session.getSystemProperty(ACCELERATED_REPARTITIONING_ENABLED, Boolean.class);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/output/PartitionedOutputOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/PartitionedOutputOperator.java
@@ -39,6 +39,7 @@ import java.util.OptionalInt;
 import java.util.function.Function;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.trino.SystemSessionProperties.isAcceleratedRepartitioningEnabled;
 import static java.util.Objects.requireNonNull;
 
 public class PartitionedOutputOperator
@@ -164,7 +165,8 @@ public class PartitionedOutputOperator
                     outputBuffer,
                     serdeFactory,
                     maxMemory,
-                    positionsAppenderFactory);
+                    positionsAppenderFactory,
+                    isAcceleratedRepartitioningEnabled(driverContext.getSession()));
         }
 
         @Override
@@ -212,7 +214,8 @@ public class PartitionedOutputOperator
             OutputBuffer outputBuffer,
             PagesSerdeFactory serdeFactory,
             DataSize maxMemory,
-            PositionsAppenderFactory positionsAppenderFactory)
+            PositionsAppenderFactory positionsAppenderFactory,
+            boolean acceleratedRepartitioningEnabled)
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
         this.pagePreprocessor = requireNonNull(pagePreprocessor, "pagePreprocessor is null");
@@ -227,7 +230,8 @@ public class PartitionedOutputOperator
                 sourceTypes,
                 maxMemory,
                 operatorContext,
-                positionsAppenderFactory);
+                positionsAppenderFactory,
+                acceleratedRepartitioningEnabled);
 
         operatorContext.setInfoSupplier(this.partitionFunction.getOperatorInfoSupplier());
         this.memoryContext = operatorContext.newLocalUserMemoryContext(PartitionedOutputOperator.class.getSimpleName());

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPagePartitioner.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPagePartitioner.java
@@ -134,7 +134,7 @@ public class TestPagePartitioner
     @Test
     public void testOutputForEmptyPage()
     {
-        PagePartitioner pagePartitioner = pagePartitioner(BIGINT).build();
+        PagePartitioner pagePartitioner = pagePartitioner(PartitioningMode.DEFAULT_WITH_COLUMNAR_ON, BIGINT).build();
         Page page = new Page(createLongsBlock(ImmutableList.of()));
 
         pagePartitioner.partitionPage(page);
@@ -147,7 +147,7 @@ public class TestPagePartitioner
     @Test(dataProvider = "partitioningMode")
     public void testOutputEqualsInput(PartitioningMode partitioningMode)
     {
-        PagePartitioner pagePartitioner = pagePartitioner(BIGINT).build();
+        PagePartitioner pagePartitioner = pagePartitioner(partitioningMode, BIGINT).build();
         Page page = new Page(createLongSequenceBlock(0, POSITIONS_PER_PAGE));
         List<Object> expected = readLongs(Stream.of(page), 0);
 
@@ -160,7 +160,7 @@ public class TestPagePartitioner
     @Test(dataProvider = "partitioningMode")
     public void testOutputForPageWithNoBlockPartitionFunction(PartitioningMode partitioningMode)
     {
-        PagePartitioner pagePartitioner = pagePartitioner(BIGINT)
+        PagePartitioner pagePartitioner = pagePartitioner(partitioningMode, BIGINT)
                 .withPartitionFunction(new BucketPartitionFunction(
                         ROUND_ROBIN.createBucketFunction(null, false, PARTITION_COUNT, null),
                         IntStream.range(0, PARTITION_COUNT).toArray()))
@@ -179,7 +179,7 @@ public class TestPagePartitioner
     @Test(dataProvider = "partitioningMode")
     public void testOutputForMultipleSimplePages(PartitioningMode partitioningMode)
     {
-        PagePartitioner pagePartitioner = pagePartitioner(BIGINT).build();
+        PagePartitioner pagePartitioner = pagePartitioner(partitioningMode, BIGINT).build();
         Page page1 = new Page(createLongSequenceBlock(0, POSITIONS_PER_PAGE));
         Page page2 = new Page(createLongSequenceBlock(1, POSITIONS_PER_PAGE));
         Page page3 = new Page(createLongSequenceBlock(2, POSITIONS_PER_PAGE));
@@ -194,7 +194,7 @@ public class TestPagePartitioner
     @Test(dataProvider = "partitioningMode")
     public void testOutputForSimplePageWithReplication(PartitioningMode partitioningMode)
     {
-        PagePartitioner pagePartitioner = pagePartitioner(BIGINT).replicate().build();
+        PagePartitioner pagePartitioner = pagePartitioner(partitioningMode, BIGINT).replicate().build();
         Page page = new Page(createLongsBlock(0L, 1L, 2L, 3L, null));
 
         processPages(pagePartitioner, partitioningMode, page);
@@ -208,7 +208,7 @@ public class TestPagePartitioner
     @Test(dataProvider = "partitioningMode")
     public void testOutputForSimplePageWithNullChannel(PartitioningMode partitioningMode)
     {
-        PagePartitioner pagePartitioner = pagePartitioner(BIGINT).withNullChannel(0).build();
+        PagePartitioner pagePartitioner = pagePartitioner(partitioningMode, BIGINT).withNullChannel(0).build();
         Page page = new Page(createLongsBlock(0L, 1L, 2L, 3L, null));
 
         processPages(pagePartitioner, partitioningMode, page);
@@ -222,7 +222,7 @@ public class TestPagePartitioner
     @Test(dataProvider = "partitioningMode")
     public void testOutputForSimplePageWithPartitionConstant(PartitioningMode partitioningMode)
     {
-        PagePartitioner pagePartitioner = pagePartitioner(BIGINT)
+        PagePartitioner pagePartitioner = pagePartitioner(partitioningMode, BIGINT)
                 .withPartitionConstants(ImmutableList.of(Optional.of(new NullableValue(BIGINT, 1L))))
                 .withPartitionChannels(-1)
                 .build();
@@ -240,7 +240,7 @@ public class TestPagePartitioner
     @Test(dataProvider = "partitioningMode")
     public void testOutputForSimplePageWithPartitionConstantAndHashBlock(PartitioningMode partitioningMode)
     {
-        PagePartitioner pagePartitioner = pagePartitioner(BIGINT)
+        PagePartitioner pagePartitioner = pagePartitioner(partitioningMode, BIGINT)
                 .withPartitionConstants(ImmutableList.of(Optional.empty(), Optional.of(new NullableValue(BIGINT, 1L))))
                 .withPartitionChannels(0, -1) // use first block and constant block at index 1 as input to partitionFunction
                 .withHashChannels(0, 1) // use both channels to calculate partition (a+b) mod 2
@@ -258,7 +258,7 @@ public class TestPagePartitioner
     @Test(dataProvider = "partitioningMode")
     public void testPartitionPositionsWithRleNotNull(PartitioningMode partitioningMode)
     {
-        PagePartitioner pagePartitioner = pagePartitioner(BIGINT, BIGINT).build();
+        PagePartitioner pagePartitioner = pagePartitioner(partitioningMode, BIGINT, BIGINT).build();
         Page page = new Page(createRLEBlock(0, POSITIONS_PER_PAGE), createLongSequenceBlock(0, POSITIONS_PER_PAGE));
 
         processPages(pagePartitioner, partitioningMode, page);
@@ -273,7 +273,7 @@ public class TestPagePartitioner
     @Test(dataProvider = "partitioningMode")
     public void testPartitionPositionsWithRleNotNullWithReplication(PartitioningMode partitioningMode)
     {
-        PagePartitioner pagePartitioner = pagePartitioner(BIGINT, BIGINT).replicate().build();
+        PagePartitioner pagePartitioner = pagePartitioner(partitioningMode, BIGINT, BIGINT).replicate().build();
         Page page = new Page(createRLEBlock(0, POSITIONS_PER_PAGE), createLongSequenceBlock(0, POSITIONS_PER_PAGE));
 
         processPages(pagePartitioner, partitioningMode, page);
@@ -287,7 +287,7 @@ public class TestPagePartitioner
     @Test(dataProvider = "partitioningMode")
     public void testPartitionPositionsWithRleNullWithNullChannel(PartitioningMode partitioningMode)
     {
-        PagePartitioner pagePartitioner = pagePartitioner(BIGINT, BIGINT).withNullChannel(0).build();
+        PagePartitioner pagePartitioner = pagePartitioner(partitioningMode, BIGINT, BIGINT).withNullChannel(0).build();
         Page page = new Page(new RunLengthEncodedBlock(createLongsBlock((Long) null), POSITIONS_PER_PAGE), createLongSequenceBlock(0, POSITIONS_PER_PAGE));
 
         processPages(pagePartitioner, partitioningMode, page);
@@ -301,7 +301,7 @@ public class TestPagePartitioner
     @Test(dataProvider = "partitioningMode")
     public void testOutputForDictionaryBlock(PartitioningMode partitioningMode)
     {
-        PagePartitioner pagePartitioner = pagePartitioner(BIGINT).build();
+        PagePartitioner pagePartitioner = pagePartitioner(partitioningMode, BIGINT).build();
         Page page = new Page(createLongDictionaryBlock(0, 10)); // must have at least 10 position to have non-trivial dict
 
         processPages(pagePartitioner, partitioningMode, page);
@@ -315,7 +315,7 @@ public class TestPagePartitioner
     @Test(dataProvider = "partitioningMode")
     public void testOutputForOneValueDictionaryBlock(PartitioningMode partitioningMode)
     {
-        PagePartitioner pagePartitioner = pagePartitioner(BIGINT).build();
+        PagePartitioner pagePartitioner = pagePartitioner(partitioningMode, BIGINT).build();
         Page page = new Page(new DictionaryBlock(createLongsBlock(0), new int[] {0, 0, 0, 0}));
 
         processPages(pagePartitioner, partitioningMode, page);
@@ -329,7 +329,7 @@ public class TestPagePartitioner
     @Test(dataProvider = "partitioningMode")
     public void testOutputForViewDictionaryBlock(PartitioningMode partitioningMode)
     {
-        PagePartitioner pagePartitioner = pagePartitioner(BIGINT).build();
+        PagePartitioner pagePartitioner = pagePartitioner(partitioningMode, BIGINT).build();
         Page page = new Page(new DictionaryBlock(createLongSequenceBlock(4, 8), new int[] {1, 0, 3, 2}));
 
         processPages(pagePartitioner, partitioningMode, page);
@@ -343,7 +343,9 @@ public class TestPagePartitioner
     @Test(dataProvider = "typesWithPartitioningMode")
     public void testOutputForSimplePageWithType(Type type, PartitioningMode partitioningMode)
     {
-        PagePartitioner pagePartitioner = pagePartitioner(BIGINT, type).build();
+        PagePartitioner pagePartitioner = pagePartitioner(partitioningMode, BIGINT, type)
+                .withAcceleratedRepartitioningEnabled(partitioningMode.isAcceleratedRepartitioningEnabled())
+                .build();
         Page page = new Page(
                 createLongSequenceBlock(0, POSITIONS_PER_PAGE), // partition block
                 createBlockForType(type, POSITIONS_PER_PAGE));
@@ -364,7 +366,7 @@ public class TestPagePartitioner
 
     private void testOutputEqualsInput(Type type, PartitioningMode mode1, PartitioningMode mode2)
     {
-        PagePartitionerBuilder pagePartitionerBuilder = pagePartitioner(BIGINT, type, type);
+        PagePartitionerBuilder pagePartitionerBuilder = pagePartitioner(PartitioningMode.DEFAULT_WITH_COLUMNAR_ON, BIGINT, type, type);
         PagePartitioner pagePartitioner = pagePartitionerBuilder.build();
         Page input = new Page(
                 createLongSequenceBlock(0, POSITIONS_PER_PAGE), // partition block
@@ -386,7 +388,9 @@ public class TestPagePartitioner
     @DataProvider(name = "partitioningMode")
     public static Object[][] partitioningMode()
     {
-        return new Object[][] {{PartitioningMode.ROW_WISE}, {PartitioningMode.COLUMNAR}};
+        return Stream.of(PartitioningMode.values())
+                .map(partitioningMode -> new Object[] {partitioningMode})
+                .toArray(Object[][]::new);
     }
 
     @DataProvider(name = "types")
@@ -461,9 +465,10 @@ public class TestPagePartitioner
         return unmodifiableList(result);
     }
 
-    private PagePartitionerBuilder pagePartitioner(Type... types)
+    private PagePartitionerBuilder pagePartitioner(PartitioningMode partitioningMode, Type... types)
     {
-        return pagePartitioner(ImmutableList.copyOf(types));
+        return pagePartitioner(ImmutableList.copyOf(types))
+                .withAcceleratedRepartitioningEnabled(partitioningMode.isAcceleratedRepartitioningEnabled());
     }
 
     private PagePartitionerBuilder pagePartitioner(List<Type> types)
@@ -478,22 +483,48 @@ public class TestPagePartitioner
 
     private enum PartitioningMode
     {
-        ROW_WISE {
+        ROW_WISE(true) {
             @Override
             public void partitionPage(PagePartitioner pagePartitioner, Page page)
             {
                 pagePartitioner.partitionPageByRow(page);
             }
         },
-        COLUMNAR {
+        COLUMNAR(true) {
             @Override
             public void partitionPage(PagePartitioner pagePartitioner, Page page)
             {
                 pagePartitioner.partitionPageByColumn(page);
             }
+        },
+        DEFAULT_WITH_COLUMNAR_ON(true) {
+            @Override
+            public void partitionPage(PagePartitioner pagePartitioner, Page page)
+            {
+                pagePartitioner.partitionPage(page);
+            }
+        },
+        DEFAULT_WITH_COLUMNAR_OFF(false) {
+            @Override
+            public void partitionPage(PagePartitioner pagePartitioner, Page page)
+            {
+                pagePartitioner.partitionPage(page);
+            }
         };
 
+        private final boolean acceleratedRepartitioningEnabled;
+
+        PartitioningMode(boolean acceleratedRepartitioningEnabled)
+        {
+            this.acceleratedRepartitioningEnabled = acceleratedRepartitioningEnabled;
+        }
+
         public abstract void partitionPage(PagePartitioner pagePartitioner, Page page);
+
+        public boolean isAcceleratedRepartitioningEnabled()
+        {
+            return acceleratedRepartitioningEnabled;
+        }
     }
 
     public static class PagePartitionerBuilder
@@ -509,6 +540,7 @@ public class TestPagePartitioner
         private boolean shouldReplicate;
         private OptionalInt nullChannel = OptionalInt.empty();
         private List<Type> types;
+        private boolean acceleratedRepartitioningEnabled = true;
 
         PagePartitionerBuilder(ExecutorService executor, ScheduledExecutorService scheduledExecutor, OutputBuffer outputBuffer)
         {
@@ -578,6 +610,12 @@ public class TestPagePartitioner
             return this;
         }
 
+        public PagePartitionerBuilder withAcceleratedRepartitioningEnabled(boolean acceleratedRepartitioningEnabled)
+        {
+            this.acceleratedRepartitioningEnabled = acceleratedRepartitioningEnabled;
+            return this;
+        }
+
         public PartitionedOutputOperator buildPartitionedOutputOperator()
         {
             DriverContext driverContext = buildDriverContext();
@@ -614,7 +652,8 @@ public class TestPagePartitioner
                     types,
                     PARTITION_MAX_MEMORY,
                     operatorContext,
-                    POSITIONS_APPENDER_FACTORY);
+                    POSITIONS_APPENDER_FACTORY,
+                    acceleratedRepartitioningEnabled);
         }
 
         private DriverContext buildDriverContext()

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestFeaturesConfig.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestFeaturesConfig.java
@@ -66,7 +66,8 @@ public class TestFeaturesConfig
                 .setLegacyCatalogRoles(false)
                 .setIncrementalHashArrayLoadFactorEnabled(true)
                 .setHideInaccessibleColumns(false)
-                .setAllowSetViewAuthorization(false));
+                .setAllowSetViewAuthorization(false)
+                .setAcceleratedRepartitioningEnabled(true));
     }
 
     @Test
@@ -104,6 +105,7 @@ public class TestFeaturesConfig
                 .put("incremental-hash-array-load-factor.enabled", "false")
                 .put("hide-inaccessible-columns", "true")
                 .put("legacy.allow-set-view-authorization", "true")
+                .put("accelerated-repartitioning.enabled", "false")
                 .buildOrThrow();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -137,7 +139,8 @@ public class TestFeaturesConfig
                 .setLegacyCatalogRoles(true)
                 .setIncrementalHashArrayLoadFactorEnabled(false)
                 .setHideInaccessibleColumns(true)
-                .setAllowSetViewAuthorization(true);
+                .setAllowSetViewAuthorization(true)
+                .setAcceleratedRepartitioningEnabled(false);
         assertFullMapping(properties, expected);
     }
 }


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
Add an option to disable columnar page partitioning
in case of issues or performance degradation.
<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

improvement
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core query engine
> How would you describe this change to a non-technical end user or system administrator?

Add config and session property to disable accelerated partitioned exchange if necessary.
## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
