### PR TITLE
Remove outdated static INET type in CassandraTypes

### DIFF
--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraTypes.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraTypes.java
@@ -27,16 +27,10 @@ import io.trino.spi.type.UuidType;
 import io.trino.spi.type.VarbinaryType;
 
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
-import static io.trino.spi.type.VarcharType.createVarcharType;
 
 public final class CassandraTypes
 {
     private CassandraTypes() {}
-
-    // IPv4: 255.255.255.255 - 15 characters
-    // IPv6: FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF - 39 characters
-    // IPv4 embedded into IPv6: FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:255.255.255.255 - 45 characters
-    private static final int IP_ADDRESS_STRING_MAX_LENGTH = 45;
 
     public static final CassandraType ASCII = new CassandraType(Kind.ASCII, createUnboundedVarcharType());
     public static final CassandraType BIGINT = new CassandraType(Kind.BIGINT, BigintType.BIGINT);
@@ -48,7 +42,6 @@ public final class CassandraTypes
     public static final CassandraType DECIMAL = new CassandraType(Kind.DECIMAL, DoubleType.DOUBLE);
     public static final CassandraType DOUBLE = new CassandraType(Kind.DOUBLE, DoubleType.DOUBLE);
     public static final CassandraType FLOAT = new CassandraType(Kind.FLOAT, RealType.REAL);
-    public static final CassandraType INET = new CassandraType(Kind.INET, createVarcharType(IP_ADDRESS_STRING_MAX_LENGTH));
     public static final CassandraType INT = new CassandraType(Kind.INT, IntegerType.INTEGER);
     public static final CassandraType LIST = new CassandraType(Kind.LIST, createUnboundedVarcharType());
     public static final CassandraType MAP = new CassandraType(Kind.MAP, createUnboundedVarcharType());


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Removal of unused code.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

The Cassandra connector.

> How would you describe this change to a non-technical end user or system administrator?

Won't change any behavior.

## Related issues, pull requests, and links
This was meant to be part of https://github.com/trinodb/trino/pull/13068, but the change was lost while resolving a conflict during one of the fixes.

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->