### PR TITLE
Explicitly set argLine property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,9 @@
         <air.check.skip-spotbugs>true</air.check.skip-spotbugs>
         <air.check.skip-pmd>true</air.check.skip-pmd>
         <air.check.skip-jacoco>true</air.check.skip-jacoco>
+        <!-- Jacoco is explicitly disabled, but the profiles setting this property are activated
+             by a different property, so we have to set this as well: -->
+        <argLine/>
 
         <project.build.targetJdk>11</project.build.targetJdk>
         <air.java.version>11.0.11</air.java.version>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

This property is used by Jacoco to store its agent properties; it's then used in Surefire configuration to paste these properties as JVM command arguments. Normally this is managed by two profiles in Airbase POM: `jacoco-check`, which configures the Jacoco plugin to initialize this property, and `jacoco-defaults`, which sets the property to empty. These two profiles are activated by the `air.check.skip-all` property being `false` and `true` respectively.

The problem is, though, that we disable Jacoco by setting `air.check.skip-jacoco` instead. This means that the Jacoco plugin is configured, but not executed - and the profile which sets `argLine` to empty is not activated. This leaves the `argLine` property uinitialized, and the Surefire configuration ends up having literal `${argLine}` in the JVM commands. This confuses some tools which rely on this configuration (though not Surefire itself), including at least one popular IDE.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Build scripts.

> How would you describe this change to a non-technical end user or system administrator?

Makes some tests work in an IDE.

## Related issues, pull requests, and links

airlift/airbase#300

airlift/airbase#301

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
