### PR TITLE
Enforce `delta.checkpoint.writeStatsAsJson` and `delta.checkpoint.writeStatsAsStruct` option in Delta Lake

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/MetadataEntry.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/MetadataEntry.java
@@ -32,6 +32,9 @@ import static java.lang.String.format;
 
 public class MetadataEntry
 {
+    public static final String DELTA_CHECKPOINT_WRITE_STATS_AS_JSON_PROPERTY = "delta.checkpoint.writeStatsAsJson";
+    public static final String DELTA_CHECKPOINT_WRITE_STATS_AS_STRUCT_PROPERTY = "delta.checkpoint.writeStatsAsStruct";
+
     private static final String DELTA_CHECKPOINT_INTERVAL_PROPERTY = "delta.checkpointInterval";
 
     private final String id;

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
@@ -201,7 +201,7 @@ public class CheckpointEntryIterator
                 type = schemaManager.getTxnEntryType();
                 break;
             case ADD:
-                type = schemaManager.getAddEntryType(metadataEntry);
+                type = schemaManager.getAddEntryType(metadataEntry, true, true);
                 break;
             case REMOVE:
                 type = schemaManager.getRemoveEntryType();

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointSchemaManager.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointSchemaManager.java
@@ -106,7 +106,7 @@ public class CheckpointSchemaManager
         return metadataEntryType;
     }
 
-    public RowType getAddEntryType(MetadataEntry metadataEntry)
+    public RowType getAddEntryType(MetadataEntry metadataEntry, boolean requireWriteStatsAsJson, boolean requireWriteStatsAsStruct)
     {
         List<DeltaLakeColumnMetadata> allColumns = extractSchema(metadataEntry, typeManager);
         List<DeltaLakeColumnMetadata> minMaxColumns = columnsWithStats(metadataEntry, typeManager);
@@ -143,8 +143,12 @@ public class CheckpointSchemaManager
         addFields.add(RowType.field("size", BigintType.BIGINT));
         addFields.add(RowType.field("modificationTime", BigintType.BIGINT));
         addFields.add(RowType.field("dataChange", BooleanType.BOOLEAN));
-        addFields.add(RowType.field("stats", VarcharType.createUnboundedVarcharType()));
-        addFields.add(RowType.field("stats_parsed", RowType.from(statsColumns.build())));
+        if (requireWriteStatsAsJson) {
+            addFields.add(RowType.field("stats", VarcharType.createUnboundedVarcharType()));
+        }
+        if (requireWriteStatsAsStruct) {
+            addFields.add(RowType.field("stats_parsed", RowType.from(statsColumns.build())));
+        }
         addFields.add(RowType.field("tags", stringMap));
 
         return RowType.from(addFields.build());

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointSchemaManager.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointSchemaManager.java
@@ -137,17 +137,17 @@ public class CheckpointSchemaManager
                 RowType.from(allColumns.stream().map(column -> buildNullCountType(Optional.of(column.getPhysicalName()), column.getPhysicalColumnType())).collect(toImmutableList()))));
 
         MapType stringMap = (MapType) typeManager.getType(TypeSignature.mapType(VarcharType.VARCHAR.getTypeSignature(), VarcharType.VARCHAR.getTypeSignature()));
-        List<RowType.Field> addFields = ImmutableList.of(
-                RowType.field("path", VarcharType.createUnboundedVarcharType()),
-                RowType.field("partitionValues", stringMap),
-                RowType.field("size", BigintType.BIGINT),
-                RowType.field("modificationTime", BigintType.BIGINT),
-                RowType.field("dataChange", BooleanType.BOOLEAN),
-                RowType.field("stats", VarcharType.createUnboundedVarcharType()),
-                RowType.field("stats_parsed", RowType.from(statsColumns.build())),
-                RowType.field("tags", stringMap));
+        ImmutableList.Builder<RowType.Field> addFields = ImmutableList.builder();
+        addFields.add(RowType.field("path", VarcharType.createUnboundedVarcharType()));
+        addFields.add(RowType.field("partitionValues", stringMap));
+        addFields.add(RowType.field("size", BigintType.BIGINT));
+        addFields.add(RowType.field("modificationTime", BigintType.BIGINT));
+        addFields.add(RowType.field("dataChange", BooleanType.BOOLEAN));
+        addFields.add(RowType.field("stats", VarcharType.createUnboundedVarcharType()));
+        addFields.add(RowType.field("stats_parsed", RowType.from(statsColumns.build())));
+        addFields.add(RowType.field("tags", stringMap));
 
-        return RowType.from(addFields);
+        return RowType.from(addFields.build());
     }
 
     private static RowType.Field buildNullCountType(Optional<String> columnName, Type columnType)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriter.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriter.java
@@ -13,14 +13,17 @@
  */
 package io.trino.plugin.deltalake.transactionlog.checkpoint;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableList;
 import io.trino.hdfs.HdfsContext;
 import io.trino.hdfs.HdfsEnvironment;
+import io.trino.plugin.deltalake.DeltaLakeColumnMetadata;
 import io.trino.plugin.deltalake.transactionlog.AddFileEntry;
 import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
 import io.trino.plugin.deltalake.transactionlog.ProtocolEntry;
 import io.trino.plugin.deltalake.transactionlog.RemoveFileEntry;
 import io.trino.plugin.deltalake.transactionlog.TransactionEntry;
+import io.trino.plugin.deltalake.transactionlog.statistics.DeltaLakeFileStatistics;
 import io.trino.plugin.deltalake.transactionlog.statistics.DeltaLakeJsonFileStatistics;
 import io.trino.plugin.deltalake.transactionlog.statistics.DeltaLakeParquetFileStatistics;
 import io.trino.plugin.hive.RecordFileWriter;
@@ -49,9 +52,16 @@ import java.util.Properties;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.hdfs.ConfigurationUtils.toJobConf;
 import static io.trino.plugin.deltalake.DeltaLakeSchemaProperties.buildHiveSchema;
+import static io.trino.plugin.deltalake.transactionlog.DeltaLakeParquetStatisticsUtils.jsonValueToTrinoValue;
+import static io.trino.plugin.deltalake.transactionlog.DeltaLakeParquetStatisticsUtils.toJsonValues;
+import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.extractSchema;
+import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.serializeStatsAsJson;
+import static io.trino.plugin.deltalake.transactionlog.MetadataEntry.DELTA_CHECKPOINT_WRITE_STATS_AS_JSON_PROPERTY;
+import static io.trino.plugin.deltalake.transactionlog.MetadataEntry.DELTA_CHECKPOINT_WRITE_STATS_AS_STRUCT_PROPERTY;
 import static io.trino.plugin.hive.HiveCompressionCodec.SNAPPY;
 import static io.trino.plugin.hive.HiveStorageFormat.PARQUET;
 import static io.trino.plugin.hive.metastore.StorageFormat.fromHiveStorageFormat;
@@ -59,6 +69,7 @@ import static io.trino.plugin.hive.util.CompressionConfigUtil.configureCompressi
 import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.trino.spi.type.TypeUtils.writeNativeValue;
 import static java.lang.Math.multiplyExact;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toMap;
 
@@ -86,10 +97,15 @@ public class CheckpointWriter
 
     public void write(ConnectorSession session, CheckpointEntries entries, Path targetPath)
     {
+        Map<String, String> configuration = entries.getMetadataEntry().getConfiguration();
+        boolean writeStatsAsJson = Boolean.parseBoolean(configuration.getOrDefault(DELTA_CHECKPOINT_WRITE_STATS_AS_JSON_PROPERTY, "true"));
+        // The default value is false in https://github.com/delta-io/delta/blob/master/PROTOCOL.md#checkpoint-format, but Databricks defaults to true
+        boolean writeStatsAsStruct = Boolean.parseBoolean(configuration.getOrDefault(DELTA_CHECKPOINT_WRITE_STATS_AS_STRUCT_PROPERTY, "true"));
+
         RowType metadataEntryType = checkpointSchemaManager.getMetadataEntryType();
         RowType protocolEntryType = checkpointSchemaManager.getProtocolEntryType();
         RowType txnEntryType = checkpointSchemaManager.getTxnEntryType();
-        RowType addEntryType = checkpointSchemaManager.getAddEntryType(entries.getMetadataEntry());
+        RowType addEntryType = checkpointSchemaManager.getAddEntryType(entries.getMetadataEntry(), writeStatsAsJson, writeStatsAsStruct);
         RowType removeEntryType = checkpointSchemaManager.getRemoveEntryType();
 
         List<String> columnNames = ImmutableList.of(
@@ -130,7 +146,7 @@ public class CheckpointWriter
             writeTransactionEntry(pageBuilder, txnEntryType, transactionEntry);
         }
         for (AddFileEntry addFileEntry : entries.getAddFileEntries()) {
-            writeAddFileEntry(pageBuilder, addEntryType, addFileEntry);
+            writeAddFileEntry(pageBuilder, addEntryType, addFileEntry, entries.getMetadataEntry(), writeStatsAsJson, writeStatsAsStruct);
         }
         for (RemoveFileEntry removeFileEntry : entries.getRemoveFileEntries()) {
             writeRemoveFileEntry(pageBuilder, removeEntryType, removeFileEntry);
@@ -193,60 +209,107 @@ public class CheckpointWriter
         appendNullOtherBlocks(pageBuilder, TXN_BLOCK_CHANNEL);
     }
 
-    private void writeAddFileEntry(PageBuilder pageBuilder, RowType entryType, AddFileEntry addFileEntry)
+    private void writeAddFileEntry(PageBuilder pageBuilder, RowType entryType, AddFileEntry addFileEntry, MetadataEntry metadataEntry, boolean writeStatsAsJson, boolean writeStatsAsStruct)
     {
         pageBuilder.declarePosition();
         BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(ADD_BLOCK_CHANNEL);
         BlockBuilder entryBlockBuilder = blockBuilder.beginBlockEntry();
-        writeString(entryBlockBuilder, entryType, 0, "path", addFileEntry.getPath());
-        writeStringMap(entryBlockBuilder, entryType, 1, "partitionValues", addFileEntry.getPartitionValues());
-        writeLong(entryBlockBuilder, entryType, 2, "size", addFileEntry.getSize());
-        writeLong(entryBlockBuilder, entryType, 3, "modificationTime", addFileEntry.getModificationTime());
-        writeBoolean(entryBlockBuilder, entryType, 4, "dataChange", addFileEntry.isDataChange());
-        // TODO: determine stats format in checkpoint based on table configuration; (https://github.com/trinodb/trino/issues/12031)
-        // currently if addFileEntry contains JSON stats we will write JSON
-        // stats to checkpoint and if addEntryFile contains parsed stats, we
-        // will write parsed stats to the checkpoint.
-        writeJsonStats(entryBlockBuilder, entryType, addFileEntry);
-        writeParsedStats(entryBlockBuilder, entryType, addFileEntry);
-        writeStringMap(entryBlockBuilder, entryType, 7, "tags", addFileEntry.getTags());
+        int fieldId = 0;
+        writeString(entryBlockBuilder, entryType, fieldId++, "path", addFileEntry.getPath());
+        writeStringMap(entryBlockBuilder, entryType, fieldId++, "partitionValues", addFileEntry.getPartitionValues());
+        writeLong(entryBlockBuilder, entryType, fieldId++, "size", addFileEntry.getSize());
+        writeLong(entryBlockBuilder, entryType, fieldId++, "modificationTime", addFileEntry.getModificationTime());
+        writeBoolean(entryBlockBuilder, entryType, fieldId++, "dataChange", addFileEntry.isDataChange());
+        if (writeStatsAsJson) {
+            writeJsonStats(entryBlockBuilder, entryType, addFileEntry, metadataEntry, fieldId++);
+        }
+        if (writeStatsAsStruct) {
+            writeParsedStats(entryBlockBuilder, entryType, addFileEntry, fieldId++);
+        }
+        writeStringMap(entryBlockBuilder, entryType, fieldId++, "tags", addFileEntry.getTags());
         blockBuilder.closeEntry();
 
         // null for others
         appendNullOtherBlocks(pageBuilder, ADD_BLOCK_CHANNEL);
     }
 
-    private void writeJsonStats(BlockBuilder entryBlockBuilder, RowType entryType, AddFileEntry addFileEntry)
+    private void writeJsonStats(BlockBuilder entryBlockBuilder, RowType entryType, AddFileEntry addFileEntry, MetadataEntry metadataEntry, int fieldId)
     {
         String statsJson = null;
-        if (addFileEntry.getStats().isPresent() && addFileEntry.getStats().get() instanceof DeltaLakeJsonFileStatistics) {
-            statsJson = addFileEntry.getStatsString().orElse(null);
+        if (addFileEntry.getStats().isPresent()) {
+            DeltaLakeFileStatistics statistics = addFileEntry.getStats().get();
+            if (statistics instanceof DeltaLakeParquetFileStatistics parquetFileStatistics) {
+                Map<String, Type> columnTypeMapping = getColumnTypeMapping(metadataEntry);
+                DeltaLakeJsonFileStatistics jsonFileStatistics = new DeltaLakeJsonFileStatistics(
+                        parquetFileStatistics.getNumRecords(),
+                        parquetFileStatistics.getMinValues().map(values -> toJsonValues(columnTypeMapping, values)),
+                        parquetFileStatistics.getMaxValues().map(values -> toJsonValues(columnTypeMapping, values)),
+                        parquetFileStatistics.getNullCount());
+                statsJson = getStatsString(jsonFileStatistics).orElse(null);
+            }
+            else {
+                statsJson = addFileEntry.getStatsString().orElse(null);
+            }
         }
-        writeString(entryBlockBuilder, entryType, 5, "stats", statsJson);
+        writeString(entryBlockBuilder, entryType, fieldId, "stats", statsJson);
     }
 
-    private void writeParsedStats(BlockBuilder entryBlockBuilder, RowType entryType, AddFileEntry addFileEntry)
+    private Map<String, Type> getColumnTypeMapping(MetadataEntry deltaMetadata)
     {
-        RowType statsType = getInternalRowType(entryType, 6, "stats_parsed");
-        if (addFileEntry.getStats().isEmpty() || !(addFileEntry.getStats().get() instanceof DeltaLakeParquetFileStatistics)) {
+        return extractSchema(deltaMetadata, typeManager).stream()
+                .collect(toImmutableMap(DeltaLakeColumnMetadata::getName, DeltaLakeColumnMetadata::getType));
+    }
+
+    private Optional<String> getStatsString(DeltaLakeJsonFileStatistics parsedStats)
+    {
+        try {
+            return Optional.of(serializeStatsAsJson(parsedStats));
+        }
+        catch (JsonProcessingException e) {
+            return Optional.empty();
+        }
+    }
+
+    private void writeParsedStats(BlockBuilder entryBlockBuilder, RowType entryType, AddFileEntry addFileEntry, int fieldId)
+    {
+        RowType statsType = getInternalRowType(entryType, fieldId, "stats_parsed");
+        if (addFileEntry.getStats().isEmpty()) {
             entryBlockBuilder.appendNull();
             return;
         }
-        DeltaLakeParquetFileStatistics stats = (DeltaLakeParquetFileStatistics) addFileEntry.getStats().get();
+        DeltaLakeFileStatistics stats = addFileEntry.getStats().get();
         BlockBuilder statsBlockBuilder = entryBlockBuilder.beginBlockEntry();
 
-        writeLong(statsBlockBuilder, statsType, 0, "numRecords", stats.getNumRecords().orElse(null));
-        writeMinMaxMapAsFields(statsBlockBuilder, statsType, 1, "minValues", stats.getMinValues());
-        writeMinMaxMapAsFields(statsBlockBuilder, statsType, 2, "maxValues", stats.getMaxValues());
-        writeObjectMapAsFields(statsBlockBuilder, statsType, 3, "nullCount", stats.getNullCount());
+        if (stats instanceof DeltaLakeParquetFileStatistics) {
+            writeLong(statsBlockBuilder, statsType, 0, "numRecords", stats.getNumRecords().orElse(null));
+            writeMinMaxMapAsFields(statsBlockBuilder, statsType, 1, "minValues", stats.getMinValues(), false);
+            writeMinMaxMapAsFields(statsBlockBuilder, statsType, 2, "maxValues", stats.getMaxValues(), false);
+            writeNullCountAsFields(statsBlockBuilder, statsType, 3, "nullCount", stats.getNullCount());
+        }
+        else {
+            int internalFieldId = 0;
+            writeLong(statsBlockBuilder, statsType, internalFieldId++, "numRecords", stats.getNumRecords().orElse(null));
+            if (statsType.getFields().stream().anyMatch(field -> field.getName().orElseThrow().equals("minValues"))) {
+                writeMinMaxMapAsFields(statsBlockBuilder, statsType, internalFieldId++, "minValues", stats.getMinValues(), true);
+            }
+            if (statsType.getFields().stream().anyMatch(field -> field.getName().orElseThrow().equals("maxValues"))) {
+                writeMinMaxMapAsFields(statsBlockBuilder, statsType, internalFieldId++, "maxValues", stats.getMaxValues(), true);
+            }
+            writeNullCountAsFields(statsBlockBuilder, statsType, internalFieldId++, "nullCount", stats.getNullCount());
+        }
         entryBlockBuilder.closeEntry();
     }
 
-    private void writeMinMaxMapAsFields(BlockBuilder blockBuilder, RowType type, int fieldId, String fieldName, Optional<Map<String, Object>> values)
+    private void writeMinMaxMapAsFields(BlockBuilder blockBuilder, RowType type, int fieldId, String fieldName, Optional<Map<String, Object>> values, boolean isJson)
     {
         RowType.Field valuesField = validateAndGetField(type, fieldId, fieldName);
         RowType valuesFieldType = (RowType) valuesField.getType();
-        writeObjectMapAsFields(blockBuilder, type, fieldId, fieldName, preprocessMinMaxValues(valuesFieldType, values));
+        writeObjectMapAsFields(blockBuilder, type, fieldId, fieldName, preprocessMinMaxValues(valuesFieldType, values, isJson));
+    }
+
+    private void writeNullCountAsFields(BlockBuilder blockBuilder, RowType type, int fieldId, String fieldName, Optional<Map<String, Object>> values)
+    {
+        writeObjectMapAsFields(blockBuilder, type, fieldId, fieldName, preprocessNullCount(values));
     }
 
     private void writeObjectMapAsFields(BlockBuilder blockBuilder, RowType type, int fieldId, String fieldName, Optional<Map<String, Object>> values)
@@ -263,6 +326,11 @@ public class CheckpointWriter
                 Object value = values.get().get(valueField.getName().orElseThrow());
                 if (valueField.getType() instanceof RowType) {
                     Block rowBlock = (Block) value;
+                    // Statistics were not collected
+                    if (rowBlock == null) {
+                        fieldBlockBuilder.appendNull();
+                        continue;
+                    }
                     checkState(rowBlock.getPositionCount() == 1, "Invalid RowType statistics for writing Delta Lake checkpoint");
                     if (rowBlock.isNull(0)) {
                         fieldBlockBuilder.appendNull();
@@ -279,7 +347,7 @@ public class CheckpointWriter
         blockBuilder.closeEntry();
     }
 
-    private Optional<Map<String, Object>> preprocessMinMaxValues(RowType valuesType, Optional<Map<String, Object>> valuesOptional)
+    private Optional<Map<String, Object>> preprocessMinMaxValues(RowType valuesType, Optional<Map<String, Object>> valuesOptional, boolean isJson)
     {
         return valuesOptional.map(
                 values -> {
@@ -292,8 +360,11 @@ public class CheckpointWriter
                             .collect(toMap(
                                     Map.Entry::getKey,
                                     entry -> {
-                                        Type type = fieldTypes.get(entry.getKey());
+                                        Type type = fieldTypes.get(entry.getKey().toLowerCase(ENGLISH));
                                         Object value = entry.getValue();
+                                        if (isJson) {
+                                            return jsonValueToTrinoValue(type, value);
+                                        }
                                         if (type instanceof TimestampType) {
                                             // We need to remap TIMESTAMP WITH TIME ZONE -> TIMESTAMP here because of
                                             // inconsistency in what type is used for DL "timestamp" type in data processing and in min/max statistics map.
@@ -302,6 +373,22 @@ public class CheckpointWriter
                                         return value;
                                     }));
                 });
+    }
+
+    private Optional<Map<String, Object>> preprocessNullCount(Optional<Map<String, Object>> valuesOptional)
+    {
+        return valuesOptional.map(
+                values ->
+                    values.entrySet().stream()
+                            .collect(toMap(
+                                    Map.Entry::getKey,
+                                    entry -> {
+                                        Object value = entry.getValue();
+                                        if (value instanceof Integer) {
+                                            return (long) (int) value;
+                                        }
+                                        return value;
+                                    })));
     }
 
     private void writeRemoveFileEntry(PageBuilder pageBuilder, RowType entryType, RemoveFileEntry removeFileEntry)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/statistics/DeltaLakeFileStatistics.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/statistics/DeltaLakeFileStatistics.java
@@ -27,6 +27,12 @@ public interface DeltaLakeFileStatistics
 {
     Optional<Long> getNumRecords();
 
+    Optional<Map<String, Object>> getMinValues();
+
+    Optional<Map<String, Object>> getMaxValues();
+
+    Optional<Map<String, Object>> getNullCount();
+
     Optional<Long> getNullCount(String columnName);
 
     Optional<Object> getMinColumnValue(DeltaLakeColumnHandle columnHandle);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/statistics/DeltaLakeJsonFileStatistics.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/statistics/DeltaLakeJsonFileStatistics.java
@@ -89,18 +89,21 @@ public class DeltaLakeJsonFileStatistics
     }
 
     @JsonProperty
+    @Override
     public Optional<Map<String, Object>> getMinValues()
     {
         return minValues.map(TransactionLogAccess::toOriginalNameKeyedMap);
     }
 
     @JsonProperty
+    @Override
     public Optional<Map<String, Object>> getMaxValues()
     {
         return maxValues.map(TransactionLogAccess::toOriginalNameKeyedMap);
     }
 
     @JsonProperty
+    @Override
     public Optional<Map<String, Object>> getNullCount()
     {
         return nullCount.map(TransactionLogAccess::toOriginalNameKeyedMap);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/statistics/DeltaLakeParquetFileStatistics.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/statistics/DeltaLakeParquetFileStatistics.java
@@ -61,16 +61,19 @@ public class DeltaLakeParquetFileStatistics
         return numRecords;
     }
 
+    @Override
     public Optional<Map<String, Object>> getMinValues()
     {
         return minValues.map(TransactionLogAccess::toOriginalNameKeyedMap);
     }
 
+    @Override
     public Optional<Map<String, Object>> getMaxValues()
     {
         return maxValues.map(TransactionLogAccess::toOriginalNameKeyedMap);
     }
 
+    @Override
     public Optional<Map<String, Object>> getNullCount()
     {
         return nullCount.map(TransactionLogAccess::toOriginalNameKeyedMap);

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksCheckpointsCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksCheckpointsCompatibility.java
@@ -21,6 +21,8 @@ import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import io.trino.tempto.BeforeTestWithContext;
 import io.trino.tempto.assertions.QueryAssert;
+import org.testng.SkipException;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -31,16 +33,19 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tests.product.TestGroups.DELTA_LAKE_DATABRICKS;
+import static io.trino.tests.product.TestGroups.DELTA_LAKE_EXCLUDE_73;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static io.trino.tests.product.deltalake.TransactionLogAssertions.assertLastEntryIsCheckpointed;
 import static io.trino.tests.product.deltalake.TransactionLogAssertions.assertTransactionLogVersion;
 import static io.trino.tests.product.deltalake.util.DeltaLakeTestUtils.DATABRICKS_104_RUNTIME_VERSION;
+import static io.trino.tests.product.deltalake.util.DeltaLakeTestUtils.DATABRICKS_91_RUNTIME_VERSION;
 import static io.trino.tests.product.deltalake.util.DeltaLakeTestUtils.getDatabricksRuntimeVersion;
 import static io.trino.tests.product.hive.util.TemporaryHiveTable.randomTableSuffix;
 import static io.trino.tests.product.utils.QueryExecutors.onDelta;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestDeltaLakeDatabricksCheckpointsCompatibility
         extends BaseTestDeltaLakeS3Storage
@@ -374,6 +379,233 @@ public class TestDeltaLakeDatabricksCheckpointsCompatibility
         }
         finally {
             // cleanup
+            onDelta().executeQuery("DROP TABLE default." + tableName);
+        }
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_EXCLUDE_73, PROFILE_SPECIFIC_TESTS})
+    public void testTrinoWriteStatsAsJsonDisabled()
+    {
+        String tableName = "test_dl_checkpoints_write_stats_as_json_disabled_trino_" + randomTableSuffix();
+        testWriteStatsAsJsonDisabled(sql -> onTrino().executeQuery(sql), tableName, "delta.default." + tableName);
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_EXCLUDE_73, PROFILE_SPECIFIC_TESTS})
+    public void testDatabricksWriteStatsAsJsonDisabled()
+    {
+        String tableName = "test_dl_checkpoints_write_stats_as_json_disabled_databricks_" + randomTableSuffix();
+        testWriteStatsAsJsonDisabled(sql -> onDelta().executeQuery(sql), tableName, "default." + tableName);
+    }
+
+    private void testWriteStatsAsJsonDisabled(Consumer<String> sqlExecutor, String tableName, String qualifiedTableName)
+    {
+        onDelta().executeQuery(format(
+                "CREATE TABLE default.%s" +
+                        "(a_number INT, a_string STRING) " +
+                        "USING DELTA " +
+                        "PARTITIONED BY (a_number) " +
+                        "LOCATION 's3://%s/databricks-compatibility-test-%1$s' " +
+                        "TBLPROPERTIES (" +
+                        " delta.checkpointInterval = 5, " +
+                        " delta.checkpoint.writeStatsAsJson = false)",
+                tableName, bucketName));
+
+        try {
+            sqlExecutor.accept("INSERT INTO " + qualifiedTableName + " VALUES (1,'ala')");
+
+            assertThat(onTrino().executeQuery("SHOW STATS FOR delta.default." + tableName))
+                    .containsOnly(ImmutableList.of(
+                            row("a_number", null, 1.0, 0.0, null, null, null),
+                            row("a_string", null, null, 0.0, null, null, null),
+                            row(null, null, null, null, 1.0, null, null)));
+        }
+        finally {
+            onDelta().executeQuery("DROP TABLE default." + tableName);
+        }
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_EXCLUDE_73, PROFILE_SPECIFIC_TESTS})
+    public void testTrinoWriteStatsAsStructDisabled()
+    {
+        String tableName = "test_dl_checkpoints_write_stats_as_struct_disabled_trino_" + randomTableSuffix();
+        testWriteStatsAsStructDisabled(sql -> onTrino().executeQuery(sql), tableName, "delta.default." + tableName);
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_EXCLUDE_73, PROFILE_SPECIFIC_TESTS})
+    public void testDatabricksWriteStatsAsStructDisabled()
+    {
+        String tableName = "test_dl_checkpoints_write_stats_as_struct_disabled_databricks_" + randomTableSuffix();
+        testWriteStatsAsStructDisabled(sql -> onDelta().executeQuery(sql), tableName, "default." + tableName);
+    }
+
+    private void testWriteStatsAsStructDisabled(Consumer<String> sqlExecutor, String tableName, String qualifiedTableName)
+    {
+        onDelta().executeQuery(format(
+                "CREATE TABLE default.%s" +
+                        "(a_number INT, a_string STRING) " +
+                        "USING DELTA " +
+                        "PARTITIONED BY (a_number) " +
+                        "LOCATION 's3://%s/databricks-compatibility-test-%1$s' " +
+                        "TBLPROPERTIES (" +
+                        " delta.checkpointInterval = 1, " +
+                        " delta.checkpoint.writeStatsAsJson = false, " + // Disable json stats to avoid merging statistics with 'stats' field
+                        " delta.checkpoint.writeStatsAsStruct = false)",
+                tableName, bucketName));
+
+        try {
+            sqlExecutor.accept("INSERT INTO " + qualifiedTableName + " VALUES (1,'ala')");
+
+            assertThat(onTrino().executeQuery("SHOW STATS FOR delta.default." + tableName))
+                    .containsOnly(ImmutableList.of(
+                            row("a_number", null, null, null, null, null, null),
+                            row("a_string", null, null, null, null, null, null),
+                            row(null, null, null, null, null, null, null)));
+        }
+        finally {
+            onDelta().executeQuery("DROP TABLE default." + tableName);
+        }
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_EXCLUDE_73, PROFILE_SPECIFIC_TESTS}, dataProvider = "testTrinoCheckpointWriteStatsAsJson")
+    public void testTrinoWriteStatsAsJsonEnabled(String type, String inputValue, Double nullsFraction, Object statsValue)
+    {
+        String tableName = "test_dl_checkpoints_write_stats_as_json_enabled_trino_" + randomTableSuffix();
+        testWriteStatsAsJsonEnabled(sql -> onTrino().executeQuery(sql), tableName, "delta.default." + tableName, type, inputValue, nullsFraction, statsValue);
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_EXCLUDE_73, PROFILE_SPECIFIC_TESTS}, dataProvider = "testDeltaCheckpointWriteStatsAsJson")
+    public void testDatabricksWriteStatsAsJsonEnabled(String type, String inputValue, Double nullsFraction, Object statsValue)
+    {
+        String tableName = "test_dl_checkpoints_write_stats_as_json_enabled_databricks_" + randomTableSuffix();
+        testWriteStatsAsJsonEnabled(sql -> onDelta().executeQuery(sql), tableName, "default." + tableName, type, inputValue, nullsFraction, statsValue);
+    }
+
+    private void testWriteStatsAsJsonEnabled(Consumer<String> sqlExecutor, String tableName, String qualifiedTableName, String type, String inputValue, Double nullsFraction, Object statsValue)
+    {
+        String createTableSql = format(
+                "CREATE TABLE default.%s" +
+                        "(col %s) " +
+                        "USING DELTA " +
+                        "LOCATION 's3://%s/databricks-compatibility-test-%1$s' " +
+                        "TBLPROPERTIES (" +
+                        " delta.checkpointInterval = 2, " +
+                        " delta.checkpoint.writeStatsAsJson = false, " +
+                        " delta.checkpoint.writeStatsAsStruct = true)",
+                tableName, type, bucketName);
+
+        if (getDatabricksRuntimeVersion().equals(DATABRICKS_91_RUNTIME_VERSION) && type.equals("struct<x bigint>")) {
+            assertThatThrownBy(() -> onDelta().executeQuery(createTableSql)).hasStackTraceContaining("ParseException");
+            throw new SkipException("New runtime version covers the type");
+        }
+
+        onDelta().executeQuery(createTableSql);
+
+        try {
+            sqlExecutor.accept("INSERT INTO " + qualifiedTableName + " SELECT " + inputValue);
+            sqlExecutor.accept("INSERT INTO " + qualifiedTableName + " SELECT " + inputValue);
+
+            // SET TBLPROPERTIES increments checkpoint
+            onDelta().executeQuery("" +
+                    "ALTER TABLE default." + tableName + " SET TBLPROPERTIES (" +
+                    "'delta.checkpoint.writeStatsAsJson' = true, " +
+                    "'delta.checkpoint.writeStatsAsStruct' = false)");
+
+            sqlExecutor.accept("INSERT INTO " + qualifiedTableName + " SELECT " + inputValue);
+
+            assertThat(onTrino().executeQuery("SHOW STATS FOR delta.default." + tableName))
+                    .containsOnly(ImmutableList.of(
+                            row("col", null, null, nullsFraction, null, statsValue, statsValue),
+                            row(null, null, null, null, 3.0, null, null)));
+        }
+        finally {
+            onDelta().executeQuery("DROP TABLE default." + tableName);
+        }
+    }
+
+    @DataProvider
+    public Object[][] testTrinoCheckpointWriteStatsAsJson()
+    {
+        return new Object[][] {
+                {"boolean", "true", 0.0, null},
+                {"integer", "1", 0.0, "1"},
+                {"tinyint", "2", 0.0, "2"},
+                {"smallint", "3", 0.0, "3"},
+                {"bigint", "1000", 0.0, "1000"},
+                {"real", "0.1", 0.0, "0.1"},
+                {"double", "1.0", 0.0, "1.0"},
+                {"decimal(3,2)", "3.14", 0.0, "3.14"},
+                {"decimal(30,1)", "12345", 0.0, "12345.0"},
+                {"string", "'test'", 0.0, null},
+                {"binary", "X'65683F'", 0.0, null},
+                {"date", "date '2021-02-03'", 0.0, "2021-02-03"},
+                {"timestamp", "timestamp '2001-08-22 11:04:05.321 UTC'", 0.0, "2001-08-22 11:04:05.321 UTC"},
+                {"array<int>", "array[1]", null, null},
+                {"map<string,int>", "map(array['key1', 'key2'], array[1, 2])", null, null},
+                {"struct<x bigint>", "cast(row(1) as row(x bigint))", null, null},
+        };
+    }
+
+    @DataProvider
+    public Object[][] testDeltaCheckpointWriteStatsAsJson()
+    {
+        return new Object[][] {
+                {"boolean", "true", 0.0, null},
+                {"integer", "1", 0.0, "1"},
+                {"tinyint", "2", 0.0, "2"},
+                {"smallint", "3", 0.0, "3"},
+                {"bigint", "1000", 0.0, "1000"},
+                {"real", "0.1", 0.0, "0.1"},
+                {"double", "1.0", 0.0, "1.0"},
+                {"decimal(3,2)", "3.14", 0.0, "3.14"},
+                {"decimal(30,1)", "12345", 0.0, "12345.0"},
+                {"string", "'test'", 0.0, null},
+                {"binary", "X'65683F'", 0.0, null},
+                {"date", "date '2021-02-03'", 0.0, "2021-02-03"},
+                {"timestamp", "timestamp '2001-08-22 11:04:05.321 UTC'", 0.0, "2001-08-22 11:04:05.321 UTC"},
+                {"array<int>", "array(1)", 0.0, null},
+                {"map<string,int>", "map('key1', 1, 'key2', 2)", 0.0, null},
+                {"struct<x bigint>", "named_struct('x', 1)", null, null},
+        };
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_EXCLUDE_73, PROFILE_SPECIFIC_TESTS})
+    public void testTrinoWriteStatsAsStructEnabled()
+    {
+        String tableName = "test_dl_checkpoints_write_stats_as_struct_enabled_trino_" + randomTableSuffix();
+        testWriteStatsAsStructEnabled(sql -> onTrino().executeQuery(sql), tableName, "delta.default." + tableName);
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_EXCLUDE_73, PROFILE_SPECIFIC_TESTS})
+    public void testDatabricksWriteStatsAsStructEnabled()
+    {
+        String tableName = "test_dl_checkpoints_write_stats_as_struct_enabled_databricks_" + randomTableSuffix();
+        testWriteStatsAsStructEnabled(sql -> onDelta().executeQuery(sql), tableName, "default." + tableName);
+    }
+
+    private void testWriteStatsAsStructEnabled(Consumer<String> sqlExecutor, String tableName, String qualifiedTableName)
+    {
+        onDelta().executeQuery(format(
+                "CREATE TABLE default.%s" +
+                        "(a_number INT, a_string STRING) " +
+                        "USING DELTA " +
+                        "PARTITIONED BY (a_number) " +
+                        "LOCATION 's3://%s/databricks-compatibility-test-%1$s' " +
+                        "TBLPROPERTIES (" +
+                        " delta.checkpointInterval = 1, " +
+                        " delta.checkpoint.writeStatsAsJson = false, " +
+                        " delta.checkpoint.writeStatsAsStruct = true)",
+                tableName, bucketName));
+
+        try {
+            sqlExecutor.accept("INSERT INTO " + qualifiedTableName + " VALUES (1,'ala')");
+
+            assertThat(onTrino().executeQuery("SHOW STATS FOR delta.default." + tableName))
+                    .containsOnly(ImmutableList.of(
+                            row("a_number", null, 1.0, 0.0, null, null, null),
+                            row("a_string", null, null, 0.0, null, null, null),
+                            row(null, null, null, null, 1.0, null, null)));
+        }
+        finally {
             onDelta().executeQuery("DROP TABLE default." + tableName);
         }
     }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/util/DeltaLakeTestUtils.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/util/DeltaLakeTestUtils.java
@@ -23,6 +23,7 @@ import static java.lang.String.format;
 public final class DeltaLakeTestUtils
 {
     public static final String DATABRICKS_104_RUNTIME_VERSION = "10.4";
+    public static final String DATABRICKS_91_RUNTIME_VERSION = "9.1";
 
     private DeltaLakeTestUtils() {}
 


### PR DESCRIPTION
## Description

Enforce `delta.checkpoint.writeStatsAsJson` and `delta.checkpoint.writeStatsAsStruct` option in Delta Lake
Fixes #12031

## Documentation

(x) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# Delta Lake
* Enforce `delta.checkpoint.writeStatsAsJson` and `delta.checkpoint.writeStatsAsStruct` table properties. ({issue}`12031`)
```
