### PR TITLE
Move pushdown test to `BaseRedisConnectorTest`

### DIFF
--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisConnectorTest.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisConnectorTest.java
@@ -15,12 +15,9 @@ package io.trino.plugin.redis;
 
 import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.redis.util.RedisServer;
-import io.trino.sql.planner.plan.FilterNode;
 import io.trino.testing.QueryRunner;
-import org.testng.annotations.Test;
 
 import static io.trino.plugin.redis.RedisQueryRunner.createRedisQueryRunner;
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestRedisConnectorTest
         extends BaseRedisConnectorTest
@@ -31,44 +28,5 @@ public class TestRedisConnectorTest
     {
         RedisServer redisServer = closeAfterClass(new RedisServer());
         return createRedisQueryRunner(redisServer, ImmutableMap.of(), ImmutableMap.of(), "string", REQUIRED_TPCH_TABLES);
-    }
-
-    @Test
-    public void testPredicatePushdown()
-    {
-        // redis key equality
-        assertThat(query("SELECT regionkey, nationkey, name FROM tpch.nation WHERE redis_key = 'tpch:nation:19'"))
-                .matches("VALUES (BIGINT '3', BIGINT '19', CAST('ROMANIA' AS varchar(25)))")
-                .isFullyPushedDown();
-
-        // redis key equality
-        assertThat(query("SELECT regionkey, nationkey, name FROM tpch.nation WHERE redis_key = 'tpch:nation:19' AND regionkey = 3"))
-                .matches("VALUES (BIGINT '3', BIGINT '19', CAST('ROMANIA' AS varchar(25)))")
-                .isNotFullyPushedDown(FilterNode.class);
-
-        // redis key equality
-        assertThat(query("SELECT regionkey, nationkey, name FROM tpch.nation WHERE redis_key = 'tpch:nation:19' AND regionkey = 4"))
-                .returnsEmptyResult()
-                .isNotFullyPushedDown(FilterNode.class);
-
-        // redis key different case
-        assertThat(query("SELECT regionkey, nationkey, name FROM nation WHERE redis_key = 'tpch:nation:100'"))
-                .returnsEmptyResult()
-                .isFullyPushedDown();
-
-        // redis key IN case
-        assertThat(query("SELECT regionkey, nationkey, name FROM tpch.nation WHERE redis_key IN ('tpch:nation:19', 'tpch:nation:2', 'tpch:nation:24')"))
-                .matches("VALUES " +
-                        "(BIGINT '3', BIGINT '19', CAST('ROMANIA' AS varchar(25))), " +
-                        "(BIGINT '1', BIGINT '2', CAST('BRAZIL' AS varchar(25))), " +
-                        "(BIGINT '1', BIGINT '24', CAST('UNITED STATES' AS varchar(25)))")
-                .isFullyPushedDown();
-
-        // redis key range
-        assertThat(query("SELECT regionkey, nationkey, name FROM tpch.nation WHERE redis_key BETWEEN 'tpch:nation:23' AND 'tpch:nation:24'"))
-                .matches("VALUES " +
-                        "(BIGINT '3', BIGINT '23', CAST('UNITED KINGDOM' AS varchar(25))), " +
-                        "(BIGINT '1', BIGINT '24', CAST('UNITED STATES' AS varchar(25)))")
-                .isNotFullyPushedDown(FilterNode.class);
     }
 }


### PR DESCRIPTION
## Description
Move pushdown test to `BaseRedisConnectorTest`.

## Related issues, pull requests, and links
Related comment: https://github.com/trinodb/trino/commit/ff2308db2e87a0ac6b0a9b5948983f0357e2b090#r76764100

## Documentation
(x) No documentation is needed.

## Release notes
(x) No release notes entries required.