### PR TITLE
Exclude tests which can't be executed on Databricks 7.3 runtime

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeAlterTableCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeAlterTableCompatibility.java
@@ -101,7 +101,7 @@ public class TestDeltaLakeAlterTableCompatibility
         }
     }
 
-    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_OSS, PROFILE_SPECIFIC_TESTS})
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_OSS, DELTA_LAKE_EXCLUDE_73, PROFILE_SPECIFIC_TESTS})
     public void testCommentOnTableUnsupportedWriterVersion()
     {
         String tableName = "test_dl_comment_table_unsupported_writer_" + randomTableSuffix();
@@ -145,7 +145,7 @@ public class TestDeltaLakeAlterTableCompatibility
         }
     }
 
-    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_OSS, PROFILE_SPECIFIC_TESTS})
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_OSS, DELTA_LAKE_EXCLUDE_73, PROFILE_SPECIFIC_TESTS})
     public void testCommentOnColumnUnsupportedWriterVersion()
     {
         String tableName = "test_dl_comment_column_unsupported_writer_" + randomTableSuffix();


### PR DESCRIPTION
### Delta Lake Databricks product tests infrastructure changes

The table property `delta.minWriterVersion` is an unknown
table property in the Databricks 7.3 runtime.