### PR TITLE
Use unique schema names in tests

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -810,22 +810,22 @@ public abstract class BaseHiveConnectorTest
                 .setIdentity(Identity.forUser("alice").build())
                 .build();
 
-        assertUpdate(admin, "CREATE SCHEMA test_table_authorization");
-        assertUpdate(admin, "CREATE TABLE test_table_authorization.foo (col int)");
+        assertUpdate(admin, "CREATE SCHEMA test_table_authorization_role");
+        assertUpdate(admin, "CREATE TABLE test_table_authorization_role.foo (col int)");
 
         // TODO Change assertions once https://github.com/trinodb/trino/issues/5706 is done
         assertAccessDenied(
                 alice,
-                "ALTER TABLE test_table_authorization.foo SET AUTHORIZATION ROLE admin",
-                "Cannot set authorization for table test_table_authorization.foo to ROLE admin");
-        assertUpdate(admin, "ALTER TABLE test_table_authorization.foo SET AUTHORIZATION alice");
+                "ALTER TABLE test_table_authorization_role.foo SET AUTHORIZATION ROLE admin",
+                "Cannot set authorization for table test_table_authorization_role.foo to ROLE admin");
+        assertUpdate(admin, "ALTER TABLE test_table_authorization_role.foo SET AUTHORIZATION alice");
         assertQueryFails(
                 alice,
-                "ALTER TABLE test_table_authorization.foo SET AUTHORIZATION ROLE admin",
+                "ALTER TABLE test_table_authorization_role.foo SET AUTHORIZATION ROLE admin",
                 "Setting table owner type as a role is not supported");
 
-        assertUpdate(admin, "DROP TABLE test_table_authorization.foo");
-        assertUpdate(admin, "DROP SCHEMA test_table_authorization");
+        assertUpdate(admin, "DROP TABLE test_table_authorization_role.foo");
+        assertUpdate(admin, "DROP SCHEMA test_table_authorization_role");
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/trinodb/trino/issues/12858
## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
