### PR TITLE
Pass table handle to finishTableExecute

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -97,7 +97,7 @@ public interface Metadata
 
     BeginTableExecuteResult<TableExecuteHandle, TableHandle> beginTableExecute(Session session, TableExecuteHandle handle, TableHandle updatedSourceTableHandle);
 
-    void finishTableExecute(Session session, TableExecuteHandle handle, Collection<Slice> fragments, List<Object> tableExecuteState);
+    void finishTableExecute(Session session, TableHandle sourceHandle, TableExecuteHandle handle, Collection<Slice> fragments, List<Object> tableExecuteState);
 
     void executeTableExecute(Session session, TableExecuteHandle handle);
 

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -328,11 +328,11 @@ public final class MetadataManager
     }
 
     @Override
-    public void finishTableExecute(Session session, TableExecuteHandle tableExecuteHandle, Collection<Slice> fragments, List<Object> tableExecuteState)
+    public void finishTableExecute(Session session, TableHandle sourceHandle, TableExecuteHandle tableExecuteHandle, Collection<Slice> fragments, List<Object> tableExecuteState)
     {
         CatalogName catalogName = tableExecuteHandle.getCatalogName();
         ConnectorMetadata metadata = getMetadata(session, catalogName);
-        metadata.finishTableExecute(session.toConnectorSession(catalogName), tableExecuteHandle.getConnectorHandle(), fragments, tableExecuteState);
+        metadata.finishTableExecute(session.toConnectorSession(catalogName), sourceHandle.getConnectorHandle(), tableExecuteHandle.getConnectorHandle(), fragments, tableExecuteState);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -3984,8 +3984,9 @@ public class LocalExecutionPlanner
                 return Optional.empty();
             }
             else if (target instanceof TableExecuteTarget) {
+                TableHandle tableHandle = ((TableExecuteTarget) target).getSourceHandle().orElseThrow();
                 TableExecuteHandle tableExecuteHandle = ((TableExecuteTarget) target).getExecuteHandle();
-                metadata.finishTableExecute(session, tableExecuteHandle, fragments, tableExecuteContext.getSplitsInfo());
+                metadata.finishTableExecute(session, tableHandle, tableExecuteHandle, fragments, tableExecuteContext.getSplitsInfo());
                 return Optional.empty();
             }
             else {

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -139,7 +139,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public void finishTableExecute(Session session, TableExecuteHandle handle, Collection<Slice> fragments, List<Object> tableExecuteState)
+    public void finishTableExecute(Session session, TableHandle sourceHandle, TableExecuteHandle handle, Collection<Slice> fragments, List<Object> tableExecuteState)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-main/src/test/java/io/trino/metadata/CountingAccessMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/CountingAccessMetadata.java
@@ -151,9 +151,9 @@ public class CountingAccessMetadata
     }
 
     @Override
-    public void finishTableExecute(Session session, TableExecuteHandle handle, Collection<Slice> fragments, List<Object> tableExecuteState)
+    public void finishTableExecute(Session session, TableHandle sourceHandle, TableExecuteHandle handle, Collection<Slice> fragments, List<Object> tableExecuteState)
     {
-        delegate.finishTableExecute(session, handle, fragments, tableExecuteState);
+        delegate.finishTableExecute(session, sourceHandle, handle, fragments, tableExecuteState);
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -160,7 +160,7 @@ public interface ConnectorMetadata
      *
      * @param fragments all fragments returned by {@link ConnectorPageSink#finish()}
      */
-    default void finishTableExecute(ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle, Collection<Slice> fragments, List<Object> tableExecuteState)
+    default void finishTableExecute(ConnectorSession session, ConnectorTableHandle sourceHandle, ConnectorTableExecuteHandle tableExecuteHandle, Collection<Slice> fragments, List<Object> tableExecuteState)
     {
         throw new TrinoException(GENERIC_INTERNAL_ERROR, "ConnectorMetadata getTableHandleForExecute() is implemented without finishTableExecute()");
     }

--- a/core/trino-spi/src/test/java/io/trino/spi/TestSpiBackwardCompatibility.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/TestSpiBackwardCompatibility.java
@@ -72,6 +72,7 @@ public class TestSpiBackwardCompatibility
             .put("386", "Method: public default boolean io.trino.spi.connector.ConnectorMetadata.isSupportedVersionType(io.trino.spi.connector.ConnectorSession,io.trino.spi.connector.SchemaTableName,io.trino.spi.connector.PointerType,io.trino.spi.type.Type)")
             .put("386", "Method: public static io.trino.spi.ptf.TableArgumentSpecification$Builder io.trino.spi.ptf.TableArgumentSpecification.builder(java.lang.String)")
             .put("387", "Constructor: public io.trino.spi.eventlistener.QueryContext(java.lang.String,java.util.Optional<java.lang.String>,java.util.Set<java.lang.String>,java.util.Optional<java.lang.String>,java.util.Optional<java.lang.String>,java.util.Optional<java.lang.String>,java.util.Optional<java.lang.String>,java.util.Set<java.lang.String>,java.util.Set<java.lang.String>,java.util.Optional<java.lang.String>,java.util.Optional<java.lang.String>,java.util.Optional<java.lang.String>,java.util.Optional<io.trino.spi.resourcegroups.ResourceGroupId>,java.util.Map<java.lang.String, java.lang.String>,io.trino.spi.session.ResourceEstimates,java.lang.String,java.lang.String,java.lang.String,java.util.Optional<io.trino.spi.resourcegroups.QueryType>)")
+            .put("388", "Method: public default void io.trino.spi.connector.ConnectorMetadata.finishTableExecute(io.trino.spi.connector.ConnectorSession,io.trino.spi.connector.ConnectorTableExecuteHandle,java.util.Collection<io.airlift.slice.Slice>,java.util.List<java.lang.Object>)")
             .build();
 
     @Test

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -232,10 +232,10 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
-    public void finishTableExecute(ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle, Collection<Slice> fragments, List<Object> tableExecuteState)
+    public void finishTableExecute(ConnectorSession session, ConnectorTableHandle sourceHandle, ConnectorTableExecuteHandle tableExecuteHandle, Collection<Slice> fragments, List<Object> tableExecuteState)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.finishTableExecute(session, tableExecuteHandle, fragments, tableExecuteState);
+            delegate.finishTableExecute(session, sourceHandle, tableExecuteHandle, fragments, tableExecuteState);
         }
     }
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/DeltaTableOptimizeHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/DeltaTableOptimizeHandle.java
@@ -34,7 +34,6 @@ public class DeltaTableOptimizeHandle
     private final List<String> originalPartitionColumns;
     private final DataSize maxScannedFileSize;
     private final Optional<Long> currentVersion;
-    private final boolean retriesEnabled;
 
     @JsonCreator
     public DeltaTableOptimizeHandle(
@@ -42,15 +41,13 @@ public class DeltaTableOptimizeHandle
             List<DeltaLakeColumnHandle> tableColumns,
             List<String> originalPartitionColumns,
             DataSize maxScannedFileSize,
-            Optional<Long> currentVersion,
-            boolean retriesEnabled)
+            Optional<Long> currentVersion)
     {
         this.metadataEntry = requireNonNull(metadataEntry, "metadataEntry is null");
         this.tableColumns = ImmutableList.copyOf(requireNonNull(tableColumns, "tableColumns is null"));
         this.originalPartitionColumns = ImmutableList.copyOf(requireNonNull(originalPartitionColumns, "originalPartitionColumns is null"));
         this.maxScannedFileSize = requireNonNull(maxScannedFileSize, "maxScannedFileSize is null");
         this.currentVersion = requireNonNull(currentVersion, "currentVersion is null");
-        this.retriesEnabled = retriesEnabled;
     }
 
     public DeltaTableOptimizeHandle withCurrentVersion(long currentVersion)
@@ -61,8 +58,7 @@ public class DeltaTableOptimizeHandle
                 tableColumns,
                 originalPartitionColumns,
                 maxScannedFileSize,
-                Optional.of(currentVersion),
-                retriesEnabled);
+                Optional.of(currentVersion));
     }
 
     @JsonProperty
@@ -96,11 +92,5 @@ public class DeltaTableOptimizeHandle
     public DataSize getMaxScannedFileSize()
     {
         return maxScannedFileSize;
-    }
-
-    @JsonProperty
-    public boolean isRetriesEnabled()
-    {
-        return retriesEnabled;
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -2163,7 +2163,7 @@ public class HiveMetadata
     }
 
     @Override
-    public void finishTableExecute(ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle, Collection<Slice> fragments, List<Object> splitSourceInfo)
+    public void finishTableExecute(ConnectorSession session, ConnectorTableHandle sourceHandle, ConnectorTableExecuteHandle tableExecuteHandle, Collection<Slice> fragments, List<Object> splitSourceInfo)
     {
         String procedureName = ((HiveTableExecuteHandle) tableExecuteHandle).getProcedureName();
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergOptimizeHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergOptimizeHandle.java
@@ -37,7 +37,6 @@ public class IcebergOptimizeHandle
     private final IcebergFileFormat fileFormat;
     private final Map<String, String> tableStorageProperties;
     private final DataSize maxScannedFileSize;
-    private final boolean retriesEnabled;
 
     @JsonCreator
     public IcebergOptimizeHandle(
@@ -47,8 +46,7 @@ public class IcebergOptimizeHandle
             List<IcebergColumnHandle> tableColumns,
             IcebergFileFormat fileFormat,
             Map<String, String> tableStorageProperties,
-            DataSize maxScannedFileSize,
-            boolean retriesEnabled)
+            DataSize maxScannedFileSize)
     {
         this.snapshotId = snapshotId;
         this.schemaAsJson = requireNonNull(schemaAsJson, "schemaAsJson is null");
@@ -57,7 +55,6 @@ public class IcebergOptimizeHandle
         this.fileFormat = requireNonNull(fileFormat, "fileFormat is null");
         this.tableStorageProperties = ImmutableMap.copyOf(requireNonNull(tableStorageProperties, "tableStorageProperties is null"));
         this.maxScannedFileSize = requireNonNull(maxScannedFileSize, "maxScannedFileSize is null");
-        this.retriesEnabled = retriesEnabled;
     }
 
     @JsonProperty
@@ -102,12 +99,6 @@ public class IcebergOptimizeHandle
         return maxScannedFileSize;
     }
 
-    @JsonProperty
-    public boolean isRetriesEnabled()
-    {
-        return retriesEnabled;
-    }
-
     @Override
     public String toString()
     {
@@ -119,7 +110,6 @@ public class IcebergOptimizeHandle
                 .add("fileFormat", fileFormat)
                 .add("tableStorageProperties", tableStorageProperties)
                 .add("maxScannedFileSize", maxScannedFileSize)
-                .add("retriesEnabled", retriesEnabled)
                 .toString();
     }
 }


### PR DESCRIPTION
It may contain information that's useful for the `finishTableExecute`.
Otherwise the connector needs to add such information to
`ConnectorTableExecuteHandle`.
