### PR TITLE
Map MySQL `enum` type to Trino `varchar` type

### DIFF
--- a/docs/src/main/sphinx/connector/mysql.rst
+++ b/docs/src/main/sphinx/connector/mysql.rst
@@ -167,6 +167,9 @@ table.
   * - ``LONGTEXT``
     - ``VARCHAR``
     -
+  * - ``ENUM(n)``
+    - ``VARCHAR(n)``
+    -
   * - ``BINARY``, ``VARBINARY``, ``TINYBLOB``, ``BLOB``, ``MEDIUMBLOB``, ``LONGBLOB``
     - ``VARBINARY``
     -

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
@@ -371,6 +371,8 @@ public class MySqlClient
                 return Optional.of(decimalColumnMapping(createDecimalType(20)));
             case "json":
                 return Optional.of(jsonColumnMapping());
+            case "enum":
+                return Optional.of(defaultVarcharColumnMapping(typeHandle.getRequiredColumnSize(), false));
         }
 
         switch (typeHandle.getJdbcType()) {

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTypeMapping.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTypeMapping.java
@@ -1005,6 +1005,33 @@ public class TestMySqlTypeMapping
                 .execute(getQueryRunner(), mysqlCreateAndInsert("tpch.mysql_test_unsigned"));
     }
 
+    @Test
+    public void testEnum()
+    {
+        SqlExecutor jdbcSqlExecutor = mySqlServer::execute;
+        // Define enum values in an order different from lexicographical
+        jdbcSqlExecutor.execute("CREATE TABLE tpch.test_enum(id int, enum_column ENUM ('b','a','C'))");
+        assertUpdate("INSERT INTO tpch.test_enum(id, enum_column) values (1,'a'),(2,'b'),(3, NULL)", 3);
+        try {
+            assertQuery(
+                    "SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'tpch' AND table_name = 'test_enum'",
+                    "VALUES ('id','integer'),('enum_column','varchar(1)')");
+            assertQuery("SELECT * FROM test_enum", "VALUES (1,'a'),(2,'b'),(3,NULL)");
+            assertQuery("SELECT * FROM test_enum WHERE enum_column = 'a'", "VALUES (1, 'a')");
+            assertQuery("SELECT * FROM test_enum WHERE enum_column != 'a'", "VALUES (2, 'b')");
+            assertQuery("SELECT * FROM test_enum WHERE enum_column <= 'a'", "VALUES (1, 'a')");
+            assertQuery("SELECT * FROM test_enum WHERE enum_column <= 'b'", "VALUES (1, 'a'), (2, 'b')");
+            assertQuery("SELECT * FROM test_enum WHERE enum_column <= 'c'", "VALUES (1, 'a'), (2, 'b')");
+            assertQueryReturnsEmptyResult("SELECT * FROM test_enum WHERE enum_column <= 'C'");
+            assertQuery("SELECT * FROM test_enum WHERE enum_column IS NOT NULL", "VALUES (1, 'a'), (2, 'b')");
+            assertQuery("SELECT * FROM test_enum WHERE enum_column IS NULL", "VALUES (3, NULL)");
+            assertQuery("SELECT id FROM test_enum ORDER BY enum_column LIMIT 1", "VALUES (1)");
+        }
+        finally {
+            jdbcSqlExecutor.execute("DROP TABLE tpch.test_enum");
+        }
+    }
+
     private void testUnsupportedDataType(String databaseDataType)
     {
         SqlExecutor jdbcSqlExecutor = mySqlServer::execute;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix issue where enum type is converted as char for mysql connector, while others convert it as varchar

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Mysql Connector

> How would you describe this change to a non-technical end user or system administrator?

Java API for mysql does not support ENUM type, so ENUM type is converted to CHAR type.
However, VARCHAR instead of CHAR is more accurate, so we make an exception, just like other connectors (postgresql) does.

Fixes #13303

### Test

#### Before

> mysql
![image](https://user-images.githubusercontent.com/25147023/180351567-46843d71-992b-48cc-b168-c3843fc32ada.png)

> trino
![image](https://user-images.githubusercontent.com/25147023/180351583-66cff5fa-1ff4-4fc9-b844-5a989b55e866.png)

#### After

> trino
![image](https://user-images.githubusercontent.com/25147023/180351632-2fc73909-3cd6-4ddd-a3db-929fd9bc8db2.png)

> trino - test length
![image](https://user-images.githubusercontent.com/25147023/180351670-522e89ed-acdf-4064-9feb-c6a1b2fbcad0.png)


## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

Check out slack message, where we agreed on using varchar(x) for enum type.
https://trinodb.slack.com/archives/CGB0QHWSW/p1658214604393009?thread_ts=1626249411.412400&cid=CGB0QHWSW

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# MySQL
* Map MySQL `enum` type to Trino `varchar` type. Previously, it was mapped to `char` type. ({issue}`13303`)
```
