### PR TITLE
Filter Delta Lake splits based on `$path` column predicates

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
@@ -50,6 +50,8 @@ import java.util.stream.Stream;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.deltalake.DeltaLakeColumnHandle.pathColumnHandle;
 import static io.trino.plugin.deltalake.DeltaLakeMetadata.createStatisticsPredicate;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getDynamicFilteringWaitTimeout;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getMaxInitialSplitSize;
@@ -131,6 +133,7 @@ public class DeltaLakeSplitManager
         List<AddFileEntry> validDataFiles = metastore.getValidDataFiles(tableHandle.getSchemaTableName(), session);
         TupleDomain<DeltaLakeColumnHandle> enforcedPartitionConstraint = tableHandle.getEnforcedPartitionConstraint();
         TupleDomain<DeltaLakeColumnHandle> nonPartitionConstraint = tableHandle.getNonPartitionConstraint();
+        Domain pathDomain = getPathDomain(nonPartitionConstraint);
 
         // Delta Lake handles updates and deletes by copying entire data files, minus updates/deletes. Because of this we can only have one Split/UpdatablePageSource
         // per file.
@@ -154,6 +157,11 @@ public class DeltaLakeSplitManager
                 .flatMap(addAction -> {
                     if (tableHandle.getAnalyzeHandle().isPresent() && !tableHandle.getAnalyzeHandle().get().isInitialAnalyze() && !addAction.isDataChange()) {
                         // skip files which do not introduce data change on non-initial ANALYZE
+                        return Stream.empty();
+                    }
+
+                    String splitPath = buildSplitPath(tableLocation, addAction);
+                    if (!pathMatchesPredicate(pathDomain, splitPath)) {
                         return Stream.empty();
                     }
 
@@ -194,7 +202,7 @@ public class DeltaLakeSplitManager
                     return splitsForFile(
                             session,
                             addAction,
-                            tableLocation,
+                            splitPath,
                             addAction.getCanonicalPartitionValues(),
                             statisticsPredicate,
                             splittable,
@@ -215,17 +223,28 @@ public class DeltaLakeSplitManager
         return true;
     }
 
+    private static Domain getPathDomain(TupleDomain<DeltaLakeColumnHandle> effectivePredicate)
+    {
+        return effectivePredicate.getDomains()
+                .flatMap(domains -> Optional.ofNullable(domains.get(pathColumnHandle())))
+                .orElse(Domain.all(pathColumnHandle().getType()));
+    }
+
+    private static boolean pathMatchesPredicate(Domain pathDomain, String path)
+    {
+        return pathDomain.includesNullableValue(utf8Slice(path));
+    }
+
     private List<DeltaLakeSplit> splitsForFile(
             ConnectorSession session,
             AddFileEntry addFileEntry,
-            String tableLocation,
+            String splitPath,
             Map<String, Optional<String>> partitionKeys,
             TupleDomain<DeltaLakeColumnHandle> statisticsPredicate,
             boolean splittable,
             AtomicInteger remainingInitialSplits)
     {
         long fileSize = addFileEntry.getSize();
-        String splitPath = buildSplitPath(tableLocation, addFileEntry);
 
         if (!splittable) {
             // remainingInitialSplits is not used when !splittable


### PR DESCRIPTION
## Description

Filter Delta Lake splits based on `$path` column predicates
Fixes #13169

## Documentation

(x) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# Delta Lake
* Support filtering splits based on `$path` column predicates. ({issue}`13169`)
```
