### PR TITLE
Fix query executor used in TestIcebergSparkDropTableCompatibility

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/Engine.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/Engine.java
@@ -16,6 +16,7 @@ package io.trino.tests.product.hive;
 import io.trino.tempto.query.QueryExecutor;
 
 import static io.trino.tests.product.utils.QueryExecutors.onHive;
+import static io.trino.tests.product.utils.QueryExecutors.onSpark;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 
 public enum Engine
@@ -38,7 +39,7 @@ public enum Engine
         @Override
         public QueryExecutor queryExecutor()
         {
-            return onTrino();
+            return onSpark();
         }
     },
     /**/;

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkDropTableCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkDropTableCompatibility.java
@@ -83,7 +83,8 @@ public class TestIcebergSparkDropTableCompatibility
         List<String> dataFilePaths = getDataFilePaths(tableName);
 
         tableDropperEngine.queryExecutor().executeQuery("DROP TABLE " + tableName);
-        assertFileExistence(tableDirectory, false, format("The table directory %s should be removed after dropping the table", tableDirectory));
+        boolean expectExists = tableDropperEngine == SPARK; // Note: Spark's behavior is Catalog dependent
+        assertFileExistence(tableDirectory, expectExists, format("The table directory %s should be removed after dropping the table", tableDirectory));
         dataFilePaths.forEach(dataFilePath -> assertFileExistence(dataFilePath, false, format("The data file %s removed after dropping the table", dataFilePath)));
     }
 


### PR DESCRIPTION
Fix query executor used in
TestIcebergSparkDropTableCompatibility.testCleanupOnDropTable.
