### PR TITLE
Fix predicate failure for negative offset value on _timestamp column

### DIFF
--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaIntegrationPushDown.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaIntegrationPushDown.java
@@ -101,12 +101,12 @@ public class TestKafkaIntegrationPushDown
     public void testOffsetPushDown()
     {
         createMessages(topicNameOffset);
-        assertProcessedInputPossitions(format("SELECT count(*) FROM default.%s WHERE _partition_offset between 2 and 10", topicNameOffset), 18);
-        assertProcessedInputPossitions(format("SELECT count(*) FROM default.%s WHERE _partition_offset > 2 and _partition_offset < 10", topicNameOffset), 14);
-        assertProcessedInputPossitions(format("SELECT count(*) FROM default.%s WHERE _partition_offset = 3", topicNameOffset), 2);
+        assertProcessedInputPositions(format("SELECT count(*) FROM default.%s WHERE _partition_offset between 2 and 10", topicNameOffset), 18);
+        assertProcessedInputPositions(format("SELECT count(*) FROM default.%s WHERE _partition_offset > 2 and _partition_offset < 10", topicNameOffset), 14);
+        assertProcessedInputPositions(format("SELECT count(*) FROM default.%s WHERE _partition_offset = 3", topicNameOffset), 2);
     }
 
-    private void assertProcessedInputPossitions(String sql, long expectedProcessedInputPositions)
+    private void assertProcessedInputPositions(String sql, long expectedProcessedInputPositions)
     {
         DistributedQueryRunner queryRunner = getDistributedQueryRunner();
         assertEventually(() -> {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
A fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
Kafka connector

> How would you describe this change to a non-technical end user or system administrator?
Fix predicate failure for negative offset value on _timestamp column

## Related issues, pull requests, and links

Fixes #13167

## Documentation

(x) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

Issue:[#13167](https://github.com/trinodb/trino/issues/13167)
