### PR TITLE
Fix failure when inserting into Kudu table having row uuid column

### DIFF
--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduInsertTableHandle.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduInsertTableHandle.java
@@ -30,23 +30,27 @@ public class KuduInsertTableHandle
 {
     private final SchemaTableName schemaTableName;
     private final List<Type> columnTypes;
+    private final boolean generateUUID;
     private transient KuduTable table;
 
     @JsonCreator
     public KuduInsertTableHandle(
             @JsonProperty("schemaTableName") SchemaTableName schemaTableName,
-            @JsonProperty("columnTypes") List<Type> columnTypes)
+            @JsonProperty("columnTypes") List<Type> columnTypes,
+            @JsonProperty("generateUUID") boolean generateUUID)
     {
-        this(schemaTableName, columnTypes, null);
+        this(schemaTableName, columnTypes, generateUUID, null);
     }
 
     public KuduInsertTableHandle(
             SchemaTableName schemaTableName,
             List<Type> columnTypes,
+            boolean generateUUID,
             KuduTable table)
     {
         this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
         this.columnTypes = ImmutableList.copyOf(requireNonNull(columnTypes, "columnTypes is null"));
+        this.generateUUID = generateUUID;
         this.table = table;
     }
 
@@ -70,9 +74,10 @@ public class KuduInsertTableHandle
     }
 
     @Override
+    @JsonProperty
     public boolean isGenerateUUID()
     {
-        return false;
+        return generateUUID;
     }
 
     public KuduTable getTable(KuduClientSession session)

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduMetadata.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduMetadata.java
@@ -71,6 +71,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.kudu.KuduColumnHandle.ROW_ID;
 import static io.trino.plugin.kudu.KuduSessionProperties.isKuduGroupedExecutionEnabled;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -166,7 +167,7 @@ public class KuduMetadata
         Schema schema = table.getSchema();
 
         List<ColumnMetadata> columnsMetaList = schema.getColumns().stream()
-                .filter(column -> !column.isKey() || !column.getName().equals(KuduColumnHandle.ROW_ID))
+                .filter(column -> !column.isKey() || !column.getName().equals(ROW_ID))
                 .map(this::getColumnMetadata)
                 .collect(toImmutableList());
 
@@ -198,7 +199,7 @@ public class KuduMetadata
         KuduColumnHandle kuduColumnHandle = (KuduColumnHandle) columnHandle;
         if (kuduColumnHandle.isVirtualRowId()) {
             return ColumnMetadata.builder()
-                    .setName(KuduColumnHandle.ROW_ID)
+                    .setName(ROW_ID)
                     .setType(VarbinaryType.VARBINARY)
                     .setHidden(true)
                     .build();
@@ -342,7 +343,7 @@ public class KuduMetadata
         boolean generateUUID = !design.hasPartitions();
         ConnectorTableMetadata finalTableMetadata = tableMetadata;
         if (generateUUID) {
-            String rowId = KuduColumnHandle.ROW_ID;
+            String rowId = ROW_ID;
             List<ColumnMetadata> copy = new ArrayList<>(tableMetadata.getColumns());
             Map<String, Object> columnProperties = new HashMap<>();
             columnProperties.put(KuduTableProperties.PRIMARY_KEY, true);

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduMetadata.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduMetadata.java
@@ -313,6 +313,8 @@ public class KuduMetadata
         return new KuduInsertTableHandle(
                 tableHandle.getSchemaTableName(),
                 columnTypes,
+                columns.stream()
+                        .anyMatch(column -> column.getName().equals(ROW_ID)),
                 table);
     }
 

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/AbstractKuduConnectorTest.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/AbstractKuduConnectorTest.java
@@ -334,6 +334,17 @@ public abstract class AbstractKuduConnectorTest
     }
 
     @Test
+    public void testInsertIntoTableHavingRowUuid()
+    {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_insert_", " AS SELECT * FROM region WITH NO DATA")) {
+            assertUpdate("INSERT INTO " + table.getName() + " SELECT * FROM region", 5);
+
+            assertThat(query("SELECT * FROM " + table.getName()))
+                    .matches("SELECT * FROM region");
+        }
+    }
+
+    @Test
     @Override
     public void testInsertUnicode()
     {


### PR DESCRIPTION
## Description

Fix failure when inserting into Kudu table having row uuid column

## Documentation

(x) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# Kudu
* Fix failure when inserting into a table having a `row_uuid` column. ({issue}`12915`)
```
