### PR TITLE
Fix ignoring trailing content in JsonUtils

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/util/JsonUtils.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/util/JsonUtils.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.base.util;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -81,6 +82,10 @@ public final class JsonUtils
     static <T> T parseJson(byte[] jsonBytes, Class<T> javaType)
             throws IOException
     {
-        return OBJECT_MAPPER.readValue(jsonBytes, javaType);
+        try (JsonParser parser = OBJECT_MAPPER.createParser(jsonBytes)) {
+            T value = OBJECT_MAPPER.readValue(parser, javaType);
+            checkArgument(parser.nextToken() == null, "Found characters after the expected end of input");
+            return value;
+        }
     }
 }


### PR DESCRIPTION
Similar to commit a7bc2bacbac476b78a3a2673e4484653beb3453d, but in
plugin toolkit's `JsonUtils`.
