### PR TITLE
Write Int96 timestamps in optimized parquet writer for hive

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTimestampUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTimestampUtils.java
@@ -13,7 +13,6 @@
  */
 package io.trino.parquet;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import io.trino.plugin.base.type.DecodedTimestamp;
@@ -40,8 +39,7 @@ import static java.lang.StrictMath.toIntExact;
  */
 public final class ParquetTimestampUtils
 {
-    @VisibleForTesting
-    static final int JULIAN_EPOCH_OFFSET_DAYS = 2_440_588;
+    public static final int JULIAN_EPOCH_OFFSET_DAYS = 2_440_588;
 
     private ParquetTimestampUtils() {}
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriters.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriters.java
@@ -23,6 +23,7 @@ import io.trino.parquet.writer.valuewriter.FixedLenByteArrayLongDecimalValueWrit
 import io.trino.parquet.writer.valuewriter.FixedLenByteArrayShortDecimalValueWriter;
 import io.trino.parquet.writer.valuewriter.Int32ShortDecimalValueWriter;
 import io.trino.parquet.writer.valuewriter.Int64ShortDecimalValueWriter;
+import io.trino.parquet.writer.valuewriter.Int96TimestampValueWriter;
 import io.trino.parquet.writer.valuewriter.IntegerValueWriter;
 import io.trino.parquet.writer.valuewriter.PrimitiveValueWriter;
 import io.trino.parquet.writer.valuewriter.RealValueWriter;
@@ -35,6 +36,7 @@ import io.trino.parquet.writer.valuewriter.UuidValueWriter;
 import io.trino.spi.TrinoException;
 import io.trino.spi.type.CharType;
 import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.UuidType;
 import io.trino.spi.type.VarbinaryType;
@@ -49,10 +51,12 @@ import org.apache.parquet.schema.LogicalTypeAnnotation.TimestampLogicalTypeAnnot
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.OriginalType;
 import org.apache.parquet.schema.PrimitiveType;
+import org.joda.time.DateTimeZone;
 
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -80,9 +84,14 @@ final class ParquetWriters
 {
     private ParquetWriters() {}
 
-    static List<ColumnWriter> getColumnWriters(MessageType messageType, Map<List<String>, Type> trinoTypes, ParquetProperties parquetProperties, CompressionCodecName compressionCodecName)
+    static List<ColumnWriter> getColumnWriters(
+            MessageType messageType,
+            Map<List<String>, Type> trinoTypes,
+            ParquetProperties parquetProperties,
+            CompressionCodecName compressionCodecName,
+            Optional<DateTimeZone> parquetTimeZone)
     {
-        WriteBuilder writeBuilder = new WriteBuilder(messageType, trinoTypes, parquetProperties, compressionCodecName);
+        WriteBuilder writeBuilder = new WriteBuilder(messageType, trinoTypes, parquetProperties, compressionCodecName, parquetTimeZone);
         ParquetTypeVisitor.visit(messageType, writeBuilder);
         return writeBuilder.build();
     }
@@ -94,14 +103,21 @@ final class ParquetWriters
         private final Map<List<String>, Type> trinoTypes;
         private final ParquetProperties parquetProperties;
         private final CompressionCodecName compressionCodecName;
+        private final Optional<DateTimeZone> parquetTimeZone;
         private final ImmutableList.Builder<ColumnWriter> builder = ImmutableList.builder();
 
-        WriteBuilder(MessageType messageType, Map<List<String>, Type> trinoTypes, ParquetProperties parquetProperties, CompressionCodecName compressionCodecName)
+        WriteBuilder(
+                MessageType messageType,
+                Map<List<String>, Type> trinoTypes,
+                ParquetProperties parquetProperties,
+                CompressionCodecName compressionCodecName,
+                Optional<DateTimeZone> parquetTimeZone)
         {
             this.type = requireNonNull(messageType, "messageType is null");
             this.trinoTypes = requireNonNull(trinoTypes, "trinoTypes is null");
             this.parquetProperties = requireNonNull(parquetProperties, "parquetProperties is null");
             this.compressionCodecName = requireNonNull(compressionCodecName, "compressionCodecName is null");
+            this.parquetTimeZone = requireNonNull(parquetTimeZone, "parquetTimeZone is null");
         }
 
         List<ColumnWriter> build()
@@ -152,7 +168,7 @@ final class ParquetWriters
             Type trinoType = requireNonNull(trinoTypes.get(ImmutableList.copyOf(path)), "Trino type is null");
             return new PrimitiveColumnWriter(
                     columnDescriptor,
-                    getValueWriter(parquetProperties.newValuesWriter(columnDescriptor), trinoType, columnDescriptor.getPrimitiveType()),
+                    getValueWriter(parquetProperties.newValuesWriter(columnDescriptor), trinoType, columnDescriptor.getPrimitiveType(), parquetTimeZone),
                     parquetProperties.newDefinitionLevelWriter(columnDescriptor),
                     parquetProperties.newRepetitionLevelWriter(columnDescriptor),
                     compressionCodecName,
@@ -172,7 +188,7 @@ final class ParquetWriters
         }
     }
 
-    private static PrimitiveValueWriter getValueWriter(ValuesWriter valuesWriter, Type type, PrimitiveType parquetType)
+    private static PrimitiveValueWriter getValueWriter(ValuesWriter valuesWriter, Type type, PrimitiveType parquetType, Optional<DateTimeZone> parquetTimeZone)
     {
         if (BOOLEAN.equals(type)) {
             return new BooleanValueWriter(valuesWriter, parquetType);
@@ -202,21 +218,28 @@ final class ParquetWriters
             verifyParquetType(type, parquetType, OriginalType.TIME_MICROS);
             return new TimeMicrosValueWriter(valuesWriter, parquetType);
         }
-        if (TIMESTAMP_MILLIS.equals(type)) {
-            verifyParquetType(type, parquetType, OriginalType.TIMESTAMP_MILLIS);
-            verifyParquetType(type, parquetType, TimestampLogicalTypeAnnotation.class, isTimestamp(LogicalTypeAnnotation.TimeUnit.MILLIS));
-            return new TimestampMillisValueWriter(valuesWriter, type, parquetType);
+        if (type instanceof TimestampType) {
+            if (parquetType.getPrimitiveTypeName().equals(PrimitiveType.PrimitiveTypeName.INT96)) {
+                checkArgument(parquetTimeZone.isPresent(), "parquetTimeZone must be provided for INT96 timestamps");
+                return new Int96TimestampValueWriter(valuesWriter, type, parquetType, parquetTimeZone.get());
+            }
+            if (TIMESTAMP_MILLIS.equals(type)) {
+                verifyParquetType(type, parquetType, OriginalType.TIMESTAMP_MILLIS);
+                verifyParquetType(type, parquetType, TimestampLogicalTypeAnnotation.class, isTimestamp(LogicalTypeAnnotation.TimeUnit.MILLIS));
+                return new TimestampMillisValueWriter(valuesWriter, type, parquetType);
+            }
+            if (TIMESTAMP_MICROS.equals(type)) {
+                verifyParquetType(type, parquetType, OriginalType.TIMESTAMP_MICROS);
+                verifyParquetType(type, parquetType, TimestampLogicalTypeAnnotation.class, isTimestamp(LogicalTypeAnnotation.TimeUnit.MICROS));
+                return new BigintValueWriter(valuesWriter, type, parquetType);
+            }
+            if (TIMESTAMP_NANOS.equals(type)) {
+                verifyParquetType(type, parquetType, (OriginalType) null); // no OriginalType for timestamp NANOS
+                verifyParquetType(type, parquetType, TimestampLogicalTypeAnnotation.class, isTimestamp(LogicalTypeAnnotation.TimeUnit.NANOS));
+                return new TimestampNanosValueWriter(valuesWriter, type, parquetType);
+            }
         }
-        if (TIMESTAMP_MICROS.equals(type)) {
-            verifyParquetType(type, parquetType, OriginalType.TIMESTAMP_MICROS);
-            verifyParquetType(type, parquetType, TimestampLogicalTypeAnnotation.class, isTimestamp(LogicalTypeAnnotation.TimeUnit.MICROS));
-            return new BigintValueWriter(valuesWriter, type, parquetType);
-        }
-        if (TIMESTAMP_NANOS.equals(type)) {
-            verifyParquetType(type, parquetType, (OriginalType) null); // no OriginalType for timestamp NANOS
-            verifyParquetType(type, parquetType, TimestampLogicalTypeAnnotation.class, isTimestamp(LogicalTypeAnnotation.TimeUnit.NANOS));
-            return new TimestampNanosValueWriter(valuesWriter, type, parquetType);
-        }
+
         if (TIMESTAMP_TZ_MILLIS.equals(type)) {
             verifyParquetType(type, parquetType, OriginalType.TIMESTAMP_MILLIS);
             return new TimestampTzMillisValueWriter(valuesWriter, parquetType);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriters.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriters.java
@@ -204,14 +204,12 @@ final class ParquetWriters
         }
         if (TIMESTAMP_MILLIS.equals(type)) {
             verifyParquetType(type, parquetType, OriginalType.TIMESTAMP_MILLIS);
-            // TODO when writing with Hive connector, isAdjustedToUTC is being set to true, which might be incorrect
-            //   verifyParquetType(type, parquetType, TimestampLogicalTypeAnnotation.class, isTimestamp(LogicalTypeAnnotation.TimeUnit.MILLIS));
+            verifyParquetType(type, parquetType, TimestampLogicalTypeAnnotation.class, isTimestamp(LogicalTypeAnnotation.TimeUnit.MILLIS));
             return new TimestampMillisValueWriter(valuesWriter, type, parquetType);
         }
         if (TIMESTAMP_MICROS.equals(type)) {
             verifyParquetType(type, parquetType, OriginalType.TIMESTAMP_MICROS);
-            // TODO when writing with Hive connector, isAdjustedToUTC is being set to true, which might be incorrect
-            //   verifyParquetType(type, parquetType, TimestampLogicalTypeAnnotation.class, isTimestamp(LogicalTypeAnnotation.TimeUnit.MICROS));
+            verifyParquetType(type, parquetType, TimestampLogicalTypeAnnotation.class, isTimestamp(LogicalTypeAnnotation.TimeUnit.MICROS));
             return new BigintValueWriter(valuesWriter, type, parquetType);
         }
         if (TIMESTAMP_NANOS.equals(type)) {

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/Int96TimestampValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/Int96TimestampValueWriter.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.writer.valuewriter;
+
+import io.trino.spi.block.Block;
+import io.trino.spi.type.LongTimestamp;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.Type;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.PrimitiveType;
+import org.joda.time.DateTimeZone;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.parquet.ParquetTimestampUtils.JULIAN_EPOCH_OFFSET_DAYS;
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
+import static io.trino.spi.type.Timestamps.MILLISECONDS_PER_DAY;
+import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MICROSECOND;
+import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MILLISECOND;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
+import static java.lang.Math.floorDiv;
+import static java.lang.Math.floorMod;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+
+public class Int96TimestampValueWriter
+        extends PrimitiveValueWriter
+{
+    private final TimestampType timestampType;
+    private final DateTimeZone parquetTimeZone;
+
+    public Int96TimestampValueWriter(ValuesWriter valuesWriter, Type type, PrimitiveType parquetType, DateTimeZone parquetTimeZone)
+    {
+        super(parquetType, valuesWriter);
+        requireNonNull(type, "type is null");
+        checkArgument(
+                type instanceof TimestampType && ((TimestampType) type).getPrecision() <= 9,
+                "type %s is not a TimestampType with precision <= 9",
+                type);
+        this.timestampType = (TimestampType) type;
+        checkArgument(
+                parquetType.getPrimitiveTypeName().equals(PrimitiveType.PrimitiveTypeName.INT96),
+                "parquetType %s is not INT96",
+                parquetType);
+        this.parquetTimeZone = requireNonNull(parquetTimeZone, "parquetTimeZone is null");
+    }
+
+    @Override
+    public void write(Block block)
+    {
+        int positionCount = block.getPositionCount();
+        long[] localEpochMillis = new long[positionCount];
+        int[] nanosOfMillis = new int[positionCount];
+        int nonNullsCount = 0;
+        if (timestampType.isShort()) {
+            for (int position = 0; position < positionCount; position++) {
+                if (!block.isNull(position)) {
+                    long epochMicros = timestampType.getLong(block, position);
+                    localEpochMillis[nonNullsCount] = floorDiv(epochMicros, MICROSECONDS_PER_MILLISECOND);
+                    nanosOfMillis[nonNullsCount] = floorMod(epochMicros, MICROSECONDS_PER_MILLISECOND) * NANOSECONDS_PER_MICROSECOND;
+                    nonNullsCount++;
+                }
+            }
+        }
+        else {
+            for (int position = 0; position < positionCount; position++) {
+                if (!block.isNull(position)) {
+                    LongTimestamp timestamp = (LongTimestamp) timestampType.getObject(block, position);
+                    long epochMicros = timestamp.getEpochMicros();
+                    // This should divide exactly because timestamp precision is <= 9
+                    int nanosOfMicro = timestamp.getPicosOfMicro() / PICOSECONDS_PER_NANOSECOND;
+                    localEpochMillis[nonNullsCount] = floorDiv(epochMicros, MICROSECONDS_PER_MILLISECOND);
+                    nanosOfMillis[nonNullsCount] = floorMod(epochMicros, MICROSECONDS_PER_MILLISECOND) * NANOSECONDS_PER_MICROSECOND + nanosOfMicro;
+                    nonNullsCount++;
+                }
+            }
+        }
+
+        for (int i = 0; i < nonNullsCount; i++) {
+            long epochMillis = parquetTimeZone.convertLocalToUTC(localEpochMillis[i], false);
+            long epochDay = floorDiv(epochMillis, MILLISECONDS_PER_DAY);
+            int julianDay = JULIAN_EPOCH_OFFSET_DAYS + toIntExact(epochDay);
+
+            long nanosOfEpochDay = nanosOfMillis[i] + ((long) floorMod(epochMillis, MILLISECONDS_PER_DAY) * NANOSECONDS_PER_MILLISECOND);
+            Binary binary = toBinary(julianDay, nanosOfEpochDay);
+            getValueWriter().writeBytes(binary);
+            getStatistics().updateStats(binary);
+        }
+    }
+
+    private Binary toBinary(int julianDay, long nanosOfEpochDay)
+    {
+        byte[] buffer = new byte[Long.BYTES + Integer.BYTES];
+        longToBytes(buffer, nanosOfEpochDay);
+        intToBytes(buffer, julianDay);
+        return Binary.fromConstantByteArray(buffer);
+    }
+
+    private static void intToBytes(byte[] outBuffer, int value)
+    {
+        outBuffer[Long.BYTES + 3] = (byte) (value >>> 24);
+        outBuffer[Long.BYTES + 2] = (byte) (value >>> 16);
+        outBuffer[Long.BYTES + 1] = (byte) (value >>> 8);
+        outBuffer[Long.BYTES] = (byte) value;
+    }
+
+    private static void longToBytes(byte[] outBuffer, long value)
+    {
+        outBuffer[7] = (byte) (value >>> 56);
+        outBuffer[6] = (byte) (value >>> 48);
+        outBuffer[5] = (byte) (value >>> 40);
+        outBuffer[4] = (byte) (value >>> 32);
+        outBuffer[3] = (byte) (value >>> 24);
+        outBuffer[2] = (byte) (value >>> 16);
+        outBuffer[1] = (byte) (value >>> 8);
+        outBuffer[0] = (byte) value;
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriter.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriter.java
@@ -29,9 +29,13 @@ public class TestParquetWriter
             throws VersionParser.VersionParseException, IOException
     {
         String createdBy = ParquetWriter.formatCreatedBy("test-version");
+        // createdBy must start with "parquet-mr" to make Apache Hive perform timezone conversion on INT96 timestamps correctly
+        // when hive.parquet.timestamp.skip.conversion is set to true.
+        // Apache Hive 3.2 and above, and CDH 5 enable hive.parquet.timestamp.skip.conversion by default
+        assertThat(createdBy).startsWith("parquet-mr");
         VersionParser.ParsedVersion version = VersionParser.parse(createdBy);
         assertThat(version).isNotNull();
-        assertThat(version.application).isEqualTo("Trino");
+        assertThat(version.application).isEqualTo("parquet-mr-trino");
         assertThat(version.version).isEqualTo("test-version");
         assertThat(version.appBuildHash).isEqualTo("n/a");
 
@@ -40,7 +44,7 @@ public class TestParquetWriter
         Pattern pattern = Pattern.compile("(.+) version ((.*) )?\\(build ?(.*)\\)");
         Matcher matcher = pattern.matcher(createdBy);
         assertThat(matcher.matches()).isTrue();
-        assertThat(matcher.group(1)).isEqualTo("Trino");
+        assertThat(matcher.group(1)).isEqualTo("parquet-mr-trino");
         assertThat(matcher.group(3)).isEqualTo("test-version");
         assertThat(matcher.group(4)).isEqualTo("n/a");
     }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSink.java
@@ -488,7 +488,7 @@ public class DeltaLakePageSink
                 identityMapping[i] = i;
             }
 
-            ParquetSchemaConverter schemaConverter = new ParquetSchemaConverter(parquetTypes, dataColumnNames, false);
+            ParquetSchemaConverter schemaConverter = new ParquetSchemaConverter(parquetTypes, dataColumnNames, false, false);
             return new ParquetFileWriter(
                     fileSystem.create(path),
                     rollbackAction,
@@ -498,7 +498,8 @@ public class DeltaLakePageSink
                     parquetWriterOptions,
                     identityMapping,
                     compressionCodecName,
-                    trinoVersion);
+                    trinoVersion,
+                    Optional.empty());
         }
         catch (IOException e) {
             throw new TrinoException(DELTA_LAKE_BAD_WRITE, "Error creating Parquet file", e);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriter.java
@@ -25,6 +25,7 @@ import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.type.Type;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.schema.MessageType;
+import org.joda.time.DateTimeZone;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
@@ -32,6 +33,7 @@ import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -58,7 +60,8 @@ public class ParquetFileWriter
             ParquetWriterOptions parquetWriterOptions,
             int[] fileInputColumnIndexes,
             CompressionCodecName compressionCodecName,
-            String trinoVersion)
+            String trinoVersion,
+            Optional<DateTimeZone> parquetTimeZone)
     {
         requireNonNull(outputStream, "outputStream is null");
         requireNonNull(trinoVersion, "trinoVersion is null");
@@ -69,7 +72,8 @@ public class ParquetFileWriter
                 primitiveTypes,
                 parquetWriterOptions,
                 compressionCodecName,
-                trinoVersion);
+                trinoVersion,
+                parquetTimeZone);
 
         this.rollbackAction = requireNonNull(rollbackAction, "rollbackAction is null");
         this.fileInputColumnIndexes = requireNonNull(fileInputColumnIndexes, "fileInputColumnIndexes is null");

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriterFactory.java
@@ -17,6 +17,7 @@ import io.trino.parquet.writer.ParquetSchemaConverter;
 import io.trino.parquet.writer.ParquetWriterOptions;
 import io.trino.plugin.hive.FileWriter;
 import io.trino.plugin.hive.HdfsEnvironment;
+import io.trino.plugin.hive.HiveConfig;
 import io.trino.plugin.hive.HiveFileWriterFactory;
 import io.trino.plugin.hive.HiveSessionProperties;
 import io.trino.plugin.hive.NodeVersion;
@@ -33,6 +34,7 @@ import org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.parquet.hadoop.ParquetOutputFormat;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.joda.time.DateTimeZone;
 
 import javax.inject.Inject;
 
@@ -43,6 +45,7 @@ import java.util.OptionalInt;
 import java.util.Properties;
 import java.util.concurrent.Callable;
 
+import static io.trino.parquet.writer.ParquetSchemaConverter.HIVE_PARQUET_USE_INT96_TIMESTAMP_ENCODING;
 import static io.trino.parquet.writer.ParquetSchemaConverter.HIVE_PARQUET_USE_LEGACY_DECIMAL_ENCODING;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITER_OPEN_ERROR;
 import static io.trino.plugin.hive.HiveSessionProperties.getTimestampPrecision;
@@ -57,16 +60,19 @@ public class ParquetFileWriterFactory
     private final HdfsEnvironment hdfsEnvironment;
     private final NodeVersion nodeVersion;
     private final TypeManager typeManager;
+    private final DateTimeZone parquetTimeZone;
 
     @Inject
     public ParquetFileWriterFactory(
             HdfsEnvironment hdfsEnvironment,
             NodeVersion nodeVersion,
-            TypeManager typeManager)
+            TypeManager typeManager,
+            HiveConfig hiveConfig)
     {
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.nodeVersion = requireNonNull(nodeVersion, "nodeVersion is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.parquetTimeZone = requireNonNull(hiveConfig, "hiveConfig is null").getParquetDateTimeZone();
     }
 
     @Override
@@ -115,7 +121,11 @@ public class ParquetFileWriterFactory
                 return null;
             };
 
-            ParquetSchemaConverter schemaConverter = new ParquetSchemaConverter(fileColumnTypes, fileColumnNames, HIVE_PARQUET_USE_LEGACY_DECIMAL_ENCODING);
+            ParquetSchemaConverter schemaConverter = new ParquetSchemaConverter(
+                    fileColumnTypes,
+                    fileColumnNames,
+                    HIVE_PARQUET_USE_LEGACY_DECIMAL_ENCODING,
+                    HIVE_PARQUET_USE_INT96_TIMESTAMP_ENCODING);
 
             return Optional.of(new ParquetFileWriter(
                     fileSystem.create(path, false),
@@ -126,7 +136,8 @@ public class ParquetFileWriterFactory
                     parquetWriterOptions,
                     fileInputColumnIndexes,
                     compressionCodecName,
-                    nodeVersion.toString()));
+                    nodeVersion.toString(),
+                    Optional.of(parquetTimeZone)));
         }
         catch (IOException e) {
             throw new TrinoException(HIVE_WRITER_OPEN_ERROR, "Error creating Parquet file", e);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
@@ -446,7 +446,7 @@ public class TestHiveFileFormats
                 .withSession(session)
                 .withColumns(testColumns)
                 .withRowsCount(rowCount)
-                .withFileWriterFactory(new ParquetFileWriterFactory(HDFS_ENVIRONMENT, new NodeVersion("test-version"), TESTING_TYPE_MANAGER))
+                .withFileWriterFactory(new ParquetFileWriterFactory(HDFS_ENVIRONMENT, new NodeVersion("test-version"), TESTING_TYPE_MANAGER, new HiveConfig()))
                 .isReadableByPageSource(new ParquetPageSourceFactory(HDFS_ENVIRONMENT, STATS, new ParquetReaderConfig(), new HiveConfig()));
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/StandardFileFormats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/StandardFileFormats.java
@@ -47,6 +47,7 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.type.Type;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.JobConf;
+import org.joda.time.DateTimeZone;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -55,6 +56,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static io.trino.orc.OrcWriteValidation.OrcWriteValidationMode.BOTH;
+import static io.trino.parquet.writer.ParquetSchemaConverter.HIVE_PARQUET_USE_INT96_TIMESTAMP_ENCODING;
 import static io.trino.parquet.writer.ParquetSchemaConverter.HIVE_PARQUET_USE_LEGACY_DECIMAL_ENCODING;
 import static io.trino.plugin.hive.HiveTestUtils.createGenericHiveRecordCursorProvider;
 import static io.trino.plugin.hive.benchmark.AbstractFileFormat.createSchema;
@@ -171,7 +173,7 @@ public final class StandardFileFormats
         @Override
         public Optional<HivePageSourceFactory> getHivePageSourceFactory(HdfsEnvironment hdfsEnvironment)
         {
-            return Optional.of(new ParquetPageSourceFactory(hdfsEnvironment, new FileFormatDataSourceStats(), new ParquetReaderConfig(), new HiveConfig().setParquetTimeZone("UTC")));
+            return Optional.of(new ParquetPageSourceFactory(hdfsEnvironment, new FileFormatDataSourceStats(), new ParquetReaderConfig(), new HiveConfig()));
         }
 
         @Override
@@ -299,7 +301,11 @@ public final class StandardFileFormats
         public PrestoParquetFormatWriter(File targetFile, List<String> columnNames, List<Type> types, HiveCompressionCodec compressionCodec)
                 throws IOException
         {
-            ParquetSchemaConverter schemaConverter = new ParquetSchemaConverter(types, columnNames, HIVE_PARQUET_USE_LEGACY_DECIMAL_ENCODING);
+            ParquetSchemaConverter schemaConverter = new ParquetSchemaConverter(
+                    types,
+                    columnNames,
+                    HIVE_PARQUET_USE_LEGACY_DECIMAL_ENCODING,
+                    HIVE_PARQUET_USE_INT96_TIMESTAMP_ENCODING);
 
             writer = new ParquetWriter(
                     new FileOutputStream(targetFile),
@@ -307,7 +313,8 @@ public final class StandardFileFormats
                     schemaConverter.getPrimitiveTypes(),
                     ParquetWriterOptions.builder().build(),
                     compressionCodec.getParquetCompressionCodec(),
-                    "test-version");
+                    "test-version",
+                    Optional.of(DateTimeZone.getDefault()));
         }
 
         @Override

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/AbstractTestParquetReader.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/AbstractTestParquetReader.java
@@ -81,12 +81,16 @@ import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.RowType.field;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.Timestamps.MILLISECONDS_PER_SECOND;
+import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MILLISECOND;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.testing.DateTimeTestingUtils.sqlTimestampOf;
 import static io.trino.testing.StructuralTestUtil.mapType;
+import static java.lang.Math.floorDiv;
+import static java.lang.Math.floorMod;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.lang.String.join;
@@ -2005,18 +2009,13 @@ public abstract class AbstractTestParquetReader
         return new SqlVarbinary(input);
     }
 
-    private static Timestamp intToTimestamp(Integer input)
+    private static Timestamp intToTimestamp(Integer epochMillis)
     {
-        if (input == null) {
+        if (epochMillis == null) {
             return null;
         }
-        long seconds = (input / 1000);
-        int nanos = ((input % 1000) * 1_000_000);
-
-        if (nanos < 0) {
-            nanos += 1_000_000_000;
-            seconds -= 1;
-        }
+        long seconds = floorDiv(epochMillis, MILLISECONDS_PER_SECOND);
+        int nanos = floorMod(epochMillis, MILLISECONDS_PER_SECOND) * NANOSECONDS_PER_MILLISECOND;
         return Timestamp.ofEpochSecond(seconds, nanos);
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/AbstractTestParquetReader.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/AbstractTestParquetReader.java
@@ -631,7 +631,7 @@ public abstract class AbstractTestParquetReader
         List<Type> types = ImmutableList.of(struct1Type, struct2Type, struct3Type, struct4Type, mapType(INTEGER, DOUBLE), new ArrayType(BOOLEAN), mapType(VARCHAR, VARCHAR));
 
         Iterable<?>[] values = new Iterable<?>[] {structs1, structs2, structs3, structs4, mapsIntDouble, arraysBoolean, mapsStringString};
-        tester.assertRoundTrip(objectInspectors, values, values, structFieldNames, types, Optional.empty());
+        tester.assertRoundTrip(objectInspectors, values, values, structFieldNames, types, Optional.empty(), false);
     }
 
     @Test
@@ -1275,8 +1275,7 @@ public abstract class AbstractTestParquetReader
         List<List<?>> aValues = createTestStructs(bValues, eValues);
         ObjectInspector bInspector = getStandardStructObjectInspector(asList("c", "d"), asList(javaStringObjectInspector, javaIntObjectInspector));
         ObjectInspector aInspector = getStandardStructObjectInspector(asList("b", "e"), asList(bInspector, javaStringObjectInspector));
-        tester.assertRoundTrip(singletonList(aInspector), new Iterable<?>[] {aValues}, new Iterable<?>[] {
-                aValues}, singletonList("a"), singletonList(aType), Optional.of(parquetSchema));
+        tester.assertRoundTrip(aInspector, aValues, aValues, "a", aType, Optional.of(parquetSchema));
     }
 
     @Test
@@ -1381,8 +1380,13 @@ public abstract class AbstractTestParquetReader
                 "  }" +
                 "} ");
         Iterable<List<Integer>> values = createTestArrays(limit(cycle(asList(1, null, 3, 5, null, null, null, 7, 11, null, 13, 17)), 30_000));
-        tester.assertRoundTrip(singletonList(getStandardListObjectInspector(javaIntObjectInspector)), new Iterable<?>[] {values}, new Iterable<?>[] {
-                values}, singletonList("my_list"), singletonList(new ArrayType(INTEGER)), Optional.of(parquetMrNonNullSpecSchema));
+        tester.assertRoundTrip(
+                getStandardListObjectInspector(javaIntObjectInspector),
+                values,
+                values,
+                "my_list",
+                new ArrayType(INTEGER),
+                Optional.of(parquetMrNonNullSpecSchema));
 
         MessageType sparkSchema = parseMessageType("message hive_schema {" +
                 "  optional group my_list (LIST){" +
@@ -1455,8 +1459,13 @@ public abstract class AbstractTestParquetReader
                 "    }   " +
                 "  }" +
                 " }  ");
-        tester.assertRoundTrip(singletonList(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector)), new Iterable<?>[] {nullableValues},
-                new Iterable<?>[] {nullableValues}, singletonList("my_map"), singletonList(mapType(VARCHAR, INTEGER)), Optional.of(map));
+        tester.assertRoundTrip(
+                getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector),
+                nullableValues,
+                nullableValues,
+                "my_map",
+                mapType(VARCHAR, INTEGER),
+                Optional.of(map));
 
         // Map<String, Integer> (non-null map, nullable values)
         map = parseMessageType("message hive_schema {" +
@@ -1467,8 +1476,13 @@ public abstract class AbstractTestParquetReader
                 "    }   " +
                 "  }" +
                 " }  ");
-        tester.assertRoundTrip(singletonList(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector)), new Iterable<?>[] {nullableValues},
-                new Iterable<?>[] {nullableValues}, singletonList("my_map"), singletonList(mapType(VARCHAR, INTEGER)), Optional.of(map));
+        tester.assertRoundTrip(
+                getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector),
+                nullableValues,
+                nullableValues,
+                "my_map",
+                mapType(VARCHAR, INTEGER),
+                Optional.of(map));
 
         // Map<String, Integer> (non-null map, nullable values)
         map = parseMessageType("message hive_schema {" +
@@ -1479,8 +1493,13 @@ public abstract class AbstractTestParquetReader
                 "    }   " +
                 "  }" +
                 " }  ");
-        tester.assertRoundTrip(singletonList(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector)), new Iterable<?>[] {values},
-                new Iterable<?>[] {values}, singletonList("my_map"), singletonList(mapType(VARCHAR, INTEGER)), Optional.of(map));
+        tester.assertRoundTrip(
+                getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector),
+                values,
+                values,
+                "my_map",
+                mapType(VARCHAR, INTEGER),
+                Optional.of(map));
 
         // Map<String, Integer> (non-null map, nullable values)
         map = parseMessageType("message hive_schema {" +
@@ -1491,8 +1510,13 @@ public abstract class AbstractTestParquetReader
                 "    }   " +
                 "  }" +
                 " }  ");
-        tester.assertRoundTrip(singletonList(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector)), new Iterable<?>[] {values},
-                new Iterable<?>[] {values}, singletonList("my_map"), singletonList(mapType(VARCHAR, INTEGER)), Optional.of(map));
+        tester.assertRoundTrip(
+                getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector),
+                values,
+                values,
+                "my_map",
+                mapType(VARCHAR, INTEGER),
+                Optional.of(map));
 
         // Map<String, Integer> (nullable map, nullable values)
         map = parseMessageType("message hive_schema {" +

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/AbstractTestParquetReader.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/AbstractTestParquetReader.java
@@ -63,8 +63,10 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Iterables.cycle;
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Iterables.limit;
 import static com.google.common.collect.Iterables.transform;
+import static io.trino.plugin.hive.parquet.ParquetTester.TEST_COLUMN;
 import static io.trino.plugin.hive.parquet.ParquetTester.insertNullEvery;
 import static io.trino.plugin.hive.parquet.ParquetTester.ParquetSchemaOptions;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -884,8 +886,10 @@ public abstract class AbstractTestParquetReader
                     intValues.stream()
                             .map(value -> SqlDecimal.of(value, expectedPrecision, scale))
                             .collect(Collectors.toList()),
+                    getOnlyElement(TEST_COLUMN),
                     createDecimalType(precision, scale),
-                    Optional.of(parquetSchema));
+                    Optional.of(parquetSchema),
+                    ParquetSchemaOptions.withIntegerBackedDecimals());
 
             tester.testRoundTrip(
                     javaIntObjectInspector,
@@ -893,8 +897,10 @@ public abstract class AbstractTestParquetReader
                     intValues.stream()
                             .map(value -> SqlDecimal.of(value, MAX_PRECISION, scale))
                             .collect(Collectors.toList()),
+                    getOnlyElement(TEST_COLUMN),
                     createDecimalType(MAX_PRECISION, scale),
-                    Optional.of(parquetSchema));
+                    Optional.of(parquetSchema),
+                    ParquetSchemaOptions.withIntegerBackedDecimals());
         }
     }
 
@@ -922,8 +928,10 @@ public abstract class AbstractTestParquetReader
                     longValues.stream()
                             .map(value -> SqlDecimal.of(value, expectedPrecision, scale))
                             .collect(Collectors.toList()),
+                    getOnlyElement(TEST_COLUMN),
                     createDecimalType(precision, scale),
-                    Optional.of(parquetSchema));
+                    Optional.of(parquetSchema),
+                    ParquetSchemaOptions.withIntegerBackedDecimals());
 
             tester.testRoundTrip(
                     javaLongObjectInspector,
@@ -931,8 +939,10 @@ public abstract class AbstractTestParquetReader
                     longValues.stream()
                             .map(value -> SqlDecimal.of(value, MAX_PRECISION, scale))
                             .collect(Collectors.toList()),
+                    getOnlyElement(TEST_COLUMN),
                     createDecimalType(MAX_PRECISION, scale),
-                    Optional.of(parquetSchema));
+                    Optional.of(parquetSchema),
+                    ParquetSchemaOptions.withIntegerBackedDecimals());
         }
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetTester.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetTester.java
@@ -210,10 +210,10 @@ public class ParquetTester
     {
         List<TypeInfo> typeInfos = getTypeInfosFromTypeString(objectInspector.getTypeName());
         MessageType schema = SingleLevelArraySchemaConverter.convert(TEST_COLUMN, typeInfos);
-        testSingleLevelArrayRoundTrip(objectInspector, writeValues, readValues, type, Optional.of(schema));
+        testSingleLevelArrayRoundTrip(objectInspector, writeValues, readValues, getOnlyElement(TEST_COLUMN), type, Optional.of(schema));
         if (objectInspector.getTypeName().contains("map<")) {
             schema = SingleLevelArrayMapKeyValuesSchemaConverter.convert(TEST_COLUMN, typeInfos);
-            testSingleLevelArrayRoundTrip(objectInspector, writeValues, readValues, type, Optional.of(schema));
+            testSingleLevelArrayRoundTrip(objectInspector, writeValues, readValues, getOnlyElement(TEST_COLUMN), type, Optional.of(schema));
         }
     }
 
@@ -244,12 +244,6 @@ public class ParquetTester
             throws Exception
     {
         testRoundTrip(singletonList(objectInspector), new Iterable<?>[] {writeValues}, new Iterable<?>[] {readValues}, TEST_COLUMN, singletonList(type), parquetSchema, false);
-    }
-
-    public void testSingleLevelArrayRoundTrip(ObjectInspector objectInspector, Iterable<?> writeValues, Iterable<?> readValues, Type type, Optional<MessageType> parquetSchema)
-            throws Exception
-    {
-        testRoundTrip(singletonList(objectInspector), new Iterable<?>[] {writeValues}, new Iterable<?>[] {readValues}, TEST_COLUMN, singletonList(type), parquetSchema, true);
     }
 
     public void testRoundTrip(ObjectInspector objectInspector, Iterable<?> writeValues, Iterable<?> readValues, String columnName, Type type, Optional<MessageType> parquetSchema)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetTester.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetTester.java
@@ -220,23 +220,12 @@ public class ParquetTester
     public void testRoundTrip(ObjectInspector objectInspector, Iterable<?> writeValues, Iterable<?> readValues, Type type)
             throws Exception
     {
-        // just the values
-        testRoundTripType(singletonList(objectInspector), new Iterable<?>[] {writeValues},
-                new Iterable<?>[] {readValues}, TEST_COLUMN, singletonList(type), Optional.empty(), ParquetSchemaOptions.defaultOptions());
+        testRoundTrip(objectInspector, writeValues, readValues, type, Optional.empty());
 
-        // all nulls
-        assertRoundTrip(objectInspector, transform(writeValues, constant(null)),
-                transform(writeValues, constant(null)), getOnlyElement(TEST_COLUMN), type, Optional.empty());
         if (objectInspector.getTypeName().contains("map<")) {
             List<TypeInfo> typeInfos = getTypeInfosFromTypeString(objectInspector.getTypeName());
             MessageType schema = MapKeyValuesSchemaConverter.convert(TEST_COLUMN, typeInfos);
-            // just the values
-            testRoundTripType(singletonList(objectInspector), new Iterable<?>[] {writeValues}, new Iterable<?>[] {
-                    readValues}, TEST_COLUMN, singletonList(type), Optional.of(schema), ParquetSchemaOptions.defaultOptions());
-
-            // all nulls
-            assertRoundTrip(objectInspector, transform(writeValues, constant(null)),
-                    transform(writeValues, constant(null)), getOnlyElement(TEST_COLUMN), type, Optional.of(schema));
+            testRoundTrip(objectInspector, writeValues, readValues, type, Optional.of(schema));
         }
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetTester.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetTester.java
@@ -95,6 +95,7 @@ import static com.google.common.base.Functions.constant;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Iterables.transform;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
@@ -224,8 +225,8 @@ public class ParquetTester
                 new Iterable<?>[] {readValues}, TEST_COLUMN, singletonList(type), Optional.empty(), false);
 
         // all nulls
-        assertRoundTrip(singletonList(objectInspector), new Iterable<?>[] {transform(writeValues, constant(null))},
-                new Iterable<?>[] {transform(writeValues, constant(null))}, TEST_COLUMN, singletonList(type), Optional.empty());
+        assertRoundTrip(objectInspector, transform(writeValues, constant(null)),
+                transform(writeValues, constant(null)), getOnlyElement(TEST_COLUMN), type, Optional.empty());
         if (objectInspector.getTypeName().contains("map<")) {
             List<TypeInfo> typeInfos = getTypeInfosFromTypeString(objectInspector.getTypeName());
             MessageType schema = MapKeyValuesSchemaConverter.convert(TEST_COLUMN, typeInfos);
@@ -234,8 +235,8 @@ public class ParquetTester
                     readValues}, TEST_COLUMN, singletonList(type), Optional.of(schema), false);
 
             // all nulls
-            assertRoundTrip(singletonList(objectInspector), new Iterable<?>[] {transform(writeValues, constant(null))},
-                    new Iterable<?>[] {transform(writeValues, constant(null))}, TEST_COLUMN, singletonList(type), Optional.of(schema));
+            assertRoundTrip(objectInspector, transform(writeValues, constant(null)),
+                    transform(writeValues, constant(null)), getOnlyElement(TEST_COLUMN), type, Optional.of(schema));
         }
     }
 
@@ -311,15 +312,22 @@ public class ParquetTester
     }
 
     void assertRoundTrip(
-            List<ObjectInspector> objectInspectors,
-            Iterable<?>[] writeValues,
-            Iterable<?>[] readValues,
-            List<String> columnNames,
-            List<Type> columnTypes,
+            ObjectInspector objectInspectors,
+            Iterable<?> writeValues,
+            Iterable<?> readValues,
+            String columnName,
+            Type columnType,
             Optional<MessageType> parquetSchema)
             throws Exception
     {
-        assertRoundTrip(objectInspectors, writeValues, readValues, columnNames, columnTypes, parquetSchema, false);
+        assertRoundTrip(
+                singletonList(objectInspectors),
+                new Iterable[] {writeValues},
+                new Iterable[] {readValues},
+                singletonList(columnName),
+                singletonList(columnType),
+                parquetSchema,
+                false);
     }
 
     void assertRoundTrip(

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetDecimalScaling.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetDecimalScaling.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.parquet.schema.MessageType;
+import org.joda.time.DateTimeZone;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -448,7 +449,7 @@ public class TestParquetDecimalScaling
         jobConf.setEnum(WRITER_VERSION, writerVersion);
 
         try {
-            FileSinkOperator.RecordWriter recordWriter = new TestMapredParquetOutputFormat(Optional.of(parquetSchema), true)
+            FileSinkOperator.RecordWriter recordWriter = new TestMapredParquetOutputFormat(Optional.of(parquetSchema), true, DateTimeZone.getDefault())
                     .getHiveRecordWriter(
                             jobConf,
                             path,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestTimestamp.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestTimestamp.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.schema.MessageType;
+import org.joda.time.DateTimeZone;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -83,7 +84,8 @@ public class TestTimestamp
                     getStandardStructObjectInspector(columnNames, objectInspectors),
                     new Iterator<?>[] {epochMillisValues.iterator()},
                     Optional.of(parquetSchema),
-                    false);
+                    false,
+                    DateTimeZone.getDefault());
 
             testReadingAs(TIMESTAMP_MILLIS, session, tempFile, columnNames, timestampsMillis.build());
             testReadingAs(BIGINT, session, tempFile, columnNames, bigints.build());

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/write/TestDataWritableWriteSupport.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/write/TestDataWritableWriteSupport.java
@@ -19,8 +19,11 @@ import org.apache.hadoop.hive.serde2.io.ParquetHiveRecord;
 import org.apache.parquet.hadoop.api.WriteSupport;
 import org.apache.parquet.io.api.RecordConsumer;
 import org.apache.parquet.schema.MessageType;
+import org.joda.time.DateTimeZone;
 
 import java.util.HashMap;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * This class is copied from org.apache.hadoop.hive.ql.io.parquet.write.DataWritableWriteSupport
@@ -32,10 +35,12 @@ class TestDataWritableWriteSupport
     private TestDataWritableWriter writer;
     private MessageType schema;
     private final boolean singleLevelArray;
+    private final DateTimeZone dateTimeZone;
 
-    public TestDataWritableWriteSupport(boolean singleLevelArray)
+    public TestDataWritableWriteSupport(boolean singleLevelArray, DateTimeZone dateTimeZone)
     {
         this.singleLevelArray = singleLevelArray;
+        this.dateTimeZone = requireNonNull(dateTimeZone, "dateTimeZone is null");
     }
 
     @Override
@@ -48,7 +53,7 @@ class TestDataWritableWriteSupport
     @Override
     public void prepareForWrite(RecordConsumer recordConsumer)
     {
-        writer = new TestDataWritableWriter(recordConsumer, schema, singleLevelArray);
+        writer = new TestDataWritableWriter(recordConsumer, schema, singleLevelArray, dateTimeZone);
     }
 
     @Override

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/write/TestDataWritableWriter.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/write/TestDataWritableWriter.java
@@ -45,9 +45,12 @@ import org.apache.parquet.io.api.RecordConsumer;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.OriginalType;
 import org.apache.parquet.schema.Type;
+import org.joda.time.DateTimeZone;
 
 import java.util.List;
 import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * This class is copied from org.apache.hadoop.hive.ql.io.parquet.write.DataWritableWriter
@@ -62,12 +65,14 @@ public class TestDataWritableWriter
     private final RecordConsumer recordConsumer;
     private final GroupType schema;
     private final boolean singleLevelArray;
+    private final DateTimeZone timeZone;
 
-    public TestDataWritableWriter(RecordConsumer recordConsumer, GroupType schema, boolean singleLevelArray)
+    public TestDataWritableWriter(RecordConsumer recordConsumer, GroupType schema, boolean singleLevelArray, DateTimeZone timeZone)
     {
         this.recordConsumer = recordConsumer;
         this.schema = schema;
         this.singleLevelArray = singleLevelArray;
+        this.timeZone = requireNonNull(timeZone, "timeZone is null");
     }
 
     /**
@@ -366,6 +371,7 @@ public class TestDataWritableWriter
                 break;
             case TIMESTAMP:
                 Timestamp ts = ((TimestampObjectInspector) inspector).getPrimitiveJavaObject(value);
+                ts = Timestamp.ofEpochMilli(timeZone.convertLocalToUTC(ts.toEpochMilli(), true), ts.getNanos());
                 recordConsumer.addBinary(NanoTimeUtils.getNanoTime(ts, false).toBinary());
                 break;
             case DECIMAL:

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/write/TestMapredParquetOutputFormat.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/write/TestMapredParquetOutputFormat.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.util.Progressable;
 import org.apache.parquet.hadoop.ParquetOutputFormat;
 import org.apache.parquet.schema.MessageType;
+import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -41,9 +42,9 @@ public class TestMapredParquetOutputFormat
 {
     private final Optional<MessageType> schema;
 
-    public TestMapredParquetOutputFormat(Optional<MessageType> schema, boolean singleLevelArray)
+    public TestMapredParquetOutputFormat(Optional<MessageType> schema, boolean singleLevelArray, DateTimeZone dateTimeZone)
     {
-        super(new ParquetOutputFormat<>(new TestDataWritableWriteSupport(singleLevelArray)));
+        super(new ParquetOutputFormat<>(new TestDataWritableWriteSupport(singleLevelArray, dateTimeZone)));
         this.schema = requireNonNull(schema, "schema is null");
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergParquetFileWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergParquetFileWriter.java
@@ -28,6 +28,7 @@ import org.apache.parquet.schema.MessageType;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 
 import static java.util.Objects.requireNonNull;
@@ -64,7 +65,8 @@ public class IcebergParquetFileWriter
                 parquetWriterOptions,
                 fileInputColumnIndexes,
                 compressionCodecName,
-                trinoVersion);
+                trinoVersion,
+                Optional.empty());
         this.metricsConfig = requireNonNull(metricsConfig, "metricsConfig is null");
         this.outputPath = requireNonNull(outputPath, "outputPath is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCompatibility.java
@@ -14,6 +14,7 @@
 package io.trino.tests.product.hive;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.math.IntMath;
 import com.google.inject.Inject;
 import io.trino.plugin.hive.HiveTimestampPrecision;
 import io.trino.tempto.assertions.QueryAssert;
@@ -25,6 +26,7 @@ import org.testng.annotations.Test;
 import javax.inject.Named;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.Date;
@@ -39,7 +41,6 @@ import java.util.function.Function;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
-import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tests.product.TestGroups.STORAGE_FORMATS_DETAILED;
 import static io.trino.tests.product.utils.JdbcDriverUtils.setSessionProperty;
@@ -73,8 +74,6 @@ public class TestHiveCompatibility
 
         boolean isAvroStorageFormat = "AVRO".equals(storageFormat.getName());
         boolean isParquetStorageFormat = "PARQUET".equals(storageFormat.getName());
-        boolean isParquetOptimizedWriterEnabled = Boolean.parseBoolean(
-                storageFormat.getSessionProperties().getOrDefault("hive.experimental_parquet_optimized_writer_enabled", "false"));
         List<HiveCompatibilityColumnData> columnDataList = new ArrayList<>();
         columnDataList.add(new HiveCompatibilityColumnData("c_boolean", "boolean", "true", true));
         if (!isAvroStorageFormat) {
@@ -111,7 +110,7 @@ public class TestHiveCompatibility
                                 : Timestamp.valueOf(LocalDateTime.of(2015, 5, 10, 12, 15, 35, 123_000_000))));
             }
         }
-        else if (!(isParquetStorageFormat && isParquetOptimizedWriterEnabled)) {
+        else {
             // Hive expects `INT96` (deprecated on Parquet) for timestamp values
             columnDataList.add(new HiveCompatibilityColumnData(
                     "c_timestamp",
@@ -170,7 +169,7 @@ public class TestHiveCompatibility
     }
 
     @Test(groups = STORAGE_FORMATS_DETAILED)
-    public void testTimestampFieldWrittenByOptimizedParquetWriterCannotBeReadByHive()
+    public void testTimestampFieldWrittenByOptimizedParquetWriterCanBeReadByHive()
             throws Exception
     {
         // only admin user is allowed to change session properties
@@ -184,8 +183,21 @@ public class TestHiveCompatibility
             setSessionProperty(onTrino().getConnection(), "hive.timestamp_precision", hiveTimestampPrecision.name());
             onTrino().executeQuery("INSERT INTO " + tableName + " VALUES ('" + hiveTimestampPrecision.name() + "', TIMESTAMP '2021-01-05 12:01:00.111901001')");
             // Hive expects `INT96` (deprecated on Parquet) for timestamp values
-            assertQueryFailure(() -> onHive().executeQuery("SELECT a_timestamp FROM " + tableName + " WHERE timestamp_precision = '" + hiveTimestampPrecision.name() + "'"))
-                    .hasMessageMatching(".*java.lang.ClassCastException: org.apache.hadoop.io.LongWritable cannot be cast to org.apache.hadoop.hive.serde2.io.(TimestampWritable|TimestampWritableV2)");
+            int precisionScalingFactor = (int) Math.pow(10, 9 - hiveTimestampPrecision.getPrecision());
+            int nanoOfSecond = IntMath.divide(111901001, precisionScalingFactor, RoundingMode.HALF_UP) * precisionScalingFactor;
+            LocalDateTime expectedValue = LocalDateTime.of(2021, 1, 5, 12, 1, 0, nanoOfSecond);
+            assertThat(onHive().executeQuery("SELECT a_timestamp FROM " + tableName + " WHERE timestamp_precision = '" + hiveTimestampPrecision.name() + "'"))
+                    .containsOnly(row(Timestamp.valueOf(expectedValue)));
+            // Verify with hive.parquet.timestamp.skip.conversion explicitly enabled
+            // CDH 5 and Apache Hive 3.2 and above enable this by default
+            try {
+                onHive().executeQuery("SET hive.parquet.timestamp.skip.conversion=true");
+                assertThat(onHive().executeQuery("SELECT a_timestamp FROM " + tableName + " WHERE timestamp_precision = '" + hiveTimestampPrecision.name() + "'"))
+                        .containsOnly(row(Timestamp.valueOf(expectedValue)));
+            }
+            finally {
+                onHive().executeQuery("RESET");
+            }
         }
         onTrino().executeQuery(format("DROP TABLE %s", tableName));
     }


### PR DESCRIPTION
## Description

INT64 backed timestamps are not compatible with Apache Hive 3 and older.
Delta Lake connector will continue to use INT64 backed timestamps.

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Native parquet writer, hive connector
> How would you describe this change to a non-technical end user or system administrator?

Timestamps written by optimized parquet writer will be compatible with Apache Hive version 3 or lower.
## Related issues, pull requests, and links

https://github.com/trinodb/trino/issues/6377
https://github.com/trinodb/trino/issues/10486
## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Section
* Fixes compatibility of files produced by optimized parquet writer for timestamp columns in Trino hive connnector with Apache Hive. ({issue}`issuenumber`)
```
