### PR TITLE
Fix inserting into table with identifiers with quotes

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/util/PrimitiveTypeMapBuilder.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/util/PrimitiveTypeMapBuilder.java
@@ -82,7 +82,7 @@ public class PrimitiveTypeMapBuilder
         parent = ImmutableList.<String>builder().addAll(parent).add(name).build();
         for (RowType.Field field : type.getFields()) {
             checkArgument(field.getName().isPresent(), "field in struct type doesn't have name");
-            visitType(field.getType(), field.getName().get(), parent);
+            visitType(field.getType(), makeCompatibleName(field.getName().get()), parent);
         }
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -4402,6 +4402,17 @@ public abstract class BaseIcebergConnectorTest
         assertUpdate(format("DROP TABLE %s", tableName));
     }
 
+    @Test
+    public void testInsertingIntoTablesWithColumnsWithQuotesInName()
+    {
+        String tableName = "test_inserting_into_tables_with_quotes_" + randomTableSuffix();
+        assertUpdate(format("CREATE TABLE %s (\"an identifier with \"\"quotes\"\" \" INTEGER, x row (\"another identifier\" INTEGER))", tableName));
+        assertUpdate(format("INSERT INTO %s VALUES (1, row(11))", tableName), 1);
+        assertThat(query(format("SELECT * FROM %s", tableName)))
+                .matches("VALUES (INTEGER '1', CAST(ROW(11) AS ROW(\"another identifier\"INTEGER)))");
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
     @Override
     protected OptionalInt maxTableNameLength()
     {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/util/TestPrimitiveTypeMapBuilder.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/util/TestPrimitiveTypeMapBuilder.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.util;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestPrimitiveTypeMapBuilder
+{
+    @Test
+    public void testMakeTypeMapProducesCorrectMapForTypesWithQuotes()
+    {
+        List<Type> inputTypes = ImmutableList.of(INTEGER, RowType.from(ImmutableList.of(new RowType.Field(Optional.of("another identifier"), INTEGER))));
+        List<String> inputColumnNames = ImmutableList.of("an identifier with \"quotes\" ", "a");
+
+        assertThat(PrimitiveTypeMapBuilder.makeTypeMap(inputTypes, inputColumnNames)).containsExactly(
+                Map.entry(ImmutableList.of("an_x20identifier_x20with_x20_x22quotes_x22_x20"), INTEGER),
+                Map.entry(ImmutableList.of("a", "another_x20identifier"), INTEGER));
+    }
+}


### PR DESCRIPTION
## Description

> Is this change a fix, improvement, new feature, refactoring, or other?

a fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

a connector

> How would you describe this change to a non-technical end user or system administrator?

It fixes inserts for tables with columns with quotes in their names

## Related issues, pull requests, and links

Fixes: https://github.com/trinodb/trino/issues/13074

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Iceberg
* Fix failure when inserting into a Parquet table with columns with quotes in names. ({issue}`13074`)
```
