### PR TITLE
Remove redundant not null check in `HttpRemoteTask`

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
@@ -248,7 +248,7 @@ public final class HttpRemoteTask
             long pendingSourceSplitsWeight = 0;
             for (PlanNodeId planNodeId : planFragment.getPartitionedSources()) {
                 Collection<Split> tableScanSplits = initialSplits.get(planNodeId);
-                if (tableScanSplits != null && !tableScanSplits.isEmpty()) {
+                if (!tableScanSplits.isEmpty()) {
                     pendingSourceSplitCount += tableScanSplits.size();
                     pendingSourceSplitsWeight = addExact(pendingSourceSplitsWeight, SplitWeight.rawValueSum(tableScanSplits, Split::getSplitWeight));
                 }


### PR DESCRIPTION
## Description
Condition `tableScanSplits != null` is always true, because `Multimap.get` returns an empty collection, not null.

## Documentation
(✓) No documentation is needed.

## Release notes
(✓) No release notes entries required.
