### PR TITLE
Downgrade docker based image to 17.0.3

### DIFF
--- a/core/docker/Dockerfile
+++ b/core/docker/Dockerfile
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ARG AZUL_DOCKER_TAG=17.0.4
+ARG AZUL_DOCKER_TAG=17.0.3
 FROM azul/zulu-openjdk:$AZUL_DOCKER_TAG
 
 ENV JAVA_HOME /usr/lib/jvm/zulu17


### PR DESCRIPTION
The 17.0.4 base images don't seem to be working:

https://github.com/zulu-openjdk/zulu-openjdk/issues/154

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
