### PR TITLE
Fix TestingTrinoServer connector event listener registration

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
+++ b/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
@@ -42,6 +42,7 @@ import io.airlift.tracetoken.TraceTokenModule;
 import io.trino.connector.CatalogHandle;
 import io.trino.connector.CatalogManagerModule;
 import io.trino.connector.ConnectorManager;
+import io.trino.connector.ConnectorServicesProvider;
 import io.trino.cost.StatsCalculator;
 import io.trino.dispatcher.DispatchManager;
 import io.trino.eventlistener.EventListenerConfig;
@@ -58,6 +59,7 @@ import io.trino.execution.resourcegroups.InternalResourceGroupManager;
 import io.trino.memory.ClusterMemoryManager;
 import io.trino.memory.LocalMemoryManager;
 import io.trino.metadata.AllNodes;
+import io.trino.metadata.CatalogManager;
 import io.trino.metadata.FunctionBundle;
 import io.trino.metadata.FunctionManager;
 import io.trino.metadata.GlobalFunctionCatalog;
@@ -439,6 +441,10 @@ public class TestingTrinoServer
     {
         CatalogHandle catalogHandle = connectorManager.createCatalog(catalogName, connectorName, properties);
         updateConnectorIdAnnouncement(announcer, catalogHandle, nodeManager);
+
+        EventListenerManager eventListenerManager = injector.getInstance(EventListenerManager.class);
+        connectorManager.getConnectorServices(catalogHandle).getEventListeners().forEach(eventListenerManager::addEventListener);
+
         return catalogHandle;
     }
 

--- a/testing/trino-tests/src/test/java/io/trino/execution/EventsAwaitingQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/EventsAwaitingQueries.java
@@ -78,7 +78,7 @@ class EventsAwaitingQueries
         }
 
         QueryEvents queryEvents = eventsCollector.getQueryEvents(queryId);
-        queryEvents.waitForQueryCompletion(new Duration(30, SECONDS));
+        queryEvents.waitForQueryCompletion(new Duration(3, SECONDS));
 
         // Sleep some more so extraneous, unexpected events can be recorded too.
         // This is not rock solid but improves effectiveness on detecting duplicate events.


### PR DESCRIPTION
Tests like `TestConnectorEventListener.testConnectorEventHandlerReceivingEvents` are broken on master because connector's event listeners are never registered when `createCatalog` is called on `TestingTrinoServer` (changed since https://github.com/trinodb/trino/commit/ff323dcb81085a1a5d9ba6f862305c94ba799d84)

