### PR TITLE
Do not enforce fixed partitioning in Hive connector

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/NodePartitioningManager.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/NodePartitioningManager.java
@@ -152,18 +152,19 @@ public class NodePartitioningManager
     {
         ConnectorBucketNodeMap connectorBucketNodeMap = getConnectorBucketNodeMap(session, partitioningHandle);
 
+        ToIntFunction<Split> splitToBucket = getSplitToBucket(session, partitioningHandle);
         if (connectorBucketNodeMap.hasFixedMapping()) {
-            return new FixedBucketNodeMap(getSplitToBucket(session, partitioningHandle), getFixedMapping(connectorBucketNodeMap));
+            return new FixedBucketNodeMap(splitToBucket, getFixedMapping(connectorBucketNodeMap));
         }
 
         if (preferDynamic) {
-            return new DynamicBucketNodeMap(getSplitToBucket(session, partitioningHandle), connectorBucketNodeMap.getBucketCount());
+            return new DynamicBucketNodeMap(splitToBucket, connectorBucketNodeMap.getBucketCount());
         }
 
         Optional<CatalogHandle> catalogName = partitioningHandle.getCatalogHandle();
         checkArgument(catalogName.isPresent(), "No catalog handle for partitioning handle: %s", partitioningHandle);
         return new FixedBucketNodeMap(
-                getSplitToBucket(session, partitioningHandle),
+                splitToBucket,
                 createArbitraryBucketToNode(
                         new ArrayList<>(nodeScheduler.createNodeSelector(session, catalogName).allNodes()),
                         connectorBucketNodeMap.getBucketCount()));

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -5678,8 +5678,7 @@ public abstract class AbstractTestHive
                 assertEquals(insertLayout.get().getPartitionColumns(), ImmutableList.of("column1", "column2"));
                 ConnectorBucketNodeMap connectorBucketNodeMap = nodePartitioningProvider.getBucketNodeMap(transaction.getTransactionHandle(), session, partitioningHandle);
                 assertEquals(connectorBucketNodeMap.getBucketCount(), 32);
-                assertTrue(connectorBucketNodeMap.hasFixedMapping());
-                assertEquals(connectorBucketNodeMap.getFixedMapping().size(), 32);
+                assertFalse(connectorBucketNodeMap.hasFixedMapping());
             }
         }
         finally {
@@ -5773,8 +5772,7 @@ public abstract class AbstractTestHive
             assertEquals(newTableLayout.get().getPartitionColumns(), ImmutableList.of("column1", "column2"));
             ConnectorBucketNodeMap connectorBucketNodeMap = nodePartitioningProvider.getBucketNodeMap(transaction.getTransactionHandle(), session, partitioningHandle);
             assertEquals(connectorBucketNodeMap.getBucketCount(), 32);
-            assertTrue(connectorBucketNodeMap.hasFixedMapping());
-            assertEquals(connectorBucketNodeMap.getFixedMapping().size(), 32);
+            assertFalse(connectorBucketNodeMap.hasFixedMapping());
         }
     }
 


### PR DESCRIPTION
Engine will ensure that consecutive buckets are assigned
to shuffled nodes, therefore it's not needed to explicity
provide that by connector

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
