### PR TITLE
Add javadoc for ConnectorSplit#isRemotelyAccessible

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorSplit.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorSplit.java
@@ -20,6 +20,13 @@ import java.util.List;
 
 public interface ConnectorSplit
 {
+    /**
+     * Returns true when this ConnectorSplit can be scheduled on any node.
+     * <p>
+     * When true, the addresses returned by {@link #getAddresses()} may be used as hints by the scheduler
+     * during splits assignment.
+     * When false, the split will always be scheduled on one of the addresses returned by {@link #getAddresses()}.
+     */
     boolean isRemotelyAccessible();
 
     List<HostAddress> getAddresses();


### PR DESCRIPTION
## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:
