### PR TITLE
Add `insert-existing-partitions-behavior` property in Delta Lake

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.rst
+++ b/docs/src/main/sphinx/connector/delta-lake.rst
@@ -155,6 +155,14 @@ values. Typical usage does not require you to configure them.
     * - ``delta.unique-table-location``
       - Use randomized, unique table locations.
       - ``true``
+    * - ``delta.insert-existing-partitions-behavior``
+      - What happens when data is inserted into an existing partition?
+        Possible values are
+
+        * ``APPEND`` - appends data to existing partitions
+        * ``OVERWRITE`` - overwrites existing partitions
+        * ``ERROR`` - modifying existing partitions is not allowed
+      - ``APPEND``
 
 The following table describes performance tuning catalog properties for the
 connector.

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConfig.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConfig.java
@@ -20,6 +20,7 @@ import io.airlift.configuration.DefunctConfig;
 import io.airlift.configuration.LegacyConfig;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.trino.plugin.deltalake.DeltaLakeSessionProperties.InsertExistingPartitionsBehavior;
 import io.trino.plugin.hive.HiveCompressionCodec;
 import org.joda.time.DateTimeZone;
 
@@ -34,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.InsertExistingPartitionsBehavior.APPEND;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -60,6 +62,7 @@ public class DeltaLakeConfig
     private DataSize maxSplitSize = DataSize.of(64, MEGABYTE);
     private double minimumAssignedSplitWeight = 0.05;
     private int maxPartitionsPerWriter = 100;
+    private InsertExistingPartitionsBehavior insertExistingPartitionsBehavior = APPEND;
     private boolean unsafeWritesEnabled;
     private boolean checkpointRowStatisticsWritingEnabled = true;
     private long defaultCheckpointWritingInterval = 10;
@@ -236,6 +239,19 @@ public class DeltaLakeConfig
     public DeltaLakeConfig setMaxPartitionsPerWriter(int maxPartitionsPerWriter)
     {
         this.maxPartitionsPerWriter = maxPartitionsPerWriter;
+        return this;
+    }
+
+    public InsertExistingPartitionsBehavior getInsertExistingPartitionsBehavior()
+    {
+        return insertExistingPartitionsBehavior;
+    }
+
+    @Config("delta.insert-existing-partitions-behavior")
+    @ConfigDescription("Insert existing partitions behavior")
+    public DeltaLakeConfig setInsertExistingPartitionsBehavior(InsertExistingPartitionsBehavior insertExistingPartitionsBehavior)
+    {
+        this.insertExistingPartitionsBehavior = insertExistingPartitionsBehavior;
         return this;
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConfig.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConfig.java
@@ -16,6 +16,7 @@ package io.trino.plugin.deltalake;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.trino.plugin.deltalake.DeltaLakeSessionProperties.InsertExistingPartitionsBehavior;
 import io.trino.plugin.hive.HiveCompressionCodec;
 import org.testng.annotations.Test;
 
@@ -27,6 +28,7 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertFullMappin
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
+import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.InsertExistingPartitionsBehavior.APPEND;
 import static io.trino.plugin.hive.util.TestHiveUtil.nonDefaultTimeZone;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.HOURS;
@@ -51,6 +53,7 @@ public class TestDeltaLakeConfig
                 .setMaxSplitSize(DataSize.of(64, DataSize.Unit.MEGABYTE))
                 .setMinimumAssignedSplitWeight(0.05)
                 .setMaxPartitionsPerWriter(100)
+                .setInsertExistingPartitionsBehavior(APPEND)
                 .setUnsafeWritesEnabled(false)
                 .setDefaultCheckpointWritingInterval(10)
                 .setCheckpointRowStatisticsWritingEnabled(true)
@@ -83,6 +86,7 @@ public class TestDeltaLakeConfig
                 .put("delta.max-split-size", "10 MB")
                 .put("delta.minimum-assigned-split-weight", "0.01")
                 .put("delta.max-partitions-per-writer", "200")
+                .put("delta.insert-existing-partitions-behavior", "OVERWRITE")
                 .put("delta.enable-non-concurrent-writes", "true")
                 .put("delta.default-checkpoint-writing-interval", "15")
                 .put("delta.checkpoint-row-statistics-writing.enabled", "false")
@@ -112,6 +116,7 @@ public class TestDeltaLakeConfig
                 .setMaxSplitSize(DataSize.of(10, DataSize.Unit.MEGABYTE))
                 .setMinimumAssignedSplitWeight(0.01)
                 .setMaxPartitionsPerWriter(200)
+                .setInsertExistingPartitionsBehavior(InsertExistingPartitionsBehavior.OVERWRITE)
                 .setUnsafeWritesEnabled(true)
                 .setDefaultCheckpointWritingInterval(15)
                 .setCheckpointRowStatisticsWritingEnabled(false)


### PR DESCRIPTION
## Description

Add `insert-existing-partitions-behavior` property in Delta Lake

## Documentation

(x) Sufficient documentation is included in this PR.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# Delta Lake
* Allow overwrite on insert using the `insert-existing-partitions-behavior` configuration property. ({issue}`issuenumber`)
```
