### PR TITLE
Execute SELECT query to verify connection in JDBC driver

### DIFF
--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
@@ -507,7 +507,17 @@ public class TrinoConnection
         if (timeout < 0) {
             throw new SQLException("Timeout is negative");
         }
-        return !isClosed();
+
+        if (isClosed()) {
+            return false;
+        }
+
+        try (TrinoStatement statement = doCreateStatement()) {
+            return statement.internalExecute("SELECT 1");
+        }
+        catch (SQLException e) {
+            return false;
+        }
     }
 
     @Override

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcConnection.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcConnection.java
@@ -292,6 +292,23 @@ public class TestJdbcConnection
     }
 
     @Test
+    public void testIsValid()
+            throws SQLException
+    {
+        try (Connection connection = createConnection()) {
+            assertTrue(connection.isValid(0));
+        }
+
+        try (Connection connection = createInvalidConnection()) {
+            assertFalse(connection.isValid(0));
+        }
+
+        Connection connection = createConnection();
+        connection.close();
+        assertFalse(connection.isValid(0));
+    }
+
+    @Test
     public void testApplicationName()
             throws SQLException
     {
@@ -550,6 +567,12 @@ public class TestJdbcConnection
     {
         String url = format("jdbc:trino://%s/hive/default?%s", server.getAddress(), extra);
         return DriverManager.getConnection(url, "admin", null);
+    }
+
+    private Connection createInvalidConnection()
+            throws SQLException
+    {
+        return DriverManager.getConnection("jdbc:trino://invalid:1234", "admin", null);
     }
 
     private static Set<String> listTables(Connection connection)


### PR DESCRIPTION
## Description

Execute `SELECT 1` statement to verify connection in JDBC driver. 
https://docs.oracle.com/en/java/javase/11/docs/api/java.sql/java/sql/Connection.html#isValid(int)
> Returns true if the connection has not been closed and is still valid. The driver shall submit a query on the connection or use some other mechanism that positively verifies the connection is still valid when this method is called.
The query submitted by the driver to validate the connection shall be executed in the context of the current transaction.

Fixes #13341
Fixes https://github.com/trinodb/trino/issues/8542

## Documentation

(x) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# JDBC
* Verify connection by executing `SELECT 1` in `Connection.isValid` method. ({issue}`13341`)
```
