### PR TITLE
Cache Iceberg equality and positional delete filters.

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -54,7 +54,6 @@ import io.trino.plugin.iceberg.IcebergParquetColumnIOConverter.FieldContext;
 import io.trino.plugin.iceberg.delete.DummyFileScanTask;
 import io.trino.plugin.iceberg.delete.IcebergPositionDeletePageSink;
 import io.trino.plugin.iceberg.delete.TrinoDeleteFilter;
-import io.trino.plugin.iceberg.delete.TrinoRow;
 import io.trino.spi.PageIndexerFactory;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ColumnHandle;
@@ -86,7 +85,6 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
-import org.apache.iceberg.data.DeleteFilter;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.mapping.MappedField;
@@ -299,7 +297,7 @@ public class IcebergPageSourceProvider
         List<IcebergColumnHandle> readColumns = dataPageSource.getReaderColumns()
                 .map(readerColumns -> readerColumns.get().stream().map(IcebergColumnHandle.class::cast).collect(toList()))
                 .orElse(requiredColumns);
-        DeleteFilter<TrinoRow> deleteFilter = new TrinoDeleteFilter(
+        TrinoDeleteFilter deleteFilter = new TrinoDeleteFilter(
                 dummyFileScanTask,
                 tableSchema,
                 readColumns,

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergDeleteFilter.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergDeleteFilter.java
@@ -80,6 +80,6 @@ public class TestIcebergDeleteFilter
                 .entrySet().stream()
                 .filter(entry -> entry.getKey().getFilePath().contains("/data/") && entry.getKey().getFilePath().endsWith(".orc"))
                 .count();
-        assertThat(deleteFilterCount).isEqualTo(25);
+        assertThat(deleteFilterCount).isEqualTo(1);
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergDeleteFilter.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergDeleteFilter.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import io.trino.Session;
+import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.tpch.TpchTable;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Optional;
+
+import static com.google.inject.util.Modules.EMPTY_MODULE;
+import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
+import static io.trino.plugin.hive.metastore.file.FileHiveMetastore.createTestingFileHiveMetastore;
+import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static io.trino.testing.QueryAssertions.copyTpchTables;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Test(singleThreaded = true) // e.g. trackingFileIoProvider is shared mutable state
+public class TestIcebergDeleteFilter
+        extends AbstractTestQueryFramework
+{
+    private TrackingFileIoProvider trackingFileIoProvider;
+
+    @Override
+    protected DistributedQueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("iceberg")
+                .setSchema("test_schema")
+                .build();
+
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session)
+                // Tests that inspect MBean attributes need to run with just one node, otherwise
+                // the attributes may come from the bound class instance in non-coordinator node
+                .setNodeCount(1)
+                .build();
+
+        File baseDir = queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg_data").toFile();
+        HiveMetastore metastore = createTestingFileHiveMetastore(baseDir);
+
+        trackingFileIoProvider = new TrackingFileIoProvider(new HdfsFileIoProvider(HDFS_ENVIRONMENT));
+        queryRunner.installPlugin(new TestingIcebergPlugin(Optional.of(metastore), Optional.of(trackingFileIoProvider), EMPTY_MODULE));
+        queryRunner.createCatalog("iceberg", "iceberg");
+        queryRunner.installPlugin(new TpchPlugin());
+        queryRunner.createCatalog("tpch", "tpch");
+
+        queryRunner.execute("CREATE SCHEMA test_schema");
+
+        copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, session, TpchTable.getTables());
+        return queryRunner;
+    }
+
+    @Test
+    public void testDeleteFilterCaching()
+    {
+        assertUpdate("DELETE FROM lineitem WHERE extendedprice > 1000", 60048);
+        trackingFileIoProvider.reset();
+
+        assertQuerySucceeds("SELECT COUNT(*) FROM lineitem");
+
+        long deleteFilterCount = trackingFileIoProvider.getOperationCounts()
+                .entrySet().stream()
+                .filter(entry -> entry.getKey().getFilePath().contains("/data/") && entry.getKey().getFilePath().endsWith(".orc"))
+                .count();
+        assertThat(deleteFilterCount).isEqualTo(25);
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
@@ -40,6 +40,7 @@ import static io.trino.plugin.iceberg.TestIcebergMetadataFileOperations.FileType
 import static io.trino.plugin.iceberg.TestIcebergMetadataFileOperations.FileType.SNAPSHOT;
 import static io.trino.plugin.iceberg.TestIcebergMetadataFileOperations.FileType.fromFilePath;
 import static io.trino.plugin.iceberg.TrackingFileIoProvider.OperationType.INPUT_FILE_GET_LENGTH;
+import static io.trino.plugin.iceberg.TrackingFileIoProvider.OperationType.INPUT_FILE_LOCATION;
 import static io.trino.plugin.iceberg.TrackingFileIoProvider.OperationType.INPUT_FILE_NEW_STREAM;
 import static io.trino.plugin.iceberg.TrackingFileIoProvider.OperationType.OUTPUT_FILE_CREATE;
 import static io.trino.plugin.iceberg.TrackingFileIoProvider.OperationType.OUTPUT_FILE_CREATE_OR_OVERWRITE;
@@ -129,9 +130,11 @@ public class TestIcebergMetadataFileOperations
         assertUpdate("CREATE TABLE test_select AS SELECT 1 col_name", 1);
         assertFileSystemAccesses("SELECT * FROM test_select",
                 ImmutableMultiset.builder()
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_LOCATION), 2)
                         .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 2)
                         .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 2)
                         .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_LOCATION), 2)
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH), 1)
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM), 1)
                         .build());
@@ -143,9 +146,11 @@ public class TestIcebergMetadataFileOperations
         assertUpdate("CREATE TABLE test_select_with_filter AS SELECT 1 col_name", 1);
         assertFileSystemAccesses("SELECT * FROM test_select_with_filter WHERE col_name = 1",
                 ImmutableMultiset.builder()
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_LOCATION), 2)
                         .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 2)
                         .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 2)
                         .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_LOCATION), 2)
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH), 1)
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM), 1)
                         .build());
@@ -159,9 +164,11 @@ public class TestIcebergMetadataFileOperations
 
         assertFileSystemAccesses("SELECT name, age FROM test_join_t1 JOIN test_join_t2 ON test_join_t2.id = test_join_t1.id",
                 ImmutableMultiset.builder()
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_LOCATION), 10)
                         .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 10)
                         .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 10)
                         .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM), 2)
+                        .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_LOCATION), 4)
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH), 2)
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM), 2)
                         .build());
@@ -177,9 +184,11 @@ public class TestIcebergMetadataFileOperations
 
         assertFileSystemAccesses("SELECT count(*) FROM test_join_partitioned_t1 t1 join test_join_partitioned_t2 t2 on t1.a = t2.foo",
                 ImmutableMultiset.builder()
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_LOCATION), 10)
                         .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 10)
                         .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 10)
                         .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM), 2)
+                        .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_LOCATION), 4)
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH), 2)
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM), 2)
                         .build());
@@ -192,9 +201,11 @@ public class TestIcebergMetadataFileOperations
 
         assertFileSystemAccesses("EXPLAIN SELECT * FROM test_explain",
                 ImmutableMultiset.builder()
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_LOCATION), 2)
                         .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 2)
                         .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 2)
                         .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_LOCATION), 2)
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH), 1)
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM), 1)
                         .build());
@@ -207,9 +218,11 @@ public class TestIcebergMetadataFileOperations
 
         assertFileSystemAccesses("SHOW STATS FOR test_show_stats",
                 ImmutableMultiset.builder()
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_LOCATION), 4)
                         .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 4)
                         .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 4)
                         .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_LOCATION), 2)
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH), 1)
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM), 1)
                         .build());
@@ -224,9 +237,11 @@ public class TestIcebergMetadataFileOperations
 
         assertFileSystemAccesses("SHOW STATS FOR test_show_stats_partitioned",
                 ImmutableMultiset.builder()
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_LOCATION), 4)
                         .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 4)
                         .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 4)
                         .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_LOCATION), 2)
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH), 1)
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM), 1)
                         .build());
@@ -239,9 +254,11 @@ public class TestIcebergMetadataFileOperations
 
         assertFileSystemAccesses("SHOW STATS FOR (SELECT * FROM test_show_stats_with_filter WHERE age >= 2)",
                 ImmutableMultiset.builder()
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_LOCATION), 4)
                         .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 4)
                         .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 4)
                         .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_LOCATION), 2)
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH), 1)
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM), 1)
                         .build());

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TrackingFileIoProvider.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TrackingFileIoProvider.java
@@ -32,6 +32,7 @@ import java.util.function.Consumer;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.trino.plugin.iceberg.TrackingFileIoProvider.OperationType.INPUT_FILE_EXISTS;
 import static io.trino.plugin.iceberg.TrackingFileIoProvider.OperationType.INPUT_FILE_GET_LENGTH;
+import static io.trino.plugin.iceberg.TrackingFileIoProvider.OperationType.INPUT_FILE_LOCATION;
 import static io.trino.plugin.iceberg.TrackingFileIoProvider.OperationType.INPUT_FILE_NEW_STREAM;
 import static io.trino.plugin.iceberg.TrackingFileIoProvider.OperationType.OUTPUT_FILE_CREATE;
 import static io.trino.plugin.iceberg.TrackingFileIoProvider.OperationType.OUTPUT_FILE_CREATE_OR_OVERWRITE;
@@ -47,6 +48,7 @@ public class TrackingFileIoProvider
         INPUT_FILE_GET_LENGTH,
         INPUT_FILE_NEW_STREAM,
         INPUT_FILE_EXISTS,
+        INPUT_FILE_LOCATION,
         OUTPUT_FILE_CREATE,
         OUTPUT_FILE_CREATE_OR_OVERWRITE,
         OUTPUT_FILE_LOCATION,
@@ -158,6 +160,7 @@ public class TrackingFileIoProvider
         @Override
         public String location()
         {
+            tracker.accept(INPUT_FILE_LOCATION);
             return delegate.location();
         }
 


### PR DESCRIPTION
## Description

This follows the apparent design choice of iceberg's delete filters operating on partitions at a time.

Before this change Iceberg DeleteFilters were reloaded and reparsed for each page. This PR keeps filters for the split, which is how Iceberg delete filters are designed.
This uses only existing API from Iceberg's `DeleteFilter`.
This speeds up some queries involving delete filters by a factor of 1000 or more. See #13092 for an explanation.

> Is this change a fix, improvement, new feature, refactoring, or other?

Performance Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Iceberg Connector

> How would you describe this change to a non-technical end user or system administrator?

Deleting rows in Iceberg V2 leads to very slow read performance following the delete.

## Related issues, pull requests, and links

* Fixes #13092

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:
