### PR TITLE
Avoid overriding nullability decision

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/NullabilityAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/NullabilityAnalyzer.java
@@ -65,7 +65,7 @@ public final class NullabilityAnalyzer
             // except for the CAST(NULL AS x) case -- we should fix this at some point)
             //
             // Also, try_cast (i.e., safe cast) can return null
-            result.set(node.isSafe() || !node.isTypeOnly());
+            result.compareAndSet(false, node.isSafe() || !node.isTypeOnly());
             return null;
         }
 


### PR DESCRIPTION
mayReturnNullOnNonNullInput currently returns different results for
expressions such as:

CAST(...) = CASE ...

when the terms appear in the opposite order.

This causes problems for some rules such as ReorderJoins, which relies
on the result of the check from one form of the expression to make
decisions about the alternative form of the expression.

Fixes https://github.com/trinodb/trino/issues/13145

## Documentation

(x) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# General
* Fix incorrect results for certain join queries containing filters involving explicit or implicit casts. ({issue}`13145 `)
```
