### PR TITLE
Fix query completion timout in EventsAwaitingQueries

### DIFF
--- a/testing/trino-tests/src/test/java/io/trino/execution/EventsAwaitingQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/EventsAwaitingQueries.java
@@ -78,7 +78,7 @@ class EventsAwaitingQueries
         }
 
         QueryEvents queryEvents = eventsCollector.getQueryEvents(queryId);
-        queryEvents.waitForQueryCompletion(new Duration(3, SECONDS));
+        queryEvents.waitForQueryCompletion(new Duration(30, SECONDS));
 
         // Sleep some more so extraneous, unexpected events can be recorded too.
         // This is not rock solid but improves effectiveness on detecting duplicate events.


### PR DESCRIPTION
## Description

The timeout was lowered during testing and accidentally committed.

## Documentation

(X) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(X) No release notes entries required.
( ) Release notes entries required with the following suggested text:
