### PR TITLE
Finish query only after the results are fully consumed

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/DataDefinitionExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DataDefinitionExecution.java
@@ -177,6 +177,12 @@ public class DataDefinitionExecution<T extends Statement>
     }
 
     @Override
+    public void resultsConsumed()
+    {
+        stateMachine.resultsConsumed();
+    }
+
+    @Override
     public ListenableFuture<QueryState> getStateChange(QueryState currentState)
     {
         return stateMachine.getStateChange(currentState);

--- a/core/trino-main/src/main/java/io/trino/execution/QueryExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryExecution.java
@@ -47,6 +47,8 @@ public interface QueryExecution
 
     void outputTaskFailed(TaskId taskId, Throwable failure);
 
+    void resultsConsumed();
+
     Plan getQueryPlan();
 
     BasicQueryInfo getBasicQueryInfo();

--- a/core/trino-main/src/main/java/io/trino/execution/QueryManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryManager.java
@@ -42,6 +42,11 @@ public interface QueryManager
     void outputTaskFailed(TaskId taskId, Throwable failure);
 
     /**
+     * Notify that the query results for a query have been fully consumed by the client
+     */
+    void resultsConsumed(QueryId queryId);
+
+    /**
      * Add a listener that fires each time the query state changes.
      * Listener is always notified asynchronously using a dedicated notification thread pool so, care should
      * be taken to avoid leaking {@code this} when adding a listener in a constructor. Additionally, it is

--- a/core/trino-main/src/main/java/io/trino/execution/SqlQueryExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlQueryExecution.java
@@ -599,6 +599,12 @@ public class SqlQueryExecution
     }
 
     @Override
+    public void resultsConsumed()
+    {
+        stateMachine.resultsConsumed();
+    }
+
+    @Override
     public ListenableFuture<QueryState> getStateChange(QueryState currentState)
     {
         return stateMachine.getStateChange(currentState);

--- a/core/trino-main/src/main/java/io/trino/execution/SqlQueryManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlQueryManager.java
@@ -162,6 +162,12 @@ public class SqlQueryManager
     }
 
     @Override
+    public void resultsConsumed(QueryId queryId)
+    {
+        queryTracker.getQuery(queryId).resultsConsumed();
+    }
+
+    @Override
     public void addStateChangeListener(QueryId queryId, StateChangeListener<QueryState> listener)
     {
         requireNonNull(listener, "listener is null");

--- a/core/trino-main/src/test/java/io/trino/execution/TestQueryStateMachine.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestQueryStateMachine.java
@@ -126,6 +126,9 @@ public class TestQueryStateMachine
         assertState(stateMachine, RUNNING);
 
         assertTrue(stateMachine.transitionToFinishing());
+        assertState(stateMachine, FINISHING);
+
+        stateMachine.resultsConsumed();
         tryGetFutureValue(stateMachine.getStateChange(FINISHING), 2, SECONDS);
         assertState(stateMachine, FINISHED);
     }
@@ -152,6 +155,7 @@ public class TestQueryStateMachine
         assertState(stateMachine, RUNNING);
 
         assertTrue(stateMachine.transitionToFinishing());
+        stateMachine.resultsConsumed();
         tryGetFutureValue(stateMachine.getStateChange(FINISHING), 2, SECONDS);
         assertState(stateMachine, FINISHED);
     }
@@ -168,6 +172,7 @@ public class TestQueryStateMachine
         assertAllTimeSpentInQueueing(RUNNING, QueryStateMachine::transitionToRunning);
 
         assertAllTimeSpentInQueueing(FINISHED, stateMachine -> {
+            stateMachine.resultsConsumed();
             stateMachine.transitionToFinishing();
             tryGetFutureValue(stateMachine.getStateChange(FINISHING), 2, SECONDS);
         });
@@ -217,6 +222,7 @@ public class TestQueryStateMachine
         stateMachine = createQueryStateMachine();
         stateMachine.transitionToPlanning();
         assertTrue(stateMachine.transitionToFinishing());
+        stateMachine.resultsConsumed();
         tryGetFutureValue(stateMachine.getStateChange(FINISHING), 2, SECONDS);
         assertState(stateMachine, FINISHED);
 
@@ -247,6 +253,7 @@ public class TestQueryStateMachine
 
         stateMachine = createQueryStateMachine();
         stateMachine.transitionToStarting();
+        stateMachine.resultsConsumed();
         assertTrue(stateMachine.transitionToFinishing());
         tryGetFutureValue(stateMachine.getStateChange(FINISHING), 2, SECONDS);
         assertState(stateMachine, FINISHED);
@@ -276,6 +283,7 @@ public class TestQueryStateMachine
         assertFalse(stateMachine.transitionToRunning());
         assertState(stateMachine, RUNNING);
 
+        stateMachine.resultsConsumed();
         assertTrue(stateMachine.transitionToFinishing());
         tryGetFutureValue(stateMachine.getStateChange(FINISHING), 2, SECONDS);
         assertState(stateMachine, FINISHED);
@@ -291,6 +299,8 @@ public class TestQueryStateMachine
     {
         QueryStateMachine stateMachine = createQueryStateMachine();
         assertTrue(stateMachine.transitionToFinishing());
+        assertState(stateMachine, FINISHING);
+        stateMachine.resultsConsumed();
         tryGetFutureValue(stateMachine.getStateChange(FINISHING), 2, SECONDS);
         assertFinalState(stateMachine, FINISHED);
     }
@@ -340,6 +350,7 @@ public class TestQueryStateMachine
 
         mockTicker.increment(400, MILLISECONDS);
         assertTrue(stateMachine.transitionToFinishing());
+        stateMachine.resultsConsumed();
         tryGetFutureValue(stateMachine.getStateChange(FINISHING), 2, SECONDS);
         assertState(stateMachine, FINISHED);
 

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestQueues.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestQueues.java
@@ -35,6 +35,7 @@ import static io.airlift.units.DataSize.Unit.TERABYTE;
 import static io.trino.SystemSessionProperties.HASH_PARTITION_COUNT;
 import static io.trino.execution.QueryState.FAILED;
 import static io.trino.execution.QueryState.FINISHED;
+import static io.trino.execution.QueryState.FINISHING;
 import static io.trino.execution.QueryState.QUEUED;
 import static io.trino.execution.QueryState.RUNNING;
 import static io.trino.execution.TestQueryRunnerUtil.cancelQuery;
@@ -291,7 +292,7 @@ public class TestQueues
             throws InterruptedException
     {
         QueryId queryId = createQuery(queryRunner, session, query);
-        waitForQueryState(queryRunner, queryId, ImmutableSet.of(RUNNING, FINISHED));
+        waitForQueryState(queryRunner, queryId, ImmutableSet.of(RUNNING, FINISHING, FINISHED));
         Optional<ResourceGroupId> resourceGroupId = queryRunner.getCoordinator().getQueryManager().getFullQueryInfo(queryId).getResourceGroupId();
         assertTrue(resourceGroupId.isPresent(), "Query should have a resource group");
         assertEquals(resourceGroupId.get(), expectedResourceGroup, format("Expected: '%s' resource group, found: %s", expectedResourceGroup, resourceGroupId.get()));


### PR DESCRIPTION
This commit makes it consistent with QueryState#FINISHED documentation.

This change is needed to allow spooling exchange to be used for query
results delivery. Spooling exchanges in fault tolerant execution are
closed on query completion. It is important not to close an exchange
before the results are fully consumed.

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core engine

> How would you describe this change to a non-technical end user or system administrator?

With this change a query is considered finished successfully only when the query results are successfully consumed by the client. Before it was possible that a query might've been marked as successful even when client experienced a failure or dropped a connection.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Core
* Queries are now marked as finished successfully only when the query results are successfully consumed by the client
```
