### PR TITLE
Adding support for getRowFilter & getColumnMask in connector access control

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorAccessControl.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorAccessControl.java
@@ -631,7 +631,7 @@ public interface ConnectorAccessControl
      */
     default List<ViewExpression> getRowFilters(ConnectorSecurityContext context, SchemaTableName tableName)
     {
-        return emptyList();
+        return getRowFilter(context, tableName).map(List::of).orElseGet(List::of);
     }
 
     /**
@@ -659,6 +659,6 @@ public interface ConnectorAccessControl
      */
     default List<ViewExpression> getColumnMasks(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
     {
-        return emptyList();
+        return getColumnMask(context, tableName, columnName, type).map(List::of).orElseGet(List::of);
     }
 }


### PR DESCRIPTION
Currently system access control still supports getColumnMask & getRowFilter.  Same methods are not supported in connector access control.Added implementation for that, so that existing access control using them still works.

> Is this change a fix, improvement, new feature, refactoring, or other?
Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
SPI connector access control interface

> How would you describe this change to a non-technical end user or system administrator?
THe access for specific connector in trino is not in sync with system access control. Impementation for Column Mask & Row Filter not provided

## Related issues, pull requests, and links
https://github.com/trinodb/trino/issues/12992

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

