### PR TITLE
Disable redundant Parquet tests

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetReader.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetReader.java
@@ -17,7 +17,9 @@ import org.testng.annotations.Test;
 
 // Failing on multiple threads because of org.apache.hadoop.hive.ql.io.parquet.write.ParquetRecordWriterWrapper
 // uses a single record writer across all threads.
-@Test(singleThreaded = true)
+// This test is disabled as it is contained in the io.trino.plugin.hive.parquet.TestFullParquetReader class.
+// In order to run it, remove the 'enabled = false' property.
+@Test(singleThreaded = true, enabled = false)
 public class TestParquetReader
         extends AbstractTestParquetReader
 {


### PR DESCRIPTION
Tests in `TestParquetReader` are already contained in much broader
`TestFullParquetReader` class. It can be handy, however, to run those
tests manually, so they remain in the code but are disabled.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

other
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

tests
> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
