### PR TITLE
Interrupt stuck splits

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/TaskManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TaskManagerConfig.java
@@ -82,6 +82,9 @@ public class TaskManagerConfig
     private BigDecimal levelTimeMultiplier = new BigDecimal(2.0);
 
     private Duration longRunningSplitWarningThreshold = new Duration(10, TimeUnit.MINUTES);
+    private boolean enableInterruptStuckSplits = true;
+    private Duration interruptStuckSplitsTimeout = new Duration(10, TimeUnit.MINUTES);
+    private Duration stuckSplitDetectionInterval = new Duration(1, TimeUnit.MINUTES);
 
     @MinDuration("1ms")
     @MaxDuration("10s")
@@ -477,6 +480,46 @@ public class TaskManagerConfig
     public TaskManagerConfig setLongRunningSplitWarningThreshold(Duration longRunningSplitWarningThreshold)
     {
         this.longRunningSplitWarningThreshold = longRunningSplitWarningThreshold;
+        return this;
+    }
+
+    public boolean isEnableInterruptStuckSplits()
+    {
+        return enableInterruptStuckSplits;
+    }
+
+    @Config("task.enable-interrupt-stuck-splits")
+    public TaskManagerConfig setEnableInterruptStuckSplits(boolean enableInterruptStuckSplits)
+    {
+        this.enableInterruptStuckSplits = enableInterruptStuckSplits;
+        return this;
+    }
+
+    @MinDuration("1s")
+    public Duration getInterruptStuckSplitsTimeout()
+    {
+        return interruptStuckSplitsTimeout;
+    }
+
+    @Config("task.interrupt-stuck-splits-timeout")
+    @ConfigDescription("Interrupt task processing thread after this timeout if the thread is stuck in certain external libraries used by Trino functions")
+    public TaskManagerConfig setInterruptStuckSplitsTimeout(Duration interruptStuckSplitsTimeout)
+    {
+        this.interruptStuckSplitsTimeout = interruptStuckSplitsTimeout;
+        return this;
+    }
+
+    @MinDuration("1ms")
+    public Duration getStuckSplitDetectionInterval()
+    {
+        return stuckSplitDetectionInterval;
+    }
+
+    @Config("task.stuck-split-detection-interval")
+    @ConfigDescription("Interval between detecting stuck split")
+    public TaskManagerConfig setStuckSplitDetectionInterval(Duration stuckSplitDetectionInterval)
+    {
+        this.stuckSplitDetectionInterval = stuckSplitDetectionInterval;
         return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/TaskManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TaskManagerConfig.java
@@ -81,6 +81,8 @@ public class TaskManagerConfig
 
     private BigDecimal levelTimeMultiplier = new BigDecimal(2.0);
 
+    private Duration longRunningSplitWarningThreshold = new Duration(10, TimeUnit.MINUTES);
+
     @MinDuration("1ms")
     @MaxDuration("10s")
     @NotNull
@@ -461,6 +463,20 @@ public class TaskManagerConfig
     public TaskManagerConfig setTaskYieldThreads(int taskYieldThreads)
     {
         this.taskYieldThreads = taskYieldThreads;
+        return this;
+    }
+
+    @MinDuration("1ms")
+    public Duration getLongRunningSplitWarningThreshold()
+    {
+        return longRunningSplitWarningThreshold;
+    }
+
+    @Config("task.long-running-split-warning-threshold")
+    @ConfigDescription("Print out split call stack when it runs longer than this threshold")
+    public TaskManagerConfig setLongRunningSplitWarningThreshold(Duration longRunningSplitWarningThreshold)
+    {
+        this.longRunningSplitWarningThreshold = longRunningSplitWarningThreshold;
         return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/TaskExecutorResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/TaskExecutorResource.java
@@ -25,7 +25,7 @@ import javax.ws.rs.core.MediaType;
 import static io.trino.server.security.ResourceSecurity.AccessType.MANAGEMENT_READ;
 import static java.util.Objects.requireNonNull;
 
-@Path("/v1/maxActiveSplits")
+@Path("/v1/stuckSplits")
 public class TaskExecutorResource
 {
     private final TaskExecutor taskExecutor;
@@ -40,8 +40,8 @@ public class TaskExecutorResource
     @ResourceSecurity(MANAGEMENT_READ)
     @GET
     @Produces(MediaType.TEXT_PLAIN)
-    public String getMaxActiveSplit()
+    public String getStuckSplits()
     {
-        return taskExecutor.getMaxActiveSplitsInfo();
+        return taskExecutor.getStuckSplitsInfo();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/TestMemoryRevokingScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestMemoryRevokingScheduler.java
@@ -68,7 +68,7 @@ import static org.testng.Assert.assertTrue;
 @Test(singleThreaded = true)
 public class TestMemoryRevokingScheduler
 {
-    private final AtomicInteger idGeneator = new AtomicInteger();
+    private final AtomicInteger idGenerator = new AtomicInteger();
     private final SpillSpaceTracker spillSpaceTracker = new SpillSpaceTracker(DataSize.of(10, GIGABYTE));
     private final Map<QueryId, QueryContext> queryContexts = new HashMap<>();
 
@@ -219,9 +219,8 @@ public class TestMemoryRevokingScheduler
         TaskContext taskContext = getOrCreateTaskContext(sqlTask);
         PipelineContext pipelineContext = taskContext.addPipelineContext(0, false, false, false);
         DriverContext driverContext = pipelineContext.addDriverContext();
-        OperatorContext operatorContext = driverContext.addOperatorContext(1, new PlanNodeId("na"), "na");
 
-        return operatorContext;
+        return driverContext.addOperatorContext(1, new PlanNodeId("na"), "na");
     }
 
     private void requestMemoryRevoking(MemoryRevokingScheduler scheduler)
@@ -256,7 +255,7 @@ public class TestMemoryRevokingScheduler
     {
         QueryContext queryContext = getOrCreateQueryContext(queryId);
 
-        TaskId taskId = new TaskId(new StageId(queryId.getId(), 0), idGeneator.incrementAndGet(), 0);
+        TaskId taskId = new TaskId(new StageId(queryId.getId(), 0), idGenerator.incrementAndGet(), 0);
         URI location = URI.create("fake://task/" + taskId);
 
         return createSqlTask(

--- a/core/trino-main/src/test/java/io/trino/execution/TestMemoryRevokingScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestMemoryRevokingScheduler.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Sets;
 import io.airlift.stats.CounterStat;
 import io.airlift.stats.TestingGcMonitor;
 import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
 import io.trino.exchange.ExchangeManagerRegistry;
 import io.trino.execution.executor.TaskExecutor;
 import io.trino.memory.MemoryPool;
@@ -61,6 +62,7 @@ import static io.trino.execution.buffer.OutputBuffers.BufferType.PARTITIONED;
 import static io.trino.execution.buffer.OutputBuffers.createInitialEmptyOutputBuffers;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -84,7 +86,7 @@ public class TestMemoryRevokingScheduler
     {
         memoryPool = new MemoryPool(DataSize.ofBytes(10));
 
-        TaskExecutor taskExecutor = new TaskExecutor(8, 16, 3, 4, Ticker.systemTicker());
+        TaskExecutor taskExecutor = new TaskExecutor(8, 16, 3, 4, new Duration(10, MINUTES), Ticker.systemTicker());
         taskExecutor.start();
 
         // Must be single threaded

--- a/core/trino-main/src/test/java/io/trino/execution/TestMemoryRevokingScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestMemoryRevokingScheduler.java
@@ -45,6 +45,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledExecutorService;
@@ -86,7 +87,7 @@ public class TestMemoryRevokingScheduler
     {
         memoryPool = new MemoryPool(DataSize.ofBytes(10));
 
-        TaskExecutor taskExecutor = new TaskExecutor(8, 16, 3, 4, new Duration(10, MINUTES), Ticker.systemTicker());
+        TaskExecutor taskExecutor = new TaskExecutor(8, 16, 3, 4, new Duration(10, MINUTES), Optional.empty(), Ticker.systemTicker());
         taskExecutor.start();
 
         // Must be single threaded

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTask.java
@@ -21,6 +21,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.stats.CounterStat;
 import io.airlift.stats.TestingGcMonitor;
 import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
 import io.trino.exchange.ExchangeManagerRegistry;
 import io.trino.execution.buffer.BufferResult;
 import io.trino.execution.buffer.BufferState;
@@ -65,6 +66,7 @@ import static io.trino.execution.buffer.PagesSerde.getSerializedPagePositionCoun
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
@@ -86,7 +88,7 @@ public class TestSqlTask
 
     public TestSqlTask()
     {
-        taskExecutor = new TaskExecutor(8, 16, 3, 4, Ticker.systemTicker());
+        taskExecutor = new TaskExecutor(8, 16, 3, 4, new Duration(10, MINUTES), Ticker.systemTicker());
         taskExecutor.start();
 
         taskNotificationExecutor = newScheduledThreadPool(10, threadsNamed("task-notification-%s"));

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTask.java
@@ -282,7 +282,7 @@ public class TestSqlTask
         sqlTask.cancel();
         assertEquals(sqlTask.getTaskInfo().getTaskStatus().getState(), TaskState.CANCELED);
 
-        // buffer future will complete.. the event is async so wait a bit for event to propagate
+        // buffer future will complete, the event is async so wait a bit for event to propagate
         bufferResult.get(1, SECONDS);
 
         bufferResult = sqlTask.getTaskResults(OUT, 0, DataSize.of(1, MEGABYTE));
@@ -332,7 +332,7 @@ public class TestSqlTask
         ListenableFuture<?> future = sqlTask.getTaskStatus(STARTING_VERSION);
         assertFalse(future.isDone());
 
-        // make sure future gets unblocked when dynamic filters version is updated
+        // make sure future gets unblocked when dynamic filter's version is updated
         taskContext.updateDomains(ImmutableMap.of(new DynamicFilterId("filter"), Domain.none(BIGINT)));
         assertEquals(sqlTask.getTaskStatus().getVersion(), STARTING_VERSION + 1);
         assertEquals(sqlTask.getTaskStatus().getDynamicFiltersVersion(), INITIAL_DYNAMIC_FILTERS_VERSION + 1);

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTask.java
@@ -88,7 +88,7 @@ public class TestSqlTask
 
     public TestSqlTask()
     {
-        taskExecutor = new TaskExecutor(8, 16, 3, 4, new Duration(10, MINUTES), Ticker.systemTicker());
+        taskExecutor = new TaskExecutor(8, 16, 3, 4, new Duration(10, MINUTES), Optional.empty(), Ticker.systemTicker());
         taskExecutor.start();
 
         taskNotificationExecutor = newScheduledThreadPool(10, threadsNamed("task-notification-%s"));

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskExecution.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskExecution.java
@@ -103,7 +103,7 @@ public class TestSqlTaskExecution
     {
         ScheduledExecutorService taskNotificationExecutor = newScheduledThreadPool(10, threadsNamed("task-notification-%s"));
         ScheduledExecutorService driverYieldExecutor = newScheduledThreadPool(2, threadsNamed("driver-yield-%s"));
-        TaskExecutor taskExecutor = new TaskExecutor(5, 10, 3, 4, Ticker.systemTicker());
+        TaskExecutor taskExecutor = new TaskExecutor(5, 10, 3, 4, new Duration(10, TimeUnit.MINUTES), Ticker.systemTicker());
         taskExecutor.start();
 
         try {

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskExecution.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskExecution.java
@@ -50,7 +50,6 @@ import io.trino.spi.QueryId;
 import io.trino.spi.block.TestingBlockEncodingSerde;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.UpdatablePageSource;
-import io.trino.spi.type.Type;
 import io.trino.spiller.SpillSpaceTracker;
 import io.trino.sql.planner.LocalExecutionPlanner.LocalExecutionPlan;
 import io.trino.sql.planner.plan.PlanNodeId;
@@ -103,7 +102,7 @@ public class TestSqlTaskExecution
     {
         ScheduledExecutorService taskNotificationExecutor = newScheduledThreadPool(10, threadsNamed("task-notification-%s"));
         ScheduledExecutorService driverYieldExecutor = newScheduledThreadPool(2, threadsNamed("driver-yield-%s"));
-        TaskExecutor taskExecutor = new TaskExecutor(5, 10, 3, 4, new Duration(10, TimeUnit.MINUTES), Ticker.systemTicker());
+        TaskExecutor taskExecutor = new TaskExecutor(5, 10, 3, 4, new Duration(10, TimeUnit.MINUTES), Optional.empty(), Ticker.systemTicker());
         taskExecutor.start();
 
         try {

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskExecution.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskExecution.java
@@ -82,7 +82,6 @@ import static io.trino.execution.buffer.OutputBuffers.BufferType.PARTITIONED;
 import static io.trino.execution.buffer.OutputBuffers.createInitialEmptyOutputBuffers;
 import static io.trino.execution.buffer.PagesSerde.getSerializedPagePositionCount;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
-import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.TimeUnit.HOURS;
@@ -122,7 +121,7 @@ public class TestSqlTaskExecution
             //      |
             //    Scan
             //
-            TestingScanOperatorFactory testingScanOperatorFactory = new TestingScanOperatorFactory(0, TABLE_SCAN_NODE_ID, ImmutableList.of(VARCHAR));
+            TestingScanOperatorFactory testingScanOperatorFactory = new TestingScanOperatorFactory(0, TABLE_SCAN_NODE_ID);
             TaskOutputOperatorFactory taskOutputOperatorFactory = new TaskOutputOperatorFactory(
                     1,
                     TABLE_SCAN_NODE_ID,
@@ -337,8 +336,7 @@ public class TestSqlTaskExecution
 
         public TestingScanOperatorFactory(
                 int operatorId,
-                PlanNodeId sourceId,
-                List<Type> types)
+                PlanNodeId sourceId)
         {
             this.operatorId = operatorId;
             this.sourceId = requireNonNull(sourceId, "sourceId is null");

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskManager.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskManager.java
@@ -82,7 +82,7 @@ public class TestSqlTaskManager
     {
         localMemoryManager = new LocalMemoryManager(new NodeMemoryConfig());
         localSpillManager = new LocalSpillManager(new NodeSpillConfig());
-        taskExecutor = new TaskExecutor(8, 16, 3, 4, Ticker.systemTicker());
+        taskExecutor = new TaskExecutor(8, 16, 3, 4, new Duration(10, TimeUnit.MINUTES), Ticker.systemTicker());
         taskExecutor.start();
         taskManagementExecutor = new TaskManagementExecutor();
     }

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskManager.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskManager.java
@@ -82,7 +82,7 @@ public class TestSqlTaskManager
     {
         localMemoryManager = new LocalMemoryManager(new NodeMemoryConfig());
         localSpillManager = new LocalSpillManager(new NodeSpillConfig());
-        taskExecutor = new TaskExecutor(8, 16, 3, 4, new Duration(10, TimeUnit.MINUTES), Ticker.systemTicker());
+        taskExecutor = new TaskExecutor(8, 16, 3, 4, new Duration(10, TimeUnit.MINUTES), Optional.empty(), Ticker.systemTicker());
         taskExecutor.start();
         taskManagementExecutor = new TaskManagementExecutor();
     }

--- a/core/trino-main/src/test/java/io/trino/execution/TestTaskManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestTaskManagerConfig.java
@@ -66,7 +66,10 @@ public class TestTaskManagerConfig
                 .setTaskYieldThreads(3)
                 .setLevelTimeMultiplier(new BigDecimal("2"))
                 .setStatisticsCpuTimerEnabled(true)
-                .setLongRunningSplitWarningThreshold(new Duration(10, TimeUnit.MINUTES)));
+                .setLongRunningSplitWarningThreshold(new Duration(10, TimeUnit.MINUTES))
+                .setEnableInterruptStuckSplits(true)
+                .setInterruptStuckSplitsTimeout(new Duration(10, TimeUnit.MINUTES))
+                .setStuckSplitDetectionInterval(new Duration(1, TimeUnit.MINUTES)));
     }
 
     @Test
@@ -103,6 +106,9 @@ public class TestTaskManagerConfig
                 .put("task.level-time-multiplier", "2.1")
                 .put("task.statistics-cpu-timer-enabled", "false")
                 .put("task.long-running-split-warning-threshold", "9m")
+                .put("task.enable-interrupt-stuck-splits", "false")
+                .put("task.interrupt-stuck-splits-timeout", "9m")
+                .put("task.stuck-split-detection-interval", "1s")
                 .buildOrThrow();
 
         TaskManagerConfig expected = new TaskManagerConfig()
@@ -134,7 +140,10 @@ public class TestTaskManagerConfig
                 .setTaskYieldThreads(8)
                 .setLevelTimeMultiplier(new BigDecimal("2.1"))
                 .setStatisticsCpuTimerEnabled(false)
-                .setLongRunningSplitWarningThreshold(new Duration(9, TimeUnit.MINUTES));
+                .setLongRunningSplitWarningThreshold(new Duration(9, TimeUnit.MINUTES))
+                .setEnableInterruptStuckSplits(false)
+                .setInterruptStuckSplitsTimeout(new Duration(9, TimeUnit.MINUTES))
+                .setStuckSplitDetectionInterval(new Duration(1, TimeUnit.SECONDS));
 
         assertFullMapping(properties, expected);
     }

--- a/core/trino-main/src/test/java/io/trino/execution/TestTaskManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestTaskManagerConfig.java
@@ -65,7 +65,8 @@ public class TestTaskManagerConfig
                 .setTaskNotificationThreads(5)
                 .setTaskYieldThreads(3)
                 .setLevelTimeMultiplier(new BigDecimal("2"))
-                .setStatisticsCpuTimerEnabled(true));
+                .setStatisticsCpuTimerEnabled(true)
+                .setLongRunningSplitWarningThreshold(new Duration(10, TimeUnit.MINUTES)));
     }
 
     @Test
@@ -101,6 +102,7 @@ public class TestTaskManagerConfig
                 .put("task.task-yield-threads", "8")
                 .put("task.level-time-multiplier", "2.1")
                 .put("task.statistics-cpu-timer-enabled", "false")
+                .put("task.long-running-split-warning-threshold", "9m")
                 .buildOrThrow();
 
         TaskManagerConfig expected = new TaskManagerConfig()
@@ -131,7 +133,8 @@ public class TestTaskManagerConfig
                 .setTaskNotificationThreads(13)
                 .setTaskYieldThreads(8)
                 .setLevelTimeMultiplier(new BigDecimal("2.1"))
-                .setStatisticsCpuTimerEnabled(false);
+                .setStatisticsCpuTimerEnabled(false)
+                .setLongRunningSplitWarningThreshold(new Duration(9, TimeUnit.MINUTES));
 
         assertFullMapping(properties, expected);
     }

--- a/core/trino-main/src/test/java/io/trino/execution/executor/TaskExecutorSimulator.java
+++ b/core/trino-main/src/test/java/io/trino/execution/executor/TaskExecutorSimulator.java
@@ -154,7 +154,7 @@ public class TaskExecutorSimulator
 
         SECONDS.sleep(30);
 
-        // this gets the executor into a more realistic point-in-time state, where long running tasks start to make progress
+        // this gets the executor into a more realistic point-in-time state, where long-running tasks start to make progress
         for (int i = 0; i < 20; i++) {
             controller.clearPendingQueue();
             MINUTES.sleep(1);

--- a/core/trino-main/src/test/java/io/trino/execution/executor/TaskExecutorSimulator.java
+++ b/core/trino-main/src/test/java/io/trino/execution/executor/TaskExecutorSimulator.java
@@ -33,6 +33,7 @@ import java.io.Closeable;
 import java.util.List;
 import java.util.LongSummaryStatistics;
 import java.util.Map;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
@@ -79,7 +80,7 @@ public class TaskExecutorSimulator
     private TaskExecutorSimulator()
     {
         splitQueue = new MultilevelSplitQueue(2);
-        taskExecutor = new TaskExecutor(36, 72, 3, 8, new Duration(10, MINUTES), splitQueue, Ticker.systemTicker());
+        taskExecutor = new TaskExecutor(36, 72, 3, 8, new Duration(10, MINUTES), Optional.empty(), splitQueue, Ticker.systemTicker());
         taskExecutor.start();
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/executor/TaskExecutorSimulator.java
+++ b/core/trino-main/src/test/java/io/trino/execution/executor/TaskExecutorSimulator.java
@@ -79,7 +79,7 @@ public class TaskExecutorSimulator
     private TaskExecutorSimulator()
     {
         splitQueue = new MultilevelSplitQueue(2);
-        taskExecutor = new TaskExecutor(36, 72, 3, 8, splitQueue, Ticker.systemTicker());
+        taskExecutor = new TaskExecutor(36, 72, 3, 8, new Duration(10, MINUTES), splitQueue, Ticker.systemTicker());
         taskExecutor.start();
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/executor/TestTaskExecutor.java
+++ b/core/trino-main/src/test/java/io/trino/execution/executor/TestTaskExecutor.java
@@ -78,9 +78,9 @@ public class TestTaskExecutor
             assertEquals(driver1.getCompletedPhases(), 0);
             assertEquals(driver2.getCompletedPhases(), 0);
             ticker.increment(60, SECONDS);
-            assertEquals(taskExecutor.getRunAwaySplitCount(), 0);
+            assertEquals(taskExecutor.getStuckSplitsCount(), 0);
             ticker.increment(600, SECONDS);
-            assertEquals(taskExecutor.getRunAwaySplitCount(), 2);
+            assertEquals(taskExecutor.getStuckSplitsCount(), 2);
             verificationComplete.arriveAndAwaitAdvance();
 
             // advance one phase and verify
@@ -135,7 +135,7 @@ public class TestTaskExecutor
 
             // no splits remaining
             ticker.increment(610, SECONDS);
-            assertEquals(taskExecutor.getRunAwaySplitCount(), 0);
+            assertEquals(taskExecutor.getStuckSplitsCount(), 0);
         }
         finally {
             taskExecutor.stop();

--- a/core/trino-main/src/test/java/io/trino/execution/executor/TestTaskExecutor.java
+++ b/core/trino-main/src/test/java/io/trino/execution/executor/TestTaskExecutor.java
@@ -52,7 +52,7 @@ public class TestTaskExecutor
             throws Exception
     {
         TestingTicker ticker = new TestingTicker();
-        TaskExecutor taskExecutor = new TaskExecutor(4, 8, 3, 4, ticker);
+        TaskExecutor taskExecutor = new TaskExecutor(4, 8, 3, 4, new Duration(10, MINUTES), ticker);
         taskExecutor.start();
         ticker.increment(20, MILLISECONDS);
 
@@ -146,7 +146,7 @@ public class TestTaskExecutor
     public void testQuantaFairness()
     {
         TestingTicker ticker = new TestingTicker();
-        TaskExecutor taskExecutor = new TaskExecutor(1, 2, 3, 4, ticker);
+        TaskExecutor taskExecutor = new TaskExecutor(1, 2, 3, 4, new Duration(10, MINUTES), ticker);
         taskExecutor.start();
         ticker.increment(20, MILLISECONDS);
 
@@ -180,7 +180,7 @@ public class TestTaskExecutor
     public void testLevelMovement()
     {
         TestingTicker ticker = new TestingTicker();
-        TaskExecutor taskExecutor = new TaskExecutor(2, 2, 3, 4, ticker);
+        TaskExecutor taskExecutor = new TaskExecutor(2, 2, 3, 4, new Duration(10, MINUTES), ticker);
         taskExecutor.start();
         ticker.increment(20, MILLISECONDS);
 
@@ -219,7 +219,7 @@ public class TestTaskExecutor
             throws Exception
     {
         TestingTicker ticker = new TestingTicker();
-        TaskExecutor taskExecutor = new TaskExecutor(6, 3, 3, 4, new MultilevelSplitQueue(2), ticker);
+        TaskExecutor taskExecutor = new TaskExecutor(6, 3, 3, 4, new Duration(10, MINUTES), new MultilevelSplitQueue(2), ticker);
         taskExecutor.start();
         ticker.increment(20, MILLISECONDS);
 
@@ -297,7 +297,7 @@ public class TestTaskExecutor
     public void testTaskHandle()
     {
         TestingTicker ticker = new TestingTicker();
-        TaskExecutor taskExecutor = new TaskExecutor(4, 8, 3, 4, ticker);
+        TaskExecutor taskExecutor = new TaskExecutor(4, 8, 3, 4, new Duration(10, MINUTES), ticker);
         taskExecutor.start();
 
         try {
@@ -372,7 +372,7 @@ public class TestTaskExecutor
         int maxDriversPerTask = 2;
         MultilevelSplitQueue splitQueue = new MultilevelSplitQueue(2);
         TestingTicker ticker = new TestingTicker();
-        TaskExecutor taskExecutor = new TaskExecutor(4, 16, 1, maxDriversPerTask, splitQueue, ticker);
+        TaskExecutor taskExecutor = new TaskExecutor(4, 16, 1, maxDriversPerTask, new Duration(10, MINUTES), splitQueue, ticker);
         taskExecutor.start();
         try {
             TaskHandle testTaskHandle = taskExecutor.addTask(new TaskId(new StageId("test", 0), 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
@@ -412,7 +412,7 @@ public class TestTaskExecutor
         MultilevelSplitQueue splitQueue = new MultilevelSplitQueue(2);
         TestingTicker ticker = new TestingTicker();
         // create a task executor with min/max drivers per task to be 2 and 4
-        TaskExecutor taskExecutor = new TaskExecutor(4, 16, 2, 4, splitQueue, ticker);
+        TaskExecutor taskExecutor = new TaskExecutor(4, 16, 2, 4, new Duration(10, MINUTES), splitQueue, ticker);
         taskExecutor.start();
         try {
             // overwrite the max drivers per task to be 1
@@ -451,7 +451,7 @@ public class TestTaskExecutor
         MultilevelSplitQueue splitQueue = new MultilevelSplitQueue(2);
         TestingTicker ticker = new TestingTicker();
         // create a task executor with min/max drivers per task to be 2
-        TaskExecutor taskExecutor = new TaskExecutor(4, 1, 2, 2, splitQueue, ticker);
+        TaskExecutor taskExecutor = new TaskExecutor(4, 1, 2, 2, new Duration(10, MINUTES), splitQueue, ticker);
         taskExecutor.start();
 
         try {

--- a/docs/src/main/sphinx/admin/properties-task.rst
+++ b/docs/src/main/sphinx/admin/properties-task.rst
@@ -124,3 +124,13 @@ of additional CPU for parallel writes. Some connectors can be bottlenecked on CP
 writing due to compression or other factors. Setting this too high may cause the cluster
 to become overloaded due to excessive resource utilization. This can also be specified on
 a per-query basis using the ``task_writer_count`` session property.
+
+``task.long-running-split-warning-threshold``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** :ref:`prop-type-duration`
+* **Minimum value:** ``1ms``
+* **Default value:** ``10m``
+
+When split runs longer than this threshold, we can get the call stack via
+``/v1/stuckSplits`` endpoint on coordinator.

--- a/docs/src/main/sphinx/admin/properties-task.rst
+++ b/docs/src/main/sphinx/admin/properties-task.rst
@@ -134,3 +134,13 @@ a per-query basis using the ``task_writer_count`` session property.
 
 When split runs longer than this threshold, we can get the call stack via
 ``/v1/stuckSplits`` endpoint on coordinator.
+
+``task.interrupt-stuck-splits-timeout``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** :ref:`prop-type-duration`
+* **Minimum value:** ``1s``
+* **Default value:** ``10m``
+
+The length of time Trino waits for a blocked split processing thread before interrupting the thread.
+Only applies to threads that are blocked by the third-party Joni regular expression library.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

For regular expression matching, especially when using the Joni regular library,
this may cause the task thread to take so long that it looks like a dead loop,
which may result in no free threads for the worker to process other splits.

Since the Joni regular library supports handling interrupts, this PR gives
the task thread a chance to exit by interrupting the task thread of Joni regular
functions that has been running for a long time.

Co-authored-by: @leetcode-1533

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core query engine.

> How would you describe this change to a non-technical end user or system administrator?

Fix potential deadlock during execution of Joni regular functions.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->
Superceding #12392

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
