### PR TITLE
Fix incorrect pushdown of expression below join

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJoin.java
@@ -225,4 +225,24 @@ public class TestJoin
                                                 values())
                                                 .with(JoinNode.class, JoinNode::isMaySkipOutputDuplicates)))));
     }
+
+    @Test
+    public void testPredicateOverOuterJoin()
+    {
+        assertThat(assertions.query(
+                "SELECT 5 " +
+                        "FROM (VALUES (1,'foo')) l(l1, l2) " +
+                        "LEFT JOIN (VALUES (2,'bar')) r(r1, r2) " +
+                        "ON l2 = r2 " +
+                        "WHERE l1 >= COALESCE(r1, 0)"))
+                .matches("VALUES 5");
+
+        assertThat(assertions.query(
+                "SELECT 5 " +
+                        "FROM (VALUES (2,'foo')) l(l1, l2) " +
+                        "RIGHT JOIN (VALUES (1,'bar')) r(r1, r2) " +
+                        "ON l2 = r2 " +
+                        "WHERE r1 >= COALESCE(l1, 0)"))
+                .matches("VALUES 5");
+    }
 }


### PR DESCRIPTION
PushInequalityFilterExpressionBelowJoin was incorrectly
pushing a projection into the inner side of an outer join.
This is an invalid transformation when the outer join produces
a null for the columns of the inner table in case of a mismatch
and the expression that's pushed down does not preserve nulls.

Fixes https://github.com/trinodb/trino/issues/13109

## Documentation

(x) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# General
* Fix incorrect results for queries involving certain non-equality filters on top of an outer join. ({issue}`13109`)
```

