### PR TITLE
Set default shell for CI run commands

### DIFF
--- a/.github/workflows/annotate.yml
+++ b/.github/workflows/annotate.yml
@@ -6,6 +6,10 @@ on:
     types:
       - completed
 
+defaults:
+  run:
+    shell: bash --noprofile --norc -euo pipefail {0}
+
 jobs:
   annotate:
     if: github.repository_owner == 'trinodb'
@@ -35,7 +39,7 @@ jobs:
               fs.writeFileSync('${{github.workspace}}/' + artifact.name + '.zip', Buffer.from(download.data));
             }
       - run: |
-          set -xeuo pipefail
+          set -x
           pwd
           ls
           for archive in *.zip; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
     paths-ignore:
       - 'docs/**'
 
+defaults:
+  run:
+    shell: bash --noprofile --norc -euo pipefail {0}
+
 env:
   # An envar that signals to tests we are executing in the CI environment
   CONTINUOUS_INTEGRATION: true
@@ -747,7 +751,7 @@ jobs:
           testing/bin/ptl suite run \
             --suite ${{ matrix.suite }} \
             --config config-${{ matrix.config }} \
-            $PTL_OPTS \
+            ${PTL_OPTS:-} \
             --bind=off --logs-dir logs/ --timeout 2h
       - name: Upload test logs and results
         uses: actions/upload-artifact@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - 'docs/**'
 
+defaults:
+  run:
+    shell: bash --noprofile --norc -euo pipefail {0}
+
 env:
   # An envar that signals to tests we are executing in the CI environment
   CONTINUOUS_INTEGRATION: true

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [master]
 
+defaults:
+  run:
+    shell: bash --noprofile --norc -euo pipefail {0}
+
 jobs:
   set-milestone:
     if: github.repository_owner == 'trinodb'


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->
Use safer shell defaults to detect silent failures in CI steps executing shell commands.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
ci

> How would you describe this change to a non-technical end user or system administrator?
n/a

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
