### PR TITLE
Make AbstractRowBlock#copyPositions branchless

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/block/AbstractRowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/AbstractRowBlock.java
@@ -98,12 +98,10 @@ public abstract class AbstractRowBlock
             for (int i = 0; i < length; i++) {
                 newOffsets[i] = fieldBlockPositionCount;
                 int position = positions[offset + i];
-                if (isNull(position)) {
-                    newRowIsNull[i] = true;
-                }
-                else {
-                    fieldBlockPositions[fieldBlockPositionCount++] = getFieldBlockOffset(position);
-                }
+                boolean positionIsNull = isNull(position);
+                newRowIsNull[i] = positionIsNull;
+                fieldBlockPositions[fieldBlockPositionCount] = getFieldBlockOffset(position);
+                fieldBlockPositionCount += positionIsNull ? 0 : 1;
             }
             // Record last offset position
             newOffsets[length] = fieldBlockPositionCount;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
Make AbstractRowBlock#copyPositions branchless to avoid branch misprediction penalties

#### JMH benchmarks

```
Benchmark                             nullsAllowed  selectedPositions  selectedPositionsCount  type         baseline  branchless  branchless%
BenchmarkCopyPositions.copyPositions  FALSE         GROUPED            200                     ROW(BIGINT)  0.484     0.484       0
BenchmarkCopyPositions.copyPositions  FALSE         GROUPED            1000                    ROW(BIGINT)  2.082     2.083       0.04803073967
BenchmarkCopyPositions.copyPositions  FALSE         GROUPED            8000                    ROW(BIGINT)  18.698    18.893      1.042892288
BenchmarkCopyPositions.copyPositions  FALSE         SEQUENCE           200                     ROW(BIGINT)  0.484     0.492       1.652892562
BenchmarkCopyPositions.copyPositions  FALSE         SEQUENCE           1000                    ROW(BIGINT)  2.097     2.102       0.2384358608
BenchmarkCopyPositions.copyPositions  FALSE         SEQUENCE           8000                    ROW(BIGINT)  18.881    18.914      0.1747788782
BenchmarkCopyPositions.copyPositions  FALSE         RANDOM             200                     ROW(BIGINT)  0.489     0.492       0.6134969325
BenchmarkCopyPositions.copyPositions  FALSE         RANDOM             1000                    ROW(BIGINT)  2.181     2.145       -1.650618982
BenchmarkCopyPositions.copyPositions  FALSE         RANDOM             8000                    ROW(BIGINT)  21.12     20.017      -5.222537879
BenchmarkCopyPositions.copyPositions  TRUE          GROUPED            200                     ROW(BIGINT)  0.862     0.894       3.712296984
BenchmarkCopyPositions.copyPositions  TRUE          GROUPED            1000                    ROW(BIGINT)  3.968     4.005       0.9324596774
BenchmarkCopyPositions.copyPositions  TRUE          GROUPED            8000                    ROW(BIGINT)  41.909    27.061      -35.4291441
BenchmarkCopyPositions.copyPositions  TRUE          SEQUENCE           200                     ROW(BIGINT)  0.902     0.94        4.21286031
BenchmarkCopyPositions.copyPositions  TRUE          SEQUENCE           1000                    ROW(BIGINT)  4.389     4.174       -4.898610162
BenchmarkCopyPositions.copyPositions  TRUE          SEQUENCE           8000                    ROW(BIGINT)  41.143    28.406      -30.95787862
BenchmarkCopyPositions.copyPositions  TRUE          RANDOM             200                     ROW(BIGINT)  0.9       0.927       3
BenchmarkCopyPositions.copyPositions  TRUE          RANDOM             1000                    ROW(BIGINT)  4.556     4.17        -8.472344162
BenchmarkCopyPositions.copyPositions  TRUE          RANDOM             8000                    ROW(BIGINT)  41.507    29.262      -29.50104802
```

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

improvement
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core query engine
> How would you describe this change to a non-technical end user or system administrator?

Improve read performance with ROW data types

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Section
* Improve read performance with ROW data types. ({issue}`12926`)
```
