### PR TITLE
Use lock to ensure consistency during runaway split detection

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
@@ -727,7 +727,7 @@ public class SqlTaskManager
 
         private void failStuckSplitTasks()
         {
-            Set<TaskId> stuckSplitTaskIds = taskExecutor.getStuckSplitTaskIds(interruptStuckSplitTasksTimeout,
+            taskExecutor.interruptStuckSplitTasks(interruptStuckSplitTasksTimeout,
                     (RunningSplitInfo splitInfo) -> {
                         List<StackTraceElement> stackTraceElements = asList(splitInfo.getThread().getStackTrace());
                         if (!splitInfo.isPrinted()) {
@@ -736,11 +736,9 @@ public class SqlTaskManager
                         }
 
                         return stuckSplitStackTracePredicate.test(stackTraceElements);
+                    }, (TaskId taskId) -> {
+                        failTask(taskId, new TrinoException(GENERIC_USER_ERROR, format("Task %s is failed, due to containing long running stuck splits.", taskId)));
                     });
-
-            for (TaskId stuckSplitTaskId : stuckSplitTaskIds) {
-                failTask(stuckSplitTaskId, new TrinoException(GENERIC_USER_ERROR, format("Task %s is failed, due to containing long running stuck splits.", stuckSplitTaskId)));
-            }
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

Improve detection of runaway splits and related task killing code to
ensure that we do not kill a thread which we suppose hung, but moved to
execute on behalf of another query, just before we issue kill command.

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->
Bugfix (for a very low probablity race condition)

## Related issues, pull requests, and links
Improvement on top of https://github.com/trinodb/trino/pull/12392

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

