### PR TITLE
Only remove Iceberg delete files when safe to do so

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -895,8 +895,7 @@ public class IcebergMetadata
                         getFileFormat(icebergTable),
                         icebergTable.properties(),
                         maxScannedFileSize,
-                        retryMode != NO_RETRIES,
-                        tableHandle.getEnforcedPredicate().isAll()),
+                        retryMode != NO_RETRIES),
                 icebergTable.location()));
     }
 
@@ -1016,7 +1015,7 @@ public class IcebergMetadata
         ImmutableSet.Builder<DeleteFile> scannedDeleteFilesBuilder = ImmutableSet.builder();
         splitSourceInfo.stream().map(DataFileWithDeleteFiles.class::cast).forEach(dataFileWithDeleteFiles -> {
             scannedDataFilesBuilder.add(dataFileWithDeleteFiles.getDataFile());
-            scannedDeleteFilesBuilder.addAll(filterDeleteFilesThatWereNotScannedDuringOptimize(dataFileWithDeleteFiles.getDeleteFiles(), optimizeHandle.isWholeTableScan()));
+            scannedDeleteFilesBuilder.addAll(dataFileWithDeleteFiles.getDeleteFiles());
         });
 
         Set<DataFile> scannedDataFiles = scannedDataFilesBuilder.build();
@@ -1071,20 +1070,6 @@ public class IcebergMetadata
         rewriteFiles.commit();
         transaction.commitTransaction();
         transaction = null;
-    }
-
-    private static Set<DeleteFile> filterDeleteFilesThatWereNotScannedDuringOptimize(List<DeleteFile> deleteFiles, boolean isWholeTableScan)
-    {
-        // if whole table was scanned all delete files were read and applied
-        // so it is safe to remove them
-        if (isWholeTableScan) {
-            return ImmutableSet.copyOf(deleteFiles);
-        }
-        return deleteFiles.stream()
-                // equality delete files can be global so we can't clean them up unless we optimize whole table
-                // position delete files cannot be global so it is safe to clean them if they were scanned
-                .filter(deleteFile -> (deleteFile.content() == POSITION_DELETES) || deleteFile.partition() != null)
-                .collect(toImmutableSet());
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
@@ -235,7 +235,10 @@ public class IcebergSplitSource
                 continue;
             }
             if (recordScannedFiles) {
-                scannedFiles.add(new DataFileWithDeleteFiles(scanTask.file(), scanTask.deletes()));
+                // Positional and Equality deletes can only be cleaned up if the whole table has been optimized.
+                // Equality deletes may apply to many files, and position deletes may be grouped together. This makes it difficult to know if they are obsolete.
+                List<org.apache.iceberg.DeleteFile> fullyAppliedDeletes = tableHandle.getEnforcedPredicate().isAll() ? scanTask.deletes() : ImmutableList.of();
+                scannedFiles.add(new DataFileWithDeleteFiles(scanTask.file(), fullyAppliedDeletes));
             }
             splits.add(icebergSplit);
         }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergOptimizeHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergOptimizeHandle.java
@@ -38,7 +38,6 @@ public class IcebergOptimizeHandle
     private final Map<String, String> tableStorageProperties;
     private final DataSize maxScannedFileSize;
     private final boolean retriesEnabled;
-    private final boolean wholeTableScan;
 
     @JsonCreator
     public IcebergOptimizeHandle(
@@ -49,8 +48,7 @@ public class IcebergOptimizeHandle
             IcebergFileFormat fileFormat,
             Map<String, String> tableStorageProperties,
             DataSize maxScannedFileSize,
-            boolean retriesEnabled,
-            boolean wholeTableScan)
+            boolean retriesEnabled)
     {
         this.snapshotId = snapshotId;
         this.schemaAsJson = requireNonNull(schemaAsJson, "schemaAsJson is null");
@@ -60,7 +58,6 @@ public class IcebergOptimizeHandle
         this.tableStorageProperties = ImmutableMap.copyOf(requireNonNull(tableStorageProperties, "tableStorageProperties is null"));
         this.maxScannedFileSize = requireNonNull(maxScannedFileSize, "maxScannedFileSize is null");
         this.retriesEnabled = retriesEnabled;
-        this.wholeTableScan = wholeTableScan;
     }
 
     @JsonProperty
@@ -111,12 +108,6 @@ public class IcebergOptimizeHandle
         return retriesEnabled;
     }
 
-    @JsonProperty
-    public boolean isWholeTableScan()
-    {
-        return wholeTableScan;
-    }
-
     @Override
     public String toString()
     {
@@ -129,7 +120,6 @@ public class IcebergOptimizeHandle
                 .add("tableStorageProperties", tableStorageProperties)
                 .add("maxScannedFileSize", maxScannedFileSize)
                 .add("retriesEnabled", retriesEnabled)
-                .add("tupleDomainAll", wholeTableScan)
                 .toString();
     }
 }


### PR DESCRIPTION
The initial implementation removed delete files from a partition
even if the whole table was not scanned. This was fine, but assumes
the enforced predicate describes entire partitions. This
assumption will not be true after https://github.com/trinodb/trino/pull/13012

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
