### PR TITLE
Remove @Deprecated from OidcDiscoveryConfig fields

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OidcDiscovery.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OidcDiscovery.java
@@ -146,6 +146,8 @@ public class OidcDiscovery
             if (!configurationValue.equals(metadataValue)) {
                 LOG.warn("Overriding \"%s=%s\" from OpenID metadata document with value \"%s=%s\" defined in configuration",
                         metadataField, metadataValue.orElse(""), configurationField, configurationValue.orElse(""));
+            } else {
+                LOG.warn("Provided redundant configuration property \"%s\" with the same value as \"%s\" field in OpenID metadata document");
             }
             return configurationValue;
         }

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OidcDiscovery.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OidcDiscovery.java
@@ -142,16 +142,23 @@ public class OidcDiscovery
 
     private static Optional<String> getOptionalField(String metadataField, Optional<String> metadataValue, String configurationField, Optional<String> configurationValue)
     {
-        if (configurationValue.isPresent()) {
-            if (!configurationValue.equals(metadataValue)) {
-                LOG.warn("Overriding \"%s=%s\" from OpenID metadata document with value \"%s=%s\" defined in configuration",
-                        metadataField, metadataValue.orElse(""), configurationField, configurationValue.orElse(""));
-            } else {
-                LOG.warn("Provided redundant configuration property \"%s\" with the same value as \"%s\" field in OpenID metadata document");
-            }
+        if (configurationValue.isEmpty()) {
+            return metadataValue;
+        }
+
+        if (metadataValue.isEmpty()) {
             return configurationValue;
         }
-        return metadataValue;
+
+        if (!configurationValue.equals(metadataValue)) {
+            LOG.warn("Overriding \"%s=%s\" from OpenID metadata document with value \"%s=%s\" defined in configuration",
+                    metadataField, metadataValue.orElse(""), configurationField, configurationValue.orElse(""));
+        }
+        else {
+            LOG.warn("Provided redundant configuration property \"%s\" with the same value as \"%s\" field in OpenID metadata document",
+                    configurationField, metadataField);
+        }
+        return configurationValue;
     }
 
     private static void checkMetadataState(boolean expression, String additionalMessage, String... additionalMessageArgs)

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OidcDiscoveryConfig.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OidcDiscoveryConfig.java
@@ -68,7 +68,6 @@ public class OidcDiscoveryConfig
     }
 
     @NotNull
-    @Deprecated
     public Optional<String> getAccessTokenIssuer()
     {
         return accessTokenIssuer;
@@ -76,7 +75,6 @@ public class OidcDiscoveryConfig
 
     @Config(ACCESS_TOKEN_ISSUER)
     @ConfigDescription("The required issuer for access tokens")
-    @Deprecated
     public OidcDiscoveryConfig setAccessTokenIssuer(String accessTokenIssuer)
     {
         this.accessTokenIssuer = Optional.ofNullable(accessTokenIssuer);
@@ -84,7 +82,6 @@ public class OidcDiscoveryConfig
     }
 
     @NotNull
-    @Deprecated
     public Optional<String> getAuthUrl()
     {
         return authUrl;
@@ -92,7 +89,6 @@ public class OidcDiscoveryConfig
 
     @Config(AUTH_URL)
     @ConfigDescription("URL of the authorization server's authorization endpoint")
-    @Deprecated
     public OidcDiscoveryConfig setAuthUrl(String authUrl)
     {
         this.authUrl = Optional.ofNullable(authUrl);
@@ -100,7 +96,6 @@ public class OidcDiscoveryConfig
     }
 
     @NotNull
-    @Deprecated
     public Optional<String> getTokenUrl()
     {
         return tokenUrl;
@@ -108,7 +103,6 @@ public class OidcDiscoveryConfig
 
     @Config(TOKEN_URL)
     @ConfigDescription("URL of the authorization server's token endpoint")
-    @Deprecated
     public OidcDiscoveryConfig setTokenUrl(String tokenUrl)
     {
         this.tokenUrl = Optional.ofNullable(tokenUrl);
@@ -116,7 +110,6 @@ public class OidcDiscoveryConfig
     }
 
     @NotNull
-    @Deprecated
     public Optional<String> getJwksUrl()
     {
         return jwksUrl;
@@ -124,7 +117,6 @@ public class OidcDiscoveryConfig
 
     @Config(JWKS_URL)
     @ConfigDescription("URL of the authorization server's JWKS (JSON Web Key Set) endpoint")
-    @Deprecated
     public OidcDiscoveryConfig setJwksUrl(String jwksUrl)
     {
         this.jwksUrl = Optional.ofNullable(jwksUrl);
@@ -132,7 +124,6 @@ public class OidcDiscoveryConfig
     }
 
     @NotNull
-    @Deprecated
     public Optional<String> getUserinfoUrl()
     {
         return userinfoUrl;
@@ -140,7 +131,6 @@ public class OidcDiscoveryConfig
 
     @Config(USERINFO_URL)
     @ConfigDescription("URL of the userinfo endpoint")
-    @Deprecated
     public OidcDiscoveryConfig setUserinfoUrl(String userinfoUrl)
     {
         this.userinfoUrl = Optional.ofNullable(userinfoUrl);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Remove `@Deprecated` from OidcDiscoveryConfig fields

Using deprecated annotations had unintended consequence of printing
deprecation warnings even when these properties are actually used
for providing additional configuration.
Additionally, simplify logic of getting value of OIDC field.


<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

