### PR TITLE
Rename parameters in Hive flush_metadata_cache procedure

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/procedure/FlushHiveMetastoreCacheProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/procedure/FlushHiveMetastoreCacheProcedure.java
@@ -42,8 +42,8 @@ public class FlushHiveMetastoreCacheProcedure
 
     private static final String PARAM_SCHEMA_NAME = "SCHEMA_NAME";
     private static final String PARAM_TABLE_NAME = "TABLE_NAME";
-    private static final String PARAM_PARTITION_COLUMN = "PARTITION_COLUMN";
-    private static final String PARAM_PARTITION_VALUE = "PARTITION_VALUE";
+    private static final String PARAM_PARTITION_COLUMNS = "PARTITION_COLUMNS";
+    private static final String PARAM_PARTITION_VALUES = "PARTITION_VALUES";
 
     private static final String PROCEDURE_USAGE_EXAMPLES = format(
             "Valid usages:%n" +
@@ -53,8 +53,8 @@ public class FlushHiveMetastoreCacheProcedure
             // Use lowercase parameter names per convention. In the usage example the names are not delimited.
             PARAM_SCHEMA_NAME.toLowerCase(ENGLISH),
             PARAM_TABLE_NAME.toLowerCase(ENGLISH),
-            PARAM_PARTITION_COLUMN.toLowerCase(ENGLISH),
-            PARAM_PARTITION_VALUE.toLowerCase(ENGLISH));
+            PARAM_PARTITION_COLUMNS.toLowerCase(ENGLISH),
+            PARAM_PARTITION_VALUES.toLowerCase(ENGLISH));
 
     private static final MethodHandle FLUSH_HIVE_METASTORE_CACHE = methodHandle(
             FlushHiveMetastoreCacheProcedure.class,
@@ -84,8 +84,8 @@ public class FlushHiveMetastoreCacheProcedure
                         new Procedure.Argument("$FAKE_FIRST_PARAMETER", VARCHAR, false, FAKE_PARAM_DEFAULT_VALUE),
                         new Procedure.Argument(PARAM_SCHEMA_NAME, VARCHAR, false, null),
                         new Procedure.Argument(PARAM_TABLE_NAME, VARCHAR, false, null),
-                        new Procedure.Argument(PARAM_PARTITION_COLUMN, new ArrayType(VARCHAR), false, null),
-                        new Procedure.Argument(PARAM_PARTITION_VALUE, new ArrayType(VARCHAR), false, null)),
+                        new Procedure.Argument(PARAM_PARTITION_COLUMNS, new ArrayType(VARCHAR), false, null),
+                        new Procedure.Argument(PARAM_PARTITION_VALUES, new ArrayType(VARCHAR), false, null)),
                 FLUSH_HIVE_METASTORE_CACHE.bindTo(this));
     }
 
@@ -108,7 +108,7 @@ public class FlushHiveMetastoreCacheProcedure
 
         checkState(
                 partitionColumns.size() == partitionValues.size(),
-                "Parameters partition_column and partition_value should have same length");
+                "Parameters partition_columns and partition_values should have same length");
 
         if (schemaName.isEmpty() && tableName.isEmpty() && partitionColumns.isEmpty()) {
             cachingHiveMetastore.flushCache();

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveOnDataLake.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveOnDataLake.java
@@ -230,9 +230,9 @@ public abstract class BaseTestHiveOnDataLake
         assertQueryReturnsEmptyResult(queryUsingPartitionCacheForValue1);
         assertQueryReturnsEmptyResult(queryUsingPartitionCacheForValue2);
 
-        // Refresh cache for schema_name => 'dummy_schema', table_name => 'dummy_table', partition_column =>
+        // Refresh cache for schema_name => 'dummy_schema', table_name => 'dummy_table', partition_columns =>
         getQueryRunner().execute(format(
-                "CALL system.flush_metadata_cache(schema_name => '%s', table_name => '%s', partition_column => ARRAY['%s'], partition_value => ARRAY['%s'])",
+                "CALL system.flush_metadata_cache(schema_name => '%s', table_name => '%s', partition_columns => ARRAY['%s'], partition_values => ARRAY['%s'])",
                 HIVE_TEST_SCHEMA,
                 tableName,
                 partitionColumn,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastoreWithQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastoreWithQueryRunner.java
@@ -144,7 +144,7 @@ public class TestCachingHiveMetastoreWithQueryRunner
     public void testIllegalFlushHiveMetastoreCacheProcedureCalls()
     {
         String illegalParameterMessage = "Illegal parameter set passed. ";
-        String validUsageExample = "Valid usages:\n - 'flush_metadata_cache()'\n - flush_metadata_cache(schema_name => ..., table_name => ..., partition_column => ARRAY['...'], partition_value => ARRAY['...'])";
+        String validUsageExample = "Valid usages:\n - 'flush_metadata_cache()'\n - flush_metadata_cache(schema_name => ..., table_name => ..., partition_columns => ARRAY['...'], partition_values => ARRAY['...'])";
 
         assertThatThrownBy(() -> getQueryRunner().execute("CALL system.flush_metadata_cache('dummy_schema')"))
                 .hasMessage("Procedure should only be invoked with named parameters. " + validUsageExample);
@@ -154,8 +154,8 @@ public class TestCachingHiveMetastoreWithQueryRunner
         assertThatThrownBy(() -> getQueryRunner().execute("CALL system.flush_metadata_cache(schema_name => 'dummy_schema', table_name => 'dummy_table')"))
                 .hasMessage(illegalParameterMessage + validUsageExample);
 
-        assertThatThrownBy(() -> getQueryRunner().execute("CALL system.flush_metadata_cache(schema_name => 'dummy_schema', table_name => 'dummy_table', partition_column => ARRAY['dummy_partition'])"))
-                .hasMessage("Parameters partition_column and partition_value should have same length");
+        assertThatThrownBy(() -> getQueryRunner().execute("CALL system.flush_metadata_cache(schema_name => 'dummy_schema', table_name => 'dummy_table', partition_columns => ARRAY['dummy_partition'])"))
+                .hasMessage("Parameters partition_columns and partition_values should have same length");
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

All other Hive procedures use the params `partition_columns` and `partition_values` instead of the singular `partition_column` and `partition_value`. This renames them for parity.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix/refactor

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Hive connector

> How would you describe this change to a non-technical end user or system administrator?

Renaming procedure parameters

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed - the documentation already (inaccurately) reflects this change.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:
