### PR TITLE
Avoid reading Iceberg delete files when not needed

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSource.java
@@ -59,7 +59,7 @@ public class IcebergPageSource
     private final int[] expectedColumnIndexes;
     private final ConnectorPageSource delegate;
     private final Optional<ReaderProjectionsAdapter> projectionsAdapter;
-    private final Optional<RowPredicate> deletePredicate;
+    private final Supplier<Optional<RowPredicate>> deletePredicate;
     private final Supplier<IcebergPositionDeletePageSink> positionDeleteSinkSupplier;
     private final Supplier<IcebergPageSink> updatedRowPageSinkSupplier;
     // An array with one element per field in the $row_id column. The value in the array points to the
@@ -83,7 +83,7 @@ public class IcebergPageSource
             List<IcebergColumnHandle> requiredColumns,
             ConnectorPageSource delegate,
             Optional<ReaderProjectionsAdapter> projectionsAdapter,
-            Optional<RowPredicate> deletePredicate,
+            Supplier<Optional<RowPredicate>> deletePredicate,
             Supplier<IcebergPositionDeletePageSink> positionDeleteSinkSupplier,
             Supplier<IcebergPageSink> updatedRowPageSinkSupplier,
             List<IcebergColumnHandle> updatedColumns)
@@ -159,8 +159,9 @@ public class IcebergPageSource
                 return null;
             }
 
-            if (deletePredicate.isPresent()) {
-                dataPage = deletePredicate.get().filterPage(dataPage);
+            Optional<RowPredicate> deleteFilterPredicate = deletePredicate.get();
+            if (deleteFilterPredicate.isPresent()) {
+                dataPage = deleteFilterPredicate.get().filterPage(dataPage);
             }
 
             if (projectionsAdapter.isPresent()) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/DeleteFilter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/DeleteFilter.java
@@ -14,13 +14,10 @@
 package io.trino.plugin.iceberg.delete;
 
 import io.trino.plugin.iceberg.IcebergColumnHandle;
-import org.apache.iceberg.Schema;
 
 import java.util.List;
 
 public interface DeleteFilter
 {
-    Schema schema();
-
     RowPredicate createPredicate(List<IcebergColumnHandle> columns);
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/EqualityDeleteFilter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/EqualityDeleteFilter.java
@@ -43,12 +43,6 @@ public final class EqualityDeleteFilter
     }
 
     @Override
-    public Schema schema()
-    {
-        return schema;
-    }
-
-    @Override
     public RowPredicate createPredicate(List<IcebergColumnHandle> columns)
     {
         Type[] types = columns.stream()

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/PositionDeleteFilter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/PositionDeleteFilter.java
@@ -18,8 +18,6 @@ import io.trino.plugin.iceberg.IcebergColumnHandle;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.connector.ConnectorPageSource;
-import org.apache.iceberg.MetadataColumns;
-import org.apache.iceberg.Schema;
 import org.roaringbitmap.longlong.ImmutableLongBitmapDataProvider;
 import org.roaringbitmap.longlong.LongBitmapDataProvider;
 
@@ -38,12 +36,6 @@ public final class PositionDeleteFilter
     public PositionDeleteFilter(ImmutableLongBitmapDataProvider deletedRows)
     {
         this.deletedRows = requireNonNull(deletedRows, "deletedRows is null");
-    }
-
-    @Override
-    public Schema schema()
-    {
-        return new Schema(MetadataColumns.ROW_POSITION);
     }
 
     @Override


### PR DESCRIPTION
## Description

Parqet only.

Skip reading the delete files associated with a data file if the deletes are
not relevant. This can happen when the statistics from the data file already
show the split can be skipped. Additionally, this can happen when the line
numbers read by the split are known and can be used to filter positional
deletes.

> Is this change a fix, improvement, new feature, refactoring, or other?

Performance improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Iceberg connector

> How would you describe this change to a non-technical end user or system administrator?

Minimize I/O operations

## Related issues, pull requests, and links

https://github.com/trinodb/trino/pull/13219

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text: