### PR TITLE
Fallback to loading all active data files for cached Delta table log

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/MissingTransactionLogException.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/MissingTransactionLogException.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake.transactionlog;
+
+import io.trino.spi.TrinoException;
+import org.apache.hadoop.fs.Path;
+
+import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_INVALID_TABLE;
+import static java.lang.String.format;
+
+public class MissingTransactionLogException
+        extends TrinoException
+{
+    public MissingTransactionLogException(Path transactionLogPath)
+    {
+        super(DELTA_LAKE_INVALID_TABLE, format("The transaction log file %s was not found", transactionLogPath));
+    }
+}

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeTransactionLogCache.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeTransactionLogCache.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.deltalake;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
+import com.amazonaws.services.s3.model.DeleteObjectsResult;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import io.trino.tempto.BeforeTestWithContext;
+import io.trino.tempto.assertions.QueryAssert;
+import org.assertj.core.api.Assertions;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertThat;
+import static io.trino.tests.product.TestGroups.DELTA_LAKE_DATABRICKS;
+import static io.trino.tests.product.TestGroups.DELTA_LAKE_OSS;
+import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static io.trino.tests.product.hive.util.TemporaryHiveTable.randomTableSuffix;
+import static io.trino.tests.product.utils.QueryExecutors.onDelta;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
+import static java.lang.String.format;
+
+public class TestDeltaLakeTransactionLogCache
+        extends BaseTestDeltaLakeS3Storage
+{
+    @Inject
+    @Named("s3.server_type")
+    private String s3ServerType;
+
+    private AmazonS3 s3;
+
+    @BeforeTestWithContext
+    public void setup()
+    {
+        super.setUp();
+        s3 = new S3ClientFactory().createS3Client(s3ServerType);
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_OSS, PROFILE_SPECIFIC_TESTS})
+    public void testAllDataFilesAreLoadedWhenTransactionLogFileAfterTheCachedTableVersionIsMissing()
+    {
+        String tableName = "test_dl_cached_table_files_accuracy_" + randomTableSuffix();
+        String tableDirectory = "databricks-compatibility-test-" + tableName;
+
+        onTrino().executeQuery(format("CREATE TABLE delta.default.%s (col INT) WITH (location = 's3://%s/%s')",
+                tableName,
+                bucketName,
+                tableDirectory));
+
+        onTrino().executeQuery("INSERT INTO " + tableName + " VALUES 1");
+        assertThat(onTrino().executeQuery("SELECT * FROM " + tableName)).containsOnly(row(1));
+
+        // Perform multiple changes on the table outside of Trino to avoid updating the Trino table active files cache
+        onDelta().executeQuery("DELETE FROM default." + tableName);
+        // Perform more than 10 to make sure there is a checkpoint being created
+        IntStream.range(2, 13).forEach(v -> onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES " + v));
+
+        List<QueryAssert.Row> expectedRows = List.of(
+                row(2),
+                row(3),
+                row(4),
+                row(5),
+                row(6),
+                row(7),
+                row(8),
+                row(9),
+                row(10),
+                row(11),
+                row(12));
+
+        // Delete the first few transaction log files because they can safely be discarded
+        // once there is a checkpoint created.
+        String[] transactionLogFilesToRemove = {
+                tableDirectory + "/_delta_log/00000000000000000000.json",
+                tableDirectory + "/_delta_log/00000000000000000001.json",
+                tableDirectory + "/_delta_log/00000000000000000002.json",
+                tableDirectory + "/_delta_log/00000000000000000003.json",
+                tableDirectory + "/_delta_log/00000000000000000004.json",
+                tableDirectory + "/_delta_log/00000000000000000005.json"
+        };
+        DeleteObjectsResult deleteObjectsResult = s3.deleteObjects(
+                new DeleteObjectsRequest(bucketName)
+                        .withKeys(transactionLogFilesToRemove));
+        Assertions.assertThat(
+                        deleteObjectsResult.getDeletedObjects().stream()
+                                .map(DeleteObjectsResult.DeletedObject::getKey)
+                                .collect(Collectors.toList()))
+                .containsExactlyInAnyOrder(transactionLogFilesToRemove);
+
+        assertThat(onDelta().executeQuery("SELECT * FROM default." + tableName))
+                .containsOnly(expectedRows);
+        // The internal data files table cached value for the Delta table should be
+        // fully refreshed now.
+        assertThat(onTrino().executeQuery("SELECT * FROM " + tableName))
+                .containsOnly(expectedRows);
+
+        onTrino().executeQuery("DROP TABLE " + tableName);
+    }
+}


### PR DESCRIPTION
When having an outdated version of the transaction log of a Delta Lake
table, fallback to loading all active data files for the table if newer
transaction log files than the cached table version are missing.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Delta Lake connector

> How would you describe this change to a non-technical end user or system administrator?

The Delta Lake connector should still be able to build up internally the actual state of a table which already has its transaction log cached but pointing to an outdated transaction log version which has been garbage collected by an external process (Spark).

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->
Fixes https://github.com/trinodb/trino/issues/13181

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Delta Lake
* Fix incorrect query results when reading a Delta Lake table with a cached representation of its active data files which is outdated
```
