### PR TITLE
Correct release notes for Iceberg Parquet writes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
           cache: 'maven'
       - name: Configure Problem Matchers
         run: |
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
           cache: 'maven'
       - name: Configure Problem Matchers
         run: |

--- a/docs/src/main/sphinx/release/release-389.md
+++ b/docs/src/main/sphinx/release/release-389.md
@@ -1,3 +1,4 @@
+
 # Release 389 (7 July 2022)
 
 ## General
@@ -31,7 +32,7 @@
 
 ## Iceberg connector
 
-* Improve optimized Parquet writer performance for
+* Improve performance when writing Parquet files with
   [non-structural data types](structural-data-types). ({issue}`13030`)
 
 ## MongoDB connector


### PR DESCRIPTION
Iceberg connector has just one Parquet writer, so "optimized writer" has
no meaning there.

Follows https://github.com/trinodb/trino/pull/13030