### PR TITLE
Extract `buildSchemaProperties` method in Delta Lake

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSchemaProperties.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSchemaProperties.java
@@ -15,14 +15,20 @@ package io.trino.plugin.deltalake;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.hive.HiveType;
+import io.trino.plugin.hive.HiveTypeName;
 import io.trino.plugin.hive.metastore.Database;
 import io.trino.spi.session.PropertyMetadata;
+import io.trino.spi.type.Type;
+import org.apache.hadoop.hive.ql.io.IOConstants;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
 
 import static io.trino.spi.session.PropertyMetadata.stringProperty;
+import static java.util.stream.Collectors.joining;
 
 public class DeltaLakeSchemaProperties
 {
@@ -48,5 +54,17 @@ public class DeltaLakeSchemaProperties
     public static Optional<String> getLocation(Map<String, Object> schemaProperties)
     {
         return Optional.ofNullable((String) schemaProperties.get(LOCATION_PROPERTY));
+    }
+
+    public static Properties buildHiveSchema(List<String> columnNames, List<Type> columnTypes)
+    {
+        Properties schema = new Properties();
+        schema.setProperty(IOConstants.COLUMNS, String.join(",", columnNames));
+        schema.setProperty(IOConstants.COLUMNS_TYPES, columnTypes.stream()
+                .map(DeltaHiveTypeTranslator::toHiveType)
+                .map(HiveType::getHiveTypeName)
+                .map(HiveTypeName::toString)
+                .collect(joining(":")));
+        return schema;
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeUpdatablePageSource.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeUpdatablePageSource.java
@@ -63,6 +63,7 @@ import static io.trino.plugin.deltalake.DeltaLakeColumnType.REGULAR;
 import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_BAD_DATA;
 import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_BAD_WRITE;
 import static io.trino.plugin.deltalake.DeltaLakePageSink.createPartitionValues;
+import static io.trino.plugin.deltalake.DeltaLakeSchemaProperties.buildHiveSchema;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetMaxReadBlockSize;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.isParquetUseColumnIndex;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.extractSchema;
@@ -577,7 +578,7 @@ public class DeltaLakeUpdatablePageSource
         Configuration conf = hdfsEnvironment.getConfiguration(new HdfsEnvironment.HdfsContext(session), targetFile);
         configureCompression(conf, SNAPPY);
 
-        Properties schema = DeltaLakePageSink.buildSchemaProperties(
+        Properties schema = buildHiveSchema(
                 dataColumns.stream().map(DeltaLakeColumnHandle::getName).collect(toImmutableList()),
                 dataColumns.stream().map(DeltaLakeColumnHandle::getType).collect(toImmutableList()));
         RecordFileWriter recordFileWriter = new RecordFileWriter(


### PR DESCRIPTION
## Description

Extract `buildSchemaProperties` method in Delta Lake
Fixes #12030

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
