### PR TITLE
Implement timestamp predicate pushdown in Druid connector

### DIFF
--- a/plugin/trino-druid/pom.xml
+++ b/plugin/trino-druid/pom.xml
@@ -166,6 +166,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.freemarker</groupId>
+            <artifactId>freemarker</artifactId>
+            <version>2.3.31</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <scope>test</scope>

--- a/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClient.java
+++ b/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClient.java
@@ -134,6 +134,8 @@ public class DruidJdbcClient
     private static final String DRUID_CATALOG = "druid";
     // All the datasources in Druid are created under schema "druid"
     private static final String DRUID_SCHEMA = "druid";
+
+    // TODO We could also re-evaluate this logic by using a new Calendar for each row if necessary
     private static final Calendar UTC_CALENDAR = Calendar.getInstance(TimeZone.getTimeZone(UTC));
 
     private static final DateTimeFormatter LOCAL_DATE_TIME = new DateTimeFormatterBuilder()
@@ -309,7 +311,7 @@ public class DruidJdbcClient
         return ColumnMapping.longMapping(
                 timestampType,
                 (resultSet, columnIndex) -> {
-                    // Druis's ResultSet depends on JDBC Connection TimeZone, so we pass the Calendar to get the result at UTC.
+                    // Druid's ResultSet depends on JDBC Connection TimeZone, so we pass the Calendar to get the result at UTC.
                     Instant instant = Instant.ofEpochMilli(resultSet.getTimestamp(columnIndex, UTC_CALENDAR).getTime());
                     LocalDateTime timestamp = LocalDateTime.ofInstant(instant, UTC);
                     return toTrinoTimestamp(timestampType, timestamp);

--- a/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClient.java
+++ b/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClient.java
@@ -114,7 +114,7 @@ public class DruidJdbcClient
     // to druid will always have the TABLE_CATALOG set to DRUID_CATALOG
     private static final String DRUID_CATALOG = "druid";
     // All the datasources in Druid are created under schema "druid"
-    public static final String DRUID_SCHEMA = "druid";
+    private static final String DRUID_SCHEMA = "druid";
 
     @Inject
     public DruidJdbcClient(BaseJdbcConfig config, ConnectionFactory connectionFactory, QueryBuilder queryBuilder, IdentifierMapping identifierMapping)

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/DruidCreateAndInsertDataSetup.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/DruidCreateAndInsertDataSetup.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.druid;
+
+import io.airlift.log.Logger;
+import io.trino.plugin.druid.ingestion.IndexTaskBuilder;
+import io.trino.plugin.druid.ingestion.TimestampSpec;
+import io.trino.testing.datatype.ColumnSetup;
+import io.trino.testing.datatype.DataSetup;
+import io.trino.testing.sql.TemporaryRelation;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class DruidCreateAndInsertDataSetup
+        implements DataSetup
+{
+    private static final Logger log = Logger.get(DruidCreateAndInsertDataSetup.class);
+    private final TestingDruidServer druidServer;
+    private final String dataSourceNamePrefix;
+
+    public DruidCreateAndInsertDataSetup(TestingDruidServer druidServer, String dataSourceNamePrefix)
+    {
+        this.druidServer = druidServer;
+        this.dataSourceNamePrefix = dataSourceNamePrefix;
+    }
+
+    @Override
+    public TemporaryRelation setupTemporaryRelation(List<ColumnSetup> inputs)
+    {
+        DruidTable testTable = new DruidTable(this.dataSourceNamePrefix);
+        try {
+            ingestData(testTable, inputs);
+        }
+        catch (Exception e) {
+            log.error(e);
+        }
+        return testTable;
+    }
+
+    private void ingestData(DruidTable testTable, List<ColumnSetup> inputs)
+            throws Exception
+    {
+        IndexTaskBuilder builder = new IndexTaskBuilder();
+        builder.setDatasource(testTable.getName());
+        TimestampSpec timestampSpec = getTimestampSpec(inputs);
+        builder.setTimestampSpec(timestampSpec);
+
+        List<ColumnSetup> normalInputs = inputs.stream().filter(input -> !isTimestampDimension(input)).collect(Collectors.toList());
+        for (int index = 0; index < inputs.size() - 1; index++) {
+            builder.addColumn(format("col_%s", index), normalInputs.get(index).getDeclaredType().orElse("string"));
+        }
+
+        String dataFilePath = format("%s/%s.tsv", druidServer.getHostWorkingDirectory(), testTable.getName());
+        writeTsvFile(dataFilePath, inputs);
+
+        log.debug(builder.build());
+        this.druidServer.ingestData(testTable.getName(), builder.build(), dataFilePath);
+    }
+
+    private TimestampSpec getTimestampSpec(List<ColumnSetup> inputs)
+    {
+        List<ColumnSetup> timestampInputs = inputs.stream().filter(this::isTimestampDimension).collect(Collectors.toList());
+
+        if (timestampInputs.size() > 1) {
+            throw new UnsupportedOperationException("Druid only allows one timestamp field");
+        }
+
+        return new TimestampSpec("dummy_druid_ts", "auto");
+    }
+
+    private boolean isTimestampDimension(ColumnSetup input)
+    {
+        if (input.getDeclaredType().isEmpty()) {
+            return false;
+        }
+        String type = input.getDeclaredType().get();
+
+        // TODO: support more types
+        return type.startsWith("timestamp");
+    }
+
+    private void writeTsvFile(String dataFilePath, List<ColumnSetup> inputs)
+            throws IOException
+    {
+        File file = new File(dataFilePath);
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(file, UTF_8))) {
+            writer.write(inputs.stream().map(ColumnSetup::getInputLiteral).collect(Collectors.joining("\t")));
+        }
+    }
+}

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/DruidQueryRunner.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/DruidQueryRunner.java
@@ -15,6 +15,7 @@ package io.trino.plugin.druid;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Resources;
 import io.airlift.log.Logger;
 import io.trino.Session;
 import io.trino.plugin.tpch.TpchPlugin;
@@ -27,11 +28,13 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.google.common.io.Resources.getResource;
 import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.airlift.units.Duration.nanosSince;
 import static io.trino.testing.TestingSession.testSessionBuilder;
@@ -93,7 +96,12 @@ public class DruidQueryRunner
     {
         String tsvFileLocation = format("%s/%s.tsv", testingDruidServer.getHostWorkingDirectory(), druidDatasource);
         writeDataAsTsv(rows, tsvFileLocation);
-        testingDruidServer.ingestData(druidDatasource, getIngestionSpecFileName(druidDatasource), tsvFileLocation);
+        testingDruidServer.ingestData(
+                druidDatasource,
+                Resources.toString(
+                        getResource(getIngestionSpecFileName(druidDatasource)),
+                        Charset.defaultCharset()),
+                tsvFileLocation);
     }
 
     private static String getIngestionSpecFileName(String datasource)

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/DruidTable.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/DruidTable.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.druid;
+
+import io.trino.testing.sql.TemporaryRelation;
+
+import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static java.util.Objects.requireNonNull;
+
+public class DruidTable
+        implements TemporaryRelation
+{
+    private final String tableName;
+
+    public DruidTable(String namePrefix)
+    {
+        requireNonNull(namePrefix, "namePrefix is null");
+        this.tableName = namePrefix + randomTableSuffix();
+    }
+
+    @Override
+    public String getName()
+    {
+        return tableName;
+    }
+
+    @Override
+    public void close()
+    {
+        // Do nothing
+    }
+}

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidTypeMapping.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidTypeMapping.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.druid;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.datatype.DataSetup;
+import io.trino.testing.datatype.SqlDataTypeTest;
+import org.testng.annotations.Test;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestDruidTypeMapping
+        extends AbstractTestQueryFramework
+{
+    private static final String DRUID_DOCKER_IMAGE = "apache/druid:0.18.0";
+    protected TestingDruidServer druidServer;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        this.druidServer = new TestingDruidServer(DRUID_DOCKER_IMAGE);
+        return DruidQueryRunner.createDruidQueryRunnerTpch(druidServer, ImmutableMap.of(), ImmutableList.of());
+    }
+
+    @Test
+    public void testLong()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("__time", "timestamp", "2020-01-01 00:00:00.000", TIMESTAMP_MILLIS, "TIMESTAMP '2020-01-01 00:00:00.000'")
+                .addRoundTrip("col_0", "long", "NULL", BIGINT, "BIGINT '0'")
+                .addRoundTrip("col_1", "long", "0", BIGINT, "BIGINT '0'")
+                .addRoundTrip("col_2", "long", "-9223372036854775808", BIGINT, "-9223372036854775808") // min value in Trino
+                .addRoundTrip("col_3", "long", "123456789012", BIGINT, "123456789012")
+                .addRoundTrip("col_4", "long", "9223372036854775807", BIGINT, "9223372036854775807") // max value in Trino
+                .execute(getQueryRunner(), druidCreateAndInsert("test_bigint"));
+    }
+
+    @Test
+    public void testDouble()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("__time", "timestamp", "2020-01-01 00:00:00.000", TIMESTAMP_MILLIS, "TIMESTAMP '2020-01-01 00:00:00.000'")
+                .addRoundTrip("col_0", "double", "NULL", DOUBLE, "DOUBLE '0.0'")
+                .addRoundTrip("col_1", "double", "0.0", DOUBLE, "DOUBLE '0.0'")
+                .addRoundTrip("col_2", "double", "1.0E100", DOUBLE, "1.0E100")
+                .addRoundTrip("col_3", "double", "123.456E10", DOUBLE, "123.456E10")
+                .addRoundTrip("col_4", "double", "Invalid String", DOUBLE, "DOUBLE '0.0'")
+                .execute(getQueryRunner(), druidCreateAndInsert("test_double"));
+    }
+
+    @Test
+    public void testDoubleNaN()
+    {
+        assertThatThrownBy(() ->
+                SqlDataTypeTest.create()
+                        .addRoundTrip("__time", "timestamp", "2020-01-01 00:00:00.000", TIMESTAMP_MILLIS, "TIMESTAMP '2020-01-01 00:00:00.000'")
+                        .addRoundTrip("col_0", "double", "NaN", DOUBLE, "nan()")
+                        .execute(getQueryRunner(), druidCreateAndInsert("test_double_with_nan")))
+                .hasMessageMatching(".*class java.lang.String cannot be cast to class java.lang.Number.*");
+    }
+
+    @Test
+    public void testDoubleInfinity()
+    {
+        assertThatThrownBy(() ->
+                SqlDataTypeTest.create()
+                        .addRoundTrip("__time", "timestamp", "2020-01-01 00:00:00.000", TIMESTAMP_MILLIS, "TIMESTAMP '2020-01-01 00:00:00.000'")
+                        .addRoundTrip("col_0", "double", "Infinity", DOUBLE, "+infinity()")
+                        .execute(getQueryRunner(), druidCreateAndInsert("test_double_with_positive_infinity")))
+                .hasMessageMatching(".*class java.lang.String cannot be cast to class java.lang.Number.*");
+    }
+
+    @Test
+    public void testDoubleNegativeInfinity()
+    {
+        assertThatThrownBy(() ->
+                SqlDataTypeTest.create()
+                        .addRoundTrip("__time", "timestamp", "2020-01-01 00:00:00.000", TIMESTAMP_MILLIS, "TIMESTAMP '2020-01-01 00:00:00.000'")
+                        .addRoundTrip("col_0", "double", "-Infinity", DOUBLE, "-infinity()")
+                        .execute(getQueryRunner(), druidCreateAndInsert("test_double_with_negative_infinity")))
+                .hasMessageMatching(".*class java.lang.String cannot be cast to class java.lang.Number.*");
+    }
+
+    @Test
+    public void testFloat()
+    {
+        //TODO Map Druid's Float data type to Trino's Real data type
+        SqlDataTypeTest.create()
+                .addRoundTrip("__time", "timestamp", "2020-01-01 00:00:00.000", TIMESTAMP_MILLIS, "TIMESTAMP '2020-01-01 00:00:00.000'")
+                .addRoundTrip("col_0", "float", "NULL", DOUBLE, "DOUBLE '0.0'")
+                .addRoundTrip("col_1", "float", "0.0", DOUBLE, "DOUBLE '0.0'")
+                .addRoundTrip("col_2", "float", "3.14", DOUBLE, "DOUBLE '3.14'")
+                .addRoundTrip("col_3", "float", "3.1415927", DOUBLE, "DOUBLE '3.1415927'")
+                .addRoundTrip("col_4", "float", "Invalid String", DOUBLE, "DOUBLE '0.0'")
+                .execute(getQueryRunner(), druidCreateAndInsert("test_float"));
+    }
+
+    @Test
+    public void testFloatNaN()
+    {
+        //TODO Map Druid's Float data type to Trino's Real data type
+        assertThatThrownBy(() ->
+                SqlDataTypeTest.create()
+                        .addRoundTrip("__time", "timestamp", "2020-01-01 00:00:00.000", TIMESTAMP_MILLIS, "TIMESTAMP '2020-01-01 00:00:00.000'")
+                        .addRoundTrip("col_0", "float", "NaN", DOUBLE, "CAST(nan() AS double)")
+                        .execute(getQueryRunner(), druidCreateAndInsert("test_float_with_nan")))
+                .hasMessageMatching(".*class java.lang.String cannot be cast to class java.lang.Number.*");
+    }
+
+    @Test
+    public void testFloatInfinity()
+    {
+        //TODO Map Druid's Float data type to Trino's Real data type
+        assertThatThrownBy(() ->
+                SqlDataTypeTest.create()
+                        .addRoundTrip("__time", "timestamp", "2020-01-01 00:00:00.000", TIMESTAMP_MILLIS, "TIMESTAMP '2020-01-01 00:00:00.000'")
+                        .addRoundTrip("col_0", "float", "Infinity", DOUBLE, "+infinity()")
+                        .execute(getQueryRunner(), druidCreateAndInsert("test_float_with_positive_infinity")))
+                .hasMessageMatching(".*class java.lang.String cannot be cast to class java.lang.Number.*");
+    }
+
+    @Test
+    public void testFloatNegativeInfinity()
+    {
+        //TODO Map Druid's Float data type to Trino's Real data type
+        assertThatThrownBy(() ->
+                SqlDataTypeTest.create()
+                        .addRoundTrip("__time", "timestamp", "2020-01-01 00:00:00.000", TIMESTAMP_MILLIS, "TIMESTAMP '2020-01-01 00:00:00.000'")
+                        .addRoundTrip("col_0", "double", "-Infinity", DOUBLE, "-infinity()")
+                        .execute(getQueryRunner(), druidCreateAndInsert("test_float_with_negative_infinity")))
+                .hasMessageMatching(".*class java.lang.String cannot be cast to class java.lang.Number.*");
+    }
+
+    @Test
+    public void testVarchar()
+    {
+        //TODO Add test for unicode characters
+        SqlDataTypeTest.create()
+                .addRoundTrip("__time", "timestamp", "2020-01-01 00:00:00.000", TIMESTAMP_MILLIS, "TIMESTAMP '2020-01-01 00:00:00.000'")
+                .addRoundTrip("col_0", "string", "null", createUnboundedVarcharType(), "CAST('null' AS varchar)")
+                .addRoundTrip("col_1", "string", "NULL", createUnboundedVarcharType(), "CAST('NULL' AS varchar)")
+                .addRoundTrip("col_2", "string", "text_a", createUnboundedVarcharType(), "CAST('text_a' AS varchar)")
+                .addRoundTrip("col_3", "string", "text_b", createUnboundedVarcharType(), "CAST('text_b' AS varchar)")
+                .execute(getQueryRunner(), druidCreateAndInsert("test_unbounded_varchar"));
+    }
+
+    private DataSetup druidCreateAndInsert(String dataSourceName)
+    {
+        return new DruidCreateAndInsertDataSetup(druidServer, dataSourceName);
+    }
+}

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestingDruidServer.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestingDruidServer.java
@@ -16,7 +16,6 @@ package io.trino.plugin.druid;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Closer;
 import com.google.common.io.MoreFiles;
-import com.google.common.io.Resources;
 import io.trino.testing.assertions.Assert;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -31,7 +30,6 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -42,7 +40,6 @@ import java.sql.Statement;
 import java.util.Map;
 
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
-import static com.google.common.io.Resources.getResource;
 import static java.lang.String.format;
 import static java.util.UUID.randomUUID;
 import static org.testcontainers.utility.MountableFile.forClasspathResource;
@@ -234,12 +231,11 @@ public class TestingDruidServer
         return format("jdbc:avatica:remote:url=http://localhost:%s/druid/v2/sql/avatica/", port);
     }
 
-    void ingestData(String datasource, String indexTaskFile, String dataFilePath)
+    void ingestData(String datasource, String indexTask, String dataFilePath)
             throws IOException, InterruptedException
     {
         middleManager.withCopyFileToContainer(forHostPath(dataFilePath),
                 getMiddleManagerContainerPathForDataFile(dataFilePath));
-        String indexTask = Resources.toString(getResource(indexTaskFile), Charset.defaultCharset());
 
         Request.Builder requestBuilder = new Request.Builder();
         requestBuilder.addHeader("content-type", "application/json;charset=utf-8")

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/ingestion/ColumnSpec.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/ingestion/ColumnSpec.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.druid.ingestion;
+
+import static java.util.Objects.requireNonNull;
+
+public class ColumnSpec
+{
+    private final String name;
+    private final String type;
+
+    public ColumnSpec(String name, String type)
+    {
+        this.name = requireNonNull(name, "name is null");
+        this.type = requireNonNull(type, "type is null");
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public String getType()
+    {
+        return type;
+    }
+}

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/ingestion/IndexTaskBuilder.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/ingestion/IndexTaskBuilder.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.druid.ingestion;
+
+import com.google.common.io.Resources;
+import freemarker.template.Template;
+import io.airlift.log.Logger;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+
+import static com.google.common.io.Resources.getResource;
+
+/**
+ * This builder is used to build Druid index task request body
+ * and follows same format as files inside resources directory
+ */
+
+public class IndexTaskBuilder
+{
+    private static final Logger log = Logger.get(IndexTaskBuilder.class);
+    private final ArrayList<ColumnSpec> columns;
+    private String datasource;
+    private TimestampSpec timestampSpec;
+
+    public IndexTaskBuilder()
+    {
+        this.columns = new ArrayList<>();
+    }
+
+    public IndexTaskBuilder addColumn(String name, String type)
+    {
+        columns.add(new ColumnSpec(name, type));
+        return this;
+    }
+
+    public String getDatasource()
+    {
+        return datasource;
+    }
+
+    public IndexTaskBuilder setDatasource(String datasource)
+    {
+        this.datasource = datasource;
+        return this;
+    }
+
+    public TimestampSpec getTimestampSpec()
+    {
+        return timestampSpec;
+    }
+
+    public IndexTaskBuilder setTimestampSpec(TimestampSpec timestampSpec)
+    {
+        this.timestampSpec = timestampSpec;
+        return this;
+    }
+
+    public ArrayList<ColumnSpec> getColumns()
+    {
+        return columns;
+    }
+
+    public String build()
+    {
+        String tplContent;
+        try {
+            String tmpFile = "ingestion-index.tpl";
+            tplContent = Resources.toString(getResource(tmpFile), Charset.defaultCharset());
+            Template template = new Template("ingestion-task", new StringReader(tplContent));
+            StringWriter writer = new StringWriter();
+            template.process(this, writer);
+            return writer.toString();
+        }
+        catch (Exception ex) {
+            log.error(ex);
+        }
+        return "";
+    }
+}

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/ingestion/TimestampSpec.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/ingestion/TimestampSpec.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.druid.ingestion;
+
+import static java.util.Objects.requireNonNull;
+
+public class TimestampSpec
+{
+    private final String column;
+    private final String format;
+
+    public TimestampSpec(String column, String format)
+    {
+        this.column = requireNonNull(column, "columns is null");
+        this.format = requireNonNull(format, "format is null");
+    }
+
+    public String getColumn()
+    {
+        return column;
+    }
+
+    public String getFormat()
+    {
+        return format;
+    }
+}

--- a/plugin/trino-druid/src/test/resources/ingestion-index.tpl
+++ b/plugin/trino-druid/src/test/resources/ingestion-index.tpl
@@ -1,0 +1,59 @@
+ {
+     "type": "index",
+     "spec": {
+         "dataSchema": {
+             "dataSource": "${datasource}",
+             "parser": {
+                 "type": "string",
+                 "parseSpec": {
+                     "format": "tsv",
+                     "timestampSpec": {
+                         "column": "${timestampSpec.column}",
+                         "format": "${timestampSpec.format}"
+                     },
+                     "columns": [
+                        "${timestampSpec.column}",
+                        <#list columns as column>
+                        "${column.name}"<#sep>, </#sep>
+                        </#list>
+                     ],
+                     "dimensionsSpec": {
+                         "dimensions": [
+                            <#list columns as column>
+                            {
+                                "name": "${column.name}",
+                                "type": "${column.type}"
+                            }<#sep>,
+                            </#list>
+                         ]
+                     }
+                 }
+             },
+             "granularitySpec": {
+                 "type": "uniform",
+                 "intervals": [
+                     "1958-01-01/2028-12-01"
+                 ],
+                 "segmentGranularity": "year",
+                 "queryGranularity": "none"
+             }
+         },
+         "ioConfig": {
+             "type": "index",
+             "firehose": {
+                 "type": "local",
+                 "baseDir": "/opt/druid/var/",
+                 "filter": "${datasource}.tsv"
+             },
+             "appendToExisting": false
+         },
+         "tuningConfig": {
+             "type": "index",
+             "maxRowsPerSegment": 5000000,
+             "maxRowsInMemory": 250000,
+             "segmentWriteOutMediumFactory": {
+                 "type": "offHeapMemory"
+             }
+         }
+     }
+ }

--- a/testing/trino-testing/src/main/java/io/trino/testing/datatype/SqlDataTypeTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/datatype/SqlDataTypeTest.java
@@ -52,7 +52,7 @@ public final class SqlDataTypeTest
 
     public SqlDataTypeTest addRoundTrip(String inputLiteral, String expectedLiteral)
     {
-        testCases.add(new TestCase(Optional.empty(), inputLiteral, Optional.empty(), expectedLiteral));
+        testCases.add(new TestCase(Optional.empty(), Optional.empty(), inputLiteral, Optional.empty(), expectedLiteral));
         return this;
     }
 
@@ -63,7 +63,19 @@ public final class SqlDataTypeTest
 
     public SqlDataTypeTest addRoundTrip(String inputType, String inputLiteral, Type expectedType, String expectedLiteral)
     {
-        testCases.add(new TestCase(Optional.of(inputType), inputLiteral, Optional.of(expectedType), expectedLiteral));
+        addRoundTrip(Optional.empty(), inputType, inputLiteral, expectedType, expectedLiteral);
+        return this;
+    }
+
+    public SqlDataTypeTest addRoundTrip(String columnName, String inputType, String inputLiteral, Type expectedType, String expectedLiteral)
+    {
+        addRoundTrip(Optional.of(columnName), inputType, inputLiteral, expectedType, expectedLiteral);
+        return this;
+    }
+
+    public SqlDataTypeTest addRoundTrip(Optional<String> columnName, String inputType, String inputLiteral, Type expectedType, String expectedLiteral)
+    {
+        testCases.add(new TestCase(columnName, Optional.of(inputType), inputLiteral, Optional.of(expectedType), expectedLiteral));
         return this;
     }
 
@@ -130,19 +142,22 @@ public final class SqlDataTypeTest
 
     private String getPredicate(int column)
     {
-        return format("col_%s IS NOT DISTINCT FROM %s", column, testCases.get(column).getExpectedLiteral());
+        String columnName = testCases.get(column).getColumnName().orElseGet(() -> "col_" + column);
+        return format("%s IS NOT DISTINCT FROM %s", columnName, testCases.get(column).getExpectedLiteral());
     }
 
     private static class TestCase
             implements ColumnSetup
     {
+        private final Optional<String> columnName;
         private final Optional<String> declaredType;
         private final String inputLiteral;
         private final Optional<Type> expectedType;
         private final String expectedLiteral;
 
-        public TestCase(Optional<String> declaredType, String inputLiteral, Optional<Type> expectedType, String expectedLiteral)
+        public TestCase(Optional<String> columnName, Optional<String> declaredType, String inputLiteral, Optional<Type> expectedType, String expectedLiteral)
         {
+            this.columnName = requireNonNull(columnName, "columnName is null");
             this.declaredType = requireNonNull(declaredType, "declaredType is null");
             this.expectedType = requireNonNull(expectedType, "expectedType is null");
             this.inputLiteral = requireNonNull(inputLiteral, "inputLiteral is null");
@@ -169,6 +184,11 @@ public final class SqlDataTypeTest
         public String getExpectedLiteral()
         {
             return expectedLiteral;
+        }
+
+        public Optional<String> getColumnName()
+        {
+            return columnName;
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement to Druid connector. 

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Druid connector. 

> How would you describe this change to a non-technical end user or system administrator?

Now we will be able to push down the filters applied on `__time` column in druid. 

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber

Fixes https://github.com/trinodb/trino/issues/8404.

Overrides - https://github.com/trinodb/trino/pull/8474

* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Section
* Implement timestamp predicate pushdown in Druid connector. ({issue}`8404`)
```
