### PR TITLE
Correctly propagate 0 in PreAggregateCaseAggregations

### DIFF
--- a/testing/trino-tests/src/test/java/io/trino/tests/TestAggregations.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestAggregations.java
@@ -128,6 +128,31 @@ public class TestAggregations
                         "GROUP BY key",
                 "VALUES ('a', 1, 2, 1, 100), ('b', 21, 13, 11, 100)",
                 plan -> assertAggregationNodeCount(plan, 2));
+
+        // no rows matching sequence number
+        assertQuery(
+                memorySession,
+                "SELECT " +
+                        "key, " +
+                        "sum(CASE WHEN sequence = 42 THEN value ELSE 0 END), " +
+                        "sum(CASE WHEN sequence = 42 THEN value END), " +
+                        "sum(CASE WHEN sequence = 24 THEN cast(value * 2 as real) ELSE cast(0 as real) END), " +
+                        "sum(CASE WHEN sequence = 24 THEN cast(value * 2 as real) END) " +
+                        "FROM test_table " +
+                        "GROUP BY key",
+                "VALUES ('a', 0, null, 0, null), ('b', 0, null, 0, null)",
+                plan -> assertAggregationNodeCount(plan, 4));
+
+        assertQuery(
+                memorySession,
+                "SELECT " +
+                        "sum(CASE WHEN sequence = 42 THEN value ELSE 0 END), " +
+                        "sum(CASE WHEN sequence = 42 THEN value END), " +
+                        "sum(CASE WHEN sequence = 24 THEN cast(value * 2 as real) ELSE cast(0 as real) END), " +
+                        "sum(CASE WHEN sequence = 24 THEN cast(value * 2 as real) END) " +
+                        "FROM test_table",
+                "VALUES (0, null, 0, null)",
+                plan -> assertAggregationNodeCount(plan, 4));
     }
 
     private void assertAggregationNodeCount(Plan plan, int count)


### PR DESCRIPTION
For CASE aggregations like:

```
    sum(CASE WHEN sequence = 42 THEN value ELSE 0 END)
```

0 needs to be attached to final CASE aggregation as default value.
Otherwise incorrect result is returned when there are no rows
matching WHERE clause (e.g. `sequence=42`), but there are rows which don't match
WHERE clause (e.g. `sequence!=42`)

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fixes bug introduced in https://github.com/trinodb/trino/pull/12548
Fixes https://github.com/trinodb/trino/issues/13269

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

ENGINE

> How would you describe this change to a non-technical end user or system administrator?

FIXES BUG IN https://github.com/trinodb/trino/pull/12548 for unreleased version

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
