### PR TITLE
Cleanup TestDeltaLakeDropTableCompatibility

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDropTableCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDropTableCompatibility.java
@@ -18,12 +18,17 @@ import com.amazonaws.services.s3.model.ObjectListing;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import io.trino.tempto.BeforeTestWithContext;
+import io.trino.tests.product.hive.Engine;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import java.util.Optional;
 
 import static io.trino.tests.product.TestGroups.DELTA_LAKE_DATABRICKS;
 import static io.trino.tests.product.TestGroups.DELTA_LAKE_OSS;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static io.trino.tests.product.hive.Engine.DELTA;
+import static io.trino.tests.product.hive.Engine.TRINO;
 import static io.trino.tests.product.hive.util.TemporaryHiveTable.randomTableSuffix;
 import static io.trino.tests.product.utils.QueryExecutors.onDelta;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
@@ -33,9 +38,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestDeltaLakeDropTableCompatibility
         extends BaseTestDeltaLakeS3Storage
 {
-    private static final Engine TRINO_ENGINE = new TrinoEngine();
-    private static final Engine DATABRICKS_ENGINE = new DatabricksEngine();
-
     @Inject
     @Named("s3.server_type")
     private String s3ServerType;
@@ -53,39 +55,62 @@ public class TestDeltaLakeDropTableCompatibility
     public static Object[][] engineConfigurations()
     {
         return new Object[][] {
-                {TRINO_ENGINE, TRINO_ENGINE, true},
-                {TRINO_ENGINE, TRINO_ENGINE, false},
-                {TRINO_ENGINE, DATABRICKS_ENGINE, true},
-                {TRINO_ENGINE, DATABRICKS_ENGINE, false},
-                {DATABRICKS_ENGINE, TRINO_ENGINE, true},
-                {DATABRICKS_ENGINE, TRINO_ENGINE, false},
-                {DATABRICKS_ENGINE, DATABRICKS_ENGINE, true},
-                {DATABRICKS_ENGINE, DATABRICKS_ENGINE, false},
+                {TRINO, TRINO, true},
+                {TRINO, TRINO, false},
+                {TRINO, DELTA, true},
+                {TRINO, DELTA, false},
+                {DELTA, TRINO, true},
+                {DELTA, TRINO, false},
+                {DELTA, DELTA, true},
+                {DELTA, DELTA, false},
         };
     }
 
     @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_OSS, PROFILE_SPECIFIC_TESTS}, dataProvider = "engineConfigurations")
     public void testDatabricksManagedTableDroppedFromTrino(Engine creator, Engine dropper, boolean explicitLocation)
     {
-        testCleanupOnDrop(creator, dropper, explicitLocation);
-    }
-
-    private void testCleanupOnDrop(Engine creator, Engine dropper, boolean explicitLocation)
-    {
         String schemaName = "schema_with_location_" + randomTableSuffix();
+        String schemaLocation = format("s3://%s/databricks-compatibility-test-%s", bucketName, schemaName);
         String tableName = explicitLocation ? "external_table" : "managed_table";
-        creator.createSchema(schemaName, format("s3://%s/databricks-compatibility-test-%s", bucketName, schemaName));
+        Optional<String> tableLocation = explicitLocation
+                ? Optional.of(format("s3://" + bucketName + "/databricks-compatibility-test-%s/%s", schemaName, tableName))
+                : Optional.empty();
+
+        switch (creator) {
+            case TRINO:
+                onTrino().executeQuery(format("CREATE SCHEMA delta.%s WITH (location = '%s')", schemaName, schemaLocation));
+                break;
+            case DELTA:
+                onDelta().executeQuery(format("CREATE SCHEMA %s LOCATION \"%s\"", schemaName, schemaLocation));
+                break;
+            default:
+                throw new UnsupportedOperationException("Unsupported engine: " + creator);
+        }
         try {
             onTrino().executeQuery("USE delta." + schemaName);
-            String tableLocation = explicitLocation ?
-                    format("s3://" + bucketName + "/databricks-compatibility-test-%s/%s", schemaName, tableName) :
-                    "";
-            creator.createTable(schemaName, tableName, tableLocation);
+            switch (creator) {
+                case TRINO:
+                    onTrino().executeQuery(format(
+                            "CREATE TABLE %s.%s (a, b) %s AS VALUES (1, 2), (2, 3), (3, 4)",
+                            schemaName,
+                            tableName,
+                            tableLocation.map(location -> "WITH (location = '" + location + "')").orElse("")));
+                    break;
+                case DELTA:
+                    onDelta().executeQuery(format(
+                            "CREATE TABLE %s.%s USING DELTA %s AS VALUES (1, 2), (2, 3), (3, 4)",
+                            schemaName,
+                            tableName,
+                            tableLocation.map(location -> "LOCATION \"" + location + "\"").orElse("")));
+                    break;
+                default:
+                    throw new UnsupportedOperationException("Unsupported engine: " + creator);
+            }
 
             ObjectListing tableFiles = s3.listObjects(bucketName, "databricks-compatibility-test-" + schemaName + "/" + tableName);
             assertThat(tableFiles.getObjectSummaries()).isNotEmpty();
 
-            dropper.dropTable(schemaName, tableName);
+            dropper.queryExecutor().executeQuery("DROP TABLE " + schemaName + "." + tableName);
             tableFiles = s3.listObjects(bucketName, "databricks-compatibility-test-" + schemaName + "/" + tableName);
             if (explicitLocation) {
                 assertThat(tableFiles.getObjectSummaries()).isNotEmpty();
@@ -97,61 +122,6 @@ public class TestDeltaLakeDropTableCompatibility
         finally {
             onDelta().executeQuery("DROP TABLE IF EXISTS " + schemaName + "." + tableName);
             onDelta().executeQuery("DROP SCHEMA " + schemaName);
-        }
-    }
-
-    private interface Engine
-    {
-        void createSchema(String schemaName, String location);
-
-        void createTable(String schemaName, String tableName, String location);
-
-        void dropTable(String schemaName, String tableName);
-    }
-
-    private static class TrinoEngine
-            implements Engine
-    {
-        @Override
-        public void createSchema(String schemaName, String location)
-        {
-            onTrino().executeQuery(format("CREATE SCHEMA delta.%s WITH (location = '%s')", schemaName, location));
-        }
-
-        @Override
-        public void createTable(String schemaName, String tableName, String location)
-        {
-            String locationStatement = location.isEmpty() ? "" : "WITH (location = '" + location + "')";
-            onTrino().executeQuery(format("CREATE TABLE %s.%s (a, b) %s AS VALUES (1, 2), (2, 3), (3, 4)", schemaName, tableName, locationStatement));
-        }
-
-        @Override
-        public void dropTable(String schemaName, String tableName)
-        {
-            onTrino().executeQuery("DROP TABLE " + schemaName + "." + tableName);
-        }
-    }
-
-    private static class DatabricksEngine
-            implements Engine
-    {
-        @Override
-        public void createSchema(String schemaName, String location)
-        {
-            onDelta().executeQuery(format("CREATE SCHEMA %s LOCATION \"%s\"", schemaName, location));
-        }
-
-        @Override
-        public void createTable(String schemaName, String tableName, String location)
-        {
-            String locationStatement = location.isEmpty() ? "" : "LOCATION \"" + location + "\"";
-            onDelta().executeQuery(format("CREATE TABLE %s.%s USING DELTA %s AS VALUES (1, 2), (2, 3), (3, 4)", schemaName, tableName, locationStatement));
-        }
-
-        @Override
-        public void dropTable(String schemaName, String tableName)
-        {
-            onDelta().executeQuery("DROP TABLE " + schemaName + "." + tableName);
         }
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/Engine.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/Engine.java
@@ -15,6 +15,7 @@ package io.trino.tests.product.hive;
 
 import io.trino.tempto.query.QueryExecutor;
 
+import static io.trino.tests.product.utils.QueryExecutors.onDelta;
 import static io.trino.tests.product.utils.QueryExecutors.onHive;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 
@@ -32,6 +33,13 @@ public enum Engine
         public QueryExecutor queryExecutor()
         {
             return onTrino();
+        }
+    },
+    DELTA {
+        @Override
+        public QueryExecutor queryExecutor()
+        {
+            return onDelta();
         }
     },
     SPARK {


### PR DESCRIPTION
Remove `Engine` interface (local to this test) and replace its use with
the `Engine` enum used in other tests.
