### PR TITLE
Fix faulty flag

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -2787,7 +2787,7 @@ public class LocalExecutionPlanner
 
             int taskConcurrency = getTaskConcurrency(session);
             OperatorFactory hashBuilderOperatorFactory;
-            if (useSpillingJoinOperator()) {
+            if (useSpillingJoinOperator(session)) {
                 hashBuilderOperatorFactory = new HashBuilderOperatorFactory(
                         buildContext.getNextOperatorId(),
                         node.getId(),
@@ -2967,7 +2967,7 @@ public class LocalExecutionPlanner
                             outputSingleMatch,
                             waitForBuild,
                             node.getFilter().isPresent(),
-                            useSpillingJoinOperator(),
+                            useSpillingJoinOperator(session),
                             probeTypes,
                             probeJoinChannels,
                             probeHashChannel,
@@ -2982,7 +2982,7 @@ public class LocalExecutionPlanner
                             lookupSourceFactoryManager,
                             outputSingleMatch,
                             node.getFilter().isPresent(),
-                            useSpillingJoinOperator(),
+                            useSpillingJoinOperator(session),
                             probeTypes,
                             probeJoinChannels,
                             probeHashChannel,
@@ -2997,7 +2997,7 @@ public class LocalExecutionPlanner
                             lookupSourceFactoryManager,
                             waitForBuild,
                             node.getFilter().isPresent(),
-                            useSpillingJoinOperator(),
+                            useSpillingJoinOperator(session),
                             probeTypes,
                             probeJoinChannels,
                             probeHashChannel,
@@ -3011,7 +3011,7 @@ public class LocalExecutionPlanner
                             node.getId(),
                             lookupSourceFactoryManager,
                             node.getFilter().isPresent(),
-                            useSpillingJoinOperator(),
+                            useSpillingJoinOperator(session),
                             probeTypes,
                             probeJoinChannels,
                             probeHashChannel,
@@ -3021,11 +3021,6 @@ public class LocalExecutionPlanner
                             blockTypeOperators);
             }
             throw new UnsupportedOperationException("Unsupported join type: " + node.getType());
-        }
-
-        private boolean useSpillingJoinOperator()
-        {
-            return isSpillEnabled(session) || isForceSpillingOperator(session);
         }
 
         private Map<Symbol, Integer> createJoinSourcesLayout(Map<Symbol, Integer> lookupSourceLayout, Map<Symbol, Integer> probeSourceLayout)
@@ -3886,7 +3881,7 @@ public class LocalExecutionPlanner
             List<Type> buildTypes,
             Session session)
     {
-        if (isSpillEnabled(session) && !isForceSpillingOperator(session)) {
+        if (useSpillingJoinOperator(session)) {
             return new PartitionedLookupSourceFactory(
                     buildTypes,
                     buildOutputTypes,
@@ -4297,5 +4292,10 @@ public class LocalExecutionPlanner
                     .add("boundSignature", boundSignature)
                     .toString();
         }
+    }
+
+    private boolean useSpillingJoinOperator(Session session)
+    {
+        return isSpillEnabled(session) || isForceSpillingOperator(session);
     }
 }

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestJoinQueriesWithForceSpilling.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestJoinQueriesWithForceSpilling.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests;
+
+import io.trino.testing.AbstractTestJoinQueries;
+import io.trino.testing.QueryRunner;
+import io.trino.tests.tpch.TpchQueryRunnerBuilder;
+
+public class TestJoinQueriesWithForceSpilling
+        extends AbstractTestJoinQueries
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return TpchQueryRunnerBuilder.builder()
+                .addExtraProperty("force-spilling-join-operator", "true")
+                .build();
+    }
+}


### PR DESCRIPTION
The `force-spilling-join-operator` config flag and the corresponding session
property might have not been working properly and produce ClassCastException.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

fix
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core query engine
> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
