### PR TITLE
Add `ignore_broken_catalogs` system session property

### DIFF
--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaDataWithBrokenCatalog.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaDataWithBrokenCatalog.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.jdbc;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.log.Logging;
+import io.trino.server.testing.TestingTrinoServer;
+import io.trino.testing.BrokenConnector;
+import io.trino.util.AutoCloseableCloser;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Properties;
+
+import static io.trino.jdbc.TestingJdbcUtils.readRows;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestTrinoDatabaseMetaDataWithBrokenCatalog
+{
+    private static final String BROKEN_CATALOG = "mock_catalog";
+
+    private BrokenConnector brokenConnector;
+    private TestingTrinoServer server;
+
+    private Connection connection;
+
+    @BeforeClass
+    public void setupServer()
+    {
+        Logging.initialize();
+        server = TestingTrinoServer.create();
+
+        brokenConnector = new BrokenConnector();
+        server.installPlugin(brokenConnector.getPlugin());
+        server.createCatalog(BROKEN_CATALOG, "mock", ImmutableMap.of());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDownServer()
+            throws Exception
+    {
+        try (AutoCloseableCloser closer = AutoCloseableCloser.create()) {
+            if (server != null) {
+                closer.register(server);
+                server = null;
+            }
+            if (connection != null) {
+                closer.register(connection);
+                connection = null;
+            }
+            brokenConnector = null;
+        }
+    }
+
+    @Test
+    public void testGetSchemasIgnoreBrokenCatalogsEnabled()
+            throws Exception
+    {
+        try (Connection connection = createConnection(true)) {
+            try (ResultSet rs = connection.getMetaData().getSchemas()) {
+                assertThat(readRows(rs)).isNotEmpty();
+            }
+
+            try (ResultSet rs = connection.getMetaData().getSchemas(null, null)) {
+                assertThat(readRows(rs)).isNotEmpty();
+            }
+
+            try (ResultSet rs = connection.getMetaData().getSchemas(BROKEN_CATALOG, "information_schema")) {
+                assertThat(readRows(rs)).isNotEmpty();
+            }
+        }
+    }
+
+    @Test(expectedExceptions = SQLException.class)
+    public void testGetSchemasIgnoreBrokenCatalogsDisabled()
+            throws Exception
+    {
+        try (Connection connection = createConnection(false)) {
+            try (ResultSet rs = connection.getMetaData().getSchemas()) {
+                readRows(rs);
+            }
+        }
+    }
+
+    @Test
+    public void testGetTablesIgnoreBrokenCatalogsEnabled()
+            throws Exception
+    {
+        try (Connection connection = createConnection(true)) {
+            try (ResultSet rs = connection.getMetaData().getTables(null, null, null, null)) {
+                assertThat(readRows(rs)).isNotEmpty();
+            }
+
+            try (ResultSet rs = connection.getMetaData().getTables(BROKEN_CATALOG, null, null, null)) {
+                assertThat(readRows(rs)).isNotEmpty();
+            }
+        }
+    }
+
+    @Test(expectedExceptions = SQLException.class)
+    public void testGetTablesIgnoreBrokenCatalogsDisabled()
+            throws Exception
+    {
+        try (Connection connection = createConnection(false)) {
+            try (ResultSet rs = connection.getMetaData().getTables(null, null, null, null)) {
+                readRows(rs);
+            }
+        }
+    }
+
+    @Test
+    public void testGetColumnsIgnoreBrokenCatalogsEnabled()
+            throws Exception
+    {
+        try (Connection connection = createConnection(true)) {
+            try (ResultSet rs = connection.getMetaData().getColumns(null, "information_schema", "tables", "table_name")) {
+                assertThat(readRows(rs)).hasSize(2);
+            }
+        }
+    }
+
+    @Test(expectedExceptions = SQLException.class)
+    public void testGetColumnsIgnoreBrokenCatalogsDisabled()
+            throws Exception
+    {
+        try (Connection connection = createConnection(false)) {
+            try (ResultSet rs = connection.getMetaData().getColumns(null, "information_schema", "tables", "table_name")) {
+                readRows(rs);
+            }
+        }
+    }
+
+    private Connection createConnection(boolean ignoreBrokenCatalogs)
+            throws SQLException
+    {
+        String url = format("jdbc:trino://%s", server.getAddress());
+
+        Properties properties = new Properties();
+
+        properties.setProperty("user", "some_user");
+        properties.setProperty("sessionProperties", "ignore_broken_catalogs:" + ignoreBrokenCatalogs);
+
+        return DriverManager.getConnection(url, properties);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -182,6 +182,7 @@ public final class SystemSessionProperties
     public static final String FORCE_SPILLING_JOIN = "force_spilling_join";
     public static final String FAULT_TOLERANT_EXECUTION_FORCE_PREFERRED_WRITE_PARTITIONING_ENABLED = "fault_tolerant_execution_force_preferred_write_partitioning_enabled";
     public static final String PAGE_PARTITIONING_BUFFER_POOL_SIZE = "page_partitioning_buffer_pool_size";
+    public static final String IGNORE_BROKEN_CATALOGS = "ignore_broken_catalogs";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -911,7 +912,12 @@ public final class SystemSessionProperties
                 integerProperty(PAGE_PARTITIONING_BUFFER_POOL_SIZE,
                         "Maximum number of free buffers in the per task partitioned page buffer pool. Setting this to zero effectively disables the pool",
                         taskManagerConfig.getPagePartitioningBufferPoolSize(),
-                        true));
+                        true),
+                booleanProperty(
+                        IGNORE_BROKEN_CATALOGS,
+                        "Ignore broken catalogs in metadata retrieval",
+                        false,
+                        false));
     }
 
     @Override
@@ -1623,5 +1629,10 @@ public final class SystemSessionProperties
     public static int getPagePartitioningBufferPoolSize(Session session)
     {
         return session.getSystemProperty(PAGE_PARTITIONING_BUFFER_POOL_SIZE, Integer.class);
+    }
+
+    public static boolean isIgnoreBrokenCatalogs(Session session)
+    {
+        return session.getSystemProperty(IGNORE_BROKEN_CATALOGS, Boolean.class);
     }
 }

--- a/testing/trino-testing/src/main/java/io/trino/testing/BrokenConnector.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BrokenConnector.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.connector.MockConnectorFactory;
+import io.trino.spi.Plugin;
+import io.trino.spi.connector.ConnectorFactory;
+
+public class BrokenConnector
+{
+    public Plugin getPlugin()
+    {
+        return new Plugin()
+        {
+            @Override
+            public Iterable<ConnectorFactory> getConnectorFactories()
+            {
+                return ImmutableList.of(getConnectorFactory());
+            }
+        };
+    }
+
+    private ConnectorFactory getConnectorFactory()
+    {
+        MockConnectorFactory mockConnectorFactory = MockConnectorFactory.builder()
+                .withListSchemaNames(connectorSession -> {
+                    throw new RuntimeException("I'm a broken connector");
+                })
+                .withListTables((connectorSession, schemaName) -> {
+                    throw new RuntimeException("I'm a broken connector");
+                })
+                .withGetTableHandle((connectorSession, schemaTableName) -> {
+                    throw new RuntimeException("I'm a broken connector");
+                })
+                .withGetColumns(schemaTableName -> {
+                    throw new RuntimeException("I'm a broken connector");
+                })
+                .withListRoleGrants((connectorSession, roles, grantees, limit) -> {
+                    throw new RuntimeException("I'm a broken connector");
+                })
+                .build();
+
+        return mockConnectorFactory;
+    }
+}


### PR DESCRIPTION
## Description

Provide a jdbc driver property `ignoreBrokenCatalogs` to avoid metadata queries to error out on a broken catalog (eg. not working Hive Metastore).

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Change to the JDBC client

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
