### PR TITLE
Revert "Release columnWriters on ParquetWriter#close"

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
@@ -184,7 +184,6 @@ public class ParquetWriter
         try (outputStream) {
             columnWriters.forEach(ColumnWriter::close);
             flush();
-            columnWriters = ImmutableList.of();
             writeFooter();
         }
         bufferedBytes = 0;


### PR DESCRIPTION
This reverts commit 822f43e00c2db438291cbcbc4dac5c64cd426766.
Insert query failures like below were observed due to the above change

Caused by: io.trino.jdbc.$internal.client.FailureInfo$FailureException: bytes cannot be negative
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:145) ~[guava-31.0.1-jre.jar!/:na]
	at io.trino.memory.context.SimpleLocalMemoryContext.setBytes(SimpleLocalMemoryContext.java:59) ~[na:na]
	at io.trino.operator.OperatorContext$InternalLocalMemoryContext.setBytes(OperatorContext.java:697) ~[na:na]
	at io.trino.operator.TableWriterOperator.updateMemoryUsage(TableWriterOperator.java:397)

> Is this change a fix, improvement, new feature, refactoring, or other?

fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

optimized parquet writer

> How would you describe this change to a non-technical end user or system administrator?

fixes insert query failures with optimized parquet writer

## Related issues, pull requests, and links

Reverts a commit that was part of https://github.com/trinodb/trino/pull/13208

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:
