### PR TITLE
Translate input properties to exchange output symbols

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
@@ -646,9 +646,13 @@ public final class PropertyDerivations
                 if (inputProperties.size() == 1) {
                     ActualProperties inputProperty = inputProperties.get(0);
                     if (inputProperty.isEffectivelySingleStream() && node.getOrderingScheme().isEmpty()) {
+                        verify(node.getInputs().size() == 1);
+                        Map<Symbol, Symbol> inputToOutput = exchangeInputToOutput(node, 0);
                         // Single stream input's local sorting and grouping properties are preserved
                         // In case of merging exchange, it's orderingScheme takes precedence
-                        localProperties.addAll(inputProperty.getLocalProperties());
+                        localProperties.addAll(LocalProperties.translate(
+                                inputProperty.getLocalProperties(),
+                                symbol -> Optional.ofNullable(inputToOutput.get(symbol))));
                     }
                 }
 


### PR DESCRIPTION
Exchange might use different symbols even for single
input exchange. Therefore input properties need to
be translated to output symbols.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fixes a bug

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core

> How would you describe this change to a non-technical end user or system administrator?

Prevent planner to fail in certain complex queries

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix certain complex queries failures due to planning error. ({issue}`issuenumber`)
```
