### PR TITLE
Add check for jdbc:mariadb legacy connection-url

### DIFF
--- a/plugin/trino-singlestore/pom.xml
+++ b/plugin/trino-singlestore/pom.xml
@@ -72,6 +72,12 @@
         <!-- used by tests but also needed transitively -->
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>log-manager</artifactId>
             <scope>runtime</scope>
         </dependency>

--- a/plugin/trino-singlestore/src/main/java/io/trino/plugin/singlestore/SingleStoreClientModule.java
+++ b/plugin/trino-singlestore/src/main/java/io/trino/plugin/singlestore/SingleStoreClientModule.java
@@ -19,7 +19,6 @@ import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import com.singlestore.jdbc.Driver;
-import io.trino.plugin.jdbc.BaseJdbcConfig;
 import io.trino.plugin.jdbc.ConnectionFactory;
 import io.trino.plugin.jdbc.DecimalModule;
 import io.trino.plugin.jdbc.DriverConnectionFactory;
@@ -41,6 +40,7 @@ public class SingleStoreClientModule
     public void configure(Binder binder)
     {
         binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class).to(SingleStoreClient.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfig(SingleStoreJdbcConfig.class);
         configBinder(binder).bindConfig(SingleStoreConfig.class);
         binder.install(new DecimalModule());
         newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(Query.class).in(Scopes.SINGLETON);
@@ -49,7 +49,7 @@ public class SingleStoreClientModule
     @Provides
     @Singleton
     @ForBaseJdbc
-    public static ConnectionFactory createConnectionFactory(BaseJdbcConfig config, CredentialProvider credentialProvider, SingleStoreConfig singleStoreConfig)
+    public static ConnectionFactory createConnectionFactory(SingleStoreJdbcConfig config, CredentialProvider credentialProvider, SingleStoreConfig singleStoreConfig)
     {
         Properties connectionProperties = new Properties();
         // we don't want to interpret tinyInt type (with cardinality as 2) as boolean/bit

--- a/plugin/trino-singlestore/src/main/java/io/trino/plugin/singlestore/SingleStoreJdbcConfig.java
+++ b/plugin/trino-singlestore/src/main/java/io/trino/plugin/singlestore/SingleStoreJdbcConfig.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.singlestore;
+
+import io.trino.plugin.jdbc.BaseJdbcConfig;
+
+import javax.validation.constraints.AssertFalse;
+
+public class SingleStoreJdbcConfig
+        extends BaseJdbcConfig
+{
+    public static final String DRIVER_PROTOCOL_ERROR = "This connector uses the official Single Store JDBC Driver. As a result, `connection-url` in catalog " +
+            " configuration files needs to be updated from `jdbc:mariadb:...` to `jdbc:singlestore:...`";
+
+    @AssertFalse(message = DRIVER_PROTOCOL_ERROR)
+    public boolean isLegacyDriverConnectionUrl()
+    {
+        // including "jdbc:" portion in case-insensitive match in case other url parts also contain "mariadb" literal
+        return getConnectionUrl().matches("(?i)jdbc:mariadb:.*");
+    }
+}

--- a/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/TestSingleStoreJdbcConfig.java
+++ b/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/TestSingleStoreJdbcConfig.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.singlestore;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.bootstrap.ApplicationConfigurationException;
+import io.trino.spi.Plugin;
+import io.trino.spi.connector.ConnectorFactory;
+import io.trino.testing.TestingConnectorContext;
+import org.testng.annotations.Test;
+
+import static com.google.common.collect.MoreCollectors.toOptional;
+import static com.google.common.collect.Streams.stream;
+import static io.trino.plugin.singlestore.SingleStoreJdbcConfig.DRIVER_PROTOCOL_ERROR;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestSingleStoreJdbcConfig
+{
+    @Test
+    public void testCreateConnectorLegacyUrl()
+    {
+        Plugin plugin = new SingleStorePlugin();
+        ConnectorFactory factory = stream(plugin.getConnectorFactories())
+                .filter(connectorFactory -> connectorFactory.getName().equals("singlestore"))
+                .collect(toOptional())
+                .orElseThrow();
+        assertThatThrownBy(() -> factory.create("test", ImmutableMap.of("connection-url", "jdbc:mariadb:test"), new TestingConnectorContext()))
+                .isInstanceOf(ApplicationConfigurationException.class)
+                .hasMessageContaining(DRIVER_PROTOCOL_ERROR);
+    }
+
+    @Test
+    public void testLegacyConnectionUrl()
+    {
+        assertTrue(isLegacyDriverSubprotocol("jdbc:mariadb:"));
+        assertTrue(isLegacyDriverSubprotocol("JDBC:MARIADB:"));
+        assertTrue(isLegacyDriverSubprotocol("jdbc:mariadb:test"));
+        assertFalse(isLegacyDriverSubprotocol("jdbc:singlestore:test"));
+    }
+
+    private static boolean isLegacyDriverSubprotocol(String url)
+    {
+        SingleStoreJdbcConfig config = new SingleStoreJdbcConfig();
+        config.setConnectionUrl(url);
+        return config.isLegacyDriverConnectionUrl();
+    }
+}

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-all/memsql.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-all/memsql.properties
@@ -1,4 +1,4 @@
 connector.name=memsql
-connection-url=jdbc:mariadb://host1.invalid:3306
+connection-url=jdbc:singlestore://host1.invalid:3306
 connection-user=root
 connection-password=secret


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

Since Trino 374 SingleStore Connector Connection URL subprotocol has changed from `jdbc:mariadb` to `jdbc:singlestore`.
This PR attempts to detect legacy connection urls and provide an exception message which is useful for the user.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement in error message

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Connector (SingleStore Connector)

> How would you describe this change to a non-technical end user or system administrator?

Improved error message for common misconfiguration error

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
