### PR TITLE
Allow injecting authentication components for ThriftMetastore

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePerTransactionMetastoreCache.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePerTransactionMetastoreCache.java
@@ -26,16 +26,16 @@ import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
 import io.trino.plugin.hive.metastore.RawHiveMetastoreFactory;
 import io.trino.plugin.hive.metastore.thrift.BridgingHiveMetastoreFactory;
 import io.trino.plugin.hive.metastore.thrift.DefaultThriftMetastoreClientFactory;
-import io.trino.plugin.hive.metastore.thrift.MetastoreLocator;
+import io.trino.plugin.hive.metastore.thrift.IdentityAwareMetastoreClientFactory;
 import io.trino.plugin.hive.metastore.thrift.StaticMetastoreConfig;
-import io.trino.plugin.hive.metastore.thrift.StaticMetastoreLocator;
+import io.trino.plugin.hive.metastore.thrift.StaticTokenAwareMetastoreClientFactory;
 import io.trino.plugin.hive.metastore.thrift.ThriftHiveMetastore;
 import io.trino.plugin.hive.metastore.thrift.ThriftHiveMetastoreFactory;
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreAuthenticationModule;
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreClientFactory;
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreConfig;
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreFactory;
-import io.trino.plugin.hive.metastore.thrift.TokenDelegationThriftMetastoreFactory;
+import io.trino.plugin.hive.metastore.thrift.TokenAwareMetastoreClientFactory;
 import io.trino.spi.security.ConnectorIdentity;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.tpch.TpchEntity;
@@ -97,10 +97,10 @@ public class TestDeltaLakePerTransactionMetastoreCache
                     protected void setup(Binder binder)
                     {
                         newOptionalBinder(binder, ThriftMetastoreClientFactory.class).setDefault().to(DefaultThriftMetastoreClientFactory.class).in(Scopes.SINGLETON);
-                        binder.bind(MetastoreLocator.class).to(StaticMetastoreLocator.class).in(Scopes.SINGLETON);
+                        binder.bind(TokenAwareMetastoreClientFactory.class).to(StaticTokenAwareMetastoreClientFactory.class).in(Scopes.SINGLETON);
                         configBinder(binder).bindConfig(StaticMetastoreConfig.class);
                         configBinder(binder).bindConfig(ThriftMetastoreConfig.class);
-                        binder.bind(TokenDelegationThriftMetastoreFactory.class);
+                        binder.bind(IdentityAwareMetastoreClientFactory.class);
                         binder.bind(ThriftMetastoreFactory.class).to(ThriftHiveMetastoreFactory.class).in(Scopes.SINGLETON);
                         newExporter(binder).export(ThriftMetastoreFactory.class)
                                 .as(generator -> generator.generatedNameOf(ThriftHiveMetastore.class));

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePerTransactionMetastoreCache.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePerTransactionMetastoreCache.java
@@ -26,7 +26,6 @@ import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
 import io.trino.plugin.hive.metastore.RawHiveMetastoreFactory;
 import io.trino.plugin.hive.metastore.thrift.BridgingHiveMetastoreFactory;
 import io.trino.plugin.hive.metastore.thrift.DefaultThriftMetastoreClientFactory;
-import io.trino.plugin.hive.metastore.thrift.IdentityAwareMetastoreClientFactory;
 import io.trino.plugin.hive.metastore.thrift.StaticMetastoreConfig;
 import io.trino.plugin.hive.metastore.thrift.StaticTokenAwareMetastoreClientFactory;
 import io.trino.plugin.hive.metastore.thrift.ThriftHiveMetastore;
@@ -100,7 +99,6 @@ public class TestDeltaLakePerTransactionMetastoreCache
                         binder.bind(TokenAwareMetastoreClientFactory.class).to(StaticTokenAwareMetastoreClientFactory.class).in(Scopes.SINGLETON);
                         configBinder(binder).bindConfig(StaticMetastoreConfig.class);
                         configBinder(binder).bindConfig(ThriftMetastoreConfig.class);
-                        binder.bind(IdentityAwareMetastoreClientFactory.class);
                         binder.bind(ThriftMetastoreFactory.class).to(ThriftHiveMetastoreFactory.class).in(Scopes.SINGLETON);
                         newExporter(binder).export(ThriftMetastoreFactory.class)
                                 .as(generator -> generator.generatedNameOf(ThriftHiveMetastore.class));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/IdentityAwareMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/IdentityAwareMetastoreClientFactory.java
@@ -34,20 +34,20 @@ import static io.trino.plugin.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-public class TokenDelegationThriftMetastoreFactory
+public class IdentityAwareMetastoreClientFactory
 {
-    private final MetastoreLocator clientProvider;
+    private final TokenAwareMetastoreClientFactory clientProvider;
     private final boolean impersonationEnabled;
     private final boolean authenticationEnabled;
     private final NonEvictableLoadingCache<String, String> delegationTokenCache;
 
     @Inject
-    public TokenDelegationThriftMetastoreFactory(
-            MetastoreLocator metastoreLocator,
+    public IdentityAwareMetastoreClientFactory(
+            TokenAwareMetastoreClientFactory tokenAwareMetastoreClientFactory,
             ThriftMetastoreConfig thriftConfig,
             ThriftMetastoreAuthenticationConfig authenticationConfig)
     {
-        this.clientProvider = requireNonNull(metastoreLocator, "metastoreLocator is null");
+        this.clientProvider = requireNonNull(tokenAwareMetastoreClientFactory, "tokeAwareMetastoreClientFactory is null");
         this.impersonationEnabled = thriftConfig.isImpersonationEnabled();
         this.authenticationEnabled = authenticationConfig.getAuthenticationType() != ThriftMetastoreAuthenticationType.NONE;
 
@@ -64,7 +64,7 @@ public class TokenDelegationThriftMetastoreFactory
         return clientProvider.createMetastoreClient(Optional.empty());
     }
 
-    public ThriftMetastoreClient createMetastoreClient(Optional<ConnectorIdentity> identity)
+    public ThriftMetastoreClient createMetastoreClientFor(Optional<ConnectorIdentity> identity)
             throws TException
     {
         if (!impersonationEnabled) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/StaticTokenAwareMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/StaticTokenAwareMetastoreClientFactory.java
@@ -41,21 +41,21 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-public class StaticMetastoreLocator
-        implements MetastoreLocator
+public class StaticTokenAwareMetastoreClientFactory
+        implements TokenAwareMetastoreClientFactory
 {
     private final List<Backoff> backoffs;
     private final ThriftMetastoreClientFactory clientFactory;
     private final String metastoreUsername;
 
     @Inject
-    public StaticMetastoreLocator(StaticMetastoreConfig config, ThriftMetastoreAuthenticationConfig authenticationConfig, ThriftMetastoreClientFactory clientFactory)
+    public StaticTokenAwareMetastoreClientFactory(StaticMetastoreConfig config, ThriftMetastoreAuthenticationConfig authenticationConfig, ThriftMetastoreClientFactory clientFactory)
     {
         this(config, authenticationConfig, clientFactory, Ticker.systemTicker());
     }
 
     @VisibleForTesting
-    StaticMetastoreLocator(StaticMetastoreConfig config, ThriftMetastoreAuthenticationConfig authenticationConfig, ThriftMetastoreClientFactory clientFactory, Ticker ticker)
+    StaticTokenAwareMetastoreClientFactory(StaticMetastoreConfig config, ThriftMetastoreAuthenticationConfig authenticationConfig, ThriftMetastoreClientFactory clientFactory, Ticker ticker)
     {
         this(config.getMetastoreUris(), config.getMetastoreUsername(), clientFactory, ticker);
 
@@ -66,17 +66,17 @@ public class StaticMetastoreLocator
                 authenticationConfig.getAuthenticationType());
     }
 
-    public StaticMetastoreLocator(List<URI> metastoreUris, @Nullable String metastoreUsername, ThriftMetastoreClientFactory clientFactory)
+    public StaticTokenAwareMetastoreClientFactory(List<URI> metastoreUris, @Nullable String metastoreUsername, ThriftMetastoreClientFactory clientFactory)
     {
         this(metastoreUris, metastoreUsername, clientFactory, Ticker.systemTicker());
     }
 
-    private StaticMetastoreLocator(List<URI> metastoreUris, @Nullable String metastoreUsername, ThriftMetastoreClientFactory clientFactory, Ticker ticker)
+    private StaticTokenAwareMetastoreClientFactory(List<URI> metastoreUris, @Nullable String metastoreUsername, ThriftMetastoreClientFactory clientFactory, Ticker ticker)
     {
         requireNonNull(metastoreUris, "metastoreUris is null");
         checkArgument(!metastoreUris.isEmpty(), "metastoreUris must specify at least one URI");
         this.backoffs = metastoreUris.stream()
-                .map(StaticMetastoreLocator::checkMetastoreUri)
+                .map(StaticTokenAwareMetastoreClientFactory::checkMetastoreUri)
                 .map(uri -> HostAndPort.fromParts(uri.getHost(), uri.getPort()))
                 .map(address -> new Backoff(address, ticker))
                 .collect(toImmutableList());

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -143,7 +143,7 @@ public class ThriftHiveMetastore
 
     private final Optional<ConnectorIdentity> identity;
     private final HdfsEnvironment hdfsEnvironment;
-    private final TokenDelegationThriftMetastoreFactory metastoreFactory;
+    private final IdentityAwareMetastoreClientFactory metastoreClientFactory;
     private final double backoffScaleFactor;
     private final Duration minBackoffDelay;
     private final Duration maxBackoffDelay;
@@ -158,7 +158,7 @@ public class ThriftHiveMetastore
     public ThriftHiveMetastore(
             Optional<ConnectorIdentity> identity,
             HdfsEnvironment hdfsEnvironment,
-            TokenDelegationThriftMetastoreFactory metastoreFactory,
+            IdentityAwareMetastoreClientFactory metastoreClientFactory,
             double backoffScaleFactor,
             Duration minBackoffDelay,
             Duration maxBackoffDelay,
@@ -172,7 +172,7 @@ public class ThriftHiveMetastore
     {
         this.identity = requireNonNull(identity, "identity is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
-        this.metastoreFactory = requireNonNull(metastoreFactory, "metastoreFactory is null");
+        this.metastoreClientFactory = requireNonNull(metastoreClientFactory, "metastoreClientFactory is null");
         this.backoffScaleFactor = backoffScaleFactor;
         this.minBackoffDelay = requireNonNull(minBackoffDelay, "minBackoffDelay is null");
         this.maxBackoffDelay = requireNonNull(maxBackoffDelay, "maxBackoffDelay is null");
@@ -1848,7 +1848,7 @@ public class ThriftHiveMetastore
     private ThriftMetastoreClient createMetastoreClient()
             throws TException
     {
-        return metastoreFactory.createMetastoreClient(identity);
+        return metastoreClientFactory.createMetastoreClientFor(identity);
     }
 
     private RetryDriver retry()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreFactory.java
@@ -31,7 +31,7 @@ public class ThriftHiveMetastoreFactory
         implements ThriftMetastoreFactory
 {
     private final HdfsEnvironment hdfsEnvironment;
-    private final TokenDelegationThriftMetastoreFactory metastoreFactory;
+    private final IdentityAwareMetastoreClientFactory metastoreClientFactory;
     private final double backoffScaleFactor;
     private final Duration minBackoffDelay;
     private final Duration maxBackoffDelay;
@@ -46,13 +46,13 @@ public class ThriftHiveMetastoreFactory
 
     @Inject
     public ThriftHiveMetastoreFactory(
-            TokenDelegationThriftMetastoreFactory metastoreFactory,
+            IdentityAwareMetastoreClientFactory metastoreClientFactory,
             @HideDeltaLakeTables boolean hideDeltaLakeTables,
             @TranslateHiveViews boolean translateHiveViews,
             ThriftMetastoreConfig thriftConfig,
             HdfsEnvironment hdfsEnvironment)
     {
-        this.metastoreFactory = requireNonNull(metastoreFactory, "metastoreFactory is null");
+        this.metastoreClientFactory = requireNonNull(metastoreClientFactory, "metastoreClientFactory is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.backoffScaleFactor = thriftConfig.getBackoffScaleFactor();
         this.minBackoffDelay = thriftConfig.getMinBackoffDelay();
@@ -87,7 +87,7 @@ public class ThriftHiveMetastoreFactory
         return new ThriftHiveMetastore(
                 identity,
                 hdfsEnvironment,
-                metastoreFactory,
+                metastoreClientFactory,
                 backoffScaleFactor,
                 minBackoffDelay,
                 maxBackoffDelay,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreAuthenticationModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreAuthenticationModule.java
@@ -50,6 +50,7 @@ public class ThriftMetastoreAuthenticationModule
         @Override
         public void configure(Binder binder)
         {
+            binder.bind(IdentityAwareMetastoreClientFactory.class).to(UgiBasedMetastoreClientFactory.class).in(SINGLETON);
             binder.bind(HiveMetastoreAuthentication.class).to(NoHiveMetastoreAuthentication.class).in(SINGLETON);
         }
     }
@@ -60,6 +61,7 @@ public class ThriftMetastoreAuthenticationModule
         @Override
         public void configure(Binder binder)
         {
+            binder.bind(IdentityAwareMetastoreClientFactory.class).to(TokenFetchingMetastoreClientFactory.class).in(SINGLETON);
             binder.bind(HiveMetastoreAuthentication.class).to(KerberosHiveMetastoreAuthentication.class).in(SINGLETON);
             configBinder(binder).bindConfig(MetastoreKerberosConfig.class);
         }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreModule.java
@@ -32,7 +32,6 @@ public class ThriftMetastoreModule
         OptionalBinder.newOptionalBinder(binder, ThriftMetastoreClientFactory.class)
                 .setDefault().to(DefaultThriftMetastoreClientFactory.class).in(Scopes.SINGLETON);
         binder.bind(TokenAwareMetastoreClientFactory.class).to(StaticTokenAwareMetastoreClientFactory.class).in(Scopes.SINGLETON);
-        binder.bind(IdentityAwareMetastoreClientFactory.class);
         configBinder(binder).bindConfig(StaticMetastoreConfig.class);
         configBinder(binder).bindConfig(ThriftMetastoreConfig.class);
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreModule.java
@@ -31,8 +31,8 @@ public class ThriftMetastoreModule
     {
         OptionalBinder.newOptionalBinder(binder, ThriftMetastoreClientFactory.class)
                 .setDefault().to(DefaultThriftMetastoreClientFactory.class).in(Scopes.SINGLETON);
-        binder.bind(MetastoreLocator.class).to(StaticMetastoreLocator.class).in(Scopes.SINGLETON);
-        binder.bind(TokenDelegationThriftMetastoreFactory.class);
+        binder.bind(TokenAwareMetastoreClientFactory.class).to(StaticTokenAwareMetastoreClientFactory.class).in(Scopes.SINGLETON);
+        binder.bind(IdentityAwareMetastoreClientFactory.class);
         configBinder(binder).bindConfig(StaticMetastoreConfig.class);
         configBinder(binder).bindConfig(ThriftMetastoreConfig.class);
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/TokenAwareMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/TokenAwareMetastoreClientFactory.java
@@ -17,7 +17,7 @@ import org.apache.thrift.TException;
 
 import java.util.Optional;
 
-public interface MetastoreLocator
+public interface TokenAwareMetastoreClientFactory
 {
     /**
      * Create a connected {@link ThriftMetastoreClient}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/TokenDelegationThriftMetastoreFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/TokenDelegationThriftMetastoreFactory.java
@@ -17,7 +17,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.trino.collect.cache.NonEvictableLoadingCache;
-import io.trino.hdfs.HdfsEnvironment;
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreAuthenticationConfig.ThriftMetastoreAuthenticationType;
 import io.trino.spi.TrinoException;
 import io.trino.spi.security.ConnectorIdentity;
@@ -46,8 +45,7 @@ public class TokenDelegationThriftMetastoreFactory
     public TokenDelegationThriftMetastoreFactory(
             MetastoreLocator metastoreLocator,
             ThriftMetastoreConfig thriftConfig,
-            ThriftMetastoreAuthenticationConfig authenticationConfig,
-            HdfsEnvironment hdfsEnvironment)
+            ThriftMetastoreAuthenticationConfig authenticationConfig)
     {
         this.clientProvider = requireNonNull(metastoreLocator, "metastoreLocator is null");
         this.impersonationEnabled = thriftConfig.isImpersonationEnabled();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/TokenFetchingMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/TokenFetchingMetastoreClientFactory.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.metastore.thrift;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import io.trino.collect.cache.NonEvictableLoadingCache;
+import io.trino.spi.TrinoException;
+import io.trino.spi.security.ConnectorIdentity;
+import org.apache.thrift.TException;
+
+import javax.inject.Inject;
+
+import java.util.Optional;
+
+import static com.google.common.base.Throwables.throwIfInstanceOf;
+import static io.trino.collect.cache.SafeCaches.buildNonEvictableCache;
+import static io.trino.plugin.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class TokenFetchingMetastoreClientFactory
+        implements IdentityAwareMetastoreClientFactory
+{
+    private final TokenAwareMetastoreClientFactory clientProvider;
+    private final boolean impersonationEnabled;
+    private final NonEvictableLoadingCache<String, String> delegationTokenCache;
+
+    @Inject
+    public TokenFetchingMetastoreClientFactory(
+            TokenAwareMetastoreClientFactory tokenAwareMetastoreClientFactory,
+            ThriftMetastoreConfig thriftConfig)
+    {
+        this.clientProvider = requireNonNull(tokenAwareMetastoreClientFactory, "tokenAwareMetastoreClientFactory is null");
+        this.impersonationEnabled = thriftConfig.isImpersonationEnabled();
+
+        this.delegationTokenCache = buildNonEvictableCache(
+                CacheBuilder.newBuilder()
+                        .expireAfterWrite(thriftConfig.getDelegationTokenCacheTtl().toMillis(), MILLISECONDS)
+                        .maximumSize(thriftConfig.getDelegationTokenCacheMaximumSize()),
+                CacheLoader.from(this::loadDelegationToken));
+    }
+
+    private ThriftMetastoreClient createMetastoreClient()
+            throws TException
+    {
+        return clientProvider.createMetastoreClient(Optional.empty());
+    }
+
+    @Override
+    public ThriftMetastoreClient createMetastoreClientFor(Optional<ConnectorIdentity> identity)
+            throws TException
+    {
+        if (!impersonationEnabled) {
+            return createMetastoreClient();
+        }
+
+        String username = identity.map(ConnectorIdentity::getUser)
+                .orElseThrow(() -> new IllegalStateException("End-user name should exist when metastore impersonation is enabled"));
+
+        String delegationToken;
+        try {
+            delegationToken = delegationTokenCache.getUnchecked(username);
+        }
+        catch (UncheckedExecutionException e) {
+            throwIfInstanceOf(e.getCause(), TrinoException.class);
+            throw e;
+        }
+        return clientProvider.createMetastoreClient(Optional.of(delegationToken));
+    }
+
+    private String loadDelegationToken(String username)
+    {
+        try (ThriftMetastoreClient client = createMetastoreClient()) {
+            return client.getDelegationToken(username);
+        }
+        catch (TException e) {
+            throw new TrinoException(HIVE_METASTORE_ERROR, e);
+        }
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/UgiBasedMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/UgiBasedMetastoreClientFactory.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.metastore.thrift;
+
+import io.trino.spi.security.ConnectorIdentity;
+import org.apache.thrift.TException;
+
+import javax.inject.Inject;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class UgiBasedMetastoreClientFactory
+        implements IdentityAwareMetastoreClientFactory
+{
+    private final TokenAwareMetastoreClientFactory clientProvider;
+    private final boolean impersonationEnabled;
+
+    @Inject
+    public UgiBasedMetastoreClientFactory(
+            TokenAwareMetastoreClientFactory clientProvider,
+            ThriftMetastoreConfig thriftConfig)
+    {
+        this.clientProvider = requireNonNull(clientProvider, "clientProvider is null");
+        this.impersonationEnabled = thriftConfig.isImpersonationEnabled();
+    }
+
+    @Override
+    public ThriftMetastoreClient createMetastoreClientFor(Optional<ConnectorIdentity> identity)
+            throws TException
+    {
+        ThriftMetastoreClient client = clientProvider.createMetastoreClient(Optional.empty());
+
+        if (impersonationEnabled) {
+            String username = identity.map(ConnectorIdentity::getUser)
+                    .orElseThrow(() -> new IllegalStateException("End-user name should exist when metastore impersonation is enabled"));
+            setMetastoreUserOrClose(client, username);
+        }
+
+        return client;
+    }
+
+    private static void setMetastoreUserOrClose(ThriftMetastoreClient client, String username)
+            throws TException
+    {
+        try {
+            client.setUGI(username);
+        }
+        catch (Throwable t) {
+            // close client and suppress any error from close
+            try (Closeable ignored = client) {
+                throw t;
+            }
+            catch (IOException e) {
+                // impossible; will be suppressed
+            }
+        }
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestingThriftHiveMetastoreBuilder.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestingThriftHiveMetastoreBuilder.java
@@ -26,14 +26,13 @@ import io.trino.plugin.hive.azure.TrinoAzureConfigurationInitializer;
 import io.trino.plugin.hive.gcs.GoogleGcsConfigurationInitializer;
 import io.trino.plugin.hive.gcs.HiveGcsConfig;
 import io.trino.plugin.hive.metastore.HiveMetastoreConfig;
-import io.trino.plugin.hive.metastore.thrift.IdentityAwareMetastoreClientFactory;
 import io.trino.plugin.hive.metastore.thrift.TestingTokenAwareMetastoreClientFactory;
 import io.trino.plugin.hive.metastore.thrift.ThriftHiveMetastoreFactory;
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastore;
-import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreAuthenticationConfig;
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreClient;
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreConfig;
 import io.trino.plugin.hive.metastore.thrift.TokenAwareMetastoreClientFactory;
+import io.trino.plugin.hive.metastore.thrift.UgiBasedMetastoreClientFactory;
 import io.trino.plugin.hive.s3.HiveS3Config;
 import io.trino.plugin.hive.s3.TrinoS3ConfigurationInitializer;
 
@@ -116,10 +115,7 @@ public final class TestingThriftHiveMetastoreBuilder
     {
         checkState(tokenAwareMetastoreClientFactory != null, "metastore client not set");
         ThriftHiveMetastoreFactory metastoreFactory = new ThriftHiveMetastoreFactory(
-                new IdentityAwareMetastoreClientFactory(
-                        tokenAwareMetastoreClientFactory,
-                        thriftMetastoreConfig,
-                        new ThriftMetastoreAuthenticationConfig()),
+                new UgiBasedMetastoreClientFactory(tokenAwareMetastoreClientFactory, thriftMetastoreConfig),
                 new HiveMetastoreConfig().isHideDeltaLakeTables(),
                 hiveConfig.isTranslateHiveViews(),
                 thriftMetastoreConfig,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestingThriftHiveMetastoreBuilder.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestingThriftHiveMetastoreBuilder.java
@@ -119,8 +119,7 @@ public final class TestingThriftHiveMetastoreBuilder
                 new TokenDelegationThriftMetastoreFactory(
                         metastoreLocator,
                         thriftMetastoreConfig,
-                        new ThriftMetastoreAuthenticationConfig(),
-                        hdfsEnvironment),
+                        new ThriftMetastoreAuthenticationConfig()),
                 new HiveMetastoreConfig().isHideDeltaLakeTables(),
                 hiveConfig.isTranslateHiveViews(),
                 thriftMetastoreConfig,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestingTokenAwareMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestingTokenAwareMetastoreClientFactory.java
@@ -22,8 +22,8 @@ import java.util.Optional;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-public class TestingMetastoreLocator
-        implements MetastoreLocator
+public class TestingTokenAwareMetastoreClientFactory
+        implements TokenAwareMetastoreClientFactory
 {
     private static final HiveMetastoreAuthentication AUTHENTICATION = new NoHiveMetastoreAuthentication();
     public static final Duration TIMEOUT = new Duration(20, SECONDS);
@@ -31,12 +31,12 @@ public class TestingMetastoreLocator
     private final DefaultThriftMetastoreClientFactory factory;
     private final HostAndPort address;
 
-    public TestingMetastoreLocator(Optional<HostAndPort> socksProxy, HostAndPort address)
+    public TestingTokenAwareMetastoreClientFactory(Optional<HostAndPort> socksProxy, HostAndPort address)
     {
         this(socksProxy, address, TIMEOUT);
     }
 
-    public TestingMetastoreLocator(Optional<HostAndPort> socksProxy, HostAndPort address, Duration timeout)
+    public TestingTokenAwareMetastoreClientFactory(Optional<HostAndPort> socksProxy, HostAndPort address, Duration timeout)
     {
         this.factory = new DefaultThriftMetastoreClientFactory(Optional.empty(), socksProxy, timeout, AUTHENTICATION, "localhost");
         this.address = requireNonNull(address, "address is null");

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/S3HiveQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/S3HiveQueryRunner.java
@@ -20,7 +20,7 @@ import io.airlift.units.Duration;
 import io.trino.plugin.hive.HiveQueryRunner;
 import io.trino.plugin.hive.containers.HiveMinioDataLake;
 import io.trino.plugin.hive.metastore.thrift.BridgingHiveMetastore;
-import io.trino.plugin.hive.metastore.thrift.TestingMetastoreLocator;
+import io.trino.plugin.hive.metastore.thrift.TestingTokenAwareMetastoreClientFactory;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.tpch.TpchTable;
 
@@ -84,7 +84,7 @@ public final class S3HiveQueryRunner
             extends HiveQueryRunner.Builder<Builder>
     {
         private HostAndPort hiveMetastoreEndpoint;
-        private Duration thriftMetastoreTimeout = TestingMetastoreLocator.TIMEOUT;
+        private Duration thriftMetastoreTimeout = TestingTokenAwareMetastoreClientFactory.TIMEOUT;
         private String s3Endpoint;
         private String s3AccessKey;
         private String s3SecretKey;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

We've a requirement for using an external service to authenticate to HMS as Trino, and also fetch HMS delegation tokens for the end-user. So proposing this change to make these components to be provided by an external module.  ( Using optional binder to avoid having to make ThriftMetastoreAuthenticationType enum a string)

The PR contains following major changes:

* Rename the Thrift metastore client factories to distinguish them better given what the interface exposes

| Interface old name                          | Signature                                                     | Return Type           | New name                                 |
|---------------------------------------------|---------------------------------------------------------------|-----------------------|------------------------------------------|
| ThriftMetastoreFactory (highest level)      | createMetastore(Optional\<ConnectorIdentity\> identity)         | ThriftMetastore       | ThriftMetastoreFactory (unchanged)       |
| TokenDelegationThriftMetastoreFactory       | createMetastoreClient(Optional\<ConnectorIdentity\> identity)   | ThriftMetastoreClient | **IdentityAwareMetastoreClientFactory**      |
| MetastoreLocator                            | createMetastoreClient(Optional\<String\> token)         | ThriftMetastoreClient | **TokenAwareMetastoreClientFactory**          |
| ThriftMetastoreClientFactory (lowest level) | create(HostAndPort address, Optional\<String\> delegationToken) | ThriftMetastoreClient | ThriftMetastoreClientFactory (unchanged) |

* Narrow down usage of `ThriftMetastoreAuthenticationType` to make auth decision. (Also makes `TokenDelegationThriftMetastoreFactory` aka `IdentityAwareMetastoreClientFactory` an interface)

* Allow binding your own thrift authentication module 

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
