### PR TITLE
Deprecate assumeLiteralNamesInMetadataCallsForNonConformingClients in favor of assumeLiteralUnderscoreInMetadataCallsForNonConformingClients

### DIFF
--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
@@ -288,6 +288,9 @@ final class ConnectionProperties
         }
     }
 
+    /**
+     * @deprecated use {@link AssumeLiteralUnderscoreInMetadataCallsForNonConformingClients}
+     */
     private static class AssumeLiteralNamesInMetadataCallsForNonConformingClients
             extends AbstractConnectionProperty<Boolean>
     {

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
@@ -58,6 +58,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -79,6 +81,8 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 public class TrinoConnection
         implements Connection
 {
+    private static final Logger logger = Logger.getLogger(TrinoConnection.class.getPackage().getName());
+
     private final AtomicBoolean closed = new AtomicBoolean();
     private final AtomicBoolean autoCommit = new AtomicBoolean(true);
     private final AtomicInteger isolationLevel = new AtomicInteger(TRANSACTION_READ_UNCOMMITTED);
@@ -124,7 +128,14 @@ public class TrinoConnection
         this.extraCredentials = uri.getExtraCredentials();
         this.compressionDisabled = uri.isCompressionDisabled();
         this.assumeLiteralNamesInMetadataCallsForNonConformingClients = uri.isAssumeLiteralNamesInMetadataCallsForNonConformingClients();
+
+        if (this.assumeLiteralNamesInMetadataCallsForNonConformingClients) {
+            logger.log(Level.WARNING, "Connection config assumeLiteralNamesInMetadataCallsForNonConformingClients is deprecated, please use " +
+                    "assumeLiteralUnderscoreInMetadataCallsForNonConformingClients.");
+        }
+
         this.assumeLiteralUnderscoreInMetadataCallsForNonConformingClients = uri.isAssumeLiteralUnderscoreInMetadataCallsForNonConformingClients();
+
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
         uri.getClientInfo().ifPresent(tags -> clientInfo.put(CLIENT_INFO, tags));
         uri.getClientTags().ifPresent(tags -> clientInfo.put(CLIENT_TAGS, tags));

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriver.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriver.java
@@ -816,6 +816,24 @@ public class TestTrinoDriver
                         .put("SSLVerification", "NONE")
                         .buildOrThrow())))
                 .isNotNull();
+
+        assertThat(DriverManager.getConnection(jdbcUrl(),
+                toProperties(ImmutableMap.<String, String>builder()
+                        .put("user", "test")
+                        .put("SSL", "true")
+                        .put("SSLVerification", "NONE")
+                        .put("assumeLiteralNamesInMetadataCallsForNonConformingClients", "true")
+                        .buildOrThrow())))
+                .isNotNull();
+
+        assertThat(DriverManager.getConnection(jdbcUrl(),
+                toProperties(ImmutableMap.<String, String>builder()
+                        .put("user", "test")
+                        .put("SSL", "true")
+                        .put("SSLVerification", "NONE")
+                        .put("assumeLiteralUnderscoreInMetadataCallsForNonConformingClients", "true")
+                        .buildOrThrow())))
+                .isNotNull();
     }
 
     @Test

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriverUri.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriverUri.java
@@ -181,6 +181,9 @@ public class TestTrinoDriverUri
 
         // legacy url
         assertInvalid("jdbc:presto://localhost:8080", "Invalid JDBC URL: jdbc:presto://localhost:8080");
+
+        // cannot set mutually exclusive properties for non-conforming clients to true
+        assertInvalid("jdbc:trino://localhost:8080?assumeLiteralNamesInMetadataCallsForNonConformingClients=true&assumeLiteralUnderscoreInMetadataCallsForNonConformingClients=true", "Connection property 'assumeLiteralNamesInMetadataCallsForNonConformingClients' is not allowed");
     }
 
     @Test(expectedExceptions = SQLException.class, expectedExceptionsMessageRegExp = "Connection property 'user' value is empty")
@@ -399,6 +402,24 @@ public class TestTrinoDriverUri
         TrinoDriverUri parameters = createDriverUri("jdbc:trino://localhost:8080/catalog");
         assertThat(parameters.getCatalog()).isPresent();
         assertThat(parameters.getSchema()).isEmpty();
+    }
+
+    @Test
+    public void testAssumeLiteralNamesInMetadataCallsForNonConformingClients()
+            throws SQLException
+    {
+        TrinoDriverUri parameters = createDriverUri("jdbc:trino://localhost:8080?assumeLiteralNamesInMetadataCallsForNonConformingClients=true");
+        assertThat(parameters.isAssumeLiteralNamesInMetadataCallsForNonConformingClients()).isTrue();
+        assertThat(parameters.isAssumeLiteralUnderscoreInMetadataCallsForNonConformingClients()).isFalse();
+    }
+
+    @Test
+    public void testAssumeLiteralUnderscoreInMetadataCallsForNonConformingClients()
+            throws SQLException
+    {
+        TrinoDriverUri parameters = createDriverUri("jdbc:trino://localhost:8080?assumeLiteralUnderscoreInMetadataCallsForNonConformingClients=true");
+        assertThat(parameters.isAssumeLiteralUnderscoreInMetadataCallsForNonConformingClients()).isTrue();
+        assertThat(parameters.isAssumeLiteralNamesInMetadataCallsForNonConformingClients()).isFalse();
     }
 
     private static void assertUriPortScheme(TrinoDriverUri parameters, int port, String scheme)

--- a/docs/src/main/sphinx/client/jdbc.rst
+++ b/docs/src/main/sphinx/client/jdbc.rst
@@ -204,10 +204,6 @@ Name                                                              Description
                                                                   in a shared mode by different users, the first registered token is stored
                                                                   and authenticates all users.
 ``disableCompression``                                            Whether compression should be enabled.
-``assumeLiteralNamesInMetadataCallsForNonConformingClients``      When enabled, the name patterns passed to ``DatabaseMetaData`` methods
-                                                                  are treated as literals. You can use this as a workaround for
-                                                                  applications that do not escape schema or table names when passing them
-                                                                  to ``DatabaseMetaData`` methods as schema or table name patterns.
 ``assumeLiteralUnderscoreInMetadataCallsForNonConformingClients`` When enabled, the name patterns passed to ``DatabaseMetaData`` methods
                                                                   are treated as underscores. You can use this as a workaround for
                                                                   applications that do not escape schema or table names when passing them


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

The old parameter `assumeLiteralNamesInMetadataCallsForNonConformingClients` was originally introduced to fix issues in Tableau but it introduced its own issues in Tableau while loading a table metadata by not escaping a wildcard character. It can now be replaced now by the newer param `assumeLiteralUnderscoreInMetadataCallsForNonConformingClients` which resolved that bug.

### Approach

Since the new field `assumeLiteralUnderscoreInMetadataCallsForNonConformingClients` is what clients should be using, this PR assumes that any users using the deprecated param actually want to now start using the new param. These changes will warn users that the older param they are using is deprecated, then it will set the new param to true.

I also removed the deprecated param for the docs.

Please let me know if there is a more preferred approach to param deprecation. An alternative could be to just remove the deprecated param altogether. 

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

refactoring

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

jdbc

> How would you describe this change to a non-technical end user or system administrator?

I am removing an older, deprecated JDBC parameter that has issues in favor of a newer param.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->
See: https://github.com/trinodb/trino/issues/12761

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(X) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
