### PR TITLE
Revert "Retry TestingTrinoServer setup when port is already used"

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
+++ b/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
@@ -36,7 +36,6 @@ import io.airlift.http.server.testing.TestingHttpServerModule;
 import io.airlift.jaxrs.JaxrsModule;
 import io.airlift.jmx.testing.TestingJmxModule;
 import io.airlift.json.JsonModule;
-import io.airlift.log.Logger;
 import io.airlift.node.testing.TestingNodeModule;
 import io.airlift.tracetoken.TraceTokenModule;
 import io.trino.connector.CatalogName;
@@ -97,8 +96,6 @@ import io.trino.testing.TestingGroupProvider;
 import io.trino.testing.TestingWarningCollectorModule;
 import io.trino.transaction.TransactionManager;
 import io.trino.transaction.TransactionManagerModule;
-import net.jodah.failsafe.Failsafe;
-import net.jodah.failsafe.RetryPolicy;
 import org.weakref.jmx.guice.MBeanModule;
 
 import javax.annotation.concurrent.GuardedBy;
@@ -123,7 +120,6 @@ import java.util.concurrent.TimeoutException;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.nullToEmpty;
-import static com.google.common.base.Throwables.getStackTraceAsString;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static com.google.inject.util.Modules.EMPTY_MODULE;
@@ -137,8 +133,6 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public class TestingTrinoServer
         implements Closeable
 {
-    private static final Logger log = Logger.get(TestingTrinoServer.class);
-
     public static TestingTrinoServer create()
     {
         return builder().build();
@@ -292,17 +286,17 @@ public class TestingTrinoServer
 
         modules.add(additionalModule);
 
+        Bootstrap app = new Bootstrap(modules.build());
+
         Map<String, String> optionalProperties = new HashMap<>();
         environment.ifPresent(env -> optionalProperties.put("node.environment", env));
 
-        injector = Failsafe.with(new RetryPolicy<>()
-                        .withMaxRetries(5)
-                        .handleIf(throwable -> getStackTraceAsString(throwable).contains("BindException: Address already in use"))
-                .onRetry(event -> log.debug(
-                        "Initialization failed on attempt %s, will retry. Exception: %s",
-                        event.getAttemptCount(),
-                        event.getLastFailure().getMessage())))
-                .get(() -> initialize(serverProperties.buildOrThrow(), modules.build(), optionalProperties));
+        injector = app
+                .doNotInitializeLogging()
+                .setRequiredConfigurationProperties(serverProperties.buildOrThrow())
+                .setOptionalConfigurationProperties(optionalProperties)
+                .quiet()
+                .initialize();
 
         injector.getInstance(Announcer.class).start();
 
@@ -367,16 +361,6 @@ public class TestingTrinoServer
         announcer.forceAnnounce();
 
         refreshNodes();
-    }
-
-    private static Injector initialize(Map<String, String> serverProperties, List<Module> modules, Map<String, String> optionalProperties)
-    {
-        return new Bootstrap(modules)
-                .doNotInitializeLogging()
-                .setRequiredConfigurationProperties(serverProperties)
-                .setOptionalConfigurationProperties(optionalProperties)
-                .quiet()
-                .initialize();
     }
 
     @Override


### PR DESCRIPTION
This reverts commit 5a72170419ff51f1372d06a2dafd76eab724ae33. The change
was not necessary. The rationale was

    Even we typically use random port to setup TestingTrinoServer there is a
    low likelihood of a race condition where same port is used by two
    concurrent tests.

However, in practice, we always bind to 0, and such a bind is guaranteed
to succeed. If a specific test binds to a specific port, it's this
test's responsibility to guarantee the port is free, not
`TestingTrinoServer`'s.

Reverts trinodb/trino#13077