### PR TITLE
Canonicalize Hive short timezone IDs

### DIFF
--- a/plugin/trino-hive-hadoop2/src/main/java/io/trino/plugin/hive/CanonicalizeHiveTimezoneId.java
+++ b/plugin/trino-hive-hadoop2/src/main/java/io/trino/plugin/hive/CanonicalizeHiveTimezoneId.java
@@ -18,6 +18,10 @@ import io.trino.spi.function.LiteralParameters;
 import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.SqlType;
 
+import java.time.ZoneId;
+
+import static io.airlift.slice.Slices.utf8Slice;
+
 /**
  * Translate timezone id used by Hive to canonical form which is understandable by Trino; used in Hive view translation logic
  */
@@ -30,7 +34,12 @@ public final class CanonicalizeHiveTimezoneId
     @SqlType("varchar")
     public static Slice canonicalizeHiveTimezoneId(@SqlType("varchar(x)") Slice hiveTimeZoneId)
     {
-        // TODO(https://github.com/trinodb/trino/issues/8853) no-op for now; actual cannicalization logic to be added
+        if (hiveTimeZoneId != null) {
+            String zoneId = hiveTimeZoneId.toStringUtf8();
+            if (ZoneId.SHORT_IDS.containsKey(zoneId)) {
+                return utf8Slice(ZoneId.SHORT_IDS.get(zoneId));
+            }
+        }
         return hiveTimeZoneId;
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveViews.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveViews.java
@@ -23,6 +23,7 @@ import org.testng.annotations.Test;
 import java.math.BigDecimal;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tests.product.TestGroups.HIVE_VIEWS;
 import static io.trino.tests.product.utils.QueryExecutors.onHive;
@@ -271,31 +272,50 @@ public class TestHiveViews
         onHive().executeQuery("CREATE VIEW " +
                 "test_from_utc_timestamp_view " +
                 "AS SELECT " +
-                // TODO(https://github.com/trinodb/trino/issues/8853) add testcases with 3-letter tz names (like PST) when we have $canonicalize_hive_timezone_id logic in place
                 "   CAST(from_utc_timestamp(source_tinyint, 'America/Los_Angeles') AS STRING) ts_tinyint, " +
+                "   CAST(from_utc_timestamp(source_tinyint, 'PST') AS STRING) ts_tinyint_short_tz, " +
                 "   CAST(from_utc_timestamp(source_smallint, 'America/Los_Angeles') AS STRING) ts_smallint, " +
+                "   CAST(from_utc_timestamp(source_smallint, 'PST') AS STRING) ts_smallint_short_tz, " +
                 "   CAST(from_utc_timestamp(source_integer, 'America/Los_Angeles') AS STRING) ts_integer, " +
+                "   CAST(from_utc_timestamp(source_integer, 'PST') AS STRING) ts_integer_short_tz, " +
                 "   CAST(from_utc_timestamp(source_bigint, 'America/Los_Angeles') AS STRING) ts_bigint, " +
+                "   CAST(from_utc_timestamp(source_bigint, 'PST') AS STRING) ts_bigint_short_tz, " +
                 "   CAST(from_utc_timestamp(source_float, 'America/Los_Angeles') AS STRING) ts_float, " +
+                "   CAST(from_utc_timestamp(source_float, 'PST') AS STRING) ts_float_short_tz, " +
                 "   CAST(from_utc_timestamp(source_double, 'America/Los_Angeles') AS STRING) ts_double, " +
+                "   CAST(from_utc_timestamp(source_double, 'PST') AS STRING) ts_double_short_tz, " +
                 "   CAST(from_utc_timestamp(source_decimal_three, 'America/Los_Angeles') AS STRING) ts_decimal_three, " +
+                "   CAST(from_utc_timestamp(source_decimal_three, 'PST') AS STRING) ts_decimal_three_short_tz, " +
                 "   CAST(from_utc_timestamp(source_decimal_zero, 'America/Los_Angeles') AS STRING) ts_decimal_zero, " +
+                "   CAST(from_utc_timestamp(source_decimal_zero, 'PST') AS STRING) ts_decimal_zero_short_tz, " +
                 "   CAST(from_utc_timestamp(source_timestamp, 'America/Los_Angeles') AS STRING) ts_timestamp, " +
-                "   CAST(from_utc_timestamp(source_date, 'America/Los_Angeles') AS STRING) ts_date " +
+                "   CAST(from_utc_timestamp(source_timestamp, 'PST') AS STRING) ts_timestamp_short_tz, " +
+                "   CAST(from_utc_timestamp(source_date, 'America/Los_Angeles') AS STRING) ts_date, " +
+                "   CAST(from_utc_timestamp(source_date, 'PST') AS STRING) ts_date_short_tz " +
                 "FROM test_from_utc_timestamp_source");
 
         // check result on Trino
         assertThat(onTrino().executeQuery("SELECT * FROM test_from_utc_timestamp_view"))
                 .containsOnly(row(
                         "1969-12-31 16:00:00.123",
+                        "1969-12-31 16:00:00.123",
+                        "1969-12-31 16:00:10.123",
                         "1969-12-31 16:00:10.123",
                         "1970-01-03 16:00:00.123",
+                        "1970-01-03 16:00:00.123",
                         "1970-01-30 16:00:00.123",
+                        "1970-01-30 16:00:00.123",
+                        "1970-01-30 16:00:00.000",
                         "1970-01-30 16:00:00.000",
                         "1970-01-30 16:00:00.123",
                         "1970-01-30 16:00:00.123",
+                        "1970-01-30 16:00:00.123",
+                        "1970-01-30 16:00:00.123",
+                        "1970-01-30 16:00:00.000",
                         "1970-01-30 16:00:00.000",
                         "1970-01-30 08:00:00.000",
+                        "1970-01-30 08:00:00.000",
+                        "1970-01-29 16:00:00.000",
                         "1970-01-29 16:00:00.000"));
 
         // check result on Hive
@@ -306,30 +326,75 @@ public class TestHiveViews
             assertThat(onHive().executeQuery("SELECT * FROM test_from_utc_timestamp_view"))
                     .containsOnly(row(
                             "1969-12-31 21:30:00.123",
+                            "1969-12-31 21:30:00.123",
+                            "1969-12-31 21:30:10.123",
                             "1969-12-31 21:30:10.123",
                             "1970-01-03 21:30:00.123",
+                            "1970-01-03 21:30:00.123",
                             "1970-01-30 21:30:00.123",
+                            "1970-01-30 21:30:00.123",
+                            "1970-01-30 21:30:00",
                             "1970-01-30 21:30:00",
                             "1970-01-30 21:30:00.123",
                             "1970-01-30 21:30:00.123",
+                            "1970-01-30 21:30:00.123",
+                            "1970-01-30 21:30:00.123",
+                            "1970-01-30 21:30:00",
                             "1970-01-30 21:30:00",
                             "1970-01-30 08:00:00",
+                            "1970-01-30 08:00:00",
+                            "1970-01-29 16:00:00",
                             "1970-01-29 16:00:00"));
         }
         else {
             assertThat(onHive().executeQuery("SELECT * FROM test_from_utc_timestamp_view"))
                     .containsOnly(row(
                             "1969-12-31 16:00:00.123",
+                            "1969-12-31 16:00:00.123",
+                            "1969-12-31 16:00:10.123",
                             "1969-12-31 16:00:10.123",
                             "1970-01-03 16:00:00.123",
+                            "1970-01-03 16:00:00.123",
                             "1970-01-30 16:00:00.123",
+                            "1970-01-30 16:00:00.123",
+                            "1970-01-30 16:00:00",
                             "1970-01-30 16:00:00",
                             "1970-01-30 16:00:00.123",
                             "1970-01-30 16:00:00.123",
+                            "1970-01-30 16:00:00.123",
+                            "1970-01-30 16:00:00.123",
+                            "1970-01-30 16:00:00",
                             "1970-01-30 16:00:00",
                             "1970-01-30 08:00:00",
+                            "1970-01-30 08:00:00",
+                            "1970-01-29 16:00:00",
                             "1970-01-29 16:00:00"));
         }
+    }
+
+    @Test(groups = HIVE_VIEWS)
+    public void testFromUtcTimestampInvalidTimeZone()
+    {
+        onTrino().executeQuery("DROP TABLE IF EXISTS test_from_utc_timestamp_invalid_time_zone_source");
+        onHive().executeQuery("CREATE TABLE test_from_utc_timestamp_invalid_time_zone_source (source_timestamp timestamp)");
+
+        // insert via Trino as we noticed problems with creating test table in Hive using CTAS at one go for some Hive distributions
+        onTrino().executeQuery("INSERT INTO test_from_utc_timestamp_invalid_time_zone_source VALUES (timestamp '1970-01-30 16:00:00.000')");
+
+        onHive().executeQuery("DROP VIEW IF EXISTS test_from_utc_timestamp_invalid_time_zone_view");
+        onHive().executeQuery("CREATE VIEW " +
+                "test_from_utc_timestamp_invalid_time_zone_view " +
+                "AS SELECT " +
+                "   CAST(from_utc_timestamp(source_timestamp, 'Matrix/Zion') AS STRING) ts_timestamp " +
+                "FROM test_from_utc_timestamp_invalid_time_zone_source");
+
+        // check result on Trino
+        assertQueryFailure(() -> onTrino().executeQuery("SELECT * FROM test_from_utc_timestamp_invalid_time_zone_view"))
+                .hasMessageContaining("'Matrix/Zion' is not a valid time zone");
+        // check result on Hive - Hive falls back to GMT in case of dealing with an invalid time zone
+        assertThat(onHive().executeQuery("SELECT * FROM test_from_utc_timestamp_invalid_time_zone_view"))
+                .containsOnly(row("1970-01-30 16:00:00"));
+        onTrino().executeQuery("DROP TABLE test_from_utc_timestamp_invalid_time_zone_source");
     }
 
     @Test(groups = HIVE_VIEWS)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Enable the translation of Hive views making use ofshort time-zone names to be used in
time zone conversions.

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Hive

> How would you describe this change to a non-technical end user or system administrator?

`$canonicalize_hive_timezone_id` function is used for canonicalizing time zone passed to `from_utc_timestamp` when we are translating Hive view which uses this UDF to Trino. This function supports now short time zone ids (aliases) 

e.g. : `JST` which will be internally translated to `Asia/Tokyo`

**NOTE**: As seen in the example above, the time zone delivered back to the user is the time zone `Asia/Tokyo` to which the `JST` corresponds to.
This may cause some confusion to some of the users.


## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

Fixes: https://github.com/trinodb/trino/issues/8853

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Hive
* Canonicalize short time-zone IDs (`JST` is an alias for `Asia/Tokyo`) in Hive view translation
```
