### PR TITLE
[WIP] Support execution by partition in addition to by bucket for Hive connector

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
@@ -122,6 +122,7 @@ public class HiveConfig
     private boolean skipTargetCleanupOnRollback;
 
     private boolean bucketExecutionEnabled = true;
+    private int partitionExecutionMinPartitions;
     private boolean sortedWritingEnabled = true;
     private boolean propagateTableScanSortingProperties;
 
@@ -871,6 +872,24 @@ public class HiveConfig
     public HiveConfig setBucketExecutionEnabled(boolean bucketExecutionEnabled)
     {
         this.bucketExecutionEnabled = bucketExecutionEnabled;
+        return this;
+    }
+
+    @Min(0)
+    public int getPartitionExecutionMinPartitions()
+    {
+        return partitionExecutionMinPartitions;
+    }
+
+    @Config("hive.partition-execution-min-partitions")
+    @ConfigDescription(
+            "Enable partition-aware execution: only use a single worker per partition " +
+            "for tables where at least this many partitions are being requested (if " +
+            "bucket-aware execution is also enabled, work will be assigned based on the " +
+            "intersection of bucket and partition for bucketed and partitioned tables.")
+    public HiveConfig setPartitionExecutionMinPartitions(int partitionExecutionMinPartitions)
+    {
+        this.partitionExecutionMinPartitions = partitionExecutionMinPartitions;
         return this;
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveNodePartitioningProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveNodePartitioningProvider.java
@@ -87,7 +87,7 @@ public class HiveNodePartitioningProvider
     {
         HivePartitioningHandle handle = (HivePartitioningHandle) partitioningHandle;
         if (!handle.isUsePartitionedBucketingForWrites()) {
-            return createBucketNodeMap(handle.getBucketCount() * handle.getPartitions().size());
+            return createBucketNodeMap(handle.getBucketCount() * Integer.max(1, handle.getPartitions().size()));
         }
 
         // Create a bucket to node mapping. Consecutive buckets are assigned

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSink.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSink.java
@@ -154,7 +154,7 @@ public class HivePageSink
             List<HiveType> bucketColumnTypes = bucketProperty.get().getBucketedBy().stream()
                     .map(dataColumnNameToTypeMap::get)
                     .collect(toList());
-            bucketFunction = new HiveBucketFunction(bucketingVersion, bucketCount, bucketColumnTypes);
+            bucketFunction = new HiveBucketFunction(bucketingVersion, bucketCount, bucketColumnTypes, ImmutableList.of(), ImmutableList.of());
         }
         else {
             bucketColumns = null;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePartitioningHandle.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePartitioningHandle.java
@@ -19,7 +19,6 @@ import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.collect.ImmutableList;
 import io.trino.plugin.hive.util.HiveBucketing.BucketingVersion;
 import io.trino.spi.connector.ConnectorPartitioningHandle;
-import io.trino.spi.predicate.NullableValue;
 
 import java.util.List;
 import java.util.Objects;
@@ -33,7 +32,7 @@ public class HivePartitioningHandle
 {
     private final BucketingVersion bucketingVersion;
     private final int bucketCount;
-    private final List<List<NullableValue>> partitions;
+    private final List<String> partitions;
     private final List<HiveType> hiveTypes;
     private final OptionalInt maxCompatibleBucketCount;
     private final boolean usePartitionedBucketingForWrites;
@@ -45,7 +44,7 @@ public class HivePartitioningHandle
             @JsonProperty("hiveBucketTypes") List<HiveType> hiveTypes,
             @JsonProperty("maxCompatibleBucketCount") OptionalInt maxCompatibleBucketCount,
             @JsonProperty("usePartitionedBucketingForWrites") boolean usePartitionedBucketingForWrites,
-            @JsonProperty("partitions") List<List<NullableValue>> partitions)
+            @JsonProperty("partitions") List<String> partitions)
     {
         this.bucketingVersion = requireNonNull(bucketingVersion, "bucketingVersion is null");
         this.bucketCount = bucketCount;
@@ -55,7 +54,7 @@ public class HivePartitioningHandle
         this.usePartitionedBucketingForWrites = usePartitionedBucketingForWrites;
     }
 
-    public static HivePartitioningHandle partitionsOnly(List<List<NullableValue>> partitions)
+    public static HivePartitioningHandle partitionsOnly(List<String> partitions)
     {
         return new HivePartitioningHandle(
                 BucketingVersion.BUCKETING_V2,
@@ -97,7 +96,7 @@ public class HivePartitioningHandle
     }
 
     @JsonProperty
-    public List<List<NullableValue>> getPartitions()
+    public List<String> getPartitions()
     {
         return this.partitions;
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
@@ -56,6 +56,7 @@ public final class HiveSessionProperties
         implements SessionPropertiesProvider
 {
     private static final String BUCKET_EXECUTION_ENABLED = "bucket_execution_enabled";
+    private static final String PARTITION_EXECUTION_MIN_PARTITIONS = "partition_execution_min_partitions";
     private static final String VALIDATE_BUCKETING = "validate_bucketing";
     private static final String TARGET_MAX_FILE_SIZE = "target_max_file_size";
     private static final String PARALLEL_PARTITIONED_BUCKETED_WRITES = "parallel_partitioned_bucketed_writes";
@@ -153,6 +154,14 @@ public final class HiveSessionProperties
                         BUCKET_EXECUTION_ENABLED,
                         "Enable bucket-aware execution: only use a single worker per bucket",
                         hiveConfig.isBucketExecutionEnabled(),
+                        false),
+                integerProperty(
+                        PARTITION_EXECUTION_MIN_PARTITIONS,
+                        "Enable partition-aware execution: only use a single worker per partition " +
+                                  "for tables where at least this many partitions are being requested (if " +
+                                  "bucket-aware execution is also enabled, work will be assigned based on the " +
+                                  "intersection of bucket and partition for bucketed and partitioned tables)",
+                        hiveConfig.getPartitionExecutionMinPartitions(),
                         false),
                 booleanProperty(
                         VALIDATE_BUCKETING,
@@ -511,6 +520,11 @@ public final class HiveSessionProperties
     public static boolean isBucketExecutionEnabled(ConnectorSession session)
     {
         return session.getProperty(BUCKET_EXECUTION_ENABLED, Boolean.class);
+    }
+
+    public static int getPartitionExecutionMinPartitions(ConnectorSession session)
+    {
+        return session.getProperty(PARTITION_EXECUTION_MIN_PARTITIONS, Integer.class);
     }
 
     public static boolean isValidateBucketing(ConnectorSession session)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -5539,7 +5539,8 @@ public abstract class AbstractTestHive
                         bucketProperty.getBucketCount(),
                         ImmutableList.of(HIVE_STRING),
                         OptionalInt.empty(),
-                        false);
+                        false,
+                        ImmutableList.of());
                 assertEquals(insertLayout.get().getPartitioning(), Optional.of(partitioningHandle));
                 assertEquals(insertLayout.get().getPartitionColumns(), ImmutableList.of("column1"));
                 ConnectorBucketNodeMap connectorBucketNodeMap = nodePartitioningProvider.getBucketNodeMap(transaction.getTransactionHandle(), session, partitioningHandle);
@@ -5589,7 +5590,8 @@ public abstract class AbstractTestHive
                         bucketProperty.getBucketCount(),
                         ImmutableList.of(HIVE_STRING),
                         OptionalInt.empty(),
-                        true);
+                        true,
+                        ImmutableList.of());
                 assertEquals(insertLayout.get().getPartitioning(), Optional.of(partitioningHandle));
                 assertEquals(insertLayout.get().getPartitionColumns(), ImmutableList.of("column1", "column2"));
                 ConnectorBucketNodeMap connectorBucketNodeMap = nodePartitioningProvider.getBucketNodeMap(transaction.getTransactionHandle(), session, partitioningHandle);
@@ -5651,7 +5653,8 @@ public abstract class AbstractTestHive
                     10,
                     ImmutableList.of(HIVE_LONG),
                     OptionalInt.empty(),
-                    false);
+                    false,
+                    ImmutableList.of());
             assertEquals(newTableLayout.get().getPartitioning(), Optional.of(partitioningHandle));
             assertEquals(newTableLayout.get().getPartitionColumns(), ImmutableList.of("column1"));
             ConnectorBucketNodeMap connectorBucketNodeMap = nodePartitioningProvider.getBucketNodeMap(transaction.getTransactionHandle(), session, partitioningHandle);
@@ -5684,7 +5687,8 @@ public abstract class AbstractTestHive
                     10,
                     ImmutableList.of(HIVE_LONG),
                     OptionalInt.empty(),
-                    true);
+                    true,
+                    ImmutableList.of());
             assertEquals(newTableLayout.get().getPartitioning(), Optional.of(partitioningHandle));
             assertEquals(newTableLayout.get().getPartitionColumns(), ImmutableList.of("column1", "column2"));
             ConnectorBucketNodeMap connectorBucketNodeMap = nodePartitioningProvider.getBucketNodeMap(transaction.getTransactionHandle(), session, partitioningHandle);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
@@ -115,7 +115,8 @@ public class TestHiveConfig
                 .setMinimumAssignedSplitWeight(0.05)
                 .setDeltaLakeCatalogName(null)
                 .setAutoPurge(false)
-                .setPartitionProjectionEnabled(false));
+                .setPartitionProjectionEnabled(false)
+                .setPartitionExecutionMinPartitions(0);
     }
 
     @Test
@@ -201,6 +202,7 @@ public class TestHiveConfig
                 .put("hive.delta-lake-catalog-name", "delta")
                 .put("hive.auto-purge", "true")
                 .put(CONFIGURATION_HIVE_PARTITION_PROJECTION_ENABLED, "true")
+                .put("hive.partition-execution-min-partitions", "4")
                 .buildOrThrow();
 
         HiveConfig expected = new HiveConfig()
@@ -282,7 +284,8 @@ public class TestHiveConfig
                 .setMinimumAssignedSplitWeight(1.0)
                 .setDeltaLakeCatalogName("delta")
                 .setAutoPurge(true)
-                .setPartitionProjectionEnabled(true);
+                .setPartitionProjectionEnabled(true)
+                .setPartitionExecutionMinPartitions(4);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
@@ -116,7 +116,7 @@ public class TestHiveConfig
                 .setDeltaLakeCatalogName(null)
                 .setAutoPurge(false)
                 .setPartitionProjectionEnabled(false)
-                .setPartitionExecutionMinPartitions(0);
+                .setPartitionExecutionMinPartitions(0));
     }
 
     @Test

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePartitionedBucketFunction.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePartitionedBucketFunction.java
@@ -180,7 +180,7 @@ public class TestHivePartitionedBucketFunction
 
     private static BucketFunction partitionedBucketFunction(BucketingVersion hiveBucketingVersion, int hiveBucketCount, List<HiveType> hiveBucketTypes, List<Type> partitionColumnsTypes, int bucketCount)
     {
-        return new HivePartitionedBucketFunction(
+        return new HivePartitionHashBucketFunction(
                 hiveBucketingVersion,
                 hiveBucketCount,
                 hiveBucketTypes,
@@ -191,6 +191,6 @@ public class TestHivePartitionedBucketFunction
 
     private static BucketFunction bucketFunction(BucketingVersion hiveBucketingVersion, int hiveBucketCount, List<HiveType> hiveBucketTypes)
     {
-        return new HiveBucketFunction(hiveBucketingVersion, hiveBucketCount, hiveBucketTypes);
+        return new HiveBucketFunction(hiveBucketingVersion, hiveBucketCount, hiveBucketTypes, ImmutableList.of(), ImmutableList.of());
     }
 }


### PR DESCRIPTION
## Description

Just as it can be helpful to do bucketed execution, execution by partition can improve performance in a number of situations, especially aggregation by partition, and enables colocated joins where the partition key is part of the join key. In particular, with fault-tolerant execution, this means that it is possible to join two tables by partition without persisting either side of the join to the exchange.

The main limitation to the feature as implemented in this PR is that it is all-or-nothing with respect to partition columns. That is, if a join uses one partitioned column but the table is partitioned on two columns, execution by partition cannot be used.

> Is this change a fix, improvement, new feature, refactoring, or other?

New feature

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Hive connector only

> How would you describe this change to a non-technical end user or system administrator?

If you have a large table with many partitions, this makes it easier to query the table or join it with other tables in an efficient way.

I will write some tests but wanted to make sure I'm taking the right approach first!

## Related issues, pull requests, and links
* Fixes #930 (which references grouped execution; this feature is still useful without grouped execution, however.)

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Hive Connector
* Partitioned execution support (similar to bucketed execution, but for partitioned tables)
```
