### PR TITLE
Create home dir for trino user in Docker image

### DIFF
--- a/core/docker/Dockerfile
+++ b/core/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN \
     rm -rf /var/cache/yum && \
     alternatives --set python /usr/bin/python3 && \
     groupadd trino --gid 1000 && \
-    useradd trino --uid 1000 --gid 1000 && \
+    useradd trino --uid 1000 --gid 1000 --create-home && \
     mkdir -p /usr/lib/trino /data/trino && \
     chown -R "trino:trino" /usr/lib/trino /data/trino
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->
When running the trino CLI in the Docker image, it complains that it can't save user history. This is because the user's home directory doesn't exist:

```
$ docker exec -it trino trino
trino> 
trino> 
trino> show catalogs;Jul 26, 2022 6:54:04 PM org.jline.utils.Log logr
WARNING: Failed to save history
java.nio.file.AccessDeniedException: /home/trino
...
trino@51ccc3bab429:/$ whoami
trino
trino@51ccc3bab429:/$ ls -la /home/trino
ls: cannot access '/home/trino': No such file or directory
```

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
docker image

> How would you describe this change to a non-technical end user or system administrator?
When running the Trino CLI in the Docker container, it should not complain about not being able to  save history

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
