### PR TITLE
Fix partition predicate pushdown containing null in Glue

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueExpressionUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueExpressionUtil.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
@@ -156,11 +157,13 @@ public final class GlueExpressionUtil
         }
 
         if (domain.getValues().isAll()) {
+            verify(!domain.isNullAllowed(), "Unexpected domain: %s", domain);
             return Optional.of(format("(%s <> '%s')", columnName, NULL_STRING));
         }
 
-        // null must be allowed for this case since callers must filter Domain.none() out
         if (domain.getValues().isNone()) {
+            // null must be allowed for this case since callers must filter Domain.none() out
+            verify(domain.isNullAllowed(), "Unexpected domain: %s", domain);
             return Optional.of(format("(%s = '%s')", columnName, NULL_STRING));
         }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueExpressionUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueExpressionUtil.java
@@ -151,7 +151,7 @@ public final class GlueExpressionUtil
         // for column <> '__HIVE_DEFAULT_PARTITION__' or column = '__HIVE_DEFAULT_PARTITION__' expression on numeric types
         // "IS NULL" operator in the official documentation always returns empty result regardless of the type.
         // https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-partitions.html#aws-glue-api-catalog-partitions-GetPartitions
-        if ((domain.getValues().isAll() || domain.getValues().isNone()) && !isQuotedType(domain.getType())) {
+        if ((domain.getValues().isAll() || domain.isNullAllowed()) && !isQuotedType(domain.getType())) {
             return Optional.empty();
         }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueExpressionUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueExpressionUtil.java
@@ -204,6 +204,10 @@ public final class GlueExpressionUtil
             disjuncts.add(inClause);
         }
 
+        if (domain.isNullAllowed()) {
+            disjuncts.add(format("(%s = '%s')", columnName, NULL_STRING));
+        }
+
         return Optional.of("(" + DISJUNCT_JOINER.join(disjuncts) + ")");
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -48,6 +48,7 @@ import io.trino.plugin.hive.metastore.StorageFormat;
 import io.trino.plugin.hive.metastore.Table;
 import io.trino.plugin.hive.metastore.cache.CachingHiveMetastoreConfig;
 import io.trino.plugin.hive.metastore.thrift.BridgingHiveMetastore;
+import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreConfig;
 import io.trino.plugin.hive.orc.OrcPageSource;
 import io.trino.plugin.hive.parquet.ParquetPageSource;
 import io.trino.plugin.hive.rcfile.RcFilePageSource;
@@ -615,6 +616,7 @@ public abstract class AbstractTestHive
     protected String database;
     protected SchemaTableName tablePartitionFormat;
     protected SchemaTableName tableUnpartitioned;
+    protected SchemaTableName tablePartitionedWithNull;
     protected SchemaTableName tableOffline;
     protected SchemaTableName tableOfflinePartition;
     protected SchemaTableName tableNotReadable;
@@ -634,6 +636,8 @@ public abstract class AbstractTestHive
     protected ColumnHandle dummyColumn;
     protected ColumnHandle intColumn;
     protected ColumnHandle invalidColumnHandle;
+    protected ColumnHandle pStringColumn;
+    protected ColumnHandle pIntegerColumn;
 
     protected ConnectorTableProperties tablePartitionFormatProperties;
     protected ConnectorTableProperties tableUnpartitionedProperties;
@@ -692,6 +696,7 @@ public abstract class AbstractTestHive
         database = databaseName;
         tablePartitionFormat = new SchemaTableName(database, "trino_test_partition_format");
         tableUnpartitioned = new SchemaTableName(database, "trino_test_unpartitioned");
+        tablePartitionedWithNull = new SchemaTableName(database, "trino_test_partitioned_with_null");
         tableOffline = new SchemaTableName(database, "trino_test_offline");
         tableOfflinePartition = new SchemaTableName(database, "trino_test_offline_partition");
         tableNotReadable = new SchemaTableName(database, "trino_test_not_readable");
@@ -711,6 +716,8 @@ public abstract class AbstractTestHive
         dummyColumn = createBaseColumn("dummy", -1, HIVE_INT, INTEGER, PARTITION_KEY, Optional.empty());
         intColumn = createBaseColumn("t_int", -1, HIVE_INT, INTEGER, PARTITION_KEY, Optional.empty());
         invalidColumnHandle = createBaseColumn(INVALID_COLUMN, 0, HIVE_STRING, VARCHAR, REGULAR, Optional.empty());
+        pStringColumn = createBaseColumn("p_string", -1, HIVE_STRING, VARCHAR, PARTITION_KEY, Optional.empty());
+        pIntegerColumn = createBaseColumn("p_integer", -1, HIVE_INT, INTEGER, PARTITION_KEY, Optional.empty());
 
         List<ColumnHandle> partitionColumns = ImmutableList.of(dsColumn, fileFormatColumn, dummyColumn);
         tablePartitionFormatPartitions = ImmutableList.<HivePartition>builder()
@@ -783,6 +790,8 @@ public abstract class AbstractTestHive
                 new BridgingHiveMetastore(testingThriftHiveMetastoreBuilder()
                         .metastoreClient(HostAndPort.fromParts(host, port))
                         .hiveConfig(hiveConfig)
+                        .thriftMetastoreConfig(new ThriftMetastoreConfig()
+                                .setAssumeCanonicalPartitionKeys(true))
                         .hdfsEnvironment(hdfsEnvironment)
                         .build()),
                 executor,
@@ -1112,6 +1121,80 @@ public abstract class AbstractTestHive
             assertExpectedTableProperties(properties, tablePartitionFormatProperties);
             assertExpectedPartitions(tableHandle, tablePartitionFormatPartitions);
         }
+    }
+
+    @Test
+    public void testGetPartitionsWithFilter()
+    {
+        try (Transaction transaction = newTransaction()) {
+            ConnectorMetadata metadata = transaction.getMetadata();
+            ConnectorTableHandle tableHandle = getTableHandle(metadata, tablePartitionedWithNull);
+
+            Domain varcharSomeValue = Domain.singleValue(VARCHAR, utf8Slice("abc"));
+            Domain varcharOnlyNull = Domain.onlyNull(VARCHAR);
+            Domain varcharNotNull = Domain.notNull(VARCHAR);
+
+            Domain integerSomeValue = Domain.singleValue(INTEGER, 123L);
+            Domain integerOnlyNull = Domain.onlyNull(INTEGER);
+            Domain integerNotNull = Domain.notNull(INTEGER);
+
+            // all
+            assertThat(getPartitionNamesByFilter(metadata, tableHandle, new Constraint(TupleDomain.all())))
+                    .containsOnly(
+                            "p_string=__HIVE_DEFAULT_PARTITION__/p_integer=__HIVE_DEFAULT_PARTITION__",
+                            "p_string=abc/p_integer=123",
+                            "p_string=def/p_integer=456");
+
+            // is some value
+            assertThat(getPartitionNamesByFilter(metadata, tableHandle, pStringColumn, varcharSomeValue))
+                    .containsOnly("p_string=abc/p_integer=123");
+            assertThat(getPartitionNamesByFilter(metadata, tableHandle, pIntegerColumn, integerSomeValue))
+                    .containsOnly("p_string=abc/p_integer=123");
+
+            // IS NULL
+            assertThat(getPartitionNamesByFilter(metadata, tableHandle, pStringColumn, varcharOnlyNull))
+                    .containsOnly("p_string=__HIVE_DEFAULT_PARTITION__/p_integer=__HIVE_DEFAULT_PARTITION__");
+            assertThat(getPartitionNamesByFilter(metadata, tableHandle, pIntegerColumn, integerOnlyNull))
+                    .containsOnly("p_string=__HIVE_DEFAULT_PARTITION__/p_integer=__HIVE_DEFAULT_PARTITION__");
+
+            // IS NOT NULL
+            assertThat(getPartitionNamesByFilter(metadata, tableHandle, pStringColumn, varcharNotNull))
+                    .containsOnly("p_string=abc/p_integer=123", "p_string=def/p_integer=456");
+            assertThat(getPartitionNamesByFilter(metadata, tableHandle, pIntegerColumn, integerNotNull))
+                    .containsOnly("p_string=abc/p_integer=123", "p_string=def/p_integer=456");
+
+            // IS NULL OR is some value
+            assertThat(getPartitionNamesByFilter(metadata, tableHandle, pStringColumn, varcharOnlyNull.union(varcharSomeValue)))
+                    .containsOnly("p_string=__HIVE_DEFAULT_PARTITION__/p_integer=__HIVE_DEFAULT_PARTITION__", "p_string=abc/p_integer=123");
+            assertThat(getPartitionNamesByFilter(metadata, tableHandle, pIntegerColumn, integerOnlyNull.union(integerSomeValue)))
+                    .containsOnly("p_string=__HIVE_DEFAULT_PARTITION__/p_integer=__HIVE_DEFAULT_PARTITION__", "p_string=abc/p_integer=123");
+
+            // IS NOT NULL AND is NOT some value
+            assertThat(getPartitionNamesByFilter(metadata, tableHandle, pStringColumn, varcharSomeValue.complement().intersect(varcharNotNull)))
+                    .containsOnly("p_string=def/p_integer=456");
+            assertThat(getPartitionNamesByFilter(metadata, tableHandle, pIntegerColumn, integerSomeValue.complement().intersect(integerNotNull)))
+                    .containsOnly("p_string=def/p_integer=456");
+
+            // IS NULL OR is NOT some value
+            assertThat(getPartitionNamesByFilter(metadata, tableHandle, pStringColumn, varcharSomeValue.complement()))
+                    .containsOnly("p_string=__HIVE_DEFAULT_PARTITION__/p_integer=__HIVE_DEFAULT_PARTITION__", "p_string=def/p_integer=456");
+            assertThat(getPartitionNamesByFilter(metadata, tableHandle, pIntegerColumn, integerSomeValue.complement()))
+                    .containsOnly("p_string=__HIVE_DEFAULT_PARTITION__/p_integer=__HIVE_DEFAULT_PARTITION__", "p_string=def/p_integer=456");
+        }
+    }
+
+    private Set<String> getPartitionNamesByFilter(ConnectorMetadata metadata, ConnectorTableHandle tableHandle, ColumnHandle columnHandle, Domain domain)
+    {
+        return getPartitionNamesByFilter(metadata, tableHandle, new Constraint(TupleDomain.withColumnDomains(ImmutableMap.of(columnHandle, domain))));
+    }
+
+    private Set<String> getPartitionNamesByFilter(ConnectorMetadata metadata, ConnectorTableHandle tableHandle, Constraint constraint)
+    {
+        return applyFilter(metadata, tableHandle, constraint)
+                .getPartitions().orElseThrow(() -> new IllegalStateException("No partitions"))
+                .stream()
+                .map(HivePartition::getPartitionId)
+                .collect(toImmutableSet());
     }
 
     @Test
@@ -5090,10 +5173,11 @@ public abstract class AbstractTestHive
         return handle;
     }
 
-    private ConnectorTableHandle applyFilter(ConnectorMetadata metadata, ConnectorTableHandle tableHandle, Constraint constraint)
+    private HiveTableHandle applyFilter(ConnectorMetadata metadata, ConnectorTableHandle tableHandle, Constraint constraint)
     {
         return metadata.applyFilter(newSession(), tableHandle, constraint)
                 .map(ConstraintApplicationResult::getHandle)
+                .map(HiveTableHandle.class::cast)
                 .orElseThrow(AssertionError::new);
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestingThriftHiveMetastoreBuilder.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestingThriftHiveMetastoreBuilder.java
@@ -54,6 +54,7 @@ public final class TestingThriftHiveMetastoreBuilder
 
     private MetastoreLocator metastoreLocator;
     private HiveConfig hiveConfig = new HiveConfig();
+    private ThriftMetastoreConfig thriftMetastoreConfig = new ThriftMetastoreConfig();
     private HdfsEnvironment hdfsEnvironment = HDFS_ENVIRONMENT;
 
     public static TestingThriftHiveMetastoreBuilder testingThriftHiveMetastoreBuilder()
@@ -85,6 +86,12 @@ public final class TestingThriftHiveMetastoreBuilder
         return this;
     }
 
+    public TestingThriftHiveMetastoreBuilder thriftMetastoreConfig(ThriftMetastoreConfig thriftMetastoreConfig)
+    {
+        this.thriftMetastoreConfig = requireNonNull(thriftMetastoreConfig, "thriftMetastoreConfig is null");
+        return this;
+    }
+
     public TestingThriftHiveMetastoreBuilder hdfsEnvironment(HdfsEnvironment hdfsEnvironment)
     {
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
@@ -97,12 +104,12 @@ public final class TestingThriftHiveMetastoreBuilder
         ThriftHiveMetastoreFactory metastoreFactory = new ThriftHiveMetastoreFactory(
                 new TokenDelegationThriftMetastoreFactory(
                         metastoreLocator,
-                        new ThriftMetastoreConfig(),
+                        thriftMetastoreConfig,
                         new ThriftMetastoreAuthenticationConfig(),
                         hdfsEnvironment),
                 new HiveMetastoreConfig().isHideDeltaLakeTables(),
                 hiveConfig.isTranslateHiveViews(),
-                new ThriftMetastoreConfig(),
+                thriftMetastoreConfig,
                 hdfsEnvironment);
         return metastoreFactory.createMetastore(Optional.empty());
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueExpressionUtil.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueExpressionUtil.java
@@ -145,6 +145,28 @@ public class TestGlueExpressionUtil
     }
 
     @Test
+    public void testBuildGlueExpressionTupleDomainEqualsOrIsNull()
+    {
+        TupleDomain<String> filter = new PartitionFilterBuilder()
+                .addStringValues("col1", "2020-01-01")
+                .addDomain("col1", Domain.onlyNull(VarcharType.VARCHAR))
+                .build();
+        String expression = buildGlueExpression(ImmutableList.of("col1"), filter, true);
+        assertEquals(expression, format("((col1 = '2020-01-01') OR (col1 = '%s'))", GlueExpressionUtil.NULL_STRING));
+    }
+
+    @Test
+    public void testBuildGlueExpressionTupleDomainEqualsAndIsNotNull()
+    {
+        TupleDomain<String> filter = new PartitionFilterBuilder()
+                .addStringValues("col1", "2020-01-01")
+                .addDomain("col2", Domain.notNull(VarcharType.VARCHAR))
+                .build();
+        String expression = buildGlueExpression(ImmutableList.of("col1", "col2"), filter, true);
+        assertEquals(expression, format("((col1 = '2020-01-01')) AND (col2 <> '%s')", GlueExpressionUtil.NULL_STRING));
+    }
+
+    @Test
     public void testBuildGlueExpressionMaxLengthNone()
     {
         TupleDomain<String> filter = new PartitionFilterBuilder()

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
@@ -832,18 +832,29 @@ public class TestHiveGlueMetastore
     public void testGetPartitionsFilterIsNullWithValue()
             throws Exception
     {
-        TupleDomain<String> isNullFilter = new PartitionFilterBuilder()
-                .addDomain(PARTITION_KEY, Domain.onlyNull(VarcharType.VARCHAR))
-                .build();
         List<String> partitionList = new ArrayList<>();
         partitionList.add("100");
         partitionList.add(null);
+
         doGetPartitionsFilterTest(
                 CREATE_TABLE_COLUMNS_PARTITIONED_VARCHAR,
                 PARTITION_KEY,
                 partitionList,
-                ImmutableList.of(isNullFilter),
+                ImmutableList.of(new PartitionFilterBuilder()
+                        // IS NULL
+                        .addDomain(PARTITION_KEY, Domain.onlyNull(VarcharType.VARCHAR))
+                        .build()),
                 ImmutableList.of(ImmutableList.of(GlueExpressionUtil.NULL_STRING)));
+
+        doGetPartitionsFilterTest(
+                CREATE_TABLE_COLUMNS_PARTITIONED_VARCHAR,
+                PARTITION_KEY,
+                partitionList,
+                ImmutableList.of(new PartitionFilterBuilder()
+                        // IS NULL or is a specific value
+                        .addDomain(PARTITION_KEY, Domain.create(ValueSet.of(VARCHAR, utf8Slice("100")), true))
+                        .build()),
+                ImmutableList.of(ImmutableList.of("100", GlueExpressionUtil.NULL_STRING)));
     }
 
     @Test

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
@@ -846,6 +846,28 @@ public class TestHiveGlueMetastore
     }
 
     @Test
+    public void testGetPartitionsFilterEqualsOrIsNullWithValue()
+            throws Exception
+    {
+        TupleDomain<String> equalsOrIsNullFilter = new PartitionFilterBuilder()
+                .addStringValues(PARTITION_KEY, "2020-03-01")
+                .addDomain(PARTITION_KEY, Domain.onlyNull(VarcharType.VARCHAR))
+                .build();
+        List<String> partitionList = new ArrayList<>();
+        partitionList.add("2020-01-01");
+        partitionList.add("2020-02-01");
+        partitionList.add("2020-03-01");
+        partitionList.add(null);
+
+        doGetPartitionsFilterTest(
+                CREATE_TABLE_COLUMNS_PARTITIONED_VARCHAR,
+                PARTITION_KEY,
+                partitionList,
+                ImmutableList.of(equalsOrIsNullFilter),
+                ImmutableList.of(ImmutableList.of("2020-03-01", GlueExpressionUtil.NULL_STRING)));
+    }
+
+    @Test
     public void testGetPartitionsFilterIsNotNull()
             throws Exception
     {
@@ -920,6 +942,27 @@ public class TestHiveGlueMetastore
                 {CREATE_TABLE_COLUMNS_PARTITIONED_DATE, DateType.DATE, "2022-07-11"},
                 {CREATE_TABLE_COLUMNS_PARTITIONED_TIMESTAMP, TimestampType.TIMESTAMP_MILLIS, "2022-07-11 01:02:03.123"},
         };
+    }
+
+    @Test
+    public void testGetPartitionsFilterEqualsAndIsNotNull()
+            throws Exception
+    {
+        TupleDomain<String> equalsAndIsNotNullFilter = new PartitionFilterBuilder()
+                .addDomain(PARTITION_KEY, Domain.notNull(VarcharType.VARCHAR))
+                .addBigintValues(PARTITION_KEY2, 300L)
+                .build();
+
+        doGetPartitionsFilterTest(
+                CREATE_TABLE_COLUMNS_PARTITIONED_TWO_KEYS,
+                ImmutableList.of(PARTITION_KEY, PARTITION_KEY2),
+                ImmutableList.of(
+                        PartitionValues.make("2020-01-01", "100"),
+                        PartitionValues.make("2020-02-01", "200"),
+                        PartitionValues.make("2020-03-01", "300"),
+                        PartitionValues.make(null, "300")),
+                ImmutableList.of(equalsAndIsNotNullFilter),
+                ImmutableList.of(ImmutableList.of(PartitionValues.make("2020-03-01", "300"))));
     }
 
     @Test

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
@@ -53,6 +53,7 @@ import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.Range;
 import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
 import io.trino.spi.statistics.ColumnStatisticMetadata;
 import io.trino.spi.statistics.ComputedStatistics;
 import io.trino.spi.statistics.TableStatisticType;

--- a/plugin/trino-hive/src/test/sql/create-test.sql
+++ b/plugin/trino-hive/src/test/sql/create-test.sql
@@ -1,3 +1,7 @@
+set hive.exec.dynamic.partition.mode=nonstrict;
+
+CREATE TABLE dummy (dummy varchar(1));
+
 CREATE TABLE trino_test_sequence (
   n INT
 )
@@ -23,6 +27,13 @@ CREATE TABLE trino_test_unpartitioned (
   t_tinyint TINYINT
 )
 COMMENT 'Presto test data'
+STORED AS TEXTFILE
+;
+
+CREATE TABLE trino_test_partitioned_with_null (
+    a_value STRING
+)
+PARTITIONED BY (p_string STRING, p_integer int)
 STORED AS TEXTFILE
 ;
 
@@ -124,6 +135,8 @@ LOAD DATA LOCAL INPATH '/docker/files/words'
 INTO TABLE tmp_trino_test_load
 ;
 
+INSERT INTO dummy VALUES ('x');
+
 INSERT OVERWRITE TABLE trino_test_sequence
 SELECT TRANSFORM(word)
 USING 'awk "BEGIN { n = 0 } { print ++n }"' AS n
@@ -192,6 +205,10 @@ SELECT
   CASE n % 19 WHEN 0 THEN NULL WHEN 1 THEN '' ELSE 'unpartitioned' END
 , 1 + n
 FROM trino_test_sequence LIMIT 100;
+
+INSERT INTO TABLE trino_test_partitioned_with_null PARTITION (p_string, p_integer) SELECT 'NULL row', NULL, NULL FROM dummy;
+INSERT INTO TABLE trino_test_partitioned_with_null PARTITION (p_string, p_integer) SELECT 'value row', 'abc', 123 FROM dummy;
+INSERT INTO TABLE trino_test_partitioned_with_null PARTITION (p_string, p_integer) SELECT 'another value row', 'def', 456 FROM dummy;
 
 INSERT INTO TABLE trino_test_offline_partition PARTITION (ds='2012-12-29')
 SELECT 'test' FROM trino_test_sequence LIMIT 100;


### PR DESCRIPTION
## Description

Fix partition predicate pushdown containing null in Glue
Fixes #13083

## Documentation

(x) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# Hive, Iceberg, Delta Lake
* Fix incorrect results when using the Glue metastore and queries contain `IS NULL` with additional filters. ({issue}`13124`). ({issue}`13083`)
```
