### PR TITLE
Implement getReadTimeNanos for JdbcRecordCursor

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRecordCursor.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRecordCursor.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -57,6 +58,7 @@ public class JdbcRecordCursor
     private final JdbcClient jdbcClient;
     private final Connection connection;
     private final PreparedStatement statement;
+    private final AtomicLong readTimeNanos = new AtomicLong(0);
     @Nullable
     private ResultSet resultSet;
     private boolean closed;
@@ -117,7 +119,7 @@ public class JdbcRecordCursor
     @Override
     public long getReadTimeNanos()
     {
-        return 0;
+        return readTimeNanos.get();
     }
 
     @Override
@@ -141,6 +143,7 @@ public class JdbcRecordCursor
 
         try {
             if (resultSet == null) {
+                long start = System.nanoTime();
                 Future<ResultSet> resultSetFuture = executor.submit(() -> {
                     log.debug("Executing: %s", statement);
                     return statement.executeQuery();
@@ -165,6 +168,9 @@ public class JdbcRecordCursor
                     Thread.currentThread().interrupt();
                     resultSetFuture.cancel(true);
                     throw new RuntimeException(e);
+                }
+                finally {
+                    readTimeNanos.addAndGet(System.nanoTime() - start);
                 }
             }
             return resultSet.next();

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
@@ -1273,6 +1273,14 @@ public abstract class BaseJdbcConnectorTest
         }
     }
 
+    @Test
+    public void testExplainAnalyzePhysicalReadWallTime()
+    {
+        assertExplainAnalyze(
+                "EXPLAIN ANALYZE VERBOSE SELECT * FROM nation a",
+                "'Physical input read time' = \\{duration=.*}");
+    }
+
     protected QueryAssert assertConditionallyPushedDown(
             Session session,
             @Language("SQL") String query,

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcRecordSet.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcRecordSet.java
@@ -35,6 +35,7 @@ import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.testing.TestingConnectorSession.SESSION;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 
@@ -122,6 +123,8 @@ public class TestJdbcRecordSet
                     .put("eleven", 11L)
                     .put("twelve", 12L)
                     .buildOrThrow());
+
+            assertThat(cursor.getReadTimeNanos()).isGreaterThan(0);
         }
     }
 
@@ -152,6 +155,8 @@ public class TestJdbcRecordSet
                     .put("eleven", 11L)
                     .put("twelve", 12L)
                     .buildOrThrow());
+
+            assertThat(cursor.getReadTimeNanos()).isGreaterThan(0);
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Implement the `getReadTimeNanos` method in `JdbcRecordCursor` so that `physicalInputReadTime` will represent how long was spent reading data.

This will also show up in a in `EXPLAIN ANALYZE VERBOSE` output for scans on JDBC connectors. For example, with this change a `TableScan` operator against a MySQL table shows physical input read time in connector metrics:

```
 Fragment 1 [SOURCE]
     CPU: 44.27ms, Scheduled: 73.26ms, Blocked 0.00ns (Input: 0.00ns, Output: 0.00ns), Input: 1503 rows (281.36kB); per task: avg.: 1503.00 std.dev.: 0
     Output layout: [custkey, name, address, nationkey, phone, acctbal, mktsegment, comment, dummy_col]
     Output partitioning: SINGLE []
     TableScan[table = mysql:junk.customer junk.customer]
         Layout: [custkey:bigint, name:varchar(255), address:varchar(255), nationkey:bigint, phone:varchar(255), acctbal:double, mktsegment:varchar(255
         Estimates: {rows: 1483 (517.02kB), cpu: 517.02k, memory: 0B, network: 0B}
         CPU: 43.00ms (100.00%), Scheduled: 71.00ms (100.00%), Blocked: 0.00ns (?%), Output: 1503 rows (281.36kB)
         connector metrics:
           'Physical input read time' = {duration=5.20ms}
```

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Minor improvement.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( X) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

() No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# ClickHouse, Druid, MariaDb, MySql, Oracle, PostgreSQL, Redshift, SingleStore, SQL server, Phoenix
* Report wall time spent reading data from JDBC sources. ({issue}`13132`)
```
