### PR TITLE
Support env var replacement for exchange spooling configs

### DIFF
--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeManagerFactory.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeManagerFactory.java
@@ -26,6 +26,7 @@ import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
 
+import static io.airlift.configuration.ConfigurationUtils.replaceEnvironmentVariables;
 import static java.util.Objects.requireNonNull;
 
 public class FileSystemExchangeManagerFactory
@@ -40,7 +41,7 @@ public class FileSystemExchangeManagerFactory
     @Override
     public ExchangeManager create(Map<String, String> config)
     {
-        requireNonNull(config, "config is null");
+        config = replaceEnvironmentVariables(requireNonNull(config, "config is null"));
 
         Bootstrap app = new Bootstrap(
                 new MBeanModule(),


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

In production deployment using secret keys, it's common practice to inject the secret keys into the runtime environment, instead of writing them in config files. This PR allows users to use env vars for their exchange spooling configs, e.g.:
```
exchange-manager.name=filesystem
exchange.base-directories=abfs://container@account.dfs.core.windows.net
exchange.azure.connection-string=${ENV:AZURE_STORAGE_CONNECTION_STRING}
```

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

trino-exchange-filesystem plugin

> How would you describe this change to a non-technical end user or system administrator?

This allows users to configure their exchange spooling configs via environment variables!

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
