### PR TITLE
Support execution by partition in addition to by bucket for Hive connector

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
@@ -121,6 +121,7 @@ public class HiveConfig
     private boolean skipTargetCleanupOnRollback;
 
     private boolean bucketExecutionEnabled = true;
+    private boolean partitionExecutionEnabled;
     private boolean sortedWritingEnabled = true;
     private boolean propagateTableScanSortingProperties;
 
@@ -892,6 +893,22 @@ public class HiveConfig
     public HiveConfig setBucketExecutionEnabled(boolean bucketExecutionEnabled)
     {
         this.bucketExecutionEnabled = bucketExecutionEnabled;
+        return this;
+    }
+
+    public boolean isPartitionExecutionEnabled()
+    {
+        return partitionExecutionEnabled;
+    }
+
+    @Config("hive.partition-execution")
+    @ConfigDescription(
+            "Enable partition-aware execution: only use a single worker per partition (if " +
+            "bucket-aware execution is also enabled, work will be assigned based on the " +
+            "intersection of bucket and partition for bucketed and partitioned tables.")
+    public HiveConfig setPartitionExecutionEnabled(boolean partitionExecutionEnabled)
+    {
+        this.partitionExecutionEnabled = partitionExecutionEnabled;
         return this;
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveNodePartitioningProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveNodePartitioningProvider.java
@@ -13,7 +13,9 @@
  */
 package io.trino.plugin.hive;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
+import io.trino.plugin.hive.util.HiveUtil;
 import io.trino.spi.NodeManager;
 import io.trino.spi.connector.BucketFunction;
 import io.trino.spi.connector.ConnectorBucketNodeMap;
@@ -27,6 +29,7 @@ import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.TypeOperators;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.ToIntFunction;
 
@@ -56,15 +59,29 @@ public class HiveNodePartitioningProvider
             List<Type> partitionChannelTypes,
             int bucketCount)
     {
-        if (partitioningHandle instanceof HiveUpdateHandle) {
+        if (partitioningHandle instanceof HiveUpdateHandle handle) {
             return new HiveUpdateBucketFunction(bucketCount);
         }
         HivePartitioningHandle handle = (HivePartitioningHandle) partitioningHandle;
         List<HiveType> hiveBucketTypes = handle.getHiveTypes();
-        if (!handle.isUsePartitionedBucketing()) {
-            return new HiveBucketFunction(handle.getBucketingVersion(), bucketCount, hiveBucketTypes);
+        if (!handle.isUsePartitionedBucketingForWrites()) {
+            List<String> partitions = handle.getPartitions();
+            if (partitions.size() > 0) {
+                return new HivePartitionedBucketFunction(
+                        handle.getBucketingVersion(),
+                        bucketCount,
+                        hiveBucketTypes,
+                        partitionChannelTypes.subList(0, partitionChannelTypes.size() - hiveBucketTypes.size()),
+                        partitions);
+            }
+            else {
+                return new HiveBucketFunction(
+                        handle.getBucketingVersion(),
+                        bucketCount,
+                        hiveBucketTypes);
+            }
         }
-        return new HivePartitionedBucketFunction(
+        return new HivePartitionHashBucketFunction(
                 handle.getBucketingVersion(),
                 handle.getBucketCount(),
                 hiveBucketTypes,
@@ -77,8 +94,8 @@ public class HiveNodePartitioningProvider
     public Optional<ConnectorBucketNodeMap> getBucketNodeMapping(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle)
     {
         HivePartitioningHandle handle = (HivePartitioningHandle) partitioningHandle;
-        if (!handle.isUsePartitionedBucketing()) {
-            return Optional.of(createBucketNodeMap(handle.getBucketCount()));
+        if (!handle.isUsePartitionedBucketingForWrites()) {
+            return Optional.of(createBucketNodeMap(handle.getBucketCount() * Integer.max(1, handle.getPartitions().size())));
         }
 
         // Allocate a fixed number of buckets. Trino will assign consecutive buckets
@@ -100,7 +117,22 @@ public class HiveNodePartitioningProvider
             ConnectorSession session,
             ConnectorPartitioningHandle partitioningHandle)
     {
-        return value -> ((HiveSplit) value).getReadBucketNumber()
-                .orElseThrow(() -> new IllegalArgumentException("Bucket number not set in split"));
+        HivePartitioningHandle handle = (HivePartitioningHandle) partitioningHandle;
+        if (handle.getPartitions().isEmpty()) {
+            return value -> ((HiveSplit) value).getReadBucketNumber()
+                    .orElseThrow(() -> new IllegalArgumentException("Bucket number not set in split"));
+        }
+        List<String> partitions = handle.getPartitions();
+        ImmutableMap.Builder<String, Integer> partitionToIndexBuilder = ImmutableMap.builder();
+        for (int i = 0; i < partitions.size(); i++) {
+            partitionToIndexBuilder.put(partitions.get(i), i);
+        }
+        Map<String, Integer> partitionToIndex = partitionToIndexBuilder.buildOrThrow();
+        return value -> {
+            HiveSplit split = (HiveSplit) value;
+            String partitionValues = HiveUtil.erasePartitionColumnNames(split.getPartitionName());
+            int partitionIndex = partitionToIndex.getOrDefault(partitionValues, 0);
+            return split.getReadBucketNumber().orElse(0) + (handle.getBucketCount() * partitionIndex);
+        };
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePartitionHashBucketFunction.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePartitionHashBucketFunction.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import io.trino.plugin.hive.type.TypeInfo;
+import io.trino.plugin.hive.util.HiveBucketing;
+import io.trino.plugin.hive.util.HiveBucketing.BucketingVersion;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.connector.BucketFunction;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeOperators;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Throwables.throwIfUnchecked;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.function.InvocationConvention.simpleConvention;
+import static java.util.Objects.requireNonNull;
+
+public class HivePartitionHashBucketFunction
+        implements BucketFunction
+{
+    private final BucketingVersion bucketingVersion;
+    private final int hiveBucketCount;
+    private final List<TypeInfo> bucketTypeInfos;
+    private final int bucketCount;
+    private final int firstPartitionColumnIndex;
+    private final List<MethodHandle> hashCodeInvokers;
+
+    public HivePartitionHashBucketFunction(
+            BucketingVersion bucketingVersion,
+            int hiveBucketCount,
+            List<HiveType> hiveBucketTypes,
+            List<Type> partitionColumnsTypes,
+            TypeOperators typeOperators,
+            int bucketCount)
+    {
+        this.bucketingVersion = requireNonNull(bucketingVersion, "bucketingVersion is null");
+        this.hiveBucketCount = hiveBucketCount;
+        this.bucketTypeInfos = hiveBucketTypes.stream()
+                .map(HiveType::getTypeInfo)
+                .collect(toImmutableList());
+        this.firstPartitionColumnIndex = hiveBucketTypes.size();
+        this.hashCodeInvokers = partitionColumnsTypes.stream()
+                .map(type -> typeOperators.getHashCodeOperator(type, simpleConvention(FAIL_ON_NULL, BLOCK_POSITION)))
+                .collect(toImmutableList());
+        this.bucketCount = bucketCount;
+    }
+
+    private int getHiveBucket(Page page, int position)
+    {
+        return HiveBucketing.getHiveBucket(bucketingVersion, hiveBucketCount, bucketTypeInfos, page, position);
+    }
+
+    @Override
+    public int getBucket(Page page, int position)
+    {
+        // This bucket function is used for writing, when we don't know in advance the partitions that will be created.
+        // So we assign partitions to buckets by hashing, which means that in all likelihood different partitions will
+        // be split across buckets. This is not a great bucket function when reading partitioned data, however, when we
+        // can do better by creating a separate bucket for each partition to begin with and ensuring that each one is
+        // bucketed uniquely.
+        long partitionHash = 0;
+        for (int i = 0; i < hashCodeInvokers.size(); i++) {
+            try {
+                Block partitionColumn = page.getBlock(i + firstPartitionColumnIndex);
+                partitionHash = (31 * partitionHash) + hashCodeNullSafe(hashCodeInvokers.get(i), partitionColumn, position);
+            }
+            catch (Throwable throwable) {
+                throwIfUnchecked(throwable);
+                throw new RuntimeException(throwable);
+            }
+        }
+
+        int hiveBucket = getHiveBucket(page, position);
+
+        return (int) ((((31 * partitionHash) + hiveBucket) & Long.MAX_VALUE) % bucketCount);
+    }
+
+    private static long hashCodeNullSafe(MethodHandle hashCode, Block block, int position)
+            throws Throwable
+    {
+        if (block.isNull(position)) {
+            // use -1 as a hash for null value as it's less likely to collide with
+            // hash for non-null values (mainly 0 bigints/integers)
+            return -1;
+        }
+        return (long) hashCode.invokeExact(block, position);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("version", bucketingVersion)
+                .add("hiveBucketCount", hiveBucketCount)
+                .add("bucketTypeInfos", bucketTypeInfos)
+                .add("firstPartitionColumnIndex", firstPartitionColumnIndex)
+                .add("bucketCount", bucketCount)
+                .toString();
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePartitioningHandle.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePartitioningHandle.java
@@ -16,6 +16,7 @@ package io.trino.plugin.hive;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects.ToStringHelper;
+import com.google.common.collect.ImmutableList;
 import io.trino.plugin.hive.util.HiveBucketing.BucketingVersion;
 import io.trino.spi.connector.ConnectorPartitioningHandle;
 
@@ -31,9 +32,10 @@ public class HivePartitioningHandle
 {
     private final BucketingVersion bucketingVersion;
     private final int bucketCount;
+    private final List<String> partitions;
     private final List<HiveType> hiveTypes;
     private final OptionalInt maxCompatibleBucketCount;
-    private final boolean usePartitionedBucketing;
+    private final boolean usePartitionedBucketingForWrites;
 
     @JsonCreator
     public HivePartitioningHandle(
@@ -41,13 +43,26 @@ public class HivePartitioningHandle
             @JsonProperty("bucketCount") int bucketCount,
             @JsonProperty("hiveBucketTypes") List<HiveType> hiveTypes,
             @JsonProperty("maxCompatibleBucketCount") OptionalInt maxCompatibleBucketCount,
-            @JsonProperty("usePartitionedBucketing") boolean usePartitionedBucketing)
+            @JsonProperty("usePartitionedBucketingForWrites") boolean usePartitionedBucketingForWrites,
+            @JsonProperty("partitions") List<String> partitions)
     {
         this.bucketingVersion = requireNonNull(bucketingVersion, "bucketingVersion is null");
         this.bucketCount = bucketCount;
         this.hiveTypes = requireNonNull(hiveTypes, "hiveTypes is null");
         this.maxCompatibleBucketCount = maxCompatibleBucketCount;
-        this.usePartitionedBucketing = usePartitionedBucketing;
+        this.partitions = partitions;
+        this.usePartitionedBucketingForWrites = usePartitionedBucketingForWrites;
+    }
+
+    public static HivePartitioningHandle partitionsOnly(List<String> partitions)
+    {
+        return new HivePartitioningHandle(
+                BucketingVersion.BUCKETING_V2,
+                1,
+                ImmutableList.of(),
+                OptionalInt.empty(),
+                false,
+                partitions);
     }
 
     @JsonProperty
@@ -75,9 +90,15 @@ public class HivePartitioningHandle
     }
 
     @JsonProperty
-    public boolean isUsePartitionedBucketing()
+    public boolean isUsePartitionedBucketingForWrites()
     {
-        return usePartitionedBucketing;
+        return usePartitionedBucketingForWrites;
+    }
+
+    @JsonProperty
+    public List<String> getPartitions()
+    {
+        return this.partitions;
     }
 
     @Override
@@ -86,8 +107,11 @@ public class HivePartitioningHandle
         ToStringHelper helper = toStringHelper(this)
                 .add("buckets", bucketCount)
                 .add("hiveTypes", hiveTypes);
-        if (usePartitionedBucketing) {
-            helper.add("usePartitionedBucketing", usePartitionedBucketing);
+        if (partitions.size() > 0) {
+            helper.add("partitions", partitions.size());
+        }
+        if (usePartitionedBucketingForWrites) {
+            helper.add("usePartitionedBucketingForWrites", usePartitionedBucketingForWrites);
         }
         return helper.toString();
     }
@@ -102,14 +126,16 @@ public class HivePartitioningHandle
             return false;
         }
         HivePartitioningHandle that = (HivePartitioningHandle) o;
+
         return bucketCount == that.bucketCount &&
-                usePartitionedBucketing == that.usePartitionedBucketing &&
+                partitions.equals(that.partitions) &&
+                usePartitionedBucketingForWrites == that.usePartitionedBucketingForWrites &&
                 Objects.equals(hiveTypes, that.hiveTypes);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(bucketCount, hiveTypes, usePartitionedBucketing);
+        return Objects.hash(bucketCount, hiveTypes, partitions.isEmpty(), usePartitionedBucketingForWrites);
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
@@ -60,6 +60,7 @@ public final class HiveSessionProperties
         implements SessionPropertiesProvider
 {
     private static final String BUCKET_EXECUTION_ENABLED = "bucket_execution_enabled";
+    private static final String PARTITION_EXECUTION_ENABLED = "partition_execution_enabled";
     private static final String VALIDATE_BUCKETING = "validate_bucketing";
     private static final String TARGET_MAX_FILE_SIZE = "target_max_file_size";
     private static final String PARALLEL_PARTITIONED_BUCKETED_WRITES = "parallel_partitioned_bucketed_writes";
@@ -175,6 +176,13 @@ public final class HiveSessionProperties
                         BUCKET_EXECUTION_ENABLED,
                         "Enable bucket-aware execution: only use a single worker per bucket",
                         hiveConfig.isBucketExecutionEnabled(),
+                        false),
+                booleanProperty(
+                        PARTITION_EXECUTION_ENABLED,
+                        "Enable partition-aware execution: only use a single worker per partition (if " +
+                                  "bucket-aware execution is also enabled, work will be assigned based on the " +
+                                  "intersection of bucket and partition for bucketed and partitioned tables)",
+                        hiveConfig.isPartitionExecutionEnabled(),
                         false),
                 booleanProperty(
                         VALIDATE_BUCKETING,
@@ -644,6 +652,11 @@ public final class HiveSessionProperties
     public static boolean isBucketExecutionEnabled(ConnectorSession session)
     {
         return session.getProperty(BUCKET_EXECUTION_ENABLED, Boolean.class);
+    }
+
+    public static boolean isPartitionExecutionEnabled(ConnectorSession session)
+    {
+        return session.getProperty(PARTITION_EXECUTION_ENABLED, Boolean.class);
     }
 
     public static boolean isValidateBucketing(ConnectorSession session)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveUpdateHandle.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveUpdateHandle.java
@@ -15,6 +15,7 @@ package io.trino.plugin.hive;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 import io.trino.plugin.hive.util.HiveBucketing.BucketingVersion;
 
 import java.util.List;
@@ -29,8 +30,8 @@ public class HiveUpdateHandle
             @JsonProperty("bucketCount") int bucketCount,
             @JsonProperty("hiveBucketTypes") List<HiveType> hiveTypes,
             @JsonProperty("maxCompatibleBucketCount") OptionalInt maxCompatibleBucketCount,
-            @JsonProperty("usePartitionedBucketing") boolean usePartitionedBucketing)
+            @JsonProperty("usePartitionedBucketingForWrites") boolean usePartitionedBucketingForWrites)
     {
-        super(bucketingVersion, bucketCount, hiveTypes, maxCompatibleBucketCount, usePartitionedBucketing);
+        super(bucketingVersion, bucketCount, hiveTypes, maxCompatibleBucketCount, usePartitionedBucketingForWrites, ImmutableList.of());
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -5744,7 +5744,8 @@ public abstract class AbstractTestHive
                         bucketProperty.getBucketCount(),
                         ImmutableList.of(HIVE_STRING),
                         OptionalInt.empty(),
-                        false);
+                        false,
+                        ImmutableList.of());
                 assertEquals(insertLayout.get().getPartitioning(), Optional.of(partitioningHandle));
                 assertEquals(insertLayout.get().getPartitionColumns(), ImmutableList.of("column1"));
                 ConnectorBucketNodeMap connectorBucketNodeMap = nodePartitioningProvider.getBucketNodeMapping(transaction.getTransactionHandle(), session, partitioningHandle).orElseThrow();
@@ -5794,7 +5795,8 @@ public abstract class AbstractTestHive
                         bucketProperty.getBucketCount(),
                         ImmutableList.of(HIVE_STRING),
                         OptionalInt.empty(),
-                        true);
+                        true,
+                        ImmutableList.of());
                 assertEquals(insertLayout.get().getPartitioning(), Optional.of(partitioningHandle));
                 assertEquals(insertLayout.get().getPartitionColumns(), ImmutableList.of("column1", "column2"));
                 ConnectorBucketNodeMap connectorBucketNodeMap = nodePartitioningProvider.getBucketNodeMapping(transaction.getTransactionHandle(), session, partitioningHandle).orElseThrow();
@@ -5855,7 +5857,8 @@ public abstract class AbstractTestHive
                     10,
                     ImmutableList.of(HIVE_LONG),
                     OptionalInt.empty(),
-                    false);
+                    false,
+                    ImmutableList.of());
             assertEquals(newTableLayout.get().getPartitioning(), Optional.of(partitioningHandle));
             assertEquals(newTableLayout.get().getPartitionColumns(), ImmutableList.of("column1"));
             ConnectorBucketNodeMap connectorBucketNodeMap = nodePartitioningProvider.getBucketNodeMapping(transaction.getTransactionHandle(), session, partitioningHandle).orElseThrow();
@@ -5888,7 +5891,8 @@ public abstract class AbstractTestHive
                     10,
                     ImmutableList.of(HIVE_LONG),
                     OptionalInt.empty(),
-                    true);
+                    true,
+                    ImmutableList.of());
             assertEquals(newTableLayout.get().getPartitioning(), Optional.of(partitioningHandle));
             assertEquals(newTableLayout.get().getPartitionColumns(), ImmutableList.of("column1", "column2"));
             ConnectorBucketNodeMap connectorBucketNodeMap = nodePartitioningProvider.getBucketNodeMapping(transaction.getTransactionHandle(), session, partitioningHandle).orElseThrow();

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
@@ -118,7 +118,8 @@ public class TestHiveConfig
                 .setDeltaLakeCatalogName(null)
                 .setHudiCatalogName(null)
                 .setAutoPurge(false)
-                .setPartitionProjectionEnabled(false));
+                .setPartitionProjectionEnabled(false)
+                .setPartitionExecutionEnabled(false));
     }
 
     @Test
@@ -205,6 +206,7 @@ public class TestHiveConfig
                 .put("hive.hudi-catalog-name", "hudi")
                 .put("hive.auto-purge", "true")
                 .put(CONFIGURATION_HIVE_PARTITION_PROJECTION_ENABLED, "true")
+                .put("hive.partition-execution", "true")
                 .buildOrThrow();
 
         HiveConfig expected = new HiveConfig()
@@ -287,7 +289,8 @@ public class TestHiveConfig
                 .setDeltaLakeCatalogName("delta")
                 .setHudiCatalogName("hudi")
                 .setAutoPurge(true)
-                .setPartitionProjectionEnabled(true);
+                .setPartitionProjectionEnabled(true)
+                .setPartitionExecutionEnabled(true);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveDynamicPartitionPruningTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveDynamicPartitionPruningTest.java
@@ -32,7 +32,12 @@ public class TestHiveDynamicPartitionPruningTest
     {
         return HiveQueryRunner.builder()
                 .setExtraProperties(EXTRA_PROPERTIES)
-                .setHiveProperties(ImmutableMap.of("hive.dynamic-filtering.wait-timeout", "1h"))
+                .setHiveProperties(ImmutableMap.of(
+                        "hive.dynamic-filtering.wait-timeout", "1h",
+
+                        // With partition-execution, the test queries get broken up into fewer stages which
+                        // prevents dynamic filters from being executed lazily.
+                        "hive.partition-execution", "false"))
                 .setInitialTables(REQUIRED_TABLES)
                 .build();
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePartitionedBucketFunction.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePartitionedBucketFunction.java
@@ -180,7 +180,7 @@ public class TestHivePartitionedBucketFunction
 
     private static BucketFunction partitionedBucketFunction(BucketingVersion hiveBucketingVersion, int hiveBucketCount, List<HiveType> hiveBucketTypes, List<Type> partitionColumnsTypes, int bucketCount)
     {
-        return new HivePartitionedBucketFunction(
+        return new HivePartitionHashBucketFunction(
                 hiveBucketingVersion,
                 hiveBucketCount,
                 hiveBucketTypes,


### PR DESCRIPTION
## Description

Just as it can be helpful to do bucketed execution, execution by partition can improve performance in a number of situations, especially aggregation by partition, and enables colocated joins where the partition key is part of the join key. In particular, with fault-tolerant execution, this means that it is possible to join two tables by partition without persisting either side of the join to the exchange.

The main limitation to the feature as implemented in this PR is that it is all-or-nothing with respect to partition columns. That is, if a join uses one partitioned column but the table is partitioned on two columns, execution by partition cannot be used. Similarly, if a table is partitioned and bucketed, both the partition key and bucketing key must be used in a join.

> Is this change a fix, improvement, new feature, refactoring, or other?

New feature

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Hive connector only

> How would you describe this change to a non-technical end user or system administrator?

If you have a large table with many partitions, this makes it easier to query the table or join it with other tables in an efficient way.

## Related issues, pull requests, and links
* Fixes #930 (which references grouped execution; this feature is still useful without grouped execution, however.)

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Hive Connector
* Partitioned execution support (similar to bucketed execution, but for partitioned tables)
```