### PR TITLE
Support parameters in table function arguments

### DIFF
--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
@@ -977,4 +977,14 @@ public abstract class DefaultTraversalVisitor<C>
 
         return null;
     }
+
+    @Override
+    protected Void visitTableFunctionInvocation(TableFunctionInvocation node, C context)
+    {
+        for (TableFunctionArgument argument : node.getArguments()) {
+            process(argument.getValue(), context);
+        }
+
+        return null;
+    }
 }

--- a/docs/src/main/sphinx/functions/table.rst
+++ b/docs/src/main/sphinx/functions/table.rst
@@ -68,4 +68,10 @@ skipped arguments are declared with default values.
 You cannot mix the argument conventions in one invocation.
 
 All arguments must be constant expressions, and they can be of any SQL type,
-which is compatible with the declared argument type.
+which is compatible with the declared argument type. You can also use
+parameters in arguments::
+
+    PREPARE stmt FROM
+    SELECT * FROM TABLE(my_function("row_count" => ? + 1, "column_count" => ?));
+
+    EXECUTE stmt USING 100, 1;

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
@@ -1592,6 +1592,17 @@ public abstract class BaseJdbcConnectorTest
     }
 
     @Test
+    public void testNativeQueryParameters()
+    {
+        Session session = Session.builder(getSession())
+                .addPreparedStatement("my_query_simple", "SELECT * FROM TABLE(system.query(query => ?))")
+                .addPreparedStatement("my_query", "SELECT * FROM TABLE(system.query(query => format('SELECT %s FROM %s', ?, ?)))")
+                .build();
+        assertQuery(session, "EXECUTE my_query_simple USING 'SELECT 1 a'", "VALUES 1");
+        assertQuery(session, "EXECUTE my_query USING 'a', '(SELECT 2 a) t'", "VALUES 2");
+    }
+
+    @Test
     public void testNativeQuerySelectFromNation()
     {
         assertQuery(

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorTest.java
@@ -427,6 +427,18 @@ public abstract class BaseOracleConnectorTest
     }
 
     @Override
+    public void testNativeQueryParameters()
+    {
+        // override because Oracle requires the FROM clause, and it needs explicit type
+        Session session = Session.builder(getSession())
+                .addPreparedStatement("my_query_simple", "SELECT * FROM TABLE(system.query(query => ?))")
+                .addPreparedStatement("my_query", "SELECT * FROM TABLE(system.query(query => format('SELECT %s FROM %s', ?, ?)))")
+                .build();
+        assertQuery(session, "EXECUTE my_query_simple USING 'SELECT CAST(1 AS number(2, 1)) a FROM DUAL'", "VALUES 1");
+        assertQuery(session, "EXECUTE my_query USING 'a', '(SELECT CAST(2 AS number(2, 1)) a FROM DUAL) t'", "VALUES 2");
+    }
+
+    @Override
     public void testNativeQueryInsertStatementTableDoesNotExist()
     {
         // override because Oracle succeeds in preparing query, and then fails because of no metadata available

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
@@ -573,6 +573,18 @@ public class TestPhoenixConnectorTest
     }
 
     @Override
+    public void testNativeQueryParameters()
+    {
+        // not implemented
+        Session session = Session.builder(getSession())
+                .addPreparedStatement("my_query_simple", "SELECT * FROM TABLE(system.query(query => ?))")
+                .addPreparedStatement("my_query", "SELECT * FROM TABLE(system.query(query => format('SELECT %s FROM %s', ?, ?)))")
+                .build();
+        assertQueryFails(session, "EXECUTE my_query_simple USING 'SELECT 1 a'", "line 1:21: Table function system.query not registered");
+        assertQueryFails(session, "EXECUTE my_query USING 'a', '(SELECT 2 a) t'", "line 1:21: Table function system.query not registered");
+    }
+
+    @Override
     public void testNativeQuerySelectFromNation()
     {
         // not implemented


### PR DESCRIPTION
This is an improvement. It allows you to use parameters in table function scalar arguments:

```
PREPARE stmt1 FROM 
SELECT * FROM TABLE(postgresql.system.query(query => ?));

EXECUTE stmt1 USING 'SELECT * FROM tpch.region';
```
```
PREPARE stmt2 FROM
SELECT * FROM TABLE(postgresql.system.query(query => format('SELECT * FROM %s', ?)));

EXECUTE stmt2 USING 'tpch.region';
```

## Documentation
Existing documentation is updated in this PR. Some examples (like the above) should be added to the documentation of the query pass-through table functions https://github.com/trinodb/trino/pull/12725 cc @colebow @mosabua 

## Release notes
```markdown
# General
* Support parameters in table function arguments.
```
