### PR TITLE
Remove list of table functions by connector

### DIFF
--- a/docs/src/main/sphinx/functions/table.rst
+++ b/docs/src/main/sphinx/functions/table.rst
@@ -19,6 +19,10 @@ Trino supports adding custom table functions. They are declared by connectors
 through implementing dedicated interfaces. For guidance on adding new table
 functions, see the :doc:`developer guide</develop/table-functions>`.
 
+Connectors offer support for different functions on a per-connector basis. For
+more information about supported table functions, refer to the :doc:`connector
+documentation <../../connector>`.
+
 Table function invocation
 -------------------------
 
@@ -74,38 +78,3 @@ parameters in arguments::
     SELECT * FROM TABLE(my_function("row_count" => ? + 1, "column_count" => ?));
 
     EXECUTE stmt USING 100, 1;
-
-List of table functions by connector
-------------------------------------
-
-* Druid
-
-  * :ref:`query <druid-query-function>` for full query pass-through.
-
-* MariaDB
-
-  * :ref:`query <mariadb-query-function>` for full query pass-through.
-
-* MySQL
-
-  * :ref:`query <mysql-query-function>` for full query pass-through.
-
-* Oracle
-
-  * :ref:`query <oracle-query-function>` for full query pass-through.
-
-* PostgreSQL
-
-  * :ref:`query <postgresql-query-function>` for full query pass-through.
-
-* Redshift
-
-  * :ref:`query <redshift-query-function>` for full query pass-through.
-
-* SQL Server
-
-  * :ref:`query <sqlserver-query-function>` for full query pass-through.
-
-
-
-


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

The list of table functions by connector that's currently in the table functions page adds unnecessary overhead for little benefit. Similar to what we do for SQL statements, we should instead have a more general link to the connector docs for information on what's supported.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Documentation

> How would you describe this change to a non-technical end user or system administrator?

Removes an unnecessary list to reduce maintenance and docs overhead.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
