### PR TITLE
Prevent `COMMENT ON TABLE` statement for view and materialized view

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/CommentTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CommentTask.java
@@ -89,6 +89,20 @@ public class CommentTask
     private void commentOnTable(Comment statement, Session session)
     {
         QualifiedObjectName originalTableName = createQualifiedObjectName(session, statement, statement.getName());
+        if (metadata.isMaterializedView(session, originalTableName)) {
+            throw semanticException(
+                    TABLE_NOT_FOUND,
+                    statement,
+                    "Table '%s' does not exist, but a materialized view with that name exists. Setting comments on materialized views is unsupported.", originalTableName);
+        }
+
+        if (metadata.isView(session, originalTableName)) {
+            throw semanticException(
+                    TABLE_NOT_FOUND,
+                    statement,
+                    "Table '%1$s' does not exist, but a view with that name exists. Did you mean COMMENT ON VIEW %1$s IS ...?", originalTableName);
+        }
+
         RedirectionAwareTableHandle redirectionAwareTableHandle = metadata.getRedirectionAwareTableHandle(session, originalTableName);
         if (redirectionAwareTableHandle.getTableHandle().isEmpty()) {
             throw semanticException(TABLE_NOT_FOUND, statement, "Table does not exist: %s", originalTableName);

--- a/core/trino-main/src/main/java/io/trino/execution/CommentTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CommentTask.java
@@ -119,7 +119,7 @@ public class CommentTask
         if (metadata.getView(session, viewName).isEmpty()) {
             String exceptionMessage = format("View '%s' does not exist", viewName);
             if (metadata.getMaterializedView(session, viewName).isPresent()) {
-                exceptionMessage += ", but a materialized view with that name exists.";
+                exceptionMessage += ", but a materialized view with that name exists. Setting comments on materialized views is unsupported.";
             }
             else if (metadata.getTableHandle(session, viewName).isPresent()) {
                 exceptionMessage += ", but a table with that name exists. Did you mean COMMENT ON TABLE " + viewName + " IS ...?";

--- a/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
+++ b/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
@@ -392,6 +392,18 @@ public abstract class BaseDataDefinitionTaskTest
         }
 
         @Override
+        public void setTableComment(Session session, TableHandle tableHandle, Optional<String> comment)
+        {
+            ConnectorTableMetadata tableMetadata = getTableMetadata(tableHandle);
+            ConnectorTableMetadata newTableMetadata = new ConnectorTableMetadata(
+                    tableMetadata.getTable(),
+                    tableMetadata.getColumns(),
+                    tableMetadata.getProperties(),
+                    comment);
+            tables.put(tableMetadata.getTable(), newTableMetadata);
+        }
+
+        @Override
         public void setViewComment(Session session, QualifiedObjectName viewName, Optional<String> comment)
         {
             ViewDefinition view = views.get(viewName.asSchemaTableName());

--- a/core/trino-main/src/test/java/io/trino/execution/TestCommentTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCommentTask.java
@@ -102,7 +102,7 @@ public class TestCommentTask
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(setComment(VIEW, asQualifiedName(materializedViewName), Optional.of("new comment"))))
                 .hasErrorCode(TABLE_NOT_FOUND)
-                .hasMessage("View '%s' does not exist, but a materialized view with that name exists.", materializedViewName);
+                .hasMessage("View '%s' does not exist, but a materialized view with that name exists. Setting comments on materialized views is unsupported.", materializedViewName);
     }
 
     private ListenableFuture<Void> setComment(Comment.Type type, QualifiedName viewName, Optional<String> comment)


### PR DESCRIPTION
## Description

Prevent `COMMENT ON TABLE` statement for view and materialized view.
The similar logic exists in `RenameTableTask` & `DropTableTask`.

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
