### PR TITLE
Add support for pinot proxy

### DIFF
--- a/docs/src/main/sphinx/connector/pinot.rst
+++ b/docs/src/main/sphinx/connector/pinot.rst
@@ -74,6 +74,7 @@ Property name                                             Required   Description
 ``pinot.aggregation-pushdown.enabled``                    No         Push down aggregation queries, default is ``true``.
 ``pinot.count-distinct-pushdown.enabled``                 No         Push down count distinct queries to Pinot, default is ``true``.
 ``pinot.target-segment-page-size``                        No         Max allowed page size for segment query, default is ``1MB``.
+``pinot.proxy.enabled``                                   No         Use Pinot Proxy for controller and broker requests, default is ``false``.
 ========================================================= ========== ==============================================================================
 
 If ``pinot.controller.authentication.type`` is set to ``PASSWORD`` then both ``pinot.controller.authentication.user`` and
@@ -101,6 +102,7 @@ Property name                                             Required   Description
 ``pinot.grpc.tls.truststore-path``                        No         TLS truststore file location for gRPC connection, default is empty.
 ``pinot.grpc.tls.truststore-password``                    No         TLS truststore password, default is empty.
 ``pinot.grpc.tls.ssl-provider``                           No         SSL provider, default is ``JDK``.
+``pinot.grpc.proxy-uri``                                  No         Pinot Rest Proxy gRPC endpoint URI, default is null.
 ========================================================= ========== ==============================================================================
 
 For more Apache Pinot TLS configurations, please also refer to `Configuring TLS/SSL <https://docs.pinot.apache.org/operators/tutorials/configuring-tls-ssl>`_.

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotConfig.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotConfig.java
@@ -64,6 +64,7 @@ public class PinotConfig
     private boolean aggregationPushdownEnabled = true;
     private boolean countDistinctPushdownEnabled = true;
     private boolean grpcEnabled = true;
+    private boolean proxyEnabled;
     private DataSize targetSegmentPageSize = DataSize.of(1, MEGABYTE);
 
     @NotEmpty(message = "pinot.controller-urls cannot be empty")
@@ -245,6 +246,18 @@ public class PinotConfig
         return "https".equalsIgnoreCase(getControllerUrls().get(0).getScheme());
     }
 
+    public boolean getProxyEnabled()
+    {
+        return proxyEnabled;
+    }
+
+    @Config("pinot.proxy.enabled")
+    public PinotConfig setProxyEnabled(boolean proxyEnabled)
+    {
+        this.proxyEnabled = proxyEnabled;
+        return this;
+    }
+
     public DataSize getTargetSegmentPageSize()
     {
         return this.targetSegmentPageSize;
@@ -272,5 +285,14 @@ public class PinotConfig
                 .map(URI::getScheme)
                 .distinct()
                 .count() == 1;
+    }
+
+    @AssertTrue(message = "Using the rest proxy requires GRPC to be enabled by setting pinot.grpc.enabled=true")
+    public boolean proxyRestAndGrpcAreRequired()
+    {
+        if (proxyEnabled) {
+            return grpcEnabled;
+        }
+        return true;
     }
 }

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotClient.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotClient.java
@@ -122,6 +122,7 @@ public class PinotClient
     private final HttpClient httpClient;
     private final PinotHostMapper pinotHostMapper;
     private final String scheme;
+    private final boolean proxyEnabled;
 
     private final NonEvictableLoadingCache<String, List<String>> brokersForTableCache;
     private final NonEvictableLoadingCache<Object, Multimap<String, String>> allTablesCache;
@@ -154,7 +155,9 @@ public class PinotClient
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)).jsonCodec(Schema.class);
         this.brokerResponseCodec = requireNonNull(brokerResponseCodec, "brokerResponseCodec is null");
         this.pinotHostMapper = requireNonNull(pinotHostMapper, "pinotHostMapper is null");
+        requireNonNull(config, "config is null");
         this.scheme = config.isTlsEnabled() ? "https" : "http";
+        this.proxyEnabled = config.getProxyEnabled();
 
         this.controllerUrls = config.getControllerUrls();
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
@@ -228,16 +231,20 @@ public class PinotClient
     {
         ImmutableMultimap.Builder<String, String> additionalHeadersBuilder = ImmutableMultimap.builder();
         brokerAuthenticationProvider.getAuthenticationToken().ifPresent(token -> additionalHeadersBuilder.put(AUTHORIZATION, token));
-        URI brokerPathUri = HttpUriBuilder.uriBuilder()
-                .hostAndPort(HostAndPort.fromString(getBrokerHost(table)))
-                .scheme(scheme)
-                .appendPath(path)
-                .build();
+        HttpUriBuilder httpUriBuilder = getBrokerHttpUriBuilder(getBrokerHost(table));
+        URI brokerPathUri = httpUriBuilder.scheme(scheme).appendPath(path).build();
         return doHttpActionWithHeadersJson(
                 Request.Builder.prepareGet().setUri(brokerPathUri),
                 Optional.empty(),
                 codec,
                 additionalHeadersBuilder.build());
+    }
+
+    private HttpUriBuilder getBrokerHttpUriBuilder(String hostAndPort)
+    {
+        return proxyEnabled ?
+                HttpUriBuilder.uriBuilderFrom(getControllerUrl()) :
+                HttpUriBuilder.uriBuilder().hostAndPort(HostAndPort.fromString(hostAndPort));
     }
 
     private URI getControllerUrl()
@@ -531,8 +538,8 @@ public class PinotClient
     {
         String queryRequest = QUERY_REQUEST_JSON_CODEC.toJson(new QueryRequest(query.getQuery()));
         return doWithRetries(PinotSessionProperties.getPinotRetryCount(session), retryNumber -> {
-            URI queryPathUri = HttpUriBuilder.uriBuilder()
-                    .hostAndPort(HostAndPort.fromString(getBrokerHost(query.getTable())))
+            HttpUriBuilder httpUriBuilder = getBrokerHttpUriBuilder(getBrokerHost(query.getTable()));
+            URI queryPathUri = httpUriBuilder
                     .scheme(scheme)
                     .appendPath(QUERY_URL_PATH)
                     .build();

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotGrpcServerQueryClientConfig.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotGrpcServerQueryClientConfig.java
@@ -16,6 +16,8 @@ package io.trino.plugin.pinot.client;
 import io.airlift.configuration.Config;
 import io.airlift.units.DataSize;
 
+import java.util.Optional;
+
 import static org.apache.pinot.common.config.GrpcConfig.DEFAULT_MAX_INBOUND_MESSAGE_BYTES_SIZE;
 
 public class PinotGrpcServerQueryClientConfig
@@ -24,6 +26,7 @@ public class PinotGrpcServerQueryClientConfig
     private int grpcPort = 8090;
     private DataSize maxInboundMessageSize = DataSize.ofBytes(DEFAULT_MAX_INBOUND_MESSAGE_BYTES_SIZE);
     private boolean usePlainText = true;
+    private Optional<String> proxyUri = Optional.empty();
 
     public int getMaxRowsPerSplitForSegmentQueries()
     {
@@ -70,6 +73,20 @@ public class PinotGrpcServerQueryClientConfig
     public PinotGrpcServerQueryClientConfig setUsePlainText(boolean usePlainText)
     {
         this.usePlainText = usePlainText;
+        return this;
+    }
+
+    public Optional<String> getProxyUri()
+    {
+        return proxyUri;
+    }
+
+    @Config("pinot.grpc.proxy-uri")
+    public PinotGrpcServerQueryClientConfig setProxyUri(String proxyUri)
+    {
+        if (proxyUri != null && !proxyUri.isEmpty()) {
+            this.proxyUri = Optional.of(proxyUri);
+        }
         return this;
     }
 }

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/PinotProxyGrpcRequestBuilder.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/PinotProxyGrpcRequestBuilder.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.pinot.query;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.pinot.common.proto.Server;
+import org.apache.pinot.spi.utils.CommonConstants;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class PinotProxyGrpcRequestBuilder
+{
+    private static final String KEY_OF_PROXY_GRPC_FORWARD_HOST = "FORWARD_HOST";
+    private static final String KEY_OF_PROXY_GRPC_FORWARD_PORT = "FORWARD_PORT";
+
+    private String hostName;
+    private int port = -1;
+    private int requestId;
+    private String brokerId = "unknown";
+    private boolean enableTrace;
+    private boolean enableStreaming;
+    private String payloadType;
+    private String sql;
+    private List<String> segments;
+
+    public PinotProxyGrpcRequestBuilder setHostName(String hostName)
+    {
+        this.hostName = hostName;
+        return this;
+    }
+
+    public PinotProxyGrpcRequestBuilder setPort(int port)
+    {
+        this.port = port;
+        return this;
+    }
+
+    public PinotProxyGrpcRequestBuilder setRequestId(int requestId)
+    {
+        this.requestId = requestId;
+        return this;
+    }
+
+    public PinotProxyGrpcRequestBuilder setBrokerId(String brokerId)
+    {
+        this.brokerId = brokerId;
+        return this;
+    }
+
+    public PinotProxyGrpcRequestBuilder setEnableTrace(boolean enableTrace)
+    {
+        this.enableTrace = enableTrace;
+        return this;
+    }
+
+    public PinotProxyGrpcRequestBuilder setEnableStreaming(boolean enableStreaming)
+    {
+        this.enableStreaming = enableStreaming;
+        return this;
+    }
+
+    public PinotProxyGrpcRequestBuilder setSql(String sql)
+    {
+        payloadType = CommonConstants.Query.Request.PayloadType.SQL;
+        this.sql = sql;
+        return this;
+    }
+
+    public PinotProxyGrpcRequestBuilder setSegments(List<String> segments)
+    {
+        this.segments = ImmutableList.copyOf(segments);
+        return this;
+    }
+
+    public Server.ServerRequest build()
+    {
+        if (!payloadType.equals(CommonConstants.Query.Request.PayloadType.SQL)) {
+            throw new RuntimeException("Only [SQL] Payload type is allowed: " + payloadType);
+        }
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put(CommonConstants.Query.Request.MetadataKeys.REQUEST_ID, Integer.toString(requestId));
+        metadata.put(CommonConstants.Query.Request.MetadataKeys.BROKER_ID, brokerId);
+        metadata.put(CommonConstants.Query.Request.MetadataKeys.ENABLE_TRACE, Boolean.toString(enableTrace));
+        metadata.put(CommonConstants.Query.Request.MetadataKeys.ENABLE_STREAMING, Boolean.toString(enableStreaming));
+        metadata.put(CommonConstants.Query.Request.MetadataKeys.PAYLOAD_TYPE, payloadType);
+        if (this.hostName != null) {
+            metadata.put(KEY_OF_PROXY_GRPC_FORWARD_HOST, this.hostName);
+        }
+        if (this.port > 0) {
+            metadata.put(KEY_OF_PROXY_GRPC_FORWARD_PORT, String.valueOf(this.port));
+        }
+        return Server.ServerRequest.newBuilder()
+            .putAllMetadata(metadata)
+            .setSql(sql)
+            .addAllSegments(segments)
+            .build();
+    }
+}

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotConfig.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotConfig.java
@@ -47,6 +47,7 @@ public class TestPinotConfig
                         .setAggregationPushdownEnabled(true)
                         .setCountDistinctPushdownEnabled(true)
                         .setGrpcEnabled(true)
+                        .setProxyEnabled(false)
                         .setTargetSegmentPageSize(DataSize.of(1, MEGABYTE)));
     }
 
@@ -67,6 +68,7 @@ public class TestPinotConfig
                 .put("pinot.aggregation-pushdown.enabled", "false")
                 .put("pinot.count-distinct-pushdown.enabled", "false")
                 .put("pinot.grpc.enabled", "false")
+                .put("pinot.proxy.enabled", "true")
                 .put("pinot.target-segment-page-size", "2MB")
                 .buildOrThrow();
 
@@ -84,6 +86,7 @@ public class TestPinotConfig
                 .setAggregationPushdownEnabled(false)
                 .setCountDistinctPushdownEnabled(false)
                 .setGrpcEnabled(false)
+                .setProxyEnabled(true)
                 .setTargetSegmentPageSize(DataSize.of(2, MEGABYTE));
 
         ConfigAssertions.assertFullMapping(properties, expected);

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotGrpcServerQueryClientConfig.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotGrpcServerQueryClientConfig.java
@@ -33,7 +33,8 @@ public class TestPinotGrpcServerQueryClientConfig
                         .setMaxRowsPerSplitForSegmentQueries(Integer.MAX_VALUE - 1)
                         .setGrpcPort(8090)
                         .setUsePlainText(true)
-                        .setMaxInboundMessageSize(DataSize.ofBytes(DEFAULT_MAX_INBOUND_MESSAGE_BYTES_SIZE)));
+                        .setMaxInboundMessageSize(DataSize.ofBytes(DEFAULT_MAX_INBOUND_MESSAGE_BYTES_SIZE))
+                        .setProxyUri(null));
     }
 
     @Test
@@ -44,12 +45,14 @@ public class TestPinotGrpcServerQueryClientConfig
                 .put("pinot.grpc.port", "8091")
                 .put("pinot.grpc.use-plain-text", "false")
                 .put("pinot.grpc.max-inbound-message-size", String.valueOf(DataSize.ofBytes(1)))
+                .put("pinot.grpc.proxy-uri", "my-pinot-proxy:8094")
                 .buildOrThrow();
         PinotGrpcServerQueryClientConfig expected = new PinotGrpcServerQueryClientConfig()
                 .setMaxRowsPerSplitForSegmentQueries(10)
                 .setGrpcPort(8091)
                 .setUsePlainText(false)
-                .setMaxInboundMessageSize(DataSize.ofBytes(1));
+                .setMaxInboundMessageSize(DataSize.ofBytes(1))
+                .setProxyUri("my-pinot-proxy:8094");
         ConfigAssertions.assertFullMapping(properties, expected);
     }
 }


### PR DESCRIPTION
## Description
Pinot proxy is used as the global user-facing endpoint to handle all controller/broker HTTP requests as well as server gRPC requests for Trino. This is a must when connecting pinot inside a k8s cluster externally.

Adding support to enable pinot proxy for broker and grpc requests.
This feature is default disabled and can be enabled by specifying the rest proxy REST/GRPC endpoints:
```
pinot.controller-urls=https://my-pinot-rest-proxy:8123
pinot.proxy.enabled=true
pinot.grpc.proxy-uri=my-pinot-rest-proxy:8124
```

## Release notes 

```markdown
# Pinot Changes
* Adding support to enable pinot proxy for controller/broker and server grpc requests.
```
