### PR TITLE
Document max query in query management properties

### DIFF
--- a/docs/src/main/sphinx/admin/properties-query-management.rst
+++ b/docs/src/main/sphinx/admin/properties-query-management.rst
@@ -102,6 +102,16 @@ The maximum allowed time for a query to be actively executing on the
 cluster, before it is terminated. Compared to the run time below, execution
 time does not include analysis, query planning or wait times in a queue.
 
+``query.max-length``
+^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** :ref:`prop-type-integer`
+* **Default value:** ``1,000,000``
+* **Maximum value:** ``1,000,000,000``
+
+The maximum number of characters allowed for the SQL query text. Longer queries
+are not processed, and terminated with error ``QUERY_TEXT_TOO_LARGE``.
+
 ``query.max-planning-time``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
This fix adds documentation to the Query management properties page for the query.max-length property. 

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
Improvement.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
Documentation.

> How would you describe this change to a non-technical end user or system administrator?
Adds documentation for the query.max-length property. 

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
