### PR TITLE
Fix events collector

### DIFF
--- a/core/trino-main/src/main/java/io/trino/testing/MaterializedResultWithQueryId.java
+++ b/core/trino-main/src/main/java/io/trino/testing/MaterializedResultWithQueryId.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing;
+
+import io.trino.spi.QueryId;
+
+import static java.util.Objects.requireNonNull;
+
+public class MaterializedResultWithQueryId
+{
+    private final QueryId queryId;
+    private final MaterializedResult result;
+
+    public MaterializedResultWithQueryId(QueryId queryId, MaterializedResult result)
+    {
+        this.queryId = requireNonNull(queryId, "queryId is null");
+        this.result = requireNonNull(result, "result is null");
+    }
+
+    public QueryId getQueryId()
+    {
+        return queryId;
+    }
+
+    public MaterializedResult getResult()
+    {
+        return result;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/testing/QueryFailedException.java
+++ b/core/trino-main/src/main/java/io/trino/testing/QueryFailedException.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing;
+
+import io.trino.spi.QueryId;
+
+public class QueryFailedException
+        extends RuntimeException
+{
+    private final QueryId queryId;
+
+    public QueryFailedException(QueryId queryId, String message)
+    {
+        super(message);
+        this.queryId = queryId;
+    }
+
+    public QueryFailedException(QueryId queryId, String message, Throwable cause)
+    {
+        super(message, cause);
+        this.queryId = queryId;
+    }
+
+    public QueryId getQueryId()
+    {
+        return queryId;
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -30,8 +30,8 @@ import io.trino.sql.planner.OptimizerConfig.JoinDistributionType;
 import io.trino.testing.BaseConnectorSmokeTest;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.MaterializedResult;
+import io.trino.testing.MaterializedResultWithQueryId;
 import io.trino.testing.QueryRunner;
-import io.trino.testing.ResultWithQueryId;
 import io.trino.testing.TestingConnectorBehavior;
 import io.trino.tpch.TpchTable;
 import org.intellij.lang.annotations.Language;
@@ -327,9 +327,9 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
                         hiveTableName,
                         getLocationForTable(bucketName, "foo")));
 
-        ResultWithQueryId<MaterializedResult> deltaResult = queryRunner.executeWithQueryId(broadcastJoinDistribution(true), "SELECT * FROM foo");
+        MaterializedResultWithQueryId deltaResult = queryRunner.executeWithQueryId(broadcastJoinDistribution(true), "SELECT * FROM foo");
         assertEquals(deltaResult.getResult().getRowCount(), 2);
-        ResultWithQueryId<MaterializedResult> hiveResult = queryRunner.executeWithQueryId(broadcastJoinDistribution(true), format("SELECT * FROM %s.%s.%s", "hive", SCHEMA, hiveTableName));
+        MaterializedResultWithQueryId hiveResult = queryRunner.executeWithQueryId(broadcastJoinDistribution(true), format("SELECT * FROM %s.%s.%s", "hive", SCHEMA, hiveTableName));
         assertEquals(hiveResult.getResult().getRowCount(), 2);
 
         QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
@@ -1544,7 +1544,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
 
     private void testCountQuery(@Language("SQL") String sql, long expectedRowCount, long expectedSplitCount)
     {
-        ResultWithQueryId<MaterializedResult> result = getDistributedQueryRunner().executeWithQueryId(getSession(), sql);
+        MaterializedResultWithQueryId result = getDistributedQueryRunner().executeWithQueryId(getSession(), sql);
         assertEquals(result.getResult().getOnlyColumnAsSet(), ImmutableSet.of(expectedRowCount));
         verifySplitCount(result.getQueryId(), expectedSplitCount);
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeMinioConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeMinioConnectorTest.java
@@ -23,9 +23,9 @@ import io.trino.plugin.hive.containers.HiveMinioDataLake;
 import io.trino.testing.BaseConnectorTest;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.MaterializedResult;
+import io.trino.testing.MaterializedResultWithQueryId;
 import io.trino.testing.MaterializedRow;
 import io.trino.testing.QueryRunner;
-import io.trino.testing.ResultWithQueryId;
 import io.trino.testing.TestingConnectorBehavior;
 import io.trino.testing.sql.TestTable;
 import io.trino.tpch.TpchTable;
@@ -336,7 +336,7 @@ public abstract class BaseDeltaLakeMinioConnectorTest
         assertUpdate("INSERT INTO " + tableName + " VALUES (TIMESTAMP '" + value + "')", 1);
 
         DistributedQueryRunner queryRunner = (DistributedQueryRunner) getQueryRunner();
-        ResultWithQueryId<MaterializedResult> queryResult = queryRunner.executeWithQueryId(
+        MaterializedResultWithQueryId queryResult = queryRunner.executeWithQueryId(
                 getSession(),
                 "SELECT * FROM " + tableName + " WHERE t < TIMESTAMP '" + value + "'");
         assertEquals(getQueryInfo(queryRunner, queryResult).getQueryStats().getProcessedInputDataSize().toBytes(), 0);
@@ -394,7 +394,7 @@ public abstract class BaseDeltaLakeMinioConnectorTest
         }
     }
 
-    private QueryInfo getQueryInfo(DistributedQueryRunner queryRunner, ResultWithQueryId<MaterializedResult> queryResult)
+    private QueryInfo getQueryInfo(DistributedQueryRunner queryRunner, MaterializedResultWithQueryId queryResult)
     {
         return queryRunner.getCoordinator().getQueryManager().getFullQueryInfo(queryResult.getQueryId());
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAnalyze.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAnalyze.java
@@ -19,9 +19,8 @@ import io.trino.operator.OperatorStats;
 import io.trino.plugin.hive.containers.HiveMinioDataLake;
 import io.trino.spi.QueryId;
 import io.trino.testing.AbstractTestQueryFramework;
-import io.trino.testing.MaterializedResult;
+import io.trino.testing.MaterializedResultWithQueryId;
 import io.trino.testing.QueryRunner;
-import io.trino.testing.ResultWithQueryId;
 import io.trino.testing.sql.TestTable;
 import org.testng.annotations.Test;
 
@@ -498,7 +497,7 @@ public class TestDeltaLakeAnalyze
 
     private void runAnalyzeVerifySplitCount(String tableName, long expectedSplitCount)
     {
-        ResultWithQueryId<MaterializedResult> analyzeResult = getDistributedQueryRunner().executeWithQueryId(getSession(), "ANALYZE " + tableName);
+        MaterializedResultWithQueryId analyzeResult = getDistributedQueryRunner().executeWithQueryId(getSession(), "ANALYZE " + tableName);
         verifySplitCount(analyzeResult.getQueryId(), expectedSplitCount);
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeDynamicFiltering.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeDynamicFiltering.java
@@ -32,9 +32,8 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.split.SplitSource;
 import io.trino.sql.planner.OptimizerConfig.JoinDistributionType;
 import io.trino.testing.AbstractTestQueryFramework;
-import io.trino.testing.MaterializedResult;
+import io.trino.testing.MaterializedResultWithQueryId;
 import io.trino.testing.QueryRunner;
-import io.trino.testing.ResultWithQueryId;
 import io.trino.transaction.TransactionId;
 import io.trino.transaction.TransactionManager;
 import org.testng.annotations.DataProvider;
@@ -107,8 +106,8 @@ public class TestDeltaLakeDynamicFiltering
     public void testDynamicFiltering(JoinDistributionType joinDistributionType)
     {
         String query = "SELECT * FROM lineitem JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.totalprice > 59995 AND orders.totalprice < 60000";
-        ResultWithQueryId<MaterializedResult> filteredResult = getDistributedQueryRunner().executeWithQueryId(sessionWithDynamicFiltering(true, joinDistributionType), query);
-        ResultWithQueryId<MaterializedResult> unfilteredResult = getDistributedQueryRunner().executeWithQueryId(sessionWithDynamicFiltering(false, joinDistributionType), query);
+        MaterializedResultWithQueryId filteredResult = getDistributedQueryRunner().executeWithQueryId(sessionWithDynamicFiltering(true, joinDistributionType), query);
+        MaterializedResultWithQueryId unfilteredResult = getDistributedQueryRunner().executeWithQueryId(sessionWithDynamicFiltering(false, joinDistributionType), query);
         assertEqualsIgnoreOrder(filteredResult.getResult().getMaterializedRows(), unfilteredResult.getResult().getMaterializedRows());
 
         QueryInputStats filteredStats = getQueryInputStats(filteredResult.getQueryId());

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestPredicatePushdown.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestPredicatePushdown.java
@@ -19,9 +19,9 @@ import io.trino.plugin.hive.containers.HiveMinioDataLake;
 import io.trino.spi.QueryId;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.MaterializedResult;
+import io.trino.testing.MaterializedResultWithQueryId;
 import io.trino.testing.MaterializedRow;
 import io.trino.testing.QueryRunner;
-import io.trino.testing.ResultWithQueryId;
 import org.testng.annotations.Test;
 import org.testng.asserts.SoftAssert;
 
@@ -143,7 +143,7 @@ public class TestPredicatePushdown
      */
     private void assertPushdown(String actual, String expected, long countProcessed)
     {
-        ResultWithQueryId<MaterializedResult> result = executeWithQueryId(actual);
+        MaterializedResultWithQueryId result = executeWithQueryId(actual);
         Set<MaterializedRow> actualRows = Set.copyOf(result.getResult().getMaterializedRows());
         Set<MaterializedRow> expectedRows = Set.copyOf(
                 computeExpected(expected, result.getResult().getTypes()).getMaterializedRows());
@@ -176,7 +176,7 @@ public class TestPredicatePushdown
      */
     private void assertPushdownUpdate(String sql, long count, long countProcessed)
     {
-        ResultWithQueryId<MaterializedResult> result = executeWithQueryId(sql);
+        MaterializedResultWithQueryId result = executeWithQueryId(sql);
         OptionalLong actualCount = result.getResult().getUpdateCount();
 
         SoftAssert softly = new SoftAssert();
@@ -189,7 +189,7 @@ public class TestPredicatePushdown
         softly.assertAll();
     }
 
-    private ResultWithQueryId<MaterializedResult> executeWithQueryId(String sql)
+    private MaterializedResultWithQueryId executeWithQueryId(String sql)
     {
         return getDistributedQueryRunner().executeWithQueryId(getSession(), sql);
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestSplitPruning.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestSplitPruning.java
@@ -20,7 +20,6 @@ import io.trino.operator.OperatorStats;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.MaterializedResult;
 import io.trino.testing.QueryRunner;
-import io.trino.testing.ResultWithQueryId;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -135,10 +134,10 @@ public class TestSplitPruning
                 Set.of(),
                 0);
 
-        ResultWithQueryId<MaterializedResult> result = getDistributedQueryRunner().executeWithQueryId(
+        MaterializedResult result = getDistributedQueryRunner().execute(
                 getSession(),
                 format("SELECT name FROM %s WHERE val IS NOT NULL", tableName));
-        assertEquals(result.getResult().getOnlyColumnAsSet(), Set.of("a5", "b5", "a6", "b6"));
+        assertEquals(result.getOnlyColumnAsSet(), Set.of("a5", "b5", "a6", "b6"));
     }
 
     @Test

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -53,9 +53,9 @@ import io.trino.sql.planner.planprinter.IoPlanPrinter.IoPlan.TableColumnInfo;
 import io.trino.testing.BaseConnectorTest;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.MaterializedResult;
+import io.trino.testing.MaterializedResultWithQueryId;
 import io.trino.testing.MaterializedRow;
 import io.trino.testing.QueryRunner;
-import io.trino.testing.ResultWithQueryId;
 import io.trino.testing.TestingConnectorBehavior;
 import io.trino.testing.sql.TestTable;
 import io.trino.testing.sql.TrinoSqlExecutor;
@@ -4725,7 +4725,7 @@ public abstract class BaseHiveConnectorTest
         assertQuery(session, "SELECT * FROM " + tableName, format("VALUES (%s)", formatTimestamp(value)));
 
         DistributedQueryRunner queryRunner = (DistributedQueryRunner) getQueryRunner();
-        ResultWithQueryId<MaterializedResult> queryResult = queryRunner.executeWithQueryId(
+        MaterializedResultWithQueryId queryResult = queryRunner.executeWithQueryId(
                 session,
                 format("SELECT * FROM %s WHERE t < %s", tableName, formatTimestamp(value)));
         assertEquals(getQueryInfo(queryRunner, queryResult).getQueryStats().getProcessedInputDataSize().toBytes(), 0);
@@ -4756,7 +4756,7 @@ public abstract class BaseHiveConnectorTest
         // to account for the fact that ORC stats are stored at millisecond precision and Trino rounds timestamps,
         // we filter by timestamps that differ from the actual value by at least 1ms, to observe pruning
         DistributedQueryRunner queryRunner = getDistributedQueryRunner();
-        ResultWithQueryId<MaterializedResult> queryResult = queryRunner.executeWithQueryId(
+        MaterializedResultWithQueryId queryResult = queryRunner.executeWithQueryId(
                 session,
                 format("SELECT * FROM test_orc_timestamp_predicate_pushdown WHERE t < %s", formatTimestamp(value.minusNanos(MILLISECONDS.toNanos(1)))));
         assertEquals(getQueryInfo(queryRunner, queryResult).getQueryStats().getProcessedInputDataSize().toBytes(), 0);
@@ -4845,7 +4845,7 @@ public abstract class BaseHiveConnectorTest
                 results -> assertThat(results.getRowCount()).isEqualTo(0));
     }
 
-    private QueryInfo getQueryInfo(DistributedQueryRunner queryRunner, ResultWithQueryId<MaterializedResult> queryResult)
+    private QueryInfo getQueryInfo(DistributedQueryRunner queryRunner, MaterializedResultWithQueryId queryResult)
     {
         return queryRunner.getCoordinator().getQueryManager().getFullQueryInfo(queryResult.getQueryId());
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveDistributedJoinQueries.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveDistributedJoinQueries.java
@@ -18,9 +18,8 @@ import io.trino.execution.DynamicFilterConfig;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.operator.OperatorStats;
 import io.trino.testing.AbstractTestJoinQueries;
-import io.trino.testing.MaterializedResult;
+import io.trino.testing.MaterializedResultWithQueryId;
 import io.trino.testing.QueryRunner;
-import io.trino.testing.ResultWithQueryId;
 import org.testng.annotations.Test;
 
 import static com.google.common.base.Verify.verify;
@@ -59,7 +58,7 @@ public class TestHiveDistributedJoinQueries
         Session session = Session.builder(getSession())
                 .setSystemProperty(JOIN_DISTRIBUTION_TYPE, BROADCAST.name())
                 .build();
-        ResultWithQueryId<MaterializedResult> result = getDistributedQueryRunner().executeWithQueryId(
+        MaterializedResultWithQueryId result = getDistributedQueryRunner().executeWithQueryId(
                 session,
                 "SELECT * FROM lineitem JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.totalprice = 123.4567");
         assertEquals(result.getResult().getRowCount(), 0);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -36,9 +36,9 @@ import io.trino.sql.planner.plan.ValuesNode;
 import io.trino.testing.BaseConnectorTest;
 import io.trino.testing.DataProviders;
 import io.trino.testing.MaterializedResult;
+import io.trino.testing.MaterializedResultWithQueryId;
 import io.trino.testing.MaterializedRow;
 import io.trino.testing.QueryRunner;
-import io.trino.testing.ResultWithQueryId;
 import io.trino.testing.TestingConnectorBehavior;
 import io.trino.testing.sql.TestTable;
 import io.trino.tpch.TpchTable;
@@ -3277,15 +3277,15 @@ public abstract class BaseIcebergConnectorTest
 
     private void verifySplitCount(String query, int expectedSplitCount)
     {
-        ResultWithQueryId<MaterializedResult> selectAllPartitionsResult = getDistributedQueryRunner().executeWithQueryId(getSession(), query);
+        MaterializedResultWithQueryId selectAllPartitionsResult = getDistributedQueryRunner().executeWithQueryId(getSession(), query);
         assertEqualsIgnoreOrder(selectAllPartitionsResult.getResult().getMaterializedRows(), computeActual(withoutPredicatePushdown(getSession()), query).getMaterializedRows());
         verifySplitCount(selectAllPartitionsResult.getQueryId(), expectedSplitCount);
     }
 
     private void verifyPredicatePushdownDataRead(@Language("SQL") String query, boolean supportsPushdown)
     {
-        ResultWithQueryId<MaterializedResult> resultWithPredicatePushdown = getDistributedQueryRunner().executeWithQueryId(getSession(), query);
-        ResultWithQueryId<MaterializedResult> resultWithoutPredicatePushdown = getDistributedQueryRunner().executeWithQueryId(
+        MaterializedResultWithQueryId resultWithPredicatePushdown = getDistributedQueryRunner().executeWithQueryId(getSession(), query);
+        MaterializedResultWithQueryId resultWithoutPredicatePushdown = getDistributedQueryRunner().executeWithQueryId(
                 withoutPredicatePushdown(getSession()),
                 query);
 

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaIntegrationPushDown.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaIntegrationPushDown.java
@@ -19,9 +19,8 @@ import io.trino.execution.QueryInfo;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.DistributedQueryRunner;
-import io.trino.testing.MaterializedResult;
+import io.trino.testing.MaterializedResultWithQueryId;
 import io.trino.testing.QueryRunner;
-import io.trino.testing.ResultWithQueryId;
 import io.trino.testing.kafka.TestingKafka;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
@@ -93,7 +92,7 @@ public class TestKafkaIntegrationPushDown
         String sql = format("SELECT count(*) FROM default.%s WHERE _partition_id=1", topicNamePartition);
 
         assertEventually(() -> {
-            ResultWithQueryId<MaterializedResult> queryResult = getDistributedQueryRunner().executeWithQueryId(getSession(), sql);
+            MaterializedResultWithQueryId queryResult = getDistributedQueryRunner().executeWithQueryId(getSession(), sql);
             assertEquals(getQueryInfo(getDistributedQueryRunner(), queryResult).getQueryStats().getProcessedInputPositions(), MESSAGE_NUM / 2);
         });
     }
@@ -111,7 +110,7 @@ public class TestKafkaIntegrationPushDown
     {
         DistributedQueryRunner queryRunner = getDistributedQueryRunner();
         assertEventually(() -> {
-            ResultWithQueryId<MaterializedResult> queryResult = queryRunner.executeWithQueryId(getSession(), sql);
+            MaterializedResultWithQueryId queryResult = queryRunner.executeWithQueryId(getSession(), sql);
             assertEquals(getQueryInfo(queryRunner, queryResult).getQueryStats().getProcessedInputPositions(), expectedProcessedInputPositions);
         });
     }
@@ -131,7 +130,7 @@ public class TestKafkaIntegrationPushDown
 
         // timestamp_upper_bound_force_push_down_enabled default as false.
         assertEventually(() -> {
-            ResultWithQueryId<MaterializedResult> queryResult = queryRunner.executeWithQueryId(getSession(), sql);
+            MaterializedResultWithQueryId queryResult = queryRunner.executeWithQueryId(getSession(), sql);
             assertThat(getQueryInfo(queryRunner, queryResult).getQueryStats().getProcessedInputPositions())
                     .isEqualTo(998);
         });
@@ -143,7 +142,7 @@ public class TestKafkaIntegrationPushDown
                     .setSystemProperty("kafka.timestamp_upper_bound_force_push_down_enabled", "true")
                     .build();
 
-            ResultWithQueryId<MaterializedResult> queryResult = queryRunner.executeWithQueryId(sessionWithUpperBoundPushDownEnabled, sql);
+            MaterializedResultWithQueryId queryResult = queryRunner.executeWithQueryId(sessionWithUpperBoundPushDownEnabled, sql);
             assertThat(getQueryInfo(queryRunner, queryResult).getQueryStats().getProcessedInputPositions())
                     .isEqualTo(2);
         });
@@ -163,13 +162,13 @@ public class TestKafkaIntegrationPushDown
                 recordMessage.getEndTime());
 
         assertEventually(() -> {
-            ResultWithQueryId<MaterializedResult> queryResult = queryRunner.executeWithQueryId(getSession(), sql);
+            MaterializedResultWithQueryId queryResult = queryRunner.executeWithQueryId(getSession(), sql);
             assertThat(getQueryInfo(queryRunner, queryResult).getQueryStats().getProcessedInputPositions())
                     .isEqualTo(2);
         });
     }
 
-    private static QueryInfo getQueryInfo(DistributedQueryRunner queryRunner, ResultWithQueryId<MaterializedResult> queryResult)
+    private static QueryInfo getQueryInfo(DistributedQueryRunner queryRunner, MaterializedResultWithQueryId queryResult)
     {
         return queryRunner.getCoordinator().getQueryManager().getFullQueryInfo(queryResult.getQueryId());
     }

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduIntegrationDynamicFilter.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduIntegrationDynamicFilter.java
@@ -30,9 +30,8 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.split.SplitSource;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.DistributedQueryRunner;
-import io.trino.testing.MaterializedResult;
+import io.trino.testing.MaterializedResultWithQueryId;
 import io.trino.testing.QueryRunner;
-import io.trino.testing.ResultWithQueryId;
 import io.trino.tpch.TpchTable;
 import io.trino.transaction.TransactionId;
 import io.trino.transaction.TransactionManager;
@@ -180,7 +179,7 @@ public class TestKuduIntegrationDynamicFilter
     private void assertDynamicFiltering(@Language("SQL") String selectQuery, Session session, int expectedRowCount, int... expectedOperatorRowsRead)
     {
         DistributedQueryRunner runner = getDistributedQueryRunner();
-        ResultWithQueryId<MaterializedResult> result = runner.executeWithQueryId(session, selectQuery);
+        MaterializedResultWithQueryId result = runner.executeWithQueryId(session, selectQuery);
 
         assertEquals(result.getResult().getRowCount(), expectedRowCount);
         assertEquals(getOperatorRowsRead(runner, result.getQueryId()), Ints.asList(expectedOperatorRowsRead));

--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
@@ -25,9 +25,8 @@ import io.trino.spi.metrics.Count;
 import io.trino.spi.metrics.Metrics;
 import io.trino.testing.BaseConnectorTest;
 import io.trino.testing.DistributedQueryRunner;
-import io.trino.testing.MaterializedResult;
+import io.trino.testing.MaterializedResultWithQueryId;
 import io.trino.testing.QueryRunner;
-import io.trino.testing.ResultWithQueryId;
 import io.trino.testing.TestingConnectorBehavior;
 import io.trino.testing.sql.TestTable;
 import io.trino.testng.services.Flaky;
@@ -187,7 +186,7 @@ public class TestMemoryConnectorTest
     private Metrics collectCustomMetrics(String sql)
     {
         DistributedQueryRunner runner = (DistributedQueryRunner) getQueryRunner();
-        ResultWithQueryId<MaterializedResult> result = runner.executeWithQueryId(getSession(), sql);
+        MaterializedResultWithQueryId result = runner.executeWithQueryId(getSession(), sql);
         return runner
                 .getCoordinator()
                 .getQueryManager()
@@ -202,7 +201,7 @@ public class TestMemoryConnectorTest
     @Test(timeOut = 30_000)
     public void testPhysicalInputPositions()
     {
-        ResultWithQueryId<MaterializedResult> result = getDistributedQueryRunner().executeWithQueryId(
+        MaterializedResultWithQueryId result = getDistributedQueryRunner().executeWithQueryId(
                 getSession(),
                 "SELECT * FROM lineitem JOIN tpch.tiny.supplier ON lineitem.suppkey = supplier.suppkey " +
                         "AND supplier.name = 'Supplier#000000001'");
@@ -455,7 +454,7 @@ public class TestMemoryConnectorTest
 
     private void assertDynamicFiltering(@Language("SQL") String selectQuery, Session session, int expectedRowCount, int... expectedOperatorRowsRead)
     {
-        ResultWithQueryId<MaterializedResult> result = getDistributedQueryRunner().executeWithQueryId(session, selectQuery);
+        MaterializedResultWithQueryId result = getDistributedQueryRunner().executeWithQueryId(session, selectQuery);
 
         assertEquals(result.getResult().getRowCount(), expectedRowCount);
         assertEquals(getOperatorRowsRead(getDistributedQueryRunner(), result.getQueryId()), Ints.asList(expectedOperatorRowsRead));

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/BaseFailureRecoveryTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/BaseFailureRecoveryTest.java
@@ -29,8 +29,8 @@ import io.trino.spi.ErrorType;
 import io.trino.spi.QueryId;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.MaterializedResult;
+import io.trino.testing.MaterializedResultWithQueryId;
 import io.trino.testing.QueryRunner;
-import io.trino.testing.ResultWithQueryId;
 import io.trino.tpch.TpchTable;
 import org.assertj.core.api.AbstractThrowableAssert;
 import org.intellij.lang.annotations.Language;
@@ -563,7 +563,7 @@ public abstract class BaseFailureRecoveryTest
             String tableName = "table_" + randomTableSuffix();
             setup.ifPresent(sql -> getQueryRunner().execute(noRetries(session), resolveTableName(sql, tableName)));
 
-            ResultWithQueryId<MaterializedResult> resultWithQueryId = null;
+            MaterializedResultWithQueryId resultWithQueryId = null;
             RuntimeException failure = null;
             try {
                 resultWithQueryId = getDistributedQueryRunner().executeWithQueryId(withTraceToken(session, traceToken), resolveTableName(query, tableName));
@@ -722,7 +722,7 @@ public abstract class BaseFailureRecoveryTest
         private final Optional<MaterializedResult> updatedTableStatistics;
 
         private ExecutionResult(
-                ResultWithQueryId<MaterializedResult> resultWithQueryId,
+                MaterializedResultWithQueryId resultWithQueryId,
                 Optional<MaterializedResult> updatedTableContent,
                 Optional<MaterializedResult> updatedTableStatistics)
         {

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestJoinQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestJoinQueries.java
@@ -2349,7 +2349,7 @@ public abstract class AbstractTestJoinQueries
 
     private void assertJoinOutputPositions(@Language("SQL") String sql, int expectedJoinOutputPositions)
     {
-        ResultWithQueryId<MaterializedResult> result = getDistributedQueryRunner().executeWithQueryId(
+        MaterializedResultWithQueryId result = getDistributedQueryRunner().executeWithQueryId(
                 Session.builder(getSession())
                         .setSystemProperty(JOIN_REORDERING_STRATEGY, "NONE")
                         .build(),

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
@@ -465,7 +465,7 @@ public abstract class AbstractTestQueryFramework
             Consumer<MaterializedResult> resultAssertion)
     {
         DistributedQueryRunner queryRunner = getDistributedQueryRunner();
-        ResultWithQueryId<MaterializedResult> resultWithQueryId = queryRunner.executeWithQueryId(session, query);
+        MaterializedResultWithQueryId resultWithQueryId = queryRunner.executeWithQueryId(session, query);
         QueryStats queryStats = queryRunner.getCoordinator()
                 .getQueryManager()
                 .getFullQueryInfo(resultWithQueryId.getQueryId())

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -3408,7 +3408,7 @@ public abstract class BaseConnectorTest
         String tableName = "test_written_stats_" + randomTableSuffix();
         try {
             String sql = "CREATE TABLE " + tableName + " AS SELECT * FROM nation";
-            ResultWithQueryId<MaterializedResult> resultResultWithQueryId = getDistributedQueryRunner().executeWithQueryId(getSession(), sql);
+            MaterializedResultWithQueryId resultResultWithQueryId = getDistributedQueryRunner().executeWithQueryId(getSession(), sql);
             QueryInfo queryInfo = getDistributedQueryRunner().getCoordinator().getQueryManager().getFullQueryInfo(resultResultWithQueryId.getQueryId());
 
             assertEquals(queryInfo.getQueryStats().getOutputPositions(), 1L);

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseDynamicPartitionPruningTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseDynamicPartitionPruningTest.java
@@ -99,7 +99,7 @@ public abstract class BaseDynamicPartitionPruningTest
     public void testJoinWithEmptyBuildSide()
     {
         @Language("SQL") String selectQuery = "SELECT * FROM partitioned_lineitem JOIN supplier ON partitioned_lineitem.suppkey = supplier.suppkey AND supplier.name = 'abc'";
-        ResultWithQueryId<MaterializedResult> result = getDistributedQueryRunner().executeWithQueryId(
+        MaterializedResultWithQueryId result = getDistributedQueryRunner().executeWithQueryId(
                 getSession(),
                 selectQuery);
         MaterializedResult expected = computeActual(withDynamicFilteringDisabled(), selectQuery);
@@ -124,7 +124,7 @@ public abstract class BaseDynamicPartitionPruningTest
     {
         @Language("SQL") String selectQuery = "SELECT * FROM partitioned_lineitem JOIN supplier ON partitioned_lineitem.suppkey = supplier.suppkey " +
                 "AND supplier.name = 'Supplier#000000001'";
-        ResultWithQueryId<MaterializedResult> result = getDistributedQueryRunner().executeWithQueryId(
+        MaterializedResultWithQueryId result = getDistributedQueryRunner().executeWithQueryId(
                 getSession(),
                 selectQuery);
         MaterializedResult expected = computeActual(withDynamicFilteringDisabled(), selectQuery);
@@ -148,7 +148,7 @@ public abstract class BaseDynamicPartitionPruningTest
     public void testJoinWithNonSelectiveBuildSide()
     {
         @Language("SQL") String selectQuery = "SELECT * FROM partitioned_lineitem JOIN supplier ON partitioned_lineitem.suppkey = supplier.suppkey";
-        ResultWithQueryId<MaterializedResult> result = getDistributedQueryRunner().executeWithQueryId(
+        MaterializedResultWithQueryId result = getDistributedQueryRunner().executeWithQueryId(
                 getSession(),
                 selectQuery);
         MaterializedResult expected = computeActual(withDynamicFilteringDisabled(), selectQuery);
@@ -173,7 +173,7 @@ public abstract class BaseDynamicPartitionPruningTest
     public void testJoinLargeBuildSideRangeDynamicFiltering()
     {
         @Language("SQL") String selectQuery = "SELECT * FROM partitioned_lineitem JOIN orders ON partitioned_lineitem.orderkey = orders.orderkey";
-        ResultWithQueryId<MaterializedResult> result = getDistributedQueryRunner().executeWithQueryId(
+        MaterializedResultWithQueryId result = getDistributedQueryRunner().executeWithQueryId(
                 getSession(),
                 selectQuery);
         MaterializedResult expected = computeActual(withDynamicFilteringDisabled(), selectQuery);
@@ -204,7 +204,7 @@ public abstract class BaseDynamicPartitionPruningTest
                 "SELECT supplier.suppkey FROM " +
                 "partitioned_lineitem JOIN tpch.tiny.supplier ON partitioned_lineitem.suppkey = supplier.suppkey AND supplier.name IN ('Supplier#000000001', 'Supplier#000000002')" +
                 ") t JOIN supplier ON t.suppkey = supplier.suppkey AND supplier.suppkey IN (2, 3)";
-        ResultWithQueryId<MaterializedResult> result = getDistributedQueryRunner().executeWithQueryId(
+        MaterializedResultWithQueryId result = getDistributedQueryRunner().executeWithQueryId(
                 getSession(),
                 selectQuery);
         MaterializedResult expected = computeActual(withDynamicFilteringDisabled(), selectQuery);
@@ -237,7 +237,7 @@ public abstract class BaseDynamicPartitionPruningTest
                 "VALUES " + LINEITEM_COUNT);
 
         @Language("SQL") String selectQuery = "SELECT * FROM partitioned_lineitem_int l JOIN supplier s ON l.suppkey_int = s.suppkey AND s.name = 'Supplier#000000001'";
-        ResultWithQueryId<MaterializedResult> result = getDistributedQueryRunner().executeWithQueryId(
+        MaterializedResultWithQueryId result = getDistributedQueryRunner().executeWithQueryId(
                 getSession(),
                 selectQuery);
         MaterializedResult expected = computeActual(withDynamicFilteringDisabled(), selectQuery);
@@ -260,7 +260,7 @@ public abstract class BaseDynamicPartitionPruningTest
     public void testSemiJoinWithEmptyBuildSide()
     {
         @Language("SQL") String selectQuery = "SELECT * FROM partitioned_lineitem WHERE suppkey IN (SELECT suppkey FROM supplier WHERE name = 'abc')";
-        ResultWithQueryId<MaterializedResult> result = getDistributedQueryRunner().executeWithQueryId(
+        MaterializedResultWithQueryId result = getDistributedQueryRunner().executeWithQueryId(
                 getSession(),
                 selectQuery);
         MaterializedResult expected = computeActual(withDynamicFilteringDisabled(), selectQuery);
@@ -283,7 +283,7 @@ public abstract class BaseDynamicPartitionPruningTest
     public void testSemiJoinWithSelectiveBuildSide()
     {
         @Language("SQL") String selectQuery = "SELECT * FROM partitioned_lineitem WHERE suppkey IN (SELECT suppkey FROM supplier WHERE name = 'Supplier#000000001')";
-        ResultWithQueryId<MaterializedResult> result = getDistributedQueryRunner().executeWithQueryId(
+        MaterializedResultWithQueryId result = getDistributedQueryRunner().executeWithQueryId(
                 getSession(),
                 selectQuery);
         MaterializedResult expected = computeActual(withDynamicFilteringDisabled(), selectQuery);
@@ -307,7 +307,7 @@ public abstract class BaseDynamicPartitionPruningTest
     public void testSemiJoinWithNonSelectiveBuildSide()
     {
         @Language("SQL") String selectQuery = "SELECT * FROM partitioned_lineitem WHERE suppkey IN (SELECT suppkey FROM supplier)";
-        ResultWithQueryId<MaterializedResult> result = getDistributedQueryRunner().executeWithQueryId(
+        MaterializedResultWithQueryId result = getDistributedQueryRunner().executeWithQueryId(
                 getSession(),
                 selectQuery);
         MaterializedResult expected = computeActual(withDynamicFilteringDisabled(), selectQuery);
@@ -332,7 +332,7 @@ public abstract class BaseDynamicPartitionPruningTest
     public void testSemiJoinLargeBuildSideRangeDynamicFiltering()
     {
         @Language("SQL") String selectQuery = "SELECT * FROM partitioned_lineitem WHERE orderkey IN (SELECT orderkey FROM orders)";
-        ResultWithQueryId<MaterializedResult> result = getDistributedQueryRunner().executeWithQueryId(
+        MaterializedResultWithQueryId result = getDistributedQueryRunner().executeWithQueryId(
                 getSession(),
                 selectQuery);
         MaterializedResult expected = computeActual(withDynamicFilteringDisabled(), selectQuery);
@@ -359,7 +359,7 @@ public abstract class BaseDynamicPartitionPruningTest
     public void testRightJoinWithEmptyBuildSide()
     {
         @Language("SQL") String selectQuery = "SELECT * FROM partitioned_lineitem l RIGHT JOIN supplier s ON l.suppkey = s.suppkey WHERE name = 'abc'";
-        ResultWithQueryId<MaterializedResult> result = getDistributedQueryRunner().executeWithQueryId(
+        MaterializedResultWithQueryId result = getDistributedQueryRunner().executeWithQueryId(
                 getSession(),
                 selectQuery);
         MaterializedResult expected = computeActual(withDynamicFilteringDisabled(), selectQuery);
@@ -382,7 +382,7 @@ public abstract class BaseDynamicPartitionPruningTest
     public void testRightJoinWithSelectiveBuildSide()
     {
         @Language("SQL") String selectQuery = "SELECT * FROM partitioned_lineitem l RIGHT JOIN supplier s ON l.suppkey = s.suppkey WHERE name = 'Supplier#000000001'";
-        ResultWithQueryId<MaterializedResult> result = getDistributedQueryRunner().executeWithQueryId(
+        MaterializedResultWithQueryId result = getDistributedQueryRunner().executeWithQueryId(
                 getSession(),
                 selectQuery);
         MaterializedResult expected = computeActual(withDynamicFilteringDisabled(), selectQuery);
@@ -406,7 +406,7 @@ public abstract class BaseDynamicPartitionPruningTest
     public void testRightJoinWithNonSelectiveBuildSide()
     {
         @Language("SQL") String selectQuery = "SELECT * FROM partitioned_lineitem l RIGHT JOIN supplier s ON l.suppkey = s.suppkey";
-        ResultWithQueryId<MaterializedResult> result = getDistributedQueryRunner().executeWithQueryId(
+        MaterializedResultWithQueryId result = getDistributedQueryRunner().executeWithQueryId(
                 getSession(),
                 selectQuery);
         MaterializedResult expected = computeActual(withDynamicFilteringDisabled(), selectQuery);
@@ -494,7 +494,7 @@ public abstract class BaseDynamicPartitionPruningTest
     private long getQueryInputPositions(Session session, @Language("SQL") String sql, int expectedRowCount)
     {
         DistributedQueryRunner runner = (DistributedQueryRunner) getQueryRunner();
-        ResultWithQueryId<MaterializedResult> result = runner.executeWithQueryId(session, sql);
+        MaterializedResultWithQueryId result = runner.executeWithQueryId(session, sql);
         assertThat(result.getResult().getRowCount()).isEqualTo(expectedRowCount);
         QueryId queryId = result.getQueryId();
         QueryStats stats = runner.getCoordinator().getQueryManager().getFullQueryInfo(queryId).getQueryStats();

--- a/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
@@ -536,11 +536,12 @@ public class DistributedQueryRunner
         }
     }
 
-    public ResultWithQueryId<MaterializedResult> executeWithQueryId(Session session, @Language("SQL") String sql)
+    public MaterializedResultWithQueryId executeWithQueryId(Session session, @Language("SQL") String sql)
     {
         lock.readLock().lock();
         try {
-            return trinoClient.execute(session, sql);
+            ResultWithQueryId<MaterializedResult> result = trinoClient.execute(session, sql);
+            return new MaterializedResultWithQueryId(result.getQueryId(), result.getResult());
         }
         finally {
             lock.readLock().unlock();
@@ -550,7 +551,7 @@ public class DistributedQueryRunner
     @Override
     public MaterializedResultWithPlan executeWithPlan(Session session, String sql, WarningCollector warningCollector)
     {
-        ResultWithQueryId<MaterializedResult> resultWithQueryId = executeWithQueryId(session, sql);
+        MaterializedResultWithQueryId resultWithQueryId = executeWithQueryId(session, sql);
         return new MaterializedResultWithPlan(resultWithQueryId.getResult().toTestTypes(), getQueryPlan(resultWithQueryId.getQueryId()));
     }
 

--- a/testing/trino-tests/src/test/java/io/trino/execution/EventsAwaitingQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/EventsAwaitingQueries.java
@@ -13,46 +13,51 @@
  */
 package io.trino.execution;
 
+import io.airlift.units.Duration;
 import io.trino.Session;
+import io.trino.execution.EventsCollector.QueryEvents;
+import io.trino.spi.QueryId;
+import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.MaterializedResult;
-import io.trino.testing.QueryRunner;
+import io.trino.testing.MaterializedResultWithQueryId;
+import io.trino.testing.QueryFailedException;
 import org.intellij.lang.annotations.Language;
 
-import java.time.Duration;
 import java.util.Optional;
 
 import static com.google.common.base.Strings.nullToEmpty;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.fail;
 
 class EventsAwaitingQueries
 {
     private final EventsCollector eventsCollector;
 
-    private final QueryRunner queryRunner;
-    private final Duration extraWaitTime;
+    private final DistributedQueryRunner queryRunner;
 
-    EventsAwaitingQueries(EventsCollector eventsCollector, QueryRunner queryRunner, Duration extraWaitTime)
+    EventsAwaitingQueries(EventsCollector eventsCollector, DistributedQueryRunner queryRunner)
     {
         this.eventsCollector = requireNonNull(eventsCollector, "eventsCollector is null");
         this.queryRunner = requireNonNull(queryRunner, "queryRunner is null");
-        this.extraWaitTime = extraWaitTime;
     }
 
-    MaterializedResult runQueryAndWaitForEvents(@Language("SQL") String sql, int numEventsExpected, Session session)
+    MaterializedResultWithEvents runQueryAndWaitForEvents(@Language("SQL") String sql, Session session)
             throws Exception
     {
-        return runQueryAndWaitForEvents(sql, numEventsExpected, session, Optional.empty());
+        return runQueryAndWaitForEvents(sql, session, Optional.empty());
     }
 
-    MaterializedResult runQueryAndWaitForEvents(@Language("SQL") String sql, int numEventsExpected, Session session, Optional<String> expectedExceptionRegEx)
+    MaterializedResultWithEvents runQueryAndWaitForEvents(@Language("SQL") String sql, Session session, Optional<String> expectedExceptionRegEx)
             throws Exception
     {
-        eventsCollector.reset(numEventsExpected);
+        QueryId queryId = null;
         MaterializedResult result = null;
         try {
-            result = queryRunner.execute(session, sql);
+            MaterializedResultWithQueryId materializedResultWithQueryId = queryRunner.executeWithQueryId(session, sql);
+            queryId = materializedResultWithQueryId.getQueryId();
+            result = materializedResultWithQueryId.getResult();
         }
         catch (RuntimeException exception) {
             if (expectedExceptionRegEx.isPresent()) {
@@ -64,12 +69,43 @@ class EventsAwaitingQueries
             else {
                 throw exception;
             }
+            if (exception instanceof QueryFailedException) {
+                queryId = ((QueryFailedException) exception).getQueryId();
+            }
+        }
+        if (queryId == null) {
+            return null;
         }
 
-        eventsCollector.waitForEvents(10);
+        QueryEvents queryEvents = eventsCollector.getQueryEvents(queryId);
+        queryEvents.waitForQueryCompletion(new Duration(3, SECONDS));
+
         // Sleep some more so extraneous, unexpected events can be recorded too.
         // This is not rock solid but improves effectiveness on detecting duplicate events.
-        Thread.sleep(extraWaitTime.toMillis());
-        return result;
+        SECONDS.sleep(1);
+
+        return new MaterializedResultWithEvents(result, queryEvents);
+    }
+
+    public static class MaterializedResultWithEvents
+    {
+        private final MaterializedResult materializedResult;
+        private final QueryEvents queryEvents;
+
+        public MaterializedResultWithEvents(MaterializedResult materializedResult, QueryEvents queryEvents)
+        {
+            this.materializedResult = materializedResult;
+            this.queryEvents = requireNonNull(queryEvents, "queryEvents is null");
+        }
+
+        public MaterializedResult getMaterializedResult()
+        {
+            return materializedResult;
+        }
+
+        public QueryEvents getQueryEvents()
+        {
+            return queryEvents;
+        }
     }
 }

--- a/testing/trino-tests/src/test/java/io/trino/execution/EventsCollector.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/EventsCollector.java
@@ -14,6 +14,8 @@
 package io.trino.execution;
 
 import com.google.common.collect.ImmutableList;
+import io.airlift.units.Duration;
+import io.trino.spi.QueryId;
 import io.trino.spi.eventlistener.QueryCompletedEvent;
 import io.trino.spi.eventlistener.QueryCreatedEvent;
 import io.trino.spi.eventlistener.SplitCompletedEvent;
@@ -21,164 +23,163 @@ import io.trino.spi.eventlistener.SplitCompletedEvent;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Predicate;
+import java.util.concurrent.TimeoutException;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 @ThreadSafe
 final class EventsCollector
 {
-    private final EventFilters eventFilters;
-    @GuardedBy("this")
-    private ImmutableList.Builder<QueryCreatedEvent> queryCreatedEvents;
-    @GuardedBy("this")
-    private ImmutableList.Builder<QueryCompletedEvent> queryCompletedEvents;
-    @GuardedBy("this")
-    private ImmutableList.Builder<SplitCompletedEvent> splitCompletedEvents;
-    @GuardedBy("this")
-    private CountDownLatch eventsLatch;
-
-    public EventsCollector()
-    {
-        this(EventFilters.builder().build());
-    }
-
-    public EventsCollector(EventFilters eventFilters)
-    {
-        this.eventFilters = requireNonNull(eventFilters, "eventFilters is null");
-        reset(0);
-    }
-
-    public synchronized void reset(int numEvents)
-    {
-        queryCreatedEvents = ImmutableList.builder();
-        queryCompletedEvents = ImmutableList.builder();
-        splitCompletedEvents = ImmutableList.builder();
-
-        eventsLatch = new CountDownLatch(numEvents);
-    }
-
-    public void waitForEvents(int timeoutSeconds)
-            throws InterruptedException
-    {
-        CountDownLatch eventsLatch;
-        synchronized (this) {
-            // since the eventsLatch is replaced in the reset method, a lock is required for proper memory visibility
-            eventsLatch = this.eventsLatch;
-        }
-        eventsLatch.await(timeoutSeconds, TimeUnit.SECONDS);
-    }
+    private final ConcurrentHashMap<QueryId, QueryEvents> queryEvents = new ConcurrentHashMap<>();
 
     public synchronized void addQueryCreated(QueryCreatedEvent event)
     {
-        if (!eventFilters.getQueryCreatedFilter().test(event)) {
-            return;
-        }
-        queryCreatedEvents.add(event);
-        eventsLatch.countDown();
+        getQueryEvents(new QueryId(event.getMetadata().getQueryId())).addQueryCreated(event);
     }
 
     public synchronized void addQueryCompleted(QueryCompletedEvent event)
     {
-        if (!eventFilters.getQueryCompletedFilter().test(event)) {
-            return;
-        }
-        queryCompletedEvents.add(event);
-        eventsLatch.countDown();
+        getQueryEvents(new QueryId(event.getMetadata().getQueryId())).addQueryCompleted(event);
     }
 
     public synchronized void addSplitCompleted(SplitCompletedEvent event)
     {
-        if (!eventFilters.getSplitCompletedFilter().test(event)) {
-            return;
-        }
-        splitCompletedEvents.add(event);
-        eventsLatch.countDown();
+        getQueryEvents(new QueryId(event.getQueryId())).addSplitCompleted(event);
     }
 
-    public synchronized List<QueryCreatedEvent> getQueryCreatedEvents()
+    public QueryEvents getQueryEvents(QueryId queryId)
     {
-        return queryCreatedEvents.build();
-    }
-
-    public synchronized List<QueryCompletedEvent> getQueryCompletedEvents()
-    {
-        return queryCompletedEvents.build();
-    }
-
-    public synchronized List<SplitCompletedEvent> getSplitCompletedEvents()
-    {
-        return splitCompletedEvents.build();
+        return queryEvents.computeIfAbsent(queryId, ignored -> new QueryEvents());
     }
 
     @ThreadSafe
-    public static class EventFilters
+    public static class QueryEvents
     {
-        private final Predicate<QueryCreatedEvent> queryCreatedFilter;
-        private final Predicate<QueryCompletedEvent> queryCompletedFilter;
-        private final Predicate<SplitCompletedEvent> splitCompletedFilter;
+        @GuardedBy("this")
+        private QueryCreatedEvent queryCreatedEvent;
+        @GuardedBy("this")
+        private QueryCompletedEvent queryCompletedEvent;
+        @GuardedBy("this")
+        private final CountDownLatch queryCompleteLatch = new CountDownLatch(1);
 
-        private EventFilters(
-                Predicate<QueryCreatedEvent> queryCreatedFilter,
-                Predicate<QueryCompletedEvent> queryCompletedFilter,
-                Predicate<SplitCompletedEvent> splitCompletedFilter)
+        @GuardedBy("this")
+        private final List<SplitCompletedEvent> splitCompletedEvents = new ArrayList<>();
+        @GuardedBy("this")
+        private CountDownLatch splitEventLatch;
+
+        @GuardedBy("this")
+        private final List<Exception> failures = new ArrayList<>();
+
+        public synchronized QueryCreatedEvent getQueryCreatedEvent()
         {
-            this.queryCreatedFilter = requireNonNull(queryCreatedFilter, "queryCreatedFilter is null");
-            this.queryCompletedFilter = requireNonNull(queryCompletedFilter, "queryCompletedFilter is null");
-            this.splitCompletedFilter = requireNonNull(splitCompletedFilter, "splitCompletedFilter is null");
+            checkFailure();
+            if (queryCreatedEvent == null) {
+                throw new IllegalStateException("QueryCreatedEvent has not been set");
+            }
+            return queryCreatedEvent;
         }
 
-        Predicate<QueryCreatedEvent> getQueryCreatedFilter()
+        public synchronized QueryCompletedEvent getQueryCompletedEvent()
         {
-            return queryCreatedFilter;
+            checkFailure();
+            if (queryCompletedEvent == null) {
+                throw new IllegalStateException("QueryCompletedEvent has not been set");
+            }
+            return queryCompletedEvent;
         }
 
-        Predicate<QueryCompletedEvent> getQueryCompletedFilter()
+        private synchronized void addQueryCreated(QueryCreatedEvent event)
         {
-            return queryCompletedFilter;
+            requireNonNull(event, "event is null");
+            if (queryCreatedEvent != null) {
+                failures.add(new RuntimeException("QueryCreateEvent already set"));
+                return;
+            }
+            queryCreatedEvent = event;
+
+            if (queryCompletedEvent != null) {
+                queryCompleteLatch.countDown();
+            }
         }
 
-        Predicate<SplitCompletedEvent> getSplitCompletedFilter()
+        private synchronized void addQueryCompleted(QueryCompletedEvent event)
         {
-            return splitCompletedFilter;
+            requireNonNull(event, "event is null");
+            if (queryCompletedEvent != null) {
+                failures.add(new RuntimeException("QueryCompletedEvent already set"));
+                return;
+            }
+            queryCompletedEvent = event;
+
+            if (queryCreatedEvent != null) {
+                queryCompleteLatch.countDown();
+            }
         }
 
-        public static Builder builder()
+        private synchronized void addSplitCompleted(SplitCompletedEvent event)
         {
-            return new Builder();
+            splitCompletedEvents.add(event);
+            if (splitEventLatch != null) {
+                splitEventLatch.countDown();
+            }
         }
 
-        public static class Builder
+        public void waitForQueryCompletion(Duration timeout)
+                throws InterruptedException, TimeoutException
         {
-            private Predicate<QueryCreatedEvent> queryCreatedFilter = queryCreatedEvent -> true;
-            private Predicate<QueryCompletedEvent> queryCompletedFilter = queryCompletedEvent -> true;
-            private Predicate<SplitCompletedEvent> splitCompletedFilter = splitCompletedEvent -> true;
-
-            public Builder setQueryCreatedFilter(Predicate<QueryCreatedEvent> queryCreatedFilter)
-            {
-                this.queryCreatedFilter = queryCreatedFilter;
-                return this;
+            CountDownLatch latch;
+            synchronized (this) {
+                latch = queryCompleteLatch;
             }
 
-            public Builder setQueryCompletedFilter(Predicate<QueryCompletedEvent> queryCompletedFilter)
-            {
-                this.queryCompletedFilter = queryCompletedFilter;
-                return this;
+            boolean finished = latch.await(timeout.toMillis(), MILLISECONDS);
+            if (!finished) {
+                throw new TimeoutException("Query did not complete in " + timeout);
+            }
+        }
+
+        public synchronized List<SplitCompletedEvent> waitForSplitCompletedEvents(int numberOfSplitEvents, Duration timeout)
+                throws InterruptedException, TimeoutException
+        {
+            CountDownLatch latch;
+            synchronized (this) {
+                checkFailure();
+
+                if (splitCompletedEvents.size() >= numberOfSplitEvents) {
+                    return ImmutableList.copyOf(splitCompletedEvents);
+                }
+
+                if (splitEventLatch != null) {
+                    // support for waiting multiple times is complex and currently not needed, so it has not been implemented
+                    throw new IllegalStateException("Wait for split completion already triggered for this query");
+                }
+                splitEventLatch = new CountDownLatch(numberOfSplitEvents - splitCompletedEvents.size());
+                latch = splitEventLatch;
             }
 
-            public Builder setSplitCompletedFilter(Predicate<SplitCompletedEvent> splitCompletedFilter)
-            {
-                this.splitCompletedFilter = splitCompletedFilter;
-                return this;
+            boolean finished = latch.await(timeout.toMillis(), MILLISECONDS);
+            if (!finished) {
+                throw new TimeoutException("Split events did not complete in " + timeout);
             }
 
-            public EventFilters build()
-            {
-                return new EventFilters(queryCreatedFilter, queryCompletedFilter, splitCompletedFilter);
+            synchronized (this) {
+                checkFailure();
+                return ImmutableList.copyOf(splitCompletedEvents);
             }
+        }
+
+        private synchronized void checkFailure()
+        {
+            if (failures.isEmpty()) {
+                return;
+            }
+            RuntimeException exception = new RuntimeException("Event collection failed");
+            failures.forEach(exception::addSuppressed);
         }
     }
 }

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestLateMaterializationQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestLateMaterializationQueries.java
@@ -18,8 +18,8 @@ import io.trino.execution.QueryInfo;
 import io.trino.execution.QueryManager;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.MaterializedResult;
+import io.trino.testing.MaterializedResultWithQueryId;
 import io.trino.testing.QueryRunner;
-import io.trino.testing.ResultWithQueryId;
 import io.trino.tests.tpch.TpchQueryRunnerBuilder;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
@@ -87,10 +87,10 @@ public class TestLateMaterializationQueries
     {
         QueryManager queryManager = getDistributedQueryRunner().getCoordinator().getQueryManager();
 
-        ResultWithQueryId<MaterializedResult> workProcessorResultResultWithQueryId = getDistributedQueryRunner().executeWithQueryId(lateMaterialization(), sql);
+        MaterializedResultWithQueryId workProcessorResultResultWithQueryId = getDistributedQueryRunner().executeWithQueryId(lateMaterialization(), sql);
         QueryInfo workProcessorQueryInfo = queryManager.getFullQueryInfo(workProcessorResultResultWithQueryId.getQueryId());
 
-        ResultWithQueryId<MaterializedResult> noWorkProcessorResultResultWithQueryId = getDistributedQueryRunner().executeWithQueryId(noLateMaterialization(), sql);
+        MaterializedResultWithQueryId noWorkProcessorResultResultWithQueryId = getDistributedQueryRunner().executeWithQueryId(noLateMaterialization(), sql);
         QueryInfo noWorkProcessorQueryInfo = queryManager.getFullQueryInfo(noWorkProcessorResultResultWithQueryId.getQueryId());
 
         // ensure results are correct

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestMinWorkerRequirement.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestMinWorkerRequirement.java
@@ -21,8 +21,7 @@ import io.trino.Session;
 import io.trino.execution.QueryInfo;
 import io.trino.execution.QueryManager;
 import io.trino.testing.DistributedQueryRunner;
-import io.trino.testing.MaterializedResult;
-import io.trino.testing.ResultWithQueryId;
+import io.trino.testing.MaterializedResultWithQueryId;
 import io.trino.tests.tpch.TpchQueryRunnerBuilder;
 import org.testng.annotations.Test;
 
@@ -186,17 +185,17 @@ public class TestMinWorkerRequirement
                     .setCatalog("tpch")
                     .setSchema("tiny")
                     .build();
-            ListenableFuture<ResultWithQueryId<MaterializedResult>> queryFuture1 = service.submit(() -> queryRunner.executeWithQueryId(session1, "SELECT COUNT(*) from lineitem"));
+            ListenableFuture<MaterializedResultWithQueryId> queryFuture1 = service.submit(() -> queryRunner.executeWithQueryId(session1, "SELECT COUNT(*) from lineitem"));
 
             Session session2 = Session.builder(session1)
                     .setSystemProperty(REQUIRED_WORKERS_COUNT, "3")
                     .build();
-            ListenableFuture<ResultWithQueryId<MaterializedResult>> queryFuture2 = service.submit(() -> queryRunner.executeWithQueryId(session2, "SELECT COUNT(*) from lineitem"));
+            ListenableFuture<MaterializedResultWithQueryId> queryFuture2 = service.submit(() -> queryRunner.executeWithQueryId(session2, "SELECT COUNT(*) from lineitem"));
 
             Session session3 = Session.builder(session1)
                     .setSystemProperty(REQUIRED_WORKERS_COUNT, "4")
                     .build();
-            ListenableFuture<ResultWithQueryId<MaterializedResult>> queryFuture3 = service.submit(() -> queryRunner.executeWithQueryId(session3, "SELECT COUNT(*) from lineitem"));
+            ListenableFuture<MaterializedResultWithQueryId> queryFuture3 = service.submit(() -> queryRunner.executeWithQueryId(session3, "SELECT COUNT(*) from lineitem"));
 
             MILLISECONDS.sleep(1000);
             // None of the queries should run


### PR DESCRIPTION
## Description

This is a new attempt at fixing #5922.  The new fix rewrites EventsCollector to collect events on a per query basis, which eliminates the concurrency issues of separating events from different queries.  This requires exposing the `QueryId` to results from `QueryRunner` executions including in exceptions.

## Related issues, pull requests, and links

* Fixes #5922

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:
