### PR TITLE
Update docker-images to v61

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <dep.casandra.version>4.14.0</dep.casandra.version>
         <dep.minio.version>7.1.4</dep.minio.version>
 
-        <dep.docker.images.version>59</dep.docker.images.version>
+        <dep.docker.images.version>61</dep.docker.images.version>
 
         <!--
           America/Bahia_Banderas has:


### PR DESCRIPTION
## Description

Update docker-images to v61. This upgrade contains
* https://github.com/trinodb/docker-images/pull/129
* https://github.com/trinodb/docker-images/pull/130 (I didn't mention in commit message as it's unrelated now)
* https://github.com/trinodb/docker-images/pull/131

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
