### PR TITLE
Fix reading Iceberg $partitions table after updating partition schema

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTable.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.iceberg;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.spi.block.Block;
@@ -335,7 +336,8 @@ public class PartitionTable
         return columnMetricType.getObject(rowBlockBuilder, 0);
     }
 
-    private static class StructLikeWrapperWithFieldIdToIndex
+    @VisibleForTesting
+    static class StructLikeWrapperWithFieldIdToIndex
     {
         private final StructLikeWrapper structLikeWrapper;
         private final Map<Integer, Integer> fieldIdToIndex;
@@ -360,13 +362,14 @@ public class PartitionTable
                 return false;
             }
             StructLikeWrapperWithFieldIdToIndex that = (StructLikeWrapperWithFieldIdToIndex) o;
-            return Objects.equals(structLikeWrapper, that.structLikeWrapper) && Objects.equals(fieldIdToIndex, that.fieldIdToIndex);
+            // Due to bogus implementation of equals in StructLikeWrapper https://github.com/apache/iceberg/issues/5064 order here matters.
+            return Objects.equals(fieldIdToIndex, that.fieldIdToIndex) && Objects.equals(structLikeWrapper, that.structLikeWrapper);
         }
 
         @Override
         public int hashCode()
         {
-            return Objects.hash(structLikeWrapper, fieldIdToIndex);
+            return Objects.hash(fieldIdToIndex, structLikeWrapper);
         }
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestStructLikeWrapperWithFieldIdToIndex.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestStructLikeWrapperWithFieldIdToIndex.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types.IntegerType;
+import org.apache.iceberg.types.Types.NestedField;
+import org.apache.iceberg.types.Types.StringType;
+import org.apache.iceberg.types.Types.StructType;
+import org.apache.iceberg.util.StructLikeWrapper;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestStructLikeWrapperWithFieldIdToIndex
+{
+    @Test
+    public void testStructLikeWrapperWithFieldIdToIndexEquals()
+    {
+        StructType firstStructType = StructType.of(
+                NestedField.optional(1001, "level", StringType.get()),
+                NestedField.optional(1002, "event_time_hour", IntegerType.get()));
+        StructType secondStructType = StructType.of(
+                NestedField.optional(1000, "event_time_day", StringType.get()),
+                NestedField.optional(1001, "level", IntegerType.get()));
+        PartitionData firstPartitionData = PartitionData.fromJson("{\"partitionValues\":[\"ERROR\",\"449245\"]}", new Type[] {StringType.get(), IntegerType.get()});
+        PartitionData secondPartitionData = PartitionData.fromJson("{\"partitionValues\":[\"449245\",\"ERROR\"]}", new Type[] {IntegerType.get(), StringType.get()});
+        PartitionTable.StructLikeWrapperWithFieldIdToIndex first = new PartitionTable.StructLikeWrapperWithFieldIdToIndex(StructLikeWrapper.forType(firstStructType).set(firstPartitionData), firstStructType);
+        PartitionTable.StructLikeWrapperWithFieldIdToIndex second = new PartitionTable.StructLikeWrapperWithFieldIdToIndex(StructLikeWrapper.forType(secondStructType).set(secondPartitionData), secondStructType);
+        assertThat(first).isNotEqualTo(second);
+    }
+}


### PR DESCRIPTION
## Description
Reimplement equals in StructLikeWrapperWithFieldIdToIndex so it relies less on StructLikeWrapper.equals which is invalid (https://github.com/apache/iceberg/issues/5064)
> Is this change a fix, improvement, new feature, refactoring, or other?

fix
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

connector
> How would you describe this change to a non-technical end user or system administrator?

it fixes very specific situation regarding partitioning in iceberg tables 
## Related issues, pull requests, and links
Fixes: https://github.com/trinodb/trino/issues/12874

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
