### PR TITLE
Remove instance checks in PositionAppenders

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/output/BytePositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/BytePositionsAppender.java
@@ -22,7 +22,6 @@ import org.openjdk.jol.info.ClassLayout;
 import java.util.Arrays;
 import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.operator.output.PositionsAppenderUtil.calculateBlockResetSize;
 import static io.trino.operator.output.PositionsAppenderUtil.calculateNewArraySize;
@@ -56,13 +55,12 @@ public class BytePositionsAppender
     }
 
     @Override
+    // TODO: Make PositionsAppender work performant with different block types (https://github.com/trinodb/trino/issues/13267)
     public void append(IntArrayList positions, Block block)
     {
         if (positions.isEmpty()) {
             return;
         }
-        // performance of this method depends on block being always the same, flat type
-        checkArgument(block instanceof ByteArrayBlock);
         int[] positionArray = positions.elements();
         int positionsSize = positions.size();
         ensureCapacity(positionCount + positionsSize);

--- a/core/trino-main/src/main/java/io/trino/operator/output/Int128PositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/Int128PositionsAppender.java
@@ -22,7 +22,6 @@ import org.openjdk.jol.info.ClassLayout;
 import java.util.Arrays;
 import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.operator.output.PositionsAppenderUtil.calculateBlockResetSize;
@@ -57,13 +56,12 @@ public class Int128PositionsAppender
     }
 
     @Override
+    // TODO: Make PositionsAppender work performant with different block types (https://github.com/trinodb/trino/issues/13267)
     public void append(IntArrayList positions, Block block)
     {
         if (positions.isEmpty()) {
             return;
         }
-        // performance of this method depends on block being always the same, flat type
-        checkArgument(block instanceof Int128ArrayBlock);
         int[] positionArray = positions.elements();
         int positionsSize = positions.size();
         ensureCapacity(positionCount + positionsSize);

--- a/core/trino-main/src/main/java/io/trino/operator/output/Int96PositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/Int96PositionsAppender.java
@@ -22,7 +22,6 @@ import org.openjdk.jol.info.ClassLayout;
 import java.util.Arrays;
 import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.operator.output.PositionsAppenderUtil.calculateBlockResetSize;
@@ -58,13 +57,12 @@ public class Int96PositionsAppender
     }
 
     @Override
+    // TODO: Make PositionsAppender work performant with different block types (https://github.com/trinodb/trino/issues/13267)
     public void append(IntArrayList positions, Block block)
     {
         if (positions.isEmpty()) {
             return;
         }
-        // performance of this method depends on block being always the same, flat type
-        checkArgument(block instanceof Int96ArrayBlock);
         int[] positionArray = positions.elements();
         int positionsSize = positions.size();
         ensureCapacity(positionCount + positionsSize);

--- a/core/trino-main/src/main/java/io/trino/operator/output/IntPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/IntPositionsAppender.java
@@ -22,7 +22,6 @@ import org.openjdk.jol.info.ClassLayout;
 import java.util.Arrays;
 import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.operator.output.PositionsAppenderUtil.calculateBlockResetSize;
 import static io.trino.operator.output.PositionsAppenderUtil.calculateNewArraySize;
@@ -56,13 +55,12 @@ public class IntPositionsAppender
     }
 
     @Override
+    // TODO: Make PositionsAppender work performant with different block types (https://github.com/trinodb/trino/issues/13267)
     public void append(IntArrayList positions, Block block)
     {
         if (positions.isEmpty()) {
             return;
         }
-        // performance of this method depends on block being always the same, flat type
-        checkArgument(block instanceof IntArrayBlock);
         int[] positionArray = positions.elements();
         int positionsSize = positions.size();
         ensureCapacity(positionCount + positionsSize);

--- a/core/trino-main/src/main/java/io/trino/operator/output/LongPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/LongPositionsAppender.java
@@ -22,7 +22,6 @@ import org.openjdk.jol.info.ClassLayout;
 import java.util.Arrays;
 import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.operator.output.PositionsAppenderUtil.calculateBlockResetSize;
 import static io.trino.operator.output.PositionsAppenderUtil.calculateNewArraySize;
@@ -56,13 +55,12 @@ public class LongPositionsAppender
     }
 
     @Override
+    // TODO: Make PositionsAppender work performant with different block types (https://github.com/trinodb/trino/issues/13267)
     public void append(IntArrayList positions, Block block)
     {
         if (positions.isEmpty()) {
             return;
         }
-        // performance of this method depends on block being always the same, flat type
-        checkArgument(block instanceof LongArrayBlock);
         int[] positionArray = positions.elements();
         int positionsSize = positions.size();
         ensureCapacity(positionCount + positionsSize);

--- a/core/trino-main/src/main/java/io/trino/operator/output/ShortPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/ShortPositionsAppender.java
@@ -22,7 +22,6 @@ import org.openjdk.jol.info.ClassLayout;
 import java.util.Arrays;
 import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.operator.output.PositionsAppenderUtil.calculateBlockResetSize;
 import static io.trino.operator.output.PositionsAppenderUtil.calculateNewArraySize;
@@ -56,13 +55,12 @@ public class ShortPositionsAppender
     }
 
     @Override
+    // TODO: Make PositionsAppender work performant with different block types (https://github.com/trinodb/trino/issues/13267)
     public void append(IntArrayList positions, Block block)
     {
         if (positions.isEmpty()) {
             return;
         }
-        // performance of this method depends on block being always the same, flat type
-        checkArgument(block instanceof ShortArrayBlock);
         int[] positionArray = positions.elements();
         int positionsSize = positions.size();
         ensureCapacity(positionCount + positionsSize);

--- a/core/trino-main/src/main/java/io/trino/operator/output/SlicePositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/SlicePositionsAppender.java
@@ -24,7 +24,6 @@ import org.openjdk.jol.info.ClassLayout;
 import java.util.Arrays;
 import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.sizeOf;
@@ -74,13 +73,12 @@ public class SlicePositionsAppender
     }
 
     @Override
+    // TODO: Make PositionsAppender work performant with different block types (https://github.com/trinodb/trino/issues/13267)
     public void append(IntArrayList positions, Block block)
     {
         if (positions.isEmpty()) {
             return;
         }
-        // performance of this method depends on block being always the same, flat type
-        checkArgument(block instanceof VariableWidthBlock);
         ensurePositionCapacity(positionCount + positions.size());
         int[] positionArray = positions.elements();
         int newByteCount = 0;


### PR DESCRIPTION
    Current Type contract does not enforce
    particular block type for data.
    Hence PositionAppenders should work with
    generic Block type.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# General
* Fix query failures when UUID type is used. ({issue}`issuenumber`)
```

Fixes: https://github.com/trinodb/trino/issues/13265