### PR TITLE
Validate argument declarations of a table function

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -1596,14 +1596,16 @@ class StatementAnalyzer
                 throw semanticException(INVALID_ARGUMENTS, errorLocation, "All arguments must be passed by name or all must be passed positionally");
             }
 
+            // validate argument specifications: check there are no duplicate names
+            Map<String, ArgumentSpecification> argumentSpecificationsByName = new HashMap<>();
+            for (ArgumentSpecification argumentSpecification : argumentSpecifications) {
+                if (argumentSpecificationsByName.put(argumentSpecification.getName(), argumentSpecification) != null) {
+                    throw new IllegalStateException("Duplicate argument specification for name: " + argumentSpecification.getName());
+                }
+            }
+
             ImmutableMap.Builder<String, Argument> passedArguments = ImmutableMap.builder();
             if (argumentsPassedByName) {
-                Map<String, ArgumentSpecification> argumentSpecificationsByName = new HashMap<>();
-                for (ArgumentSpecification argumentSpecification : argumentSpecifications) {
-                    if (argumentSpecificationsByName.put(argumentSpecification.getName(), argumentSpecification) != null) {
-                        throw new IllegalStateException("Duplicate argument specification for name: " + argumentSpecification.getName());
-                    }
-                }
                 Set<String> uniqueArgumentNames = new HashSet<>();
                 for (TableFunctionArgument argument : arguments) {
                     String argumentName = argument.getName().get().getCanonicalValue();

--- a/core/trino-spi/src/main/java/io/trino/spi/ptf/AbstractConnectorTableFunction.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/ptf/AbstractConnectorTableFunction.java
@@ -16,8 +16,10 @@ package io.trino.spi.ptf;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
@@ -35,6 +37,14 @@ public abstract class AbstractConnectorTableFunction
         this.name = requireNonNull(name, "name is null");
         this.arguments = List.copyOf(requireNonNull(arguments, "arguments is null"));
         this.returnTypeSpecification = requireNonNull(returnTypeSpecification, "returnTypeSpecification is null");
+
+        // validate argument specifications: check there are no duplicate names
+        Set<String> names = new HashSet<>();
+        for (ArgumentSpecification argument : arguments) {
+            if (!names.add(argument.getName())) {
+                throw new IllegalStateException("Duplicate argument specification for name: " + argument.getName());
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
Check that there are no duplicate argument names.

The check is applied twice:
First, in `AbstractConnectorTableFunction`. It allows to catch
the error at function creation time, instead of failing the query
when the function is invoked. However, there is no guarantee
that each table function implementation will extend
`AbstractConnectorTableFunction`. Thus, there is the second check,
performed in `StatementAnalyzer` after the function invocation.

Without any of these checks, the query would fail anyway.
The checks provide a meaningful error message, and a chance
for earlier failure.

## Documentation
No documentation is needed.


## Release notes
No release notes entries required.
