### PR TITLE
Reimplement GroupByIdBlock

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/BigintGroupByHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/BigintGroupByHash.java
@@ -21,7 +21,6 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.DictionaryBlock;
-import io.trino.spi.block.LongArrayBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.type.AbstractLongType;
 import io.trino.spi.type.BigintType;
@@ -30,7 +29,6 @@ import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -553,7 +551,7 @@ public class BigintGroupByHash
             checkState(lastPosition == block.getPositionCount(), "process has not yet finished");
             checkState(!finished, "result has produced");
             finished = true;
-            return new GroupByIdBlock(nextGroupId, new LongArrayBlock(block.getPositionCount(), Optional.empty(), groupIds));
+            return GroupByIdBlock.ofArray(nextGroupId, groupIds);
         }
     }
 
@@ -607,7 +605,7 @@ public class BigintGroupByHash
             checkState(lastPosition == block.getPositionCount(), "process has not yet finished");
             checkState(!finished, "result has produced");
             finished = true;
-            return new GroupByIdBlock(nextGroupId, new LongArrayBlock(block.getPositionCount(), Optional.empty(), groupIds));
+            return GroupByIdBlock.ofArray(nextGroupId, groupIds);
         }
     }
 
@@ -653,12 +651,7 @@ public class BigintGroupByHash
             checkState(processFinished);
             checkState(!resultProduced);
             resultProduced = true;
-
-            return new GroupByIdBlock(
-                    nextGroupId,
-                    new RunLengthEncodedBlock(
-                            BIGINT.createFixedSizeBlockBuilder(1).writeLong(groupId).build(),
-                            block.getPositionCount()));
+            return GroupByIdBlock.rle(nextGroupId, groupId, block.getPositionCount());
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/GroupByIdBlock.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupByIdBlock.java
@@ -13,9 +13,7 @@
  */
 package io.trino.operator;
 
-import io.airlift.slice.Slice;
 import io.trino.spi.block.Block;
-import io.trino.spi.block.BlockBuilder;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
@@ -55,7 +53,7 @@ public class GroupByIdBlock
     @Override
     public Block getRegion(int positionOffset, int length)
     {
-        return block.getRegion(positionOffset, length);
+        throw new UnsupportedOperationException("GroupByIdBlock does not support getRegion");
     }
 
     @Override
@@ -77,87 +75,15 @@ public class GroupByIdBlock
     }
 
     @Override
-    public Block copyRegion(int positionOffset, int length)
+    public Block copyRegion(int position, int length)
     {
-        return block.copyRegion(positionOffset, length);
-    }
-
-    @Override
-    public int getSliceLength(int position)
-    {
-        return block.getSliceLength(position);
-    }
-
-    @Override
-    public byte getByte(int position, int offset)
-    {
-        return block.getByte(position, offset);
-    }
-
-    @Override
-    public short getShort(int position, int offset)
-    {
-        return block.getShort(position, offset);
-    }
-
-    @Override
-    public int getInt(int position, int offset)
-    {
-        return block.getInt(position, offset);
+        throw new UnsupportedOperationException("GroupByIdBlock does not support copyRegion");
     }
 
     @Override
     public long getLong(int position, int offset)
     {
         return block.getLong(position, offset);
-    }
-
-    @Override
-    public Slice getSlice(int position, int offset, int length)
-    {
-        return block.getSlice(position, offset, length);
-    }
-
-    @Override
-    public <T> T getObject(int position, Class<T> clazz)
-    {
-        return block.getObject(position, clazz);
-    }
-
-    @Override
-    public boolean bytesEqual(int position, int offset, Slice otherSlice, int otherOffset, int length)
-    {
-        return block.bytesEqual(position, offset, otherSlice, otherOffset, length);
-    }
-
-    @Override
-    public int bytesCompare(int position, int offset, int length, Slice otherSlice, int otherOffset, int otherLength)
-    {
-        return block.bytesCompare(position, offset, length, otherSlice, otherOffset, otherLength);
-    }
-
-    @Override
-    public void writeBytesTo(int position, int offset, int length, BlockBuilder blockBuilder)
-    {
-        block.writeBytesTo(position, offset, length, blockBuilder);
-    }
-
-    @Override
-    public boolean equals(int position, int offset, Block otherBlock, int otherPosition, int otherOffset, int length)
-    {
-        return block.equals(position, offset, otherBlock, otherPosition, otherOffset, length);
-    }
-
-    @Override
-    public long hash(int position, int offset, int length)
-    {
-        return block.hash(position, offset, length);
-    }
-
-    @Override
-    public int compareTo(int leftPosition, int leftOffset, int leftLength, Block rightBlock, int rightPosition, int rightOffset, int rightLength)
-    {
-        return block.compareTo(leftPosition, leftOffset, leftLength, rightBlock, rightPosition, rightOffset, rightLength);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/GroupByIdBlock.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupByIdBlock.java
@@ -13,31 +13,70 @@
  */
 package io.trino.operator;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.trino.spi.block.Block;
 import org.openjdk.jol.info.ClassLayout;
 
-import java.util.List;
 import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static io.trino.spi.type.BigintType.BIGINT;
-import static java.util.Collections.singletonList;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
+/**
+ * A block holding 'long' (8-byte) values and an additional group count value.
+ * The implementation covers both standard and rle encoding through a simple
+ * trick of a logical conjunction (&) of the position with a mask that is
+ * full (111...111) for a standard encoding and empty (000...000) for a rle.
+ * This way the rle block will always return the first position from the underlying array.
+ * <p>
+ * The implementation guarantees that every fetch of a single value will not
+ * result in a virtual call and, as a result, may be safely inlined by the compiler.
+ * <p>
+ * The only limitation is that the block cannot be dictionary encoded, but this encoding
+ * is not used within group by logic.
+ */
 public class GroupByIdBlock
         implements Block
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(GroupByIdBlock.class).instanceSize();
+    private static final int SIZE_OF_ELEMENT = Long.BYTES;
+
+    private static final int MASK_ARRAY = -1;
+    private static final int MASK_RLE = 0;
 
     private final long groupCount;
-    private final Block block;
+    private final int positionCount;
+    private final long[] groups;
+    private final int mask;
 
-    public GroupByIdBlock(long groupCount, Block block)
+    public static GroupByIdBlock ofArray(long groupCount, long[] groupIds)
     {
-        requireNonNull(block, "block is null");
+        return new GroupByIdBlock(groupCount, groupIds.length, groupIds, MASK_ARRAY);
+    }
+
+    public static GroupByIdBlock rle(long groupCount, long groupId, int length)
+    {
+        return new GroupByIdBlock(groupCount, length, new long[] {groupId}, MASK_RLE);
+    }
+
+    public static GroupByIdBlock ofBlock(long groupCount, Block block)
+    {
+        long[] groups = new long[block.getPositionCount()];
+        for (int i = 0; i < block.getPositionCount(); i++) {
+            groups[i] = block.getLong(i, 0);
+        }
+        return GroupByIdBlock.ofArray(groupCount, groups);
+    }
+
+    private GroupByIdBlock(long groupCount, int positionCount, long[] groups, int mask)
+    {
         this.groupCount = groupCount;
-        this.block = block;
+        this.positionCount = positionCount;
+        this.groups = requireNonNull(groups, "groups is null");
+        this.mask = mask;
     }
 
     public long getGroupCount()
@@ -47,31 +86,32 @@ public class GroupByIdBlock
 
     public long getGroupId(int position)
     {
-        return BIGINT.getLong(block, position);
+        checkReadablePosition(position);
+        return groups[position & mask];
     }
 
-    @Override
-    public Block getRegion(int positionOffset, int length)
+    @VisibleForTesting
+    boolean isRle()
     {
-        throw new UnsupportedOperationException("GroupByIdBlock does not support getRegion");
+        return mask == MASK_RLE;
     }
 
     @Override
     public long getRegionSizeInBytes(int positionOffset, int length)
     {
-        return block.getRegionSizeInBytes(positionOffset, length);
+        return isRle() ? SIZE_OF_ELEMENT : length * SIZE_OF_ELEMENT;
     }
 
     @Override
     public OptionalInt fixedSizeInBytesPerPosition()
     {
-        return block.fixedSizeInBytesPerPosition();
+        return isRle() ? OptionalInt.empty() : OptionalInt.of(SIZE_OF_ELEMENT);
     }
 
     @Override
     public long getPositionsSizeInBytes(boolean[] positions, int selectedPositionCount)
     {
-        return block.getPositionsSizeInBytes(positions, selectedPositionCount);
+        return (long) SIZE_OF_ELEMENT * selectedPositionCount;
     }
 
     @Override
@@ -83,55 +123,59 @@ public class GroupByIdBlock
     @Override
     public long getLong(int position, int offset)
     {
-        return block.getLong(position, offset);
+        if (offset != 0) {
+            throw new IllegalArgumentException("offset must be zero");
+        }
+        return getGroupId(position);
     }
 
     @Override
     public Block getSingleValueBlock(int position)
     {
-        return block.getSingleValueBlock(position);
+        checkReadablePosition(position);
+        return GroupByIdBlock.rle(groupCount, getGroupId(position), 1);
     }
 
     @Override
     public boolean mayHaveNull()
     {
-        return block.mayHaveNull();
+        return false;
     }
 
     @Override
     public boolean isNull(int position)
     {
-        return block.isNull(position);
+        return false;
     }
 
     @Override
     public int getPositionCount()
     {
-        return block.getPositionCount();
+        return positionCount;
     }
 
     @Override
     public long getSizeInBytes()
     {
-        return block.getSizeInBytes();
+        return getRegionSizeInBytes(0, positionCount);
     }
 
     @Override
     public long getRetainedSizeInBytes()
     {
-        return INSTANCE_SIZE + block.getRetainedSizeInBytes();
+        return INSTANCE_SIZE + sizeOf(groups);
     }
 
     @Override
     public long getEstimatedDataSizeForStats(int position)
     {
-        return block.getEstimatedDataSizeForStats(position);
+        return SIZE_OF_ELEMENT;
     }
 
     @Override
     public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
-        consumer.accept(block, block.getRetainedSizeInBytes());
+        consumer.accept(groups, sizeOf(groups));
         consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
@@ -142,9 +186,23 @@ public class GroupByIdBlock
     }
 
     @Override
-    public Block copyPositions(int[] positions, int offset, int length)
+    public GroupByIdBlock copyPositions(int[] positions, int offset, int length)
     {
-        return block.copyPositions(positions, offset, length);
+        checkArrayRange(positions, offset, length);
+        if (isRle()) {
+            return GroupByIdBlock.rle(groupCount, getGroupId(0), length);
+        }
+        long[] newGroupIds = new long[length];
+        for (int i = 0; i < length; i++) {
+            newGroupIds[i] = getGroupId(positions[i + offset]);
+        }
+        return GroupByIdBlock.ofArray(groupCount, newGroupIds);
+    }
+
+    @Override
+    public Block getRegion(int positionOffset, int length)
+    {
+        throw new UnsupportedOperationException("GroupByIdBlock does not support serialization");
     }
 
     @Override
@@ -156,27 +214,44 @@ public class GroupByIdBlock
     @Override
     public String toString()
     {
-        return toStringHelper(this)
-                .add("groupCount", groupCount)
-                .add("positionCount", getPositionCount())
-                .toString();
+        return isRle() ?
+                "RLE(" + getGroupId(0) + ")" :
+                toStringHelper(this)
+                        .add("groupCount", groupCount)
+                        .add("positionCount", getPositionCount())
+                        .toString();
     }
 
     @Override
     public boolean isLoaded()
     {
-        return block.isLoaded();
+        return true;
     }
 
     @Override
     public Block getLoadedBlock()
     {
-        return block.getLoadedBlock();
+        return this;
     }
 
     @Override
-    public final List<Block> getChildren()
+    public Block getPositions(int[] positions, int offset, int length)
     {
-        return singletonList(block);
+        return copyPositions(positions, offset, length);
+    }
+
+    private void checkReadablePosition(int position)
+    {
+        if (position < 0 || position >= getPositionCount()) {
+            throw new IllegalArgumentException(format("Invalid position %s in block with %s positions", position, getPositionCount()));
+        }
+    }
+
+    private static void checkArrayRange(int[] array, int offset, int length)
+    {
+        requireNonNull(array, "array is null");
+        if (offset < 0 || length < 0 || offset + length > array.length) {
+            throw new IndexOutOfBoundsException(format("Invalid offset %s and length %s in array with %s elements", offset, length, array.length));
+        }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/MultiChannelGroupByHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/MultiChannelGroupByHash.java
@@ -21,7 +21,6 @@ import io.trino.spi.PageBuilder;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.DictionaryBlock;
-import io.trino.spi.block.LongArrayBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.type.Type;
 import io.trino.sql.gen.JoinCompiler;
@@ -806,7 +805,7 @@ public class MultiChannelGroupByHash
             checkState(lastPosition == page.getPositionCount(), "process has not yet finished");
             checkState(!finished, "result has produced");
             finished = true;
-            return new GroupByIdBlock(nextGroupId, new LongArrayBlock(groupIds.length, Optional.empty(), groupIds));
+            return GroupByIdBlock.ofArray(nextGroupId, groupIds);
         }
     }
 
@@ -868,7 +867,7 @@ public class MultiChannelGroupByHash
         {
             checkState(!finished, "result has produced");
             finished = true;
-            return new GroupByIdBlock(nextGroupId, new LongArrayBlock(groupIds.length, Optional.empty(), groupIds));
+            return GroupByIdBlock.ofArray(nextGroupId, groupIds);
         }
     }
 
@@ -924,7 +923,7 @@ public class MultiChannelGroupByHash
             checkState(lastPosition == page.getPositionCount(), "process has not yet finished");
             checkState(!finished, "result has produced");
             finished = true;
-            return new GroupByIdBlock(nextGroupId, new LongArrayBlock(groupIds.length, Optional.empty(), groupIds));
+            return GroupByIdBlock.ofArray(nextGroupId, groupIds);
         }
     }
 
@@ -970,12 +969,7 @@ public class MultiChannelGroupByHash
             checkState(processFinished);
             checkState(!resultProduced);
             resultProduced = true;
-
-            return new GroupByIdBlock(
-                    nextGroupId,
-                    new RunLengthEncodedBlock(
-                            BIGINT.createFixedSizeBlockBuilder(1).writeLong(groupId).build(),
-                            page.getPositionCount()));
+            return GroupByIdBlock.rle(nextGroupId, groupId, page.getPositionCount());
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/NoChannelGroupByHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/NoChannelGroupByHash.java
@@ -16,13 +16,10 @@ package io.trino.operator;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
-import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
-
-import static io.trino.spi.type.BigintType.BIGINT;
 
 public class NoChannelGroupByHash
         implements GroupByHash
@@ -79,7 +76,7 @@ public class NoChannelGroupByHash
     public Work<GroupByIdBlock> getGroupIds(Page page)
     {
         updateGroupCount(page);
-        return new CompletedWork<>(new GroupByIdBlock(page.getPositionCount() > 0 ? 1 : 0, RunLengthEncodedBlock.create(BIGINT, 0L, page.getPositionCount())));
+        return new CompletedWork<>(GroupByIdBlock.rle(page.getPositionCount() > 0 ? 1 : 0, 0, page.getPositionCount()));
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/DistinctAccumulatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/DistinctAccumulatorFactory.java
@@ -225,7 +225,7 @@ public class DistinctAccumulatorFactory
             Block distinctMask = work.getResult();
 
             // 3. feed a Page with a new mask to the underlying aggregation
-            GroupByIdBlock groupIds = new GroupByIdBlock(groupIdsBlock.getGroupCount(), filteredWithGroup.getBlock(0));
+            GroupByIdBlock groupIds = (GroupByIdBlock) filteredWithGroup.getBlock(0);
 
             // drop the group id column and prepend the distinct mask column
             int[] columnIndexes = new int[filteredWithGroup.getChannelCount() - 1];

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedAccumulatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedAccumulatorFactory.java
@@ -237,10 +237,11 @@ public class OrderedAccumulatorFactory
         {
             pagesIndex.sort(orderByChannels, orderings);
             Iterator<Page> pagesIterator = pagesIndex.getSortedPages();
-            pagesIterator.forEachRemaining(page -> accumulator.addInput(
-                    new GroupByIdBlock(groupCount, page.getBlock(page.getChannelCount() - 1)),
-                    page.getColumns(argumentChannels),
-                    Optional.empty()));
+            pagesIterator.forEachRemaining(page ->
+                    accumulator.addInput(
+                            GroupByIdBlock.ofBlock(groupCount, page.getBlock(page.getChannelCount() - 1)),
+                            page.getColumns(argumentChannels),
+                            Optional.empty()));
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/partial/SkipAggregationBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/partial/SkipAggregationBuilder.java
@@ -26,7 +26,6 @@ import io.trino.operator.aggregation.builder.HashAggregationBuilder;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
-import io.trino.spi.block.LongArrayBlock;
 
 import javax.annotation.Nullable;
 
@@ -145,9 +144,7 @@ public class SkipAggregationBuilder
 
     private GroupByIdBlock getGroupByIdBlock(int positionCount)
     {
-        return new GroupByIdBlock(
-                positionCount,
-                new LongArrayBlock(positionCount, Optional.empty(), consecutive(positionCount)));
+        return GroupByIdBlock.ofArray(positionCount, consecutive(positionCount));
     }
 
     private BlockBuilder[] serializeAccumulatorState(int positionCount)

--- a/core/trino-main/src/test/java/io/trino/operator/TestGroupByHash.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestGroupByHash.java
@@ -161,10 +161,6 @@ public class TestGroupByHash
         assertEquals(groupIds.getPositionCount(), 2);
         assertEquals(groupIds.getGroupId(0), 0);
         assertEquals(groupIds.getGroupId(1), 0);
-
-        List<Block> children = groupIds.getChildren();
-        assertEquals(children.size(), 1);
-        assertTrue(children.get(0) instanceof RunLengthEncodedBlock);
     }
 
     @Test(dataProvider = "groupByHashType")

--- a/core/trino-main/src/test/java/io/trino/operator/TestGroupByIdBlock.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestGroupByIdBlock.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import org.testng.annotations.Test;
+
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestGroupByIdBlock
+{
+    private static final long[] BUFFER = IntStream.range(0, 10)
+            .mapToLong(i -> i)
+            .toArray();
+
+    @Test
+    public void testGetLong()
+    {
+        GroupByIdBlock block = GroupByIdBlock.ofArray(0, BUFFER);
+        for (int i = 0; i < 10; i++) {
+            assertThat(block.getLong(i, 0)).isEqualTo(BUFFER[i]);
+        }
+
+        assertThatThrownBy(() -> block.getLong(0, 1)).hasMessageContaining("offset must be zero");
+        assertThatThrownBy(() -> block.getLong(-1, 0)).hasMessageContaining("Invalid position");
+        assertThatThrownBy(() -> block.getLong(10, 0)).hasMessageContaining("Invalid position");
+    }
+
+    @Test
+    public void testGetLongRle()
+    {
+        GroupByIdBlock block = GroupByIdBlock.rle(0, 42, 10);
+        for (int i = 0; i < 10; i++) {
+            assertThat(block.getLong(i, 0)).isEqualTo(42);
+        }
+
+        assertThatThrownBy(() -> block.getLong(0, 1)).hasMessageContaining("offset must be zero");
+        assertThatThrownBy(() -> block.getLong(-1, 0)).hasMessageContaining("Invalid position");
+        assertThatThrownBy(() -> block.getLong(10, 0)).hasMessageContaining("Invalid position");
+    }
+
+    @Test
+    public void testCopyPositions()
+    {
+        GroupByIdBlock block = GroupByIdBlock.ofArray(0, BUFFER);
+        GroupByIdBlock rleBlock = GroupByIdBlock.rle(0, 42, 10);
+        int[] positions = new int[] {5, 4, 3, 2, 1};
+
+        GroupByIdBlock copied = block.copyPositions(positions, 1, 3);
+        GroupByIdBlock rleCopied = rleBlock.copyPositions(positions, 1, 3);
+        assertThat(copied.getPositionCount()).isEqualTo(3);
+        assertThat(rleCopied.getPositionCount()).isEqualTo(3);
+
+        assertThat(copied.getGroupId(0)).isEqualTo(4);
+        assertThat(copied.getGroupId(1)).isEqualTo(3);
+        assertThat(copied.getGroupId(2)).isEqualTo(2);
+        assertThat(rleCopied.isRle()).isTrue();
+        assertThat(rleCopied.getGroupId(0)).isEqualTo(42);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/AggregationTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/AggregationTestUtils.java
@@ -35,7 +35,6 @@ import java.util.OptionalInt;
 import java.util.function.BiFunction;
 import java.util.stream.IntStream;
 
-import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.sql.planner.plan.AggregationNode.Step.FINAL;
 import static io.trino.sql.planner.plan.AggregationNode.Step.PARTIAL;
@@ -358,11 +357,7 @@ public final class AggregationTestUtils
 
     public static GroupByIdBlock createGroupByIdBlock(int groupId, int positions)
     {
-        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, positions);
-        for (int i = 0; i < positions; i++) {
-            BIGINT.writeLong(blockBuilder, groupId);
-        }
-        return new GroupByIdBlock(groupId, blockBuilder.build());
+        return GroupByIdBlock.rle(groupId, groupId, positions);
     }
 
     static int[] createArgs(int parameterCount)

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/BenchmarkDecimalAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/BenchmarkDecimalAggregation.java
@@ -42,7 +42,6 @@ import java.util.OptionalInt;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
-import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DecimalType.createDecimalType;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static io.trino.sql.planner.plan.AggregationNode.Step.FINAL;
@@ -132,11 +131,11 @@ public class BenchmarkDecimalAggregation
                 }
             }
 
-            BlockBuilder ids = BIGINT.createBlockBuilder(null, ELEMENT_COUNT);
+            long[] ids = new long[ELEMENT_COUNT];
             for (int i = 0; i < ELEMENT_COUNT; i++) {
-                BIGINT.writeLong(ids, ThreadLocalRandom.current().nextLong(groupCount));
+                ids[i] = ThreadLocalRandom.current().nextLong(groupCount);
             }
-            groupIds = new GroupByIdBlock(groupCount, ids.build());
+            groupIds = GroupByIdBlock.ofArray(groupCount, ids);
             intermediateValues = new Page(createIntermediateValues(partialAggregatorFactory.createGroupedAggregator(), groupIds, values));
         }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

It appears that somewhere around 1% of cpu time is spent eexcuting `getLong` method in `GroupByIdBlock` class. Since this class may hold either standard or rle encoded block, the calls were virtual and could not be inlined.
This PR introduces a simple trick in which a mask is applied to the `position` argument before fetching long value from an underlying array. If encoding is standard, the mask consists of 1s and the position remains unchanged. For RLE, however, the mask is 0 and it always ends up as a 0 position and the data is fetched from the first and only array position.

This may spawn a discussion about using a similar trick for other types of blocks in the future. The megamorphic calls are all around the JFR profiles and code generation only partially mitigates this problem.

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

improvement
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core query engine
> How would you describe this change to a non-technical end user or system administrator?

As always: "slow -> fast"
## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

We usually don't put that kind of changes in the release notes, but maybe it is time to start bragging properly

```markdown
# Section
* Improve performance of aggregated blocks of data
```
