### PR TITLE
Add missing `HiveMinioDataLake.start()` in Delta Lake query runner

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
@@ -311,6 +311,7 @@ public final class DeltaLakeQueryRunner
             String bucketName = "test-bucket";
 
             HiveMinioDataLake hiveMinioDataLake = new HiveMinioDataLake(bucketName);
+            hiveMinioDataLake.start();
             DistributedQueryRunner queryRunner = createS3DeltaLakeQueryRunner(
                     DELTA_CATALOG,
                     TPCH_SCHEMA,


### PR DESCRIPTION
## Description

Add missing `HiveMinioDataLake.start()` in Delta Lake query runner

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.