### PR TITLE
Introduce TemporaryRelation 

### DIFF
--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryViewCreateAndInsertDataSetup.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryViewCreateAndInsertDataSetup.java
@@ -34,9 +34,9 @@ public class BigQueryViewCreateAndInsertDataSetup
     }
 
     @Override
-    public TestTable setupTestTable(List<ColumnSetup> inputs)
+    public TestTable setupTemporaryRelation(List<ColumnSetup> inputs)
     {
-        TestTable table = super.setupTestTable(inputs);
+        TestTable table = super.setupTemporaryRelation(inputs);
         BigQueryTestView view = new BigQueryTestView(sqlExecutor, table);
         view.createView();
         return view;

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraCreateAndInsertDataSetup.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraCreateAndInsertDataSetup.java
@@ -18,6 +18,7 @@ import io.airlift.json.JsonCodec;
 import io.trino.testing.datatype.ColumnSetup;
 import io.trino.testing.datatype.DataSetup;
 import io.trino.testing.sql.SqlExecutor;
+import io.trino.testing.sql.TemporaryRelation;
 import io.trino.testing.sql.TestTable;
 
 import java.util.List;
@@ -62,7 +63,7 @@ public class CassandraCreateAndInsertDataSetup
     }
 
     @Override
-    public TestTable setupTestTable(List<ColumnSetup> inputs)
+    public TemporaryRelation setupTemporaryRelation(List<ColumnSetup> inputs)
     {
         TestTable testTable = createTestTable(inputs);
         String tableName = testTable.getName().substring(keyspaceName.length() + 1);

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoCreateAndInsertDataSetup.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoCreateAndInsertDataSetup.java
@@ -16,6 +16,7 @@ package io.trino.plugin.mongodb;
 import com.mongodb.client.MongoClient;
 import io.trino.testing.datatype.ColumnSetup;
 import io.trino.testing.datatype.DataSetup;
+import io.trino.testing.sql.TemporaryRelation;
 import io.trino.testing.sql.TestTable;
 import io.trino.testing.sql.TrinoSqlExecutor;
 import org.bson.Document;
@@ -43,7 +44,7 @@ public final class MongoCreateAndInsertDataSetup
     }
 
     @Override
-    public TestTable setupTestTable(List<ColumnSetup> inputs)
+    public TemporaryRelation setupTemporaryRelation(List<ColumnSetup> inputs)
     {
         TestTable testTable = new MongoTestTable(trinoSqlExecutor, tableNamePrefix);
         try {

--- a/testing/trino-testing/src/main/java/io/trino/testing/datatype/CreateAndInsertDataSetup.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/datatype/CreateAndInsertDataSetup.java
@@ -38,7 +38,7 @@ public class CreateAndInsertDataSetup
     }
 
     @Override
-    public TestTable setupTestTable(List<ColumnSetup> inputs)
+    public TestTable setupTemporaryRelation(List<ColumnSetup> inputs)
     {
         TestTable testTable = createTestTable(inputs);
         try {

--- a/testing/trino-testing/src/main/java/io/trino/testing/datatype/CreateAndTrinoInsertDataSetup.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/datatype/CreateAndTrinoInsertDataSetup.java
@@ -14,6 +14,7 @@
 package io.trino.testing.datatype;
 
 import io.trino.testing.sql.SqlExecutor;
+import io.trino.testing.sql.TemporaryRelation;
 import io.trino.testing.sql.TestTable;
 import io.trino.testing.sql.TrinoSqlExecutor;
 
@@ -39,7 +40,7 @@ public class CreateAndTrinoInsertDataSetup
     }
 
     @Override
-    public TestTable setupTestTable(List<ColumnSetup> inputs)
+    public TemporaryRelation setupTemporaryRelation(List<ColumnSetup> inputs)
     {
         TestTable testTable = createTestTable(inputs);
         try {

--- a/testing/trino-testing/src/main/java/io/trino/testing/datatype/CreateAsSelectDataSetup.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/datatype/CreateAsSelectDataSetup.java
@@ -35,7 +35,7 @@ public class CreateAsSelectDataSetup
     }
 
     @Override
-    public TestTable setupTestTable(List<ColumnSetup> inputs)
+    public TestTable setupTemporaryRelation(List<ColumnSetup> inputs)
     {
         List<String> columnValues = inputs.stream()
                 .map(this::format)

--- a/testing/trino-testing/src/main/java/io/trino/testing/datatype/DataTypeTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/datatype/DataTypeTest.java
@@ -18,7 +18,7 @@ import io.trino.Session;
 import io.trino.spi.type.Type;
 import io.trino.testing.MaterializedResult;
 import io.trino.testing.QueryRunner;
-import io.trino.testing.sql.TestTable;
+import io.trino.testing.sql.TemporaryRelation;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -86,35 +86,35 @@ public class DataTypeTest
     {
         List<Type> expectedTypes = inputs.stream().map(Input::getTrinoResultType).collect(toList());
         List<Object> expectedResults = inputs.stream().map(Input::toTrinoQueryResult).collect(toList());
-        try (TestTable testTable = dataSetup.setupTestTable(unmodifiableList(inputs))) {
-            MaterializedResult materializedRows = trinoExecutor.execute(session, "SELECT * from " + testTable.getName());
+        try (TemporaryRelation temporaryRelation = dataSetup.setupTemporaryRelation(unmodifiableList(inputs))) {
+            MaterializedResult materializedRows = trinoExecutor.execute(session, "SELECT * from " + temporaryRelation.getName());
             checkResults(expectedTypes, expectedResults, materializedRows);
             if (runSelectWithWhere) {
-                queryWithWhere(trinoExecutor, session, expectedTypes, expectedResults, testTable);
+                queryWithWhere(trinoExecutor, session, expectedTypes, expectedResults, temporaryRelation);
             }
         }
         return this;
     }
 
-    private void queryWithWhere(QueryRunner trinoExecutor, Session session, List<Type> expectedTypes, List<Object> expectedResults, TestTable testTable)
+    private void queryWithWhere(QueryRunner trinoExecutor, Session session, List<Type> expectedTypes, List<Object> expectedResults, TemporaryRelation temporaryRelation)
     {
-        String trinoQuery = buildTrinoQueryWithWhereClauses(testTable);
+        String trinoQuery = buildTrinoQueryWithWhereClauses(temporaryRelation);
         try {
             MaterializedResult filteredRows = trinoExecutor.execute(session, trinoQuery);
             checkResults(expectedTypes, expectedResults, filteredRows);
         }
         catch (RuntimeException e) {
             log.error(e, "Exception caught during query with merged WHERE clause, querying one column at a time");
-            debugTypes(trinoExecutor, session, expectedTypes, expectedResults, testTable);
+            debugTypes(trinoExecutor, session, expectedTypes, expectedResults, temporaryRelation);
         }
     }
 
-    private void debugTypes(QueryRunner trinoExecutor, Session session, List<Type> expectedTypes, List<Object> expectedResults, TestTable testTable)
+    private void debugTypes(QueryRunner trinoExecutor, Session session, List<Type> expectedTypes, List<Object> expectedResults, TemporaryRelation temporaryRelation)
     {
         for (int i = 0; i < inputs.size(); i++) {
             Input<?> input = inputs.get(i);
             if (input.isUseInWhereClause()) {
-                String debugQuery = format("SELECT col_%d FROM %s WHERE col_%d IS NOT DISTINCT FROM %s", i, testTable.getName(), i, input.toTrinoLiteral());
+                String debugQuery = format("SELECT col_%d FROM %s WHERE col_%d IS NOT DISTINCT FROM %s", i, temporaryRelation.getName(), i, input.toTrinoLiteral());
                 log.info("Querying input: %d (expected type: %s, expectedResult: %s) using: %s", i, expectedTypes.get(i), expectedResults.get(i), debugQuery);
                 MaterializedResult debugRows = trinoExecutor.execute(session, debugQuery);
                 checkResults(expectedTypes.subList(i, i + 1), expectedResults.subList(i, i + 1), debugRows);
@@ -122,7 +122,7 @@ public class DataTypeTest
         }
     }
 
-    private String buildTrinoQueryWithWhereClauses(TestTable testTable)
+    private String buildTrinoQueryWithWhereClauses(TemporaryRelation temporaryRelation)
     {
         List<String> predicates = new ArrayList<>();
         for (int i = 0; i < inputs.size(); i++) {
@@ -131,7 +131,7 @@ public class DataTypeTest
                 predicates.add(format("col_%d IS NOT DISTINCT FROM %s", i, input.toTrinoLiteral()));
             }
         }
-        return "SELECT * FROM " + testTable.getName() + " WHERE " + join(" AND ", predicates);
+        return "SELECT * FROM " + temporaryRelation.getName() + " WHERE " + join(" AND ", predicates);
     }
 
     private void checkResults(List<Type> expectedTypes, List<Object> expectedResults, MaterializedResult materializedRows)

--- a/testing/trino-testing/src/main/java/io/trino/testing/sql/TemporaryRelation.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/sql/TemporaryRelation.java
@@ -11,13 +11,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.testing.datatype;
+package io.trino.testing.sql;
 
-import io.trino.testing.sql.TemporaryRelation;
-
-import java.util.List;
-
-public interface DataSetup
+public interface TemporaryRelation
+        extends AutoCloseable
 {
-    TemporaryRelation setupTemporaryRelation(List<ColumnSetup> inputs);
+    String getName();
+
+    @Override
+    void close();
 }

--- a/testing/trino-testing/src/main/java/io/trino/testing/sql/TestTable.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/sql/TestTable.java
@@ -28,7 +28,7 @@ import static java.lang.String.format;
 import static java.lang.String.join;
 
 public class TestTable
-        implements AutoCloseable
+        implements TemporaryRelation
 {
     private static final SecureRandom random = new SecureRandom();
     // The suffix needs to be long enough to "prevent" collisions in practice. The length of 5 was proven not to be long enough
@@ -67,6 +67,7 @@ public class TestTable
         }
     }
 
+    @Override
     public String getName()
     {
         return name;

--- a/testing/trino-testing/src/main/java/io/trino/testing/sql/TestView.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/sql/TestView.java
@@ -17,7 +17,7 @@ import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
 
 public class TestView
-        implements AutoCloseable
+        implements TemporaryRelation
 {
     private final SqlExecutor sqlExecutor;
     private final String name;
@@ -29,6 +29,7 @@ public class TestView
         sqlExecutor.execute(format("CREATE VIEW %s AS %s", name, viewBody));
     }
 
+    @Override
     public String getName()
     {
         return name;


### PR DESCRIPTION
DataSetup has a restriction that its implementation Data source should support SQL compatible
CREATE and INSERT operation. TemporaryRelation remove this restriction, thereby allowing support
for additional Data sources.

Extracted from this comment - https://github.com/trinodb/trino/pull/8474/files#r674815466

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Refactoring

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)


> How would you describe this change to a non-technical end user or system administrator?

Refactoring in tests

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
