### PR TITLE
Fix incorrect pushdown of expression below join

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushInequalityFilterExpressionBelowJoinRuleSet.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushInequalityFilterExpressionBelowJoinRuleSet.java
@@ -45,6 +45,7 @@ import static io.trino.sql.planner.DeterminismEvaluator.isDeterministic;
 import static io.trino.sql.planner.SymbolsExtractor.extractUnique;
 import static io.trino.sql.planner.iterative.Rule.Context;
 import static io.trino.sql.planner.iterative.Rule.Result;
+import static io.trino.sql.planner.plan.Patterns.Join.type;
 import static io.trino.sql.planner.plan.Patterns.filter;
 import static io.trino.sql.planner.plan.Patterns.join;
 import static io.trino.sql.planner.plan.Patterns.source;
@@ -84,10 +85,10 @@ public class PushInequalityFilterExpressionBelowJoinRuleSet
             GREATER_THAN_OR_EQUAL,
             LESS_THAN,
             LESS_THAN_OR_EQUAL);
-    private static final Pattern<JoinNode> JOIN_PATTERN = join();
+    private static final Pattern<JoinNode> JOIN_PATTERN = join().with(type().equalTo(JoinNode.Type.INNER));
     private static final Capture<JoinNode> JOIN_CAPTURE = newCapture();
     private static final Pattern<FilterNode> FILTER_PATTERN = filter().with(source().matching(
-            join().capturedAs(JOIN_CAPTURE)));
+            join().with(type().equalTo(JoinNode.Type.INNER)).capturedAs(JOIN_CAPTURE)));
 
     private final Metadata metadata;
     private final TypeAnalyzer typeAnalyzer;

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJoin.java
@@ -225,4 +225,24 @@ public class TestJoin
                                                 values())
                                                 .with(JoinNode.class, JoinNode::isMaySkipOutputDuplicates)))));
     }
+
+    @Test
+    public void testPredicateOverOuterJoin()
+    {
+        assertThat(assertions.query(
+                "SELECT 5 " +
+                        "FROM (VALUES (1,'foo')) l(l1, l2) " +
+                        "LEFT JOIN (VALUES (2,'bar')) r(r1, r2) " +
+                        "ON l2 = r2 " +
+                        "WHERE l1 >= COALESCE(r1, 0)"))
+                .matches("VALUES 5");
+
+        assertThat(assertions.query(
+                "SELECT 5 " +
+                        "FROM (VALUES (2,'foo')) l(l1, l2) " +
+                        "RIGHT JOIN (VALUES (1,'bar')) r(r1, r2) " +
+                        "ON l2 = r2 " +
+                        "WHERE r1 >= COALESCE(l1, 0)"))
+                .matches("VALUES 5");
+    }
 }


### PR DESCRIPTION
PushInequalityFilterExpressionBelowJoin was incorrectly
pushing a projection into the inner side of an outer join.
This is an invalid transformation when the outer join produces
a null for the columns of the inner table in case of a mismatch
and the expression that's pushed down does not preserve nulls.

As a temporary fix, limit the scope of the rule only to inner joins.

Fixes #13109 

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# General
* Fix incorrect results for queries involving certain non-equality filters on top of an outer join. ({issue}`13109`)
```
