### PR TITLE
Added support for sorted_by while creating iceberg table

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableProperties.java
@@ -41,6 +41,7 @@ public class IcebergTableProperties
 {
     public static final String FILE_FORMAT_PROPERTY = "format";
     public static final String PARTITIONING_PROPERTY = "partitioning";
+    public static final String SORTED_BY_PROPERTY = "sorted_by";
     public static final String LOCATION_PROPERTY = "location";
     public static final String FORMAT_VERSION_PROPERTY = "format_version";
     public static final String ORC_BLOOM_FILTER_COLUMNS = "orc_bloom_filter_columns";
@@ -63,6 +64,15 @@ public class IcebergTableProperties
                 .add(new PropertyMetadata<>(
                         PARTITIONING_PROPERTY,
                         "Partition transforms",
+                        new ArrayType(VARCHAR),
+                        List.class,
+                        ImmutableList.of(),
+                        false,
+                        value -> (List<?>) value,
+                        value -> value))
+                .add(new PropertyMetadata<>(
+                        SORTED_BY_PROPERTY,
+                        "Sorted columns",
                         new ArrayType(VARCHAR),
                         List.class,
                         ImmutableList.of(),
@@ -116,6 +126,13 @@ public class IcebergTableProperties
     {
         List<String> partitioning = (List<String>) tableProperties.get(PARTITIONING_PROPERTY);
         return partitioning == null ? ImmutableList.of() : ImmutableList.copyOf(partitioning);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static List<String> getSortOrder(Map<String, Object> tableProperties)
+    {
+        List<String> sortedBy = (List<String>) tableProperties.get(SORTED_BY_PROPERTY);
+        return sortedBy == null ? ImmutableList.of() : ImmutableList.copyOf(sortedBy);
     }
 
     public static Optional<String> getTableLocation(Map<String, Object> tableProperties)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/SortFields.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/SortFields.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import org.apache.iceberg.NullOrder;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortField;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.expressions.Expressions;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.iceberg.IcebergUtil.FUNCTION_ARGUMENT_NAME;
+import static io.trino.plugin.iceberg.IcebergUtil.FUNCTION_ARGUMENT_NAME_AND_INT;
+import static io.trino.plugin.iceberg.IcebergUtil.IDENTIFIER;
+import static io.trino.plugin.iceberg.IcebergUtil.fromIdentifier;
+import static io.trino.plugin.iceberg.IcebergUtil.toIdentifier;
+import static java.lang.Integer.parseInt;
+import static java.lang.String.format;
+
+public final class SortFields
+{
+    // YEAR patterns
+    private static final Pattern YEAR_PATTERN = Pattern.compile("\\s*?(?i:year)" + FUNCTION_ARGUMENT_NAME);
+    private static final Pattern YEAR_PATTERN_ASC = Pattern.compile("\\s*?(?i:year)" + FUNCTION_ARGUMENT_NAME + "\\s*?(ASC)\\s*?");
+    private static final Pattern YEAR_PATTERN_ASC_NULLS_FIRST = Pattern.compile("\\s*?(?i:year)" + FUNCTION_ARGUMENT_NAME + "\\s*?(ASC)\\s*?(NULLS\\s*?FIRST)\\s*?");
+    private static final Pattern YEAR_PATTERN_ASC_NULLS_LAST = Pattern.compile("\\s*?(?i:year)" + FUNCTION_ARGUMENT_NAME + "\\s*?(ASC)\\s*?(NULLS\\s*?LAST)\\s*?");
+    private static final Pattern YEAR_PATTERN_DESC = Pattern.compile("\\s*?year" + FUNCTION_ARGUMENT_NAME + "\\s*?(DESC)\\s*?");
+    private static final Pattern YEAR_PATTERN_DESC_NULLS_FIRST = Pattern.compile("\\s*?(?i:year)" + FUNCTION_ARGUMENT_NAME + "\\s*?(DESC)\\s*?(NULLS\\s*?FIRST)\\s*?");
+    private static final Pattern YEAR_PATTERN_DESC_NULLS_LAST = Pattern.compile("\\s*?(?i:year)" + FUNCTION_ARGUMENT_NAME + "\\s*?(DESC)\\s*?(NULLS\\s*?LAST)\\s*?");
+
+    // MONTH patterns
+    private static final Pattern MONTH_PATTERN = Pattern.compile("\\s*?(?i:month)" + FUNCTION_ARGUMENT_NAME);
+    private static final Pattern MONTH_PATTERN_ASC = Pattern.compile("\\s*?(?i:month)" + FUNCTION_ARGUMENT_NAME + "\\s*?(ASC)\\s*?");
+    private static final Pattern MONTH_PATTERN_ASC_NULLS_FIRST = Pattern.compile("\\s*?(?i:(?i:month))" + FUNCTION_ARGUMENT_NAME + "\\s*?(ASC)\\s*?(NULLS\\s*?FIRST)\\s*?");
+    private static final Pattern MONTH_PATTERN_ASC_NULLS_LAST = Pattern.compile("\\s*?(?i:month)" + FUNCTION_ARGUMENT_NAME + "\\s*?(ASC)\\s*?(NULLS\\s*?LAST)\\s*?");
+    private static final Pattern MONTH_PATTERN_DESC = Pattern.compile("\\s*?(?i:month)" + FUNCTION_ARGUMENT_NAME + "\\s*?(DESC)\\s*?");
+    private static final Pattern MONTH_PATTERN_DESC_NULLS_FIRST = Pattern.compile("\\s*?(?i:month)" + FUNCTION_ARGUMENT_NAME + "\\s*?(DESC)\\s*?(NULLS\\s*?FIRST)\\s*?");
+    private static final Pattern MONTH_PATTERN_DESC_NULLS_LAST = Pattern.compile("\\s*?(?i:month)" + FUNCTION_ARGUMENT_NAME + "\\s*?(DESC)\\s*?(NULLS\\s*?LAST)\\s*?");
+
+    // DAY patterns
+    private static final Pattern DAY_PATTERN = Pattern.compile("\\s*?(?i:day)" + FUNCTION_ARGUMENT_NAME);
+    private static final Pattern DAY_PATTERN_ASC = Pattern.compile("\\s*?(?i:day)" + FUNCTION_ARGUMENT_NAME + "\\s*?(ASC)\\s*?");
+    private static final Pattern DAY_PATTERN_ASC_NULLS_FIRST = Pattern.compile("\\s*?(?i:day)" + FUNCTION_ARGUMENT_NAME + "\\s*?(ASC)\\s*?(NULLS\\s*?FIRST)\\s*?");
+    private static final Pattern DAY_PATTERN_ASC_NULLS_LAST = Pattern.compile("\\s*?(?i:day)" + FUNCTION_ARGUMENT_NAME + "\\s*?(ASC)\\s*?(NULLS\\s*?LAST)\\s*?");
+    private static final Pattern DAY_PATTERN_DESC = Pattern.compile("\\s*?(?i:day)" + FUNCTION_ARGUMENT_NAME + "\\s*?(DESC)\\s*?");
+    private static final Pattern DAY_PATTERN_DESC_NULLS_FIRST = Pattern.compile("\\s*?(?i:day)" + FUNCTION_ARGUMENT_NAME + "\\s*?(DESC)\\s*?(NULLS\\s*?FIRST)\\s*?");
+    private static final Pattern DAY_PATTERN_DESC_NULLS_LAST = Pattern.compile("\\s*?(?i:day)" + FUNCTION_ARGUMENT_NAME + "\\s*?(DESC)\\s*?(NULLS\\s*?LAST)\\s*?");
+
+    // HOUR patterns
+    private static final Pattern HOUR_PATTERN = Pattern.compile("\\s*?(?i:hour)" + FUNCTION_ARGUMENT_NAME);
+    private static final Pattern HOUR_PATTERN_ASC = Pattern.compile("\\s*?(?i:hour)" + FUNCTION_ARGUMENT_NAME + "\\s*?(ASC)\\s*?");
+    private static final Pattern HOUR_PATTERN_ASC_NULLS_FIRST = Pattern.compile("\\s*?(?i:hour)" + FUNCTION_ARGUMENT_NAME + "\\s*?(ASC)\\s*?(NULLS\\s*?FIRST)\\s*?");
+    private static final Pattern HOUR_PATTERN_ASC_NULLS_LAST = Pattern.compile("\\s*?(?i:hour)" + FUNCTION_ARGUMENT_NAME + "\\s*?(ASC)\\s*?(NULLS\\s*?LAST)\\s*?");
+    private static final Pattern HOUR_PATTERN_DESC = Pattern.compile("\\s*?(?i:hour)" + FUNCTION_ARGUMENT_NAME + "\\s*?(DESC)\\s*?");
+    private static final Pattern HOUR_PATTERN_DESC_NULLS_FIRST = Pattern.compile("\\s*?(?i:hour)" + FUNCTION_ARGUMENT_NAME + "\\s*?(DESC)\\s*?(NULLS\\s*?FIRST)\\s*?");
+    private static final Pattern HOUR_PATTERN_DESC_NULLS_LAST = Pattern.compile("\\s*?(?i:hour)" + FUNCTION_ARGUMENT_NAME + "\\s*?(DESC)\\s*?(NULLS\\s*?LAST)\\s*?");
+
+    // Truncate
+    private static final Pattern ICEBERG_TRUNCATE_PATTERN = Pattern.compile("truncate\\[(\\d+)]");
+    private static final Pattern TRUNCATE_PATTERN = Pattern.compile("\\s*?(?i:truncate)" + FUNCTION_ARGUMENT_NAME_AND_INT);
+    private static final Pattern TRUNCATE_ASC_PATTERN = Pattern.compile("\\s*?(?i:truncate)" + FUNCTION_ARGUMENT_NAME_AND_INT + "\\s*?(ASC)\\s*?");
+    private static final Pattern TRUNCATE_ASC_NULLS_FIRST_PATTERN = Pattern.compile("\\s*?(?i:truncate)" + FUNCTION_ARGUMENT_NAME_AND_INT + "\\s*?(ASC)\\s*?(NULLS\\s*?FIRST)\\s*?");
+    private static final Pattern TRUNCATE_ASC_NULLS_LAST_PATTERN = Pattern.compile("\\s*?(?i:truncate)" + FUNCTION_ARGUMENT_NAME_AND_INT + "\\s*?(ASC)\\s*?(NULLS\\s*?LAST)\\s*?");
+    private static final Pattern TRUNCATE_DESC_PATTERN = Pattern.compile("\\s*?(?i:truncate)" + FUNCTION_ARGUMENT_NAME_AND_INT + "\\s*?(DESC)\\s*?");
+    private static final Pattern TRUNCATE_DESC_NULLS_FIRST_PATTERN = Pattern.compile("\\s*?(?i:truncate)" + FUNCTION_ARGUMENT_NAME_AND_INT + "\\s*?(DESC)\\s*?(NULLS\\s*?FIRST)\\s*?");
+    private static final Pattern TRUNCATE_DESC_NULLS_LAST_PATTERN = Pattern.compile("\\s*?(?i:truncate)" + FUNCTION_ARGUMENT_NAME_AND_INT + "\\s*?(DESC)\\s*?(NULLS\\s*?LAST)\\s*?");
+
+    // Bucket
+    private static final Pattern ICEBERG_BUCKET_PATTERN = Pattern.compile("\\s*?(?i:bucket)\\[(\\d+)]");
+    private static final Pattern BUCKET_PATTERN = Pattern.compile("\\s*?(?i:bucket)" + FUNCTION_ARGUMENT_NAME_AND_INT);
+    private static final Pattern BUCKET_ASC_PATTERN = Pattern.compile("\\s*?(?i:bucket)" + FUNCTION_ARGUMENT_NAME_AND_INT + "\\s*?(ASC)\\s*?");
+    private static final Pattern BUCKET_ASC_NULLS_FIRST_PATTERN = Pattern.compile("\\s*?(?i:bucket)" + FUNCTION_ARGUMENT_NAME_AND_INT + " \\s*?(ASC)\\s*?(NULLS\\s*?FIRST)\\s*?");
+    private static final Pattern BUCKET_ASC_NULLS_LAST_PATTERN = Pattern.compile("\\s*?(?i:bucket)" + FUNCTION_ARGUMENT_NAME_AND_INT + " \\s*?(ASC)\\s*?(NULLS\\s*?LAST)\\s*?");
+    private static final Pattern BUCKET_DESC_PATTERN = Pattern.compile("\\s*?(?i:bucket)" + FUNCTION_ARGUMENT_NAME_AND_INT + "\\s*?(DESC)\\s*?");
+    private static final Pattern BUCKET_DESC_NULLS_FIRST_PATTERN = Pattern.compile("\\s*?(?i:bucket)" + FUNCTION_ARGUMENT_NAME_AND_INT + " \\s*?(DESC)\\s*?(NULLS\\s*?FIRST)\\s*?");
+    private static final Pattern BUCKET_DESC_NULLS_LAST_PATTERN = Pattern.compile("\\s*?(?i:bucket)" + FUNCTION_ARGUMENT_NAME_AND_INT + " \\s*?(DESC)\\s*?(NULLS\\s*?LAST)\\s*?");
+
+    // identity
+    private static final Pattern IDENTITY_PATTERN = Pattern.compile(IDENTIFIER);
+    private static final Pattern IDENTITY_ASC_PATTERN = Pattern.compile(IDENTIFIER + "\\s*?(ASC)\\s*?");
+    private static final Pattern IDENTITY_ASC_NULLS_FIRST_PATTERN = Pattern.compile(IDENTIFIER + "\\s*?(ASC)\\s*?(NULLS\\s*?FIRST)\\s*?");
+    private static final Pattern IDENTITY_ASC_NULLS_LAST_PATTERN = Pattern.compile(IDENTIFIER + "\\s*?(ASC)\\s*?(NULLS\\s*?LAST)\\s*?");
+    private static final Pattern IDENTITY_DESC_PATTERN = Pattern.compile(IDENTIFIER + "\\s*?(DESC)\\s*?");
+    private static final Pattern IDENTITY_DESC_NULLS_FIRST_PATTERN = Pattern.compile(IDENTIFIER + "\\s*?(DESC)\\s*?(NULLS\\s*?FIRST)\\s*?");
+    private static final Pattern IDENTITY_DESC_NULLS_LAST_PATTERN = Pattern.compile(IDENTIFIER + "\\s*?(DESC)\\s*?(NULLS\\s*?LAST)\\s*?");
+
+    private SortFields() {}
+
+    public static SortOrder parseSortFields(Schema schema, List<String> fields)
+    {
+        SortOrder.Builder builder = SortOrder.builderFor(schema);
+        for (String field : fields) {
+            parseSortField(builder, field);
+        }
+        return builder.build();
+    }
+
+    public static void parseSortField(SortOrder.Builder builder, String field)
+    {
+        boolean matched = false ||
+                tryMatchYear(builder, field) ||
+                tryMatchMonth(builder, field) ||
+                tryMatchDay(builder, field) ||
+                tryMatchHour(builder, field) ||
+                tryMatchBucket(builder, field) ||
+                tryMatchTruncate(builder, field) ||
+                tryMatchWithoutTransform(builder, field);
+
+        if (!matched) {
+            throw new IllegalArgumentException("Invalid sort field declaration: " + field);
+        }
+    }
+
+    private static boolean tryMatchWithoutTransform(SortOrder.Builder builder, String field)
+    {
+        return tryMatch(field, IDENTITY_ASC_NULLS_FIRST_PATTERN, match -> builder.asc(fromIdentifier(match.group(1).trim()), NullOrder.NULLS_FIRST)) ||
+                tryMatch(field, IDENTITY_ASC_NULLS_LAST_PATTERN, match -> builder.asc(fromIdentifier(match.group(1).trim()), NullOrder.NULLS_LAST)) ||
+                tryMatch(field, IDENTITY_ASC_PATTERN, match -> builder.asc(fromIdentifier(match.group(1).trim()))) ||
+                tryMatch(field, IDENTITY_DESC_NULLS_FIRST_PATTERN, match -> builder.desc(fromIdentifier(match.group(1).trim()), NullOrder.NULLS_FIRST)) ||
+                tryMatch(field, IDENTITY_DESC_NULLS_LAST_PATTERN, match -> builder.desc(fromIdentifier(match.group(1).trim()), NullOrder.NULLS_LAST)) ||
+                tryMatch(field, IDENTITY_DESC_PATTERN, match -> builder.desc(fromIdentifier(match.group(1).trim()))) ||
+                tryMatch(field, IDENTITY_PATTERN, match -> builder.asc(fromIdentifier(match.group(1).trim()))) ||
+                false;
+    }
+
+    private static boolean tryMatchBucket(SortOrder.Builder builder, String field)
+    {
+        return tryMatch(field, BUCKET_ASC_NULLS_FIRST_PATTERN, match -> builder.asc(Expressions.bucket(fromIdentifier(match.group(1).trim()), parseInt(match.group(2).trim())), NullOrder.NULLS_FIRST)) ||
+                tryMatch(field, BUCKET_ASC_NULLS_LAST_PATTERN, match -> builder.asc(Expressions.bucket(fromIdentifier(match.group(1).trim()), parseInt(match.group(2).trim())), NullOrder.NULLS_LAST)) ||
+                tryMatch(field, BUCKET_ASC_PATTERN, match -> builder.asc(Expressions.bucket(fromIdentifier(match.group(1).trim()), parseInt(match.group(2).trim())))) ||
+                tryMatch(field, BUCKET_DESC_NULLS_FIRST_PATTERN, match -> builder.desc(Expressions.bucket(fromIdentifier(match.group(1).trim()), parseInt(match.group(2).trim())), NullOrder.NULLS_FIRST)) ||
+                tryMatch(field, BUCKET_DESC_NULLS_LAST_PATTERN, match -> builder.desc(Expressions.bucket(fromIdentifier(match.group(1).trim()), parseInt(match.group(2).trim())), NullOrder.NULLS_LAST)) ||
+                tryMatch(field, BUCKET_DESC_PATTERN, match -> builder.desc(Expressions.bucket(fromIdentifier(match.group(1).trim()), parseInt(match.group(2).trim())))) ||
+                tryMatch(field, BUCKET_PATTERN, match -> builder.asc(Expressions.bucket(fromIdentifier(match.group(1).trim()), parseInt(match.group(2).trim())))) ||
+                false;
+    }
+
+    private static boolean tryMatchTruncate(SortOrder.Builder builder, String field)
+    {
+        return tryMatch(field, TRUNCATE_ASC_NULLS_FIRST_PATTERN, match -> builder.asc(Expressions.truncate(fromIdentifier(match.group(1).trim()), parseInt(match.group(2).trim())), NullOrder.NULLS_FIRST)) ||
+                tryMatch(field, TRUNCATE_ASC_NULLS_LAST_PATTERN, match -> builder.asc(Expressions.truncate(fromIdentifier(match.group(1).trim()), parseInt(match.group(2).trim())), NullOrder.NULLS_LAST)) ||
+                tryMatch(field, TRUNCATE_ASC_PATTERN, match -> builder.asc(Expressions.truncate(fromIdentifier(match.group(1).trim()), parseInt(match.group(2).trim())))) ||
+                tryMatch(field, TRUNCATE_DESC_NULLS_FIRST_PATTERN, match -> builder.desc(Expressions.truncate(fromIdentifier(match.group(1).trim()), parseInt(match.group(2).trim())), NullOrder.NULLS_FIRST)) ||
+                tryMatch(field, TRUNCATE_DESC_NULLS_LAST_PATTERN, match -> builder.desc(Expressions.truncate(fromIdentifier(match.group(1).trim()), parseInt(match.group(2).trim())), NullOrder.NULLS_LAST)) ||
+                tryMatch(field, TRUNCATE_DESC_PATTERN, match -> builder.desc(Expressions.truncate(fromIdentifier(match.group(1).trim()), parseInt(match.group(2).trim())))) ||
+                tryMatch(field, TRUNCATE_PATTERN, match -> builder.asc(Expressions.truncate(fromIdentifier(match.group(1).trim()), parseInt(match.group(2).trim())))) ||
+                false;
+    }
+
+    private static boolean tryMatchHour(SortOrder.Builder builder, String field)
+    {
+        return tryMatch(field, HOUR_PATTERN_ASC_NULLS_FIRST, match -> builder.asc(Expressions.hour(fromIdentifier(match.group(1).trim())), NullOrder.NULLS_FIRST)) ||
+                tryMatch(field, HOUR_PATTERN_ASC_NULLS_LAST, match -> builder.asc(Expressions.hour(fromIdentifier(match.group(1).trim())), NullOrder.NULLS_LAST)) ||
+                tryMatch(field, HOUR_PATTERN_ASC, match -> builder.asc(Expressions.hour(fromIdentifier(match.group(1).trim())))) ||
+                tryMatch(field, HOUR_PATTERN_DESC_NULLS_FIRST, match -> builder.desc(Expressions.hour(fromIdentifier(match.group(1).trim())), NullOrder.NULLS_FIRST)) ||
+                tryMatch(field, HOUR_PATTERN_DESC_NULLS_LAST, match -> builder.desc(Expressions.hour(fromIdentifier(match.group(1).trim())), NullOrder.NULLS_LAST)) ||
+                tryMatch(field, HOUR_PATTERN_DESC, match -> builder.desc(Expressions.hour(fromIdentifier(match.group(1).trim())))) ||
+                tryMatch(field, HOUR_PATTERN, match -> builder.asc(Expressions.hour(fromIdentifier(match.group(1).trim())))) ||
+                false;
+    }
+
+    private static boolean tryMatchDay(SortOrder.Builder builder, String field)
+    {
+        return tryMatch(field, DAY_PATTERN_ASC_NULLS_FIRST, match -> builder.asc(Expressions.day(fromIdentifier(match.group(1).trim())), NullOrder.NULLS_FIRST)) ||
+                tryMatch(field, DAY_PATTERN_ASC_NULLS_LAST, match -> builder.asc(Expressions.day(fromIdentifier(match.group(1).trim())), NullOrder.NULLS_LAST)) ||
+                tryMatch(field, DAY_PATTERN_ASC, match -> builder.asc(Expressions.day(fromIdentifier(match.group(1).trim())))) ||
+                tryMatch(field, DAY_PATTERN_DESC_NULLS_FIRST, match -> builder.desc(Expressions.day(fromIdentifier(match.group(1).trim())), NullOrder.NULLS_FIRST)) ||
+                tryMatch(field, DAY_PATTERN_DESC_NULLS_LAST, match -> builder.desc(Expressions.day(fromIdentifier(match.group(1).trim())), NullOrder.NULLS_LAST)) ||
+                tryMatch(field, DAY_PATTERN_DESC, match -> builder.desc(Expressions.day(fromIdentifier(match.group(1).trim())))) ||
+                tryMatch(field, DAY_PATTERN, match -> builder.asc(Expressions.day(fromIdentifier(match.group(1).trim())))) ||
+                false;
+    }
+
+    private static boolean tryMatchMonth(SortOrder.Builder builder, String field)
+    {
+        return tryMatch(field, MONTH_PATTERN_ASC_NULLS_FIRST, match -> builder.asc(Expressions.month(fromIdentifier(match.group(1).trim())), NullOrder.NULLS_FIRST)) ||
+                tryMatch(field, MONTH_PATTERN_ASC_NULLS_LAST, match -> builder.asc(Expressions.month(fromIdentifier(match.group(1).trim())), NullOrder.NULLS_LAST)) ||
+                tryMatch(field, MONTH_PATTERN_ASC, match -> builder.asc(Expressions.month(fromIdentifier(match.group(1).trim())))) ||
+                tryMatch(field, MONTH_PATTERN_DESC_NULLS_FIRST, match -> builder.desc(Expressions.month(fromIdentifier(match.group(1).trim())), NullOrder.NULLS_FIRST)) ||
+                tryMatch(field, MONTH_PATTERN_DESC_NULLS_LAST, match -> builder.desc(Expressions.month(fromIdentifier(match.group(1).trim())), NullOrder.NULLS_LAST)) ||
+                tryMatch(field, MONTH_PATTERN_DESC, match -> builder.desc(Expressions.month(fromIdentifier(match.group(1).trim())))) ||
+                tryMatch(field, MONTH_PATTERN, match -> builder.asc(Expressions.month(fromIdentifier(match.group(1).trim())))) ||
+                false;
+    }
+
+    private static boolean tryMatchYear(SortOrder.Builder builder, String field)
+    {
+        return tryMatch(field, YEAR_PATTERN_ASC_NULLS_FIRST, match -> builder.asc(Expressions.year(fromIdentifier(match.group(1).trim())), NullOrder.NULLS_FIRST)) ||
+                tryMatch(field, YEAR_PATTERN_ASC_NULLS_LAST, match -> builder.asc(Expressions.year(fromIdentifier(match.group(1).trim())), NullOrder.NULLS_LAST)) ||
+                tryMatch(field, YEAR_PATTERN_ASC, match -> builder.asc(Expressions.year(fromIdentifier(match.group(1).trim())))) ||
+                tryMatch(field, YEAR_PATTERN_DESC_NULLS_FIRST, match -> builder.desc(Expressions.year(fromIdentifier(match.group(1).trim())), NullOrder.NULLS_FIRST)) ||
+                tryMatch(field, YEAR_PATTERN_DESC_NULLS_LAST, match -> builder.desc(Expressions.year(fromIdentifier(match.group(1).trim())), NullOrder.NULLS_LAST)) ||
+                tryMatch(field, YEAR_PATTERN_DESC, match -> builder.desc(Expressions.year(fromIdentifier(match.group(1).trim())))) ||
+                tryMatch(field, YEAR_PATTERN, match -> builder.asc(Expressions.year(fromIdentifier(match.group(1).trim())))) ||
+                false;
+    }
+
+    private static boolean tryMatch(String value, Pattern pattern, Consumer<MatchResult> match)
+    {
+        Matcher matcher = pattern.matcher(value);
+        if (matcher.matches()) {
+            match.accept(matcher.toMatchResult());
+            return true;
+        }
+        return false;
+    }
+
+    public static List<String> toSortFields(SortOrder spec)
+    {
+        return spec.fields().stream()
+                .map(field -> toSortField(spec, field))
+                .collect(toImmutableList());
+    }
+
+    private static String toSortField(SortOrder spec, SortField field)
+    {
+        String name = toIdentifier(spec.schema().findColumnName(field.sourceId()));
+        String transform = field.transform().toString();
+        String sortDirection = field.direction().toString();
+        String nullOrder = field.nullOrder().toString();
+        String suffix = format("%s %s", sortDirection, nullOrder);
+
+        switch (transform) {
+            case "identity":
+                return format("%s %s", name, suffix);
+            case "year":
+            case "month":
+            case "day":
+            case "hour":
+                return format("%s(%s) %s", transform, name, suffix);
+        }
+
+        Matcher matcher = ICEBERG_BUCKET_PATTERN.matcher(transform);
+        if (matcher.matches()) {
+            return format("bucket(%s, %s) %s", name, matcher.group(1), suffix);
+        }
+
+        matcher = ICEBERG_TRUNCATE_PATTERN.matcher(transform);
+        if (matcher.matches()) {
+            return format("truncate(%s, %s) %s", name, matcher.group(1), suffix);
+        }
+
+        throw new UnsupportedOperationException("Unsupported partition transform: " + field);
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
@@ -35,6 +35,7 @@ import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.RetryPolicy;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
@@ -165,11 +166,12 @@ public abstract class AbstractTrinoCatalog
             SchemaTableName schemaTableName,
             Schema schema,
             PartitionSpec partitionSpec,
+            SortOrder sortOrder,
             String location,
             Map<String, String> properties,
             Optional<String> owner)
     {
-        TableMetadata metadata = newTableMetadata(schema, partitionSpec, location, properties);
+        TableMetadata metadata = newTableMetadata(schema, partitionSpec, sortOrder, location, properties);
         TableOperations ops = tableOperationsProvider.createTableOperations(
                 this,
                 session,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/TrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/TrinoCatalog.java
@@ -23,6 +23,7 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.security.TrinoPrincipal;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.Transaction;
 
@@ -68,6 +69,7 @@ public interface TrinoCatalog
             SchemaTableName schemaTableName,
             Schema schema,
             PartitionSpec partitionSpec,
+            SortOrder sortOrder,
             String location,
             Map<String, String> properties);
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -60,6 +60,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
@@ -330,6 +331,7 @@ public class TrinoGlueCatalog
             SchemaTableName schemaTableName,
             Schema schema,
             PartitionSpec partitionSpec,
+            SortOrder sortOrder,
             String location,
             Map<String, String> properties)
     {
@@ -338,6 +340,7 @@ public class TrinoGlueCatalog
                 schemaTableName,
                 schema,
                 partitionSpec,
+                sortOrder,
                 location,
                 properties,
                 Optional.of(session.getUser()));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
@@ -45,6 +45,7 @@ import io.trino.spi.type.TypeManager;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.Transaction;
@@ -229,6 +230,7 @@ public class TrinoHiveCatalog
             SchemaTableName schemaTableName,
             Schema schema,
             PartitionSpec partitionSpec,
+            SortOrder sortOrder,
             String location,
             Map<String, String> properties)
     {
@@ -237,6 +239,7 @@ public class TrinoHiveCatalog
                 schemaTableName,
                 schema,
                 partitionSpec,
+                sortOrder,
                 location,
                 properties,
                 isUsingSystemSecurity ? Optional.empty() : Optional.of(session.getUser()));

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -1036,6 +1036,219 @@ public abstract class BaseIcebergConnectorTest
     }
 
     @Test
+    public void testCreateSortedWithPartitionTable()
+    {
+        assertUpdate("" +
+                "CREATE TABLE test_sorted_with_partition_table (" +
+                "  a_boolean boolean, " +
+                "  an_integer integer, " +
+                "  a_bigint bigint, " +
+                "  a_real real, " +
+                "  a_double double, " +
+                "  a_short_decimal decimal(5,2), " +
+                "  a_long_decimal decimal(38,20), " +
+                "  a_varchar varchar, " +
+                "  \"a quoted, field\" varchar, " +
+                "  a_varbinary varbinary, " +
+                "  a_date date, " +
+                "  a_time time(6), " +
+                "  a_timestamp timestamp(6), " +
+                "  a_timestamptz timestamp(6) with time zone, " +
+                "  a_uuid uuid, " +
+                "  a_row row(id integer , vc varchar), " +
+                "  an_array array(varchar), " +
+                "  a_map map(integer, varchar) " +
+                ") " +
+                "WITH (" +
+                "partitioning = ARRAY[" +
+                "  'a_boolean', " +
+                "  'an_integer', " +
+                "  'a_bigint', " +
+                "  'a_real', " +
+                "  'a_double', " +
+                "  'a_short_decimal', " +
+                "  'a_long_decimal', " +
+                "  'a_varchar', " +
+                "  'a_varbinary', " +
+                "  'a_date', " +
+                "  'a_time', " +
+                "  'a_timestamp', " +
+                "  'a_timestamptz', " +
+                "  'a_uuid' " +
+                // Note: partitioning on non-primitive columns is not allowed in Iceberg
+                "  ], " +
+                "sorted_by = ARRAY[" +
+                "  'a_boolean', " +
+                "  'an_integer', " +
+                "  'bucket(  an_integer  ,  10)', " +
+                "  'a_bigint', " +
+                "  'a_real', " +
+                "  'a_double', " +
+                "  'a_short_decimal', " +
+                "  'a_long_decimal', " +
+                "  'a_varchar', " +
+                "  '\"a quoted, field\"', " +
+                "  'truncate(\"a quoted, field\", 5)', " +
+                "  'truncate(a_varchar , 5)', " +
+                "  'truncate(a_varchar, 5)', " +
+                "  'a_varbinary', " +
+                "  'a_date', " +
+                "  '  year( a_date ) ', " +
+                "  'month( a_date)', " +
+                "  'day(a_date)', " +
+                "  'hour(  a_date)', " +
+                "  'a_time', " +
+                "  'a_timestamp', " +
+                "  'a_timestamptz', " +
+                "  'a_uuid' " +
+                "  ]" +
+                ")");
+
+        assertQueryReturnsEmptyResult("SELECT * FROM test_sorted_with_partition_table");
+
+        dropTable("test_sorted_with_partition_table");
+    }
+
+    @Test
+    public void testCreateSortedTable()
+    {
+        assertUpdate("" +
+                "CREATE TABLE test_sorted_table (" +
+                "  a_boolean boolean, " +
+                "  an_integer integer, " +
+                "  a_bigint bigint, " +
+                "  a_real real, " +
+                "  a_double double, " +
+                "  a_short_decimal decimal(5,2), " +
+                "  a_long_decimal decimal(38,20), " +
+                "  a_varchar varchar, " +
+                "  a_varbinary varbinary, " +
+                "  a_date date, " +
+                "  a_time time(6), " +
+                "  a_timestamp timestamp(6), " +
+                "  a_timestamptz timestamp(6) with time zone, " +
+                "  a_uuid uuid, " +
+                "  a_row row(id integer , vc varchar), " +
+                "  an_array array(varchar), " +
+                "  a_map map(integer, varchar) " +
+                ") " +
+                "WITH (" +
+                "sorted_by = ARRAY[" +
+                "  'a_boolean', " +
+                "  'an_integer', " +
+                "  'bucket(an_integer, 10)', " +
+                "  'a_bigint', " +
+                "  'a_real', " +
+                "  'a_double', " +
+                "  'a_short_decimal', " +
+                "  'a_long_decimal', " +
+                "  'a_varchar', " +
+                "  'truncate(a_varchar, 5)', " +
+                "  'a_varbinary', " +
+                "  'a_date', " +
+                "  'year(a_date)', " +
+                "  '  month(a_date   )  ', " +
+                "  'day(a_date)', " +
+                "  'hour(a_date)', " +
+                "  'a_time', " +
+                "  'a_timestamp', " +
+                "  'a_timestamptz', " +
+                "  'a_uuid' " +
+                "  ]" +
+                ")");
+
+        assertQueryReturnsEmptyResult("SELECT * FROM test_sorted_table");
+
+        dropTable("test_sorted_table");
+    }
+
+    @Test
+    public void testCreateBlankSortedTable()
+    {
+        assertUpdate("" +
+                "CREATE TABLE test_blank_sorted_table (" +
+                "  a_boolean boolean, " +
+                "  an_integer integer, " +
+                "  a_bigint bigint, " +
+                "  a_real real, " +
+                "  a_double double, " +
+                "  a_short_decimal decimal(5,2), " +
+                "  a_long_decimal decimal(38,20), " +
+                "  a_varchar varchar, " +
+                "  a_varbinary varbinary, " +
+                "  a_date date, " +
+                "  a_time time(6), " +
+                "  a_timestamp timestamp(6), " +
+                "  a_timestamptz timestamp(6) with time zone, " +
+                "  a_uuid uuid, " +
+                "  a_row row(id integer , vc varchar), " +
+                "  an_array array(varchar), " +
+                "  a_map map(integer, varchar) " +
+                ") " +
+                "WITH (" +
+                "partitioning = ARRAY[" +
+                "  'a_boolean', " +
+                "  'an_integer', " +
+                "  'a_bigint', " +
+                "  'a_real', " +
+                "  'a_double', " +
+                "  'a_short_decimal', " +
+                "  'a_long_decimal', " +
+                "  'a_varchar', " +
+                "  'a_varbinary', " +
+                "  'a_date', " +
+                "  'a_time', " +
+                "  'a_timestamp', " +
+                "  'a_timestamptz', " +
+                "  'a_uuid' " +
+                // Note: partitioning on non-primitive columns is not allowed in Iceberg
+                "  ], " +
+                "sorted_by = ARRAY[]" +
+                ")");
+
+        assertQueryReturnsEmptyResult("SELECT * FROM test_blank_sorted_table");
+
+        dropTable("test_blank_sorted_table");
+    }
+
+    @DataProvider(name = "sortedTableWithQuotedIdentifierCasing")
+    public static Object[][] sortedTableWithQuotedIdentifierCasing()
+    {
+        return new Object[][] {
+                {"x", "x", true},
+                {"X", "x", true},
+                {"\"x\"", "x", true},
+                {"\"X\"", "x", true},
+                {"x", "\"x\"", true},
+                {"X", "\"x\"", true},
+                {"\"x\"", "\"x\"", true},
+                {"\"X\"", "\"x\"", true},
+                {"x", "X", true},
+                {"X", "X", true},
+                {"\"x\"", "X", true},
+                {"\"X\"", "X", true},
+                {"x", "\"X\"", false},
+                {"X", "\"X\"", false},
+                {"\"x\"", "\"X\"", false},
+                {"\"X\"", "\"X\"", false},
+        };
+    }
+
+    @Test(dataProvider = "sortedTableWithQuotedIdentifierCasing")
+    public void testCreateSortedTableWithQuotedIdentifierCasing(String columnName, String sortField, boolean success)
+    {
+        String tableName = "sorting_" + randomTableSuffix();
+        @Language("SQL") String sql = format("CREATE TABLE %s (%s bigint) WITH (sorted_by = ARRAY['%s'])", tableName, columnName, sortField);
+        if (success) {
+            assertThat(query(sql)).matches("VALUES (true)");
+            dropTable(tableName);
+        }
+        else {
+            assertQueryFails(sql, "Unable to parse sorting value");
+        }
+    }
+
+    @Test
     public void testTableComments()
     {
         File tempDir = getDistributedQueryRunner().getCoordinator().getBaseDataDir().toFile();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestSortFields.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestSortFields.java
@@ -1,0 +1,270 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import org.apache.iceberg.NullOrder;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.types.Types.DoubleType;
+import org.apache.iceberg.types.Types.ListType;
+import org.apache.iceberg.types.Types.LongType;
+import org.apache.iceberg.types.Types.NestedField;
+import org.apache.iceberg.types.Types.StringType;
+import org.apache.iceberg.types.Types.TimestampType;
+import org.assertj.core.api.AbstractThrowableAssert;
+import org.testng.annotations.Test;
+
+import java.util.Locale;
+import java.util.function.Consumer;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.plugin.iceberg.IcebergUtil.fromIdentifier;
+import static io.trino.plugin.iceberg.IcebergUtil.toIdentifier;
+import static io.trino.plugin.iceberg.SortFields.parseSortField;
+import static io.trino.plugin.iceberg.SortFields.toSortFields;
+import static io.trino.testing.assertions.Assert.assertEquals;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+public class TestSortFields
+{
+    @Test
+    public void testParse()
+    {
+        assertParse("order_key", sortedOrder(builder -> builder.asc("order_key")));
+        assertParse("order_key ASC", sortedOrder(builder -> builder.asc("order_key")));
+        assertParse("order_key ASC NULLS FIRST", sortedOrder(builder -> builder.asc("order_key")));
+        assertParse("order_key ASC NULLS FIRST", sortedOrder(builder -> builder.asc("order_key", NullOrder.NULLS_FIRST)));
+        assertParse("order_key ASC NULLS LAST", sortedOrder(builder -> builder.asc("order_key", NullOrder.NULLS_LAST)));
+        assertParse("order_key DESC", sortedOrder(builder -> builder.desc("order_key")));
+        assertParse("order_key DESC NULLS FIRST", sortedOrder(builder -> builder.desc("order_key", NullOrder.NULLS_FIRST)));
+        assertParse("order_key DESC NULLS LAST", sortedOrder(builder -> builder.desc("order_key", NullOrder.NULLS_LAST)));
+        assertParse("order_key DESC NULLS LAST", sortedOrder(builder -> builder.desc("order_key")));
+
+        assertParse("comment", sortedOrder(builder -> builder.asc("comment")));
+        assertParse("\"comment\"", sortedOrder(builder -> builder.asc("comment")));
+        assertParse("\"\"\"another\"\" \"\"quoted\"\" \"\"field\"\"\"", sortedOrder(builder -> builder.asc("\"another\" \"quoted\" \"field\"")));
+        assertParse("\"\"\"another\"\" \"\"quoted\"\" \"\"field\"\"\" ASC    NULLS   FIRST  ", sortedOrder(builder -> builder.asc("\"another\" \"quoted\" \"field\"")));
+        assertParse("\"\"\"another\"\" \"\"quoted\"\" \"\"field\"\"\" ASC    NULLS   LAST    ", sortedOrder(builder -> builder.asc("\"another\" \"quoted\" \"field\"", NullOrder.NULLS_LAST)));
+        assertParse("\"\"\"another\"\" \"\"quoted\"\" \"\"field\"\"\" DESC NULLS FIRST", sortedOrder(builder -> builder.desc("\"another\" \"quoted\" \"field\"", NullOrder.NULLS_FIRST)));
+        assertParse(" comment   ", sortedOrder(builder -> builder.asc("comment")));
+        assertParse("comment ASC", sortedOrder(builder -> builder.asc("comment")));
+        assertParse("  comment    ASC  ", sortedOrder(builder -> builder.asc("comment")));
+        assertParse("comment ASC NULLS FIRST", sortedOrder(builder -> builder.asc("comment")));
+        assertParse("  comment    ASC     NULLS     FIRST    ", sortedOrder(builder -> builder.asc("comment")));
+        assertParse("comment ASC NULLS FIRST", sortedOrder(builder -> builder.asc("comment", NullOrder.NULLS_FIRST)));
+        assertParse("     comment   ASC       NULLS       FIRST    ", sortedOrder(builder -> builder.asc("comment", NullOrder.NULLS_FIRST)));
+        assertParse("comment ASC NULLS FIRST", sortedOrder(builder -> builder.asc("comment", NullOrder.NULLS_FIRST)));
+        assertParse("    comment     ASC    NULLS   FIRST      ", sortedOrder(builder -> builder.asc("comment", NullOrder.NULLS_FIRST)));
+        assertParse("comment ASC NULLS LAST", sortedOrder(builder -> builder.asc("comment", NullOrder.NULLS_LAST)));
+        assertParse("  comment   ASC    NULLS     LAST    ", sortedOrder(builder -> builder.asc("comment", NullOrder.NULLS_LAST)));
+        assertParse("comment DESC", sortedOrder(builder -> builder.desc("comment")));
+        assertParse("  comment   DESC  ", sortedOrder(builder -> builder.desc("comment")));
+        assertParse("comment DESC NULLS FIRST", sortedOrder(builder -> builder.desc("comment", NullOrder.NULLS_FIRST)));
+        assertParse("  comment     DESC  NULLS   FIRST ", sortedOrder(builder -> builder.desc("comment", NullOrder.NULLS_FIRST)));
+        assertParse("comment DESC NULLS LAST", sortedOrder(builder -> builder.desc("comment", NullOrder.NULLS_LAST)));
+        assertParse("  comment   DESC    NULLS   LAST   ", sortedOrder(builder -> builder.desc("comment", NullOrder.NULLS_LAST)));
+        assertParse("comment DESC NULLS LAST", sortedOrder(builder -> builder.desc("comment")));
+        assertParse("    comment     DESC   NULLS    LAST   ", sortedOrder(builder -> builder.desc("comment")));
+
+        assertParse("year(ts)", sortedOrder(builder -> builder.asc(Expressions.year("ts"))));
+        assertParse("YEAR(ts)", sortedOrder(builder -> builder.asc(Expressions.year("ts"))), "year(ts) ASC NULLS FIRST");
+        assertParse("YeaR(TS)", sortedOrder(builder -> builder.asc(Expressions.year("ts"))));
+        assertParse("yEAR(TS)", sortedOrder(builder -> builder.asc(Expressions.year("ts"))));
+        assertParse("  year( ts   )", sortedOrder(builder -> builder.asc(Expressions.year("ts"))));
+        assertParse("year(\"quoted ts\")", sortedOrder(builder -> builder.asc(Expressions.year("quoted ts"))));
+        assertParse("year(ts) ASC", sortedOrder(builder -> builder.asc(Expressions.year("ts"))));
+        assertParse("  year(  ts )   ASC   ", sortedOrder(builder -> builder.asc(Expressions.year("ts"))));
+        assertParse("year(\"quoted ts\")    ASC", sortedOrder(builder -> builder.asc(Expressions.year("quoted ts"))));
+        assertParse("year(ts) ASC NULLS FIRST", sortedOrder(builder -> builder.asc(Expressions.year("ts"))));
+        assertParse("  year(  ts )   ASC    NULLS      FIRST   ", sortedOrder(builder -> builder.asc(Expressions.year("ts"))));
+        assertParse("year(ts) ASC NULLS LAST", sortedOrder(builder -> builder.asc(Expressions.year("ts"), NullOrder.NULLS_LAST)));
+        assertParse("year(\"quoted ts\") ASC NULLS LAST", sortedOrder(builder -> builder.asc(Expressions.year("quoted ts"), NullOrder.NULLS_LAST)));
+        assertParse("  year( ts   )       ASC      NULLS      LAST   ", sortedOrder(builder -> builder.asc(Expressions.year("ts"), NullOrder.NULLS_LAST)));
+        assertParse("    year(  ts  )    DESC   ", sortedOrder(builder -> builder.desc(Expressions.year("ts"))));
+        assertParse("year(ts) DESC", sortedOrder(builder -> builder.desc(Expressions.year("ts"))));
+        assertParse("  year(ts)    DESC    ", sortedOrder(builder -> builder.desc(Expressions.year("ts"))));
+        assertParse("year(ts) DESC NULLS FIRST", sortedOrder(builder -> builder.desc(Expressions.year("ts"), NullOrder.NULLS_FIRST)));
+        assertParse("   year(ts)   DESC   NULLS     FIRST   ", sortedOrder(builder -> builder.desc(Expressions.year("ts"), NullOrder.NULLS_FIRST)));
+        assertParse("year(ts) DESC NULLS LAST", sortedOrder(builder -> builder.desc(Expressions.year("ts"), NullOrder.NULLS_LAST)));
+        assertParse("    year(   ts   )    DESC    NULLS   LAST    ", sortedOrder(builder -> builder.desc(Expressions.year("ts"), NullOrder.NULLS_LAST)));
+
+        assertParse("month(ts)", sortedOrder(builder -> builder.asc(Expressions.month("ts"))));
+        assertParse("MONTH(  ts  )", sortedOrder(builder -> builder.asc(Expressions.month("ts"))));
+        assertParse("MonTH(  ts  )", sortedOrder(builder -> builder.asc(Expressions.month("ts"))));
+        assertParse("monTH(  ts  )", sortedOrder(builder -> builder.asc(Expressions.month("ts"))));
+        assertParse(" month(  ts  )", sortedOrder(builder -> builder.asc(Expressions.month("ts"))));
+        assertParse("month(ts) ASC", sortedOrder(builder -> builder.asc(Expressions.month("ts"))));
+        assertParse("   month(   ts   )    ASC    ", sortedOrder(builder -> builder.asc(Expressions.month("ts"))));
+        assertParse("month(ts) ASC NULLS FIRST", sortedOrder(builder -> builder.asc(Expressions.month("ts"))));
+        assertParse("  month(  ts  )    ASC    NULLS    FIRST", sortedOrder(builder -> builder.asc(Expressions.month("ts"))));
+        assertParse("month(ts) ASC NULLS LAST", sortedOrder(builder -> builder.asc(Expressions.month("ts"), NullOrder.NULLS_LAST)));
+        assertParse("   month(  ts   )    ASC    NULLS    LAST   ", sortedOrder(builder -> builder.asc(Expressions.month("ts"), NullOrder.NULLS_LAST)));
+        assertParse("month(ts) DESC", sortedOrder(builder -> builder.desc(Expressions.month("ts"))));
+        assertParse("   month( ts   )    DESC    ", sortedOrder(builder -> builder.desc(Expressions.month("ts"))));
+        assertParse("month(ts) DESC NULLS FIRST", sortedOrder(builder -> builder.desc(Expressions.month("ts"), NullOrder.NULLS_FIRST)));
+        assertParse("   month(  ts )       DESC    NULLS   FIRST      ", sortedOrder(builder -> builder.desc(Expressions.month("ts"), NullOrder.NULLS_FIRST)));
+        assertParse("month(ts) DESC NULLS LAST", sortedOrder(builder -> builder.desc(Expressions.month("ts"), NullOrder.NULLS_LAST)));
+        assertParse("   month(  ts   )     DESC   NULLS  LAST     ", sortedOrder(builder -> builder.desc(Expressions.month("ts"), NullOrder.NULLS_LAST)));
+
+        assertParse("day(ts)", sortedOrder(builder -> builder.asc(Expressions.day("ts"))));
+        assertParse("DAY(ts)", sortedOrder(builder -> builder.asc(Expressions.day("ts"))));
+        assertParse("DaY(ts)", sortedOrder(builder -> builder.asc(Expressions.day("ts"))));
+        assertParse("daY(ts)", sortedOrder(builder -> builder.asc(Expressions.day("ts"))));
+        assertParse("  day(  ts   )", sortedOrder(builder -> builder.asc(Expressions.day("ts"))));
+        assertParse("day(ts) ASC", sortedOrder(builder -> builder.asc(Expressions.day("ts"))));
+        assertParse("   day(  ts  )       ASC      ", sortedOrder(builder -> builder.asc(Expressions.day("ts"))));
+        assertParse("day(ts) ASC NULLS FIRST", sortedOrder(builder -> builder.asc(Expressions.day("ts"))));
+        assertParse(" day(  ts  )    ASC     NULLS   FIRST    ", sortedOrder(builder -> builder.asc(Expressions.day("ts"))));
+        assertParse("day(ts) ASC NULLS LAST", sortedOrder(builder -> builder.asc(Expressions.day("ts"), NullOrder.NULLS_LAST)));
+        assertParse("   day(  ts )   ASC    NULLS    LAST   ", sortedOrder(builder -> builder.asc(Expressions.day("ts"), NullOrder.NULLS_LAST)));
+        assertParse("day(ts) DESC", sortedOrder(builder -> builder.desc(Expressions.day("ts"))));
+        assertParse("   day(   ts   )    DESC   ", sortedOrder(builder -> builder.desc(Expressions.day("ts"))));
+        assertParse("day(ts) DESC NULLS FIRST", sortedOrder(builder -> builder.desc(Expressions.day("ts"), NullOrder.NULLS_FIRST)));
+        assertParse("   day(   ts   )    DESC    NULLS     FIRST   ", sortedOrder(builder -> builder.desc(Expressions.day("ts"), NullOrder.NULLS_FIRST)));
+        assertParse("day(ts) DESC NULLS LAST", sortedOrder(builder -> builder.desc(Expressions.day("ts"), NullOrder.NULLS_LAST)));
+        assertParse("   day(   ts   )    DESC    NULLS   LAST  ", sortedOrder(builder -> builder.desc(Expressions.day("ts"), NullOrder.NULLS_LAST)));
+
+        assertParse("hour(ts)", sortedOrder(builder -> builder.asc(Expressions.hour("ts"))));
+        assertParse("HOUR(ts)", sortedOrder(builder -> builder.asc(Expressions.hour("ts"))));
+        assertParse("HouR(ts)", sortedOrder(builder -> builder.asc(Expressions.hour("ts"))));
+        assertParse("houR(ts)", sortedOrder(builder -> builder.asc(Expressions.hour("ts"))));
+        assertParse("  hour( ts  )", sortedOrder(builder -> builder.asc(Expressions.hour("ts"))));
+        assertParse("hour(ts) ASC", sortedOrder(builder -> builder.asc(Expressions.hour("ts"))));
+        assertParse("  hour(  ts  )   ASC  ", sortedOrder(builder -> builder.asc(Expressions.hour("ts"))));
+        assertParse("hour(ts) ASC NULLS FIRST", sortedOrder(builder -> builder.asc(Expressions.hour("ts"))));
+        assertParse(" hour(  ts )    ASC   NULLS   FIRST   ", sortedOrder(builder -> builder.asc(Expressions.hour("ts"))));
+        assertParse("hour(ts) ASC NULLS LAST", sortedOrder(builder -> builder.asc(Expressions.hour("ts"), NullOrder.NULLS_LAST)));
+        assertParse(" hour( ts  )   ASC   NULLS   LAST ", sortedOrder(builder -> builder.asc(Expressions.hour("ts"), NullOrder.NULLS_LAST)));
+        assertParse("hour(ts) DESC", sortedOrder(builder -> builder.desc(Expressions.hour("ts"))));
+        assertParse("    hour( ts    )    DESC             ", sortedOrder(builder -> builder.desc(Expressions.hour("ts"))));
+        assertParse("hour(ts) DESC NULLS FIRST", sortedOrder(builder -> builder.desc(Expressions.hour("ts"), NullOrder.NULLS_FIRST)));
+        assertParse("   hour(   ts          )          DESC   NULLS   FIRST   ", sortedOrder(builder -> builder.desc(Expressions.hour("ts"), NullOrder.NULLS_FIRST)));
+        assertParse("hour(ts) DESC NULLS LAST", sortedOrder(builder -> builder.desc(Expressions.hour("ts"), NullOrder.NULLS_LAST)));
+        assertParse(" hour(    ts    )        DESC       NULLS   LAST      ", sortedOrder(builder -> builder.desc(Expressions.hour("ts"), NullOrder.NULLS_LAST)));
+
+        assertParse("bucket(order_key,42)", sortedOrder(builder -> builder.asc(Expressions.bucket("order_key", 42))));
+        assertParse("BUCKET(order_key, 42)", sortedOrder(builder -> builder.asc(Expressions.bucket("order_key", 42))));
+        assertParse("BUckeT(order_key, 42)", sortedOrder(builder -> builder.asc(Expressions.bucket("order_key", 42))));
+        assertParse("buckET(order_key,    42  )", sortedOrder(builder -> builder.asc(Expressions.bucket("order_key", 42))));
+        assertParse("   bucket(  order_key  , 42  )", sortedOrder(builder -> builder.asc(Expressions.bucket("order_key", 42))));
+        assertParse("bucket(order_key, 42) ASC", sortedOrder(builder -> builder.asc(Expressions.bucket("order_key", 42))));
+        assertParse("  bucket(  order_key  , 42)   ASC  ", sortedOrder(builder -> builder.asc(Expressions.bucket("order_key", 42))));
+        assertParse("bucket(order_key, 42) ASC NULLS FIRST", sortedOrder(builder -> builder.asc(Expressions.bucket("order_key", 42), NullOrder.NULLS_FIRST)));
+        assertParse(" bucket(  order_key , 42)    ASC    NULLS  FIRST  ", sortedOrder(builder -> builder.asc(Expressions.bucket("order_key", 42), NullOrder.NULLS_FIRST)));
+        assertParse("bucket(order_key, 42) ASC NULLS LAST", sortedOrder(builder -> builder.asc(Expressions.bucket("order_key", 42), NullOrder.NULLS_LAST)));
+        assertParse("   bucket( order_key , 42)   ASC   NULLS   LAST", sortedOrder(builder -> builder.asc(Expressions.bucket("order_key", 42), NullOrder.NULLS_LAST)));
+        assertParse("bucket(order_key, 42) DESC", sortedOrder(builder -> builder.desc(Expressions.bucket("order_key", 42), NullOrder.NULLS_LAST)));
+        assertParse("  bucket(  order_key , 42)   DESC  ", sortedOrder(builder -> builder.desc(Expressions.bucket("order_key", 42), NullOrder.NULLS_LAST)));
+        assertParse("bucket(order_key, 42) DESC NULLS FIRST", sortedOrder(builder -> builder.desc(Expressions.bucket("order_key", 42), NullOrder.NULLS_FIRST)));
+        assertParse("   bucket(  order_key  , 42)   DESC   NULLS   FIRST  ", sortedOrder(builder -> builder.desc(Expressions.bucket("order_key", 42), NullOrder.NULLS_FIRST)));
+        assertParse("bucket(order_key, 42) DESC NULLS LAST", sortedOrder(builder -> builder.desc(Expressions.bucket("order_key", 42), NullOrder.NULLS_LAST)));
+        assertParse("  bucket(   order_key , 42)   DESC    NULLS  LAST  ", sortedOrder(builder -> builder.desc(Expressions.bucket("order_key", 42), NullOrder.NULLS_LAST)));
+
+        assertParse("truncate(comment, 10)", sortedOrder(builder -> builder.asc(Expressions.truncate("comment", 10))));
+        assertParse("TRUNCATE(comment, 10)", sortedOrder(builder -> builder.asc(Expressions.truncate("comment", 10))));
+        assertParse("TRuncaTE(comment, 10)", sortedOrder(builder -> builder.asc(Expressions.truncate("comment", 10))));
+        assertParse("truncaTE(comment, 10)", sortedOrder(builder -> builder.asc(Expressions.truncate("comment", 10))));
+        assertParse("   truncate(   comment , 10)", sortedOrder(builder -> builder.asc(Expressions.truncate("comment", 10))));
+        assertParse("truncate(comment, 10) ASC", sortedOrder(builder -> builder.asc(Expressions.truncate("comment", 10))));
+        assertParse(" truncate( comment , 10)    ASC   ", sortedOrder(builder -> builder.asc(Expressions.truncate("comment", 10))));
+        assertParse("truncate(comment, 10) ASC NULLS FIRST", sortedOrder(builder -> builder.asc(Expressions.truncate("comment", 10), NullOrder.NULLS_FIRST)));
+        assertParse(" truncate( comment , 10)   ASC   NULLS   FIRST   ", sortedOrder(builder -> builder.asc(Expressions.truncate("comment", 10), NullOrder.NULLS_FIRST)));
+        assertParse("truncate(comment, 10) ASC NULLS LAST", sortedOrder(builder -> builder.asc(Expressions.truncate("comment", 10), NullOrder.NULLS_LAST)));
+        assertParse("  truncate(  comment , 10)    ASC    NULLS   LAST ", sortedOrder(builder -> builder.asc(Expressions.truncate("comment", 10), NullOrder.NULLS_LAST)));
+        assertParse("truncate(comment, 10) DESC", sortedOrder(builder -> builder.desc(Expressions.truncate("comment", 10), NullOrder.NULLS_LAST)));
+        assertParse(" truncate(  comment , 10)   DESC ", sortedOrder(builder -> builder.desc(Expressions.truncate("comment", 10), NullOrder.NULLS_LAST)));
+        assertParse("truncate(comment, 10) DESC NULLS FIRST", sortedOrder(builder -> builder.desc(Expressions.truncate("comment", 10), NullOrder.NULLS_FIRST)));
+        assertParse("  truncate(  comment  , 10)   DESC   NULLS  FIRST  ", sortedOrder(builder -> builder.desc(Expressions.truncate("comment", 10), NullOrder.NULLS_FIRST)));
+        assertParse("truncate(comment, 10) DESC NULLS LAST", sortedOrder(builder -> builder.desc(Expressions.truncate("comment", 10), NullOrder.NULLS_LAST)));
+        assertParse("   truncate( comment  , 10)   DESC   NULLS LAST  ", sortedOrder(builder -> builder.desc(Expressions.truncate("comment", 10), NullOrder.NULLS_LAST)));
+        assertParse("truncate(\"quoted field\", 5) DESC NULLS FIRST", sortedOrder(builder -> builder.desc(Expressions.truncate("quoted field", 5), NullOrder.NULLS_FIRST)));
+        assertParse("truncate(\"\"\"another\"\" \"\"quoted\"\" \"\"field\"\"\", 5) DESC NULLS FIRST",
+                sortedOrder(builder -> builder.desc(Expressions.truncate("\"another\" \"quoted\" \"field\"", 5), NullOrder.NULLS_FIRST)),
+                "truncate(\"\"\"another\"\" \"\"quoted\"\" \"\"field\"\"\", 5) DESC NULLS FIRST");
+        assertInvalid("bucket()", "Invalid sort field declaration: bucket()");
+        assertInvalid("abc", "Cannot find field 'abc' in struct: struct<1: order_key: required long, 2: ts: required timestamp, 3: price: required double, 4: comment: optional string, 5: notes: optional list<string>, 7: quoted field: optional string, 8: quoted ts: optional timestamp, 9: \"another\" \"quoted\" \"field\": optional string>");
+        assertInvalid("notes", "Cannot sort by non-primitive source field: list<string>");
+        assertInvalid("bucket(price, 42)", "Cannot bind: bucket[42] cannot transform double values from 'price'");
+        assertInvalid("bucket(notes, 88)", "Cannot bind: bucket[88] cannot transform list<string> values from 'notes'");
+        assertInvalid("truncate(ts, 13)", "Cannot truncate type: timestamp");
+    }
+
+    private static void assertParse(String value, SortOrder expected, String canonicalRepresentation)
+    {
+        assertParse(value, expected);
+        assertEquals(getOnlyElement(toSortFields(expected)), canonicalRepresentation);
+    }
+
+    private static void assertParse(String value, SortOrder expected)
+    {
+        assertEquals(expected.fields().size(), 1);
+        assertEquals(parseField(value), expected);
+    }
+
+    private static void assertInvalid(String value, String message)
+    {
+        AbstractThrowableAssert throwableAssert = assertThatThrownBy(() -> parseField(value))
+                .isInstanceOfAny(
+                        IllegalArgumentException.class,
+                        UnsupportedOperationException.class,
+                        ValidationException.class);
+
+        throwableAssert.hasMessage(message);
+    }
+
+    private static SortOrder parseField(String value)
+    {
+        return sortedOrder(builder -> parseSortField(builder, value));
+    }
+
+    private static SortOrder sortedOrder(Consumer<SortOrder.Builder> consumer)
+    {
+        Schema schema = new Schema(
+                NestedField.required(1, "order_key", LongType.get()),
+                NestedField.required(2, "ts", TimestampType.withoutZone()),
+                NestedField.required(3, "price", DoubleType.get()),
+                NestedField.optional(4, "comment", StringType.get()),
+                NestedField.optional(5, "notes", ListType.ofRequired(6, StringType.get())),
+                NestedField.optional(7, "quoted field", StringType.get()),
+                NestedField.optional(8, "quoted ts", TimestampType.withoutZone()),
+                NestedField.optional(9, "\"another\" \"quoted\" \"field\"", StringType.get()));
+
+        SortOrder.Builder builder = SortOrder.builderFor(schema);
+        consumer.accept(builder);
+        return builder.build();
+    }
+
+    @Test
+    public void testFromIdentifier()
+    {
+        assertEquals(fromIdentifier("test"), "test");
+        assertEquals(fromIdentifier("TEST"), "test");
+        assertEquals(fromIdentifier("TEST"), "TEST".toLowerCase(Locale.ROOT));
+        assertEquals(fromIdentifier("\" test\""), " test");
+        assertEquals(fromIdentifier("\"20days\""), "20days");
+        assertEquals(fromIdentifier("\"\"\"another\"\" \"\"quoted\"\" \"\"field\"\"\""), "\"another\" \"quoted\" \"field\"");
+    }
+
+    @Test
+    public void testToIdentifier()
+    {
+        assertEquals(toIdentifier("test"), "test");
+        assertEquals(toIdentifier("TEST"), "test".toUpperCase(Locale.ROOT));
+        assertEquals(toIdentifier(" test"), " test");
+        assertEquals(toIdentifier("20days"), "\"20days\"");
+        assertEquals(toIdentifier("\"another\" \"quoted\" \"field\""), "\"\"\"another\"\" \"\"quoted\"\" \"\"field\"\"\"");
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

This PR is to allow to provide `sorted_by` as the properties like partitioning.

The sorted field definition will follow these rules:

1. Sorted field needs to be present as the valid column.
2. Allow quoted identifier similar to https://github.com/trinodb/trino/pull/12227 , borrowed pattern, and 2 tests methods, thanks @findepi and @mdesmet 
3. Allow spaces like 

```
    sorted_by = ARRAY['c1', '  year(    a_date )   ')
```

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

improvement, new feature

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

the Iceberg connector

> How would you describe this change to a non-technical end user or system administrator?

Add `sorted_by` properties while creating an Iceberg table like the Hive table.

```
CREATE TABLE test_table (
    c1 integer,
    c2 varchar,
    c3 double)
WITH (
    format = 'PARQUET',
    sorted_by = ARRAY['c1', 'c2'],
    location = '/var/my_tables/test_table')
``` 

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

Fixes https://github.com/trinodb/trino/issues/12447

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`https://github.com/trinodb/trino/issues/12447`)
```

Will add changes to the doc as well.
