### PR TITLE
Fix and test table functions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -1586,11 +1586,11 @@ class StatementAnalyzer
                 throw semanticException(INVALID_ARGUMENTS, errorLocation, "Too many arguments. Expected at most %s arguments, got %s arguments", argumentSpecifications.size(), arguments.size());
             }
 
-            if (arguments.isEmpty()) {
+            if (argumentSpecifications.isEmpty()) {
                 return ImmutableMap.of();
             }
 
-            boolean argumentsPassedByName = arguments.stream().allMatch(argument -> argument.getName().isPresent());
+            boolean argumentsPassedByName = !arguments.isEmpty() && arguments.stream().allMatch(argument -> argument.getName().isPresent());
             boolean argumentsPassedByPosition = arguments.stream().allMatch(argument -> argument.getName().isEmpty());
             if (!argumentsPassedByName && !argumentsPassedByPosition) {
                 throw semanticException(INVALID_ARGUMENTS, errorLocation, "All arguments must be passed by name or all must be passed positionally");

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
@@ -43,12 +43,15 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
 import io.trino.spi.connector.SortItem;
 import io.trino.spi.connector.TableColumnsMetadata;
+import io.trino.spi.connector.TableFunctionApplicationResult;
 import io.trino.spi.connector.TableScanRedirectApplicationResult;
 import io.trino.spi.connector.TopNApplicationResult;
 import io.trino.spi.eventlistener.EventListener;
 import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.metrics.Metrics;
 import io.trino.spi.procedure.Procedure;
+import io.trino.spi.ptf.ConnectorTableFunction;
+import io.trino.spi.ptf.ConnectorTableFunctionHandle;
 import io.trino.spi.security.RoleGrant;
 import io.trino.spi.security.ViewExpression;
 import io.trino.spi.session.PropertyMetadata;
@@ -91,6 +94,7 @@ public class MockConnectorFactory
     private final ApplyJoin applyJoin;
     private final ApplyTopN applyTopN;
     private final ApplyFilter applyFilter;
+    private final ApplyTableFunction applyTableFunction;
     private final ApplyTableScanRedirect applyTableScanRedirect;
     private final BiFunction<ConnectorSession, SchemaTableName, Optional<CatalogSchemaTableName>> redirectTable;
     private final BiFunction<ConnectorSession, SchemaTableName, Optional<ConnectorTableLayout>> getInsertLayout;
@@ -100,6 +104,7 @@ public class MockConnectorFactory
     private final Function<SchemaTableName, List<List<?>>> data;
     private final Function<SchemaTableName, Metrics> metrics;
     private final Set<Procedure> procedures;
+    private final Set<ConnectorTableFunction> tableFunctions;
     private final boolean allowMissingColumnsOnInsert;
     private final Supplier<List<PropertyMetadata<?>>> schemaProperties;
     private final Supplier<List<PropertyMetadata<?>>> tableProperties;
@@ -128,6 +133,7 @@ public class MockConnectorFactory
             ApplyJoin applyJoin,
             ApplyTopN applyTopN,
             ApplyFilter applyFilter,
+            ApplyTableFunction applyTableFunction,
             ApplyTableScanRedirect applyTableScanRedirect,
             BiFunction<ConnectorSession, SchemaTableName, Optional<CatalogSchemaTableName>> redirectTable,
             BiFunction<ConnectorSession, SchemaTableName, Optional<ConnectorTableLayout>> getInsertLayout,
@@ -137,6 +143,7 @@ public class MockConnectorFactory
             Function<SchemaTableName, List<List<?>>> data,
             Function<SchemaTableName, Metrics> metrics,
             Set<Procedure> procedures,
+            Set<ConnectorTableFunction> tableFunctions,
             Supplier<List<PropertyMetadata<?>>> schemaProperties,
             Supplier<List<PropertyMetadata<?>>> tableProperties,
             Optional<ConnectorNodePartitioningProvider> partitioningProvider,
@@ -162,6 +169,7 @@ public class MockConnectorFactory
         this.applyJoin = requireNonNull(applyJoin, "applyJoin is null");
         this.applyTopN = requireNonNull(applyTopN, "applyTopN is null");
         this.applyFilter = requireNonNull(applyFilter, "applyFilter is null");
+        this.applyTableFunction = requireNonNull(applyTableFunction, "applyTableFunction is null");
         this.applyTableScanRedirect = requireNonNull(applyTableScanRedirect, "applyTableScanRedirection is null");
         this.redirectTable = requireNonNull(redirectTable, "redirectTable is null");
         this.getInsertLayout = requireNonNull(getInsertLayout, "getInsertLayout is null");
@@ -176,6 +184,7 @@ public class MockConnectorFactory
         this.data = requireNonNull(data, "data is null");
         this.metrics = requireNonNull(metrics, "metrics is null");
         this.procedures = requireNonNull(procedures, "procedures is null");
+        this.tableFunctions = requireNonNull(tableFunctions, "tableFunctions is null");
         this.allowMissingColumnsOnInsert = allowMissingColumnsOnInsert;
         this.supportsReportingWrittenBytes = supportsReportingWrittenBytes;
     }
@@ -206,6 +215,7 @@ public class MockConnectorFactory
                 applyJoin,
                 applyTopN,
                 applyFilter,
+                applyTableFunction,
                 applyTableScanRedirect,
                 redirectTable,
                 getInsertLayout,
@@ -218,6 +228,7 @@ public class MockConnectorFactory
                 data,
                 metrics,
                 procedures,
+                tableFunctions,
                 allowMissingColumnsOnInsert,
                 schemaProperties,
                 tableProperties,
@@ -297,6 +308,12 @@ public class MockConnectorFactory
     }
 
     @FunctionalInterface
+    public interface ApplyTableFunction
+    {
+        Optional<TableFunctionApplicationResult<ConnectorTableHandle>> apply(ConnectorSession session, ConnectorTableFunctionHandle handle);
+    }
+
+    @FunctionalInterface
     public interface ListRoleGrants
     {
         Set<RoleGrant> apply(ConnectorSession session, Optional<Set<String>> roles, Optional<Set<String>> grantees, OptionalLong limit);
@@ -325,11 +342,13 @@ public class MockConnectorFactory
         private Supplier<Iterable<EventListener>> eventListeners = ImmutableList::of;
         private ApplyTopN applyTopN = (session, handle, topNCount, sortItems, assignments) -> Optional.empty();
         private ApplyFilter applyFilter = (session, handle, constraint) -> Optional.empty();
+        private ApplyTableFunction applyTableFunction = (session, handle) -> Optional.empty();
         private ApplyTableScanRedirect applyTableScanRedirect = (session, handle) -> Optional.empty();
         private BiFunction<ConnectorSession, SchemaTableName, Optional<CatalogSchemaTableName>> redirectTable = (session, tableName) -> Optional.empty();
         private Function<SchemaTableName, List<List<?>>> data = schemaTableName -> ImmutableList.of();
         private Function<SchemaTableName, Metrics> metrics = schemaTableName -> EMPTY;
         private Set<Procedure> procedures = ImmutableSet.of();
+        private Set<ConnectorTableFunction> tableFunctions = ImmutableSet.of();
         private Supplier<List<PropertyMetadata<?>>> schemaProperties = ImmutableList::of;
         private Supplier<List<PropertyMetadata<?>>> tableProperties = ImmutableList::of;
         private Optional<ConnectorNodePartitioningProvider> partitioningProvider = Optional.empty();
@@ -456,6 +475,12 @@ public class MockConnectorFactory
             return this;
         }
 
+        public Builder withApplyTableFunction(ApplyTableFunction applyTableFunction)
+        {
+            this.applyTableFunction = applyTableFunction;
+            return this;
+        }
+
         public Builder withApplyTableScanRedirect(ApplyTableScanRedirect applyTableScanRedirect)
         {
             this.applyTableScanRedirect = applyTableScanRedirect;
@@ -517,6 +542,12 @@ public class MockConnectorFactory
         public Builder withProcedures(Iterable<Procedure> procedures)
         {
             this.procedures = ImmutableSet.copyOf(procedures);
+            return this;
+        }
+
+        public Builder withTableFunctions(Iterable<ConnectorTableFunction> tableFunctions)
+        {
+            this.tableFunctions = ImmutableSet.copyOf(tableFunctions);
             return this;
         }
 
@@ -609,6 +640,7 @@ public class MockConnectorFactory
                     applyJoin,
                     applyTopN,
                     applyFilter,
+                    applyTableFunction,
                     applyTableScanRedirect,
                     redirectTable,
                     getInsertLayout,
@@ -618,6 +650,7 @@ public class MockConnectorFactory
                     data,
                     metrics,
                     procedures,
+                    tableFunctions,
                     schemaProperties,
                     tableProperties,
                     partitioningProvider,

--- a/core/trino-main/src/test/java/io/trino/connector/TestingTableFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/connector/TestingTableFunctions.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.connector;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.ptf.AbstractConnectorTableFunction;
+import io.trino.spi.ptf.Argument;
+import io.trino.spi.ptf.ConnectorTableFunctionHandle;
+import io.trino.spi.ptf.Descriptor;
+import io.trino.spi.ptf.ScalarArgument;
+import io.trino.spi.ptf.ScalarArgumentSpecification;
+import io.trino.spi.ptf.TableFunctionAnalysis;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.spi.ptf.ReturnTypeSpecification.GenericTable.GENERIC_TABLE;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+
+public class TestingTableFunctions
+{
+    /**
+     * A table function returning a table with single empty column of type BOOLEAN.
+     * The argument `COLUMN` is the column name.
+     * The argument `IGNORED` is ignored.
+     * Both arguments are optional.
+     */
+    public static class SimpleTableFunction
+            extends AbstractConnectorTableFunction
+    {
+        private static final String SCHEMA_NAME = "system";
+        private static final String FUNCTION_NAME = "simple_table_function";
+        private static final String TABLE_NAME = "simple_table";
+
+        public SimpleTableFunction()
+        {
+            super(
+                    SCHEMA_NAME,
+                    FUNCTION_NAME,
+                    List.of(ScalarArgumentSpecification.builder()
+                                    .name("COLUMN")
+                                    .type(VARCHAR)
+                                    .defaultValue(utf8Slice("col"))
+                                    .build(),
+                            ScalarArgumentSpecification.builder()
+                                    .name("IGNORED")
+                                    .type(BIGINT)
+                                    .defaultValue(0L)
+                                    .build()),
+                    GENERIC_TABLE);
+        }
+
+        @Override
+        public TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments)
+        {
+            ScalarArgument argument = (ScalarArgument) arguments.get("COLUMN");
+            String columnName = ((Slice) argument.getValue()).toStringUtf8();
+
+            return TableFunctionAnalysis.builder()
+                    .handle(new SimpleTableFunctionHandle(getSchema(), TABLE_NAME, columnName))
+                    .returnedType(new Descriptor(ImmutableList.of(new Descriptor.Field(columnName, Optional.of(BOOLEAN)))))
+                    .build();
+        }
+
+        public static class SimpleTableFunctionHandle
+                implements ConnectorTableFunctionHandle
+        {
+            private final MockConnectorTableHandle tableHandle;
+
+            public SimpleTableFunctionHandle(String schema, String table, String column)
+            {
+                this.tableHandle = new MockConnectorTableHandle(
+                        new SchemaTableName(schema, table),
+                        TupleDomain.all(),
+                        Optional.of(ImmutableList.of(new MockConnectorColumnHandle(column, BOOLEAN))));
+            }
+
+            public MockConnectorTableHandle getTableHandle()
+            {
+                return tableHandle;
+            }
+        }
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/Primitives.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/Primitives.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.ptf;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+// Note: this code was forked from com.google.common.primitives.Primitives
+// Copyright (C) 2007 The Guava Authors
+final class Primitives
+{
+    private Primitives() {}
+
+    private static final Map<Class<?>, Class<?>> WRAPPERS = new HashMap<>();
+
+    static {
+        WRAPPERS.put(boolean.class, Boolean.class);
+        WRAPPERS.put(byte.class, Byte.class);
+        WRAPPERS.put(char.class, Character.class);
+        WRAPPERS.put(double.class, Double.class);
+        WRAPPERS.put(float.class, Float.class);
+        WRAPPERS.put(int.class, Integer.class);
+        WRAPPERS.put(long.class, Long.class);
+        WRAPPERS.put(short.class, Short.class);
+    }
+
+    public static <T> Class<T> wrap(Class<T> type)
+    {
+        requireNonNull(type);
+
+        // cast is safe: long.class and Long.class are both of type Class<Long>
+        @SuppressWarnings("unchecked")
+        Class<T> wrapped = (Class<T>) WRAPPERS.get(type);
+        return (wrapped == null) ? type : wrapped;
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/ScalarArgumentSpecification.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/ScalarArgumentSpecification.java
@@ -29,7 +29,7 @@ public class ScalarArgumentSpecification
         super(name, required, defaultValue);
         this.type = requireNonNull(type, "type is null");
         if (defaultValue != null) {
-            checkArgument(type.getJavaType().equals(defaultValue.getClass()), format("default value %s does not match the declared type: %s", defaultValue, type));
+            checkArgument(Primitives.wrap(type.getJavaType()).isInstance(defaultValue), format("default value %s does not match the declared type: %s", defaultValue, type));
         }
     }
 

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestTableFunctionInvocation.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestTableFunctionInvocation.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests;
+
+import com.google.common.collect.ImmutableSet;
+import io.trino.connector.MockConnectorFactory;
+import io.trino.connector.MockConnectorPlugin;
+import io.trino.connector.TestingTableFunctions.SimpleTableFunction;
+import io.trino.connector.TestingTableFunctions.SimpleTableFunction.SimpleTableFunctionHandle;
+import io.trino.spi.connector.TableFunctionApplicationResult;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestTableFunctionInvocation
+        extends AbstractTestQueryFramework
+{
+    private static final String TESTING_CATALOG = "testing_catalog";
+    private static final String TABLE_FUNCTION_SCHEMA = "table_function_schema";
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return DistributedQueryRunner.builder(testSessionBuilder()
+                        .setCatalog(TESTING_CATALOG)
+                        .setSchema(TABLE_FUNCTION_SCHEMA)
+                        .build())
+                .build();
+    }
+
+    @BeforeClass
+    public void setUp()
+    {
+        DistributedQueryRunner queryRunner = getDistributedQueryRunner();
+
+        queryRunner.installPlugin(new MockConnectorPlugin(MockConnectorFactory.builder()
+                .withTableFunctions(ImmutableSet.of(new SimpleTableFunction()))
+                .withApplyTableFunction((session, handle) -> {
+                    if (handle instanceof SimpleTableFunctionHandle) {
+                        SimpleTableFunctionHandle functionHandle = (SimpleTableFunctionHandle) handle;
+                        return Optional.of(new TableFunctionApplicationResult<>(functionHandle.getTableHandle(), functionHandle.getTableHandle().getColumns().orElseThrow()));
+                    }
+                    throw new IllegalStateException("Unsupported table function handle: " + handle.getClass().getSimpleName());
+                })
+                .build()));
+        queryRunner.createCatalog(TESTING_CATALOG, "mock");
+    }
+
+    @Test
+    public void testPrimitiveDefaultArgument()
+    {
+        assertThat(query("SELECT boolean_column FROM TABLE(system.simple_table_function(column => 'boolean_column', ignored => 1))"))
+                .matches("SELECT true WHERE false");
+
+        // skip the `ignored` argument.
+        assertThat(query("SELECT boolean_column FROM TABLE(system.simple_table_function(column => 'boolean_column'))"))
+                .matches("SELECT true WHERE false");
+    }
+}

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestTableFunctionInvocation.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestTableFunctionInvocation.java
@@ -75,4 +75,11 @@ public class TestTableFunctionInvocation
         assertThat(query("SELECT boolean_column FROM TABLE(system.simple_table_function(column => 'boolean_column'))"))
                 .matches("SELECT true WHERE false");
     }
+
+    @Test
+    public void testNoArgumentsPassed()
+    {
+        assertThat(query("SELECT col FROM TABLE(system.simple_table_function())"))
+                .matches("SELECT true WHERE false");
+    }
 }


### PR DESCRIPTION
## Release notes

```markdown
# General
* Fix query failure when no arguments are passed to a table function.

// here I'm not sure about the category. The bug was in SPI, but there is no SPI change
* Fix potential failure when declaring default arguments to a table function.
```

No docs needed.