### PR TITLE
Refining the Redis types in doc

### DIFF
--- a/docs/src/main/sphinx/connector/redis.rst
+++ b/docs/src/main/sphinx/connector/redis.rst
@@ -12,8 +12,8 @@ used to join data between different systems like Redis and Hive.
 Each Redis key/value pair is presented as a single row in Trino. Rows can be
 broken down into cells by using table definition files.
 
-Only Redis string and hash value types are supported; sets and zsets cannot be
-queried from Trino.
+Currently, only Redis key of string and zset types are supported, only Redis value of
+string and hash types are supported.
 
 Requirements
 ------------


### PR DESCRIPTION
## Description
Currently, the [keyDataType](https://github.com/trinodb/trino/blob/master/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisRecordCursor.java#L407) can only be `STRING ` and `ZSET `, the [valueDataType](https://github.com/trinodb/trino/blob/master/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisRecordCursor.java#L434) can only be `STRING ` and `HASH `.

## Documentation
(✓) Sufficient documentation is included in this PR.

## Release notes
(✓) No release notes entries required.