### PR TITLE
Update TrinoFileSystemCache to represent latest hadoop implementation

### DIFF
--- a/lib/trino-hdfs/pom.xml
+++ b/lib/trino-hdfs/pom.xml
@@ -107,6 +107,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>testing</artifactId>
             <scope>test</scope>
@@ -115,6 +121,18 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/lib/trino-hdfs/pom.xml
+++ b/lib/trino-hdfs/pom.xml
@@ -98,6 +98,13 @@
             <artifactId>jmxutils</artifactId>
         </dependency>
 
+        <!-- used by tests but also needed transitively -->
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>concurrent</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>io.airlift</groupId>

--- a/lib/trino-hdfs/src/test/java/io/trino/hdfs/BenchmarkGetFileSystem.java
+++ b/lib/trino-hdfs/src/test/java/io/trino/hdfs/BenchmarkGetFileSystem.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hdfs;
+
+import io.trino.jmh.Benchmarks;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SplittableRandom;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static io.airlift.concurrent.MoreFutures.getFutureValue;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5, time = 5000, timeUnit = MILLISECONDS)
+@Fork(2)
+@Measurement(iterations = 5, time = 5000, timeUnit = MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkGetFileSystem
+{
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        @Param({"10", "100", "1000"})
+        private int userCount;
+
+        @Param({"1", "16"})
+        private int threadCount;
+
+        @Param("1000")
+        private int getCallsPerInvocation;
+
+        public List<Callable<Void>> callableTasks;
+        public ExecutorService executor;
+        public Blackhole blackhole;
+
+        @Setup(Level.Invocation)
+        public void setUp(Blackhole blackhole)
+        {
+            this.blackhole = blackhole;
+
+            this.callableTasks = new ArrayList<>();
+            for (int i = 0; i < threadCount; i++) {
+                this.callableTasks.add(new TestFileSystemCache.CreateFileSystemsAndConsume(
+                        new SplittableRandom(i), userCount, getCallsPerInvocation, fs -> {}));
+            }
+
+            this.executor = Executors.newFixedThreadPool(threadCount);
+        }
+
+        @TearDown(Level.Invocation)
+        public void tearDown()
+                throws IOException
+        {
+            TrinoFileSystemCache.INSTANCE.closeAll();
+            executor.shutdownNow();
+        }
+    }
+
+    @Benchmark
+    public void benchmark(BenchmarkData data)
+            throws InterruptedException, ExecutionException
+    {
+        data.executor.invokeAll(data.callableTasks).forEach(f -> data.blackhole.consume(getFutureValue(f)));
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        Benchmarks.benchmark(BenchmarkGetFileSystem.class).run();
+    }
+}

--- a/lib/trino-hdfs/src/test/java/io/trino/hdfs/TestFSDataInputStreamTail.java
+++ b/lib/trino-hdfs/src/test/java/io/trino/hdfs/TestFSDataInputStreamTail.java
@@ -70,6 +70,7 @@ public class TestFSDataInputStreamTail
         closeAll(
                 () -> fs.delete(new Path(tempRoot.toURI()), true),
                 fs);
+        fs = null;
     }
 
     @Test

--- a/lib/trino-hdfs/src/test/java/io/trino/hdfs/TestFileSystemCache.java
+++ b/lib/trino-hdfs/src/test/java/io/trino/hdfs/TestFileSystemCache.java
@@ -14,22 +14,45 @@
 package io.trino.hdfs;
 
 import com.google.common.collect.ImmutableSet;
+import io.airlift.concurrent.MoreFutures;
 import io.trino.hdfs.authentication.ImpersonatingHdfsAuthentication;
 import io.trino.hdfs.authentication.SimpleHadoopAuthentication;
 import io.trino.hdfs.authentication.SimpleUserNameProvider;
 import io.trino.spi.security.ConnectorIdentity;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.gaul.modernizer_maven_annotations.SuppressModernizer;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SplittableRandom;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertSame;
 
+@Test(singleThreaded = true)
 public class TestFileSystemCache
 {
+    @BeforeMethod(alwaysRun = true)
+    @AfterClass(alwaysRun = true)
+    public void cleanup()
+            throws IOException
+    {
+        FileSystem.closeAll();
+    }
+
     @Test
     public void testFileSystemCache()
             throws IOException
@@ -56,9 +79,98 @@ public class TestFileSystemCache
         assertNotSame(fs5, fs1);
     }
 
-    private FileSystem getFileSystem(HdfsEnvironment environment, ConnectorIdentity identity)
+    @Test
+    public void testFileSystemCacheException() throws IOException
+    {
+        HdfsEnvironment environment = new HdfsEnvironment(
+                new DynamicHdfsConfiguration(new HdfsConfigurationInitializer(new HdfsConfig()), ImmutableSet.of()),
+                new HdfsConfig(),
+                new ImpersonatingHdfsAuthentication(new SimpleHadoopAuthentication(), new SimpleUserNameProvider()));
+
+        int maxCacheSize = 1000;
+        for (int i = 0; i < maxCacheSize; i++) {
+            assertEquals(TrinoFileSystemCache.INSTANCE.getFileSystemCacheStats().getCacheSize(), i);
+            getFileSystem(environment, ConnectorIdentity.ofUser("user" + i));
+        }
+        assertEquals(TrinoFileSystemCache.INSTANCE.getFileSystemCacheStats().getCacheSize(), maxCacheSize);
+        assertThatThrownBy(() -> getFileSystem(environment, ConnectorIdentity.ofUser("user" + maxCacheSize)))
+                .isInstanceOf(IOException.class)
+                .hasMessage("FileSystem max cache size has been reached: " + maxCacheSize);
+    }
+
+    @Test
+    public void testFileSystemCacheConcurrency() throws InterruptedException, ExecutionException, IOException
+    {
+        int numThreads = 20;
+        List<Callable<Void>> callableTasks = new ArrayList<>();
+        for (int i = 0; i < numThreads; i++) {
+            callableTasks.add(
+                    new CreateFileSystemsAndConsume(
+                            new SplittableRandom(i),
+                            10,
+                            1000,
+                            new FileSystemCloser()));
+        }
+        ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+
+        assertEquals(TrinoFileSystemCache.INSTANCE.getFileSystemCacheStats().getCacheSize(), 0);
+        executor.invokeAll(callableTasks).forEach(MoreFutures::getFutureValue);
+        executor.shutdown();
+        assertEquals(TrinoFileSystemCache.INSTANCE.getFileSystemCacheStats().getCacheSize(), 0, "Cache size is non zero");
+    }
+
+    private static FileSystem getFileSystem(HdfsEnvironment environment, ConnectorIdentity identity)
             throws IOException
     {
         return environment.getFileSystem(identity, new Path("/"), newEmptyConfiguration());
+    }
+
+    @FunctionalInterface
+    public interface FileSystemConsumer
+    {
+        void consume(FileSystem fileSystem) throws IOException;
+    }
+
+    private static class FileSystemCloser
+            implements FileSystemConsumer
+    {
+        @Override
+        @SuppressModernizer
+        public void consume(FileSystem fileSystem) throws IOException
+        {
+            fileSystem.close();  /* triggers fscache.remove() */
+        }
+    }
+
+    public static class CreateFileSystemsAndConsume
+            implements Callable<Void>
+    {
+        private final SplittableRandom random;
+        private final int userCount;
+        private final int getCallsPerInvocation;
+        private final FileSystemConsumer consumer;
+
+        private static final HdfsEnvironment environment = new HdfsEnvironment(
+                new DynamicHdfsConfiguration(new HdfsConfigurationInitializer(new HdfsConfig()), ImmutableSet.of()),
+                new HdfsConfig(),
+                new ImpersonatingHdfsAuthentication(new SimpleHadoopAuthentication(), new SimpleUserNameProvider()));
+
+        CreateFileSystemsAndConsume(SplittableRandom random, int numUsers, int numGetCallsPerInvocation, FileSystemConsumer consumer)
+        {
+            this.random = requireNonNull(random, "random is null");
+            this.userCount = numUsers;
+            this.getCallsPerInvocation = numGetCallsPerInvocation;
+            this.consumer = consumer;
+        }
+
+        @Override
+        public Void call() throws IOException
+        {
+            for (int i = 0; i < getCallsPerInvocation; i++) {
+                FileSystem fs = getFileSystem(environment, ConnectorIdentity.ofUser("user" + random.nextInt(userCount)));
+                consumer.consume(fs);
+            }
+            return null;
+        }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
## Motivation
Hadoop's implementation of filesystem cache ([hadoop 3.2 filesystem cache](https://github.com/apache/hadoop/blob/release-3.2.0-RC1/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java#L3342)) creates the filesystem object outside of synchronized block. A side effect to this (in addition to reduced locking duration for slow-to-create filesystem implementations) is that there is no interaction between the lock in caching infrastructure and locks internal to a filesystem implementation (during filesystem object creation). We would like to bring this approach to `TrinoFileSystemCache`

A secondary motivation is to improve the concurrency of `TrinoFileSystemCache` operations by avoiding synchronized blocks.

## Description
 - Use ConcurrentHashMap to cache filesystem objects - improves
   concurrency by removing synchronized blocks
 - Filesystem object is created outside cache's lock - similar to latest
   hadoop fs cache impl, further reducing code in critical section.
   Helps with systems where filesystem creation is expensive.
 - Only one thread exclusively creates the filesystem object for a
   given key. Avoids speculative creation and then later discarding of
   filesystem objects compared to hadoop fs cache impl.

There is a more recent update in hadoop 3.3.x branch that limits the number of parallel filesystem object creations using a semaphore. Looking at the description of the issue ([HADOOP-17313](https://issues.apache.org/jira/browse/HADOOP-17313)), it seems to be created as a workaround for speculative-create-and-discard approach used in hadoop implementation which this code avoids.


Benchmark output -
Before:
```
Benchmark                         (numGetCallsPerInvocation)  (numThreads)  (numUsers)  Mode  Cnt   Score   Error  Units
BenchmarkGetFileSystem.benchmark                        1000             1          10  avgt   10   7.747 ± 0.448  ms/op
BenchmarkGetFileSystem.benchmark                        1000             1         100  avgt   10   8.041 ± 0.352  ms/op
BenchmarkGetFileSystem.benchmark                        1000             1        1000  avgt   10   7.492 ± 0.340  ms/op
BenchmarkGetFileSystem.benchmark                        1000            16          10  avgt   10  69.900 ± 8.675  ms/op
BenchmarkGetFileSystem.benchmark                        1000            16         100  avgt   10  66.847 ± 2.937  ms/op
BenchmarkGetFileSystem.benchmark                        1000            16        1000  avgt   10  70.222 ± 4.286  ms/op
```
After:
```
Benchmark                         (numGetCallsPerInvocation)  (numThreads)  (numUsers)  Mode  Cnt   Score   Error  Units
BenchmarkGetFileSystem.benchmark                        1000             1          10  avgt   10   7.767 ± 0.511  ms/op
BenchmarkGetFileSystem.benchmark                        1000             1         100  avgt   10   7.412 ± 0.267  ms/op
BenchmarkGetFileSystem.benchmark                        1000             1        1000  avgt   10   7.385 ± 0.284  ms/op
BenchmarkGetFileSystem.benchmark                        1000            16          10  avgt   10  26.333 ± 2.696  ms/op
BenchmarkGetFileSystem.benchmark                        1000            16         100  avgt   10  28.163 ± 1.489  ms/op
BenchmarkGetFileSystem.benchmark                        1000            16        1000  avgt   10  29.545 ± 4.080  ms/op
```
(above results are from an 8 core intel macbook pro)

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Update the implementation of TrinoFileSystemCache class in Hive connector.

> How would you describe this change to a non-technical end user or system administrator?

Bring `TrinoFileSystemCache` implementation inline with latest hadoop implementation and improve cache performance in the process.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Hive
* Improve performance by reducing contention in Trino's file system cache. ({issue}`13243 `)
```
