### PR TITLE
Translate IN predicate to connector expression

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/ConnectorExpressionTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ConnectorExpressionTranslator.java
@@ -28,6 +28,7 @@ import io.trino.spi.expression.Constant;
 import io.trino.spi.expression.FieldDereference;
 import io.trino.spi.expression.FunctionName;
 import io.trino.spi.expression.Variable;
+import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.Decimals;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
@@ -50,6 +51,8 @@ import io.trino.sql.tree.DoubleLiteral;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.FunctionCall;
 import io.trino.sql.tree.GenericLiteral;
+import io.trino.sql.tree.InListExpression;
+import io.trino.sql.tree.InPredicate;
 import io.trino.sql.tree.IsNotNullPredicate;
 import io.trino.sql.tree.IsNullPredicate;
 import io.trino.sql.tree.LikePredicate;
@@ -80,11 +83,13 @@ import static io.airlift.slice.SliceUtf8.countCodePoints;
 import static io.trino.SystemSessionProperties.isComplexExpressionPushdown;
 import static io.trino.spi.expression.StandardFunctions.ADD_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.AND_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.ARRAY_CONSTRUCTOR_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.CAST_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.DIVIDE_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.EQUAL_OPERATOR_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.GREATER_THAN_OPERATOR_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.GREATER_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.IN_PREDICATE_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.IS_DISTINCT_FROM_OPERATOR_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.IS_NULL_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.LESS_THAN_OPERATOR_FUNCTION_NAME;
@@ -272,6 +277,10 @@ public final class ConnectorExpressionTranslator
                 }
             }
 
+            if (IN_PREDICATE_FUNCTION_NAME.equals(call.getFunctionName()) && call.getArguments().size() == 2) {
+                return translateInPredicate(call.getArguments().get(0), call.getArguments().get(1));
+            }
+
             QualifiedName name = QualifiedName.of(call.getFunctionName().getName());
             List<TypeSignature> argumentTypes = call.getArguments().stream()
                     .map(argument -> argument.getType().getTypeSignature())
@@ -344,15 +353,8 @@ public final class ConnectorExpressionTranslator
 
         private Optional<Expression> translateLogicalExpression(LogicalExpression.Operator operator, List<ConnectorExpression> arguments)
         {
-            ImmutableList.Builder<Expression> translatedArguments = ImmutableList.builderWithExpectedSize(arguments.size());
-            for (ConnectorExpression argument : arguments) {
-                Optional<Expression> translated = translate(argument);
-                if (translated.isEmpty()) {
-                    return Optional.empty();
-                }
-                translatedArguments.add(translated.get());
-            }
-            return Optional.of(new LogicalExpression(operator, translatedArguments.build()));
+            Optional<List<Expression>> translatedArguments = translateExpressions(arguments);
+            return translatedArguments.map(expressions -> new LogicalExpression(operator, expressions));
         }
 
         private Optional<Expression> translateComparison(ComparisonExpression.Operator operator, ConnectorExpression left, ConnectorExpression right)
@@ -445,6 +447,46 @@ public final class ConnectorExpressionTranslator
             }
 
             return Optional.empty();
+        }
+
+        protected Optional<Expression> translateInPredicate(ConnectorExpression value, ConnectorExpression values)
+        {
+            Optional<Expression> translatedValue = translate(value);
+            Optional<List<Expression>> translatedValues = extractExpressionsFromArrayCall(values);
+
+            if (translatedValue.isPresent() && translatedValues.isPresent()) {
+                return Optional.of(new InPredicate(translatedValue.get(), new InListExpression(translatedValues.get())));
+            }
+
+            return Optional.empty();
+        }
+
+        protected Optional<List<Expression>> extractExpressionsFromArrayCall(ConnectorExpression expression)
+        {
+            if (!(expression instanceof Call)) {
+                return Optional.empty();
+            }
+
+            Call call = (Call) expression;
+            if (!call.getFunctionName().equals(ARRAY_CONSTRUCTOR_FUNCTION_NAME)) {
+                return Optional.empty();
+            }
+
+            return translateExpressions(call.getArguments());
+        }
+
+        protected Optional<List<Expression>> translateExpressions(List<ConnectorExpression> expressions)
+        {
+            ImmutableList.Builder<Expression> translatedExpressions = ImmutableList.builderWithExpectedSize(expressions.size());
+            for (ConnectorExpression expression : expressions) {
+                Optional<Expression> translated = translate(expression);
+                if (translated.isEmpty()) {
+                    return Optional.empty();
+                }
+                translatedExpressions.add(translated.get());
+            }
+
+            return Optional.of(translatedExpressions.build());
         }
     }
 
@@ -758,6 +800,31 @@ public final class ConnectorExpressionTranslator
             }
 
             return Optional.of(new FieldDereference(typeOf(node), translatedBase.get(), toIntExact(((LongLiteral) node.getIndex()).getValue() - 1)));
+        }
+
+        @Override
+        protected Optional<ConnectorExpression> visitInPredicate(InPredicate node, Void context)
+        {
+            InListExpression valueList = (InListExpression) node.getValueList();
+            Optional<ConnectorExpression> valueExpression = process(node.getValue());
+
+            if (valueExpression.isEmpty()) {
+                return Optional.empty();
+            }
+
+            ImmutableList.Builder<ConnectorExpression> values = ImmutableList.builderWithExpectedSize(valueList.getValues().size());
+            for (Expression value : valueList.getValues()) {
+                Optional<ConnectorExpression> processedValue = process(value);
+
+                if (processedValue.isEmpty()) {
+                    return Optional.empty();
+                }
+
+                values.add(processedValue.get());
+            }
+
+            ConnectorExpression arrayExpression = new Call(new ArrayType(typeOf(node.getValueList())), ARRAY_CONSTRUCTOR_FUNCTION_NAME, values.build());
+            return Optional.of(new Call(typeOf(node), IN_PREDICATE_FUNCTION_NAME, List.of(valueExpression.get(), arrayExpression)));
         }
 
         @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/expression/StandardFunctions.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/expression/StandardFunctions.java
@@ -82,4 +82,16 @@ public final class StandardFunctions
     public static final FunctionName NEGATE_FUNCTION_NAME = new FunctionName("$negate");
 
     public static final FunctionName LIKE_PATTERN_FUNCTION_NAME = new FunctionName("$like_pattern");
+
+    /**
+     * {@code $in(value, array)} returns {@code true} when value is equal to an element of the array,
+     * otherwise returns {@code NULL} when comparing value to an element of the array returns an
+     * indeterminate result, otherwise returns {@code false}
+     */
+    public static final FunctionName IN_PREDICATE_FUNCTION_NAME = new FunctionName("$in");
+
+    /**
+     * $array creates instance of {@link Array Type}
+     */
+    public static final FunctionName ARRAY_CONSTRUCTOR_FUNCTION_NAME = new FunctionName("$array");
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/expression/ConnectorExpressionPatterns.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/expression/ConnectorExpressionPatterns.java
@@ -79,6 +79,11 @@ public final class ConnectorExpressionPatterns
         return Property.property("argumentCount", call -> call.getArguments().size());
     }
 
+    public static Property<Call, ?, List<ConnectorExpression>> arguments()
+    {
+        return Property.property("arguments", Call::getArguments);
+    }
+
     public static Property<Call, ?, ConnectorExpression> argument(int argument)
     {
         checkArgument(0 <= argument, "Invalid argument index: %s", argument);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/RewriteCast.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/RewriteCast.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc.expression;
+
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.type.Type;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argument;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.spi.expression.StandardFunctions.CAST_FUNCTION_NAME;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class RewriteCast
+        implements ConnectorExpressionRule<Call, String>
+{
+    private static final Capture<ConnectorExpression> ARGUMENT = newCapture();
+
+    private static final Pattern<Call> PATTERN = call()
+                .with(functionName().equalTo(CAST_FUNCTION_NAME))
+            .with(argument(0).capturedAs(ARGUMENT));
+
+    private final Function<Type, Optional<String>> typeMapping;
+
+    public RewriteCast(Function<Type, Optional<String>> typeMapping)
+    {
+        this.typeMapping = requireNonNull(typeMapping, "typeMapping is null");
+    }
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<String> rewrite(Call expression, Captures captures, RewriteContext<String> context)
+    {
+        ConnectorExpression argument = captures.get(ARGUMENT);
+        Optional<String> typeCast = typeMapping.apply(expression.getType());
+
+        if (typeCast.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Optional<String> translatedArgument = context.defaultRewrite(argument);
+        if (translatedArgument.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(format("CAST(%s AS %s)", translatedArgument.get(), typeCast.get()));
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/RewriteCast.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/RewriteCast.java
@@ -68,6 +68,7 @@ public class RewriteCast
         if (translatedArgument.isEmpty()) {
             return Optional.empty();
         }
+        // todo ...
 
         return Optional.of(format("CAST(%s AS %s)", translatedArgument.get(), typeCast.get()));
     }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/RewriteCast.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/RewriteCast.java
@@ -38,7 +38,7 @@ public class RewriteCast
     private static final Capture<ConnectorExpression> ARGUMENT = newCapture();
 
     private static final Pattern<Call> PATTERN = call()
-                .with(functionName().equalTo(CAST_FUNCTION_NAME))
+            .with(functionName().equalTo(CAST_FUNCTION_NAME))
             .with(argument(0).capturedAs(ARGUMENT));
 
     private final Function<Type, Optional<String>> typeMapping;

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/RewriteIn.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/RewriteIn.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc.expression;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.Verify.verify;
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argument;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argumentCount;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.arguments;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.expression;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.jdbc.JdbcMetadataSessionProperties.getDomainCompactionThreshold;
+import static io.trino.spi.expression.StandardFunctions.ARRAY_CONSTRUCTOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.IN_PREDICATE_FUNCTION_NAME;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static java.lang.String.format;
+
+public class RewriteIn
+        implements ConnectorExpressionRule<Call, String>
+{
+    private static final Capture<ConnectorExpression> VALUE = newCapture();
+    private static final Capture<List<ConnectorExpression>> EXPRESSIONS = newCapture();
+
+    private static final Pattern<Call> PATTERN = call()
+            .with(functionName().equalTo(IN_PREDICATE_FUNCTION_NAME))
+            .with(type().equalTo(BOOLEAN))
+            .with(argumentCount().equalTo(2))
+            .with(argument(0).matching(expression().capturedAs(VALUE)))
+            .with(argument(1).matching(call().with(functionName().equalTo(ARRAY_CONSTRUCTOR_FUNCTION_NAME)).with(arguments().capturedAs(EXPRESSIONS))));
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<String> rewrite(Call call, Captures captures, RewriteContext<String> context)
+    {
+        Optional<String> value = context.defaultRewrite(captures.get(VALUE));
+        if (value.isEmpty()) {
+            return Optional.empty();
+        }
+
+        List<ConnectorExpression> expressions = captures.get(EXPRESSIONS);
+        if (expressions.size() > getDomainCompactionThreshold(context.getSession())) {
+            // We don't want to push down too long IN query text
+            return Optional.empty();
+        }
+
+        ImmutableList.Builder<String> rewrittenValues = ImmutableList.builderWithExpectedSize(expressions.size());
+        for (ConnectorExpression expression : expressions) {
+            Optional<String> rewrittenExpression = context.defaultRewrite(expression);
+            if (rewrittenExpression.isEmpty()) {
+                return Optional.empty();
+            }
+            rewrittenValues.add(rewrittenExpression.get());
+        }
+
+        List<String> values = rewrittenValues.build();
+        verify(!values.isEmpty(), "Empty values");
+        return Optional.of(format("(%s) IN (%s)", value.get(), Joiner.on(", ").join(values)));
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/RewriteVarcharConstant.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/RewriteVarcharConstant.java
@@ -40,6 +40,9 @@ public class RewriteVarcharConstant
     public Optional<String> rewrite(Constant constant, Captures captures, RewriteContext<String> context)
     {
         Slice slice = (Slice) constant.getValue();
+        if (slice == null) {
+            return Optional.empty();
+        }
         return Optional.of("'" + slice.toStringUtf8().replace("'", "''") + "'");
     }
 }

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -65,6 +65,7 @@ import io.trino.plugin.jdbc.aggregation.ImplementVariancePop;
 import io.trino.plugin.jdbc.aggregation.ImplementVarianceSamp;
 import io.trino.plugin.jdbc.expression.JdbcConnectorExpressionRewriterBuilder;
 import io.trino.plugin.jdbc.expression.RewriteComparison;
+import io.trino.plugin.jdbc.expression.RewriteIn;
 import io.trino.plugin.jdbc.mapping.IdentifierMapping;
 import io.trino.plugin.postgresql.PostgreSqlConfig.ArrayMapping;
 import io.trino.spi.TrinoException;
@@ -300,6 +301,7 @@ public class PostgreSqlClient
                 .addStandardRules(this::quoted)
                 // TODO allow all comparison operators for numeric types
                 .add(new RewriteComparison(ImmutableSet.of(RewriteComparison.ComparisonOperator.EQUAL, RewriteComparison.ComparisonOperator.NOT_EQUAL)))
+                .add(new RewriteIn())
                 .withTypeClass("integer_type", ImmutableSet.of("tinyint", "smallint", "integer", "bigint"))
                 .map("$add(left: integer_type, right: integer_type)").to("left + right")
                 .map("$subtract(left: integer_type, right: integer_type)").to("left - right")

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -64,6 +64,7 @@ import io.trino.plugin.jdbc.aggregation.ImplementSum;
 import io.trino.plugin.jdbc.aggregation.ImplementVariancePop;
 import io.trino.plugin.jdbc.aggregation.ImplementVarianceSamp;
 import io.trino.plugin.jdbc.expression.JdbcConnectorExpressionRewriterBuilder;
+import io.trino.plugin.jdbc.expression.RewriteCast;
 import io.trino.plugin.jdbc.expression.RewriteComparison;
 import io.trino.plugin.jdbc.expression.RewriteIn;
 import io.trino.plugin.jdbc.mapping.IdentifierMapping;
@@ -300,6 +301,7 @@ public class PostgreSqlClient
         this.connectorExpressionRewriter = JdbcConnectorExpressionRewriterBuilder.newBuilder()
                 .addStandardRules(this::quoted)
                 // TODO allow all comparison operators for numeric types
+                .add(new RewriteCast(this::typedCast))
                 .add(new RewriteComparison(ImmutableSet.of(RewriteComparison.ComparisonOperator.EQUAL, RewriteComparison.ComparisonOperator.NOT_EQUAL)))
                 .add(new RewriteIn())
                 .withTypeClass("integer_type", ImmutableSet.of("tinyint", "smallint", "integer", "bigint"))

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -347,7 +347,10 @@ public class PostgreSqlClient
     {
         if (type instanceof VarcharType) {
             VarcharType varcharType = (VarcharType) type;
-            return varcharType.getLength().map(length -> format("varchar(%d)", length)).or(() -> Optional.of("varchar"));
+            if (varcharType.getLength().isPresent() && varcharType.getLength().get() <= 10485760) {
+                return Optional.of(format("varchar(%d)", varcharType.getLength().get()));
+            }
+            return Optional.of("varchar");
         }
 
         if (type instanceof CharType) {

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -343,6 +343,21 @@ public class PostgreSqlClient
                         .build());
     }
 
+    private Optional<String> typedCast(Type type)
+    {
+        if (type instanceof VarcharType) {
+            VarcharType varcharType = (VarcharType) type;
+            return varcharType.getLength().map(length -> format("varchar(%d)", length)).or(() -> Optional.of("varchar"));
+        }
+
+        if (type instanceof CharType) {
+            CharType charType = (CharType) type;
+            return Optional.of(format("char(%d)", charType.getLength()));
+        }
+
+        return Optional.empty();
+    }
+
     @Override
     public void createTable(ConnectorSession session, ConnectorTableMetadata tableMetadata)
     {

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlClient.java
@@ -20,11 +20,14 @@ import io.trino.plugin.jdbc.DefaultQueryBuilder;
 import io.trino.plugin.jdbc.JdbcClient;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
+import io.trino.plugin.jdbc.JdbcMetadataConfig;
+import io.trino.plugin.jdbc.JdbcMetadataSessionProperties;
 import io.trino.plugin.jdbc.JdbcStatisticsConfig;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
 import io.trino.plugin.jdbc.mapping.DefaultIdentifierMapping;
 import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.expression.Variable;
 import io.trino.spi.type.Type;
@@ -36,6 +39,8 @@ import io.trino.sql.tree.ArithmeticBinaryExpression;
 import io.trino.sql.tree.ArithmeticUnaryExpression;
 import io.trino.sql.tree.ComparisonExpression;
 import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.InListExpression;
+import io.trino.sql.tree.InPredicate;
 import io.trino.sql.tree.IsNotNullPredicate;
 import io.trino.sql.tree.IsNullPredicate;
 import io.trino.sql.tree.LikePredicate;
@@ -44,6 +49,7 @@ import io.trino.sql.tree.NotExpression;
 import io.trino.sql.tree.NullIfExpression;
 import io.trino.sql.tree.StringLiteral;
 import io.trino.sql.tree.SymbolReference;
+import io.trino.testing.TestingConnectorSession;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -63,7 +69,6 @@ import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
 import static io.trino.sql.planner.TypeAnalyzer.createTestingTypeAnalyzer;
 import static io.trino.testing.DataProviders.toDataProvider;
-import static io.trino.testing.TestingConnectorSession.SESSION;
 import static io.trino.testing.assertions.Assert.assertEquals;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static java.lang.String.format;
@@ -93,6 +98,13 @@ public class TestPostgreSqlClient
                     .setJdbcTypeHandle(new JdbcTypeHandle(Types.VARCHAR, Optional.of("varchar"), Optional.of(10), Optional.empty(), Optional.empty(), Optional.empty()))
                     .build();
 
+    private static final JdbcColumnHandle VARCHAR_COLUMN2 =
+            JdbcColumnHandle.builder()
+                    .setColumnName("c_varchar2")
+                    .setColumnType(createVarcharType(10))
+                    .setJdbcTypeHandle(new JdbcTypeHandle(Types.VARCHAR, Optional.of("varchar"), Optional.of(10), Optional.empty(), Optional.empty(), Optional.empty()))
+                    .build();
+
     private static final JdbcClient JDBC_CLIENT = new PostgreSqlClient(
             new BaseJdbcConfig(),
             new PostgreSqlConfig(),
@@ -103,6 +115,11 @@ public class TestPostgreSqlClient
             new DefaultIdentifierMapping());
 
     private static final LiteralEncoder LITERAL_ENCODER = new LiteralEncoder(PLANNER_CONTEXT);
+
+    private static final ConnectorSession SESSION = TestingConnectorSession
+            .builder()
+            .setPropertyMetadata(new JdbcMetadataSessionProperties(new JdbcMetadataConfig(), Optional.empty()).getSessionProperties())
+            .build();
 
     @Test
     public void testImplementCount()
@@ -408,6 +425,20 @@ public class TestPostgreSqlClient
                         Map.of("c_varchar_symbol", VARCHAR_COLUMN.getColumnType())),
                 Map.of("c_varchar_symbol", VARCHAR_COLUMN)))
                 .hasValue("NOT ((\"c_varchar\") IS NOT NULL)");
+    }
+
+    @Test
+    public void testConvertIn()
+    {
+        assertThat(JDBC_CLIENT.convertPredicate(
+                SESSION,
+                translateToConnectorExpression(
+                                new InPredicate(
+                                        new SymbolReference("c_varchar"),
+                                        new InListExpression(List.of(new StringLiteral("value1"), new StringLiteral("value2"), new SymbolReference("c_varchar2")))),
+                                Map.of("c_varchar", VARCHAR_COLUMN.getColumnType(), "c_varchar2", VARCHAR_COLUMN2.getColumnType())),
+                Map.of(VARCHAR_COLUMN.getColumnName(), VARCHAR_COLUMN, VARCHAR_COLUMN2.getColumnName(), VARCHAR_COLUMN2)))
+                .hasValue("(\"c_varchar\") IN ('value1', 'value2', \"c_varchar2\")");
     }
 
     private ConnectorExpression translateToConnectorExpression(Expression expression, Map<String, Type> symbolTypes)

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlClient.java
@@ -48,6 +48,7 @@ import io.trino.sql.tree.LikePredicate;
 import io.trino.sql.tree.LogicalExpression;
 import io.trino.sql.tree.NotExpression;
 import io.trino.sql.tree.NullIfExpression;
+import io.trino.sql.tree.NullLiteral;
 import io.trino.sql.tree.StringLiteral;
 import io.trino.sql.tree.SymbolReference;
 import io.trino.testing.TestingConnectorSession;
@@ -441,20 +442,6 @@ public class TestPostgreSqlClient
                                 Map.of("c_varchar", VARCHAR_COLUMN.getColumnType(), "c_varchar2", VARCHAR_COLUMN2.getColumnType())),
                 Map.of(VARCHAR_COLUMN.getColumnName(), VARCHAR_COLUMN, VARCHAR_COLUMN2.getColumnName(), VARCHAR_COLUMN2)))
                 .hasValue("(\"c_varchar\") IN ('value1', 'value2', \"c_varchar2\")");
-    }
-
-    @Test
-    public void testConvertInWithNulls()
-    {
-        assertThat(JDBC_CLIENT.convertPredicate(
-                SESSION,
-                translateToConnectorExpression(
-                        new InPredicate(
-                                new SymbolReference("c_varchar"),
-                                new InListExpression(List.of(new StringLiteral("value1"), new StringLiteral("value2"), new Cast(new NullLiteral(), toSqlType(VARCHAR_COLUMN.getColumnType())), new SymbolReference("c_varchar2")))),
-                        Map.of("c_varchar", VARCHAR_COLUMN.getColumnType(), "c_varchar2", VARCHAR_COLUMN2.getColumnType())),
-                Map.of(VARCHAR_COLUMN.getColumnName(), VARCHAR_COLUMN, VARCHAR_COLUMN2.getColumnName(), VARCHAR_COLUMN2)))
-                .hasValue("(\"c_varchar\") IN ('value1', 'value2', CAST(NULL AS varchar(10)), \"c_varchar2\")");
     }
 
     @Test

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlClient.java
@@ -48,7 +48,6 @@ import io.trino.sql.tree.LikePredicate;
 import io.trino.sql.tree.LogicalExpression;
 import io.trino.sql.tree.NotExpression;
 import io.trino.sql.tree.NullIfExpression;
-import io.trino.sql.tree.NullLiteral;
 import io.trino.sql.tree.StringLiteral;
 import io.trino.sql.tree.SymbolReference;
 import io.trino.testing.TestingConnectorSession;

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -862,6 +862,24 @@ public class TestPostgreSqlConnectorTest
         }
     }
 
+    @Test
+    public void tmpTest()
+    {
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "test_cast_pushdown",
+                "(id bigint, id2 varchar(10485761))",
+                List.of(
+                        "1, 'b'",
+                        "2, 'c'",
+                        "3, 'c'",
+                        "4, 'd'",
+                        "5, 'f'"))) {
+            assertThat(query("SELECT id FROM " + table.getName() + " WHERE CAST(id AS VARCHAR(1)) = '2' OR id2 = 'd'"))
+                    .isFullyPushedDown();
+        }
+    }
+
     @Override
     protected String errorMessageForInsertIntoNotNullColumn(String columnName)
     {

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -811,6 +811,39 @@ public class TestPostgreSqlConnectorTest
         }
     }
 
+    @Test
+    public void testInPredicatePushdown()
+    {
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "test_in_predicate_pushdown",
+                "(id varchar(1), id2 varchar(1))",
+                List.of(
+                        "'a', 'b'",
+                        "'b', 'c'",
+                        "'c', 'c'",
+                        "'d', 'd'",
+                        "'a', 'f'"))) {
+            // IN values cannot be represented as a domain
+            assertThat(query("SELECT id FROM " + table.getName() + " WHERE id IN ('a', id2)"))
+                    .isFullyPushedDown();
+
+            assertThat(query("SELECT id FROM " + table.getName() + " WHERE id IN ('a', 'b') OR id2 IN ('c', 'd')"))
+                    .isFullyPushedDown();
+
+            assertThat(query("SELECT id FROM " + table.getName() + " WHERE id IN ('a', 'B') OR id2 IN ('c', 'D')"))
+                    .isFullyPushedDown();
+
+            assertThat(query("SELECT id FROM " + table.getName() + " WHERE id IN ('a', 'B', NULL) OR id2 IN ('C', 'd')"))
+                    // NULL constant value is currently not pushed down
+                    .isNotFullyPushedDown(FilterNode.class);
+
+            assertThat(query("SELECT id FROM " + table.getName() + " WHERE id IN ('a', 'B', CAST(NULL AS varchar(1))) OR id2 IN ('C', 'd')"))
+                    // NULL constant value is currently not pushed down
+                    .isNotFullyPushedDown(FilterNode.class);
+        }
+    }
+
     @Override
     protected String errorMessageForInsertIntoNotNullColumn(String columnName)
     {

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -844,6 +844,24 @@ public class TestPostgreSqlConnectorTest
         }
     }
 
+    @Test
+    public void testCastPushdown()
+    {
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "test_cast_pushdown",
+                "(id bigint, id2 varchar(1))",
+                List.of(
+                        "1, 'b'",
+                        "2, 'c'",
+                        "3, 'c'",
+                        "4, 'd'",
+                        "5, 'f'"))) {
+            assertThat(query("SELECT id FROM " + table.getName() + " WHERE CAST(id AS VARCHAR(1)) = '2' OR id2 = 'd'"))
+                    .isFullyPushedDown();
+        }
+    }
+
     @Override
     protected String errorMessageForInsertIntoNotNullColumn(String columnName)
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Adds translation for InPredicate and InListExpression to connector expression form.

> Is this change a fix, improvement, new feature, refactoring, or other?

New feature.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core engine & postgres connector.

> How would you describe this change to a non-technical end user or system administrator?

This enabled pushdown of IN predicates which are not expressible with Domain (i.e. references other symbols or contains function calls)

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
