### PR TITLE
Replace ValuesNode::Expression with RowExpression

### DIFF
--- a/core/trino-main/pom.xml
+++ b/core/trino-main/pom.xml
@@ -208,6 +208,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.stephenc.jcip</groupId>
+            <artifactId>jcip-annotations</artifactId>
+            <version>1.0-1</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
         </dependency>

--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionDependencies.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionDependencies.java
@@ -19,6 +19,7 @@ import io.trino.spi.function.InvocationConvention;
 import io.trino.spi.function.OperatorType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeSignature;
+import io.trino.sql.relational.StandardFunctionResolution;
 import io.trino.sql.tree.QualifiedName;
 
 import java.util.Collection;
@@ -63,7 +64,7 @@ public class FunctionDependencies
                 .filter(FunctionDependencies::isOperator)
                 .collect(toImmutableMap(OperatorKey::new, identity()));
         this.casts = functionDependencies.stream()
-                .filter(FunctionDependencies::isCast)
+                .filter(StandardFunctionResolution::isCastFunction)
                 .collect(toImmutableMap(CastKey::new, identity()));
     }
 
@@ -178,12 +179,6 @@ public class FunctionDependencies
     {
         String name = function.getSignature().getName();
         return isOperatorName(name) && unmangleOperator(name) != CAST;
-    }
-
-    public static boolean isCast(ResolvedFunction function)
-    {
-        String name = function.getSignature().getName();
-        return isOperatorName(name) && unmangleOperator(name) == CAST;
     }
 
     public static final class FunctionKey

--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionDependencies.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionDependencies.java
@@ -180,7 +180,7 @@ public class FunctionDependencies
         return isOperatorName(name) && unmangleOperator(name) != CAST;
     }
 
-    private static boolean isCast(ResolvedFunction function)
+    public static boolean isCast(ResolvedFunction function)
     {
         String name = function.getSignature().getName();
         return isOperatorName(name) && unmangleOperator(name) == CAST;

--- a/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionExtractor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionExtractor.java
@@ -31,6 +31,8 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import static io.trino.sql.planner.iterative.Lookup.noLookup;
+import static io.trino.sql.relational.OriginalExpressionUtils.castToExpression;
+import static io.trino.sql.relational.OriginalExpressionUtils.isExpression;
 import static java.util.Objects.requireNonNull;
 
 public final class ExpressionExtractor
@@ -135,7 +137,11 @@ public final class ExpressionExtractor
         @Override
         public Void visitValues(ValuesNode node, Void context)
         {
-            node.getRows().ifPresent(list -> list.forEach(consumer));
+            node.getRows().ifPresent(list -> list.forEach(rowExpression -> {
+                if (isExpression(rowExpression)) {
+                    consumer.accept(castToExpression(rowExpression));
+                }
+            }));
             return super.visitValues(node, context);
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionInterpreter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionInterpreter.java
@@ -1469,7 +1469,7 @@ public class ExpressionInterpreter
         return type instanceof ArrayType;
     }
 
-    private static class LambdaSymbolResolver
+    public static class LambdaSymbolResolver
             implements SymbolResolver
     {
         private final Map<String, Object> values;

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LiteralEncoder.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LiteralEncoder.java
@@ -26,30 +26,18 @@ import io.trino.operator.scalar.VarbinaryFunctions;
 import io.trino.operator.scalar.timestamp.TimestampToVarcharCast;
 import io.trino.operator.scalar.timestamptz.TimestampWithTimeZoneToVarcharCast;
 import io.trino.spi.block.Block;
-import io.trino.spi.connector.ConnectorSession;
-import io.trino.spi.type.BigintType;
-import io.trino.spi.type.BooleanType;
 import io.trino.spi.type.CharType;
-import io.trino.spi.type.DateType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Decimals;
-import io.trino.spi.type.DoubleType;
 import io.trino.spi.type.Int128;
-import io.trino.spi.type.IntegerType;
 import io.trino.spi.type.LongTimestamp;
 import io.trino.spi.type.LongTimestampWithTimeZone;
-import io.trino.spi.type.RealType;
-import io.trino.spi.type.SmallintType;
 import io.trino.spi.type.SqlDate;
-import io.trino.spi.type.SqlVarbinary;
 import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.TimestampWithTimeZoneType;
-import io.trino.spi.type.TinyintType;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
 import io.trino.sql.PlannerContext;
-import io.trino.sql.relational.ConstantExpression;
 import io.trino.sql.relational.RowExpression;
 import io.trino.sql.tree.ArithmeticUnaryExpression;
 import io.trino.sql.tree.BooleanLiteral;
@@ -66,13 +54,9 @@ import io.trino.sql.tree.TimestampLiteral;
 
 import javax.annotation.Nullable;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.math.MathContext;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 import static io.trino.metadata.LiteralFunction.LITERAL_FUNCTION_NAME;
 import static io.trino.metadata.LiteralFunction.typeForMagicLiteral;
 import static io.trino.spi.predicate.Utils.nativeValueToBlock;
@@ -103,49 +87,6 @@ public final class LiteralEncoder
     public LiteralEncoder(PlannerContext plannerContext)
     {
         this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
-    }
-
-    public static Object evaluate(ConnectorSession session, ConstantExpression node)
-    {
-        Type type = node.getType();
-
-        if (node.getValue() == null) {
-            return null;
-        }
-        if (type instanceof BooleanType) {
-            return node.getValue();
-        }
-        if (type instanceof BigintType || type instanceof TinyintType || type instanceof SmallintType || type instanceof IntegerType) {
-            return node.getValue();
-        }
-        if (type instanceof DoubleType) {
-            return node.getValue();
-        }
-        if (type instanceof RealType) {
-            Long number = (Long) node.getValue();
-            return intBitsToFloat(number.intValue());
-        }
-        if (type instanceof DecimalType) {
-            DecimalType decimalType = (DecimalType) type;
-            if (decimalType.isShort()) {
-                checkState(node.getValue() instanceof Long);
-                return decodeDecimal(BigInteger.valueOf((long) node.getValue()), decimalType);
-            }
-            checkState(node.getValue() instanceof Slice);
-            return (Slice) node.getValue();
-        }
-        if (type instanceof VarcharType || type instanceof CharType) {
-            return ((Slice) node.getValue()).toStringUtf8();
-        }
-        if (type instanceof VarbinaryType) {
-            return new SqlVarbinary(((Slice) node.getValue()).getBytes());
-        }
-        if (type instanceof DateType) {
-            return new SqlDate(((Long) node.getValue()).intValue());
-        }
-
-        // We should not fail at the moment; just return the raw value (block, regex, etc) to the user
-        return node.getValue();
     }
 
     public List<Expression> toExpressions(Session session, List<?> objects, List<? extends Type> types)
@@ -383,10 +324,5 @@ public final class LiteralEncoder
             rowExpressions.add(toRowExpression(values.get(i), types.get(i)));
         }
         return rowExpressions.build();
-    }
-
-    private static Number decodeDecimal(BigInteger unscaledValue, DecimalType type)
-    {
-        return new BigDecimal(unscaledValue, type.getScale(), new MathContext(type.getPrecision()));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -2069,11 +2069,9 @@ public class LocalExecutionPlanner
                 pageBuilder.declarePosition();
                 // evaluate values for non-empty rows
                 if (node.getRows().isPresent()) {
-                    Expression row = node.getRows().get().get(i);
-                    Map<NodeRef<Expression>, Type> types = typeAnalyzer.getTypes(session, TypeProvider.empty(), row);
-                    checkState(types.get(NodeRef.of(row)) instanceof RowType, "unexpected type of Values row: %s", types);
+                    RowExpression row = node.getRows().get().get(i);
                     // evaluate the literal value
-                    Object result = new ExpressionInterpreter(row, plannerContext, session, types).evaluate();
+                    Object result = new RowExpressionInterpreter(row, plannerContext, session).evaluate();
                     for (int j = 0; j < outputTypes.size(); j++) {
                         // divide row into fields
                         writeNativeValue(outputTypes.get(j), pageBuilder.getBlockBuilder(j), readNativeValue(outputTypes.get(j), (SingleRowBlock) result, j));

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
@@ -90,7 +90,6 @@ import io.trino.sql.tree.NullLiteral;
 import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.Query;
 import io.trino.sql.tree.RefreshMaterializedView;
-import io.trino.sql.tree.Row;
 import io.trino.sql.tree.Statement;
 import io.trino.sql.tree.StringLiteral;
 import io.trino.sql.tree.Table;
@@ -140,6 +139,8 @@ import static io.trino.sql.planner.plan.TableWriterNode.CreateReference;
 import static io.trino.sql.planner.plan.TableWriterNode.InsertReference;
 import static io.trino.sql.planner.plan.TableWriterNode.WriterTarget;
 import static io.trino.sql.planner.sanity.PlanSanityChecker.DISTRIBUTED_PLAN_SANITY_CHECKER;
+import static io.trino.sql.relational.Expressions.constant;
+import static io.trino.sql.relational.RowExpressionUtil.toRowConstructorExpression;
 import static io.trino.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static io.trino.sql.tree.ComparisonExpression.Operator.GREATER_THAN_OR_EQUAL;
 import static java.lang.String.format;
@@ -275,7 +276,8 @@ public class LogicalPlanner
         if ((statement instanceof CreateTableAsSelect && analysis.getCreate().orElseThrow().isCreateTableAsSelectNoOp()) ||
                 statement instanceof RefreshMaterializedView && analysis.isSkipMaterializedViewRefresh()) {
             Symbol symbol = symbolAllocator.newSymbol("rows", BIGINT);
-            PlanNode source = new ValuesNode(idAllocator.getNextId(), ImmutableList.of(symbol), ImmutableList.of(new Row(ImmutableList.of(new GenericLiteral("BIGINT", "0")))));
+            PlanNode source = new ValuesNode(idAllocator.getNextId(), ImmutableList.of(symbol), ImmutableList.of(
+                    toRowConstructorExpression(constant(0L, BIGINT))));
             return new OutputNode(idAllocator.getNextId(), source, ImmutableList.of("rows"), ImmutableList.of(symbol));
         }
         return createOutputPlan(planStatementWithoutOutput(analysis, statement), analysis);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -251,6 +251,7 @@ import io.trino.sql.planner.optimizations.PredicatePushDown;
 import io.trino.sql.planner.optimizations.ReplicateSemiJoinInDelete;
 import io.trino.sql.planner.optimizations.StatsRecordingPlanOptimizer;
 import io.trino.sql.planner.optimizations.TransformQuantifiedComparisonApplyToCorrelatedJoin;
+import io.trino.sql.planner.optimizations.TranslateExpressions;
 import io.trino.sql.planner.optimizations.UnaliasSymbolReferences;
 import io.trino.sql.planner.optimizations.WindowFilterPushDown;
 
@@ -973,6 +974,15 @@ public class PlanOptimizers
 
         // TODO: consider adding a formal final plan sanitization optimizer that prepares the plan for transmission/execution/logging
         // TODO: figure out how to improve the set flattening optimizer so that it can run at any point
+
+        // TODO: move this before optimization if possible!!
+        // Replace all expressions with row expressions
+        builder.add(new IterativeOptimizer(
+                plannerContext,
+                ruleStats,
+                statsCalculator,
+                costCalculator,
+                new TranslateExpressions(metadata, typeAnalyzer, plannerContext).rules()));
 
         this.optimizers = builder.build();
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/RowExpressionInterpreter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/RowExpressionInterpreter.java
@@ -1,0 +1,720 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.primitives.Primitives;
+import io.trino.Session;
+import io.trino.metadata.FunctionNullability;
+import io.trino.metadata.Metadata;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.RowBlockBuilder;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.function.OperatorType;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+import io.trino.sql.InterpretedFunctionInvoker;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.planner.ExpressionInterpreter.LambdaSymbolResolver;
+import io.trino.sql.relational.CallExpression;
+import io.trino.sql.relational.ConstantExpression;
+import io.trino.sql.relational.DeterminismEvaluator;
+import io.trino.sql.relational.InputReferenceExpression;
+import io.trino.sql.relational.LambdaDefinitionExpression;
+import io.trino.sql.relational.RowExpression;
+import io.trino.sql.relational.RowExpressionVisitor;
+import io.trino.sql.relational.SpecialForm;
+import io.trino.sql.relational.StandardFunctionResolution;
+import io.trino.sql.relational.VariableReferenceExpression;
+import io.trino.sql.tree.ComparisonExpression;
+import io.trino.type.FunctionType;
+import io.trino.type.TypeCoercion;
+import io.trino.type.UnknownType;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Predicates.instanceOf;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.metadata.FunctionDependencies.isCast;
+import static io.trino.spi.type.TypeUtils.readNativeValue;
+import static io.trino.spi.type.TypeUtils.writeNativeValue;
+import static io.trino.sql.DynamicFilters.isDynamicFilter;
+import static io.trino.sql.gen.VarArgsToMapAdapterGenerator.generateVarArgsToMapAdapter;
+import static io.trino.sql.relational.DeterminismEvaluator.isDeterministic;
+import static io.trino.sql.relational.Expressions.call;
+import static io.trino.sql.relational.Expressions.constantNull;
+import static io.trino.sql.relational.RowExpressionUtil.isEffectivelyLiteral;
+import static io.trino.sql.relational.SpecialForm.Form.AND;
+import static io.trino.sql.relational.SpecialForm.Form.BIND;
+import static io.trino.sql.relational.SpecialForm.Form.COALESCE;
+import static io.trino.sql.relational.SpecialForm.Form.DEREFERENCE;
+import static io.trino.sql.relational.SpecialForm.Form.IF;
+import static io.trino.sql.relational.SpecialForm.Form.IN;
+import static io.trino.sql.relational.SpecialForm.Form.IS_NULL;
+import static io.trino.sql.relational.SpecialForm.Form.NULL_IF;
+import static io.trino.sql.relational.SpecialForm.Form.OR;
+import static io.trino.sql.relational.SpecialForm.Form.ROW_CONSTRUCTOR;
+import static io.trino.sql.relational.SpecialForm.Form.SWITCH;
+import static io.trino.sql.relational.SpecialForm.Form.WHEN;
+import static java.util.Arrays.asList;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+
+public class RowExpressionInterpreter
+{
+    private final RowExpression expression;
+
+    private final PlannerContext plannerContext;
+    private final Metadata metadata;
+
+    private final LiteralEncoder literalEncoder;
+
+    private final Session session;
+
+    private final ConnectorSession connectorSession;
+
+    private final InterpretedFunctionInvoker functionInvoker;
+
+    private final TypeCoercion typeCoercion;
+    private final StandardFunctionResolution resolution;
+
+    public static Object evaluateConstantRowExpression(RowExpression expression, PlannerContext plannerContext, Session session)
+    {
+        // evaluate the expression
+        Object result = new RowExpressionInterpreter(expression, plannerContext, session).evaluate();
+        verify(!(result instanceof RowExpression), "RowExpression interpreter returned an unresolved expression");
+        return result;
+    }
+
+    public static RowExpressionInterpreter rowExpressionInterpreter(RowExpression expression, PlannerContext plannerContext, Session session)
+    {
+        return new RowExpressionInterpreter(expression, plannerContext, session);
+    }
+
+    public RowExpressionInterpreter(RowExpression expression, PlannerContext plannerContext, Session session)
+    {
+        this.expression = requireNonNull(expression, "expression is null");
+        this.plannerContext = plannerContext;
+        this.metadata = plannerContext.getMetadata();
+        this.literalEncoder = new LiteralEncoder(plannerContext);
+        this.session = requireNonNull(session, "session is null");
+        this.connectorSession = session.toConnectorSession();
+        this.functionInvoker = new InterpretedFunctionInvoker(plannerContext.getFunctionManager());
+        this.resolution = new StandardFunctionResolution(session, metadata);
+        this.typeCoercion = new TypeCoercion(plannerContext.getTypeManager()::getType);
+    }
+
+    public Type getType()
+    {
+        return expression.getType();
+    }
+
+    public Object evaluate()
+    {
+        Object result = new Visitor(false).processWithExceptionHandling(expression, null);
+        verify(!(result instanceof RowExpression), "RowExpression interpreter returned an unresolved RowExpression");
+        return result;
+    }
+
+    public Object evaluate(SymbolResolver inputs)
+    {
+        Object result = new Visitor(false).processWithExceptionHandling(expression, inputs);
+        verify(!(result instanceof RowExpression), "RowExpression interpreter returned an unresolved RowExpression");
+        return result;
+    }
+
+    @VisibleForTesting
+    public Object optimize(SymbolResolver inputs)
+    {
+        return new Visitor(true).processWithExceptionHandling(expression, inputs);
+    }
+
+    private class Visitor
+            implements RowExpressionVisitor<Object, Object>
+    {
+        private final boolean optimize;
+
+        private Visitor(boolean optimize)
+        {
+            this.optimize = optimize;
+        }
+
+        @Override
+        public Object visitInputReference(InputReferenceExpression node, Object context)
+        {
+            return node;
+        }
+
+        @Override
+        public Object visitConstant(ConstantExpression node, Object context)
+        {
+            return node.getValue();
+        }
+
+        @Override
+        public Object visitVariableReference(VariableReferenceExpression node, Object context)
+        {
+            if (context instanceof SymbolResolver) {
+                return ((SymbolResolver) context).getValue(new Symbol(node.getName()));
+            }
+            return node;
+        }
+
+        @Override
+        public Object visitCall(CallExpression node, Object context)
+        {
+            List<Type> argumentTypes = new ArrayList<>();
+            List<Object> argumentValues = new ArrayList<>();
+            for (RowExpression expression : node.getArguments()) {
+                Object value = processWithExceptionHandling(expression, context);
+                Type type = expression.getType();
+                argumentValues.add(value);
+                argumentTypes.add(type);
+            }
+
+            ResolvedFunction resolvedFunction = node.getResolvedFunction();
+            FunctionNullability functionNullability = resolvedFunction.getFunctionNullability();
+            for (int i = 0; i < argumentValues.size(); i++) {
+                Object value = argumentValues.get(i);
+                if (value == null && !functionNullability.isArgumentNullable(i)) {
+                    return null;
+                }
+            }
+
+            // do not optimize non-deterministic functions
+            if (optimize && (!metadata.getFunctionMetadata(session, resolvedFunction).isDeterministic() ||
+                    hasUnresolvedValue(argumentValues) ||
+                    isDynamicFilter(node) ||
+                    resolvedFunction.getSignature().getName().equals("fail"))) {
+                return call(resolvedFunction, toRowExpressions(argumentValues, argumentTypes));
+            }
+            return functionInvoker.invoke(resolvedFunction, connectorSession, argumentValues);
+        }
+
+        @Override
+        public Object visitLambda(LambdaDefinitionExpression node, Object context)
+        {
+            if (optimize) {
+                // TODO: enable optimization related to lambda expression
+                // A mechanism to convert function type back into lambda expression need to exist to enable optimization
+                return node;
+            }
+
+            RowExpression body = node.getBody();
+
+            List<String> argumentNames = node.getArguments();
+            FunctionType functionType = (FunctionType) node.getType();
+            checkArgument(argumentNames.size() == functionType.getArgumentTypes().size());
+
+            return generateVarArgsToMapAdapter(
+                    Primitives.wrap(functionType.getReturnType().getJavaType()),
+                    functionType.getArgumentTypes().stream()
+                            .map(Type::getJavaType)
+                            .map(Primitives::wrap)
+                            .collect(toImmutableList()),
+                    argumentNames,
+                    map -> processWithExceptionHandling(body, new LambdaSymbolResolver(map)));
+        }
+
+        @Override
+        public Object visitSpecialForm(SpecialForm node, Object context)
+        {
+            switch (node.getForm()) {
+                case IF: {
+                    checkArgument(node.getArguments().size() == 3);
+                    Object condition = processWithExceptionHandling(node.getArguments().get(0), context);
+                    Object trueValue = processWithExceptionHandling(node.getArguments().get(1), context);
+                    Object falseValue = processWithExceptionHandling(node.getArguments().get(2), context);
+
+                    if (condition instanceof RowExpression) {
+                        return new SpecialForm(
+                                IF,
+                                node.getType(),
+                                toRowExpression(condition, node.getArguments().get(0).getType()),
+                                toRowExpression(trueValue, node.getArguments().get(1).getType()),
+                                toRowExpression(falseValue, node.getArguments().get(2).getType()));
+                    }
+                    else if (Boolean.TRUE.equals(condition)) {
+                        return trueValue;
+                    }
+                    return falseValue;
+                }
+                case NULL_IF: {
+                    checkArgument(node.getArguments().size() == 2);
+                    Object left = processWithExceptionHandling(node.getArguments().get(0), context);
+                    if (left == null) {
+                        return null;
+                    }
+
+                    Object right = processWithExceptionHandling(node.getArguments().get(1), context);
+                    if (right == null) {
+                        return left;
+                    }
+
+                    if (hasUnresolvedValue(left, right)) {
+                        return new SpecialForm(
+                                NULL_IF,
+                                node.getType(),
+                                toRowExpression(left, node.getArguments().get(0).getType()),
+                                toRowExpression(right, node.getArguments().get(1).getType()));
+                    }
+
+                    Type firstType = node.getArguments().get(0).getType();
+                    Type secondType = node.getArguments().get(1).getType();
+                    Type commonType = typeCoercion.getCommonSuperType(firstType, secondType).get();
+                    ResolvedFunction firstCast = metadata.getCoercion(session, firstType, commonType);
+                    ResolvedFunction secondCast = metadata.getCoercion(session, secondType, commonType);
+
+                    // cast(first as <common type>) == cast(second as <common type>)
+                    boolean equal = Boolean.TRUE.equals(invokeOperator(
+                            OperatorType.EQUAL,
+                            ImmutableList.of(commonType, commonType),
+                            ImmutableList.of(
+                                    functionInvoker.invoke(firstCast, connectorSession, left),
+                                    functionInvoker.invoke(secondCast, connectorSession, right))));
+
+                    if (equal) {
+                        return null;
+                    }
+                    return left;
+                }
+                case IS_NULL: {
+                    checkArgument(node.getArguments().size() == 1);
+                    Object value = processWithExceptionHandling(node.getArguments().get(0), context);
+                    if (value instanceof RowExpression) {
+                        return new SpecialForm(
+                                IS_NULL,
+                                node.getType(),
+                                toRowExpression(value, node.getArguments().get(0).getType()));
+                    }
+                    return value == null;
+                }
+                case AND: {
+                    Object left = node.getArguments().get(0).accept(this, context);
+                    Object right;
+
+                    if (Boolean.FALSE.equals(left)) {
+                        return false;
+                    }
+
+                    right = node.getArguments().get(1).accept(this, context);
+
+                    if (Boolean.TRUE.equals(right)) {
+                        return left;
+                    }
+
+                    if (Boolean.FALSE.equals(right) || Boolean.TRUE.equals(left)) {
+                        return right;
+                    }
+
+                    if (left == null && right == null) {
+                        return null;
+                    }
+                    return new SpecialForm(
+                            AND,
+                            node.getType(),
+                            toRowExpressions(
+                                    asList(left, right),
+                                    ImmutableList.of(node.getArguments().get(0).getType(), node.getArguments().get(1).getType())));
+                }
+                case OR: {
+                    Object left = node.getArguments().get(0).accept(this, context);
+                    Object right;
+
+                    if (Boolean.TRUE.equals(left)) {
+                        return true;
+                    }
+
+                    right = node.getArguments().get(1).accept(this, context);
+
+                    if (Boolean.FALSE.equals(right)) {
+                        return left;
+                    }
+
+                    if (Boolean.TRUE.equals(right) || Boolean.FALSE.equals(left)) {
+                        return right;
+                    }
+
+                    if (left == null && right == null) {
+                        return null;
+                    }
+                    return new SpecialForm(
+                            OR,
+                            node.getType(),
+                            toRowExpressions(
+                                    asList(left, right),
+                                    ImmutableList.of(node.getArguments().get(0).getType(), node.getArguments().get(1).getType())));
+                }
+                case ROW_CONSTRUCTOR: {
+                    RowType rowType = (RowType) node.getType();
+                    List<Type> parameterTypes = rowType.getTypeParameters();
+                    List<RowExpression> arguments = node.getArguments();
+
+                    int cardinality = arguments.size();
+                    List<Object> values = new ArrayList<>(cardinality);
+                    arguments.forEach(argument -> values.add(processWithExceptionHandling(argument, context)));
+                    if (hasUnresolvedValue(values)) {
+                        return new SpecialForm(ROW_CONSTRUCTOR, node.getType(), toRowExpressions(values, parameterTypes));
+                    }
+                    else {
+                        BlockBuilder blockBuilder = new RowBlockBuilder(parameterTypes, null, 1);
+                        BlockBuilder singleRowBlockWriter = blockBuilder.beginBlockEntry();
+                        for (int i = 0; i < cardinality; ++i) {
+                            writeNativeValue(parameterTypes.get(i), singleRowBlockWriter, values.get(i));
+                        }
+                        blockBuilder.closeEntry();
+                        return rowType.getObject(blockBuilder, 0);
+                    }
+                }
+                case COALESCE: {
+                    List<Object> newOperands = processOperands(node, context);
+                    if (newOperands.isEmpty()) {
+                        return null;
+                    }
+                    if (newOperands.size() == 1) {
+                        return getOnlyElement(newOperands);
+                    }
+                    return new SpecialForm(COALESCE, node.getType(), newOperands.stream().map(value -> toRowExpression(value, node.getType())).collect(toImmutableList()));
+                }
+                case IN: {
+                    checkArgument(node.getArguments().size() >= 2, "values must not be empty");
+
+                    Object target = processWithExceptionHandling(node.getArguments().get(0), context);
+
+                    List<RowExpression> valueList = node.getArguments().subList(1, node.getArguments().size());
+//                    List<Object> values = valueList.stream().map(value -> value.accept(this, context)).collect(toList());
+//                    List<Type> valuesTypes = valueList.stream().map(RowExpression::getType).collect(toImmutableList());
+
+                    if (target == null) {
+                        return null;
+                    }
+
+                    boolean hasUnresolvedValue = target instanceof RowExpression;
+                    boolean hasNullValue = false;
+                    boolean found = false;
+                    List<Object> values = new ArrayList<>(valueList.size());
+                    List<Type> types = new ArrayList<>(valueList.size());
+
+                    for (RowExpression expression : valueList) {
+                        if (target instanceof RowExpression && expression instanceof ConstantExpression) {
+                            // skip interpreting of literal IN term since it cannot be compared
+                            // with unresolved "value" and it cannot be simplified further
+                            values.add(expression);
+                            types.add(expression.getType());
+                            continue;
+                        }
+
+                        // Use process() instead of processWithExceptionHandling() for processing in-list items.
+                        // Do not handle exceptions thrown while processing a single in-list expression,
+                        // but fail the whole in-predicate evaluation.
+                        // According to in-predicate semantics, all in-list items must be successfully evaluated
+                        // before a check for the match is performed.
+                        Object inValue = expression.accept(this, context);
+                        if (target instanceof RowExpression || inValue instanceof RowExpression) {
+                            hasUnresolvedValue = true;
+                            values.add(inValue);
+                            types.add(expression.getType());
+                            continue;
+                        }
+
+                        if (inValue == null) {
+                            hasNullValue = true;
+                        }
+                        else {
+                            ResolvedFunction equalsOperator = metadata.resolveOperator(session, OperatorType.EQUAL, ImmutableList.of(node.getArguments().get(0).getType(), expression.getType()));
+                            Boolean result = (Boolean) functionInvoker.invoke(equalsOperator, connectorSession, ImmutableList.of(target, inValue));
+                            if (result == null) {
+                                hasNullValue = true;
+                            }
+                            else if (!found && result) {
+                                // in does not short-circuit so we must evaluate all value in the list
+                                found = true;
+                            }
+                        }
+                    }
+                    if (found) {
+                        return true;
+                    }
+
+                    if (hasUnresolvedValue) {
+                        Type type = node.getType();
+                        List<RowExpression> expressionValues = toRowExpressions(values, types);
+                        List<RowExpression> simplifiedExpressionValues = Stream.concat(
+                                        expressionValues.stream()
+                                                .filter(DeterminismEvaluator::isDeterministic)
+                                                .distinct(),
+                                        expressionValues.stream()
+                                                .filter(DeterminismEvaluator::isDeterministic))
+                                .collect(toImmutableList());
+
+                        if (simplifiedExpressionValues.size() == 1) {
+                            return new CallExpression(resolution.comparisonFunction(ComparisonExpression.Operator.EQUAL, type, simplifiedExpressionValues.get(0).getType()), ImmutableList.of(toRowExpression(target, type), simplifiedExpressionValues.get(0)));
+                        }
+                        return new SpecialForm(IN, node.getType(), simplifiedExpressionValues);
+                    }
+                    if (hasNullValue) {
+                        return null;
+                    }
+                    return false;
+                }
+                case DEREFERENCE: {
+                    checkArgument(node.getArguments().size() == 2);
+
+                    RowExpression base = node.getArguments().get(0);
+                    RowExpression fieldIdentifier = node.getArguments().get(1);
+
+                    Type type = base.getType();
+                    // if there is no type for the base of Dereference, it must be QualifiedName
+                    if (type == null) {
+                        return node;
+                    }
+
+                    // Row dereference: process dereference base eagerly, and only then pick the expected field
+                    Object baseProcessed = processWithExceptionHandling(base, context);
+                    Object fieldIdentifierProcessed = processWithExceptionHandling(fieldIdentifier, context);
+
+                    // if the base part is evaluated to be null, the dereference expression should also be null
+                    if (baseProcessed == null) {
+                        return null;
+                    }
+
+                    if (hasUnresolvedValue(baseProcessed)) {
+                        return new SpecialForm(DEREFERENCE,
+                                type,
+                                toRowExpression(baseProcessed, node.getArguments().get(0).getType()),
+                                toRowExpression(fieldIdentifierProcessed, node.getArguments().get(1).getType()));
+                    }
+
+                    RowType rowType = (RowType) type;
+                    Block row = (Block) base;
+                    Type returnType = node.getType();
+                    checkArgument(fieldIdentifier instanceof VariableReferenceExpression);
+                    String fieldName = ((VariableReferenceExpression) fieldIdentifier).getName();
+                    List<RowType.Field> fields = rowType.getFields();
+                    int index = -1;
+                    for (int i = 0; i < fields.size(); i++) {
+                        RowType.Field field = fields.get(i);
+                        if (field.getName().isPresent() && field.getName().get().equalsIgnoreCase(fieldName)) {
+                            checkArgument(index < 0, "Ambiguous field %s in type %s", field, rowType.getDisplayName());
+                            index = i;
+                        }
+                    }
+
+                    checkState(index >= 0, "could not find field name: %s", fieldName);
+                    return readNativeValue(returnType, row, index);
+                }
+                case BIND: {
+                    checkArgument(node.getArguments().size() >= 2);
+                    List<RowExpression> values = node.getArguments().subList(0, node.getArguments().size() - 1);
+
+                    List<Object> valuesProcessed = node.getArguments().subList(0, node.getArguments().size() - 1).stream()
+                            .map(value -> processWithExceptionHandling(value, context))
+                            .collect(toList()); // values are nullable
+                    Object function = processWithExceptionHandling(node.getArguments().get(node.getArguments().size() - 1), context);
+
+                    if (hasUnresolvedValue(values) || hasUnresolvedValue(function)) {
+                        ImmutableList.Builder<RowExpression> builder = ImmutableList.builder();
+                        for (int i = 0; i < values.size(); i++) {
+                            builder.add(toRowExpression(valuesProcessed.get(i), values.get(i).getType()));
+                        }
+
+                        return new SpecialForm(BIND, node.getType(), builder.build());
+                    }
+
+                    return MethodHandles.insertArguments((MethodHandle) function, 0, valuesProcessed.toArray());
+                }
+                case SWITCH: {
+                    // arguments: operand: whenClauseList: defaultValue
+                    int argumentSize = node.getArguments().size();
+                    RowExpression operand = node.getArguments().get(0);
+                    RowExpression defaultValue = node.getArguments().get(node.getArguments().size() - 1);
+                    List<RowExpression> whenClauses = node.getArguments().subList(1, argumentSize - 1);
+
+                    Object operandProcessed = processWithExceptionHandling(node.getArguments().get(0), context);
+                    Type operandType = node.getArguments().get(0).getType();
+
+                    // if operand is null, return defaultValue
+
+                    if (operandProcessed == null) {
+                        return processWithExceptionHandling(defaultValue, context);
+                    }
+
+                    Object newDefault = null;
+                    boolean foundNewDefault = false;
+
+                    List<RowExpression> simplifiedWhenClauses = new ArrayList<>();
+                    for (RowExpression whenClause : whenClauses) {
+                        checkArgument(whenClause instanceof SpecialForm && ((SpecialForm) whenClause).getForm().equals(WHEN));
+                        Object whenOperandProcessed = processWithExceptionHandling(((SpecialForm) whenClause).getArguments().get(0), context);
+
+                        if (whenOperandProcessed instanceof RowExpression || operandProcessed instanceof RowExpression) {
+                            // cannot fully evaluate, add updated whenClause
+                            simplifiedWhenClauses.add(new SpecialForm(WHEN, whenClause.getType(),
+                                    toRowExpression(whenOperandProcessed, ((SpecialForm) whenClause).getArguments().get(0).getType()),
+                                    toRowExpression(processWithExceptionHandling(((SpecialForm) whenClause).getArguments().get(1), context), ((SpecialForm) whenClause).getArguments().get(1).getType())));
+                        }
+                        else if (whenOperandProcessed != null && isEqual(operandProcessed, operandType, whenOperandProcessed, ((SpecialForm) whenClause).getArguments().get(0).getType())) {
+                            // condition is true, use this as default
+                            foundNewDefault = true;
+                            newDefault = processWithExceptionHandling(((SpecialForm) whenClause).getArguments().get(1), context);
+                            break;
+                        }
+                    }
+
+                    Object defaultResult;
+                    if (foundNewDefault) {
+                        defaultResult = newDefault;
+                    }
+                    else {
+                        defaultResult = processWithExceptionHandling(defaultValue, context);
+                    }
+
+                    if (simplifiedWhenClauses.isEmpty()) {
+                        return defaultResult;
+                    }
+                    RowExpression defaultExpression = (defaultResult == null) ? constantNull(node.getType()) : toRowExpression(defaultResult, node.getType());
+
+                    ImmutableList.Builder<RowExpression> argumentsBuilder = ImmutableList.builder();
+                    argumentsBuilder.add(toRowExpression(operandProcessed, operand.getType()))
+                            .addAll(simplifiedWhenClauses)
+                            .add(defaultExpression);
+
+                    return new SpecialForm(SWITCH, node.getType(), argumentsBuilder.build());
+                }
+                default:
+                    throw new IllegalStateException("Can not compile special form: " + node.getForm());
+            }
+        }
+
+        private boolean isEqual(Object operand1, Type type1, Object operand2, Type type2)
+        {
+            return Boolean.TRUE.equals(invokeOperator(OperatorType.EQUAL, ImmutableList.of(type1, type2), ImmutableList.of(operand1, operand2)));
+        }
+
+        private List<Object> processOperands(SpecialForm node, Object context)
+        {
+            checkArgument(node.getForm() == COALESCE);
+            List<Object> newOperands = new ArrayList<>();
+            Set<RowExpression> uniqueNewOperands = new HashSet<>();
+            for (RowExpression operand : node.getArguments()) {
+                Object value = processWithExceptionHandling(operand, context);
+                if (value instanceof SpecialForm && ((SpecialForm) value).getForm() == COALESCE) {
+                    // The nested CoalesceExpression was recursively processed. It does not contain null.
+                    for (RowExpression nestedOperand : ((SpecialForm) value).getArguments()) {
+                        // Skip duplicates unless they are non-deterministic.
+                        if (!isDeterministic(nestedOperand) || uniqueNewOperands.add(nestedOperand)) {
+                            newOperands.add(nestedOperand);
+                        }
+                        // This operand can be evaluated to a non-null value. Remaining operands can be skipped.
+                        if (isEffectivelyLiteral(plannerContext, session, nestedOperand)) {
+                            verify(
+                                    !(nestedOperand.getType() == UnknownType.UNKNOWN) && !notCastOnNullLiteral(nestedOperand),
+                                    "Null operand should have been removed by recursive coalesce processing");
+                            return newOperands;
+                        }
+                    }
+                }
+                else if (value instanceof RowExpression) {
+                    verify(!((value instanceof ConstantExpression) && (((RowExpression) value).getType() == UnknownType.UNKNOWN)), "Null value is expected to be represented as null, not NullLiteral");
+                    // Skip duplicates unless they are non-deterministic.
+                    RowExpression expression = (RowExpression) value;
+                    if (!isDeterministic(expression) || uniqueNewOperands.add(expression)) {
+                        newOperands.add(expression);
+                    }
+                }
+                else if (value != null) {
+                    // This operand can be evaluated to a non-null value. Remaining operands can be skipped.
+                    newOperands.add(value);
+                    return newOperands;
+                }
+            }
+            return newOperands;
+        }
+
+        private boolean notCastOnNullLiteral(RowExpression expression)
+        {
+            if (!(expression instanceof CallExpression)) {
+                return true;
+            }
+            CallExpression callExpression = (CallExpression) expression;
+            ResolvedFunction function = callExpression.getResolvedFunction();
+            if (!isCast(function)) {
+                return true;
+            }
+            RowExpression nestedOperand = Iterables.getOnlyElement(callExpression.getArguments());
+            return (nestedOperand instanceof ConstantExpression) && (nestedOperand.getType() != UnknownType.UNKNOWN);
+        }
+
+        private Object processWithExceptionHandling(RowExpression expression, Object context)
+        {
+            if (expression == null) {
+                return null;
+            }
+            try {
+                return expression.accept(this, context);
+            }
+            catch (RuntimeException e) {
+                if (optimize) {
+                    // Certain operations like 0 / 0 or likeExpression may throw exceptions.
+                    // When optimizing, do not throw the exception, but delay it until the expression is actually executed.
+                    // This is to take advantage of the possibility that some other optimization removes the erroneous
+                    // expression from the plan.
+                    return expression;
+                }
+                // Do not suppress exceptions during expression execution.
+                throw e;
+            }
+        }
+
+        private boolean hasUnresolvedValue(Object... values)
+        {
+            return hasUnresolvedValue(ImmutableList.copyOf(values));
+        }
+
+        private boolean hasUnresolvedValue(List<Object> values)
+        {
+            return values.stream().anyMatch(instanceOf(RowExpression.class)::apply);
+        }
+
+        private Object invokeOperator(OperatorType operatorType, List<? extends Type> argumentTypes, List<Object> argumentValues)
+        {
+            ResolvedFunction operator = metadata.resolveOperator(session, operatorType, argumentTypes);
+            return functionInvoker.invoke(operator, connectorSession, argumentValues);
+        }
+
+        private RowExpression toRowExpression(Object base, Type type)
+        {
+            return literalEncoder.toRowExpression(base, type);
+        }
+
+        private List<RowExpression> toRowExpressions(List<Object> values, List<Type> types)
+        {
+            return literalEncoder.toRowExpressions(values, types);
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/RowExpressionNodeInliner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/RowExpressionNodeInliner.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner;
+
+import io.trino.sql.relational.RowExpression;
+import io.trino.sql.relational.RowExpressionRewriter;
+import io.trino.sql.relational.RowExpressionTreeRewriter;
+
+import java.util.Map;
+
+public class RowExpressionNodeInliner
+        extends RowExpressionRewriter<Void>
+{
+    private final Map<? extends RowExpression, ? extends RowExpression> mappings;
+
+    public static RowExpression replaceExpression(RowExpression expression, Map<? extends RowExpression, ? extends RowExpression> mappings)
+    {
+        return RowExpressionTreeRewriter.rewriteWith(new RowExpressionNodeInliner(mappings), expression);
+    }
+
+    public RowExpressionNodeInliner(Map<? extends RowExpression, ? extends RowExpression> mappings)
+    {
+        this.mappings = mappings;
+    }
+
+    @Override
+    public RowExpression rewriteRowExpression(RowExpression node, Void context, RowExpressionTreeRewriter<Void> treeRewriter)
+    {
+        return mappings.get(node);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneCountAggregationOverScalar.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneCountAggregationOverScalar.java
@@ -23,14 +23,15 @@ import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.plan.AggregationNode;
 import io.trino.sql.planner.plan.ValuesNode;
-import io.trino.sql.tree.GenericLiteral;
 import io.trino.sql.tree.QualifiedName;
-import io.trino.sql.tree.Row;
 
 import java.util.Map;
 
+import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.sql.planner.optimizations.QueryCardinalityUtil.isScalar;
 import static io.trino.sql.planner.plan.Patterns.aggregation;
+import static io.trino.sql.relational.Expressions.constant;
+import static io.trino.sql.relational.RowExpressionUtil.toRowConstructorExpression;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -71,7 +72,7 @@ public class PruneCountAggregationOverScalar
             }
         }
         if (!assignments.isEmpty() && isScalar(parent.getSource(), context.getLookup())) {
-            return Result.ofPlanNode(new ValuesNode(parent.getId(), parent.getOutputSymbols(), ImmutableList.of(new Row(ImmutableList.of(new GenericLiteral("BIGINT", "1"))))));
+            return Result.ofPlanNode(new ValuesNode(parent.getId(), parent.getOutputSymbols(), ImmutableList.of(toRowConstructorExpression(constant(1L, BIGINT)))));
         }
         return Result.empty();
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
@@ -60,6 +60,7 @@ import static io.trino.sql.planner.plan.AggregationNode.singleGroupingSet;
 import static io.trino.sql.planner.plan.Patterns.aggregation;
 import static io.trino.sql.planner.plan.Patterns.join;
 import static io.trino.sql.planner.plan.Patterns.source;
+import static io.trino.sql.relational.OriginalExpressionUtils.castToRowExpression;
 
 /**
  * This optimizer pushes aggregations below outer joins when: the aggregation
@@ -288,7 +289,7 @@ public class PushAggregationThroughOuterJoin
         ValuesNode nullRow = new ValuesNode(
                 idAllocator.getNextId(),
                 nullSymbols.build(),
-                ImmutableList.of(new Row(nullLiterals.build())));
+                ImmutableList.of(castToRowExpression(new Row(nullLiterals.build()))));
 
         // For each aggregation function in the reference node, create a corresponding aggregation function
         // that points to the nullRow. Map the symbols from the aggregations in referenceAggregation to the

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveEmptyDeleteRuleSet.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveEmptyDeleteRuleSet.java
@@ -20,16 +20,17 @@ import io.trino.matching.Pattern;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.plan.TableFinishNode;
 import io.trino.sql.planner.plan.ValuesNode;
-import io.trino.sql.tree.GenericLiteral;
-import io.trino.sql.tree.Row;
 
 import java.util.Set;
 
+import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.sql.planner.plan.Patterns.delete;
 import static io.trino.sql.planner.plan.Patterns.emptyValues;
 import static io.trino.sql.planner.plan.Patterns.exchange;
 import static io.trino.sql.planner.plan.Patterns.source;
 import static io.trino.sql.planner.plan.Patterns.tableFinish;
+import static io.trino.sql.relational.Expressions.constant;
+import static io.trino.sql.relational.RowExpressionUtil.toRowConstructorExpression;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -100,7 +101,7 @@ public final class RemoveEmptyDeleteRuleSet
                     new ValuesNode(
                             node.getId(),
                             node.getOutputSymbols(),
-                            ImmutableList.of(new Row(ImmutableList.of(new GenericLiteral("BIGINT", "0"))))));
+                            ImmutableList.of(toRowConstructorExpression(constant(0L, BIGINT)))));
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveEmptyTableExecute.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveEmptyTableExecute.java
@@ -23,8 +23,7 @@ import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.TableExecuteNode;
 import io.trino.sql.planner.plan.TableFinishNode;
 import io.trino.sql.planner.plan.ValuesNode;
-import io.trino.sql.tree.NullLiteral;
-import io.trino.sql.tree.Row;
+import io.trino.type.UnknownType;
 
 import java.util.Optional;
 
@@ -32,6 +31,8 @@ import static com.google.common.base.Verify.verify;
 import static io.trino.sql.planner.plan.Patterns.Values.rowCount;
 import static io.trino.sql.planner.plan.Patterns.tableFinish;
 import static io.trino.sql.planner.plan.Patterns.values;
+import static io.trino.sql.relational.Expressions.constantNull;
+import static io.trino.sql.relational.RowExpressionUtil.toRowConstructorExpression;
 
 /**
  * If the predicate for a table execute is optimized to false, the target table scan
@@ -88,7 +89,7 @@ public class RemoveEmptyTableExecute
                 new ValuesNode(
                         finishNode.getId(),
                         finishNode.getOutputSymbols(),
-                        ImmutableList.of(new Row(ImmutableList.of(new NullLiteral())))));
+                        ImmutableList.of(toRowConstructorExpression(constantNull(UnknownType.UNKNOWN)))));
     }
 
     private Optional<PlanNode> getSingleSourceSkipExchange(PlanNode node, Lookup lookup)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/MetadataQueryOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/MetadataQueryOptimizer.java
@@ -29,7 +29,6 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.sql.PlannerContext;
-import io.trino.sql.planner.LiteralEncoder;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.SymbolAllocator;
@@ -89,13 +88,11 @@ public class MetadataQueryOptimizer
         private final PlanNodeIdAllocator idAllocator;
         private final Session session;
         private final PlannerContext plannerContext;
-        private final LiteralEncoder literalEncoder;
 
         private Optimizer(Session session, PlannerContext plannerContext, PlanNodeIdAllocator idAllocator)
         {
             this.session = session;
             this.plannerContext = plannerContext;
-            this.literalEncoder = new LiteralEncoder(plannerContext);
             this.idAllocator = idAllocator;
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/TranslateExpressions.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/TranslateExpressions.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.sql.planner.optimizations;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.metadata.Metadata;
+import io.trino.spi.type.Type;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.TypeAnalyzer;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.iterative.Rule.Context;
+import io.trino.sql.planner.plan.ValuesNode;
+import io.trino.sql.relational.RowExpression;
+import io.trino.sql.relational.SqlToRowExpressionTranslator;
+import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.NodeRef;
+
+import java.util.Map;
+import java.util.Set;
+
+import static io.trino.sql.planner.plan.Patterns.values;
+import static io.trino.sql.relational.OriginalExpressionUtils.castToExpression;
+import static io.trino.sql.relational.OriginalExpressionUtils.isExpression;
+import static java.util.Objects.requireNonNull;
+
+public class TranslateExpressions
+{
+    private final Metadata metadata;
+
+    private final TypeAnalyzer typeAnalyzer;
+
+    private final PlannerContext plannerContext;
+
+    public TranslateExpressions(Metadata metadata, TypeAnalyzer typeAnalyzer, PlannerContext plannerContext)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.typeAnalyzer = requireNonNull(typeAnalyzer, "typeAnalyzer is null");
+        this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
+    }
+
+    public Set<Rule<?>> rules()
+    {
+        // TODO: finish all other PlanNodes that have Expression
+        return ImmutableSet.of(
+                new ValuesExpressionTranslation());
+    }
+
+    private final class ValuesExpressionTranslation
+            implements Rule<ValuesNode>
+    {
+        @Override
+        public Pattern<ValuesNode> getPattern()
+        {
+            return values();
+        }
+
+        @Override
+        public Result apply(ValuesNode valuesNode, Captures captures, Context context)
+        {
+            if (valuesNode.getRows().isEmpty()) {
+                return Result.empty();
+            }
+            boolean anyRewritten = false;
+            ImmutableList.Builder<RowExpression> rows = ImmutableList.builder();
+            for (RowExpression row : valuesNode.getRows().get()) {
+                if (isExpression(row)) {
+                    Expression expression = castToExpression(row);
+                    RowExpression rewritten = toRowExpression(expression, context, ImmutableMap.of());
+                    anyRewritten = true;
+                    rows.add(rewritten);
+                }
+                else {
+                    rows.add(row);
+                }
+            }
+            if (anyRewritten) {
+                return Result.ofPlanNode(new ValuesNode(valuesNode.getId(), valuesNode.getOutputSymbols(), rows.build()));
+            }
+            return Result.empty();
+        }
+    }
+
+    private RowExpression toRowExpression(Expression expression, Context context, Map<Symbol, Integer> sourceLayout)
+    {
+        Map<NodeRef<Expression>, Type> types = typeAnalyzer.getTypes(context.getSession(), context.getSymbolAllocator().getTypes(), expression);
+        return SqlToRowExpressionTranslator.translate(expression, types, sourceLayout, metadata, plannerContext.getFunctionManager(), context.getSession(), false);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/Patterns.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/Patterns.java
@@ -18,6 +18,7 @@ import io.trino.matching.Property;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.Lookup;
 import io.trino.sql.planner.plan.CorrelatedJoinNode.Type;
+import io.trino.sql.relational.RowExpression;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.PatternRecognitionRelation.RowsPerMatch;
 
@@ -376,7 +377,7 @@ public final class Patterns
 
     public static final class Values
     {
-        public static Property<ValuesNode, Lookup, Optional<List<Expression>>> rows()
+        public static Property<ValuesNode, Lookup, Optional<List<RowExpression>>> rows()
         {
             return property("rows", ValuesNode::getRows);
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/RowExpressionFormatter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/RowExpressionFormatter.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.planprinter;
+
+import io.trino.spi.block.Block;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarbinaryType;
+import io.trino.sql.planner.LiteralInterpreter;
+import io.trino.sql.relational.CallExpression;
+import io.trino.sql.relational.ConstantExpression;
+import io.trino.sql.relational.InputReferenceExpression;
+import io.trino.sql.relational.LambdaDefinitionExpression;
+import io.trino.sql.relational.RowExpression;
+import io.trino.sql.relational.RowExpressionVisitor;
+import io.trino.sql.relational.SpecialForm;
+import io.trino.sql.relational.StandardFunctionResolution;
+import io.trino.sql.relational.VariableReferenceExpression;
+
+import java.util.List;
+import java.util.Locale;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.metadata.Signature.unmangleOperator;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+
+public final class RowExpressionFormatter
+{
+    public RowExpressionFormatter()
+    {
+    }
+
+    public String formatRowExpression(ConnectorSession session, RowExpression expression)
+    {
+        return expression.accept(new Formatter(), requireNonNull(session, "session is null"));
+    }
+
+    private List<String> formatRowExpressions(ConnectorSession session, List<RowExpression> rowExpressions)
+    {
+        return rowExpressions.stream().map(rowExpression -> formatRowExpression(session, rowExpression)).collect(toList());
+    }
+
+    public class Formatter
+            implements RowExpressionVisitor<String, ConnectorSession>
+    {
+        @Override
+        public String visitCall(CallExpression node, ConnectorSession session)
+        {
+            if (StandardFunctionResolution.isArithmeticFunction(node.getResolvedFunction()) || StandardFunctionResolution.isComparisonFunction(node.getResolvedFunction())) {
+                String operation = unmangleOperator(node.getResolvedFunction().getSignature().getName()).getOperator();
+                return String.join(" " + operation + " ", formatRowExpressions(session, node.getArguments()).stream().map(e -> "(" + e + ")").collect(toImmutableList()));
+            }
+            else if (StandardFunctionResolution.isCastFunction(node.getResolvedFunction())) {
+                return String.format("CAST(%s AS %s)", formatRowExpression(session, node.getArguments().get(0)), node.getType().getDisplayName());
+            }
+            else if (StandardFunctionResolution.isNegateFunction(node.getResolvedFunction())) {
+                return "-(" + formatRowExpression(session, node.getArguments().get(0)) + ")";
+            }
+            else if (StandardFunctionResolution.isSubscriptFunction(node.getResolvedFunction())) {
+                return formatRowExpression(session, node.getArguments().get(0)) + "[" + formatRowExpression(session, node.getArguments().get(1)) + "]";
+            }
+            String operation = unmangleOperator(node.getResolvedFunction().getSignature().getName()).getOperator();
+            return operation + "(" + String.join(", ", formatRowExpressions(session, node.getArguments())) + ")";
+        }
+
+        @Override
+        public String visitSpecialForm(SpecialForm node, ConnectorSession session)
+        {
+            if (node.getForm().equals(SpecialForm.Form.AND) || node.getForm().equals(SpecialForm.Form.OR)) {
+                return String.join(" " + node.getForm() + " ", formatRowExpressions(session, node.getArguments()).stream().map(e -> "(" + e + ")").collect(toImmutableList()));
+            }
+            return node.getForm().name() + "(" + String.join(", ", formatRowExpressions(session, node.getArguments())) + ")";
+        }
+
+        @Override
+        public String visitInputReference(InputReferenceExpression node, ConnectorSession session)
+        {
+            return node.toString();
+        }
+
+        @Override
+        public String visitLambda(LambdaDefinitionExpression node, ConnectorSession session)
+        {
+            return "(" + String.join(", ", node.getArguments()) + ") -> " + formatRowExpression(session, node.getBody());
+        }
+
+        @Override
+        public String visitVariableReference(VariableReferenceExpression node, ConnectorSession session)
+        {
+            return node.getName();
+        }
+
+        @Override
+        public String visitConstant(ConstantExpression node, ConnectorSession session)
+        {
+            Object value = LiteralInterpreter.evaluate(node);
+
+            if (value == null) {
+                return String.valueOf((Object) null);
+            }
+
+            Type type = node.getType();
+            if (type.getJavaType() == Block.class) {
+                Block block = (Block) value;
+                // TODO: format block
+                return format("[Block: position count: %s; size: %s bytes]", block.getPositionCount(), block.getRetainedSizeInBytes());
+            }
+
+            String valueString = "'" + value.toString().replace("'", "''") + "'";
+
+            if (type instanceof VarbinaryType) {
+                return "X" + valueString;
+            }
+
+            return type.getTypeSignature().getBase().toUpperCase(Locale.ENGLISH) + valueString;
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/ValuePrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/ValuePrinter.java
@@ -38,6 +38,11 @@ public final class ValuePrinter
         this.session = requireNonNull(session, "session is null");
     }
 
+    public Session getSession()
+    {
+        return session;
+    }
+
     public String castToVarchar(Type type, Object value)
     {
         try {

--- a/core/trino-main/src/main/java/io/trino/sql/relational/CallExpression.java
+++ b/core/trino-main/src/main/java/io/trino/sql/relational/CallExpression.java
@@ -13,23 +13,31 @@
  */
 package io.trino.sql.relational;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import io.trino.metadata.ResolvedFunction;
 import io.trino.spi.type.Type;
+
+import javax.annotation.concurrent.Immutable;
 
 import java.util.List;
 import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
+@Immutable
 public final class CallExpression
         extends RowExpression
 {
     private final ResolvedFunction resolvedFunction;
     private final List<RowExpression> arguments;
 
-    public CallExpression(ResolvedFunction resolvedFunction, List<RowExpression> arguments)
+    @JsonCreator
+    public CallExpression(
+            @JsonProperty("resolvedFunction") ResolvedFunction resolvedFunction,
+            @JsonProperty("arguments") List<RowExpression> arguments)
     {
         requireNonNull(resolvedFunction, "resolvedFunction is null");
         requireNonNull(arguments, "arguments is null");
@@ -38,6 +46,7 @@ public final class CallExpression
         this.arguments = ImmutableList.copyOf(arguments);
     }
 
+    @JsonProperty
     public ResolvedFunction getResolvedFunction()
     {
         return resolvedFunction;
@@ -49,6 +58,7 @@ public final class CallExpression
         return resolvedFunction.getSignature().getReturnType();
     }
 
+    @JsonProperty
     public List<RowExpression> getArguments()
     {
         return arguments;

--- a/core/trino-main/src/main/java/io/trino/sql/relational/ConstantExpression.java
+++ b/core/trino-main/src/main/java/io/trino/sql/relational/ConstantExpression.java
@@ -13,12 +13,19 @@
  */
 package io.trino.sql.relational;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.block.Block;
+import io.trino.spi.predicate.Utils;
 import io.trino.spi.type.Type;
+
+import javax.annotation.concurrent.Immutable;
 
 import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
+@Immutable
 public final class ConstantExpression
         extends RowExpression
 {
@@ -33,12 +40,27 @@ public final class ConstantExpression
         this.type = type;
     }
 
+    @JsonCreator
+    public static ConstantExpression createConstantExpression(
+            @JsonProperty("valueBlock") Block valueBlock,
+            @JsonProperty("type") Type type)
+    {
+        return new ConstantExpression(Utils.blockToNativeValue(type, valueBlock), type);
+    }
+
+    @JsonProperty
+    public Block getValueBlock()
+    {
+        return Utils.nativeValueToBlock(type, value);
+    }
+
     public Object getValue()
     {
         return value;
     }
 
     @Override
+    @JsonProperty
     public Type getType()
     {
         return type;

--- a/core/trino-main/src/main/java/io/trino/sql/relational/InputReferenceExpression.java
+++ b/core/trino-main/src/main/java/io/trino/sql/relational/InputReferenceExpression.java
@@ -13,20 +13,26 @@
  */
 package io.trino.sql.relational;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.type.Type;
+
+import javax.annotation.concurrent.Immutable;
 
 import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
+@Immutable
 public final class InputReferenceExpression
         extends RowExpression
 {
     private final int field;
     private final Type type;
 
-    public InputReferenceExpression(int field, Type type)
+    @JsonCreator
+    public InputReferenceExpression(@JsonProperty("field") int field,
+            @JsonProperty("type") Type type)
     {
         requireNonNull(type, "type is null");
 

--- a/core/trino-main/src/main/java/io/trino/sql/relational/LambdaDefinitionExpression.java
+++ b/core/trino-main/src/main/java/io/trino/sql/relational/LambdaDefinitionExpression.java
@@ -13,10 +13,14 @@
  */
 package io.trino.sql.relational;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.type.Type;
 import io.trino.type.FunctionType;
+
+import javax.annotation.concurrent.Immutable;
 
 import java.util.List;
 import java.util.Objects;
@@ -24,6 +28,7 @@ import java.util.Objects;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
+@Immutable
 public final class LambdaDefinitionExpression
         extends RowExpression
 {
@@ -31,7 +36,10 @@ public final class LambdaDefinitionExpression
     private final List<String> arguments;
     private final RowExpression body;
 
-    public LambdaDefinitionExpression(List<Type> argumentTypes, List<String> arguments, RowExpression body)
+    @JsonCreator
+    public LambdaDefinitionExpression(@JsonProperty("argumentTypes") List<Type> argumentTypes,
+            @JsonProperty("arguments") List<String> arguments,
+            @JsonProperty("body") RowExpression body)
     {
         this.argumentTypes = ImmutableList.copyOf(requireNonNull(argumentTypes, "argumentTypes is null"));
         this.arguments = ImmutableList.copyOf(requireNonNull(arguments, "arguments is null"));
@@ -39,16 +47,19 @@ public final class LambdaDefinitionExpression
         this.body = requireNonNull(body, "body is null");
     }
 
+    @JsonProperty
     public List<Type> getArgumentTypes()
     {
         return argumentTypes;
     }
 
+    @JsonProperty
     public List<String> getArguments()
     {
         return arguments;
     }
 
+    @JsonProperty
     public RowExpression getBody()
     {
         return body;

--- a/core/trino-main/src/main/java/io/trino/sql/relational/OriginalExpressionUtils.java
+++ b/core/trino-main/src/main/java/io/trino/sql/relational/OriginalExpressionUtils.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.relational;
+
+import io.trino.spi.type.Type;
+import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.SymbolReference;
+
+import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * The following has a list of helper functions to transform between Expression and RowExpression.
+ * Ideally, users should never do type checking or down casting for future convenience of refactoring.
+ */
+public final class OriginalExpressionUtils
+{
+    private OriginalExpressionUtils() {}
+
+    /**
+     * Create a new RowExpression
+     */
+    public static RowExpression castToRowExpression(Expression expression)
+    {
+        return new OriginalExpression(expression);
+    }
+
+    public static SymbolReference asSymbolReference(VariableReferenceExpression variable)
+    {
+        return new SymbolReference(variable.getName());
+    }
+
+    /**
+     * Degrade to Expression
+     */
+    public static Expression castToExpression(RowExpression rowExpression)
+    {
+        checkArgument(isExpression(rowExpression));
+        return ((OriginalExpression) rowExpression).getExpression();
+    }
+
+    /**
+     * Check if the given {@param rowExpression} is an Expression.
+     */
+    public static boolean isExpression(RowExpression rowExpression)
+    {
+        return (rowExpression instanceof OriginalExpression);
+    }
+
+    /**
+     * OriginalExpression is a RowExpression container holding an {@param Expression} object
+     * that cannot be translated directly while constructing PlanNode.
+     * Typical examples are cases with `WITH` clauses or alias that the type or arguments information
+     * are not directly available given the substrees are not formed yet.
+     * OriginalExpression should not exist after optimization or serialized over the wire.
+     * All OriginalExpression should be translated to other corresponding RowExpression objects ultimately.
+     */
+    private static final class OriginalExpression
+            extends RowExpression
+    {
+        private final Expression expression;
+
+        OriginalExpression(Expression expression)
+        {
+            this.expression = requireNonNull(expression, "expression is null");
+        }
+
+        public Expression getExpression()
+        {
+            return expression;
+        }
+
+        @Override
+        public Type getType()
+        {
+            throw new UnsupportedOperationException("OriginalExpression does not have a type");
+        }
+
+        @Override
+        public String toString()
+        {
+            return expression.toString();
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(expression);
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            OriginalExpression other = (OriginalExpression) obj;
+            return Objects.equals(this.expression, other.expression);
+        }
+
+        @Override
+        public <R, C> R accept(RowExpressionVisitor<R, C> visitor, C context)
+        {
+            throw new UnsupportedOperationException("OriginalExpression cannot appear in a RowExpression tree");
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/relational/RowExpression.java
+++ b/core/trino-main/src/main/java/io/trino/sql/relational/RowExpression.java
@@ -13,8 +13,21 @@
  */
 package io.trino.sql.relational;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.trino.spi.type.Type;
 
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = "@type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = CallExpression.class, name = "call"),
+        @JsonSubTypes.Type(value = SpecialForm.class, name = "special"),
+        @JsonSubTypes.Type(value = LambdaDefinitionExpression.class, name = "lambda"),
+        @JsonSubTypes.Type(value = InputReferenceExpression.class, name = "input"),
+        @JsonSubTypes.Type(value = VariableReferenceExpression.class, name = "variable"),
+        @JsonSubTypes.Type(value = ConstantExpression.class, name = "constant")})
 public abstract class RowExpression
 {
     public abstract Type getType();

--- a/core/trino-main/src/main/java/io/trino/sql/relational/RowExpressionRewriter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/relational/RowExpressionRewriter.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.relational;
+
+public class RowExpressionRewriter<C>
+{
+    public RowExpression rewriteRowExpression(RowExpression node, C context, RowExpressionTreeRewriter<C> treeRewriter)
+    {
+        return null;
+    }
+
+    public RowExpression rewriteInputReference(InputReferenceExpression node, C context, RowExpressionTreeRewriter<C> treeRewriter)
+    {
+        return rewriteRowExpression(node, context, treeRewriter);
+    }
+
+    public RowExpression rewriteCall(CallExpression node, C context, RowExpressionTreeRewriter<C> treeRewriter)
+    {
+        return rewriteRowExpression(node, context, treeRewriter);
+    }
+
+    public RowExpression rewriteConstant(ConstantExpression node, C context, RowExpressionTreeRewriter<C> treeRewriter)
+    {
+        return rewriteRowExpression(node, context, treeRewriter);
+    }
+
+    public RowExpression rewriteLambda(LambdaDefinitionExpression node, C context, RowExpressionTreeRewriter<C> treeRewriter)
+    {
+        return rewriteRowExpression(node, context, treeRewriter);
+    }
+
+    public RowExpression rewriteVariableReference(VariableReferenceExpression node, C context, RowExpressionTreeRewriter<C> treeRewriter)
+    {
+        return rewriteRowExpression(node, context, treeRewriter);
+    }
+
+    public RowExpression rewriteSpecialForm(SpecialForm node, C context, RowExpressionTreeRewriter<C> treeRewriter)
+    {
+        return rewriteRowExpression(node, context, treeRewriter);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/relational/RowExpressionTreeRewriter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/relational/RowExpressionTreeRewriter.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.relational;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+
+import java.util.Iterator;
+import java.util.List;
+
+import static io.trino.sql.relational.Expressions.call;
+
+public final class RowExpressionTreeRewriter<C>
+{
+    private final RowExpressionRewriter<C> rewriter;
+    private final RowExpressionVisitor<RowExpression, Context<C>> visitor;
+
+    public static <C, T extends RowExpression> T rewriteWith(RowExpressionRewriter<C> rewriter, T node)
+    {
+        return new RowExpressionTreeRewriter<>(rewriter).rewrite(node, null);
+    }
+
+    public static <C, T extends RowExpression> T rewriteWith(RowExpressionRewriter<C> rewriter, T node, C context)
+    {
+        return new RowExpressionTreeRewriter<>(rewriter).rewrite(node, context);
+    }
+
+    public RowExpressionTreeRewriter(RowExpressionRewriter<C> rewriter)
+    {
+        this.rewriter = rewriter;
+        this.visitor = new RewritingVisitor();
+    }
+
+    private List<RowExpression> rewrite(List<RowExpression> items, Context<C> context)
+    {
+        ImmutableList.Builder<RowExpression> builder = ImmutableList.builder();
+        for (RowExpression expression : items) {
+            builder.add(rewrite(expression, context.get()));
+        }
+        return builder.build();
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T extends RowExpression> T rewrite(T node, C context)
+    {
+        return (T) node.accept(visitor, new Context<>(context, false));
+    }
+
+    /**
+     * Invoke the default rewrite logic explicitly. Specifically, it skips the invocation of the expression rewriter for the provided node.
+     */
+    @SuppressWarnings("unchecked")
+    public <T extends RowExpression> T defaultRewrite(T node, C context)
+    {
+        return (T) node.accept(visitor, new Context<>(context, true));
+    }
+
+    private class RewritingVisitor
+            implements RowExpressionVisitor<RowExpression, Context<C>>
+    {
+        @Override
+        public RowExpression visitInputReference(InputReferenceExpression input, Context<C> context)
+        {
+            if (!context.isDefaultRewrite()) {
+                RowExpression result = rewriter.rewriteInputReference(input, context.get(), RowExpressionTreeRewriter.this);
+                if (result != null) {
+                    return result;
+                }
+            }
+
+            return input;
+        }
+
+        @Override
+        public RowExpression visitCall(CallExpression call, Context<C> context)
+        {
+            if (!context.isDefaultRewrite()) {
+                RowExpression result = rewriter.rewriteCall(call, context.get(), RowExpressionTreeRewriter.this);
+                if (result != null) {
+                    return result;
+                }
+            }
+
+            List<RowExpression> arguments = rewrite(call.getArguments(), context);
+
+            if (!sameElements(call.getArguments(), arguments)) {
+                return call(call.getResolvedFunction(), arguments);
+            }
+            return call;
+        }
+
+        @Override
+        public RowExpression visitConstant(ConstantExpression literal, Context<C> context)
+        {
+            if (!context.isDefaultRewrite()) {
+                RowExpression result = rewriter.rewriteConstant(literal, context.get(), RowExpressionTreeRewriter.this);
+                if (result != null) {
+                    return result;
+                }
+            }
+
+            return literal;
+        }
+
+        @Override
+        public RowExpression visitLambda(LambdaDefinitionExpression lambda, Context<C> context)
+        {
+            if (!context.isDefaultRewrite()) {
+                RowExpression result = rewriter.rewriteLambda(lambda, context.get(), RowExpressionTreeRewriter.this);
+                if (result != null) {
+                    return result;
+                }
+            }
+
+            RowExpression body = rewrite(lambda.getBody(), context.get());
+            if (body != lambda.getBody()) {
+                return new LambdaDefinitionExpression(lambda.getArgumentTypes(), lambda.getArguments(), body);
+            }
+
+            return lambda;
+        }
+
+        @Override
+        public RowExpression visitVariableReference(VariableReferenceExpression variable, Context<C> context)
+        {
+            if (!context.isDefaultRewrite()) {
+                RowExpression result = rewriter.rewriteVariableReference(variable, context.get(), RowExpressionTreeRewriter.this);
+                if (result != null) {
+                    return result;
+                }
+            }
+
+            return variable;
+        }
+
+        @Override
+        public RowExpression visitSpecialForm(SpecialForm specialForm, Context<C> context)
+        {
+            if (!context.isDefaultRewrite()) {
+                RowExpression result = rewriter.rewriteSpecialForm(specialForm, context.get(), RowExpressionTreeRewriter.this);
+                if (result != null) {
+                    return result;
+                }
+            }
+
+            List<RowExpression> arguments = rewrite(specialForm.getArguments(), context);
+
+            if (!sameElements(specialForm.getArguments(), arguments)) {
+                return new SpecialForm(specialForm.getForm(), specialForm.getType(), arguments);
+            }
+            return specialForm;
+        }
+    }
+
+    public static class Context<C>
+    {
+        private final boolean defaultRewrite;
+        private final C context;
+
+        private Context(C context, boolean defaultRewrite)
+        {
+            this.context = context;
+            this.defaultRewrite = defaultRewrite;
+        }
+
+        public C get()
+        {
+            return context;
+        }
+
+        public boolean isDefaultRewrite()
+        {
+            return defaultRewrite;
+        }
+    }
+
+    @SuppressWarnings("ObjectEquality")
+    private static <T> boolean sameElements(Iterable<? extends T> a, Iterable<? extends T> b)
+    {
+        if (Iterables.size(a) != Iterables.size(b)) {
+            return false;
+        }
+
+        Iterator<? extends T> first = a.iterator();
+        Iterator<? extends T> second = b.iterator();
+
+        while (first.hasNext() && second.hasNext()) {
+            if (first.next() != second.next()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/relational/RowExpressionUtil.java
+++ b/core/trino-main/src/main/java/io/trino/sql/relational/RowExpressionUtil.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.relational;
+
+import com.google.common.collect.Iterables;
+import io.airlift.slice.Slice;
+import io.trino.Session;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.spi.type.RowType;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.planner.LiteralEncoder;
+import io.trino.sql.planner.NoOpSymbolResolver;
+import io.trino.sql.planner.RowExpressionInterpreter;
+import io.trino.sql.tree.BooleanLiteral;
+import io.trino.sql.tree.Cast;
+import io.trino.sql.tree.DoubleLiteral;
+import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.FunctionCall;
+import io.trino.sql.tree.GenericLiteral;
+import io.trino.sql.tree.Literal;
+import io.trino.sql.tree.LongLiteral;
+import io.trino.sql.tree.Row;
+import io.trino.sql.tree.StringLiteral;
+import io.trino.type.UnknownType;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.metadata.FunctionDependencies.isCast;
+import static io.trino.metadata.LiteralFunction.LITERAL_FUNCTION_NAME;
+import static io.trino.sql.analyzer.TypeSignatureTranslator.toSqlType;
+import static io.trino.sql.relational.OriginalExpressionUtils.castToExpression;
+import static io.trino.sql.relational.OriginalExpressionUtils.castToRowExpression;
+import static io.trino.sql.relational.OriginalExpressionUtils.isExpression;
+
+public class RowExpressionUtil
+{
+    private RowExpressionUtil() {}
+
+    /**
+     * Returns whether expression is effectively literal. An effectively literal expression is a simple constant value, or null,
+     * in either {@link Literal} form, or other form returned by {@link LiteralEncoder}. In particular, other constant expressions
+     * like a deterministic function call with constant arguments are not considered effectively literal.
+     */
+    public static boolean isEffectivelyLiteral(PlannerContext plannerContext, Session session, RowExpression expression)
+    {
+        if (expression instanceof ConstantExpression) {
+            return true;
+        }
+
+        if (expression instanceof CallExpression) {
+            CallExpression callExpression = (CallExpression) expression;
+            ResolvedFunction resolvedFunction = callExpression.getResolvedFunction();
+
+            // need testing on TRY_CAST
+            if (isCast(resolvedFunction)) {
+                RowExpression argument = Iterables.getOnlyElement(callExpression.getArguments());
+                return (argument instanceof ConstantExpression && constantExpressionEvaluatesSuccessfully(plannerContext, session, expression));
+            }
+
+            return LITERAL_FUNCTION_NAME.equals(resolvedFunction.getSignature().getName());
+        }
+        return false;
+    }
+
+    private static boolean constantExpressionEvaluatesSuccessfully(PlannerContext plannerContext, Session session, RowExpression constantExpression)
+    {
+        RowExpressionInterpreter interpreter = new RowExpressionInterpreter(constantExpression, plannerContext, session);
+        Object literalValue = interpreter.optimize(NoOpSymbolResolver.INSTANCE);
+        return !(literalValue instanceof RowExpression);
+    }
+
+    public static boolean isRow(RowExpression row)
+    {
+        if (isExpression(row)) {
+            return castToExpression(row) instanceof Row;
+        }
+        else {
+            return row instanceof SpecialForm && ((SpecialForm) row).getForm().equals(SpecialForm.Form.ROW_CONSTRUCTOR);
+        }
+    }
+
+    public static RowExpression toRowConstructorExpression(RowExpression argument)
+    {
+        return toRowConstructorExpression(List.of(argument));
+    }
+
+    public static RowExpression toRowConstructorExpression(List<RowExpression> arguments)
+    {
+        if (arguments.stream().anyMatch(OriginalExpressionUtils::isExpression)) {
+            return castToRowExpression(new Row(arguments.stream().map(OriginalExpressionUtils::castToExpression).collect(toImmutableList())));
+        }
+        else {
+            if (arguments.size() == 0) {
+                return new SpecialForm(SpecialForm.Form.ROW_CONSTRUCTOR, UnknownType.UNKNOWN, arguments);
+            }
+            else {
+                return new SpecialForm(SpecialForm.Form.ROW_CONSTRUCTOR, RowType.anonymous(arguments.stream().map(RowExpression::getType).collect(toImmutableList())), arguments);
+            }
+        }
+    }
+
+    // Hacky method to convert a RowExpression in ValuesNode to Expression, the RowExpression expression could be a constant, a cast, or a
+    // random function, we should not use this method to convert  RowExpression to Expression when all the PlanNodes refer to RowExpression
+    public static Expression castRowRowExpressionToExpression(RowExpression rowExpression)
+    {
+        if (isExpression(rowExpression)) {
+            return castToExpression(rowExpression);
+        }
+        if (rowExpression instanceof CallExpression) {
+            CallExpression callExpression = (CallExpression) rowExpression;
+            if (isCast(callExpression.getResolvedFunction())) {
+                return new Cast(Iterables.getOnlyElement(((CallExpression) rowExpression).getArguments().stream().map(RowExpressionUtil::castRowRowExpressionToExpression).collect(toImmutableList())), toSqlType(callExpression.getType()));
+            }
+            else {
+                // should be a random function here
+                checkArgument(callExpression.getArguments().size() == 0);
+                return new FunctionCall(callExpression.getResolvedFunction().toQualifiedName(), ((CallExpression) rowExpression).getArguments().stream().map(RowExpressionUtil::castRowRowExpressionToExpression).collect(toImmutableList()));
+            }
+//            return new Cast(callExpression.getResolvedFunction().toQualifiedName(), ((CallExpression) rowExpression).getArguments().stream().map(RowExpressionUtil::castRowRowExpressionToExpression).collect(toImmutableList()));
+        }
+        if (rowExpression instanceof SpecialForm) {
+            return new Row(((SpecialForm) rowExpression).getArguments().stream().map(RowExpressionUtil::castRowRowExpressionToExpression).collect(toImmutableList()));
+        }
+        ConstantExpression expression = (ConstantExpression) rowExpression;
+        if (expression.getType().getJavaType() == boolean.class) {
+            return new BooleanLiteral(String.valueOf(expression.getValue()));
+        }
+        if (expression.getType().getJavaType() == long.class) {
+            return new LongLiteral(String.valueOf(expression.getValue()));
+        }
+        if (expression.getType().getJavaType() == double.class) {
+            return new DoubleLiteral(String.valueOf(expression.getValue()));
+        }
+        if (expression.getType().getJavaType() == Slice.class) {
+            return new StringLiteral(new String(((Slice) expression.getValue()).getBytes(), StandardCharsets.UTF_8));
+        }
+        return new GenericLiteral(expression.getType().toString(), String.valueOf(expression.getValue()));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/relational/SpecialForm.java
+++ b/core/trino-main/src/main/java/io/trino/sql/relational/SpecialForm.java
@@ -13,6 +13,8 @@
  */
 package io.trino.sql.relational;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import io.trino.metadata.BoundSignature;
@@ -20,6 +22,7 @@ import io.trino.metadata.ResolvedFunction;
 import io.trino.metadata.Signature;
 import io.trino.spi.function.OperatorType;
 import io.trino.spi.type.Type;
+import net.jcip.annotations.Immutable;
 
 import java.util.List;
 import java.util.Objects;
@@ -28,6 +31,7 @@ import java.util.Optional;
 import static io.trino.spi.function.OperatorType.CAST;
 import static java.util.Objects.requireNonNull;
 
+@Immutable
 public class SpecialForm
         extends RowExpression
 {
@@ -46,7 +50,11 @@ public class SpecialForm
         this(form, returnType, arguments, ImmutableList.of());
     }
 
-    public SpecialForm(Form form, Type returnType, List<RowExpression> arguments, List<ResolvedFunction> functionDependencies)
+    @JsonCreator
+    public SpecialForm(@JsonProperty("form") Form form,
+            @JsonProperty("returnType") Type returnType,
+            @JsonProperty("arguments") List<RowExpression> arguments,
+            @JsonProperty("functionDependencies") List<ResolvedFunction> functionDependencies)
     {
         this.form = requireNonNull(form, "form is null");
         this.returnType = requireNonNull(returnType, "returnType is null");
@@ -54,11 +62,13 @@ public class SpecialForm
         this.functionDependencies = ImmutableList.copyOf(requireNonNull(functionDependencies, "functionDependencies is null"));
     }
 
+    @JsonProperty
     public Form getForm()
     {
         return form;
     }
 
+    @JsonProperty
     public List<ResolvedFunction> getFunctionDependencies()
     {
         return functionDependencies;
@@ -90,11 +100,13 @@ public class SpecialForm
     }
 
     @Override
+    @JsonProperty("returnType")
     public Type getType()
     {
         return returnType;
     }
 
+    @JsonProperty
     public List<RowExpression> getArguments()
     {
         return arguments;

--- a/core/trino-main/src/main/java/io/trino/sql/relational/SqlToRowExpressionTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/relational/SqlToRowExpressionTranslator.java
@@ -751,7 +751,7 @@ public final class SqlToRowExpressionTranslator
 
             if (getType(node.getBase()) instanceof RowType) {
                 long value = (Long) ((ConstantExpression) index).getValue();
-                return new SpecialForm(DEREFERENCE, getType(node), base, constant((int) value - 1, INTEGER));
+                return new SpecialForm(DEREFERENCE, getType(node), base, constant(value - 1, INTEGER));
             }
 
             return call(

--- a/core/trino-main/src/main/java/io/trino/sql/relational/StandardFunctionResolution.java
+++ b/core/trino-main/src/main/java/io/trino/sql/relational/StandardFunctionResolution.java
@@ -22,7 +22,10 @@ import io.trino.spi.type.Type;
 import io.trino.sql.tree.ArithmeticBinaryExpression.Operator;
 import io.trino.sql.tree.ComparisonExpression;
 
+import static io.trino.metadata.Signature.isOperatorName;
+import static io.trino.metadata.Signature.unmangleOperator;
 import static io.trino.spi.function.OperatorType.ADD;
+import static io.trino.spi.function.OperatorType.CAST;
 import static io.trino.spi.function.OperatorType.DIVIDE;
 import static io.trino.spi.function.OperatorType.EQUAL;
 import static io.trino.spi.function.OperatorType.IS_DISTINCT_FROM;
@@ -30,6 +33,8 @@ import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.function.OperatorType.MODULUS;
 import static io.trino.spi.function.OperatorType.MULTIPLY;
+import static io.trino.spi.function.OperatorType.NEGATION;
+import static io.trino.spi.function.OperatorType.SUBSCRIPT;
 import static io.trino.spi.function.OperatorType.SUBTRACT;
 import static java.util.Objects.requireNonNull;
 
@@ -90,5 +95,62 @@ public final class StandardFunctionResolution
         }
 
         return metadata.resolveOperator(session, operatorType, ImmutableList.of(leftType, rightType));
+    }
+
+    public static boolean isNegateFunction(ResolvedFunction resolvedFunction)
+    {
+        String name = resolvedFunction.getSignature().getName();
+        return isOperatorName(name) && unmangleOperator(name) == NEGATION;
+    }
+
+    public static boolean isArithmeticFunction(ResolvedFunction resolvedFunction)
+    {
+        String name = resolvedFunction.getSignature().getName();
+        return isOperatorName(name) && isArithmeticOperatorType(unmangleOperator(name));
+    }
+
+    public static boolean isComparisonFunction(ResolvedFunction resolvedFunction)
+    {
+        String name = resolvedFunction.getSignature().getName();
+        return isOperatorName(name) && isComparisonOperatorType(unmangleOperator(name));
+    }
+
+    public static boolean isCastFunction(ResolvedFunction function)
+    {
+        String name = function.getSignature().getName();
+        return isOperatorName(name) && unmangleOperator(name) == CAST;
+    }
+
+    public static boolean isSubscriptFunction(ResolvedFunction function)
+    {
+        String name = function.getSignature().getName();
+        return isOperatorName(name) && unmangleOperator(name) == SUBSCRIPT;
+    }
+
+    private static boolean isArithmeticOperatorType(OperatorType operatorType)
+    {
+        switch (operatorType) {
+            case ADD:
+            case SUBTRACT:
+            case MULTIPLY:
+            case DIVIDE:
+            case MODULUS:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static boolean isComparisonOperatorType(OperatorType operatorType)
+    {
+        switch (operatorType) {
+            case EQUAL:
+            case LESS_THAN:
+            case LESS_THAN_OR_EQUAL:
+            case IS_DISTINCT_FROM:
+                return true;
+            default:
+                return false;
+        }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/relational/VariableReferenceExpression.java
+++ b/core/trino-main/src/main/java/io/trino/sql/relational/VariableReferenceExpression.java
@@ -13,30 +13,40 @@
  */
 package io.trino.sql.relational;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.type.Type;
+
+import javax.annotation.concurrent.Immutable;
 
 import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
+@Immutable
 public final class VariableReferenceExpression
         extends RowExpression
 {
     private final String name;
     private final Type type;
 
-    public VariableReferenceExpression(String name, Type type)
+    @JsonCreator
+    public VariableReferenceExpression(
+            @JsonProperty("name") String name,
+            @JsonProperty("type") Type type)
     {
         this.name = requireNonNull(name, "name is null");
         this.type = requireNonNull(type, "type is null");
     }
 
+    @JsonProperty
     public String getName()
     {
         return name;
     }
 
     @Override
+    @JsonProperty
     public Type getType()
     {
         return type;

--- a/core/trino-main/src/test/java/io/trino/cost/StatsCalculatorTester.java
+++ b/core/trino-main/src/test/java/io/trino/cost/StatsCalculatorTester.java
@@ -57,6 +57,11 @@ public class StatsCalculatorTester
         return metadata;
     }
 
+    public Session getSession()
+    {
+        return session;
+    }
+
     private static LocalQueryRunner createQueryRunner(Session session)
     {
         LocalQueryRunner queryRunner = LocalQueryRunner.create(session);

--- a/core/trino-main/src/test/java/io/trino/execution/TestStageStateMachine.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestStageStateMachine.java
@@ -24,8 +24,6 @@ import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.plan.PlanFragmentId;
 import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.sql.planner.plan.ValuesNode;
-import io.trino.sql.tree.Row;
-import io.trino.sql.tree.StringLiteral;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -39,6 +37,8 @@ import static io.trino.operator.StageExecutionDescriptor.ungroupedExecution;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.SOURCE_DISTRIBUTION;
+import static io.trino.sql.relational.Expressions.constant;
+import static io.trino.sql.relational.RowExpressionUtil.toRowConstructorExpression;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -248,7 +248,7 @@ public class TestStageStateMachine
                 new PlanFragmentId("plan"),
                 new ValuesNode(valuesNodeId,
                         ImmutableList.of(symbol),
-                        ImmutableList.of(new Row(ImmutableList.of(new StringLiteral("foo"))))),
+                        ImmutableList.of(toRowConstructorExpression(constant("foo", VARCHAR)))),
                 ImmutableMap.of(symbol, VARCHAR),
                 SOURCE_DISTRIBUTION,
                 ImmutableList.of(valuesNodeId),

--- a/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
@@ -22,7 +22,6 @@ import io.airlift.slice.SliceOutput;
 import io.airlift.slice.Slices;
 import io.trino.FeaturesConfig;
 import io.trino.block.BlockSerdeUtil;
-import io.trino.metadata.FunctionDependencies;
 import io.trino.metadata.InternalFunctionBundle;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.MetadataManager;
@@ -96,6 +95,7 @@ import static io.trino.sql.ExpressionTestUtils.resolveFunctionCalls;
 import static io.trino.sql.ExpressionUtils.rewriteIdentifiersToSymbolReferences;
 import static io.trino.sql.ParsingUtil.createParsingOptions;
 import static io.trino.sql.planner.TypeAnalyzer.createTestingTypeAnalyzer;
+import static io.trino.sql.relational.StandardFunctionResolution.isCastFunction;
 import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
 import static io.trino.type.DateTimes.scaleEpochMillisToMicros;
 import static io.trino.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
@@ -2130,7 +2130,7 @@ public class TestExpressionInterpreter
     private static boolean isRemovableCast(Object value)
     {
         if (value instanceof CallExpression &&
-                FunctionDependencies.isCast(((CallExpression) value).getResolvedFunction())) {
+                isCastFunction(((CallExpression) value).getResolvedFunction())) {
             Type targetType = ((CallExpression) value).getType();
             Type sourceType = ((CallExpression) value).getArguments().get(0).getType();
             return typeCoercion.canCoerce(sourceType, targetType);

--- a/core/trino-main/src/test/java/io/trino/sql/TestRowExpressionSerde.java
+++ b/core/trino-main/src/test/java/io/trino/sql/TestRowExpressionSerde.java
@@ -1,0 +1,272 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.json.JsonCodec;
+import io.airlift.json.JsonModule;
+import io.airlift.slice.Slice;
+import io.airlift.stats.cardinality.HyperLogLog;
+import io.trino.FeaturesConfig;
+import io.trino.block.BlockJsonSerde;
+import io.trino.metadata.HandleJsonModule;
+import io.trino.metadata.InternalFunctionBundle;
+import io.trino.metadata.Metadata;
+import io.trino.metadata.MetadataManager;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockEncoding;
+import io.trino.spi.block.BlockEncodingSerde;
+import io.trino.spi.block.IntArrayBlock;
+import io.trino.spi.block.TestingBlockEncodingSerde;
+import io.trino.spi.function.OperatorType;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeManager;
+import io.trino.spi.type.TypeSignature;
+import io.trino.spi.type.VarcharType;
+import io.trino.sql.parser.ParsingOptions;
+import io.trino.sql.parser.SqlParser;
+import io.trino.sql.planner.TestingPlannerContext;
+import io.trino.sql.planner.TypeProvider;
+import io.trino.sql.relational.ConstantExpression;
+import io.trino.sql.relational.RowExpression;
+import io.trino.sql.relational.SpecialForm;
+import io.trino.sql.relational.SqlToRowExpressionTranslator;
+import io.trino.sql.relational.optimizer.ExpressionOptimizer;
+import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.NodeRef;
+import io.trino.sql.tree.QualifiedName;
+import io.trino.type.TypeDeserializer;
+import io.trino.type.TypeSignatureDeserializer;
+import io.trino.type.TypeSignatureKeyDeserializer;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.airlift.json.JsonBinder.jsonBinder;
+import static io.airlift.json.JsonCodecBinder.jsonCodecBinder;
+import static io.trino.SessionTestUtils.TEST_SESSION;
+import static io.trino.spi.function.OperatorType.SUBSCRIPT;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimestampType.TIMESTAMP;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.ExpressionTestUtils.planExpression;
+import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static io.trino.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DOUBLE;
+import static io.trino.sql.relational.Expressions.call;
+import static io.trino.sql.relational.Expressions.constant;
+import static io.trino.sql.relational.SpecialForm.Form.ROW_CONSTRUCTOR;
+import static java.lang.Float.floatToIntBits;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestRowExpressionSerde
+{
+    private final Metadata metadata = MetadataManager.createTestMetadataManager();
+
+    private static final PlannerContext PLANNER_CONTEXT = TestingPlannerContext.plannerContextBuilder().addFunctions(new InternalFunctionBundle()).build();
+
+    private JsonCodec<RowExpression> codec;
+
+    @BeforeClass
+    public void setUp()
+            throws Exception
+    {
+        codec = getJsonCodec();
+    }
+
+    @Test
+    public void testSimpleLiteral()
+    {
+        assertLiteral("TRUE", constant(true, BOOLEAN));
+        assertLiteral("FALSE", constant(false, BOOLEAN));
+        assertLiteral("CAST(NULL AS BOOLEAN)", constant(null, BOOLEAN));
+
+        assertLiteral("TINYINT '1'", constant(1L, TINYINT));
+        assertLiteral("SMALLINT '1'", constant(1L, SMALLINT));
+        assertLiteral("1", constant(1L, INTEGER));
+        assertLiteral("BIGINT '1'", constant(1L, BIGINT));
+
+        assertLiteral("1.1", constant(1.1, DOUBLE));
+        assertLiteral("nan()", constant(Double.NaN, DOUBLE));
+        assertLiteral("infinity()", constant(Double.POSITIVE_INFINITY, DOUBLE));
+        assertLiteral("-infinity()", constant(Double.NEGATIVE_INFINITY, DOUBLE));
+
+        assertLiteral("CAST(1.1 AS REAL)", constant((long) floatToIntBits(1.1f), REAL));
+        assertLiteral("CAST(nan() AS REAL)", constant((long) floatToIntBits(Float.NaN), REAL));
+        assertLiteral("CAST(infinity() AS REAL)", constant((long) floatToIntBits(Float.POSITIVE_INFINITY), REAL));
+        assertLiteral("CAST(-infinity() AS REAL)", constant((long) floatToIntBits(Float.NEGATIVE_INFINITY), REAL));
+
+        assertStringLiteral("'String Literal'", "String Literal", VarcharType.createVarcharType(14));
+        assertLiteral("CAST(NULL AS VARCHAR)", constant(null, VARCHAR));
+
+        assertLiteral("DATE '1991-01-01'", constant(7670L, DATE));
+        assertLiteral("TIMESTAMP '1991-01-01 00:00:00.000'", constant(662688000000000L, TIMESTAMP));
+    }
+
+    @Test
+    public void testArrayLiteral()
+    {
+        RowExpression rowExpression = getRoundTrip("ARRAY [1, 2, 3]", true);
+        assertTrue(rowExpression instanceof ConstantExpression);
+        Object value = ((ConstantExpression) rowExpression).getValue();
+        assertTrue(value instanceof IntArrayBlock);
+        IntArrayBlock block = (IntArrayBlock) value;
+        assertEquals(block.getPositionCount(), 3);
+        assertEquals(block.getInt(0, 0), 1);
+        assertEquals(block.getInt(1, 0), 2);
+        assertEquals(block.getInt(2, 0), 3);
+    }
+
+    @Test
+    public void testArrayGet()
+    {
+        assertEquals(getRoundTrip("(ARRAY [1, 2, 3])[1]", false),
+                call(operator(SUBSCRIPT, new ArrayType(INTEGER), BIGINT),
+                        call(
+                                function("array_constructor", INTEGER, INTEGER, INTEGER),
+                                constant(1L, INTEGER),
+                                constant(2L, INTEGER),
+                                constant(3L, INTEGER)),
+                        call(metadata.getCoercion(TEST_SESSION, INTEGER, BIGINT), constant(1L, INTEGER))));
+        assertEquals(getRoundTrip("(ARRAY [1, 2, 3])[1]", true), constant(1L, INTEGER));
+    }
+
+    @Test
+    public void testRowLiteral()
+    {
+        assertEquals(getRoundTrip("ROW(1, 1.1)", false),
+                 new SpecialForm(
+                        ROW_CONSTRUCTOR,
+                        RowType.anonymous(
+                                ImmutableList.of(
+                                        INTEGER,
+                                        DOUBLE)),
+                        constant(1L, INTEGER),
+                        constant(1.1, DOUBLE)));
+    }
+
+    @Test
+    public void testDereference()
+    {
+        String sql = "CAST(ROW(1) AS ROW(col1 integer)).col1";
+        RowExpression before = translate(new SqlParser().createExpression(sql, new ParsingOptions(AS_DOUBLE)), false);
+        RowExpression after = getRoundTrip(sql, false);
+        assertEquals(before, after);
+    }
+
+    @Test
+    public void testHllLiteral()
+    {
+        RowExpression rowExpression = getRoundTrip("empty_approx_set()", true);
+        assertTrue(rowExpression instanceof ConstantExpression);
+        Object value = ((ConstantExpression) rowExpression).getValue();
+        assertEquals(HyperLogLog.newInstance((Slice) value).cardinality(), 0);
+    }
+
+    private void assertLiteral(@Language("SQL") String sql, ConstantExpression expected)
+    {
+        assertEquals(getRoundTrip(sql, true), expected);
+    }
+
+    private void assertStringLiteral(@Language("SQL") String sql, String expectedString, Type expectedType)
+    {
+        RowExpression roundTrip = getRoundTrip(sql, true);
+        assertTrue(roundTrip instanceof ConstantExpression);
+        String roundTripValue = ((Slice) ((ConstantExpression) roundTrip).getValue()).toStringUtf8();
+        Type roundTripType = roundTrip.getType();
+        assertEquals(roundTripValue, expectedString);
+        assertEquals(roundTripType, expectedType);
+    }
+
+    private RowExpression getRoundTrip(String sql, boolean optimize)
+    {
+        Expression parsedExpression = new SqlParser().createExpression(sql, new ParsingOptions(AS_DOUBLE));
+        parsedExpression = planExpression(PLANNER_CONTEXT, TEST_SESSION, TypeProvider.empty(), parsedExpression);
+        RowExpression rowExpression = translate(parsedExpression, optimize);
+        String json = codec.toJson(rowExpression);
+        return codec.fromJson(json);
+    }
+
+    private ResolvedFunction operator(OperatorType operatorType, Type... types)
+    {
+        return metadata.resolveOperator(TEST_SESSION, operatorType, Arrays.asList(types));
+    }
+
+    private ResolvedFunction function(String name, Type... types)
+    {
+        return metadata.resolveFunction(TEST_SESSION, QualifiedName.of(name), fromTypes(types));
+    }
+
+    private JsonCodec<RowExpression> getJsonCodec()
+            throws Exception
+    {
+        Module module = binder -> {
+            binder.install(new JsonModule());
+            binder.install(new HandleJsonModule());
+            configBinder(binder).bindConfig(FeaturesConfig.class);
+
+            TypeManager functionManager = PLANNER_CONTEXT.getTypeManager();
+            binder.bind(TypeManager.class).toInstance(functionManager);
+            jsonBinder(binder).addDeserializerBinding(Type.class).to(TypeDeserializer.class);
+            newSetBinder(binder, Type.class);
+
+            binder.bind(BlockEncodingSerde.class).to(TestingBlockEncodingSerde.class).in(Scopes.SINGLETON);
+            newSetBinder(binder, BlockEncoding.class);
+            jsonBinder(binder).addSerializerBinding(Block.class).to(BlockJsonSerde.Serializer.class);
+            jsonBinder(binder).addDeserializerBinding(Block.class).to(BlockJsonSerde.Deserializer.class);
+            jsonBinder(binder).addDeserializerBinding(Type.class).to(TypeDeserializer.class);
+            jsonBinder(binder).addDeserializerBinding(TypeSignature.class).to(TypeSignatureDeserializer.class);
+            jsonBinder(binder).addKeyDeserializerBinding(TypeSignature.class).to(TypeSignatureKeyDeserializer.class);
+            jsonCodecBinder(binder).bindJsonCodec(RowExpression.class);
+        };
+        Bootstrap app = new Bootstrap(ImmutableList.of(module));
+        Injector injector = app
+                .doNotInitializeLogging()
+                .quiet()
+                .initialize();
+        return injector.getInstance(new Key<JsonCodec<RowExpression>>() {});
+    }
+
+    private RowExpression translate(Expression expression, boolean optimize)
+    {
+        Map<NodeRef<Expression>, Type> types = ExpressionTestUtils.getTypes(TEST_SESSION, PLANNER_CONTEXT, TypeProvider.empty(), expression);
+        RowExpression rowExpression = SqlToRowExpressionTranslator.translate(expression, types, ImmutableMap.of(), PLANNER_CONTEXT.getMetadata(), PLANNER_CONTEXT.getFunctionManager(), TEST_SESSION, optimize);
+        if (optimize) {
+            ExpressionOptimizer optimizer = new ExpressionOptimizer(metadata, PLANNER_CONTEXT.getFunctionManager(), TEST_SESSION);
+            return optimizer.optimize(rowExpression);
+        }
+        return rowExpression;
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestCanonicalize.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestCanonicalize.java
@@ -23,12 +23,15 @@ import io.trino.sql.planner.iterative.IterativeOptimizer;
 import io.trino.sql.planner.iterative.rule.RemoveRedundantIdentityProjections;
 import io.trino.sql.planner.optimizations.UnaliasSymbolReferences;
 import io.trino.sql.planner.plan.WindowNode;
-import io.trino.sql.tree.GenericLiteral;
+import io.trino.sql.tree.Cast;
 import io.trino.sql.tree.LongLiteral;
+import io.trino.sql.tree.StringLiteral;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
 
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.analyzer.TypeSignatureTranslator.toSqlType;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.functionCall;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.specification;
@@ -49,7 +52,7 @@ public class TestCanonicalize
                         ") t\n" +
                         "CROSS JOIN (VALUES 2)",
                 anyTree(
-                        values(ImmutableList.of("field", "expr"), ImmutableList.of(ImmutableList.of(new LongLiteral("2"), new GenericLiteral("BIGINT", "1"))))));
+                        values(ImmutableList.of("field", "expr"), ImmutableList.of(ImmutableList.of(new LongLiteral("2"), new Cast(new StringLiteral("1"), toSqlType(BIGINT)))))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDereferencePushDown.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDereferencePushDown.java
@@ -18,12 +18,15 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.sql.planner.assertions.BasePlanTest;
 import io.trino.sql.planner.assertions.PlanMatchPattern;
+import io.trino.sql.tree.Cast;
 import io.trino.sql.tree.DoubleLiteral;
-import io.trino.sql.tree.GenericLiteral;
+import io.trino.sql.tree.StringLiteral;
 import org.testng.annotations.Test;
 
 import static io.trino.SystemSessionProperties.FILTERING_SEMI_JOIN_TO_INNER;
 import static io.trino.SystemSessionProperties.MERGE_PROJECT_WITH_VALUES;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.analyzer.TypeSignatureTranslator.toSqlType;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.any;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
@@ -73,7 +76,7 @@ public class TestDereferencePushDown
                                         values(
                                                 ImmutableList.of("b_x", "b_y", "a_y"),
                                                 ImmutableList.of(ImmutableList.of(
-                                                        new GenericLiteral("BIGINT", "1"),
+                                                        new Cast(new StringLiteral("1"), toSqlType(BIGINT)),
                                                         new DoubleLiteral("2e0"),
                                                         new DoubleLiteral("2e0"))))))));
 
@@ -99,7 +102,7 @@ public class TestDereferencePushDown
                                         "b_y = 2e0",
                                         values(
                                                 ImmutableList.of("b_x", "b_y"),
-                                                ImmutableList.of(ImmutableList.of(new GenericLiteral("BIGINT", "1"), new DoubleLiteral("2e0")))))))));
+                                                ImmutableList.of(ImmutableList.of(new Cast(new StringLiteral("1"), toSqlType(BIGINT)), new DoubleLiteral("2e0")))))))));
     }
 
     @Test
@@ -118,9 +121,9 @@ public class TestDereferencePushDown
                                         values(
                                                 ImmutableList.of("b_x", "b_y", "a_x", "a_y"),
                                                 ImmutableList.of(ImmutableList.of(
-                                                        new GenericLiteral("BIGINT", "1"),
+                                                        new Cast(new StringLiteral("1"), toSqlType(BIGINT)),
                                                         new DoubleLiteral("2e0"),
-                                                        new GenericLiteral("BIGINT", "1"),
+                                                        new Cast(new StringLiteral("1"), toSqlType(BIGINT)),
                                                         new DoubleLiteral("2e0"))))))));
     }
 
@@ -133,7 +136,7 @@ public class TestDereferencePushDown
                 anyTree(
                         project(values(
                                 ImmutableList.of("x", "y"),
-                                ImmutableList.of(ImmutableList.of(new GenericLiteral("BIGINT", "1"), new DoubleLiteral("2e0")))))));
+                                ImmutableList.of(ImmutableList.of(new Cast(new StringLiteral("1"), toSqlType(BIGINT)), new DoubleLiteral("2e0")))))));
 
         assertPlanWithSession(
                 "WITH t(msg1, msg2, msg3, msg4, msg5) AS (VALUES " +
@@ -220,7 +223,7 @@ public class TestDereferencePushDown
                                                 values(
                                                         ImmutableList.of("b_x", "b_y", "a_y"),
                                                         ImmutableList.of(ImmutableList.of(
-                                                                new GenericLiteral("BIGINT", "1"),
+                                                                new Cast(new StringLiteral("1"), toSqlType(BIGINT)),
                                                                 new DoubleLiteral("2e0"),
                                                                 new DoubleLiteral("2e0")))))))));
 
@@ -246,7 +249,7 @@ public class TestDereferencePushDown
                                 "b_y = 2e0",
                                 values(
                                         ImmutableList.of("b_x", "b_y"),
-                                        ImmutableList.of(ImmutableList.of(new GenericLiteral("BIGINT", "1"), new DoubleLiteral("2e0")))))))));
+                                        ImmutableList.of(ImmutableList.of(new Cast(new StringLiteral("1"), toSqlType(BIGINT)), new DoubleLiteral("2e0")))))))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestDetermineJoinDistributionType.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestDetermineJoinDistributionType.java
@@ -55,8 +55,8 @@ import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
 import static io.trino.sql.planner.iterative.Lookup.noLookup;
 import static io.trino.sql.planner.iterative.rule.DetermineJoinDistributionType.getFirstKnownOutputSizeInBytes;
 import static io.trino.sql.planner.iterative.rule.DetermineJoinDistributionType.getSourceTablesSizeInBytes;
+import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.constantExpressions;
 import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expression;
-import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expressions;
 import static io.trino.sql.planner.iterative.rule.test.RuleTester.defaultRuleTester;
 import static io.trino.sql.planner.plan.JoinNode.DistributionType.PARTITIONED;
 import static io.trino.sql.planner.plan.JoinNode.DistributionType.REPLICATED;
@@ -111,8 +111,8 @@ public class TestDetermineJoinDistributionType
                 .on(p ->
                         p.join(
                                 joinType,
-                                p.values(ImmutableList.of(p.symbol("A1")), ImmutableList.of(expressions("10"), expressions("11"))),
-                                p.values(ImmutableList.of(p.symbol("B1")), ImmutableList.of(expressions("50"), expressions("11"))),
+                                p.values(ImmutableList.of(p.symbol("A1")), ImmutableList.of(constantExpressions(BIGINT, 10), constantExpressions(BIGINT, 11))),
+                                p.values(ImmutableList.of(p.symbol("B1")), ImmutableList.of(constantExpressions(BIGINT, 50), constantExpressions(BIGINT, 11))),
                                 ImmutableList.of(new JoinNode.EquiJoinClause(p.symbol("A1", BIGINT), p.symbol("B1", BIGINT))),
                                 ImmutableList.of(p.symbol("A1", BIGINT)),
                                 ImmutableList.of(p.symbol("B1", BIGINT)),
@@ -144,8 +144,8 @@ public class TestDetermineJoinDistributionType
                 .on(p ->
                         p.join(
                                 joinType,
-                                p.values(ImmutableList.of(p.symbol("A1")), ImmutableList.of(expressions("10"), expressions("11"))),
-                                p.values(ImmutableList.of(p.symbol("B1")), ImmutableList.of(expressions("50"), expressions("11"))),
+                                p.values(ImmutableList.of(p.symbol("A1")), ImmutableList.of(constantExpressions(BIGINT, 10), constantExpressions(BIGINT, 11))),
+                                p.values(ImmutableList.of(p.symbol("B1")), ImmutableList.of(constantExpressions(BIGINT, 50), constantExpressions(BIGINT, 11))),
                                 ImmutableList.of(new JoinNode.EquiJoinClause(p.symbol("A1", BIGINT), p.symbol("B1", BIGINT))),
                                 ImmutableList.of(p.symbol("A1", BIGINT)),
                                 ImmutableList.of(p.symbol("B1", BIGINT)),
@@ -167,9 +167,9 @@ public class TestDetermineJoinDistributionType
                 .on(p ->
                         p.join(
                                 INNER,
-                                p.values(ImmutableList.of(p.symbol("A1")), ImmutableList.of(expressions("10"), expressions("11"))),
+                                p.values(ImmutableList.of(p.symbol("A1")), ImmutableList.of(constantExpressions(BIGINT, 10), constantExpressions(BIGINT, 11))),
                                 p.enforceSingleRow(
-                                        p.values(ImmutableList.of(p.symbol("B1")), ImmutableList.of(expressions("50"), expressions("11")))),
+                                        p.values(ImmutableList.of(p.symbol("B1")), ImmutableList.of(constantExpressions(BIGINT, 50), constantExpressions(BIGINT, 11)))),
                                 ImmutableList.of(new JoinNode.EquiJoinClause(p.symbol("A1", BIGINT), p.symbol("B1", BIGINT))),
                                 ImmutableList.of(p.symbol("A1", BIGINT)),
                                 ImmutableList.of(p.symbol("B1", BIGINT)),
@@ -197,8 +197,8 @@ public class TestDetermineJoinDistributionType
                 .on(p ->
                         p.join(
                                 joinType,
-                                p.values(ImmutableList.of(p.symbol("A1")), ImmutableList.of(expressions("10"), expressions("11"))),
-                                p.values(ImmutableList.of(p.symbol("B1")), ImmutableList.of(expressions("50"), expressions("11"))),
+                                p.values(ImmutableList.of(p.symbol("A1")), ImmutableList.of(constantExpressions(BIGINT, 10), constantExpressions(BIGINT, 11))),
+                                p.values(ImmutableList.of(p.symbol("B1")), ImmutableList.of(constantExpressions(BIGINT, 50), constantExpressions(BIGINT, 11))),
                                 ImmutableList.of(),
                                 ImmutableList.of(p.symbol("A1", BIGINT)),
                                 ImmutableList.of(p.symbol("B1", BIGINT)),
@@ -220,8 +220,8 @@ public class TestDetermineJoinDistributionType
                 .on(p ->
                         p.join(
                                 INNER,
-                                p.values(ImmutableList.of(p.symbol("A1")), ImmutableList.of(expressions("10"), expressions("11"))),
-                                p.values(ImmutableList.of(p.symbol("B1")), ImmutableList.of(expressions("50"), expressions("11"))),
+                                p.values(ImmutableList.of(p.symbol("A1")), ImmutableList.of(constantExpressions(BIGINT, 10), constantExpressions(BIGINT, 11))),
+                                p.values(ImmutableList.of(p.symbol("B1")), ImmutableList.of(constantExpressions(BIGINT, 50), constantExpressions(BIGINT, 11))),
                                 ImmutableList.of(new JoinNode.EquiJoinClause(p.symbol("A1", BIGINT), p.symbol("B1", BIGINT))),
                                 ImmutableList.of(p.symbol("A1", BIGINT)),
                                 ImmutableList.of(p.symbol("B1", BIGINT)),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestDetermineSemiJoinDistributionType.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestDetermineSemiJoinDistributionType.java
@@ -38,7 +38,7 @@ import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.semiJoin;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
-import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expressions;
+import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.constantExpressions;
 import static io.trino.sql.planner.iterative.rule.test.RuleTester.defaultRuleTester;
 import static io.trino.sql.planner.plan.SemiJoinNode.DistributionType.PARTITIONED;
 import static io.trino.sql.planner.plan.SemiJoinNode.DistributionType.REPLICATED;
@@ -71,8 +71,8 @@ public class TestDetermineSemiJoinDistributionType
         assertDetermineSemiJoinDistributionType()
                 .on(p ->
                         p.semiJoin(
-                                p.values(ImmutableList.of(p.symbol("A1")), ImmutableList.of(expressions("10"), expressions("11"))),
-                                p.values(ImmutableList.of(p.symbol("B1")), ImmutableList.of(expressions("50"), expressions("11"))),
+                                p.values(ImmutableList.of(p.symbol("A1")), ImmutableList.of(constantExpressions(BIGINT, 10), constantExpressions(BIGINT, 11))),
+                                p.values(ImmutableList.of(p.symbol("B1")), ImmutableList.of(constantExpressions(BIGINT, 50), constantExpressions(BIGINT, 11))),
                                 p.symbol("A1"),
                                 p.symbol("B1"),
                                 p.symbol("output"),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestEvaluateZeroSample.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestEvaluateZeroSample.java
@@ -19,9 +19,10 @@ import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.plan.SampleNode.Type;
 import org.testng.annotations.Test;
 
+import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.constantExpressions;
 import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expression;
-import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expressions;
 
 public class TestEvaluateZeroSample
         extends BaseRuleTest
@@ -51,8 +52,8 @@ public class TestEvaluateZeroSample
                                         p.values(
                                                 ImmutableList.of(p.symbol("a"), p.symbol("b")),
                                                 ImmutableList.of(
-                                                        expressions("1", "10"),
-                                                        expressions("2", "11"))))))
+                                                        constantExpressions(BIGINT, 1, 10),
+                                                        constantExpressions(BIGINT, 2, 11))))))
                 // TODO: verify contents
                 .matches(values(ImmutableMap.of()));
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestExpressionRewriteRuleSet.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestExpressionRewriteRuleSet.java
@@ -18,7 +18,6 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.metadata.TestingFunctionResolution;
 import io.trino.spi.type.BigintType;
 import io.trino.spi.type.DateType;
-import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.assertions.PlanMatchPattern;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
@@ -41,6 +40,7 @@ import static io.trino.sql.planner.assertions.PlanMatchPattern.patternRecognitio
 import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
 import static io.trino.sql.planner.rowpattern.Patterns.label;
+import static io.trino.sql.relational.OriginalExpressionUtils.castToRowExpression;
 
 public class TestExpressionRewriteRuleSet
         extends BaseRuleTest
@@ -154,8 +154,8 @@ public class TestExpressionRewriteRuleSet
     {
         tester().assertThat(zeroRewriter.valuesExpressionRewrite())
                 .on(p -> p.values(
-                        ImmutableList.<Symbol>of(p.symbol("a")),
-                        ImmutableList.of((ImmutableList.of(PlanBuilder.expression("1"))))))
+                        ImmutableList.of(p.symbol("a")),
+                        ImmutableList.of((ImmutableList.of(castToRowExpression(PlanBuilder.expression("1")))))))
                 .matches(
                         values(ImmutableList.of("a"), ImmutableList.of(ImmutableList.of(new LongLiteral("0")))));
     }
@@ -165,8 +165,8 @@ public class TestExpressionRewriteRuleSet
     {
         tester().assertThat(zeroRewriter.valuesExpressionRewrite())
                 .on(p -> p.values(
-                        ImmutableList.<Symbol>of(p.symbol("a")),
-                        ImmutableList.of((ImmutableList.of(PlanBuilder.expression("0"))))))
+                        ImmutableList.of(p.symbol("a")),
+                        ImmutableList.of((ImmutableList.of(castToRowExpression(PlanBuilder.expression("0")))))))
                 .doesNotFire();
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneCountAggregationOverScalar.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneCountAggregationOverScalar.java
@@ -21,9 +21,9 @@ import io.trino.metadata.TestingFunctionResolution;
 import io.trino.plugin.tpch.TpchColumnHandle;
 import io.trino.plugin.tpch.TpchTableHandle;
 import io.trino.plugin.tpch.TpchTransactionHandle;
-import io.trino.spi.type.BigintType;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
 import io.trino.sql.planner.plan.AggregationNode;
 import io.trino.sql.planner.plan.Assignments;
 import io.trino.sql.tree.QualifiedName;
@@ -32,9 +32,9 @@ import org.testng.annotations.Test;
 
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCALE_FACTOR;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
-import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expressions;
 import static io.trino.sql.planner.plan.AggregationNode.singleGroupingSet;
 
 public class TestPruneCountAggregationOverScalar
@@ -50,7 +50,7 @@ public class TestPruneCountAggregationOverScalar
                         p.aggregation((a) -> a
                                 .globalGrouping()
                                 .addAggregation(
-                                        p.symbol("count_1", BigintType.BIGINT),
+                                        p.symbol("count_1", BIGINT),
                                         functionResolution
                                                 .functionCallBuilder(QualifiedName.of("count"))
                                                 .build(),
@@ -67,7 +67,7 @@ public class TestPruneCountAggregationOverScalar
                 .on(p ->
                         p.aggregation((a) -> a
                                 .addAggregation(
-                                        p.symbol("count_1", BigintType.BIGINT),
+                                        p.symbol("count_1", BIGINT),
                                         functionResolution
                                                 .functionCallBuilder(QualifiedName.of("count"))
                                                 .build(),
@@ -89,14 +89,14 @@ public class TestPruneCountAggregationOverScalar
                 .on(p ->
                         p.aggregation((a) -> a
                                 .addAggregation(
-                                        p.symbol("count_1", BigintType.BIGINT),
+                                        p.symbol("count_1", BIGINT),
                                         functionResolution
                                                 .functionCallBuilder(QualifiedName.of("count"))
                                                 .build(),
                                         ImmutableList.of())
                                 .step(AggregationNode.Step.SINGLE)
                                 .globalGrouping()
-                                .source(p.values(ImmutableList.of(p.symbol("orderkey")), ImmutableList.of(expressions("1"))))))
+                                .source(p.values(ImmutableList.of(p.symbol("orderkey")), ImmutableList.of(PlanBuilder.constantExpressions(BIGINT, 1))))))
                 .matches(values(ImmutableMap.of("count_1", 0)));
     }
 
@@ -107,7 +107,7 @@ public class TestPruneCountAggregationOverScalar
                 .on(p ->
                         p.aggregation((a) -> a
                                 .addAggregation(
-                                        p.symbol("count_1", BigintType.BIGINT),
+                                        p.symbol("count_1", BIGINT),
                                         functionResolution
                                                 .functionCallBuilder(QualifiedName.of("count"))
                                                 .build(),
@@ -125,7 +125,7 @@ public class TestPruneCountAggregationOverScalar
                 .on(p ->
                         p.aggregation((a) -> a
                                 .addAggregation(
-                                        p.symbol("count_1", BigintType.BIGINT),
+                                        p.symbol("count_1", BIGINT),
                                         functionResolution
                                                 .functionCallBuilder(QualifiedName.of("count"))
                                                 .build(),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneValuesColumns.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneValuesColumns.java
@@ -20,9 +20,12 @@ import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.plan.Assignments;
 import org.testng.annotations.Test;
 
+import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.constantExpressions;
 import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expression;
+import static io.trino.sql.relational.OriginalExpressionUtils.castToRowExpression;
 
 public class TestPruneValuesColumns
         extends BaseRuleTest
@@ -37,8 +40,8 @@ public class TestPruneValuesColumns
                                 p.values(
                                         ImmutableList.of(p.symbol("unused"), p.symbol("x")),
                                         ImmutableList.of(
-                                                ImmutableList.of(expression("1"), expression("2")),
-                                                ImmutableList.of(expression("3"), expression("4"))))))
+                                                constantExpressions(BIGINT, 1, 2),
+                                                constantExpressions(BIGINT, 3, 4)))))
                 .matches(
                         project(
                                 ImmutableMap.of("y", PlanMatchPattern.expression("x")),
@@ -83,7 +86,7 @@ public class TestPruneValuesColumns
                                 Assignments.of(),
                                 p.valuesOfExpressions(
                                         ImmutableList.of(p.symbol("x")),
-                                        ImmutableList.of(expression("CAST(ROW(1) AS row(bigint))")))))
+                                        ImmutableList.of(castToRowExpression(expression("CAST(ROW(1) AS row(bigint))"))))))
                 .matches(
                         project(
                                 ImmutableMap.of(),
@@ -99,7 +102,7 @@ public class TestPruneValuesColumns
                                 Assignments.of(p.symbol("x"), expression("x")),
                                 p.valuesOfExpressions(
                                         ImmutableList.of(p.symbol("x"), p.symbol("y")),
-                                        ImmutableList.of(expression("CAST(ROW(1, 'a') AS row(bigint, char(2)))")))))
+                                        ImmutableList.of(castToRowExpression(expression("CAST(ROW(1, 'a') AS row(bigint, char(2)))"))))))
                 .doesNotFire();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushAggregationThroughOuterJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushAggregationThroughOuterJoin.java
@@ -37,7 +37,7 @@ import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.singleGroupingSet;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
-import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expressions;
+import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.constantExpressions;
 import static io.trino.sql.planner.plan.AggregationNode.Step.SINGLE;
 import static io.trino.sql.planner.plan.AggregationNode.groupingSets;
 import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
@@ -55,7 +55,7 @@ public class TestPushAggregationThroughOuterJoin
                         .source(
                                 p.join(
                                         LEFT,
-                                        p.values(ImmutableList.of(p.symbol("COL1")), ImmutableList.of(expressions("10"))),
+                                        p.values(ImmutableList.of(p.symbol("COL1")), ImmutableList.of(constantExpressions(BIGINT, 10))),
                                         p.values(p.symbol("COL2")),
                                         ImmutableList.of(new EquiJoinClause(p.symbol("COL1"), p.symbol("COL2"))),
                                         ImmutableList.of(p.symbol("COL1")),
@@ -94,7 +94,7 @@ public class TestPushAggregationThroughOuterJoin
                         .source(p.join(
                                 RIGHT,
                                 p.values(p.symbol("COL2")),
-                                p.values(ImmutableList.of(p.symbol("COL1")), ImmutableList.of(expressions("10"))),
+                                p.values(ImmutableList.of(p.symbol("COL1")), ImmutableList.of(constantExpressions(BIGINT, 10))),
                                 ImmutableList.of(new EquiJoinClause(p.symbol("COL2"), p.symbol("COL1"))),
                                 ImmutableList.of(p.symbol("COL2")),
                                 ImmutableList.of(p.symbol("COL1")),
@@ -133,7 +133,7 @@ public class TestPushAggregationThroughOuterJoin
                         .source(
                                 p.join(
                                         LEFT,
-                                        p.values(ImmutableList.of(p.symbol("COL1")), ImmutableList.of(expressions("10"))),
+                                        p.values(ImmutableList.of(p.symbol("COL1")), ImmutableList.of(constantExpressions(BIGINT, 10))),
                                         p.values(p.symbol("COL2"), p.symbol("MASK")),
                                         ImmutableList.of(new EquiJoinClause(p.symbol("COL1"), p.symbol("COL2"))),
                                         ImmutableList.of(p.symbol("COL1")),
@@ -180,7 +180,7 @@ public class TestPushAggregationThroughOuterJoin
                         .source(
                                 p.join(
                                         LEFT,
-                                        p.values(ImmutableList.of(p.symbol("COL1")), ImmutableList.of(expressions("10"))),
+                                        p.values(ImmutableList.of(p.symbol("COL1")), ImmutableList.of(constantExpressions(BIGINT, 10))),
                                         p.values(p.symbol("COL2")),
                                         ImmutableList.of(new EquiJoinClause(p.symbol("COL1"), p.symbol("COL2"))),
                                         ImmutableList.of(p.symbol("COL1")),
@@ -221,10 +221,10 @@ public class TestPushAggregationThroughOuterJoin
                                         LEFT,
                                         p.values(
                                                 ImmutableList.of(p.symbol("COL1"), p.symbol("COL2")),
-                                                ImmutableList.of(expressions("1", "2"))),
+                                                ImmutableList.of(constantExpressions(BIGINT, 1, 2))),
                                         p.values(
                                                 ImmutableList.of(p.symbol("COL3")),
-                                                ImmutableList.of(expressions("1"))),
+                                                ImmutableList.of(constantExpressions(BIGINT, 1))),
                                         ImmutableList.of(new EquiJoinClause(p.symbol("COL1"), p.symbol("COL3"))),
                                         ImmutableList.of(p.symbol("COL1")),
                                         ImmutableList.of(p.symbol("COL3")),
@@ -243,7 +243,7 @@ public class TestPushAggregationThroughOuterJoin
                 .on(p -> p.aggregation(ab -> ab
                         .source(p.join(
                                 LEFT,
-                                p.values(ImmutableList.of(p.symbol("COL1")), ImmutableList.of(expressions("10"), expressions("11"))),
+                                p.values(ImmutableList.of(p.symbol("COL1")), ImmutableList.of(constantExpressions(BIGINT, 10), constantExpressions(BIGINT, 11))),
                                 p.values(new Symbol("COL2")),
                                 ImmutableList.of(new EquiJoinClause(new Symbol("COL1"), new Symbol("COL2"))),
                                 ImmutableList.of(p.symbol("COL1")),
@@ -269,7 +269,7 @@ public class TestPushAggregationThroughOuterJoin
                                                                 .source(
                                                                         p.values(
                                                                                 ImmutableList.of(p.symbol("COL1"), p.symbol("unused")),
-                                                                                ImmutableList.of(expressions("10", "1"), expressions("10", "2")))))),
+                                                                                ImmutableList.of(constantExpressions(BIGINT, 10, 1), constantExpressions(BIGINT, 10, 2)))))),
                                         p.values(p.symbol("COL2")),
                                         ImmutableList.of(new EquiJoinClause(p.symbol("COL1"), p.symbol("COL2"))),
                                         ImmutableList.of(p.symbol("COL1")),
@@ -288,7 +288,7 @@ public class TestPushAggregationThroughOuterJoin
         tester().assertThat(new PushAggregationThroughOuterJoin())
                 .on(p -> p.aggregation(ab -> ab
                         .source(p.join(LEFT,
-                                p.values(ImmutableList.of(p.symbol("COL1")), ImmutableList.of(expressions("10"))),
+                                p.values(ImmutableList.of(p.symbol("COL1")), ImmutableList.of(constantExpressions(BIGINT, 10))),
                                 p.values(new Symbol("COL2"), new Symbol("COL3")),
                                 ImmutableList.of(new EquiJoinClause(new Symbol("COL1"), new Symbol("COL2"))),
                                 ImmutableList.of(p.symbol("COL1")),
@@ -308,8 +308,8 @@ public class TestPushAggregationThroughOuterJoin
                 .on(p -> p.aggregation(ab -> ab
                         .source(p.join(
                                 LEFT,
-                                p.values(ImmutableList.of(p.symbol("COL1")), ImmutableList.of(expressions("10"))),
-                                p.values(ImmutableList.of(p.symbol("COL2")), ImmutableList.of(expressions("20"))),
+                                p.values(ImmutableList.of(p.symbol("COL1")), ImmutableList.of(constantExpressions(BIGINT, 10))),
+                                p.values(ImmutableList.of(p.symbol("COL2")), ImmutableList.of(constantExpressions(BIGINT, 20))),
                                 ImmutableList.of(new EquiJoinClause(new Symbol("COL1"), new Symbol("COL2"))),
                                 ImmutableList.of(p.symbol("COL1")),
                                 ImmutableList.of(p.symbol("COL2")),
@@ -328,8 +328,8 @@ public class TestPushAggregationThroughOuterJoin
                 .on(p -> p.aggregation(ab -> ab
                         .source(p.join(
                                 LEFT,
-                                p.values(ImmutableList.of(p.symbol("COL1")), ImmutableList.of(expressions("10"))),
-                                p.values(ImmutableList.of(p.symbol("COL2"), p.symbol("COL3")), ImmutableList.of(expressions("20", "30"))),
+                                p.values(ImmutableList.of(p.symbol("COL1")), ImmutableList.of(constantExpressions(BIGINT, 10))),
+                                p.values(ImmutableList.of(p.symbol("COL2"), p.symbol("COL3")), ImmutableList.of(constantExpressions(BIGINT, 20, 30))),
                                 ImmutableList.of(new EquiJoinClause(new Symbol("COL1"), new Symbol("COL2"))),
                                 ImmutableList.of(new Symbol("COL1")),
                                 ImmutableList.of(new Symbol("COL2")),
@@ -344,8 +344,8 @@ public class TestPushAggregationThroughOuterJoin
                 .on(p -> p.aggregation(ab -> ab
                         .source(p.join(
                                 LEFT,
-                                p.values(ImmutableList.of(p.symbol("COL1")), ImmutableList.of(expressions("10"))),
-                                p.values(ImmutableList.of(p.symbol("COL2"), p.symbol("COL3")), ImmutableList.of(expressions("20", "30"))),
+                                p.values(ImmutableList.of(p.symbol("COL1")), ImmutableList.of(constantExpressions(BIGINT, 10))),
+                                p.values(ImmutableList.of(p.symbol("COL2"), p.symbol("COL3")), ImmutableList.of(constantExpressions(BIGINT, 20, 30))),
                                 ImmutableList.of(new EquiJoinClause(new Symbol("COL1"), new Symbol("COL2"))),
                                 ImmutableList.of(new Symbol("COL1")),
                                 ImmutableList.of(new Symbol("COL2")),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveFullSample.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveFullSample.java
@@ -19,10 +19,11 @@ import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.plan.SampleNode.Type;
 import org.testng.annotations.Test;
 
+import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.constantExpressions;
 import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expression;
-import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expressions;
 
 public class TestRemoveFullSample
         extends BaseRuleTest
@@ -52,8 +53,8 @@ public class TestRemoveFullSample
                                         p.values(
                                                 ImmutableList.of(p.symbol("a"), p.symbol("b")),
                                                 ImmutableList.of(
-                                                        expressions("1", "10"),
-                                                        expressions("2", "11"))))))
+                                                        constantExpressions(BIGINT, 1, 10),
+                                                        constantExpressions(BIGINT, 2, 11))))))
                 // TODO: verify contents
                 .matches(filter("b > 5", values(ImmutableMap.of("a", 0, "b", 1))));
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveRedundantLimit.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveRedundantLimit.java
@@ -25,8 +25,8 @@ import org.testng.annotations.Test;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.constantExpressions;
 import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expression;
-import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expressions;
 
 public class TestRemoveRedundantLimit
         extends BaseRuleTest
@@ -73,8 +73,8 @@ public class TestRemoveRedundantLimit
                                         p.values(
                                                 ImmutableList.of(p.symbol("a"), p.symbol("b")),
                                                 ImmutableList.of(
-                                                        expressions("1", "10"),
-                                                        expressions("2", "11"))))))
+                                                        constantExpressions(BIGINT, 1, 10),
+                                                        constantExpressions(BIGINT, 2, 11))))))
                 // TODO: verify contents
                 .matches(values(ImmutableMap.of()));
     }
@@ -107,8 +107,8 @@ public class TestRemoveRedundantLimit
                                 p.values(
                                         ImmutableList.of(p.symbol("a"), p.symbol("b")),
                                         ImmutableList.of(
-                                                expressions("1", "10"),
-                                                expressions("2", "11"))))))
+                                                constantExpressions(BIGINT, 1, 10),
+                                                constantExpressions(BIGINT, 2, 11))))))
                 .matches(
                         node(FilterNode.class,
                                         node(ValuesNode.class)));

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveRedundantOffset.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveRedundantOffset.java
@@ -17,7 +17,9 @@ import com.google.common.collect.ImmutableList;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import org.testng.annotations.Test;
 
+import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.constantExpressions;
 import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expression;
 
 public class TestRemoveRedundantOffset
@@ -48,8 +50,8 @@ public class TestRemoveRedundantOffset
                         p.values(
                                 ImmutableList.of(p.symbol("a")),
                                 ImmutableList.of(
-                                        ImmutableList.of(expression("1")),
-                                        ImmutableList.of(expression("2"))))))
+                                        constantExpressions(BIGINT, 1),
+                                        constantExpressions(BIGINT, 2)))))
                 .matches(
                         values(
                                 ImmutableList.of("a"),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveRedundantTopN.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveRedundantTopN.java
@@ -25,8 +25,8 @@ import org.testng.annotations.Test;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.constantExpressions;
 import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expression;
-import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expressions;
 
 public class TestRemoveRedundantTopN
         extends BaseRuleTest
@@ -57,8 +57,8 @@ public class TestRemoveRedundantTopN
                                         p.values(
                                                 ImmutableList.of(p.symbol("a"), p.symbol("b")),
                                                 ImmutableList.of(
-                                                        expressions("1", "10"),
-                                                        expressions("2", "11"))))))
+                                                        constantExpressions(BIGINT, 1, 10),
+                                                        constantExpressions(BIGINT, 2, 11))))))
                 // TODO: verify contents
                 .matches(
                         node(SortNode.class,
@@ -79,8 +79,8 @@ public class TestRemoveRedundantTopN
                                         p.values(
                                                 ImmutableList.of(p.symbol("a"), p.symbol("b")),
                                                 ImmutableList.of(
-                                                        expressions("1", "10"),
-                                                        expressions("2", "11"))))))
+                                                        constantExpressions(BIGINT, 1, 10),
+                                                        constantExpressions(BIGINT, 2, 11))))))
                 // TODO: verify contents
                 .matches(values(ImmutableMap.of()));
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveTrivialFilters.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveTrivialFilters.java
@@ -17,9 +17,10 @@ import com.google.common.collect.ImmutableList;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import org.testng.annotations.Test;
 
+import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.constantExpressions;
 import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expression;
-import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expressions;
 
 public class TestRemoveTrivialFilters
         extends BaseRuleTest
@@ -48,7 +49,7 @@ public class TestRemoveTrivialFilters
                         expression("FALSE"),
                         p.values(
                                 ImmutableList.of(p.symbol("a")),
-                                ImmutableList.of(expressions("1")))))
+                                ImmutableList.of(constantExpressions(BIGINT, 10)))))
                 .matches(values("a"));
     }
 
@@ -60,7 +61,7 @@ public class TestRemoveTrivialFilters
                         expression("null"),
                         p.values(
                                 ImmutableList.of(p.symbol("a")),
-                                ImmutableList.of(expressions("1")))))
+                                ImmutableList.of(constantExpressions(BIGINT, 1)))))
                 .matches(values("a"));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestReplaceJoinOverConstantWithProject.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestReplaceJoinOverConstantWithProject.java
@@ -30,6 +30,7 @@ import static io.trino.sql.planner.plan.JoinNode.Type.FULL;
 import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
 import static io.trino.sql.planner.plan.JoinNode.Type.LEFT;
 import static io.trino.sql.planner.plan.JoinNode.Type.RIGHT;
+import static io.trino.sql.relational.OriginalExpressionUtils.castToRowExpression;
 
 public class TestReplaceJoinOverConstantWithProject
         extends BaseRuleTest
@@ -107,7 +108,7 @@ public class TestReplaceJoinOverConstantWithProject
                 .on(p ->
                         p.join(
                                 INNER,
-                                p.valuesOfExpressions(ImmutableList.of(p.symbol("a")), ImmutableList.of(expression("CAST(ROW('true') AS ROW(b boolean))"))),
+                                p.valuesOfExpressions(ImmutableList.of(p.symbol("a")), ImmutableList.of(castToRowExpression(expression("CAST(ROW('true') AS ROW(b boolean))")))),
                                 p.values(5, p.symbol("b"))))
                 .doesNotFire();
     }
@@ -163,7 +164,7 @@ public class TestReplaceJoinOverConstantWithProject
                 .on(p ->
                         p.join(
                                 INNER,
-                                p.valuesOfExpressions(ImmutableList.of(p.symbol("a"), p.symbol("b")), ImmutableList.of(expression("ROW(1, 'x')"))),
+                                p.valuesOfExpressions(ImmutableList.of(p.symbol("a"), p.symbol("b")), ImmutableList.of(castToRowExpression(expression("ROW(1, 'x')")))),
                                 p.values(5, p.symbol("c"))))
                 .matches(
                         project(
@@ -178,7 +179,7 @@ public class TestReplaceJoinOverConstantWithProject
                         p.join(
                                 INNER,
                                 p.values(5, p.symbol("c")),
-                                p.valuesOfExpressions(ImmutableList.of(p.symbol("a"), p.symbol("b")), ImmutableList.of(expression("ROW(1, 'x')")))))
+                                p.valuesOfExpressions(ImmutableList.of(p.symbol("a"), p.symbol("b")), ImmutableList.of(castToRowExpression(expression("ROW(1, 'x')"))))))
                 .matches(
                         project(
                                 ImmutableMap.of(
@@ -195,7 +196,7 @@ public class TestReplaceJoinOverConstantWithProject
                 .on(p ->
                         p.join(
                                 LEFT,
-                                p.valuesOfExpressions(ImmutableList.of(p.symbol("a"), p.symbol("b")), ImmutableList.of(expression("ROW(1, 'x')"))),
+                                p.valuesOfExpressions(ImmutableList.of(p.symbol("a"), p.symbol("b")), ImmutableList.of(castToRowExpression(expression("ROW(1, 'x')")))),
                                 p.values(5, p.symbol("c"))))
                 .matches(
                         project(
@@ -210,7 +211,7 @@ public class TestReplaceJoinOverConstantWithProject
                         p.join(
                                 LEFT,
                                 p.values(5, p.symbol("c")),
-                                p.valuesOfExpressions(ImmutableList.of(p.symbol("a"), p.symbol("b")), ImmutableList.of(expression("ROW(1, 'x')")))))
+                                p.valuesOfExpressions(ImmutableList.of(p.symbol("a"), p.symbol("b")), ImmutableList.of(castToRowExpression(expression("ROW(1, 'x')"))))))
                 .matches(
                         project(
                                 ImmutableMap.of(
@@ -227,7 +228,7 @@ public class TestReplaceJoinOverConstantWithProject
                 .on(p ->
                         p.join(
                                 RIGHT,
-                                p.valuesOfExpressions(ImmutableList.of(p.symbol("a"), p.symbol("b")), ImmutableList.of(expression("ROW(1, 'x')"))),
+                                p.valuesOfExpressions(ImmutableList.of(p.symbol("a"), p.symbol("b")), ImmutableList.of(castToRowExpression(expression("ROW(1, 'x')")))),
                                 p.values(5, p.symbol("c"))))
                 .matches(
                         project(
@@ -242,7 +243,7 @@ public class TestReplaceJoinOverConstantWithProject
                         p.join(
                                 RIGHT,
                                 p.values(5, p.symbol("c")),
-                                p.valuesOfExpressions(ImmutableList.of(p.symbol("a"), p.symbol("b")), ImmutableList.of(expression("ROW(1, 'x')")))))
+                                p.valuesOfExpressions(ImmutableList.of(p.symbol("a"), p.symbol("b")), ImmutableList.of(castToRowExpression(expression("ROW(1, 'x')"))))))
                 .matches(
                         project(
                                 ImmutableMap.of(
@@ -259,7 +260,7 @@ public class TestReplaceJoinOverConstantWithProject
                 .on(p ->
                         p.join(
                                 FULL,
-                                p.valuesOfExpressions(ImmutableList.of(p.symbol("a"), p.symbol("b")), ImmutableList.of(expression("ROW(1, 'x')"))),
+                                p.valuesOfExpressions(ImmutableList.of(p.symbol("a"), p.symbol("b")), ImmutableList.of(castToRowExpression(expression("ROW(1, 'x')")))),
                                 p.values(5, p.symbol("c"))))
                 .matches(
                         project(
@@ -274,7 +275,7 @@ public class TestReplaceJoinOverConstantWithProject
                         p.join(
                                 FULL,
                                 p.values(5, p.symbol("c")),
-                                p.valuesOfExpressions(ImmutableList.of(p.symbol("a"), p.symbol("b")), ImmutableList.of(expression("ROW(1, 'x')")))))
+                                p.valuesOfExpressions(ImmutableList.of(p.symbol("a"), p.symbol("b")), ImmutableList.of(castToRowExpression(expression("ROW(1, 'x')"))))))
                 .matches(
                         project(
                                 ImmutableMap.of(
@@ -291,7 +292,7 @@ public class TestReplaceJoinOverConstantWithProject
                 .on(p ->
                         p.join(
                                 INNER,
-                                p.valuesOfExpressions(ImmutableList.of(p.symbol("a"), p.symbol("b")), ImmutableList.of(expression("ROW(1, 'x')"))),
+                                p.valuesOfExpressions(ImmutableList.of(p.symbol("a"), p.symbol("b")), ImmutableList.of(castToRowExpression(expression("ROW(1, 'x')")))),
                                 p.values(5, p.symbol("c")),
                                 ImmutableList.of(),
                                 ImmutableList.of(p.symbol("a"), p.symbol("b"), p.symbol("a"), p.symbol("b")),
@@ -313,7 +314,7 @@ public class TestReplaceJoinOverConstantWithProject
                 .on(p ->
                         p.join(
                                 INNER,
-                                p.valuesOfExpressions(ImmutableList.of(p.symbol("a")), ImmutableList.of(expression("ROW(rand())"))),
+                                p.valuesOfExpressions(ImmutableList.of(p.symbol("a")), ImmutableList.of(castToRowExpression(expression("ROW(rand())")))),
                                 p.values(5, p.symbol("b"))))
                 .matches(
                         strictProject(

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedScalarSubquery.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedScalarSubquery.java
@@ -23,6 +23,7 @@ import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
 import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.relational.RowExpression;
 import io.trino.sql.tree.Cast;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.LongLiteral;
@@ -37,6 +38,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static io.trino.metadata.MetadataManager.createTestMetadataManager;
+import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.VarcharType.VARCHAR;
@@ -48,15 +50,15 @@ import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.markDistinct;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
-import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expressions;
+import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.constantExpressions;
+import static io.trino.sql.relational.Expressions.constant;
 import static io.trino.sql.tree.BooleanLiteral.TRUE_LITERAL;
 
 public class TestTransformCorrelatedScalarSubquery
         extends BaseRuleTest
 {
-    private static final ImmutableList<List<Expression>> ONE_ROW = ImmutableList.of(ImmutableList.of(new LongLiteral("1")));
-    private static final ImmutableList<List<Expression>> TWO_ROWS = ImmutableList.of(ImmutableList.of(new LongLiteral("1")), ImmutableList.of(new LongLiteral("2")));
-
+    private static final ImmutableList<List<RowExpression>> ONE_ROW = ImmutableList.of(ImmutableList.of(constant(1, BIGINT)));
+    private static final ImmutableList<List<RowExpression>> TWO_ROWS = ImmutableList.of(ImmutableList.of(constant(1, BIGINT)), ImmutableList.of(constant(2, BIGINT)));
     private Rule<?> rule = new TransformCorrelatedScalarSubquery(createTestMetadataManager());
 
     @Test
@@ -85,7 +87,7 @@ public class TestTransformCorrelatedScalarSubquery
                 .on(p -> p.correlatedJoin(
                         ImmutableList.<Symbol>of(),
                         p.values(p.symbol("a")),
-                        p.values(ImmutableList.of(p.symbol("b")), ImmutableList.of(expressions("1")))))
+                        p.values(ImmutableList.of(p.symbol("b")), ImmutableList.of(constantExpressions(BIGINT, 1)))))
                 .doesNotFire();
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/TestRuleTester.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/TestRuleTester.java
@@ -31,7 +31,9 @@ import org.testng.annotations.Test;
 import java.util.List;
 import java.util.Map;
 
+import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.constantExpressions;
 import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expression;
 import static io.trino.sql.planner.iterative.rule.test.RuleTester.defaultRuleTester;
 import static java.util.Objects.requireNonNull;
@@ -53,7 +55,7 @@ public class TestRuleTester
                                     Assignments.of(p.symbol("y"), expression("x")),
                                     p.values(
                                             ImmutableList.of(p.symbol("x")),
-                                            ImmutableList.of(ImmutableList.of(expression("1"))))));
+                                            ImmutableList.of((constantExpressions(BIGINT, 1))))));
 
             PlanMatchPattern expected = values(ImmutableList.of("different"), ImmutableList.of());
             assertThatThrownBy(() -> ruleAssert.matches(expected))
@@ -74,7 +76,7 @@ public class TestRuleTester
                     .on(p ->
                             p.values(
                                     List.of(p.symbol("x")),
-                                    List.of(List.of(expression("1")))));
+                                    List.of((constantExpressions(BIGINT, 1)))));
 
             PlanMatchPattern expected = values(List.of("whatever"), List.of());
             assertThatThrownBy(() -> ruleAssert.matches(expected))

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestAddExchangesPlans.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestAddExchangesPlans.java
@@ -29,8 +29,9 @@ import io.trino.sql.planner.plan.ExchangeNode;
 import io.trino.sql.planner.plan.FilterNode;
 import io.trino.sql.planner.plan.JoinNode.DistributionType;
 import io.trino.sql.planner.plan.MarkDistinctNode;
-import io.trino.sql.tree.GenericLiteral;
+import io.trino.sql.tree.Cast;
 import io.trino.sql.tree.LongLiteral;
+import io.trino.sql.tree.StringLiteral;
 import io.trino.testing.LocalQueryRunner;
 import org.testng.annotations.Test;
 
@@ -43,6 +44,8 @@ import static io.trino.SystemSessionProperties.JOIN_PARTITIONED_BUILD_MIN_ROW_CO
 import static io.trino.SystemSessionProperties.JOIN_REORDERING_STRATEGY;
 import static io.trino.SystemSessionProperties.SPILL_ENABLED;
 import static io.trino.SystemSessionProperties.TASK_CONCURRENCY;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.analyzer.TypeSignatureTranslator.toSqlType;
 import static io.trino.sql.planner.OptimizerConfig.JoinDistributionType.PARTITIONED;
 import static io.trino.sql.planner.OptimizerConfig.JoinReorderingStrategy.ELIMINATE_CROSS_JOINS;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.aggregation;
@@ -122,7 +125,7 @@ public class TestAddExchangesPlans
                                         anyTree(
                                                 exchange(REMOTE, REPARTITION,
                                                         anyTree(
-                                                                values(ImmutableList.of("expr"), ImmutableList.of(ImmutableList.of(new GenericLiteral("BIGINT", "1")))))))))));
+                                                                values(ImmutableList.of("expr"), ImmutableList.of(ImmutableList.of(new Cast(new StringLiteral("1"), toSqlType(BIGINT))))))))))));
     }
 
     @Test
@@ -159,7 +162,7 @@ public class TestAddExchangesPlans
                                                         tableScan("nation", ImmutableMap.of("nationkey", "nationkey")))),
                                         exchange(REMOTE, REPARTITION,
                                                 project(
-                                                        values(ImmutableList.of("expr"), ImmutableList.of(ImmutableList.of(new GenericLiteral("BIGINT", "1"))))))),
+                                                        values(ImmutableList.of("expr"), ImmutableList.of(ImmutableList.of(new Cast(new StringLiteral("1"), toSqlType(BIGINT)))))))),
                                 anyTree(
                                         exchange(REMOTE, REPARTITION,
                                                 anyTree(

--- a/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestRowExpressionFormatter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestRowExpressionFormatter.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.planprinter;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.BaseEncoding;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.metadata.Metadata;
+import io.trino.metadata.MetadataManager;
+import io.trino.spi.block.LongArrayBlockBuilder;
+import io.trino.spi.function.OperatorType;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Decimals;
+import io.trino.spi.type.Type;
+import io.trino.sql.relational.CallExpression;
+import io.trino.sql.relational.RowExpression;
+import io.trino.sql.relational.SpecialForm;
+import io.trino.sql.relational.VariableReferenceExpression;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.SessionTestUtils.TEST_SESSION;
+import static io.trino.spi.function.OperatorType.ADD;
+import static io.trino.spi.function.OperatorType.DIVIDE;
+import static io.trino.spi.function.OperatorType.EQUAL;
+import static io.trino.spi.function.OperatorType.HASH_CODE;
+import static io.trino.spi.function.OperatorType.IS_DISTINCT_FROM;
+import static io.trino.spi.function.OperatorType.LESS_THAN;
+import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static io.trino.spi.function.OperatorType.MODULUS;
+import static io.trino.spi.function.OperatorType.MULTIPLY;
+import static io.trino.spi.function.OperatorType.NEGATION;
+import static io.trino.spi.function.OperatorType.SUBSCRIPT;
+import static io.trino.spi.function.OperatorType.SUBTRACT;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.CharType.createCharType;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.relational.Expressions.call;
+import static io.trino.sql.relational.Expressions.constant;
+import static io.trino.sql.relational.Expressions.constantNull;
+import static io.trino.sql.relational.SpecialForm.Form.AND;
+import static io.trino.sql.relational.SpecialForm.Form.IS_NULL;
+import static io.trino.sql.relational.SpecialForm.Form.OR;
+import static io.trino.type.ColorType.COLOR;
+import static io.trino.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
+import static io.trino.type.IntervalYearMonthType.INTERVAL_YEAR_MONTH;
+import static io.trino.type.UnknownType.UNKNOWN;
+import static java.lang.Float.floatToIntBits;
+import static org.testng.Assert.assertEquals;
+
+public class TestRowExpressionFormatter
+{
+    private static final Metadata METADATA = MetadataManager.createTestMetadataManager();
+
+    private static final VariableReferenceExpression C_BIGINT = new VariableReferenceExpression("c_bigint", BIGINT);
+    private static final RowExpressionFormatter FORMATTER = new RowExpressionFormatter();
+    private static final VariableReferenceExpression C_BIGINT_ARRAY = new VariableReferenceExpression("c_bigint_array", new ArrayType(BIGINT));
+
+    @Test
+    public void testConstants()
+    {
+        // null
+        RowExpression constantExpression = constantNull(UNKNOWN);
+        assertEquals(format(constantExpression), "null");
+
+        // boolean
+        constantExpression = constant(true, BOOLEAN);
+        assertEquals(format(constantExpression), "BOOLEAN'true'");
+
+        // double
+        constantExpression = constant(1.1, DOUBLE);
+        assertEquals(format(constantExpression), "DOUBLE'1.1'");
+        constantExpression = constant(Double.NaN, DOUBLE);
+        assertEquals(format(constantExpression), "DOUBLE'NaN'");
+        constantExpression = constant(Double.POSITIVE_INFINITY, DOUBLE);
+        assertEquals(format(constantExpression), "DOUBLE'Infinity'");
+
+        // real
+        constantExpression = constant((long) floatToIntBits(1.1f), REAL);
+        assertEquals(format(constantExpression), "REAL'1.1'");
+        constantExpression = constant((long) floatToIntBits(Float.NaN), REAL);
+        assertEquals(format(constantExpression), "REAL'NaN'");
+        constantExpression = constant((long) floatToIntBits(Float.POSITIVE_INFINITY), REAL);
+        assertEquals(format(constantExpression), "REAL'Infinity'");
+
+        // string
+        constantExpression = constant(utf8Slice("abcde"), VARCHAR);
+        assertEquals(format(constantExpression), "VARCHAR'abcde'");
+        constantExpression = constant(utf8Slice("fgh"), createCharType(3));
+        assertEquals(format(constantExpression), "CHAR'fgh'");
+
+        // integer
+        constantExpression = constant(1L, TINYINT);
+        assertEquals(format(constantExpression), "TINYINT'1'");
+        constantExpression = constant(1L, SMALLINT);
+        assertEquals(format(constantExpression), "SMALLINT'1'");
+        constantExpression = constant(1L, INTEGER);
+        assertEquals(format(constantExpression), "INTEGER'1'");
+        constantExpression = constant(1L, BIGINT);
+        assertEquals(format(constantExpression), "BIGINT'1'");
+
+        // varbinary
+        Slice value = Slices.wrappedBuffer(BaseEncoding.base16().decode("123456AB"));
+        constantExpression = constant(value, VARBINARY);
+        assertEquals(format(constantExpression), "X'12 34 56 ab'");
+
+        // color
+        constantExpression = constant(256L, COLOR);
+        assertEquals(format(constantExpression), "COLOR'256'");
+
+        // long and short decimals
+        constantExpression = constant(decimal("1.2345678910"), DecimalType.createDecimalType(11, 10));
+        assertEquals(format(constantExpression), "DECIMAL'1.2345678910'");
+        constantExpression = constant(decimal("1.281734081274028174012432412423134"), DecimalType.createDecimalType(34, 33));
+        assertEquals(format(constantExpression), "DECIMAL'1.281734081274028174012432412423134'");
+
+        // time
+        constantExpression = constant(662727600000L, TIMESTAMP_MILLIS);
+        assertEquals(format(constantExpression), "TIMESTAMP'1970-01-08 16:05:27.600'");
+        constantExpression = constant(7670L, DATE);
+        assertEquals(format(constantExpression), "DATE'1991-01-01'");
+
+        // interval
+        constantExpression = constant(24L, INTERVAL_DAY_TIME);
+        assertEquals(format(constantExpression), "INTERVAL DAY TO SECOND'0 00:00:00.024'");
+        constantExpression = constant(25L, INTERVAL_YEAR_MONTH);
+        assertEquals(format(constantExpression), "INTERVAL YEAR TO MONTH'2-1'");
+
+        // block
+        constantExpression = constant(new LongArrayBlockBuilder(null, 4).writeLong(1L).writeLong(2).build(), new ArrayType(BIGINT));
+        assertEquals(format(constantExpression), "[Block: position count: 2; size: 88 bytes]");
+    }
+
+    @Test
+    public void testCalls()
+    {
+        RowExpression callExpression;
+
+        // arithmetic
+        callExpression = createCallExpression(ADD);
+        assertEquals(format(callExpression), "(c_bigint) + (BIGINT'5')");
+        callExpression = createCallExpression(SUBTRACT);
+        assertEquals(format(callExpression), "(c_bigint) - (BIGINT'5')");
+        callExpression = createCallExpression(MULTIPLY);
+        assertEquals(format(callExpression), "(c_bigint) * (BIGINT'5')");
+        callExpression = createCallExpression(DIVIDE);
+        assertEquals(format(callExpression), "(c_bigint) / (BIGINT'5')");
+        callExpression = createCallExpression(MODULUS);
+        assertEquals(format(callExpression), "(c_bigint) % (BIGINT'5')");
+
+        // comparison
+        callExpression = createCallExpression(LESS_THAN);
+        assertEquals(format(callExpression), "(c_bigint) < (BIGINT'5')");
+        callExpression = createCallExpression(LESS_THAN_OR_EQUAL);
+        assertEquals(format(callExpression), "(c_bigint) <= (BIGINT'5')");
+        callExpression = createCallExpression(EQUAL);
+        assertEquals(format(callExpression), "(c_bigint) = (BIGINT'5')");
+        callExpression = createCallExpression(IS_DISTINCT_FROM);
+        assertEquals(format(callExpression), "(c_bigint) IS DISTINCT FROM (BIGINT'5')");
+
+        // negation
+        RowExpression expression = createCallExpression(ADD);
+        callExpression = call(
+                METADATA.resolveOperator(TEST_SESSION, NEGATION, List.of(expression.getType())),
+                expression);
+        assertEquals(format(callExpression), "-((c_bigint) + (BIGINT'5'))");
+
+        // subscript
+        ArrayType arrayType = (ArrayType) C_BIGINT_ARRAY.getType();
+        Type elementType = arrayType.getElementType();
+        RowExpression subscriptExpression = call(
+                METADATA.resolveOperator(TEST_SESSION, SUBSCRIPT, ImmutableList.of(arrayType, elementType)),
+                ImmutableList.of(C_BIGINT_ARRAY, constant(0L, INTEGER)));
+        callExpression = subscriptExpression;
+        assertEquals(format(callExpression), "c_bigint_array[INTEGER'0']");
+
+        // cast
+        callExpression = call(
+                METADATA.getCoercion(TEST_SESSION, TINYINT, BIGINT),
+                constant(1L, TINYINT));
+        assertEquals(format(callExpression), "CAST(TINYINT'1' AS bigint)");
+
+        // other
+        callExpression = call(
+                METADATA.resolveOperator(TEST_SESSION, HASH_CODE, ImmutableList.of(BIGINT)),
+                constant(1L, BIGINT));
+        assertEquals(format(callExpression), "HASH CODE(BIGINT'1')");
+    }
+
+    @Test
+    public void testSpecialForm()
+    {
+        RowExpression specialFormExpression;
+
+        specialFormExpression = new SpecialForm(AND, BOOLEAN, createCallExpression(EQUAL), createCallExpression(IS_DISTINCT_FROM));
+        assertEquals(format(specialFormExpression), "((c_bigint) = (BIGINT'5')) AND ((c_bigint) IS DISTINCT FROM (BIGINT'5'))");
+
+        // other
+        specialFormExpression = new SpecialForm(IS_NULL, BOOLEAN, createCallExpression(ADD));
+        assertEquals(format(specialFormExpression), "IS_NULL((c_bigint) + (BIGINT'5'))");
+    }
+
+    @Test
+    public void testComplex()
+    {
+        RowExpression complexExpression;
+
+        RowExpression expression = createCallExpression(ADD);
+        complexExpression = call(
+                METADATA.resolveOperator(TEST_SESSION, SUBTRACT, ImmutableList.of(BIGINT, BIGINT)),
+                C_BIGINT,
+                expression);
+        assertEquals(format(complexExpression), "(c_bigint) - ((c_bigint) + (BIGINT'5'))");
+
+        RowExpression expression1 = createCallExpression(ADD);
+        RowExpression expression2 = call(
+                METADATA.resolveOperator(TEST_SESSION, MULTIPLY, ImmutableList.of(BIGINT, BIGINT)),
+                expression1,
+                C_BIGINT);
+        RowExpression expression3 = createCallExpression(LESS_THAN);
+        complexExpression = new SpecialForm(OR, BOOLEAN, expression2, expression3);
+        assertEquals(format(complexExpression), "(((c_bigint) + (BIGINT'5')) * (c_bigint)) OR ((c_bigint) < (BIGINT'5'))");
+
+        ArrayType arrayType = (ArrayType) C_BIGINT_ARRAY.getType();
+        Type elementType = arrayType.getElementType();
+        expression1 = call(
+                METADATA.resolveOperator(TEST_SESSION, SUBSCRIPT, ImmutableList.of(arrayType, elementType)),
+                ImmutableList.of(C_BIGINT_ARRAY, constant(5L, INTEGER)));
+        expression2 = call(
+                METADATA.resolveOperator(TEST_SESSION, NEGATION, ImmutableList.of(expression1.getType())),
+                expression1);
+        expression3 = call(
+                METADATA.resolveOperator(TEST_SESSION, ADD, ImmutableList.of(expression2.getType(), BIGINT)),
+                expression2,
+                constant(5L, BIGINT));
+        assertEquals(format(expression3), "(-(c_bigint_array[INTEGER'5'])) + (BIGINT'5')");
+    }
+
+    protected static Object decimal(String decimalString)
+    {
+        return Decimals.parse(decimalString).getObject();
+    }
+
+    private static CallExpression createCallExpression(OperatorType type)
+    {
+        return call(
+                METADATA.resolveOperator(TEST_SESSION, type, ImmutableList.of(BIGINT, BIGINT)),
+                C_BIGINT,
+                constant(5L, BIGINT));
+    }
+
+    private static String format(RowExpression expression)
+    {
+        return FORMATTER.formatRowExpression(TEST_SESSION.toConnectorSession(), expression);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/sanity/TestValidateLimitWithPresortedInput.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/sanity/TestValidateLimitWithPresortedInput.java
@@ -35,7 +35,6 @@ import io.trino.sql.planner.TypeProvider;
 import io.trino.sql.planner.assertions.BasePlanTest;
 import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
 import io.trino.sql.planner.plan.PlanNode;
-import io.trino.sql.tree.LongLiteral;
 import io.trino.testing.LocalQueryRunner;
 import io.trino.testing.TestingTransactionHandle;
 import org.testng.annotations.Test;
@@ -48,6 +47,7 @@ import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.sql.planner.TypeAnalyzer.createTestingTypeAnalyzer;
 import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expression;
+import static io.trino.sql.relational.Expressions.constant;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -153,8 +153,8 @@ public class TestValidateLimitWithPresortedInput
                                 p.values(
                                         ImmutableList.of(p.symbol("a", BIGINT)),
                                         ImmutableList.of(
-                                                ImmutableList.of(new LongLiteral("1")),
-                                                ImmutableList.of(new LongLiteral("1")))))));
+                                                ImmutableList.of(constant(1, BIGINT)),
+                                                ImmutableList.of(constant(1, BIGINT)))))));
     }
 
     @Test

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -169,7 +169,7 @@ public final class SqlFormatter
         return builder.toString();
     }
 
-    static String formatName(QualifiedName name)
+    public static String formatName(QualifiedName name)
     {
         return name.getOriginalParts().stream()
                 .map(ExpressionFormatter::formatExpression)


### PR DESCRIPTION
## Description

This is a port of the Expression-To-RowExpression Migration [feature](https://github.com/prestodb/presto/issues/12546) in Presto. The plan is to follow the steps in their original migration to divide and conquer each PlanNode and Symbol. This PR is the port of ValuesNode, the following PRs would port PlanNodes following this order:
- ValuesNode 
- FilterNode
- ProjectNode/ApplyNode 
- AggregationNode
- WindowNode
- JoinNode
- SpatialJoinNode
- Symbol

> Is this change a fix, improvement, new feature, refactoring, or other?

This is a port of an [improvement](https://github.com/prestodb/presto/issues/12546) in Presto, which is part of the multiple IR cleaning effort. 

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

This PR is a change to the core query engine. The future PR may need to [change SPI](https://github.com/prestodb/presto/commit/bafc4c8d4473c954db2b86196c99e26f29dda40a).

> How would you describe this change to a non-technical end user or system administrator?

This change is transparent to end user, they viable difference is that when trying to run explain plan command, the Expression part in the PlanNode would be changed to RowExpression, which includes type information of the expression so it is more self-contained.  But the end user should not notice the difference when executing a query. 

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->
Original issue in Presto: https://github.com/prestodb/presto/issues/12546.

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text: