### PR TITLE
Move TestAccumuloClient initialization out of constructor

### DIFF
--- a/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/TestAccumuloClient.java
+++ b/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/TestAccumuloClient.java
@@ -24,6 +24,8 @@ import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.SchemaTableName;
 import org.apache.accumulo.core.client.Connector;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.HashMap;
@@ -36,10 +38,11 @@ import static org.testng.Assert.assertNotNull;
 
 public class TestAccumuloClient
 {
-    private final AccumuloClient client;
-    private final ZooKeeperMetadataManager zooKeeperMetadataManager;
+    private AccumuloClient client;
+    private ZooKeeperMetadataManager zooKeeperMetadataManager;
 
-    public TestAccumuloClient()
+    @BeforeClass
+    public void setUp()
             throws Exception
     {
         AccumuloConfig config = new AccumuloConfig()
@@ -50,6 +53,13 @@ public class TestAccumuloClient
         config.setZooKeepers(connector.getInstance().getZooKeepers());
         zooKeeperMetadataManager = new ZooKeeperMetadataManager(config, TESTING_TYPE_MANAGER);
         client = new AccumuloClient(connector, config, zooKeeperMetadataManager, new AccumuloTableManager(connector), new IndexLookup(connector, new ColumnCardinalityCache(connector, config)));
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        zooKeeperMetadataManager = null;
+        client = null;
     }
 
     @Test


### PR DESCRIPTION
Surefire maven plugin has problems reporting exceptions that occur
during test instantiation.

Example exception from a CI (https://github.com/trinodb/trino/runs/7002887890?check_suite_focus=true) shows that actual problem isn't reported.

```
Error:  Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M5:test (default-test) on project trino-accumulo: There are test failures.
Error:
Error:  Please refer to /home/runner/work/trino/trino/plugin/trino-accumulo/target/surefire-reports for the individual test results.
Error:  Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
Error:  There was an error in the forked process
Error:
Error:  Cannot instantiate class io.trino.plugin.accumulo.TestAccumuloClient
Error:  org.apache.maven.surefire.booter.SurefireBooterForkException: There was an error in the forked process
Error:
Error:  Cannot instantiate class io.trino.plugin.accumulo.TestAccumuloClient
Error:  	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.fork(ForkStarter.java:733)
Error:  	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:305)
Error:  	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:265)
Error:  	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeProvider(AbstractSurefireMojo.java:1314)
Error:  	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeAfterPreconditionsChecked(AbstractSurefireMojo.java:1159)
Error:  	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.execute(AbstractSurefireMojo.java:932)
Error:  	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:137)
Error:  	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:210)
Error:  	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:156)
Error:  	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:148)
Error:  	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:117)
Error:  	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:81)
Error:  	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:56)
Error:  	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
Error:  	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:305)
Error:  	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:192)
Error:  	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:105)
Error:  	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:972)
Error:  	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:293)
Error:  	at org.apache.maven.cli.MavenCli.main(MavenCli.java:196)
Error:  	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
Error:  	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
Error:  	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
Error:  	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
Error:  	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:282)
Error:  	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:225)
Error:  	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:406)
Error:  	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:347)
Error:  	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
Error:  	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
Error:  	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
Error:  	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
Error:  	at org.apache.maven.wrapper.BootstrapMainStarter.start(BootstrapMainStarter.java:47)
Error:  	at org.apache.maven.wrapper.WrapperExecutor.execute(WrapperExecutor.java:156)
Error:  	at org.apache.maven.wrapper.MavenWrapperMain.main(MavenWrapperMain.java:72)
```
