### PR TITLE
Rename ambiguous variable in JoinUtils

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/join/JoinUtils.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/JoinUtils.java
@@ -67,7 +67,7 @@ public final class JoinUtils
                             planNode -> planNode instanceof ProjectNode ||
                                     isLocalRepartitionExchange(planNode) ||
                                     isLocalGatherExchange(planNode))  // used in cross join case
-                    .where(joinNode -> isRemoteReplicatedExchange(joinNode) || isRemoteReplicatedSourceNode(joinNode))
+                    .where(planNode -> isRemoteReplicatedExchange(planNode) || isRemoteReplicatedSourceNode(planNode))
                     .matches();
         }
         return PlanNodeSearcher.searchFrom(((SemiJoinNode) node).getFilteringSource())


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
This pr aims to fix a minor problem with variable naming, Variable `joinNode` in `JoinUtils.isBuildSideReplicated` should be `rightNode`.

