### PR TITLE
Support setting table and column comments in Delta Lake

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -135,6 +135,7 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -243,6 +244,7 @@ public class DeltaLakeMetadata
     public static final String UPDATE_OPERATION = "UPDATE";
     public static final String OPTIMIZE_OPERATION = "OPTIMIZE";
     public static final String SET_TBLPROPERTIES_OPERATION = "SET TBLPROPERTIES";
+    public static final String CHANGE_COLUMN_OPERATION = "CHANGE COLUMN";
     public static final String ISOLATION_LEVEL = "WriteSerializable";
     private static final int READER_VERSION = 1;
     private static final int WRITER_VERSION = 2;
@@ -993,6 +995,53 @@ public class DeltaLakeMetadata
         }
         catch (Exception e) {
             throw new TrinoException(DELTA_LAKE_BAD_WRITE, format("Unable to comment on table: %s.%s", handle.getSchemaName(), handle.getTableName()), e);
+        }
+    }
+
+    @Override
+    public void setColumnComment(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle column, Optional<String> comment)
+    {
+        DeltaLakeTableHandle deltaLakeTableHandle = (DeltaLakeTableHandle) tableHandle;
+        DeltaLakeColumnHandle deltaLakeColumnHandle = (DeltaLakeColumnHandle) column;
+        checkSupportedWriterVersion(session, deltaLakeTableHandle.getSchemaTableName());
+
+        ConnectorTableMetadata tableMetadata = getTableMetadata(session, deltaLakeTableHandle);
+
+        try {
+            long commitVersion = deltaLakeTableHandle.getReadVersion() + 1;
+
+            List<String> partitionColumns = getPartitionedBy(tableMetadata.getProperties());
+            List<DeltaLakeColumnHandle> columns = tableMetadata.getColumns().stream()
+                    .filter(columnMetadata -> !columnMetadata.isHidden())
+                    .map(columnMetadata -> toColumnHandle(columnMetadata, partitionColumns))
+                    .collect(toImmutableList());
+
+            ImmutableMap.Builder<String, String> columnComments = ImmutableMap.builder();
+            columnComments.putAll(getColumnComments(deltaLakeTableHandle.getMetadataEntry()).entrySet().stream()
+                    .filter(e -> !e.getKey().equals(deltaLakeColumnHandle.getName()))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+            comment.ifPresent(s -> columnComments.put(deltaLakeColumnHandle.getName(), s));
+
+            Optional<Long> checkpointInterval = DeltaLakeTableProperties.getCheckpointInterval(tableMetadata.getProperties());
+
+            TransactionLogWriter transactionLogWriter = transactionLogWriterFactory.newWriter(session, deltaLakeTableHandle.getLocation());
+            appendTableEntries(
+                    commitVersion,
+                    transactionLogWriter,
+                    deltaLakeTableHandle.getMetadataEntry().getId(),
+                    columns,
+                    partitionColumns,
+                    columnComments.buildOrThrow(),
+                    buildDeltaMetadataConfiguration(checkpointInterval),
+                    CHANGE_COLUMN_OPERATION,
+                    session,
+                    nodeVersion,
+                    nodeId,
+                    Optional.ofNullable(deltaLakeTableHandle.getMetadataEntry().getDescription()));
+            transactionLogWriter.flush();
+        }
+        catch (Exception e) {
+            throw new TrinoException(DELTA_LAKE_BAD_WRITE, format("Unable to add '%s' column comment for: %s.%s", deltaLakeColumnHandle.getName(), deltaLakeTableHandle.getSchemaName(), deltaLakeTableHandle.getTableName()), e);
         }
     }
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -242,6 +242,7 @@ public class DeltaLakeMetadata
     public static final String DELETE_OPERATION = "DELETE";
     public static final String UPDATE_OPERATION = "UPDATE";
     public static final String OPTIMIZE_OPERATION = "OPTIMIZE";
+    public static final String SET_TBLPROPERTIES_OPERATION = "SET TBLPROPERTIES";
     public static final String ISOLATION_LEVEL = "WriteSerializable";
     private static final int READER_VERSION = 1;
     private static final int WRITER_VERSION = 2;
@@ -953,6 +954,46 @@ public class DeltaLakeMetadata
     {
         Optional<String> tableQueryId = getQueryId(table);
         return tableQueryId.isPresent() && tableQueryId.get().equals(queryId);
+    }
+
+    @Override
+    public void setTableComment(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<String> comment)
+    {
+        DeltaLakeTableHandle handle = (DeltaLakeTableHandle) tableHandle;
+        checkSupportedWriterVersion(session, handle.getSchemaTableName());
+
+        ConnectorTableMetadata tableMetadata = getTableMetadata(session, handle);
+
+        try {
+            long commitVersion = handle.getReadVersion() + 1;
+
+            List<String> partitionColumns = getPartitionedBy(tableMetadata.getProperties());
+            List<DeltaLakeColumnHandle> columns = tableMetadata.getColumns().stream()
+                    .filter(column -> !column.isHidden())
+                    .map(column -> toColumnHandle(column, partitionColumns))
+                    .collect(toImmutableList());
+
+            Optional<Long> checkpointInterval = DeltaLakeTableProperties.getCheckpointInterval(tableMetadata.getProperties());
+
+            TransactionLogWriter transactionLogWriter = transactionLogWriterFactory.newWriter(session, handle.getLocation());
+            appendTableEntries(
+                    commitVersion,
+                    transactionLogWriter,
+                    handle.getMetadataEntry().getId(),
+                    columns,
+                    partitionColumns,
+                    getColumnComments(handle.getMetadataEntry()),
+                    buildDeltaMetadataConfiguration(checkpointInterval),
+                    SET_TBLPROPERTIES_OPERATION,
+                    session,
+                    nodeVersion,
+                    nodeId,
+                    comment);
+            transactionLogWriter.flush();
+        }
+        catch (Exception e) {
+            throw new TrinoException(DELTA_LAKE_BAD_WRITE, format("Unable to comment on table: %s.%s", handle.getSchemaName(), handle.getTableName()), e);
+        }
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeMinioConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeMinioConnectorTest.java
@@ -111,7 +111,6 @@ public abstract class BaseDeltaLakeMinioConnectorTest
             case SUPPORTS_RENAME_TABLE:
             case SUPPORTS_DROP_COLUMN:
             case SUPPORTS_RENAME_COLUMN:
-            case SUPPORTS_COMMENT_ON_COLUMN:
             case SUPPORTS_RENAME_SCHEMA:
             case SUPPORTS_NOT_NULL_CONSTRAINT:
                 return false;

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeMinioConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeMinioConnectorTest.java
@@ -111,7 +111,6 @@ public abstract class BaseDeltaLakeMinioConnectorTest
             case SUPPORTS_RENAME_TABLE:
             case SUPPORTS_DROP_COLUMN:
             case SUPPORTS_RENAME_COLUMN:
-            case SUPPORTS_COMMENT_ON_TABLE:
             case SUPPORTS_COMMENT_ON_COLUMN:
             case SUPPORTS_RENAME_SCHEMA:
             case SUPPORTS_NOT_NULL_CONSTRAINT:

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-delta-lake-databricks/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-delta-lake-databricks/hive.properties
@@ -7,5 +7,6 @@ hive.non-managed-table-writes-enabled=true
 # Required by some product tests
 hive.hive-views.enabled=true
 hive.allow-comment-table=true
+hive.allow-comment-column=true
 hive.allow-rename-table=true
 hive.delta-lake-catalog-name=delta

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-delta-lake-oss/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-delta-lake-oss/hive.properties
@@ -10,5 +10,6 @@ hive.s3.ssl.enabled=false
 # Required by some product tests
 hive.hive-views.enabled=true
 hive.allow-comment-table=true
+hive.allow-comment-column=true
 hive.allow-rename-table=true
 hive.delta-lake-catalog-name=delta

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksCreateTableCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksCreateTableCompatibility.java
@@ -15,7 +15,6 @@ package io.trino.tests.product.deltalake;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.tempto.assertions.QueryAssert;
-import io.trino.tempto.query.QueryResult;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -26,6 +25,7 @@ import static io.trino.tests.product.TestGroups.DELTA_LAKE_DATABRICKS;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static io.trino.tests.product.deltalake.util.DeltaLakeTestUtils.getColumnCommentOnDelta;
 import static io.trino.tests.product.deltalake.util.DeltaLakeTestUtils.getColumnCommentOnTrino;
+import static io.trino.tests.product.deltalake.util.DeltaLakeTestUtils.getTableCommentOnDelta;
 import static io.trino.tests.product.hive.util.TemporaryHiveTable.randomTableSuffix;
 import static io.trino.tests.product.utils.QueryExecutors.onDelta;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
@@ -196,15 +196,6 @@ public class TestDeltaLakeDatabricksCreateTableCompatibility
         finally {
             onTrino().executeQuery("DROP TABLE delta.default." + tableName);
         }
-    }
-
-    private static String getTableCommentOnDelta(String schemaName, String tableName)
-    {
-        QueryResult result = onDelta().executeQuery(format("DESCRIBE EXTENDED %s.%s", schemaName, tableName));
-        return (String) result.rows().stream()
-                .filter(row -> row.get(0).equals("Comment"))
-                .map(row -> row.get(1))
-                .findFirst().orElseThrow();
     }
 
     @Test(groups = {DELTA_LAKE_DATABRICKS, PROFILE_SPECIFIC_TESTS})

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/util/DeltaLakeTestUtils.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/util/DeltaLakeTestUtils.java
@@ -34,4 +34,13 @@ public final class DeltaLakeTestUtils
         QueryResult result = onDelta().executeQuery(format("DESCRIBE %s.%s %s", schemaName, tableName, columnName));
         return (String) result.row(2).get(1);
     }
+
+    public static String getTableCommentOnDelta(String schemaName, String tableName)
+    {
+        QueryResult result = onDelta().executeQuery(format("DESCRIBE EXTENDED %s.%s", schemaName, tableName));
+        return (String) result.rows().stream()
+                .filter(row -> row.get(0).equals("Comment"))
+                .map(row -> row.get(1))
+                .findFirst().orElseThrow();
+    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->


Delta Logs corresponding to comment on table and column statements via `spark-sql`:

```
COMMENT ON TABLE testdelta IS 'this is my delta table';

ALTER TABLE testdelta ALTER COLUMN a COMMENT 'this is my a column';
```

```
[root@hadoop-master /]# hdfs dfs -cat /user/hive/warehouse/testdelta/_delta_log/00000000000000000001.json
{"metaData":{"id":"e4e5196b-311c-4883-9e93-b97b7711f1a1","description":"this is my delta table","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"a\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},{\"name\":\"b\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{},"createdTime":1656043296180}}
{"commitInfo":{"timestamp":1656043342692,"operation":"SET TBLPROPERTIES","operationParameters":{"properties":"{\"comment\":\"this is my delta table\"}"},"readVersion":0,"isolationLevel":"Serializable","isBlindAppend":true,"operationMetrics":{},"engineInfo":"Apache-Spark/3.2.1 Delta-Lake/1.2.1","txnId":"2ae38bea-9f58-4628-be9e-b4a36fee8e96"}}
[root@hadoop-master /]# hdfs dfs -cat /user/hive/warehouse/testdelta/_delta_log/00000000000000000002.json
{"metaData":{"id":"e4e5196b-311c-4883-9e93-b97b7711f1a1","description":"this is my delta table","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"a\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{\"comment\":\"this is my a column\"}},{\"name\":\"b\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{},"createdTime":1656043296180}}
{"commitInfo":{"timestamp":1656043505250,"operation":"CHANGE COLUMN","operationParameters":{"column":"{\"name\":\"a\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{\"comment\":\"this is my a column\"}}"},"readVersion":1,"isolationLevel":"Serializable","isBlindAppend":true,"operationMetrics":{},"engineInfo":"Apache-Spark/3.2.1 Delta-Lake/1.2.1","txnId":"6fe8a96b-8ca6-450f-a26a-a08506db9a57"}}
```


<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

New feature.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Delta Lake connector.

> How would you describe this change to a non-technical end user or system administrator?


Add the ability to perform statements like


```
COMMENT ON TABLE deltatable IS 'My table description';
COMMENT ON COLUMN deltatable.deltacolumn IS 'My column description';
```

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Delta Lake
* Add support for `COMMENT` statement on table and column
```
