### PR TITLE
Implement concurrent tests in Kudu

### DIFF
--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduConnectorTest.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduConnectorTest.java
@@ -510,17 +510,12 @@ public class TestKuduConnectorTest
     }
 
     @Override
-    public void testInsertRowConcurrently()
+    protected TestTable createTableWithOneIntegerColumn(String namePrefix)
     {
-        // TODO Support these test once kudu connector can create tables with default partitions
-        throw new SkipException("TODO");
-    }
-
-    @Override
-    public void testAddColumnConcurrently()
-    {
-        // TODO Support these test once kudu connector can create tables with default partitions
-        throw new SkipException("TODO");
+        // TODO Remove this overriding method once kudu connector can create tables with default partitions
+        return new TestTable(getQueryRunner()::execute, namePrefix,
+                "(col integer WITH (primary_key=true)) " +
+                "WITH (partition_by_hash_columns = ARRAY['col'], partition_by_hash_buckets = 2)");
     }
 
     @Test
@@ -534,8 +529,24 @@ public class TestKuduConnectorTest
     @Override
     public void testReadMetadataWithRelationsConcurrentModifications()
     {
-        // TODO Support these test once kudu connector can create tables with default partitions
-        throw new SkipException("TODO");
+        try {
+            super.testReadMetadataWithRelationsConcurrentModifications();
+        }
+        catch (Exception expected) {
+            // The test failure is not guaranteed
+            // TODO (https://github.com/trinodb/trino/issues/12974): shouldn't fail
+            assertThat(expected)
+                    .hasMessageMatching(".* table .* was deleted: Table deleted at .* UTC");
+            throw new SkipException("to be fixed");
+        }
+    }
+
+    @Override
+    protected String createTableSqlTemplateForConcurrentModifications()
+    {
+        // TODO Remove this overriding method once kudu connector can create tables with default partitions
+        return "CREATE TABLE %s(a integer WITH (primary_key=true)) " +
+                "WITH (partition_by_hash_columns = ARRAY['a'], partition_by_hash_buckets = 2)";
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

An improvement in testing.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Connector tests.

> How would you describe this change to a non-technical end-user or system administrator?

Improved some tests that shouldn't change any behavior.

## Related issues, pull requests, and links
This is the fourth and last one of a series of PRs to fix https://github.com/trinodb/trino/issues/11815. It fixes the 3 remaining tests.

It was part of https://github.com/trinodb/trino/pull/12952 but was split into a separate PR.

`testReadMetadataWithRelationsConcurrentModifications` may result in a test failure described in https://github.com/trinodb/trino/issues/12974.

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
