### PR TITLE
Revert "Switch docker image to use Azul one as base"

### DIFF
--- a/core/docker/Dockerfile
+++ b/core/docker/Dockerfile
@@ -11,16 +11,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ARG AZUL_DOCKER_TAG=17.0.4
-FROM azul/zulu-openjdk:$AZUL_DOCKER_TAG
+FROM registry.access.redhat.com/ubi8/ubi
 
 ENV JAVA_HOME /usr/lib/jvm/zulu17
-
 RUN \
     set -xeu && \
-    apt-get update -q && \
-    apt-get install -y -q less python curl && \
-    rm -rf /var/lib/apt/lists/* && \
+    yum -y -q install https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm && \
+    yum -y -q install python3 zulu17-jdk less && \
+    yum -q clean all && \
+    rm -rf /var/cache/yum && \
+    alternatives --set python /usr/bin/python3 && \
     groupadd trino --gid 1000 && \
     useradd trino --uid 1000 --gid 1000 && \
     mkdir -p /usr/lib/trino /data/trino && \

--- a/core/docker/build.sh
+++ b/core/docker/build.sh
@@ -10,24 +10,19 @@ Builds the Trino Docker image
 -h       Display help
 -a       Build the specified comma-separated architectures, defaults to amd64,arm64
 -r       Build the specified Trino release version, downloads all required artifacts
--j       Azul JDK version as published in https://hub.docker.com/r/azul/zulu-openjdk
 EOF
 }
 
 ARCHITECTURES=(amd64 arm64)
 TRINO_VERSION=
-AZUL_DOCKER_TAG="17.0.4"
 
-while getopts ":a:h:r:j:" o; do
+while getopts ":a:h:r:" o; do
     case "${o}" in
         a)
             IFS=, read -ra ARCHITECTURES <<< "$OPTARG"
             ;;
         r)
             TRINO_VERSION=${OPTARG}
-            ;;
-        j)
-            AZUL_DOCKER_TAG=${OPTARG}
             ;;
         h)
             usage
@@ -75,15 +70,14 @@ cp -R default "${WORK_DIR}/"
 TAG_PREFIX="trino:${TRINO_VERSION}"
 
 for arch in "${ARCHITECTURES[@]}"; do
-    echo "🫙  Building the image for $arch using azul/zulu-openjdk:${AZUL_DOCKER_TAG} as a base"
+    echo "🫙  Building the image for $arch"
     docker build \
         "${WORK_DIR}" \
         --pull \
         --platform "linux/$arch" \
         -f Dockerfile \
         -t "${TAG_PREFIX}-$arch" \
-        --build-arg "TRINO_VERSION=${TRINO_VERSION}" \
-        --build-arg "AZUL_DOCKER_TAG=${AZUL_DOCKER_TAG}"
+        --build-arg "TRINO_VERSION=${TRINO_VERSION}"
 done
 
 echo "🧹 Cleaning up the build context directory"


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->
This reverts commit b0dcb8dbf44ac0a2749ae5a35e31b62b47267ae9. The Zulu
Docker images for 17.0.4 and 17.0.3 are currently not available for
the `linux/arm64` platform.

I also checked that the latest JDK 17 is installed:
```
% docker run -it --rm trino:392-SNAPSHOT-amd64 bash
[trino@dce0b1368edd /]$ java -version
openjdk version "17.0.4" 2022-07-19 LTS
OpenJDK Runtime Environment Zulu17.36+13-CA (build 17.0.4+8-LTS)
OpenJDK 64-Bit Server VM Zulu17.36+13-CA (build 17.0.4+8-LTS, mixed mode, sharing)
```

Supersedes #13373 and #13366

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
docker image

> How would you describe this change to a non-technical end user or system administrator?
Revert to using the UBI as the base Docker image.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
