### PR TITLE
Forbid specify database in MariaDB connection url

### DIFF
--- a/plugin/trino-mariadb/pom.xml
+++ b/plugin/trino-mariadb/pom.xml
@@ -29,6 +29,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
@@ -41,6 +46,11 @@
         <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
         </dependency>
 
         <dependency>

--- a/plugin/trino-mariadb/src/main/java/io/trino/plugin/mariadb/MariaDbClientModule.java
+++ b/plugin/trino-mariadb/src/main/java/io/trino/plugin/mariadb/MariaDbClientModule.java
@@ -32,6 +32,7 @@ import org.mariadb.jdbc.Driver;
 import java.util.Properties;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static io.airlift.configuration.ConfigBinder.configBinder;
 
 public class MariaDbClientModule
         implements Module
@@ -40,6 +41,7 @@ public class MariaDbClientModule
     public void configure(Binder binder)
     {
         binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class).to(MariaDbClient.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfig(MariaDbJdbcConfig.class);
         binder.install(new DecimalModule());
         newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(Query.class).in(Scopes.SINGLETON);
     }

--- a/plugin/trino-mariadb/src/main/java/io/trino/plugin/mariadb/MariaDbJdbcConfig.java
+++ b/plugin/trino-mariadb/src/main/java/io/trino/plugin/mariadb/MariaDbJdbcConfig.java
@@ -24,6 +24,13 @@ import java.sql.SQLException;
 public class MariaDbJdbcConfig
         extends BaseJdbcConfig
 {
+    @AssertTrue(message = "Invalid JDBC URL for MariaDB connector")
+    public boolean isUrlValid()
+    {
+        Driver driver = new Driver();
+        return driver.acceptsURL(getConnectionUrl());
+    }
+
     @AssertTrue(message = "Database (catalog) must not be specified in JDBC URL for MariaDB connector")
     public boolean isUrlWithoutDatabase()
     {

--- a/plugin/trino-mariadb/src/main/java/io/trino/plugin/mariadb/MariaDbJdbcConfig.java
+++ b/plugin/trino-mariadb/src/main/java/io/trino/plugin/mariadb/MariaDbJdbcConfig.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mariadb;
+
+import io.trino.plugin.jdbc.BaseJdbcConfig;
+import org.mariadb.jdbc.Configuration;
+import org.mariadb.jdbc.Driver;
+
+import javax.validation.constraints.AssertTrue;
+
+import java.sql.SQLException;
+
+public class MariaDbJdbcConfig
+        extends BaseJdbcConfig
+{
+    @AssertTrue(message = "Database (catalog) must not be specified in JDBC URL for MariaDB connector")
+    public boolean isUrlWithoutDatabase()
+    {
+        try {
+            Configuration conf = Configuration.parse(getConnectionUrl());
+            if (conf == null) {
+                return false;
+            }
+            return conf.database() == null;
+        }
+        catch (SQLException e) {
+            return false;
+        }
+    }
+}

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbJdbcConfig.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbJdbcConfig.java
@@ -21,6 +21,22 @@ import static org.testng.Assert.assertTrue;
 public class TestMariaDbJdbcConfig
 {
     @Test
+    public void testIsUrlValid()
+    {
+        assertTrue(isUrlValid("jdbc:mariadb://example.net:3306"));
+        assertTrue(isUrlValid("jdbc:mariadb://example.net:3306/"));
+        assertFalse(isUrlValid("jdbc:notmariadb://example.net:3306"));
+        assertFalse(isUrlValid("jdbc:notmariadb://example.net:3306/"));
+    }
+
+    private static boolean isUrlValid(String url)
+    {
+        MariaDbJdbcConfig config = new MariaDbJdbcConfig();
+        config.setConnectionUrl(url);
+        return config.isUrlValid();
+    }
+
+    @Test
     public void testIsUrlWithoutDatabase()
     {
         assertTrue(isUrlWithoutDatabase("jdbc:mariadb://example.net:3306"));

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbJdbcConfig.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbJdbcConfig.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mariadb;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestMariaDbJdbcConfig
+{
+    @Test
+    public void testIsUrlWithoutDatabase()
+    {
+        assertTrue(isUrlWithoutDatabase("jdbc:mariadb://example.net:3306"));
+        assertTrue(isUrlWithoutDatabase("jdbc:mariadb://example.net:3306/"));
+        assertFalse(isUrlWithoutDatabase("jdbc:mariadb://example.net:3306/somedatabase"));
+    }
+
+    private static boolean isUrlWithoutDatabase(String url)
+    {
+        MariaDbJdbcConfig config = new MariaDbJdbcConfig();
+        config.setConnectionUrl(url);
+        return config.isUrlWithoutDatabase();
+    }
+}

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbPlugin.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbPlugin.java
@@ -31,6 +31,9 @@ public class TestMariaDbPlugin
         ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
         factory.create("test", ImmutableMap.of("connection-url", "jdbc:mariadb://test"), new TestingConnectorContext()).shutdown();
 
+        assertThatThrownBy(() -> factory.create("test", ImmutableMap.of("connection-url", "test"), new TestingConnectorContext()))
+                .hasMessageContaining("Invalid JDBC URL for MariaDB connector");
+
         assertThatThrownBy(() -> factory.create("test", ImmutableMap.of("connection-url", "jdbc:mariadb://test/abc"), new TestingConnectorContext()))
                 .hasMessageContaining("Database (catalog) must not be specified in JDBC URL for MariaDB connector");
     }

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbPlugin.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbPlugin.java
@@ -20,6 +20,7 @@ import io.trino.testing.TestingConnectorContext;
 import org.testng.annotations.Test;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestMariaDbPlugin
 {
@@ -29,5 +30,8 @@ public class TestMariaDbPlugin
         Plugin plugin = new MariaDbPlugin();
         ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
         factory.create("test", ImmutableMap.of("connection-url", "jdbc:mariadb://test"), new TestingConnectorContext()).shutdown();
+
+        assertThatThrownBy(() -> factory.create("test", ImmutableMap.of("connection-url", "jdbc:mariadb://test/abc"), new TestingConnectorContext()))
+                .hasMessageContaining("Database (catalog) must not be specified in JDBC URL for MariaDB connector");
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
MariaDB connector

> How would you describe this change to a non-technical end user or system administrator?
Forbid specify database in MariaDB connection url

## Related issues, pull requests, and links
fixes [12712](https://github.com/trinodb/trino/issues/12712)

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(X) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# MariaDB
* Disallow having a database in the `connection-url` config property. ({issue}`12712`)
```
