### PR TITLE
Support table statistic and join pushdown in MariaDB

### DIFF
--- a/docs/src/main/sphinx/connector/mariadb.rst
+++ b/docs/src/main/sphinx/connector/mariadb.rst
@@ -177,6 +177,42 @@ Performance
 The connector includes a number of performance improvements, detailed in the
 following sections.
 
+.. _mariadb-table-statistics:
+
+Table statistics
+^^^^^^^^^^^^^^^^
+
+The MariaDB connector can use :doc:`table and column statistics
+</optimizer/statistics>` for :doc:`cost based optimizations
+</optimizer/cost-based-optimizations>`, to improve query processing performance
+based on the actual data in the data source.
+
+The statistics are collected by MariaDB and retrieved by the connector.
+
+The table-level statistics are based on MariaDB's ``mysql.table_stats``
+table. The column-level statistics are based on MariaDB's table statistics
+``mysql.column_stats`` table. The connector can return column-level
+statistics after run the ``ANALYZE TABLE`` command in MariaDB. You can do
+that by executing the following statement in MariaDB Database.
+
+.. code-block:: text
+
+    ANALYZE TABLE table_name PERSISTENT FOR ALL;
+
+.. note::
+
+    MariaDB and Trino may use statistics information in different ways. For this
+    reason, the accuracy of table and column statistics returned by the MariaDB
+    connector might be lower than that of others connectors.
+
+**Improving statistics accuracy**
+
+More statistics accuracy with histogram statistics with ``histogram_type=JSON_HB`` (
+available since MariaDB 10.8).
+
+Refer to MariaDB documentation for information about options, limitations
+and additional considerations.
+
 .. _mariadb-pushdown:
 
 Pushdown

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
@@ -1323,7 +1323,7 @@ public abstract class BaseJdbcConnectorTest
         throw new AssertionError(); // unreachable
     }
 
-    private boolean expectVarcharJoinPushdown(String operator)
+    protected boolean expectVarcharJoinPushdown(String operator)
     {
         if ("IS NOT DISTINCT FROM".equals(operator)) {
             // TODO (https://github.com/trinodb/trino/issues/6967) support join pushdown for IS NOT DISTINCT FROM

--- a/plugin/trino-mariadb/pom.xml
+++ b/plugin/trino-mariadb/pom.xml
@@ -29,6 +29,21 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
@@ -44,17 +59,16 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
         </dependency>
 
         <!-- used by tests but also needed transitively -->
-        <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>log</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>log-manager</artifactId>

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbClient.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbClient.java
@@ -19,6 +19,7 @@ import io.trino.plugin.jdbc.DefaultQueryBuilder;
 import io.trino.plugin.jdbc.JdbcClient;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
+import io.trino.plugin.jdbc.JdbcStatisticsConfig;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
 import io.trino.plugin.jdbc.mapping.DefaultIdentifierMapping;
 import io.trino.spi.connector.AggregateFunction;
@@ -58,6 +59,7 @@ public class TestMariaDbClient
 
     private static final JdbcClient JDBC_CLIENT = new MariaDbClient(
             new BaseJdbcConfig(),
+            new JdbcStatisticsConfig(),
             session -> {
                 throw new UnsupportedOperationException();
             },

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbConnectorTest.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbConnectorTest.java
@@ -16,6 +16,7 @@ package io.trino.plugin.mariadb;
 import com.google.common.collect.ImmutableMap;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.sql.SqlExecutor;
+import org.testng.SkipException;
 
 import static io.trino.plugin.mariadb.MariaDbQueryRunner.createMariaDbQueryRunner;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -42,5 +43,26 @@ public class TestMariaDbConnectorTest
     {
         assertThatThrownBy(super::testRenameColumn)
                 .hasMessageContaining("Rename column not supported for the MariaDB server version");
+    }
+
+    @Override
+    public void testJoinPushdown()
+    {
+        // Currently only the histogram_type=JSON_HB which enabled from MariaDB 10.8
+        throw new SkipException("Not support");
+    }
+
+    @Override
+    public void testLimitPushdown()
+    {
+        // Currently only the histogram_type=JSON_HB which enabled from MariaDB 10.8
+        throw new SkipException("Not support");
+    }
+
+    @Override
+    public void testAggregationPushdown()
+    {
+        // Currently only the histogram_type=JSON_HB which enabled from MariaDB 10.8
+        throw new SkipException("Not support");
     }
 }

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbLatestConnectorTest.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbLatestConnectorTest.java
@@ -13,12 +13,36 @@
  */
 package io.trino.plugin.mariadb;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
+import io.trino.spi.connector.JoinCondition;
+import io.trino.sql.planner.assertions.PlanMatchPattern;
+import io.trino.sql.planner.plan.AggregationNode;
+import io.trino.sql.planner.plan.ExchangeNode;
+import io.trino.sql.planner.plan.FilterNode;
+import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.LimitNode;
+import io.trino.sql.planner.plan.OutputNode;
+import io.trino.sql.planner.plan.TableScanNode;
+import io.trino.sql.planner.plan.TopNNode;
+import io.trino.sql.planner.plan.ValuesNode;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.sql.SqlExecutor;
+import io.trino.testing.sql.TestTable;
+import org.testng.annotations.BeforeClass;
 
+import java.util.List;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.mariadb.MariaDbQueryRunner.createMariaDbQueryRunner;
 import static io.trino.plugin.mariadb.TestingMariaDbServer.LATEST_VERSION;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.exchange;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestMariaDbLatestConnectorTest
         extends BaseMariaDbConnectorTest
@@ -27,7 +51,7 @@ public class TestMariaDbLatestConnectorTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        server = closeAfterClass(new TestingMariaDbServer(LATEST_VERSION));
+        server = closeAfterClass(new TestingMariaDbServer(LATEST_VERSION, null));
         return createMariaDbQueryRunner(server, ImmutableMap.of(), ImmutableMap.of(), REQUIRED_TPCH_TABLES);
     }
 
@@ -35,5 +59,368 @@ public class TestMariaDbLatestConnectorTest
     protected SqlExecutor onRemoteDatabase()
     {
         return server::execute;
+    }
+
+    @BeforeClass
+    public void setUpTables()
+    {
+        server.execute("ANALYZE TABLE tpch.nation PERSISTENT FOR ALL;");
+        server.execute("ANALYZE TABLE tpch.region PERSISTENT FOR ALL;");
+        server.execute("ANALYZE TABLE tpch.orders PERSISTENT FOR ALL;");
+        server.execute("ANALYZE TABLE tpch.customer PERSISTENT FOR ALL;");
+    }
+
+    @Override
+    public void testJoinPushdown()
+    {
+        PlanMatchPattern joinOverTableScans =
+                node(JoinNode.class,
+                        anyTree(node(TableScanNode.class)),
+                        anyTree(node(TableScanNode.class)));
+
+        PlanMatchPattern broadcastJoinOverTableScans =
+                node(JoinNode.class,
+                        node(TableScanNode.class),
+                        exchange(ExchangeNode.Scope.LOCAL,
+                                exchange(ExchangeNode.Scope.REMOTE, ExchangeNode.Type.REPLICATE,
+                                        node(TableScanNode.class))));
+
+        Session session = joinPushdownEnabled(getSession());
+
+        // Disable DF here for the sake of negative test cases' expected plan. With DF enabled, some operators return in DF's FilterNode and some do not.
+        Session withoutDynamicFiltering = Session.builder(session)
+                .setSystemProperty("enable_dynamic_filtering", "false")
+                .build();
+
+        String notDistinctOperator = "IS NOT DISTINCT FROM";
+        List<String> nonEqualities = Stream.concat(
+                        Stream.of(JoinCondition.Operator.values())
+                                .filter(operator -> operator != JoinCondition.Operator.EQUAL)
+                                .map(JoinCondition.Operator::getValue),
+                        Stream.of(notDistinctOperator))
+                .collect(toImmutableList());
+
+        try (TestTable nationLowercaseTable = new TestTable(
+                // If a connector supports Join pushdown, but does not allow CTAS, we need to make the table creation here overridable.
+                getQueryRunner()::execute,
+                "nation_lowercase",
+                "AS SELECT nationkey, lower(name) name, regionkey FROM nation")) {
+            // basic case
+            assertThat(query(session, "SELECT c.custkey, o.orderkey FROM customer c JOIN orders o ON c.custkey = o.custkey")).isFullyPushedDown();
+
+            // join over different columns
+            assertThat(query(session, "SELECT r.name, n.name FROM nation n JOIN region r ON n.nationkey = r.regionkey")).isFullyPushedDown();
+
+            // pushdown when using USING
+            assertThat(query(session, "SELECT o.orderkey FROM customer c JOIN orders o USING(custkey)")).isFullyPushedDown();
+
+            // varchar equality predicate
+            assertConditionallyPushedDown(
+                    session,
+                    "SELECT n.name, n2.regionkey FROM nation n JOIN nation n2 ON n.name = n2.name",
+                    false,
+                    joinOverTableScans);
+            assertConditionallyPushedDown(
+                    session,
+                    format("SELECT n.name, nl.regionkey FROM nation n JOIN %s nl ON n.name = nl.name", nationLowercaseTable.getName()),
+                    false,
+                    joinOverTableScans);
+
+            // multiple bigint predicates
+            assertThat(query(session, "SELECT n.name, c.name FROM nation n JOIN customer c ON n.nationkey = c.nationkey and n.regionkey = c.custkey"))
+                    .isFullyPushedDown();
+
+            // inequality
+            for (String operator : nonEqualities) {
+                // bigint inequality predicate
+                assertThat(query(withoutDynamicFiltering, format("SELECT r.name, n.name FROM nation n JOIN region r ON n.regionkey %s r.regionkey", operator)))
+                        // Currently no pushdown as inequality predicate is removed from Join to maintain Cross Join and Filter as separate nodes
+                        .isNotFullyPushedDown(broadcastJoinOverTableScans);
+
+                // varchar inequality predicate
+                assertThat(query(withoutDynamicFiltering, format("SELECT n.name, nl.name FROM nation n JOIN %s nl ON n.name %s nl.name", nationLowercaseTable.getName(), operator)))
+                        // Currently no pushdown as inequality predicate is removed from Join to maintain Cross Join and Filter as separate nodes
+                        .isNotFullyPushedDown(broadcastJoinOverTableScans);
+            }
+
+            // inequality along with an equality, which constitutes an equi-condition and allows filter to remain as part of the Join
+            for (String operator : nonEqualities) {
+                assertConditionallyPushedDown(
+                        session,
+                        format("SELECT n.nationkey FROM nation n JOIN customer c ON n.nationkey = c.nationkey AND n.regionkey %s c.custkey", operator),
+                        expectJoinPushdown(operator),
+                        joinOverTableScans);
+            }
+
+            // varchar inequality along with an equality, which constitutes an equi-condition and allows filter to remain as part of the Join
+            for (String operator : nonEqualities) {
+                assertConditionallyPushedDown(
+                        session,
+                        format("SELECT n.name, nl.name FROM nation n JOIN %s nl ON n.regionkey = nl.regionkey AND n.name %s nl.name", nationLowercaseTable.getName(), operator),
+                        expectVarcharJoinPushdown(operator),
+                        joinOverTableScans);
+            }
+
+            // LEFT JOIN
+            assertThat(query(session, "SELECT c.custkey, o.orderkey FROM customer c LEFT JOIN orders o ON c.custkey = o.custkey")).isFullyPushedDown();
+            assertThat(query(session, "SELECT c.custkey, o.orderkey FROM orders o LEFT JOIN customer c ON c.custkey = o.custkey")).isFullyPushedDown();
+
+            // RIGHT JOIN
+            assertThat(query(session, "SELECT c.custkey, o.orderkey FROM customer c RIGHT JOIN orders o ON c.custkey = o.custkey")).isFullyPushedDown();
+            assertThat(query(session, "SELECT c.custkey, o.orderkey FROM orders o RIGHT JOIN customer c ON c.custkey = o.custkey")).isFullyPushedDown();
+
+            // FULL JOIN
+            assertConditionallyPushedDown(
+                    session,
+                    "SELECT r.name, n.name FROM nation n FULL JOIN region r ON n.nationkey = r.regionkey",
+                    false,
+                    joinOverTableScans);
+
+            // Join over a (double) predicate
+            assertThat(query(session, "" +
+                    "SELECT c.name, n.name " +
+                    "FROM (SELECT * FROM customer WHERE acctbal > 8000) c " +
+                    "JOIN nation n ON c.custkey = n.nationkey"))
+                    .isFullyPushedDown();
+
+            // Join over a varchar equality predicate
+            assertConditionallyPushedDown(
+                    session,
+                    "SELECT c.name, n.name FROM (SELECT * FROM customer WHERE address = 'TcGe5gaZNgVePxU5kRrvXBfkasDTea') c " +
+                            "JOIN nation n ON c.custkey = n.nationkey",
+                    false,
+                    joinOverTableScans);
+
+            // Join over a varchar inequality predicate
+            assertConditionallyPushedDown(
+                    session,
+                    "SELECT c.name, n.name FROM (SELECT * FROM customer WHERE address < 'TcGe5gaZNgVePxU5kRrvXBfkasDTea') c " +
+                            "JOIN nation n ON c.custkey = n.nationkey",
+                    false,
+                    joinOverTableScans);
+
+            // join over aggregation
+            assertConditionallyPushedDown(
+                    session,
+                    "SELECT * FROM (SELECT regionkey rk, count(nationkey) c FROM nation GROUP BY regionkey) n " +
+                            "JOIN region r ON n.rk = r.regionkey",
+                    true,
+                    joinOverTableScans);
+
+            // join over LIMIT
+            assertConditionallyPushedDown(
+                    session,
+                    "SELECT * FROM (SELECT nationkey FROM nation LIMIT 30) n " +
+                            "JOIN region r ON n.nationkey = r.regionkey",
+                    true,
+                    joinOverTableScans);
+
+            // join over TopN
+            assertConditionallyPushedDown(
+                    session,
+                    "SELECT * FROM (SELECT nationkey FROM nation ORDER BY regionkey LIMIT 5) n " +
+                            "JOIN region r ON n.nationkey = r.regionkey",
+                    true,
+                    joinOverTableScans);
+
+            // join over join
+            assertThat(query(session, "SELECT c.custkey, o.orderkey FROM customer c, orders o, nation n WHERE c.custkey = o.custkey AND c.nationkey = n.nationkey"))
+                    .isFullyPushedDown();
+        }
+    }
+
+    @Override
+    public void testAggregationPushdown()
+    {
+        // TODO support aggregation pushdown with GROUPING SETS
+        // TODO support aggregation over expressions
+
+        // count()
+        assertThat(query("SELECT count(*) FROM nation")).isFullyPushedDown();
+        assertThat(query("SELECT count(nationkey) FROM nation")).isFullyPushedDown();
+        assertThat(query("SELECT count(1) FROM nation")).isFullyPushedDown();
+        assertThat(query("SELECT count() FROM nation")).isFullyPushedDown();
+        assertThat(query("SELECT regionkey, count(1) FROM nation GROUP BY regionkey")).isFullyPushedDown();
+        try (TestTable emptyTable = createAggregationTestTable(getSession().getSchema().orElseThrow() + ".empty_table", ImmutableList.of())) {
+            assertThat(query("SELECT count(*) FROM " + emptyTable.getName())).isFullyPushedDown();
+            assertThat(query("SELECT count(a_bigint) FROM " + emptyTable.getName())).isFullyPushedDown();
+            assertThat(query("SELECT count(1) FROM " + emptyTable.getName())).isFullyPushedDown();
+            assertThat(query("SELECT count() FROM " + emptyTable.getName())).isFullyPushedDown();
+            assertThat(query("SELECT a_bigint, count(1) FROM " + emptyTable.getName() + " GROUP BY a_bigint")).isFullyPushedDown();
+        }
+
+        // GROUP BY
+        assertThat(query("SELECT regionkey, min(nationkey) FROM nation GROUP BY regionkey")).isFullyPushedDown();
+        assertThat(query("SELECT regionkey, max(nationkey) FROM nation GROUP BY regionkey")).isFullyPushedDown();
+        assertThat(query("SELECT regionkey, sum(nationkey) FROM nation GROUP BY regionkey")).isFullyPushedDown();
+        assertThat(query("SELECT regionkey, avg(nationkey) FROM nation GROUP BY regionkey")).isFullyPushedDown();
+        try (TestTable emptyTable = createAggregationTestTable(getSession().getSchema().orElseThrow() + ".empty_table", ImmutableList.of())) {
+            assertThat(query("SELECT t_double, min(a_bigint) FROM " + emptyTable.getName() + " GROUP BY t_double")).isFullyPushedDown();
+            assertThat(query("SELECT t_double, max(a_bigint) FROM " + emptyTable.getName() + " GROUP BY t_double")).isFullyPushedDown();
+            assertThat(query("SELECT t_double, sum(a_bigint) FROM " + emptyTable.getName() + " GROUP BY t_double")).isFullyPushedDown();
+            assertThat(query("SELECT t_double, avg(a_bigint) FROM " + emptyTable.getName() + " GROUP BY t_double")).isFullyPushedDown();
+        }
+
+        // GROUP BY and WHERE on bigint column
+        // GROUP BY and WHERE on aggregation key
+        assertThat(query("SELECT regionkey, sum(nationkey) FROM nation WHERE regionkey < 4 GROUP BY regionkey")).isFullyPushedDown();
+
+        // GROUP BY and WHERE on varchar column
+        // GROUP BY and WHERE on "other" (not aggregation key, not aggregation input)
+        assertConditionallyPushedDown(
+                getSession(),
+                "SELECT regionkey, sum(nationkey) FROM nation WHERE regionkey < 4 AND name > 'AAA' GROUP BY regionkey",
+                false,
+                node(FilterNode.class, node(TableScanNode.class)));
+        // GROUP BY above WHERE and LIMIT
+        assertConditionallyPushedDown(
+                getSession(),
+                "SELECT regionkey, sum(nationkey) FROM (SELECT * FROM nation WHERE regionkey < 2 LIMIT 11) GROUP BY regionkey",
+                true,
+                node(LimitNode.class, anyTree(node(TableScanNode.class))));
+        // GROUP BY above TopN
+        assertConditionallyPushedDown(
+                getSession(),
+                "SELECT custkey, sum(totalprice) FROM (SELECT custkey, totalprice FROM orders ORDER BY orderdate ASC, totalprice ASC LIMIT 10) GROUP BY custkey",
+                true,
+                node(TopNNode.class, anyTree(node(TableScanNode.class))));
+        // GROUP BY with JOIN
+        assertConditionallyPushedDown(
+                joinPushdownEnabled(getSession()),
+                "SELECT n.regionkey, sum(c.acctbal) acctbals FROM nation n LEFT JOIN customer c USING (nationkey) GROUP BY 1",
+                true,
+                node(JoinNode.class, anyTree(node(TableScanNode.class)), anyTree(node(TableScanNode.class))));
+        // GROUP BY with WHERE on neither grouping nor aggregation column
+        assertConditionallyPushedDown(
+                getSession(),
+                "SELECT nationkey, min(regionkey) FROM nation WHERE name = 'ARGENTINA' GROUP BY nationkey",
+                false,
+                node(FilterNode.class, node(TableScanNode.class)));
+        // GROUP BY with WHERE complex predicate
+        assertConditionallyPushedDown(
+                getSession(),
+                "SELECT regionkey, sum(nationkey) FROM nation WHERE name LIKE '%N%' GROUP BY regionkey",
+                false,
+                node(FilterNode.class, node(TableScanNode.class)));
+        // aggregation on varchar column
+        assertThat(query("SELECT count(name) FROM nation")).isFullyPushedDown();
+        // aggregation on varchar column with GROUPING
+        assertThat(query("SELECT nationkey, count(name) FROM nation GROUP BY nationkey")).isFullyPushedDown();
+        // aggregation on varchar column with WHERE
+        assertConditionallyPushedDown(
+                getSession(),
+                "SELECT count(name) FROM nation WHERE name = 'ARGENTINA'",
+                false,
+                node(FilterNode.class, node(TableScanNode.class)));
+
+        // pruned away aggregation
+        assertThat(query("SELECT -13 FROM (SELECT count(*) FROM nation)"))
+                .matches("VALUES -13")
+                .hasPlan(node(OutputNode.class, node(ValuesNode.class)));
+        // aggregation over aggregation
+        assertThat(query("SELECT count(*) FROM (SELECT count(*) FROM nation)"))
+                .matches("VALUES BIGINT '1'")
+                .hasPlan(node(OutputNode.class, node(ValuesNode.class)));
+        assertThat(query("SELECT count(*) FROM (SELECT count(*) FROM nation GROUP BY regionkey)"))
+                .matches("VALUES BIGINT '5'")
+                .isFullyPushedDown();
+
+        // aggregation with UNION ALL and aggregation
+        assertThat(query("SELECT count(*) FROM (SELECT name FROM nation UNION ALL SELECT name FROM region)"))
+                .matches("VALUES BIGINT '30'")
+                // TODO (https://github.com/trinodb/trino/issues/12547): support count(*) over UNION ALL pushdown
+                .isNotFullyPushedDown(
+                        node(ExchangeNode.class,
+                                node(AggregationNode.class, node(TableScanNode.class)),
+                                node(AggregationNode.class, node(TableScanNode.class))));
+
+        // aggregation with UNION ALL and aggregation
+        assertThat(query("SELECT count(*) FROM (SELECT count(*) FROM nation UNION ALL SELECT count(*) FROM region)"))
+                .matches("VALUES BIGINT '2'")
+                .hasPlan(
+                        // Note: engine could fold this to single ValuesNode
+                        node(OutputNode.class,
+                                node(AggregationNode.class,
+                                        node(ExchangeNode.class,
+                                                node(ExchangeNode.class,
+                                                        node(AggregationNode.class, node(ValuesNode.class)),
+                                                        node(AggregationNode.class, node(ValuesNode.class)))))));
+    }
+
+    @Override
+    public void testLimitPushdown()
+    {
+        assertThat(query("SELECT name FROM nation LIMIT 30")).isFullyPushedDown(); // Use high limit for result determinism
+        assertThat(query("SELECT name FROM nation LIMIT 3")).skipResultsCorrectnessCheckForPushdown().isFullyPushedDown();
+
+        // with filter over numeric column
+        assertThat(query("SELECT name FROM nation WHERE regionkey = 3 LIMIT 5")).isFullyPushedDown();
+
+        // with filter over varchar column
+        PlanMatchPattern filterOverTableScan = node(FilterNode.class, node(TableScanNode.class));
+        assertConditionallyPushedDown(
+                getSession(),
+                "SELECT name FROM nation WHERE name < 'EEE' LIMIT 5",
+                false,
+                filterOverTableScan);
+
+        // with aggregation
+        PlanMatchPattern aggregationOverTableScan = node(AggregationNode.class, anyTree(node(TableScanNode.class)));
+        assertConditionallyPushedDown(
+                getSession(),
+                "SELECT max(regionkey) FROM nation LIMIT 5", // global aggregation, LIMIT removed
+                true,
+                aggregationOverTableScan);
+        assertConditionallyPushedDown(
+                getSession(),
+                "SELECT regionkey, max(nationkey) FROM nation GROUP BY regionkey LIMIT 5",
+                true,
+                aggregationOverTableScan);
+
+        // distinct limit can be pushed down even without aggregation pushdown
+        assertThat(query("SELECT DISTINCT regionkey FROM nation LIMIT 5")).isFullyPushedDown();
+
+        // with aggregation and filter over numeric column
+        assertConditionallyPushedDown(
+                getSession(),
+                "SELECT regionkey, count(*) FROM nation WHERE nationkey < 5 GROUP BY regionkey LIMIT 3",
+                true,
+                aggregationOverTableScan);
+        // with aggregation and filter over varchar column
+        if (false) {
+            assertConditionallyPushedDown(
+                    getSession(),
+                    "SELECT regionkey, count(*) FROM nation WHERE name < 'EGYPT' GROUP BY regionkey LIMIT 3",
+                    true,
+                    aggregationOverTableScan);
+        }
+
+        // with TopN over numeric column
+        PlanMatchPattern topnOverTableScan = node(TopNNode.class, anyTree(node(TableScanNode.class)));
+        assertConditionallyPushedDown(
+                getSession(),
+                "SELECT * FROM (SELECT regionkey FROM nation ORDER BY nationkey ASC LIMIT 10) LIMIT 5",
+                true,
+                topnOverTableScan);
+        // with TopN over varchar column
+        assertConditionallyPushedDown(
+                getSession(),
+                "SELECT * FROM (SELECT regionkey FROM nation ORDER BY name ASC LIMIT 10) LIMIT 5",
+                false,
+                topnOverTableScan);
+
+        // with join
+        PlanMatchPattern joinOverTableScans = node(JoinNode.class,
+                anyTree(node(TableScanNode.class)),
+                anyTree(node(TableScanNode.class)));
+        assertConditionallyPushedDown(
+                joinPushdownEnabled(getSession()),
+                //
+                "SELECT n.nationkey " +
+                        "FROM nation n " +
+                        "LEFT JOIN region r USING (regionkey) " +
+                        "LIMIT 30",
+                true,
+                joinOverTableScans);
     }
 }

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbTableStatisticsTest.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbTableStatisticsTest.java
@@ -1,0 +1,602 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mariadb;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
+import io.trino.SystemSessionProperties;
+import io.trino.plugin.jdbc.BaseJdbcTableStatisticsTest;
+import io.trino.sql.planner.plan.FilterNode;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.sql.TestTable;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static io.trino.plugin.mariadb.MariaDbQueryRunner.createMariaDbQueryRunner;
+import static io.trino.testing.sql.TestTable.fromColumns;
+import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.tpch.TpchTable.CUSTOMER;
+import static io.trino.tpch.TpchTable.NATION;
+import static io.trino.tpch.TpchTable.ORDERS;
+import static io.trino.tpch.TpchTable.REGION;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestMariaDbTableStatisticsTest
+        extends BaseJdbcTableStatisticsTest
+{
+    protected TestingMariaDbServer mariaDbServer;
+
+    @Override
+    protected QueryRunner createQueryRunner() throws Exception
+    {
+        // From MariaDB 10.8, JSON_HB, JSON-format histograms, are accepted, so used 10.8.3 version
+        mariaDbServer = closeAfterClass(new TestingMariaDbServer("10.8.3", "JSON_HB"));
+
+        return createMariaDbQueryRunner(
+                mariaDbServer,
+                ImmutableMap.of(),
+                ImmutableMap.of("case-insensitive-name-matching", "true"),
+                List.of(CUSTOMER, NATION, ORDERS, REGION));
+    }
+
+    @Override
+    public void setUpTables()
+    {
+        // Do nothing here
+    }
+
+    @Override
+    public void testNotAnalyzed()
+    {
+        String tableName = "test_not_analyzed_" + randomTableSuffix();
+        assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        computeActual(format("CREATE TABLE %s AS SELECT * FROM tpch.tiny.orders", tableName));
+        try {
+            assertQuery(
+                    "SHOW STATS FOR " + tableName,
+                    "VALUES " +
+                            "('orderkey', null, null, null, null, null, null)," +
+                            "('custkey', null, null, null, null, null, null)," +
+                            "('orderstatus', null, null, null, null, null, null)," +
+                            "('totalprice', null, null, null, null, null, null)," +
+                            "('orderdate', null, null, null, null, null, null)," +
+                            "('orderpriority', null, null, null, null, null, null)," +
+                            "('clerk', null, null, null, null, null, null)," +
+                            "('shippriority', null, null, null, null, null, null)," +
+                            "('comment', null, null, null, null, null, null)," +
+                            "(null, null, null, null, null, null, null)");
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableName);
+        }
+    }
+
+    @Override
+    public void testBasic()
+    {
+        String tableName = "test_stats_orders";
+        assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        computeActual(format("CREATE TABLE %s AS SELECT * FROM tpch.tiny.orders", tableName));
+        try {
+            gatherStats(tableName);
+            assertQuery(
+                    "SHOW STATS FOR " + tableName,
+                    "VALUES " +
+                            "('orderkey', null, 15000, 0, null, 1, 60000)," +
+                            "('custkey', null, 1231, 0, null, 1, 1499)," +
+                            "('orderstatus', null, null, null, null, null, null)," +
+                            "('totalprice', null, 14996, 0, null, 874.89, 466001.28)," +
+                            "('orderdate', null, 2599, 0, null, null, null)," +
+                            "('orderpriority', null, null, null, null, null, null)," +
+                            "('clerk', null, null, null, null, null, null)," +
+                            "('shippriority', null, 1, 0, null, 0, 0)," +
+                            "('comment', null, null, null, null, null, null)," +
+                            "(null, null, null, null, 15000, null, null)");
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableName);
+        }
+    }
+
+    @Override
+    public void testAllNulls()
+    {
+        String tableName = "test_stats_table_all_nulls";
+        assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        computeActual(format("CREATE TABLE %s AS SELECT orderkey, custkey, orderpriority, comment FROM tpch.tiny.orders WHERE false", tableName));
+        try {
+            computeActual(format("INSERT INTO %s (orderkey) VALUES NULL, NULL, NULL", tableName));
+            gatherStats(tableName);
+            assertQuery(
+                    "SHOW STATS FOR " + tableName,
+                    "VALUES " +
+                            "('orderkey', 0, null, 1, null, null, null)," +
+                            "('custkey', 0, null, 1, null, null, null)," +
+                            "('orderpriority', null, null, null, null, null, null)," +
+                            "('comment', null, null, null, null, null, null)," +
+                            "(null, null, null, null, 3, null, null)");
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableName);
+        }
+    }
+
+    @Override
+    public void testNullsFraction()
+    {
+        String tableName = "test_stats_table_with_nulls";
+        assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        assertUpdate("" +
+                        "CREATE TABLE " + tableName + " AS " +
+                        "SELECT " +
+                        "    orderkey, " +
+                        "    if(orderkey % 3 = 0, NULL, custkey) custkey, " +
+                        "    if(orderkey % 5 = 0, NULL, orderpriority) orderpriority " +
+                        "FROM tpch.tiny.orders",
+                15000);
+        try {
+            gatherStats(tableName);
+            assertQuery(
+                    "SHOW STATS FOR " + tableName,
+                    "VALUES " +
+                            "('orderkey', null, 15000, 0, null, 1, 60000)," +
+                            "('custkey', null, 1228, 0.33329999446868896, null, 1, 1499)," +
+                            "('orderpriority', null, null, null, null, null, null)," +
+                            "(null, null, null, null, 15000, null, null)");
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableName);
+        }
+    }
+
+    @Override
+    public void testAverageColumnLength()
+    {
+        String tableName = "test_stats_table_avg_col_len";
+        assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        computeActual("" +
+                "CREATE TABLE " + tableName + " AS SELECT " +
+                "  orderkey, " +
+                "  'abc' v3_in_3, " +
+                "  CAST('abc' AS varchar(42)) v3_in_42, " +
+                "  if(orderkey = 1, 9876543210, NULL) single_10v_value, " +
+                "  if(orderkey % 2 = 0, 9876543210, NULL) half_10v_value, " +
+                "  if(orderkey % 2 = 0, CAST((1000000 - orderkey) * (1000000 - orderkey) / 1000000 AS double), NULL) half_distinct_20v_value, " +
+                "  CAST(NULL AS varchar(10)) all_nulls " +
+                "FROM tpch.tiny.orders " +
+                "ORDER BY orderkey LIMIT 100");
+        try {
+            gatherStats(tableName);
+            assertQuery(
+                    "SHOW STATS FOR " + tableName,
+                    "VALUES " +
+                            "('orderkey', null, 100, 0, null, 1, 388)," +
+                            "('v3_in_3', null, null, null, null, null, null)," +
+                            "('v3_in_42', null, null, null, null, null, null)," +
+                            "('single_10v_value', null, 0.9999995231628418, 0.9900000047683716, null, 9876543210, 9876543210)," +
+                            "('half_10v_value', null, 1, 0.5, null, 9876543210, 9876543210)," +
+                            "('half_distinct_20v_value', null, 50, 0.5, null, 999224.0, 999996.0)," +
+                            "('all_nulls', null, null, null, null, null, null)," +
+                            "(null, null, null, null, 100, null, null)");
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableName);
+        }
+    }
+
+    @Override
+    public void testPartitionedTable()
+    {
+        String tableName = "test_stats_orders_part";
+        assertUpdate("DROP TABLE IF EXISTS " + tableName);
+
+        executeInMariaDb(format("CREATE TABLE %s (" +
+                "orderkey bigint(20) DEFAULT NULL," +
+                "custkey bigint(20) DEFAULT NULL," +
+                "orderstatus tinytext DEFAULT NULL," +
+                "totalprice double DEFAULT NULL," +
+                "orderdate date DEFAULT NULL," +
+                "orderpriority tinytext DEFAULT NULL," +
+                "clerk tinytext DEFAULT NULL," +
+                "shippriority int(11) DEFAULT NULL," +
+                "comment tinytext DEFAULT NULL" +
+                ") " +
+                "PARTITION BY RANGE (YEAR(orderdate)) " +
+                "(" +
+                "PARTITION p0 VALUES LESS THAN (1990)," +
+                "PARTITION p1 VALUES LESS THAN (1994)," +
+                "PARTITION p2 VALUES LESS THAN (1995)," +
+                "PARTITION p3 VALUES LESS THAN (1999)" +
+                ");", tableName));
+        executeInMariaDb(format("insert into %s select * from orders;", tableName));
+        try {
+            gatherStats(tableName);
+            assertQuery(
+                    "SHOW STATS FOR " + tableName,
+                    "VALUES " +
+                            "('orderkey', null, 15000, 0, null, 1, 60000)," +
+                            "('custkey', null, 1231, 0, null, 1, 1499)," +
+                            "('orderstatus', null, null, null, null, null, null)," +
+                            "('totalprice', null, 14996, 0, null, 874.89, 466001.28)," +
+                            "('orderdate', null, 2599, 0, null, null, null)," +
+                            "('orderpriority', null, null, null, null, null, null)," +
+                            "('clerk', null, null, null, null, null, null)," +
+                            "('shippriority', null, 1, 0, null, 0, 0)," +
+                            "('comment', null, null, null, null, null, null)," +
+                            "(null, null, null, null, 15000, null, null)");
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableName); // This removes child tables too
+        }
+    }
+
+    @Override
+    public void testView()
+    {
+        String tableName = "test_stats_view";
+        executeInMariaDb("CREATE OR REPLACE VIEW " + tableName + " AS SELECT orderkey, custkey, orderpriority, comment FROM orders");
+        try {
+            gatherStats(tableName);
+            assertQuery(
+                    "SHOW STATS FOR " + tableName,
+                    "VALUES " +
+                            "('orderkey', null, null, null, null, null, null)," +
+                            "('custkey', null, null, null, null, null, null)," +
+                            "('orderpriority', null, null, null, null, null, null)," +
+                            "('comment', null, null, null, null, null, null)," +
+                            "(null, null, null, null, null, null, null)");
+            // It's not possible to ANALYZE a VIEW in MariaDB
+        }
+        finally {
+            executeInMariaDb("DROP VIEW " + tableName);
+        }
+    }
+
+    @Override
+    public void testMaterializedView()
+    {
+        throw new SkipException(""); // TODO Not support materialized view in MariaDB
+    }
+
+    @Override
+    @Test(dataProvider = "testCaseColumnNamesDataProvider")
+    public void testCaseColumnNames(String tableName)
+    {
+        executeInMariaDb(("" +
+                "CREATE TABLE " + tableName + " " +
+                "AS SELECT " +
+                "  orderkey AS CASE_UNQUOTED_UPPER, " +
+                "  custkey AS case_unquoted_lower, " +
+                "  orderstatus AS cASe_uNQuoTeD_miXED, " +
+                "  totalprice AS \"CASE_QUOTED_UPPER\", " +
+                "  orderdate AS \"case_quoted_lower\"," +
+                "  orderpriority AS \"CasE_QuoTeD_miXED\" " +
+                "FROM orders")
+                .replace("\"", "`"));
+        try {
+            gatherStats(tableName.replace("\"", "`"));
+            assertQuery(
+                    "SHOW STATS FOR " + tableName,
+                    "VALUES " +
+                            "('case_unquoted_upper', null, 15000, 0, null, 1, 60000)," +
+                            "('case_unquoted_lower', null, 1231, 0, null, 1, 1499)," +
+                            "('case_unquoted_mixed', null, null, null, null, null, null)," +
+                            "('case_quoted_upper', null, 14996, 0, null, 874.89, 466001.28)," +
+                            "('case_quoted_lower', null, 2599, 0, null, null, null)," +
+                            "('case_quoted_mixed', null, null, null, null, null, null)," +
+                            "(null, null, null, null, 15000, null, null)");
+        }
+        finally {
+            executeInMariaDb("DROP TABLE " + tableName.replace("\"", "`"));
+        }
+    }
+
+    @Override
+    public void testNumericCornerCases()
+    {
+        try (TestTable table = fromColumns(
+                getQueryRunner()::execute,
+                "test_numeric_corner_cases_",
+                ImmutableMap.<String, List<String>>builder()
+                        // TODO Infinity and NaNs not supported by MariaDB
+//                        .put("only_negative_infinity double", List.of("-infinity()", "-infinity()", "-infinity()", "-infinity()"))
+//                        .put("only_positive_infinity double", List.of("infinity()", "infinity()", "infinity()", "infinity()"))
+//                        .put("mixed_infinities double", List.of("-infinity()", "infinity()", "-infinity()", "infinity()"))
+//                        .put("mixed_infinities_and_numbers double", List.of("-infinity()", "infinity()", "-5.0", "7.0"))
+//                        .put("nans_only double", List.of("nan()", "nan()"))
+//                        .put("nans_and_numbers double", List.of("nan()", "nan()", "-5.0", "7.0"))
+                        .put("large_doubles double", List.of("CAST(-50371909150609548946090.0 AS DOUBLE)", "CAST(50371909150609548946090.0 AS DOUBLE)")) // 2^77 DIV 3
+                        .put("short_decimals_big_fraction decimal(16,15)", List.of("-1.234567890123456", "1.234567890123456"))
+                        .put("short_decimals_big_integral decimal(16,1)", List.of("-123456789012345.6", "123456789012345.6"))
+                        // DECIMALS up to precision 30 are supported
+                        .put("long_decimals_big_fraction decimal(30,29)", List.of("-1.23456789012345678901234567890", "1.23456789012345678901234567890"))
+                        .put("long_decimals_middle decimal(30,16)", List.of("-12345678901234.5678901234567890", "12345678901234.5678901234567890"))
+                        .put("long_decimals_big_integral decimal(30,1)", List.of("-12345678901234567890123456789.0", "12345678901234567890123456789.0"))
+                        .buildOrThrow(),
+                "null")) {
+            gatherStats(table.getName());
+            assertQuery(
+                    "SHOW STATS FOR " + table.getName(),
+                    "VALUES " +
+                            // TODO Infinity and NaNs not supported by MariaDB
+//                            "('only_negative_infinity', null, 1, 0, null, null, null)," +
+//                            "('only_positive_infinity', null, 1, 0, null, null, null)," +
+//                            "('mixed_infinities', null, 2, 0, null, null, null)," +
+//                            "('mixed_infinities_and_numbers', null, 4.0, 0.0, null, null, null)," +
+//                            "('nans_only', null, 1.0, 0.5, null, null, null)," +
+//                            "('nans_and_numbers', null, 3.0, 0.0, null, null, null)," +
+                            "('large_doubles', null, 2.0, 0.0, null, cast(-5.037190915060955E22 as double), cast(5.037190915060955E22 as double))," +
+                            "('short_decimals_big_fraction', null, 2.0, 0.0, null, -1.234567890123456, 1.234567890123456)," +
+                            "('short_decimals_big_integral', null, 2.0, 0.0, null, -123456789012345.6, 123456789012345.6)," +
+                            "('long_decimals_big_fraction', null, 2.0, 0.0, null, -1.2345678901234567, 1.2345678901234567)," +
+                            "('long_decimals_middle', null, 2.0, 0.0, null, -12345678901234.5678901234567890, 12345678901234.5678901234567890)," +
+                            "('long_decimals_big_integral', null, 2.0, 0.0, null, -12345678901234567890123456789.0, 12345678901234567890123456789.0)," +
+                            "(null, null, null, null, 2, null, null)");
+        }
+    }
+
+    @Override
+    protected void gatherStats(String tableName)
+    {
+        executeInMariaDb(format(
+                "ANALYZE TABLE %s PERSISTENT FOR ALL;", tableName));
+    }
+
+    protected void executeInMariaDb(String sql)
+    {
+        try (Handle handle = Jdbi.open(() -> mariaDbServer.createConnection())) {
+            handle.execute("USE tpch");
+            handle.execute(sql);
+        }
+    }
+
+    @Override
+    public void testStatsWithJoinPushdown()
+    {
+        String regionTable = "region_join";
+        String nationTable = "nation_join";
+        executeInMariaDb(format("CREATE TABLE %s AS SELECT * FROM region", regionTable));
+        executeInMariaDb(format("CREATE TABLE %s AS SELECT * FROM nation", nationTable));
+        gatherStats(regionTable);
+        gatherStats(nationTable);
+        // Simple join with heavily filtered side, should be eligible for pushdown.
+        String query = format(
+                "SELECT r.regionkey regionkey, r.name r_name, n.name n_name FROM %s r JOIN %s n ON r.regionkey = n.regionkey WHERE n.nationkey = 5",
+                regionTable, nationTable);
+
+        // Verify query can be pushed down, that's the situation we want to test for.
+        assertThat(query(query)).isFullyPushedDown();
+
+        assertThat(query("SHOW STATS FOR (" + query + ")"))
+                // Not testing average length and min/max, as this would make the test less reusable and is not that important to test.
+                .projected(0, 2, 3, 4)
+                .skippingTypesCheck()
+                .matches("VALUES " +
+                        "('regionkey', 1e0, 0e0, null)," +
+                        "('r_name', null, null, null)," +
+                        "('n_name', null, null, null)," +
+                        "(null, null, null, 1e0)");
+    }
+
+    @Override
+    public void testStatsWithPredicatePushdown()
+    {
+        String nationTable = "nation_predicate";
+        executeInMariaDb(format("CREATE TABLE %s AS SELECT * FROM nation", nationTable));
+        gatherStats(nationTable);
+        // Predicate on a numeric column. Should be eligible for pushdown.
+        String query = format("SELECT * FROM %s WHERE regionkey = 1", nationTable);
+
+        // Verify query can be pushed down, that's the situation we want to test for.
+        assertThat(query(query)).isFullyPushedDown();
+
+        assertThat(query("SHOW STATS FOR (" + query + ")"))
+                // Not testing average length and min/max, as this would make the test less reusable and is not that important to test.
+                .projected(0, 2, 3, 4)
+                .skippingTypesCheck()
+                .matches("VALUES " +
+                        "('nationkey', 5e0, 0e0, null)," +
+                        "('name', null, null, null)," +
+                        "('regionkey', 1e0, 0e0, null)," +
+                        "('comment', null, null, null)," +
+                        "(null, null, null, 5e0)");
+    }
+
+    @Override
+    public void testStatsWithPredicatePushdownWithStatsPrecalculationDisabled()
+    {
+        String nationTable = "nation_predicate_with";
+        executeInMariaDb(format("CREATE TABLE %s AS SELECT * FROM nation", nationTable));
+        gatherStats(nationTable);
+        // Predicate on a numeric column. Should be eligible for pushdown.
+        String query = format("SELECT * FROM %s WHERE regionkey = 1", nationTable);
+        Session session = Session.builder(getSession())
+                .setSystemProperty(SystemSessionProperties.STATISTICS_PRECALCULATION_FOR_PUSHDOWN_ENABLED, "false")
+                .build();
+
+        // Verify query can be pushed down, that's the situation we want to test for.
+        assertThat(query(session, query)).isFullyPushedDown();
+
+        assertThat(query(session, "SHOW STATS FOR (" + query + ")"))
+                // Not testing average length and min/max, as this would make the test less reusable and is not that important to test.
+                .projected(0, 2, 3, 4)
+                .skippingTypesCheck()
+                .matches("VALUES " +
+                        "('nationkey', 25e0, 0e0, null)," +
+                        "('name', null, null, null)," +
+                        "('regionkey', 5e0, 0e0, null)," +
+                        "('comment', null, null, null)," +
+                        "(null, null, null, 25e0)");
+    }
+
+    @Override
+    public void testStatsWithSimpleJoinPushdown()
+    {
+        String regionTable = "region_join1";
+        String nationTable = "nation_join1";
+        executeInMariaDb(format("CREATE TABLE %s AS SELECT * FROM region", regionTable));
+        executeInMariaDb(format("CREATE TABLE %s AS SELECT * FROM nation", nationTable));
+        gatherStats(regionTable);
+        gatherStats(nationTable);
+        // Simple filtering join with no predicates, should be eligible for pushdown.
+        String query = format("SELECT n.name n_name FROM %s n JOIN %s r ON n.nationkey = r.regionkey", nationTable, regionTable);
+
+        // Verify query can be pushed down, that's the situation we want to test for.
+        assertThat(query(query)).isFullyPushedDown();
+
+        assertThat(query("SHOW STATS FOR (" + query + ")"))
+                // Not testing average length and min/max, as this would make the test less reusable and is not that important to test.
+                .projected(0, 2, 3, 4)
+                .skippingTypesCheck()
+                .matches("VALUES " +
+                        "('n_name', null, null, null)," +
+                        "(null, null, null, 5e0)");
+    }
+
+    @Override
+    public void testStatsWithVarcharPredicatePushdown()
+    {
+        String nationTable = "nation_varchar";
+        executeInMariaDb(format("CREATE TABLE %s AS SELECT * FROM nation", nationTable));
+        gatherStats(nationTable);
+        String query = format("SELECT * FROM %s WHERE name = 'PERU'", nationTable);
+        // mariaDB will not collect the varchar statistics, so not fully pusheddown
+        assertThat(query(query)).isNotFullyPushedDown(FilterNode.class);
+
+        String tableName = "varchar_duplicates";
+        computeActual(format("CREATE TABLE %s AS SELECT nationkey, chr(codepoint('A') + nationkey / 5) fl FROM tpch.tiny.nation", tableName));
+        gatherStats(tableName);
+
+        String query1 = format("SELECT * FROM %s WHERE fl = 'B'", tableName);
+        // mariaDB will not collect the varchar statistics, so not fully pusheddown
+        assertThat(query(query1)).isNotFullyPushedDown(FilterNode.class);
+    }
+
+    @Override
+    public void testStatsWithAggregationPushdown()
+    {
+        String nationTable = "nation_aggregation";
+        executeInMariaDb(format("CREATE TABLE %s AS SELECT * FROM nation", nationTable));
+        gatherStats(nationTable);
+        // Simple aggregation, should be eligible for pushdown.
+        String query = format("SELECT regionkey, max(nationkey) max_nationkey, count(*) c FROM %s GROUP BY regionkey", nationTable);
+
+        // Verify query can be pushed down, that's the situation we want to test for.
+        assertThat(query(query)).isFullyPushedDown();
+
+        assertThat(query("SHOW STATS FOR (" + query + ")"))
+                // Not testing average length and min/max, as this would make the test less reusable and is not that important to test.
+                .projected(0, 2, 3, 4)
+                .skippingTypesCheck()
+                .matches("VALUES " +
+                        "('regionkey', 5e0, 0e0, null)," +
+                        "('max_nationkey', null, null, null)," +
+                        "('c', null, null, null)," +
+                        "(null, null, null, 5e0)");
+    }
+
+    @Override
+    public void testStatsWithDistinctLimitPushdown()
+    {
+        String nationTable = "nation_dis_limit";
+        executeInMariaDb(format("CREATE TABLE %s AS SELECT * FROM nation", nationTable));
+        gatherStats(nationTable);
+        // Distinct with limit (DistinctLimitNode), should be eligible for pushdown.
+        String query = format("SELECT DISTINCT regionkey FROM %s LIMIT 3", nationTable);
+
+        // Verify query can be pushed down, that's the situation we want to test for.
+        // it's important that we test with LIMIT value smaller than count(DISTINCT regionkey), hence need to skip results check
+        assertThat(query(query)).skipResultsCorrectnessCheckForPushdown().isFullyPushedDown();
+
+        assertThat(query("SHOW STATS FOR (" + query + ")"))
+                // Not testing average length and min/max, as this would make the test less reusable and is not that important to test.
+                .projected(0, 2, 3, 4)
+                .skippingTypesCheck()
+                .matches("VALUES " +
+                        "('regionkey', 3e0, 0e0, null)," +
+                        "(null, null, null, 3e0)");
+    }
+
+    @Override
+    public void testStatsWithLimitPushdown()
+    {
+        String nationTable = "nation_limit";
+        executeInMariaDb(format("CREATE TABLE %s AS SELECT * FROM nation", nationTable));
+        gatherStats(nationTable);
+        // Just limit, should be eligible for pushdown.
+        String query = format("SELECT regionkey, nationkey FROM %s LIMIT 2", nationTable);
+
+        // Verify query can be pushed down, that's the situation we want to test for.
+        // it's important that we test with LIMIT value smaller than table row count, hence need to skip results check
+        assertThat(query(query)).skipResultsCorrectnessCheckForPushdown().isFullyPushedDown();
+
+        assertThat(query("SHOW STATS FOR (" + query + ")"))
+                // Not testing average length and min/max, as this would make the test less reusable and is not that important to test.
+                .projected(0, 2, 3, 4)
+                .skippingTypesCheck()
+                .matches("VALUES " +
+                        "('regionkey', 2e0, 0e0, null)," +
+                        "('nationkey', 2e0, 0e0, null)," +
+                        "(null, null, null, 2e0)");
+    }
+
+    @Override
+    public void testStatsWithTopNPushdown()
+    {
+        String nationTable = "nation_topn";
+        executeInMariaDb(format("CREATE TABLE %s AS SELECT * FROM nation", nationTable));
+        gatherStats(nationTable);
+        // TopN on a numeric column, should be eligible for pushdown.
+        String query = format("SELECT regionkey, nationkey FROM %s ORDER BY regionkey LIMIT 2", nationTable);
+
+        // Verify query can be pushed down, that's the situation we want to test for.
+        // it's important that we test with LIMIT value smaller than table row count and we intentionally sort on a non-unique regionkey, hence need to skip results check.
+        assertThat(query(query)).skipResultsCorrectnessCheckForPushdown().isFullyPushedDown();
+
+        assertThat(query("SHOW STATS FOR (" + query + ")"))
+                // Not testing average length and min/max, as this would make the test less reusable and is not that important to test.
+                .projected(0, 2, 3, 4)
+                .skippingTypesCheck()
+                .matches("VALUES " +
+                        "('regionkey', 2e0, 0e0, null)," +
+                        "('nationkey', 2e0, 0e0, null)," +
+                        "(null, null, null, 2e0)");
+    }
+
+    @Override
+    public void testStatsWithDistinctPushdown()
+    {
+        String nationTable = "nation_dis";
+        executeInMariaDb(format("CREATE TABLE %s AS SELECT * FROM nation", nationTable));
+        gatherStats(nationTable);
+        // Just distinct, should be eligible for pushdown.
+        String query = format("SELECT DISTINCT regionkey FROM %s", nationTable);
+
+        // Verify query can be pushed down, that's the situation we want to test for.
+        assertThat(query(query)).isFullyPushedDown();
+
+        assertThat(query("SHOW STATS FOR (" + query + ")"))
+                // Not testing average length and min/max, as this would make the test less reusable and is not that important to test.
+                .projected(0, 2, 3, 4)
+                .skippingTypesCheck()
+                .matches("VALUES " +
+                        "('regionkey', 5e0, 0e0, null)," +
+                        "(null, null, null, 5e0)");
+    }
+}

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestingMariaDbServer.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestingMariaDbServer.java
@@ -34,16 +34,21 @@ public class TestingMariaDbServer
 
     public TestingMariaDbServer()
     {
-        this(DEFAULT_VERSION);
+        this(DEFAULT_VERSION, null);
     }
 
-    public TestingMariaDbServer(String tag)
+    public TestingMariaDbServer(String tag, String histogramType)
     {
         container = new MariaDBContainer<>(DockerImageName.parse("mariadb").withTag(tag))
                 .withDatabaseName("tpch");
         // character-set-server：the default character set is latin1
         // explicit-defaults-for-timestamp: 1 is ON, the default set is 0 (OFF)
-        container.withCommand("--character-set-server", "utf8mb4", "--explicit-defaults-for-timestamp=1");
+        if (histogramType == null) {
+            container.withCommand("--character-set-server", "utf8mb4", "--explicit-defaults-for-timestamp=1");
+        }
+        else {
+            container.withCommand("--character-set-server", "utf8mb4", "--explicit-defaults-for-timestamp=1", format("--histogram_type=%s", histogramType));
+        }
         container.start();
         execute(format("GRANT ALL PRIVILEGES ON *.* TO '%s'", container.getUsername()), "root", container.getPassword());
     }
@@ -51,6 +56,12 @@ public class TestingMariaDbServer
     public void execute(String sql)
     {
         execute(sql, getUsername(), getPassword());
+    }
+
+    public Connection createConnection()
+            throws SQLException
+    {
+        return container.createConnection("");
     }
 
     private void execute(String sql, String user, String password)


### PR DESCRIPTION
The Statistics and join pushdown based on MariaDB
Histogram-Based Statistics JSON-format histograms
which is accepted from 10.8

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
a connector - MariaDB

> How would you describe this change to a non-technical end user or system administrator?
Support table statistics and automatic join pushdown in MariaDB connector

## Related issues, pull requests, and links
fixes [12201](https://github.com/trinodb/trino/issues/12201)

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(X) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
