### PR TITLE
Add support for BigQuery external table

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,7 +478,7 @@ jobs:
           BIGQUERY_CREDENTIALS_KEY: ${{ secrets.BIGQUERY_CREDENTIALS_KEY }}
         if: matrix.modules == 'plugin/trino-bigquery' && env.BIGQUERY_CREDENTIALS_KEY != ''
         run: |
-          $MAVEN test ${MAVEN_TEST} -pl :trino-bigquery -Pcloud-tests -Dbigquery.credentials-key="${BIGQUERY_CREDENTIALS_KEY}"
+          $MAVEN test ${MAVEN_TEST} -pl :trino-bigquery -Pcloud-tests -Dbigquery.credentials-key="${BIGQUERY_CREDENTIALS_KEY}" -Dtesting.gcp-storage-bucket="trino-ci-test"
       - name: Cloud BigQuery Case Insensitive Mapping Tests
         env:
           BIGQUERY_CASE_INSENSITIVE_CREDENTIALS_KEY: ${{ secrets.BIGQUERY_CASE_INSENSITIVE_CREDENTIALS_KEY }}

--- a/plugin/trino-bigquery/README.md
+++ b/plugin/trino-bigquery/README.md
@@ -20,6 +20,8 @@ You can follow the steps below to be able to run the integration tests locally.
 * Run the script `plugin/trino-bigquery/bin/import-tpch-to-bigquery.sh` and pass your Google Cloud project id to it as
   an argument. e.g. `plugin/trino-bigquery/bin/import-tpch-to-bigquery.sh trino-bigquery-07` where `trino-bigquery-07`
   is your Google Cloud project id.
+* Run `gsutil cp src/test/resources/region.csv gs://DESTINATION_BUCKET_NAME/tpch/tiny/region.csv` 
+  (replace `DESTINATION_BUCKET_NAME` with the target bucket name).
 * [Create a service account](https://cloud.google.com/docs/authentication/getting-started) in Google Cloud with the
   **BigQuery Admin** role assigned.
 * Get the base64 encoded text of the service account credentials file using `base64

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
@@ -65,6 +65,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import static com.google.cloud.bigquery.TableDefinition.Type.EXTERNAL;
 import static com.google.cloud.bigquery.TableDefinition.Type.MATERIALIZED_VIEW;
 import static com.google.cloud.bigquery.TableDefinition.Type.TABLE;
 import static com.google.cloud.bigquery.TableDefinition.Type.VIEW;
@@ -180,7 +181,7 @@ public class BigQueryMetadata
         ImmutableList.Builder<SchemaTableName> tableNames = ImmutableList.builder();
         for (String remoteSchemaName : remoteSchemaNames) {
             try {
-                Iterable<Table> tables = client.listTables(DatasetId.of(projectId, remoteSchemaName), TABLE, VIEW, MATERIALIZED_VIEW);
+                Iterable<Table> tables = client.listTables(DatasetId.of(projectId, remoteSchemaName), TABLE, VIEW, MATERIALIZED_VIEW, EXTERNAL);
                 for (Table table : tables) {
                     // filter ambiguous tables
                     client.toRemoteTable(projectId, remoteSchemaName, table.getTableId().getTable().toLowerCase(ENGLISH), tables)

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitManager.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitManager.java
@@ -42,6 +42,7 @@ import javax.inject.Inject;
 import java.util.List;
 import java.util.Optional;
 
+import static com.google.cloud.bigquery.TableDefinition.Type.EXTERNAL;
 import static com.google.cloud.bigquery.TableDefinition.Type.MATERIALIZED_VIEW;
 import static com.google.cloud.bigquery.TableDefinition.Type.TABLE;
 import static com.google.cloud.bigquery.TableDefinition.Type.VIEW;
@@ -123,8 +124,8 @@ public class BigQuerySplitManager
             // Storage API doesn't support reading wildcard tables
             return ImmutableList.of(BigQuerySplit.forViewStream(columns, filter));
         }
-        if (type == MATERIALIZED_VIEW) {
-            // Storage API doesn't support reading materialized views
+        if (type == MATERIALIZED_VIEW || type == EXTERNAL) {
+            // Storage API doesn't support reading materialized views and external tables
             return ImmutableList.of(BigQuerySplit.forViewStream(columns, filter));
         }
         if (isSkipViewMaterialization(session) && type == VIEW) {

--- a/plugin/trino-bigquery/src/test/resources/region.csv
+++ b/plugin/trino-bigquery/src/test/resources/region.csv
@@ -1,0 +1,6 @@
+"regionkey","name","comment"
+"0","AFRICA","lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to "
+"1","AMERICA","hs use ironic, even requests. s"
+"2","ASIA","ges. thinly even pinto beans ca"
+"3","EUROPE","ly final courts cajole furiously final excuse"
+"4","MIDDLE EAST","uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl"


### PR DESCRIPTION
## Description

Add support for BigQuery external table

## Documentation

(x) Documentation issue #12432 is filed, and can be handled later.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# BigQuery
* Support reading external tables. ({issue}`13164`)
```
