### PR TITLE
Rename class for Query pass-through in JDBC connectors

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
@@ -18,7 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
 import io.trino.plugin.jdbc.PredicatePushdownController.DomainPushdownResult;
-import io.trino.plugin.jdbc.ptf.Query.QueryHandle;
+import io.trino.plugin.jdbc.ptf.Query.QueryFunctionHandle;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.connector.AggregationApplicationResult;
@@ -579,11 +579,11 @@ public class DefaultJdbcMetadata
     @Override
     public Optional<TableFunctionApplicationResult<ConnectorTableHandle>> applyTableFunction(ConnectorSession session, ConnectorTableFunctionHandle handle)
     {
-        if (!(handle instanceof QueryHandle)) {
+        if (!(handle instanceof QueryFunctionHandle)) {
             return Optional.empty();
         }
 
-        ConnectorTableHandle tableHandle = ((QueryHandle) handle).getTableHandle();
+        ConnectorTableHandle tableHandle = ((QueryFunctionHandle) handle).getTableHandle();
         ConnectorTableSchema tableSchema = getTableSchema(session, tableHandle);
         Map<String, ColumnHandle> columnHandlesByName = getColumnHandles(session, tableHandle);
         List<ColumnHandle> columnHandles = tableSchema.getColumns().stream()

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ptf/Query.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ptf/Query.java
@@ -101,7 +101,7 @@ public class Query
                     .map(column -> new Field(column.getColumnName(), Optional.of(column.getColumnType())))
                     .collect(toImmutableList()));
 
-            QueryHandle handle = new QueryHandle(tableHandle);
+            QueryFunctionHandle handle = new QueryFunctionHandle(tableHandle);
 
             return TableFunctionAnalysis.builder()
                     .returnedType(returnedType)
@@ -110,13 +110,13 @@ public class Query
         }
     }
 
-    public static class QueryHandle
+    public static class QueryFunctionHandle
             implements ConnectorTableFunctionHandle
     {
         private final JdbcTableHandle tableHandle;
 
         @JsonCreator
-        public QueryHandle(@JsonProperty("tableHandle") JdbcTableHandle tableHandle)
+        public QueryFunctionHandle(@JsonProperty("tableHandle") JdbcTableHandle tableHandle)
         {
             this.tableHandle = requireNonNull(tableHandle, "tableHandle is null");
         }


### PR DESCRIPTION
Change the class name to be more descriptive.
Following: https://github.com/trinodb/trino/pull/12324#discussion_r907686225

No documentation or release notes needed.