### PR TITLE
Add ability to have unique table location for each delta lake table

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.rst
+++ b/docs/src/main/sphinx/connector/delta-lake.rst
@@ -153,6 +153,9 @@ values. Typical usage does not require you to configure them.
     * - ``delta.target-max-file-size``
       - Target maximum size of written files; the actual size may be larger.
       - ``1GB``
+    * - ``iceberg.unique-table-location``
+      - Use randomized, unique table locations.
+      - ``true``
 
 The following table describes performance tuning catalog properties for the
 connector.

--- a/plugin/trino-delta-lake/pom.xml
+++ b/plugin/trino-delta-lake/pom.xml
@@ -387,6 +387,7 @@
                                 <exclude>**/TestDeltaLakeGlueMetastore.java</exclude>
                                 <exclude>**/TestDeltaLakeCleanUpGlueMetastore.java</exclude>
                                 <exclude>**/TestDeltaLakeSharedGlueMetastoreWithTableRedirections.java</exclude>
+                                <exclude>**/TestDeltaLakeTableWithCustomLocationUsingGlueMetastore.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>
@@ -432,6 +433,7 @@
                                 <include>**/TestDeltaLakeGlueMetastore.java</include>
                                 <include>**/TestDeltaLakeCleanUpGlueMetastore.java</include>
                                 <include>**/TestDeltaLakeSharedGlueMetastoreWithTableRedirections.java</include>
+                                <include>**/TestDeltaLakeTableWithCustomLocationUsingGlueMetastore.java</include>
                             </includes>
                         </configuration>
                     </plugin>

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConfig.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConfig.java
@@ -69,6 +69,7 @@ public class DeltaLakeConfig
     private boolean deleteSchemaLocationsFallback;
     private String parquetTimeZone = TimeZone.getDefault().getID();
     private DataSize targetMaxFileSize = DataSize.of(1, GIGABYTE);
+    private boolean uniqueTableLocation = true;
 
     public Duration getMetadataCacheTtl()
     {
@@ -396,6 +397,19 @@ public class DeltaLakeConfig
     public DeltaLakeConfig setTargetMaxFileSize(DataSize targetMaxFileSize)
     {
         this.targetMaxFileSize = targetMaxFileSize;
+        return this;
+    }
+
+    public boolean isUniqueTableLocation()
+    {
+        return uniqueTableLocation;
+    }
+
+    @Config("delta.unique-table-location")
+    @ConfigDescription("Use randomized, unique table locations")
+    public DeltaLakeConfig setUniqueTableLocation(boolean uniqueTableLocation)
+    {
+        this.uniqueTableLocation = uniqueTableLocation;
         return this;
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeErrorCode.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeErrorCode.java
@@ -26,6 +26,7 @@ public enum DeltaLakeErrorCode
     DELTA_LAKE_INVALID_TABLE(1, EXTERNAL),
     DELTA_LAKE_BAD_DATA(2, EXTERNAL),
     DELTA_LAKE_BAD_WRITE(3, EXTERNAL),
+    DELTA_LAKE_FILESYSTEM_ERROR(4, EXTERNAL),
     /**/;
 
     private final ErrorCode errorCode;

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadataFactory.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadataFactory.java
@@ -53,6 +53,7 @@ public class DeltaLakeMetadataFactory
     private final boolean ignoreCheckpointWriteFailures;
     private final long perTransactionMetastoreCacheMaximumSize;
     private final boolean deleteSchemaLocationsFallback;
+    private final boolean useUniqueTableLocation;
 
     @Inject
     public DeltaLakeMetadataFactory(
@@ -89,6 +90,7 @@ public class DeltaLakeMetadataFactory
         this.ignoreCheckpointWriteFailures = deltaLakeConfig.isIgnoreCheckpointWriteFailures();
         this.perTransactionMetastoreCacheMaximumSize = deltaLakeConfig.getPerTransactionMetastoreCacheMaximumSize();
         this.deleteSchemaLocationsFallback = deltaLakeConfig.isDeleteSchemaLocationsFallback();
+        this.useUniqueTableLocation = deltaLakeConfig.isUniqueTableLocation();
     }
 
     public DeltaLakeMetadata create(ConnectorIdentity identity)
@@ -101,7 +103,8 @@ public class DeltaLakeMetadataFactory
                 cachingHiveMetastore,
                 transactionLogAccess,
                 typeManager,
-                statisticsAccess);
+                statisticsAccess,
+                hdfsEnvironment);
         return new DeltaLakeMetadata(
                 deltaLakeMetastore,
                 hdfsEnvironment,
@@ -118,6 +121,7 @@ public class DeltaLakeMetadataFactory
                 ignoreCheckpointWriteFailures,
                 deleteSchemaLocationsFallback,
                 deltaLakeRedirectionsProvider,
-                statisticsAccess);
+                statisticsAccess,
+                useUniqueTableLocation);
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/DeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/DeltaLakeMetastore.java
@@ -45,7 +45,7 @@ public interface DeltaLakeMetastore
 
     void createTable(ConnectorSession session, Table table, PrincipalPrivileges principalPrivileges);
 
-    void dropTable(ConnectorSession session, String databaseName, String tableName);
+    void dropTable(ConnectorSession session, String databaseName, String tableName, boolean externalTable);
 
     void renameTable(ConnectorSession session, SchemaTableName from, SchemaTableName to);
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeTableWithCustomLocation.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeTableWithCustomLocation.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import io.trino.plugin.hive.HdfsEnvironment;
+import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.plugin.hive.metastore.Table;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.MaterializedRow;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.TableType;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public abstract class BaseDeltaLakeTableWithCustomLocation
+        extends AbstractTestQueryFramework
+{
+    protected static final String SCHEMA = "test_tables_with_custom_location" + randomTableSuffix();
+    protected static final String CATALOG_NAME = "delta_with_custom_location";
+    protected File metastoreDir;
+    protected HiveMetastore metastore;
+    protected HdfsEnvironment hdfsEnvironment;
+    protected HdfsEnvironment.HdfsContext hdfsContext;
+
+    @Test
+    public void testTableHasUuidSuffixInLocation()
+    {
+        String tableName = "table_with_uuid" + randomTableSuffix();
+        assertQuerySucceeds(format("CREATE TABLE %s AS SELECT 1 as val", tableName));
+        Optional<Table> table = metastore.getTable(SCHEMA, tableName);
+        assertTrue(table.isPresent(), "Table should exists");
+        String location = table.get().getStorage().getLocation();
+        assertThat(location).matches(format(".*%s-[0-9a-f]{32}", tableName));
+    }
+
+    @Test
+    public void testCreateAndDrop()
+            throws IOException
+    {
+        String tableName = "test_create_and_drop" + randomTableSuffix();
+        assertQuerySucceeds(format("CREATE TABLE %s AS SELECT 1 as val", tableName));
+        Table table = metastore.getTable(SCHEMA, tableName).orElseThrow();
+        assertThat(table.getTableType()).isEqualTo(TableType.MANAGED_TABLE.name());
+
+        org.apache.hadoop.fs.Path tableLocation = new org.apache.hadoop.fs.Path(table.getStorage().getLocation());
+        FileSystem fileSystem = hdfsEnvironment.getFileSystem(hdfsContext, tableLocation);
+        assertTrue(fileSystem.exists(tableLocation), "The directory corresponding to the table storage location should exist");
+        List<MaterializedRow> materializedRows = computeActual("SELECT \"$path\" FROM " + tableName).getMaterializedRows();
+        assertEquals(materializedRows.size(), 1);
+        String filePath = (String) materializedRows.get(0).getField(0);
+        assertTrue(fileSystem.exists(new org.apache.hadoop.fs.Path(filePath)), "The data file should exist");
+        assertQuerySucceeds(format("DROP TABLE %s", tableName));
+        assertFalse(metastore.getTable(SCHEMA, tableName).isPresent(), "Table should be dropped");
+        assertFalse(fileSystem.exists(new Path(filePath)), "The data file should have been removed");
+        assertFalse(fileSystem.exists(tableLocation), "The directory corresponding to the dropped Delta Lake table should be removed");
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAdlsConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAdlsConnectorSmokeTest.java
@@ -159,7 +159,7 @@ public class TestDeltaLakeAdlsConnectorSmokeTest
 
     private List<String> listAllFilesRecursive(String directory)
     {
-        String azurePath = bucketName + "/" + directory + "/";
+        String azurePath = bucketName + "/" + directory;
         Duration timeout = Duration.ofMinutes(5);
         List<String> allPaths = azureContainerClient.listBlobs(new ListBlobsOptions().setPrefix(azurePath), timeout).stream()
                 .map(BlobItem::getName)

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConfig.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConfig.java
@@ -62,7 +62,8 @@ public class TestDeltaLakeConfig
                 .setDeleteSchemaLocationsFallback(false)
                 .setParquetTimeZone(TimeZone.getDefault().getID())
                 .setPerTransactionMetastoreCacheMaximumSize(1000)
-                .setTargetMaxFileSize(DataSize.of(1, GIGABYTE)));
+                .setTargetMaxFileSize(DataSize.of(1, GIGABYTE))
+                .setUniqueTableLocation(true));
     }
 
     @Test
@@ -93,6 +94,7 @@ public class TestDeltaLakeConfig
                 .put("delta.delete-schema-locations-fallback", "true")
                 .put("delta.parquet.time-zone", nonDefaultTimeZone().getID())
                 .put("delta.target-max-file-size", "2 GB")
+                .put("delta.unique-table-location", "false")
                 .buildOrThrow();
 
         DeltaLakeConfig expected = new DeltaLakeConfig()
@@ -119,7 +121,8 @@ public class TestDeltaLakeConfig
                 .setDeleteSchemaLocationsFallback(true)
                 .setParquetTimeZone(nonDefaultTimeZone().getID())
                 .setPerTransactionMetastoreCacheMaximumSize(500)
-                .setTargetMaxFileSize(DataSize.of(2, GIGABYTE));
+                .setTargetMaxFileSize(DataSize.of(2, GIGABYTE))
+                .setUniqueTableLocation(false);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
@@ -175,7 +175,8 @@ public class TestDeltaLakeMetadata
                                 hiveMetastoreFactory.createMetastore(Optional.empty()),
                                 transactionLogAccess,
                                 typeManager,
-                                statistics);
+                                statistics,
+                                HDFS_ENVIRONMENT);
                     }
                 });
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
@@ -261,7 +261,7 @@ public class TestDeltaLakeSplitManager
         }
 
         @Override
-        public void dropTable(ConnectorSession session, String databaseName, String tableName)
+        public void dropTable(ConnectorSession session, String databaseName, String tableName, boolean externalTable)
         {
             throw new UnsupportedOperationException("Unimplemented");
         }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeTableWithCustomLocationUsingGlueMetastore.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeTableWithCustomLocationUsingGlueMetastore.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.log.Logger;
+import io.trino.Session;
+import io.trino.plugin.hive.HdfsConfig;
+import io.trino.plugin.hive.HdfsConfigurationInitializer;
+import io.trino.plugin.hive.HdfsEnvironment;
+import io.trino.plugin.hive.HiveHdfsConfiguration;
+import io.trino.plugin.hive.authentication.NoHdfsAuthentication;
+import io.trino.plugin.hive.metastore.glue.DefaultGlueColumnStatisticsProviderFactory;
+import io.trino.plugin.hive.metastore.glue.GlueHiveMetastore;
+import io.trino.plugin.hive.metastore.glue.GlueHiveMetastoreConfig;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.testng.annotations.AfterClass;
+
+import java.io.File;
+import java.util.Optional;
+
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static io.trino.plugin.deltalake.DeltaLakeConnectorFactory.CONNECTOR_NAME;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+
+public class TestDeltaLakeTableWithCustomLocationUsingGlueMetastore
+        extends BaseDeltaLakeTableWithCustomLocation
+{
+    private static final Logger LOG = Logger.get(TestDeltaLakeSharedGlueMetastoreWithTableRedirections.class);
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session deltaLakeSession = testSessionBuilder()
+                .setCatalog(CATALOG_NAME)
+                .setSchema(SCHEMA)
+                .build();
+
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(deltaLakeSession).build();
+
+        this.metastoreDir = new File(queryRunner.getCoordinator().getBaseDataDir().resolve("delta_lake_data").toString());
+        this.metastoreDir.deleteOnExit();
+
+        queryRunner.installPlugin(new DeltaLakePlugin());
+        queryRunner.createCatalog(
+                CATALOG_NAME,
+                CONNECTOR_NAME,
+                ImmutableMap.<String, String>builder()
+                        .put("hive.metastore", "glue")
+                        .put("hive.metastore.glue.region", "us-east-2")
+                        .put("hive.metastore.glue.default-warehouse-dir", metastoreDir.getPath())
+                        .buildOrThrow());
+
+        HdfsConfig hdfsConfig = new HdfsConfig();
+        hdfsEnvironment = new HdfsEnvironment(
+                new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hdfsConfig), ImmutableSet.of()),
+                hdfsConfig,
+                new NoHdfsAuthentication());
+        GlueHiveMetastoreConfig glueConfig = new GlueHiveMetastoreConfig()
+                .setGlueRegion("us-east-2");
+        metastore = new GlueHiveMetastore(
+                hdfsEnvironment,
+                glueConfig,
+                DefaultAWSCredentialsProviderChain.getInstance(),
+                directExecutor(),
+                new DefaultGlueColumnStatisticsProviderFactory(directExecutor(), directExecutor()),
+                Optional.empty(),
+                table -> true);
+        hdfsContext = new HdfsEnvironment.HdfsContext(queryRunner.getDefaultSession().toConnectorSession());
+
+        queryRunner.execute("CREATE SCHEMA " + SCHEMA + " WITH (location = '" + metastoreDir.getPath() + "')");
+        return queryRunner;
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        try {
+            if (metastore != null) {
+                // Data is on the local disk and will be deleted by the deleteOnExit hook
+                metastore.dropDatabase(SCHEMA, false);
+                deleteRecursively(metastoreDir.toPath(), ALLOW_INSECURE);
+            }
+        }
+        catch (Exception e) {
+            LOG.error(e, "Failed to clean up Glue database: %s", SCHEMA);
+        }
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeTableWithCustomLocationUsingHiveMetastore.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeTableWithCustomLocationUsingHiveMetastore.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import com.google.common.collect.ImmutableSet;
+import io.trino.Session;
+import io.trino.plugin.hive.HdfsConfig;
+import io.trino.plugin.hive.HdfsConfiguration;
+import io.trino.plugin.hive.HdfsConfigurationInitializer;
+import io.trino.plugin.hive.HdfsEnvironment;
+import io.trino.plugin.hive.HdfsEnvironment.HdfsContext;
+import io.trino.plugin.hive.HiveHdfsConfiguration;
+import io.trino.plugin.hive.NodeVersion;
+import io.trino.plugin.hive.authentication.NoHdfsAuthentication;
+import io.trino.plugin.hive.metastore.file.FileHiveMetastore;
+import io.trino.plugin.hive.metastore.file.FileHiveMetastoreConfig;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.trino.plugin.deltalake.DeltaLakeConnectorFactory.CONNECTOR_NAME;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+
+public class TestDeltaLakeTableWithCustomLocationUsingHiveMetastore
+        extends BaseDeltaLakeTableWithCustomLocation
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setCatalog(CATALOG_NAME)
+                .setSchema(SCHEMA)
+                .build();
+
+        DistributedQueryRunner.Builder<?> builder = DistributedQueryRunner.builder(session);
+        DistributedQueryRunner queryRunner = builder.build();
+
+        Map<String, String> connectorProperties = new HashMap<>();
+        HdfsConfig hdfsConfig = new HdfsConfig();
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hdfsConfig), ImmutableSet.of());
+        hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hdfsConfig, new NoHdfsAuthentication());
+        metastoreDir = Files.createTempDirectory("test_delta_lake").toFile();
+        FileHiveMetastoreConfig config = new FileHiveMetastoreConfig()
+                .setCatalogDirectory(metastoreDir.toURI().toString())
+                .setMetastoreUser("test");
+        hdfsContext = new HdfsContext(ConnectorIdentity.ofUser(config.getMetastoreUser()));
+        metastore = new FileHiveMetastore(
+                new NodeVersion("testversion"),
+                hdfsEnvironment,
+                false,
+                config);
+        connectorProperties.putIfAbsent("delta.unique-table-location", "true");
+        connectorProperties.putIfAbsent("hive.metastore", "file");
+        connectorProperties.putIfAbsent("hive.metastore.catalog.dir", metastoreDir.getPath());
+
+        queryRunner.installPlugin(new TestingDeltaLakePlugin());
+        queryRunner.createCatalog(CATALOG_NAME, CONNECTOR_NAME, connectorProperties);
+
+        queryRunner.execute("CREATE SCHEMA " + SCHEMA);
+
+        return queryRunner;
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreStatistics.java
@@ -130,7 +130,8 @@ public class TestDeltaLakeMetastoreStatistics
                 hiveMetastore,
                 transactionLogAccess,
                 typeManager,
-                statistics);
+                statistics,
+                hdfsEnvironment);
     }
 
     private DeltaLakeTableHandle registerTable(String tableName)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -308,7 +308,7 @@ public class FileHiveMetastore
             checkArgument(table.getStorage().getLocation().isEmpty(), "Storage location for view must be empty");
         }
         else if (table.getTableType().equals(MANAGED_TABLE.name())) {
-            if (!tableMetadataDirectory.equals(new Path(table.getStorage().getLocation()))) {
+            if (!(new Path(table.getStorage().getLocation()).toString().contains(tableMetadataDirectory.toString()))) {
                 throw new TrinoException(HIVE_METASTORE_ERROR, "Table directory must be " + tableMetadataDirectory);
             }
         }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/TableMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/TableMetadata.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import java.util.OptionalLong;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.plugin.hive.HiveSchemaProperties.LOCATION_PROPERTY;
 import static io.trino.plugin.hive.metastore.StorageFormat.VIEW_STORAGE_FORMAT;
 import static java.util.Objects.requireNonNull;
 
@@ -279,7 +280,7 @@ public class TableMetadata
                 owner,
                 tableType,
                 Storage.builder()
-                        .setLocation(externalLocation.orElse(location))
+                        .setLocation(externalLocation.or(() -> Optional.ofNullable(parameters.get(LOCATION_PROPERTY))).orElse(location))
                         .setStorageFormat(storageFormat.map(StorageFormat::fromHiveStorageFormat).orElse(VIEW_STORAGE_FORMAT))
                         .setBucketProperty(bucketProperty)
                         .setSerdeParameters(serdeParameters)


### PR DESCRIPTION

## Description


> Is this change a fix, improvement, new feature, refactoring, or other?

improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

a connector

> How would you describe this change to a non-technical end user or system administrator?

each table will have different location random location, unique suffix will be added to the table name

## Related issues, pull requests, and links

https://github.com/trinodb/trino/issues/12980

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Delta Lake
* Add ability to have unique table location for each delta lake table  ({[issue](https://github.com/trinodb/trino/issues/12980)}`12980`)
```
