### PR TITLE
Add support for short zone IDs

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/type/TimeZoneKey.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TimeZoneKey.java
@@ -125,6 +125,21 @@ public final class TimeZoneKey
                 zoneIdToKey.put(zoneId, new TimeZoneKey(zoneId, zoneKey));
             }
 
+            // Attach mappings for short zone ids aliases
+            for (Entry<String, String> entry : ZoneId.SHORT_IDS.entrySet()) {
+                String shortNameZoneId = entry.getKey();
+                String fullNameZoneId = entry.getValue();
+
+                TimeZoneKey fullNameTimeZoneKey = zoneIdToKey.get(fullNameZoneId);
+                if (fullNameTimeZoneKey == null) {
+                    throw new AssertionError("Zone file must contain a mapping for the zone id " + fullNameZoneId);
+                }
+                if (zoneIdToKey.containsKey(shortNameZoneId)) {
+                    throw new AssertionError("Zone file must not contain a mapping for the short name zone id " + shortNameZoneId);
+                }
+                zoneIdToKey.put(shortNameZoneId, fullNameTimeZoneKey);
+            }
+
             MAX_TIME_ZONE_KEY = maxZoneKey;
             ZONE_ID_TO_KEY = Collections.unmodifiableMap(new LinkedHashMap<>(zoneIdToKey));
             ZONE_KEYS = Collections.unmodifiableSet(new LinkedHashSet<>(zoneIdToKey.values()));

--- a/core/trino-spi/src/test/java/io/trino/spi/type/TestTimeZoneKey.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/type/TestTimeZoneKey.java
@@ -21,6 +21,8 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.ZoneId;
+import java.util.Map;
 import java.util.SortedSet;
 
 import static io.trino.spi.type.TimeZoneKey.MAX_TIME_ZONE_KEY;
@@ -233,6 +235,16 @@ public class TestTimeZoneKey
             String json = mapper.writeValueAsString(zoneKey);
             Object value = mapper.readValue(json, zoneKey.getClass());
             assertEquals(value, zoneKey);
+        }
+    }
+
+    @Test
+    public void testShortZoneIds()
+    {
+        for (Map.Entry<String, String> entry : ZoneId.SHORT_IDS.entrySet()) {
+            TimeZoneKey shortNameTimeZoneKey = TimeZoneKey.getTimeZoneKey(entry.getKey());
+            TimeZoneKey fullNameTimeZoneKey = TimeZoneKey.getTimeZoneKey(entry.getValue());
+            assertEquals(shortNameTimeZoneKey, fullNameTimeZoneKey);
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Enable the usage of short time-zone names to be used in
time zone conversions.

The short time-zone names are actually aliases for existing
time zones.
e.g. : JST - Asia/Tokyo

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

SPI

> How would you describe this change to a non-technical end user or system administrator?

Add support for time zone conversions like 

```
AT TIME ZONE 'JST'
```

```
trino> select current_timestamp at time zone 'JST';
               _col0                
------------------------------------
 2022-07-14 18:05:20.882 Asia/Tokyo 
(1 row)

Query 20220714_090520_00001_uz6hg, FINISHED, 1 node
Splits: 1 total, 1 done (100.00%)
0.22 [0 rows, 0B] [0 rows/s, 0B/s]

trino> select current_timestamp at time zone 'Asia/Tokyo';
               _col0                
------------------------------------
 2022-07-14 18:05:29.782 Asia/Tokyo 
(1 row)

Query 20220714_090529_00002_uz6hg, FINISHED, 1 node
Splits: 1 total, 1 done (100.00%)
0.23 [0 rows, 0B] [0 rows/s, 0B/s]
```

**NOTE**: As seen in the example above, the time zone delivered back to the user is the time zone `Asia/Tokyo` to which the `JST` corresponds to.
This may cause some confusion to some of the users.


## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# SPI
* Add support for short time-zone IDs (`JST` is an alias for `Asia/Tokyo`)
```
