### PR TITLE
Retain Delta metadata properties after schema changes

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/MetadataEntry.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/MetadataEntry.java
@@ -153,7 +153,7 @@ public class MetadataEntry
         }
     }
 
-    public static Map<String, String> buildDeltaMetadataConfiguration(Optional<Long> checkpointInterval)
+    public static Map<String, String> configurationForNewTable(Optional<Long> checkpointInterval)
     {
         return checkpointInterval
                 .map(value -> ImmutableMap.of(DELTA_CHECKPOINT_INTERVAL_PROPERTY, String.valueOf(value)))


### PR DESCRIPTION
## Description

Schema changes like add column, setting column comment, and setting
table comment inadvertently cleared the MetadataEntry configuration
field.

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Delta connector

> How would you describe this change to a non-technical end user or system administrator?

Ensure Delta connector operations do not reset table properties

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Delta Lake
* Retain Delta metadata properties after schema changes
```
