### PR TITLE
Support creating a table with table & column comment in BigQuery

### DIFF
--- a/plugin/trino-bigquery/pom.xml
+++ b/plugin/trino-bigquery/pom.xml
@@ -175,6 +175,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
@@ -258,7 +258,7 @@ public class BigQueryMetadata
             columnMetadata.add(PARTITION_DATE.getColumnMetadata());
             columnMetadata.add(PARTITION_TIME.getColumnMetadata());
         }
-        return new ConnectorTableMetadata(handle.getSchemaTableName(), columnMetadata.build());
+        return new ConnectorTableMetadata(handle.getSchemaTableName(), columnMetadata.build(), ImmutableMap.of(), handle.getComment());
     }
 
     @Override
@@ -372,9 +372,6 @@ public class BigQueryMetadata
     @Override
     public void createTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, boolean ignoreExisting)
     {
-        if (tableMetadata.getComment().isPresent()) {
-            throw new TrinoException(NOT_SUPPORTED, "This connector does not support creating tables with table comment");
-        }
         if (tableMetadata.getColumns().stream().anyMatch(column -> column.getComment() != null)) {
             throw new TrinoException(NOT_SUPPORTED, "This connector does not support creating tables with column comment");
         }
@@ -405,9 +402,10 @@ public class BigQueryMetadata
 
         TableId tableId = TableId.of(schemaName, tableName);
         TableDefinition tableDefinition = StandardTableDefinition.of(Schema.of(fields));
-        TableInfo tableInfo = TableInfo.newBuilder(tableId, tableDefinition).build();
+        TableInfo.Builder tableInfo = TableInfo.newBuilder(tableId, tableDefinition);
+        tableMetadata.getComment().ifPresent(tableInfo::setDescription);
 
-        bigQueryClientFactory.create(session).createTable(tableInfo);
+        bigQueryClientFactory.create(session).createTable(tableInfo.build());
     }
 
     @Override

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
@@ -79,7 +79,6 @@ import static io.trino.plugin.bigquery.BigQueryPseudoColumn.PARTITION_TIME;
 import static io.trino.plugin.bigquery.BigQueryTableHandle.BigQueryPartitionType.INGESTION;
 import static io.trino.plugin.bigquery.BigQueryType.toField;
 import static io.trino.plugin.bigquery.BigQueryUtil.isWildcardTable;
-import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
@@ -372,9 +371,6 @@ public class BigQueryMetadata
     @Override
     public void createTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, boolean ignoreExisting)
     {
-        if (tableMetadata.getColumns().stream().anyMatch(column -> column.getComment() != null)) {
-            throw new TrinoException(NOT_SUPPORTED, "This connector does not support creating tables with column comment");
-        }
         try {
             createTable(session, tableMetadata);
         }
@@ -397,7 +393,7 @@ public class BigQueryMetadata
         }
 
         List<Field> fields = tableMetadata.getColumns().stream()
-                .map(column -> toField(column.getName(), column.getType()))
+                .map(column -> toField(column.getName(), column.getType(), column.getComment()))
                 .collect(toImmutableList());
 
         TableId tableId = TableId.of(schemaName, tableName);

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTableHandle.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTableHandle.java
@@ -41,6 +41,7 @@ public class BigQueryTableHandle
     private final Optional<BigQueryPartitionType> partitionType;
     private final TupleDomain<ColumnHandle> constraint;
     private final Optional<List<ColumnHandle>> projectedColumns;
+    private final Optional<String> comment;
 
     @JsonCreator
     public BigQueryTableHandle(
@@ -49,7 +50,8 @@ public class BigQueryTableHandle
             @JsonProperty("type") String type,
             @JsonProperty("partitionType") Optional<BigQueryPartitionType> partitionType,
             @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint,
-            @JsonProperty("projectedColumns") Optional<List<ColumnHandle>> projectedColumns)
+            @JsonProperty("projectedColumns") Optional<List<ColumnHandle>> projectedColumns,
+            @JsonProperty("comment") Optional<String> comment)
     {
         this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
         this.remoteTableName = requireNonNull(remoteTableName, "remoteTableName is null");
@@ -57,6 +59,7 @@ public class BigQueryTableHandle
         this.partitionType = requireNonNull(partitionType, "partitionType is null");
         this.constraint = requireNonNull(constraint, "constraint is null");
         this.projectedColumns = requireNonNull(projectedColumns, "projectedColumns is null");
+        this.comment = requireNonNull(comment, "comment is null");
     }
 
     public BigQueryTableHandle(SchemaTableName schemaTableName, RemoteTableName remoteTableName, TableInfo tableInfo)
@@ -67,7 +70,8 @@ public class BigQueryTableHandle
                 tableInfo.getDefinition().getType().toString(),
                 getPartitionType(tableInfo.getDefinition()),
                 TupleDomain.all(),
-                Optional.empty());
+                Optional.empty(),
+                Optional.ofNullable(tableInfo.getDescription()));
     }
 
     @JsonProperty
@@ -106,6 +110,12 @@ public class BigQueryTableHandle
         return projectedColumns;
     }
 
+    @JsonProperty
+    public Optional<String> getComment()
+    {
+        return comment;
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -122,13 +132,14 @@ public class BigQueryTableHandle
                 Objects.equals(type, that.type) &&
                 Objects.equals(partitionType, that.partitionType) &&
                 Objects.equals(constraint, that.constraint) &&
-                Objects.equals(projectedColumns, that.projectedColumns);
+                Objects.equals(projectedColumns, that.projectedColumns) &&
+                Objects.equals(comment, that.comment);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(schemaTableName, type, partitionType, constraint, projectedColumns);
+        return Objects.hash(schemaTableName, type, partitionType, constraint, projectedColumns, comment);
     }
 
     @Override
@@ -141,17 +152,18 @@ public class BigQueryTableHandle
                 .add("partitionType", partitionType)
                 .add("constraint", constraint)
                 .add("projectedColumns", projectedColumns)
+                .add("comment", comment)
                 .toString();
     }
 
     BigQueryTableHandle withConstraint(TupleDomain<ColumnHandle> newConstraint)
     {
-        return new BigQueryTableHandle(schemaTableName, remoteTableName, type, partitionType, newConstraint, projectedColumns);
+        return new BigQueryTableHandle(schemaTableName, remoteTableName, type, partitionType, newConstraint, projectedColumns, comment);
     }
 
     BigQueryTableHandle withProjectedColumns(List<ColumnHandle> newProjectedColumns)
     {
-        return new BigQueryTableHandle(schemaTableName, remoteTableName, type, partitionType, constraint, Optional.of(newProjectedColumns));
+        return new BigQueryTableHandle(schemaTableName, remoteTableName, type, partitionType, constraint, Optional.of(newProjectedColumns), comment);
     }
 
     public enum BigQueryPartitionType

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConnectorTest.java
@@ -70,7 +70,6 @@ public class TestBigQueryConnectorTest
             case SUPPORTS_RENAME_TABLE:
             case SUPPORTS_NOT_NULL_CONSTRAINT:
             case SUPPORTS_CREATE_TABLE_WITH_DATA:
-            case SUPPORTS_CREATE_TABLE_WITH_COLUMN_COMMENT:
             case SUPPORTS_DELETE:
             case SUPPORTS_INSERT:
             case SUPPORTS_ADD_COLUMN:

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConnectorTest.java
@@ -70,7 +70,6 @@ public class TestBigQueryConnectorTest
             case SUPPORTS_RENAME_TABLE:
             case SUPPORTS_NOT_NULL_CONSTRAINT:
             case SUPPORTS_CREATE_TABLE_WITH_DATA:
-            case SUPPORTS_CREATE_TABLE_WITH_TABLE_COMMENT:
             case SUPPORTS_CREATE_TABLE_WITH_COLUMN_COMMENT:
             case SUPPORTS_DELETE:
             case SUPPORTS_INSERT:


### PR DESCRIPTION
## Description

Support creating a table with table & column comment in BigQuery

## Documentation

(x) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# BigQuery
* Support creating a table with table and column comment. ({issue}`13105`)
```
