### PR TITLE
Increase CI timeout to 90 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
           - config-hdp3
           # TODO: config-cdh5
           # TODO: config-apache-hive3
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v2
         with:
@@ -287,7 +287,7 @@ jobs:
 
   test-other-modules:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v2
         with:
@@ -425,7 +425,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.build-test-matrix.outputs.matrix) }}
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
## Description

We sometimes see CI failure due to 60 minutes timeout. 
Reference https://nineinchnick.github.io/trino-cicd/reports/ci-cd/ 

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
