### PR TITLE
Harden runaway split detection

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/executor/TaskExecutor.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/TaskExecutor.java
@@ -479,7 +479,7 @@ public class TaskExecutor
                         return;
                     }
 
-                    String threadId = split.getTaskHandle().getTaskId() + "-" + split.getSplitId();
+                    String threadId = split.getTaskHandle().getTaskId() + "-" + split.getSplitId() + "-" + System.nanoTime();
                     try (SetThreadName splitName = new SetThreadName(threadId)) {
                         RunningSplitInfo splitInfo = new RunningSplitInfo(ticker.read(), threadId, Thread.currentThread(), split);
                         runningSplitInfos.add(splitInfo);


### PR DESCRIPTION
Improve detection of runaway splits and related task killing code to
ensure that we do not kill a thread which we suppose hung, but moved to
execute on behalf of another query, just before we issue kill command.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

Bugfix (for a very low probablity race condition)


## Related issues, pull requests, and links

Improvement on top of https://github.com/trinodb/trino/pull/12392

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
