### PR TITLE
Expose AWS Glue metastore stats via JMX

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/InternalDeltaLakeConnectorFactory.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/InternalDeltaLakeConnectorFactory.java
@@ -30,6 +30,7 @@ import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorPageSourceProvid
 import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorSplitManager;
 import io.trino.plugin.base.classloader.ClassLoaderSafeEventListener;
 import io.trino.plugin.base.classloader.ClassLoaderSafeNodePartitioningProvider;
+import io.trino.plugin.base.jmx.ConnectorObjectNameGeneratorModule;
 import io.trino.plugin.base.jmx.MBeanServerModule;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
 import io.trino.plugin.deltalake.metastore.DeltaLakeMetastoreModule;
@@ -77,6 +78,7 @@ public final class InternalDeltaLakeConnectorFactory
             Bootstrap app = new Bootstrap(
                     new EventModule(),
                     new MBeanModule(),
+                    new ConnectorObjectNameGeneratorModule(catalogName, "io.trino.plugin.deltalake", "trino.plugin.deltalake"),
                     new JsonModule(),
                     new MBeanServerModule(),
                     new HiveHdfsModule(),

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -101,6 +101,8 @@ import io.trino.spi.security.RoleGrant;
 import io.trino.spi.statistics.ColumnStatisticType;
 import io.trino.spi.type.Type;
 import org.apache.hadoop.fs.Path;
+import org.weakref.jmx.Flatten;
+import org.weakref.jmx.Managed;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -230,6 +232,8 @@ public class GlueHiveMetastore
         return asyncGlueClientBuilder.build();
     }
 
+    @Managed
+    @Flatten
     public GlueMetastoreStats getStats()
     {
         return stats;

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/IcebergGlueCatalogModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/IcebergGlueCatalogModule.java
@@ -34,6 +34,7 @@ public class IcebergGlueCatalogModule
     {
         configBinder(binder).bindConfig(GlueHiveMetastoreConfig.class);
         binder.bind(GlueMetastoreStats.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(GlueMetastoreStats.class).withGeneratedName();
         binder.bind(AWSCredentialsProvider.class).toProvider(GlueCredentialsProvider.class).in(Scopes.SINGLETON);
         binder.bind(IcebergTableOperationsProvider.class).to(GlueIcebergTableOperationsProvider.class).in(Scopes.SINGLETON);
         binder.bind(TrinoCatalogFactory.class).to(TrinoGlueCatalogFactory.class).in(Scopes.SINGLETON);

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeJmx.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeJmx.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.deltalake;
+
+import io.trino.tempto.ProductTest;
+import org.testng.annotations.Test;
+
+import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertThat;
+import static io.trino.tests.product.TestGroups.DELTA_LAKE_DATABRICKS;
+import static io.trino.tests.product.TestGroups.DELTA_LAKE_OSS;
+import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
+
+public class TestDeltaLakeJmx
+        extends ProductTest
+{
+    @Test(groups = {DELTA_LAKE_DATABRICKS, PROFILE_SPECIFIC_TESTS})
+    public void testJmxTablesExposedByDeltaLakeConnectorBackedByGlueMetastore()
+    {
+        assertThat(onTrino().executeQuery("SHOW TABLES IN jmx.current LIKE '%name=delta%'")).containsOnly(
+                row("io.trino.plugin.hive.metastore.cache:name=delta,type=cachinghivemetastore"),
+                row("io.trino.plugin.hive.s3:name=delta,type=trinos3filesystem"),
+                row("io.trino.plugin.hive:catalog=delta,name=delta,type=fileformatdatasourcestats"),
+                row("io.trino.plugin.hive:name=delta,type=namenodestats"),
+                row("trino.plugin.deltalake.transactionlog:catalog=delta,name=delta,type=transactionlogaccess"));
+    }
+
+    @Test(groups = {DELTA_LAKE_OSS, PROFILE_SPECIFIC_TESTS})
+    public void testJmxTablesExposedByDeltaLakeConnectorBackedByThriftMetastore()
+    {
+        assertThat(onTrino().executeQuery("SHOW TABLES IN jmx.current LIKE '%name=delta%'")).containsOnly(
+                row("io.trino.plugin.hive.metastore.cache:name=delta,type=cachinghivemetastore"),
+                row("io.trino.plugin.hive.metastore.thrift:name=delta,type=thrifthivemetastore"),
+                row("io.trino.plugin.hive.s3:name=delta,type=trinos3filesystem"),
+                row("io.trino.plugin.hive:catalog=delta,name=delta,type=fileformatdatasourcestats"),
+                row("io.trino.plugin.hive:name=delta,type=namenodestats"),
+                row("trino.plugin.deltalake.transactionlog:catalog=delta,name=delta,type=transactionlogaccess"));
+    }
+}

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeJmx.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeJmx.java
@@ -31,6 +31,7 @@ public class TestDeltaLakeJmx
     {
         assertThat(onTrino().executeQuery("SHOW TABLES IN jmx.current LIKE '%name=delta%'")).containsOnly(
                 row("io.trino.plugin.hive.metastore.cache:name=delta,type=cachinghivemetastore"),
+                row("io.trino.plugin.hive.metastore.glue:name=delta,type=gluehivemetastore"),
                 row("io.trino.plugin.hive.s3:name=delta,type=trinos3filesystem"),
                 row("io.trino.plugin.hive:catalog=delta,name=delta,type=fileformatdatasourcestats"),
                 row("io.trino.plugin.hive:name=delta,type=namenodestats"),


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

Expose the Glue Hive Metastore stats over JMX.
Even though the Glue stats were previously collected, due to a regression issue, they weren't exposed by JMX.



The stats are exposed in JMX under the following object names:

- hive: "trino.plugin.hive.metastore.glue:type=GlueHiveMetastore,name=hive"
- iceberg: "io.trino.plugin.hive.metastore.glue:type=GlueMetastoreStats,name=iceberg"
- delta: "io.trino.plugin.hive.metastore.glue:type=GlueHiveMetastore,name=delta"


<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Hive connector

> How would you describe this change to a non-technical end user or system administrator?

Expose the Glue Hive Metastore stats over JMX.
In Trino, the users could issue a statement like the following to retrieve the AWS Glue stats in the connectors backed by AWS Glue.


For Hive:

```
select * from jmx.current."trino.plugin.hive.metastore.glue:name=hive,type=gluehivemetastore";
```



## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Hive, Iceberg, Delta Lake
* Expose AWS Glue metastore stats via JMX
```
