### PR TITLE
Replace env variables once in DbResourceGroupConfigurationManagerFactory

### DIFF
--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/DbResourceGroupConfigurationManagerFactory.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/DbResourceGroupConfigurationManagerFactory.java
@@ -41,8 +41,7 @@ public class DbResourceGroupConfigurationManagerFactory
     @Override
     public ResourceGroupConfigurationManager<?> create(Map<String, String> config, ResourceGroupConfigurationManagerContext context)
     {
-        config = replaceEnvironmentVariables(config);
-        FlywayMigration.migrate(new ConfigurationFactory(config).build(DbResourceGroupConfig.class));
+        FlywayMigration.migrate(new ConfigurationFactory(replaceEnvironmentVariables(config)).build(DbResourceGroupConfig.class));
         Bootstrap app = new Bootstrap(
                 new MBeanModule(),
                 new MBeanServerModule(),


### PR DESCRIPTION
`Bootstrap.initialize` does `replaceEnvironmentVariables`, so we need to
call `replaceEnvironmentVariables` only for the configuration used
directly, for `FlywayMigration`.

Follows https://github.com/trinodb/trino/pull/10996