### PR TITLE
Reject SELECT after INSERT or other DML in Hive transaction

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitManager.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitManager.java
@@ -79,6 +79,7 @@ import static io.trino.plugin.hive.metastore.MetastoreUtil.makePartitionName;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.verifyOnline;
 import static io.trino.plugin.hive.util.HiveCoercionPolicy.canCoerce;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.SERVER_SHUTTING_DOWN;
 import static io.trino.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.GROUPED_SCHEDULING;
 import static java.lang.Math.min;
@@ -187,6 +188,12 @@ public class HiveSplitManager
         // get table metadata
         TransactionalMetadata transactionalMetadata = transactionManager.get(transaction, session.getIdentity());
         SemiTransactionalHiveMetastore metastore = transactionalMetadata.getMetastore();
+        if (!metastore.isReadableWithinTransaction(tableName.getSchemaName(), tableName.getTableName())) {
+            // Until transaction is committed, the table data may or may not be visible.
+            throw new TrinoException(NOT_SUPPORTED, format(
+                    "Cannot read from a table %s that was modified within transaction, you need to commit the transaction first",
+                    tableName));
+        }
         Table table = metastore.getTable(tableName.getSchemaName(), tableName.getTableName())
                 .orElseThrow(() -> new TableNotFoundException(tableName));
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -250,6 +250,28 @@ public class SemiTransactionalHiveMetastore
         throw new IllegalStateException("Unknown action type: " + tableAction.getType());
     }
 
+    public synchronized boolean isReadableWithinTransaction(String databaseName, String tableName)
+    {
+        Action<TableAndMore> tableAction = tableActions.get(new SchemaTableName(databaseName, tableName));
+        if (tableAction == null) {
+            return true;
+        }
+        switch (tableAction.getType()) {
+            case ADD:
+            case ALTER:
+                return true;
+            case INSERT_EXISTING:
+            case DELETE_ROWS:
+            case UPDATE:
+                // Until transaction is committed, the table data may or may not be visible.
+                return false;
+            case DROP:
+            case DROP_PRESERVE_DATA:
+                return false;
+        }
+        throw new IllegalStateException("Unknown action type: " + tableAction.getType());
+    }
+
     public synchronized Set<ColumnStatisticType> getSupportedColumnStatistics(Type type)
     {
         return delegate.getSupportedColumnStatistics(type);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -247,7 +247,7 @@ public class SemiTransactionalHiveMetastore
                 // TODO
                 break;
         }
-        throw new IllegalStateException("Unknown action type");
+        throw new IllegalStateException("Unknown action type: " + tableAction.getType());
     }
 
     public synchronized Set<ColumnStatisticType> getSupportedColumnStatistics(Type type)
@@ -275,7 +275,7 @@ public class SemiTransactionalHiveMetastore
                 // TODO
                 break;
         }
-        throw new IllegalStateException("Unknown action type");
+        throw new IllegalStateException("Unknown action type: " + tableAction.getType());
     }
 
     public synchronized Map<String, PartitionStatistics> getPartitionStatistics(String databaseName, String tableName, Set<String> partitionNames)
@@ -346,7 +346,7 @@ public class SemiTransactionalHiveMetastore
                 // TODO
                 break;
         }
-        throw new IllegalStateException("Unknown action type");
+        throw new IllegalStateException("Unknown action type: " + tableAction.getType());
     }
 
     public synchronized HivePageSinkMetadata generatePageSinkMetadata(SchemaTableName schemaTableName)
@@ -516,7 +516,7 @@ public class SemiTransactionalHiveMetastore
                 // TODO
                 break;
         }
-        throw new IllegalStateException("Unknown action type");
+        throw new IllegalStateException("Unknown action type: " + oldTableAction.getType());
     }
 
     public synchronized void dropTable(ConnectorSession session, String databaseName, String tableName)
@@ -544,7 +544,7 @@ public class SemiTransactionalHiveMetastore
                 // TODO
                 break;
         }
-        throw new IllegalStateException("Unknown action type");
+        throw new IllegalStateException("Unknown action type: " + oldTableAction.getType());
     }
 
     public synchronized void replaceTable(String databaseName, String tableName, Table table, PrincipalPrivileges principalPrivileges)
@@ -648,7 +648,7 @@ public class SemiTransactionalHiveMetastore
                 // TODO
                 break;
         }
-        throw new IllegalStateException("Unknown action type");
+        throw new IllegalStateException("Unknown action type: " + oldTableAction.getType());
     }
 
     private boolean isAcidTransactionRunning()
@@ -728,7 +728,7 @@ public class SemiTransactionalHiveMetastore
                 // TODO
                 break;
         }
-        throw new IllegalStateException("Unknown action type");
+        throw new IllegalStateException("Unknown action type: " + oldTableAction.getType());
     }
 
     public synchronized void finishUpdate(
@@ -775,7 +775,7 @@ public class SemiTransactionalHiveMetastore
                 // TODO
                 break;
         }
-        throw new IllegalStateException("Unknown action type");
+        throw new IllegalStateException("Unknown action type: " + oldTableAction.getType());
     }
 
     public synchronized Optional<List<String>> getPartitionNames(String databaseName, String tableName)
@@ -861,7 +861,7 @@ public class SemiTransactionalHiveMetastore
                     resultBuilder.add(partitionName);
                     break;
                 default:
-                    throw new IllegalStateException("Unknown action type");
+                    throw new IllegalStateException("Unknown action type: " + partitionAction.getType());
             }
         }
         // add newly-added partitions to the results from underlying metastore.
@@ -928,7 +928,7 @@ public class SemiTransactionalHiveMetastore
             case DROP_PRESERVE_DATA:
                 return Optional.empty();
         }
-        throw new IllegalStateException("Unknown action type");
+        throw new IllegalStateException("Unknown action type: " + partitionAction.getType());
     }
 
     public synchronized void addPartition(
@@ -969,7 +969,7 @@ public class SemiTransactionalHiveMetastore
             case UPDATE:
                 throw new TrinoException(ALREADY_EXISTS, format("Partition already exists for table '%s.%s': %s", databaseName, tableName, partition.getValues()));
         }
-        throw new IllegalStateException("Unknown action type");
+        throw new IllegalStateException("Unknown action type: " + oldPartitionAction.getType());
     }
 
     public synchronized void dropPartition(ConnectorSession session, String databaseName, String tableName, List<String> partitionValues, boolean deleteData)
@@ -1000,7 +1000,7 @@ public class SemiTransactionalHiveMetastore
                         NOT_SUPPORTED,
                         format("dropping a partition added in the same transaction is not supported: %s %s %s", databaseName, tableName, partitionValues));
         }
-        throw new IllegalStateException("Unknown action type");
+        throw new IllegalStateException("Unknown action type: " + oldPartitionAction.getType());
     }
 
     public synchronized void finishInsertIntoExistingPartition(
@@ -1053,7 +1053,7 @@ public class SemiTransactionalHiveMetastore
             case UPDATE:
                 throw new UnsupportedOperationException("Inserting into a partition that were added, altered, or inserted into in the same transaction is not supported");
         }
-        throw new IllegalStateException("Unknown action type");
+        throw new IllegalStateException("Unknown action type: " + oldPartitionAction.getType());
     }
 
     private synchronized AcidTransaction getCurrentAcidTransaction()
@@ -1161,7 +1161,7 @@ public class SemiTransactionalHiveMetastore
                 // TODO
                 break;
         }
-        throw new IllegalStateException("Unknown action type");
+        throw new IllegalStateException("Unknown action type: " + tableAction.getType());
     }
 
     private synchronized String getRequiredTableOwner(String databaseName, String tableName)
@@ -1450,7 +1450,7 @@ public class SemiTransactionalHiveMetastore
                         committer.prepareUpdateExistingTable(action.getHdfsContext(), action.getData());
                         break;
                     default:
-                        throw new IllegalStateException("Unknown action type");
+                        throw new IllegalStateException("Unknown action type: " + action.getType());
                 }
             }
             for (Map.Entry<SchemaTableName, Map<List<String>, Action<PartitionAndMore>>> tableEntry : partitionActions.entrySet()) {
@@ -1478,7 +1478,7 @@ public class SemiTransactionalHiveMetastore
                         case DELETE_ROWS:
                             break;
                         default:
-                            throw new IllegalStateException("Unknown action type");
+                            throw new IllegalStateException("Unknown action type: " + action.getType());
                     }
                 }
             }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -90,6 +90,7 @@ import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Throwables.getStackTraceAsString;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Sets.intersection;
@@ -233,6 +234,13 @@ public abstract class BaseHiveConnectorTest
             default:
                 return super.hasBehavior(connectorBehavior);
         }
+    }
+
+    @Override
+    protected void verifySelectAfterInsertFailurePermissible(Throwable e)
+    {
+        assertThat(getStackTraceAsString(e))
+                .containsPattern("io.trino.spi.TrinoException: Cannot read from a table tpch.test_insert_select_\\w+ that was modified within transaction, you need to commit the transaction first");
     }
 
     @Override


### PR DESCRIPTION
SELECT after INSERT would return incorrect results, so let's just
    disallow it.

Fixes https://github.com/trinodb/trino/issues/11769