### PR TITLE
Fix flaky TestPositionsAppender.testConsecutiveBuilds

### DIFF
--- a/core/trino-main/src/test/java/io/trino/block/BlockAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/block/BlockAssertions.java
@@ -86,8 +86,6 @@ public final class BlockAssertions
     private static final int MAX_STRING_SIZE = 50;
     private static final int RANDOM_SEED = 633969769;
 
-    private static final Random RANDOM = new Random(RANDOM_SEED);
-
     private BlockAssertions() {}
 
     public static Object getOnlyValue(Type type, Block block)
@@ -129,7 +127,7 @@ public final class BlockAssertions
         checkArgument(dictionary.getPositionCount() > 0, "dictionary position count %s is less than or equal to 0", dictionary.getPositionCount());
 
         int[] ids = IntStream.range(0, positionCount)
-                .map(i -> RANDOM.nextInt(dictionary.getPositionCount()))
+                .map(i -> random().nextInt(dictionary.getPositionCount()))
                 .toArray();
         return new DictionaryBlock(0, positionCount, dictionary, ids, false, randomDictionaryId());
     }
@@ -137,7 +135,7 @@ public final class BlockAssertions
     public static RunLengthEncodedBlock createRandomRleBlock(Block block, int positionCount)
     {
         checkArgument(block.getPositionCount() > 0, format("block positions %d is less than or equal to 0", block.getPositionCount()));
-        return new RunLengthEncodedBlock(block.getSingleValueBlock(RANDOM.nextInt(block.getPositionCount())), positionCount);
+        return new RunLengthEncodedBlock(block.getSingleValueBlock(random().nextInt(block.getPositionCount())), positionCount);
     }
 
     public static Block createRandomBlockForType(Type type, int positionCount, float nullRate)
@@ -214,7 +212,7 @@ public final class BlockAssertions
             else {
                 // RowType doesn't need offsets, so we just use 1,
                 // for ArrayType and MapType we choose randomly either array length or map size at the current position
-                offsets[position + 1] = offsets[position] + (type instanceof RowType ? 1 : RANDOM.nextInt(ENTRY_SIZE) + 1);
+                offsets[position + 1] = offsets[position] + (type instanceof RowType ? 1 : random().nextInt(ENTRY_SIZE) + 1);
             }
         }
 
@@ -246,12 +244,14 @@ public final class BlockAssertions
 
     public static Block createRandomBooleansBlock(int positionCount, float nullRate)
     {
-        return createBooleansBlock(generateListWithNulls(positionCount, nullRate, RANDOM::nextBoolean));
+        Random random = random();
+        return createBooleansBlock(generateListWithNulls(positionCount, nullRate, random::nextBoolean));
     }
 
     public static Block createRandomIntsBlock(int positionCount, float nullRate)
     {
-        return createIntsBlock(generateListWithNulls(positionCount, nullRate, RANDOM::nextInt));
+        Random random = random();
+        return createIntsBlock(generateListWithNulls(positionCount, nullRate, random::nextInt));
     }
 
     public static Block createRandomLongDecimalsBlock(int positionCount, float nullRate)
@@ -259,7 +259,7 @@ public final class BlockAssertions
         return createLongDecimalsBlock(generateListWithNulls(
                 positionCount,
                 nullRate,
-                () -> String.valueOf(RANDOM.nextLong())));
+                () -> String.valueOf(random().nextLong())));
     }
 
     public static Block createRandomShortTimestampBlock(TimestampType type, int positionCount, float nullRate)
@@ -268,7 +268,7 @@ public final class BlockAssertions
                 generateListWithNulls(
                         positionCount,
                         nullRate,
-                        () -> SqlTimestamp.fromMillis(type.getPrecision(), RANDOM.nextLong()).getEpochMicros()));
+                        () -> SqlTimestamp.fromMillis(type.getPrecision(), random().nextLong()).getEpochMicros()));
     }
 
     public static Block createRandomLongTimestampBlock(TimestampType type, int positionCount, float nullRate)
@@ -279,7 +279,7 @@ public final class BlockAssertions
                         positionCount,
                         nullRate,
                         () -> {
-                            SqlTimestamp sqlTimestamp = SqlTimestamp.fromMillis(type.getPrecision(), RANDOM.nextLong());
+                            SqlTimestamp sqlTimestamp = SqlTimestamp.fromMillis(type.getPrecision(), random().nextLong());
                             return new LongTimestamp(sqlTimestamp.getEpochMicros(), sqlTimestamp.getPicosOfMicros());
                         }));
     }
@@ -291,21 +291,22 @@ public final class BlockAssertions
                 .mapToInt(Integer::intValue)
                 .toArray();
         return createLongsBlock(IntStream.range(0, positionCount)
-                .mapToLong(position -> uniqueValues[RANDOM.nextInt(numberOfUniqueValues)])
+                .mapToLong(position -> uniqueValues[random().nextInt(numberOfUniqueValues)])
                 .boxed()
                 .collect(toImmutableList()));
     }
 
     public static Block createRandomLongsBlock(int positionCount, float nullRate)
     {
-        return createLongsBlock(generateListWithNulls(positionCount, nullRate, RANDOM::nextLong));
+        Random random = random();
+        return createLongsBlock(generateListWithNulls(positionCount, nullRate, random::nextLong));
     }
 
     public static Block createRandomSmallintsBlock(int positionCount, float nullRate)
     {
         return createTypedLongsBlock(
                 SMALLINT,
-                generateListWithNulls(positionCount, nullRate, () -> (long) (short) RANDOM.nextLong()));
+                generateListWithNulls(positionCount, nullRate, () -> (long) (short) random().nextLong()));
     }
 
     public static Block createRandomStringBlock(int positionCount, float nullRate, int maxStringLength)
@@ -316,27 +317,28 @@ public final class BlockAssertions
 
     private static Block createRandomVarbinariesBlock(int positionCount, float nullRate)
     {
-        return createSlicesBlock(VARBINARY, generateListWithNulls(positionCount, nullRate, () -> Slices.wrappedLongArray(RANDOM.nextLong(), RANDOM.nextLong())));
+        return createSlicesBlock(VARBINARY, generateListWithNulls(positionCount, nullRate, () -> Slices.wrappedLongArray(random().nextLong(), random().nextLong())));
     }
 
     private static Block createRandomUUIDsBlock(int positionCount, float nullRate)
     {
-        return createSlicesBlock(UUID, generateListWithNulls(positionCount, nullRate, () -> Slices.wrappedLongArray(RANDOM.nextLong(), RANDOM.nextLong())));
+        return createSlicesBlock(UUID, generateListWithNulls(positionCount, nullRate, () -> Slices.wrappedLongArray(random().nextLong(), random().nextLong())));
     }
 
     private static Block createRandomIpAddressesBlock(int positionCount, float nullRate)
     {
-        return createSlicesBlock(IPADDRESS, generateListWithNulls(positionCount, nullRate, () -> Slices.wrappedLongArray(RANDOM.nextLong(), RANDOM.nextLong())));
+        return createSlicesBlock(IPADDRESS, generateListWithNulls(positionCount, nullRate, () -> Slices.wrappedLongArray(random().nextLong(), random().nextLong())));
     }
 
     private static Block createRandomTinyintsBlock(int positionCount, float nullRate)
     {
-        return createTypedLongsBlock(TINYINT, generateListWithNulls(positionCount, nullRate, () -> (long) (byte) RANDOM.nextLong()));
+        return createTypedLongsBlock(TINYINT, generateListWithNulls(positionCount, nullRate, () -> (long) (byte) random().nextLong()));
     }
 
     public static Block createRandomDoublesBlock(int positionCount, float nullRate)
     {
-        return createDoublesBlock(generateListWithNulls(positionCount, nullRate, RANDOM::nextDouble));
+        Random random = random();
+        return createDoublesBlock(generateListWithNulls(positionCount, nullRate, random::nextDouble));
     }
 
     public static Block createRandomCharsBlock(CharType charType, int positionCount, float nullRate)
@@ -917,13 +919,13 @@ public final class BlockAssertions
             // it's an order of bound/count faster to use this method for small enough count/bound ratio
             Set<Integer> values = new HashSet<>(count);
             while (values.size() < count) {
-                values.add(RANDOM.nextInt(bound));
+                values.add(random().nextInt(bound));
             }
             return ImmutableSet.copyOf(values);
         }
 
         List<Integer> allNumbers = IntStream.range(0, bound).boxed().collect(toList());
-        Collections.shuffle(allNumbers, RANDOM);
+        Collections.shuffle(allNumbers, random());
         return allNumbers.stream().limit(count).collect(toImmutableSet());
     }
 
@@ -932,7 +934,7 @@ public final class BlockAssertions
         String symbols = "abcdefghijklmnopqrstuvwxyz";
         char[] chars = new char[length];
         for (int i = 0; i < length; i++) {
-            chars[i] = symbols.charAt(RANDOM.nextInt(symbols.length()));
+            chars[i] = symbols.charAt(random().nextInt(symbols.length()));
         }
         return new String(chars);
     }
@@ -940,5 +942,10 @@ public final class BlockAssertions
     private static void verifyNullRate(float nullRate)
     {
         verify(nullRate >= 0 && nullRate <= 1, "nullRate %s is not valid", nullRate);
+    }
+
+    private static Random random()
+    {
+        return new Random(RANDOM_SEED);
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
Since for nested types createRandomBlockForNestedType
chooses the lengths of the nested values randomly,
there is a chance that the chosen value length is
not big enough for the given nullRate.
To fix this, we cap the nested values nullRate, possibly to 0,
so it matches the nested position count.

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

fix flaky test
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core query engine tests
> How would you describe this change to a non-technical end user or system administrator?

fix flaky test
## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->
* Fixes #12875
<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```

Fixes https://github.com/trinodb/trino/pull/12888
