### PR TITLE
Add config for the caching duration of Delta table active data files

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.rst
+++ b/docs/src/main/sphinx/connector/delta-lake.rst
@@ -95,6 +95,10 @@ values. Typical usage does not require you to configure them.
         to be specified in :ref:`prop-type-data-size` values such as ``64MB``.
         Default is calculated to 10% of the maximum memory allocated to the JVM.
       -
+    * - ``delta.metadata.live-files.cache-ttl``
+      - Caching duration for active files which correspond to the Delta Lake
+        tables.
+      - ``30m``
     * - ``delta.compression-codec``
       - The compression codec to be used when writing new data files.
         Possible values are

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConfig.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConfig.java
@@ -47,6 +47,7 @@ public class DeltaLakeConfig
 
     private Duration metadataCacheTtl = new Duration(5, TimeUnit.MINUTES);
     private DataSize dataFileCacheSize = DEFAULT_DATA_FILE_CACHE_SIZE;
+    private Duration dataFileCacheTtl = new Duration(30, TimeUnit.MINUTES);
     private int domainCompactionThreshold = 100;
     private int maxOutstandingSplits = 1_000;
     private int maxSplitsPerSecond = Integer.MAX_VALUE;
@@ -93,6 +94,20 @@ public class DeltaLakeConfig
     public DeltaLakeConfig setDataFileCacheSize(DataSize dataFileCacheSize)
     {
         this.dataFileCacheSize = dataFileCacheSize;
+        return this;
+    }
+
+    @NotNull
+    public Duration getDataFileCacheTtl()
+    {
+        return dataFileCacheTtl;
+    }
+
+    @Config("delta.metadata.live-files.cache-ttl")
+    @ConfigDescription("Caching duration for Delta data file metadata (e.g. table schema, partition info)")
+    public DeltaLakeConfig setDataFileCacheTtl(Duration dataFileCacheTtl)
+    {
+        this.dataFileCacheTtl = dataFileCacheTtl;
         return this;
     }
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogAccess.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogAccess.java
@@ -119,6 +119,8 @@ public class TransactionLogAccess
         activeDataFileCache = EvictableCacheBuilder.newBuilder()
                 .weigher((Weigher<String, DeltaLakeDataFileCacheEntry>) (key, value) -> Ints.saturatedCast(estimatedSizeOf(key) + value.getRetainedSizeInBytes()))
                 .maximumWeight(deltaLakeConfig.getDataFileCacheSize().toBytes())
+                .expireAfterWrite(deltaLakeConfig.getDataFileCacheTtl().toMillis(), TimeUnit.MILLISECONDS)
+                .shareNothingWhenDisabled()
                 .recordStats()
                 .build();
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/AccessTrackingHdfsEnvironment.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/AccessTrackingHdfsEnvironment.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.hive.HdfsConfig;
+import io.trino.plugin.hive.HdfsConfiguration;
+import io.trino.plugin.hive.HdfsEnvironment;
+import io.trino.plugin.hive.authentication.HdfsAuthentication;
+import io.trino.spi.security.ConnectorIdentity;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class AccessTrackingHdfsEnvironment
+        extends HdfsEnvironment
+{
+    private Map<String, Integer> fileSystemPathNames = new HashMap<>();
+
+    public AccessTrackingHdfsEnvironment(HdfsConfiguration hdfsConfiguration, HdfsConfig config, HdfsAuthentication hdfsAuthentication)
+    {
+        super(hdfsConfiguration, config, hdfsAuthentication);
+    }
+
+    @Override
+    public FileSystem getFileSystem(ConnectorIdentity identity, Path path, Configuration configuration)
+            throws IOException
+    {
+        incrementAccessedPathNamesCount(path.getName());
+        return super.getFileSystem(identity, path, configuration);
+    }
+
+    public Map<String, Integer> getAccessedPathNames()
+    {
+        return ImmutableMap.copyOf(fileSystemPathNames);
+    }
+
+    private void incrementAccessedPathNamesCount(String fileName)
+    {
+        fileSystemPathNames.put(fileName, fileSystemPathNames.getOrDefault(fileName, 0) + 1);
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -126,6 +126,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
         QueryRunner queryRunner = createDeltaLakeQueryRunner(
                 ImmutableMap.<String, String>builder()
                         .put("delta.metadata.cache-ttl", TEST_METADATA_CACHE_TTL_SECONDS + "s")
+                        .put("delta.metadata.live-files.cache-ttl", TEST_METADATA_CACHE_TTL_SECONDS + "s")
                         .put("hive.metastore-cache-ttl", TEST_METADATA_CACHE_TTL_SECONDS + "s")
                         .buildOrThrow());
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConfig.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConfig.java
@@ -40,6 +40,7 @@ public class TestDeltaLakeConfig
     {
         assertRecordedDefaults(recordDefaults(DeltaLakeConfig.class)
                 .setDataFileCacheSize(DeltaLakeConfig.DEFAULT_DATA_FILE_CACHE_SIZE)
+                .setDataFileCacheTtl(new Duration(30, MINUTES))
                 .setMetadataCacheTtl(new Duration(5, TimeUnit.MINUTES))
                 .setDomainCompactionThreshold(100)
                 .setMaxSplitsPerSecond(Integer.MAX_VALUE)
@@ -71,6 +72,7 @@ public class TestDeltaLakeConfig
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("delta.metadata.cache-ttl", "10m")
                 .put("delta.metadata.live-files.cache-size", "0 MB")
+                .put("delta.metadata.live-files.cache-ttl", "60m")
                 .put("delta.domain-compaction-threshold", "500")
                 .put("delta.max-outstanding-splits", "200")
                 .put("delta.max-splits-per-second", "10")
@@ -97,6 +99,7 @@ public class TestDeltaLakeConfig
 
         DeltaLakeConfig expected = new DeltaLakeConfig()
                 .setDataFileCacheSize(DataSize.succinctBytes(0))
+                .setDataFileCacheTtl(new Duration(60, MINUTES))
                 .setMetadataCacheTtl(new Duration(10, TimeUnit.MINUTES))
                 .setDomainCompactionThreshold(500)
                 .setMaxOutstandingSplits(200)

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePlugin.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePlugin.java
@@ -117,4 +117,16 @@ public class TestDeltaLakePlugin
                         "delta.metadata.cache-ttl", "0s"),
                 new TestingConnectorContext());
     }
+
+    @Test
+    public void testNoActiveDataFilesCaching()
+    {
+        Plugin plugin = new DeltaLakePlugin();
+        ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
+        factory.create("test",
+                ImmutableMap.of(
+                        "hive.metastore.uri", "thrift://foo:1234",
+                        "delta.metadata.live-files.cache-ttl", "0s"),
+                new TestingConnectorContext());
+    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

Add config `delta.metadata.live-files.cache-ttl` for the caching duration of Delta table active data files.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Delta Lake connector

> How would you describe this change to a non-technical end user or system administrator?

Avoid holding indefinitely in the cache the active data files of the Delta Lake tables used already in SQL queries.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

Having this setting, would have probably ensured that the issue https://github.com/trinodb/trino/issues/13181 would occur far less often.


<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Delta Lake
* Add config for the caching duration of Delta table active data files
```
