### PR TITLE
Add async refresh OAuth flows

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/RefreshTokensConfig.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/RefreshTokensConfig.java
@@ -25,6 +25,7 @@ import javax.validation.constraints.NotEmpty;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class RefreshTokensConfig
 {
@@ -32,6 +33,7 @@ public class RefreshTokensConfig
     private String issuer = "Trino_coordinator";
     private String audience = "Trino_coordinator";
     private SecretKey secretKey;
+    private Duration lastEligibleRefreshTokenTimeout = Duration.succinctDuration(0, MILLISECONDS);
 
     public Duration getTokenExpiration()
     {
@@ -43,6 +45,19 @@ public class RefreshTokensConfig
     public RefreshTokensConfig setTokenExpiration(Duration tokenExpiration)
     {
         this.tokenExpiration = tokenExpiration;
+        return this;
+    }
+
+    public Duration getLastEligibleRefreshTokenTimeout()
+    {
+        return lastEligibleRefreshTokenTimeout;
+    }
+
+    @Config("http-server.authentication.oauth2.refresh-tokens.last-eligible-refresh-before-timeout")
+    @ConfigDescription("Duration to timeout, bellow which no token will be refreshed and client will be asked to re-log. It's to minimize cases for refresh failures due to refresh-token timeout")
+    public RefreshTokensConfig setLastEligibleRefreshTokenTimeout(Duration timeout)
+    {
+        this.lastEligibleRefreshTokenTimeout = timeout;
         return this;
     }
 

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/TokenPairSerializer.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/TokenPairSerializer.java
@@ -18,6 +18,9 @@ import io.trino.server.security.oauth2.OAuth2Client.Response;
 
 import javax.annotation.Nullable;
 
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Date;
 import java.util.Optional;
 
@@ -87,6 +90,14 @@ public interface TokenPairSerializer
         public Optional<String> getRefreshToken()
         {
             return refreshToken;
+        }
+
+        public boolean isBeforeExpirationForAtLeast(Duration duration, Clock clock)
+        {
+            requireNonNull(duration, "duration is null");
+            requireNonNull(clock, "clock is null");
+
+            return Instant.now(clock).isBefore(expiration.toInstant().minus(duration));
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/TokenRefresher.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/TokenRefresher.java
@@ -13,56 +13,63 @@
  */
 package io.trino.server.security.oauth2;
 
+import io.airlift.log.Logger;
 import io.trino.server.security.oauth2.OAuth2Client.Response;
 import io.trino.server.security.oauth2.TokenPairSerializer.TokenPair;
 
+import java.time.Clock;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
 
 import static io.trino.server.security.oauth2.OAuth2TokenExchange.hashAuthId;
 import static java.util.Objects.requireNonNull;
 
 public class TokenRefresher
 {
+    private static final Logger LOG = Logger.get(TokenRefresher.class);
     private final TokenPairSerializer tokenAssembler;
     private final OAuth2TokenHandler tokenHandler;
     private final OAuth2Client client;
+    private final Duration lastEligibleRefreshTokenTimeout;
+    private final ExecutorService executorService;
 
-    public TokenRefresher(TokenPairSerializer tokenAssembler, OAuth2TokenHandler tokenHandler, OAuth2Client client)
+    public TokenRefresher(TokenPairSerializer tokenAssembler, OAuth2TokenHandler tokenHandler, OAuth2Client client, Duration lastEligibleRefreshTokenTimeout, ExecutorService executorService)
     {
         this.tokenAssembler = requireNonNull(tokenAssembler, "tokenAssembler is null");
         this.tokenHandler = requireNonNull(tokenHandler, "tokenHandler is null");
         this.client = requireNonNull(client, "oAuth2Client is null");
+        this.lastEligibleRefreshTokenTimeout = requireNonNull(lastEligibleRefreshTokenTimeout, "lastEligibleRefreshTokenTimeout is null");
+        this.executorService = requireNonNull(executorService, "executorService is null");
     }
 
     public Optional<UUID> refreshToken(TokenPair tokenPair)
     {
         requireNonNull(tokenPair, "tokenPair is null");
 
-        Optional<String> refreshToken = tokenPair.getRefreshToken();
+        Optional<String> refreshToken = Optional.of(tokenPair)
+                .filter(tokens -> tokens.isBeforeExpirationForAtLeast(lastEligibleRefreshTokenTimeout, Clock.systemUTC()))
+                .flatMap(TokenPair::getRefreshToken);
         if (refreshToken.isPresent()) {
             UUID refreshingId = UUID.randomUUID();
-            try {
-                refreshToken(refreshToken.get(), refreshingId);
-                return Optional.of(refreshingId);
-            }
-            // If Refresh token has expired then restart the flow
-            catch (RuntimeException exception) {
-                return Optional.empty();
-            }
+            refreshToken(refreshToken.get(), refreshingId);
+            return Optional.of(refreshingId);
         }
         return Optional.empty();
     }
 
     private void refreshToken(String refreshToken, UUID refreshingId)
     {
-        try {
-            Response response = client.refreshTokens(refreshToken);
-            String serializedToken = tokenAssembler.serialize(TokenPair.fromOAuth2Response(response));
-            tokenHandler.setAccessToken(hashAuthId(refreshingId), serializedToken);
-        }
-        catch (ChallengeFailedException e) {
-            tokenHandler.setTokenExchangeError(hashAuthId(refreshingId), "Token refreshing has failed: " + e.getMessage());
-        }
+        executorService.submit(() -> {
+            try {
+                Response response = client.refreshTokens(refreshToken);
+                String serializedToken = tokenAssembler.serialize(TokenPair.fromOAuth2Response(response));
+                tokenHandler.setAccessToken(hashAuthId(refreshingId), serializedToken);
+            }
+            catch (Throwable e) {
+                tokenHandler.setTokenExchangeError(hashAuthId(refreshingId), "Token refreshing has failed: " + e.getMessage());
+            }
+        });
     }
 }

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestJweTokenSerializer.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestJweTokenSerializer.java
@@ -23,9 +23,6 @@ import org.testng.annotations.Test;
 import java.net.URI;
 import java.security.GeneralSecurityException;
 import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Map;
@@ -33,7 +30,6 @@ import java.util.Optional;
 
 import static io.airlift.units.Duration.succinctDuration;
 import static io.trino.server.security.oauth2.TokenPairSerializer.TokenPair.accessAndRefreshTokens;
-import static java.time.temporal.ChronoUnit.MILLIS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -137,35 +133,6 @@ public class TestJweTokenSerializer
         public Response refreshTokens(String refreshToken)
         {
             throw new UnsupportedOperationException("operation is not yet supported");
-        }
-    }
-
-    private static class TestingClock
-            extends Clock
-    {
-        private Instant currentTime = ZonedDateTime.of(2022, 5, 6, 10, 15, 0, 0, ZoneId.systemDefault()).toInstant();
-
-        @Override
-        public ZoneId getZone()
-        {
-            return ZoneId.systemDefault();
-        }
-
-        @Override
-        public Clock withZone(ZoneId zone)
-        {
-            return this;
-        }
-
-        @Override
-        public Instant instant()
-        {
-            return currentTime;
-        }
-
-        public void advanceBy(Duration currentTimeDelta)
-        {
-            this.currentTime = currentTime.plus(currentTimeDelta.toMillis(), MILLIS);
         }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestRefreshTokensConfig.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestRefreshTokensConfig.java
@@ -28,6 +28,8 @@ import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static io.airlift.units.Duration.succinctDuration;
 import static io.jsonwebtoken.io.Encoders.BASE64;
 import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class TestRefreshTokensConfig
 {
@@ -36,6 +38,7 @@ public class TestRefreshTokensConfig
     {
         assertRecordedDefaults(recordDefaults(RefreshTokensConfig.class)
                 .setTokenExpiration(succinctDuration(1, HOURS))
+                .setLastEligibleRefreshTokenTimeout(succinctDuration(0, MILLISECONDS))
                 .setIssuer("Trino_coordinator")
                 .setAudience("Trino_coordinator")
                 .setSecretKey(null));
@@ -49,6 +52,7 @@ public class TestRefreshTokensConfig
 
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("http-server.authentication.oauth2.refresh-tokens.issued-token.timeout", "24h")
+                .put("http-server.authentication.oauth2.refresh-tokens.last-eligible-refresh-before-timeout", "5s")
                 .put("http-server.authentication.oauth2.refresh-tokens.issued-token.issuer", "issuer")
                 .put("http-server.authentication.oauth2.refresh-tokens.issued-token.audience", "audience")
                 .put("http-server.authentication.oauth2.refresh-tokens.secret-key", encodedBase64SecretKey)
@@ -56,6 +60,7 @@ public class TestRefreshTokensConfig
 
         RefreshTokensConfig expected = new RefreshTokensConfig()
                 .setTokenExpiration(succinctDuration(24, HOURS))
+                .setLastEligibleRefreshTokenTimeout(succinctDuration(5, SECONDS))
                 .setIssuer("issuer")
                 .setAudience("audience")
                 .setSecretKey(encodedBase64SecretKey);

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestTokenPair.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestTokenPair.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.security.oauth2;
+
+import io.trino.server.security.oauth2.TokenPairSerializer.TokenPair;
+import org.testng.annotations.Test;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Date;
+
+import static io.trino.server.security.oauth2.TokenPairSerializer.TokenPair.accessAndRefreshTokens;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestTokenPair
+{
+    @Test
+    public void testHasExpiredWhenExpirationIsAfterCurrentTime()
+    {
+        TestingClock clock = new TestingClock();
+
+        TokenPair tokens = expiredIn(clock, Duration.ofMinutes(10));
+        clock.advanceBy(Duration.ofMinutes(11));
+
+        assertThat(tokens.isBeforeExpirationForAtLeast(Duration.ZERO, clock)).isFalse();
+    }
+
+    @Test
+    public void testHasNotExpiredWhenExpirationIsBeforeCurrentTime()
+    {
+        TestingClock clock = new TestingClock();
+
+        TokenPair tokens = expiredIn(clock, Duration.ofMinutes(10));
+        clock.advanceBy(Duration.ofMinutes(5));
+
+        assertThat(tokens.isBeforeExpirationForAtLeast(Duration.ZERO, clock)).isTrue();
+    }
+
+    @Test
+    public void testIsBeforeExpirationForAtLeastReturningFalseWhenAddedTimeExceedsCurrentTime()
+    {
+        TestingClock clock = new TestingClock();
+
+        TokenPair tokens = expiredIn(clock, Duration.ofMinutes(10));
+        clock.advanceBy(Duration.ofMinutes(5));
+
+        assertThat(tokens.isBeforeExpirationForAtLeast(Duration.ofMinutes(6), clock)).isFalse();
+    }
+
+    @Test
+    public void testIsBeforeExpirationForAtLeastReturningFalseWhenAddedTimeMatchesExactlyCurrentTime()
+    {
+        TestingClock clock = new TestingClock();
+
+        TokenPair tokens = expiredIn(clock, Duration.ofMinutes(10));
+        clock.advanceBy(Duration.ofMinutes(5));
+
+        assertThat(tokens.isBeforeExpirationForAtLeast(Duration.ofMinutes(5), clock)).isFalse();
+    }
+
+    @Test
+    public void testIsBeforeExpirationForAtLeastReturningTrueWhenAddedTimeIsBeforeCurrentTime()
+    {
+        TestingClock clock = new TestingClock();
+
+        TokenPair tokens = expiredIn(clock, Duration.ofMinutes(10));
+        clock.advanceBy(Duration.ofMinutes(5));
+
+        assertThat(tokens.isBeforeExpirationForAtLeast(Duration.ofMinutes(4), clock)).isTrue();
+    }
+
+    private static TokenPair expiredIn(Clock clock, Duration duration)
+    {
+        return accessAndRefreshTokens("access_token", Date.from(clock.instant().plus(duration)), null);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestingClock.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestingClock.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.security.oauth2;
+
+import io.airlift.units.Duration;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import static java.time.temporal.ChronoUnit.MILLIS;
+
+public class TestingClock
+        extends Clock
+{
+    private Instant currentTime = ZonedDateTime.of(2022, 5, 6, 10, 15, 0, 0, ZoneId.systemDefault()).toInstant();
+
+    @Override
+    public ZoneId getZone()
+    {
+        return ZoneId.systemDefault();
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone)
+    {
+        return this;
+    }
+
+    @Override
+    public Instant instant()
+    {
+        return Instant.from(currentTime);
+    }
+
+    public void advanceBy(Duration currentTimeDelta)
+    {
+        this.currentTime = currentTime.plus(currentTimeDelta.toMillis(), MILLIS);
+    }
+
+    public void advanceBy(java.time.Duration currentTimeDelta)
+    {
+        this.currentTime = currentTime.plus(currentTimeDelta.toMillis(), MILLIS);
+    }
+}

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-oauth2-refresh/config.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-oauth2-refresh/config.properties
@@ -23,7 +23,8 @@ http-server.authentication.oauth2.client-secret=trinodb_client_secret
 http-server.authentication.oauth2.user-mapping.pattern=(.*)(@.*)?
 http-server.authentication.oauth2.groups-field=groups
 http-server.authentication.oauth2.refresh-tokens=true
-http-server.authentication.oauth2.refresh-tokens.issued-token.timeout=30s
+http-server.authentication.oauth2.refresh-tokens.issued-token.timeout=16s
+http-server.authentication.oauth2.refresh-tokens.last-eligible-refresh-before-timeout=2s
 http-server.authentication.oauth2.oidc.discovery=false
 oauth2-jwk.http-client.trust-store-path=/docker/presto-product-tests/conf/presto/etc/hydra.pem
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/jdbc/TestExternalAuthorizerOAuth2RefreshToken.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/jdbc/TestExternalAuthorizerOAuth2RefreshToken.java
@@ -133,8 +133,14 @@ public class TestExternalAuthorizerOAuth2RefreshToken
 
             Assertions.assertThat(redirectHandler.getRedirectCount()).isEqualTo(1);
 
-            //Wait until the refresh token expires (15s) . See: HydraIdentityProvider.TTL_REFRESH_TOKEN_IN_SECONDS
-            SECONDS.sleep(20);
+            /**
+             * Wait until the refresh token expires (15s) . See: HydraIdentityProvider.TTL_REFRESH_TOKEN_IN_SECONDS
+             * To make sure that internally issued token will still be valid, last-eligible-refresh-before-timeout has been set to 2s,
+             * which allows us to sleep for 14s, but no refresh-token should be performed.
+             *
+             * Please mind that in production scenario, internal token expiration time should be no further than refresh-token expiration time.
+             */
+            SECONDS.sleep(14);
             try (PreparedStatement repeatedStatement = connection.prepareStatement("SELECT * FROM tpch.tiny.nation");
                     ResultSet repeatedResults = repeatedStatement.executeQuery()) {
                 assertThat(forResultSet(repeatedResults)).matches(TpchTableResults.PRESTO_NATION_RESULT);
@@ -159,7 +165,7 @@ public class TestExternalAuthorizerOAuth2RefreshToken
             Assertions.assertThat(redirectHandler.getRedirectCount()).isEqualTo(1);
 
             //Wait until the internally issued token expires. See: http-server.authentication.oauth2.refresh-tokens.issued-token.timeout
-            SECONDS.sleep(35);
+            SECONDS.sleep(20);
 
             try (PreparedStatement repeatedStatement = connection.prepareStatement("SELECT * FROM tpch.tiny.nation");
                     ResultSet repeatedResults = repeatedStatement.executeQuery()) {


### PR DESCRIPTION
It's still in WIP, but the idea is that
in order to get async refresh flows, we need to allow for
failure during refresh, that will not result in asking to relog, but with failing the query -
which should result in the necessity to repeat the query.

In order to prevent as much as possible such situations, I propose introducing another Duration
to config, that would allow prevent refresh token flows, when there is a chance that the call might
not be handled before refresh-token expiration. By default I keep it disabled, but normaly I would assume
that around 1-3 seconds to refreh token expiration, we should probably start requesting from clients to go through
idp login flow again.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
