### PR TITLE
Fix JDBC metadata cache invalidation for query() function

### DIFF
--- a/lib/trino-collect/src/test/java/io/trino/collect/cache/CacheStatsAssertions.java
+++ b/lib/trino-collect/src/test/java/io/trino/collect/cache/CacheStatsAssertions.java
@@ -84,19 +84,13 @@ public class CacheStatsAssertions
         T value = callable.call();
         CacheStats afterStats = stats.get();
 
-        long expectedLoad = beforeStats.loadCount() + loads;
-        long expectedMisses = beforeStats.missCount() + misses;
-        long expectedHits = beforeStats.hitCount() + hits;
+        long loadDelta = afterStats.loadCount() - beforeStats.loadCount();
+        long missesDelta = afterStats.missCount() - beforeStats.missCount();
+        long hitsDelta = afterStats.hitCount() - beforeStats.hitCount();
 
-        assertThat(afterStats.loadCount())
-                .withFailMessage("Expected load count is %d but actual is %d", expectedLoad, afterStats.loadCount())
-                .isEqualTo(expectedLoad);
-        assertThat(afterStats.hitCount())
-                .withFailMessage("Expected hit count is %d but actual is %d", expectedHits, afterStats.hitCount())
-                .isEqualTo(expectedHits);
-        assertThat(afterStats.missCount())
-                .withFailMessage("Expected miss count is %d but actual is %d", expectedMisses, afterStats.missCount())
-                .isEqualTo(expectedMisses);
+        assertThat(loadDelta).as("loads (delta)").isEqualTo(loads);
+        assertThat(hitsDelta).as("hits (delta)").isEqualTo(hits);
+        assertThat(missesDelta).as("misses (delta)").isEqualTo(misses);
 
         return value;
     }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -261,7 +261,8 @@ public abstract class BaseJdbcClient
                 Optional.empty(),
                 OptionalLong.empty(),
                 Optional.of(columns.build()),
-                ImmutableSet.of(), // Note: the query is opaque, so we cannot return other referenced tables // TODO https://github.com/trinodb/trino/issues/12526
+                // The query is opaque, so we don't know referenced tables
+                Optional.empty(),
                 0);
     }
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -496,7 +496,7 @@ public class CachingJdbcClient
 
     public void onDataChanged(SchemaTableName table)
     {
-        invalidateCache(statisticsCache, key -> key.references(table));
+        invalidateCache(statisticsCache, key -> key.mayReference(table));
     }
 
     /**
@@ -560,12 +560,11 @@ public class CachingJdbcClient
 
     private void invalidateTableCaches(SchemaTableName schemaTableName)
     {
-        // TODO https://github.com/trinodb/trino/issues/12526: invalidate tableHandlesByNameCache for handles derived from opaque queries
         invalidateColumnsCache(schemaTableName);
         invalidateCache(tableHandlesByNameCache, key -> key.tableName.equals(schemaTableName));
         tableHandlesByQueryCache.invalidateAll();
         invalidateCache(tableNamesCache, key -> key.schemaName.equals(Optional.of(schemaTableName.getSchemaName())));
-        invalidateCache(statisticsCache, key -> key.references(schemaTableName));
+        invalidateCache(statisticsCache, key -> key.mayReference(schemaTableName));
     }
 
     private void invalidateColumnsCache(SchemaTableName table)

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -580,6 +580,12 @@ public class CachingJdbcClient
     }
 
     @VisibleForTesting
+    CacheStats getTableHandlesByQueryCacheStats()
+    {
+        return tableHandlesByQueryCache.stats();
+    }
+
+    @VisibleForTesting
     CacheStats getColumnsCacheStats()
     {
         return columnsCache.stats();

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
@@ -461,10 +461,12 @@ public class DefaultJdbcMetadata
                                         .addAll(newLeftColumns.values())
                                         .addAll(newRightColumns.values())
                                         .build()),
-                        ImmutableSet.<SchemaTableName>builder()
-                                .addAll(leftHandle.getAllReferencedTables())
-                                .addAll(rightHandle.getAllReferencedTables())
-                                .build(),
+                        leftHandle.getAllReferencedTables().flatMap(leftReferencedTables ->
+                                rightHandle.getAllReferencedTables().map(rightReferencedTables ->
+                                        ImmutableSet.<SchemaTableName>builder()
+                                                .addAll(leftReferencedTables)
+                                                .addAll(rightReferencedTables)
+                                                .build())),
                         nextSyntheticColumnId),
                 ImmutableMap.copyOf(newLeftColumns),
                 ImmutableMap.copyOf(newRightColumns),

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcTableHandle.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcTableHandle.java
@@ -71,7 +71,7 @@ public class TestJdbcTableHandle
                 Optional.empty(),
                 OptionalLong.of(1),
                 Optional.of(ImmutableList.of(new JdbcColumnHandle("i", type, IntegerType.INTEGER))),
-                ImmutableSet.of(),
+                Optional.of(ImmutableSet.of()),
                 0);
     }
 
@@ -88,7 +88,7 @@ public class TestJdbcTableHandle
                 Optional.empty(),
                 OptionalLong.of(1),
                 Optional.of(ImmutableList.of(new JdbcColumnHandle("i", type, IntegerType.INTEGER))),
-                ImmutableSet.of(),
+                Optional.of(ImmutableSet.of()),
                 0);
     }
 }


### PR DESCRIPTION
`query()` PTF is an opaque pass-through, so it doesn't know which tables
are referenced. When invaliding metadata cache because of a table
change, we should invalidate all `query()`-related entries.

Fixes #12526 