### PR TITLE
Resolve transaction manager race condition

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/CallTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CallTask.java
@@ -98,7 +98,7 @@ public class CallTask
             List<Expression> parameters,
             WarningCollector warningCollector)
     {
-        if (!transactionManager.isAutoCommit(stateMachine.getSession().getRequiredTransactionId())) {
+        if (!transactionManager.getTransactionInfo(stateMachine.getSession().getRequiredTransactionId()).isAutoCommitContext()) {
             throw new TrinoException(NOT_SUPPORTED, "Procedures cannot be called within a transaction (use autocommit mode)");
         }
 

--- a/core/trino-main/src/main/java/io/trino/transaction/InMemoryTransactionManager.java
+++ b/core/trino-main/src/main/java/io/trino/transaction/InMemoryTransactionManager.java
@@ -149,6 +149,12 @@ public class InMemoryTransactionManager
     }
 
     @Override
+    public Optional<TransactionInfo> getTransactionInfoIfExist(TransactionId transactionId)
+    {
+        return tryGetTransactionMetadata(transactionId).map(TransactionMetadata::getTransactionInfo);
+    }
+
+    @Override
     public List<TransactionInfo> getAllTransactionInfos()
     {
         return transactions.values().stream()

--- a/core/trino-main/src/main/java/io/trino/transaction/NoOpTransactionManager.java
+++ b/core/trino-main/src/main/java/io/trino/transaction/NoOpTransactionManager.java
@@ -42,6 +42,12 @@ public class NoOpTransactionManager
     }
 
     @Override
+    public Optional<TransactionInfo> getTransactionInfoIfExist(TransactionId transactionId)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public List<TransactionInfo> getAllTransactionInfos()
     {
         throw new UnsupportedOperationException();

--- a/core/trino-main/src/main/java/io/trino/transaction/TransactionManager.java
+++ b/core/trino-main/src/main/java/io/trino/transaction/TransactionManager.java
@@ -30,12 +30,9 @@ public interface TransactionManager
 
     boolean transactionExists(TransactionId transactionId);
 
-    default boolean isAutoCommit(TransactionId transactionId)
-    {
-        return getTransactionInfo(transactionId).isAutoCommitContext();
-    }
-
     TransactionInfo getTransactionInfo(TransactionId transactionId);
+
+    Optional<TransactionInfo> getTransactionInfoIfExist(TransactionId transactionId);
 
     List<TransactionInfo> getAllTransactionInfos();
 

--- a/core/trino-main/src/test/java/io/trino/transaction/TestingTransactionManager.java
+++ b/core/trino-main/src/test/java/io/trino/transaction/TestingTransactionManager.java
@@ -61,6 +61,15 @@ public class TestingTransactionManager
     }
 
     @Override
+    public Optional<TransactionInfo> getTransactionInfoIfExist(TransactionId transactionId)
+    {
+        if (transactions.containsKey(transactionId)) {
+            return Optional.of(getTransactionInfo(transactionId));
+        }
+        return Optional.empty();
+    }
+
+    @Override
     public List<TransactionInfo> getAllTransactionInfos()
     {
         return transactions.keySet().stream()


### PR DESCRIPTION
When query is cancelled while being committed a transaction might
disapear in between of the `transactionExists` and `isAutoCommit`
methods.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core engine

> How would you describe this change to a non-technical end user or system administrator?

Non user visible

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
