### PR TITLE
Update docker-images to v64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <dep.casandra.version>4.14.0</dep.casandra.version>
         <dep.minio.version>7.1.4</dep.minio.version>
 
-        <dep.docker.images.version>63</dep.docker.images.version>
+        <dep.docker.images.version>64</dep.docker.images.version>
 
         <!--
           America/Bahia_Banderas has:


### PR DESCRIPTION
## Description

Update docker-images to v64
* https://github.com/trinodb/docker-images/pull/134

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
