### PR TITLE
Skew join optimizer

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -257,6 +257,7 @@ import io.trino.sql.planner.optimizations.OptimizerStats;
 import io.trino.sql.planner.optimizations.PlanOptimizer;
 import io.trino.sql.planner.optimizations.PredicatePushDown;
 import io.trino.sql.planner.optimizations.ReplicateJoinAndSemiJoinInDelete;
+import io.trino.sql.planner.optimizations.SkewJoinOptimizer;
 import io.trino.sql.planner.optimizations.StatsRecordingPlanOptimizer;
 import io.trino.sql.planner.optimizations.TransformQuantifiedComparisonApplyToCorrelatedJoin;
 import io.trino.sql.planner.optimizations.UnaliasSymbolReferences;
@@ -850,6 +851,9 @@ public class PlanOptimizers
                             // Must run before AddExchanges
                             .add(new DetermineTableScanNodePartitioning(metadata, nodePartitioningManager, taskCountEstimator))
                             .build()));
+
+            // Must be run before AddExchanges because we add new symbols to distribute by.
+            builder.add(new SkewJoinOptimizer(metadata));
 
             builder.add(
                     new IterativeOptimizer(

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SkewJoinOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SkewJoinOptimizer.java
@@ -70,15 +70,18 @@ import static io.trino.sql.planner.plan.ChildReplacer.replaceChildren;
 import static java.util.Objects.requireNonNull;
 
 public class SkewJoinOptimizer
-        implements PlanOptimizer {
+        implements PlanOptimizer
+{
     private final Metadata metadata;
 
-    public SkewJoinOptimizer(Metadata metadata) {
+    public SkewJoinOptimizer(Metadata metadata)
+    {
         this.metadata = requireNonNull(metadata, "metadata is null");
     }
 
     @Override
-    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, TableStatsProvider statsProvider) {
+    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, TableStatsProvider statsProvider)
+    {
         List<List<String>> skewedJoinMetadata = getSkewedJoinMetadata(session);
 
         if (skewedJoinMetadata.size() == 0) {
@@ -97,24 +100,28 @@ public class SkewJoinOptimizer
         return plan.accept(new PlanRewriter(session, metadata, skewedTables, rewriter), new HashMap<>());
     }
 
-    private record SkewedContext(List<String> values, DataType keyType) {
+    private record SkewedContext(List<String> values, DataType keyType)
+    {
     }
 
     private static class PlanRewriter
-            extends PlanVisitor<PlanNode, Map<Symbol, SkewedContext>> {
+            extends PlanVisitor<PlanNode, Map<Symbol, SkewedContext>>
+    {
         private final Session session;
         private final Metadata metadata;
         private final JoinRewriter joinRewriter;
         private final Map<String, SkewJoinConfig> skewedTables;
 
-        public PlanRewriter(Session session, Metadata metadata, Map<String, SkewJoinConfig> skewedTables, JoinRewriter rewriter) {
+        public PlanRewriter(Session session, Metadata metadata, Map<String, SkewJoinConfig> skewedTables, JoinRewriter rewriter)
+        {
             this.session = requireNonNull(session, "session is null");
             this.metadata = requireNonNull(metadata, "metadata is null");
             this.skewedTables = requireNonNull(skewedTables, "skewedTables is null");
             this.joinRewriter = requireNonNull(rewriter, "rewriter is null");
         }
 
-        public PlanNode passThrough(PlanNode node, Map<Symbol, SkewedContext> context) {
+        public PlanNode passThrough(PlanNode node, Map<Symbol, SkewedContext> context)
+        {
             List<PlanNode> rewrittenChildren = node.getSources().stream()
                     .map(child -> child.accept(this, context))
                     .collect(Collectors.toList());
@@ -122,7 +129,8 @@ public class SkewJoinOptimizer
         }
 
         @Override
-        public PlanNode visitJoin(JoinNode node, Map<Symbol, SkewedContext> context) {
+        public PlanNode visitJoin(JoinNode node, Map<Symbol, SkewedContext> context)
+        {
             // TODO : how do range joins behave ?
             Map<Symbol, SkewedContext> leftCtx = new HashMap<>();
             Map<Symbol, SkewedContext> rightCtx = new HashMap<>();
@@ -148,23 +156,26 @@ public class SkewJoinOptimizer
         }
 
         @Override
-        public PlanNode visitFilter(FilterNode node, Map<Symbol, SkewedContext> context) {
+        public PlanNode visitFilter(FilterNode node, Map<Symbol, SkewedContext> context)
+        {
             return passThrough(node, context);
         }
 
         @Override
-        public PlanNode visitSort(SortNode node, Map<Symbol, SkewedContext> context) {
+        public PlanNode visitSort(SortNode node, Map<Symbol, SkewedContext> context)
+        {
             return passThrough(node, context);
         }
 
         @Override
-        public PlanNode visitExchange(ExchangeNode node, Map<Symbol, SkewedContext> context) {
-
+        public PlanNode visitExchange(ExchangeNode node, Map<Symbol, SkewedContext> context)
+        {
             throw new IllegalStateException("Unexpected node: ExchangeNode , SkewJoin optimizer should be run before adding exchanges.");
         }
 
         @Override
-        public PlanNode visitProject(ProjectNode node, Map<Symbol, SkewedContext> context) {
+        public PlanNode visitProject(ProjectNode node, Map<Symbol, SkewedContext> context)
+        {
             // If any symbol assignments refers to a skewed symbol then add that symbol to the set of skewed symbols.
             PlanNode child = node.getSource().accept(this, context);
 
@@ -192,7 +203,8 @@ public class SkewJoinOptimizer
         }
 
         @Override
-        protected PlanNode visitPlan(PlanNode node, Map<Symbol, SkewedContext> context) {
+        protected PlanNode visitPlan(PlanNode node, Map<Symbol, SkewedContext> context)
+        {
             // For all other nodes, don't let the context pass through.
             List<PlanNode> children = node.getSources().stream()
                     .map(child -> child.accept(this, new HashMap<>()))
@@ -201,7 +213,8 @@ public class SkewJoinOptimizer
         }
 
         @Override
-        public PlanNode visitTableScan(TableScanNode node, Map<Symbol, SkewedContext> context) {
+        public PlanNode visitTableScan(TableScanNode node, Map<Symbol, SkewedContext> context)
+        {
             String qualifiedTableName = metadata.getTableMetadata(session, node.getTable())
                     .getQualifiedName()
                     .toString()
@@ -222,25 +235,30 @@ public class SkewJoinOptimizer
         }
     }
 
-    private record SymbolMetadata(Symbol symbol, ColumnMetadata metadata) {
+    private record SymbolMetadata(Symbol symbol, ColumnMetadata metadata)
+    {
     }
 
     // Parses and validates the user supplied session data.
-    private record SkewJoinConfig(String tableName, String columnName, List<String> values) {
+    private record SkewJoinConfig(String tableName, String columnName, List<String> values)
+    {
         private static final int TABLE_INDEX = 0;
         private static final int COLUMN_INDEX = 1;
         private static final int VALUE_INDEX = 2;
         private static final int MIN_SIZE = 3;
 
-        public String getTableName() {
+        public String getTableName()
+        {
             return tableName;
         }
 
-        public String getColumnName() {
+        public String getColumnName()
+        {
             return columnName;
         }
 
-        public static Optional<SkewJoinConfig> valueOf(List<String> rawMetadata) {
+        public static Optional<SkewJoinConfig> valueOf(List<String> rawMetadata)
+        {
             if (rawMetadata.size() < MIN_SIZE) {
                 return Optional.empty();
             }
@@ -252,9 +270,10 @@ public class SkewJoinOptimizer
         }
     }
 
-    private static class JoinRewriter {
+    private static class JoinRewriter
+    {
         private static final GenericLiteral DEFAULT_PROJECT_VALUE = new GenericLiteral("TINYINT", "0");
-        private final Expression DEFAULT_UNNEST_VALUE;
+        private final Expression defaultUnnestValue;
 
         private final LongLiteral maxReplicationFactor;
         private final Expression arrayPartitioner;
@@ -263,12 +282,13 @@ public class SkewJoinOptimizer
         private final SymbolAllocator symbolAllocator;
         private final Session session;
 
-        public JoinRewriter(Metadata metadata, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session) {
+        public JoinRewriter(Metadata metadata, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
+        {
             this.metadata = requireNonNull(metadata, "metadata is null");
             this.idAllocator = requireNonNull(idAllocator, "id allocator is null");
             this.symbolAllocator = requireNonNull(symbolAllocator, "symbol allocator is null");
             this.session = requireNonNull(session, "session is null");
-            this.DEFAULT_UNNEST_VALUE = toArrayExpression(ImmutableList.of(DEFAULT_PROJECT_VALUE));
+            this.defaultUnnestValue = toArrayExpression(ImmutableList.of(DEFAULT_PROJECT_VALUE));
 
             int maxReplicas = getSkewedJoinReplicationFactor(session) - 1;
             checkArgument(maxReplicas > 0, "skew_join_replication_factor should be >= 2");
@@ -277,11 +297,11 @@ public class SkewJoinOptimizer
             this.arrayPartitioner = toArrayExpression(IntStream.rangeClosed(0, maxReplicas)
                     .boxed()
                     .map(i -> new GenericLiteral("TINYINT", Integer.toString(i)))
-                    .collect(Collectors.toList())
-            );
+                    .collect(Collectors.toList()));
         }
 
-        private Expression toArrayExpression(List<GenericLiteral> partitions) {
+        private Expression toArrayExpression(List<GenericLiteral> partitions)
+        {
             FunctionCallBuilder builder = FunctionCallBuilder.resolve(session, metadata)
                     .setName(QualifiedName.of("$array"));
 
@@ -290,14 +310,16 @@ public class SkewJoinOptimizer
             return builder.build();
         }
 
-        private Expression ifContains(SymbolReference keyColumn, List<Expression> skewedValues, Expression then, Expression otherWise) {
+        private Expression ifContains(SymbolReference keyColumn, List<Expression> skewedValues, Expression then, Expression otherWise)
+        {
             return new IfExpression(
                     new InPredicate(keyColumn, new InListExpression(skewedValues)),
                     then,
                     otherWise);
         }
 
-        private ProjectNode projectProbeSide(PlanNode probe, SymbolReference skewedLeftKey, List<Expression> inSkewedValues, Symbol randomPartSymbol) {
+        private ProjectNode projectProbeSide(PlanNode probe, SymbolReference skewedLeftKey, List<Expression> inSkewedValues, Symbol randomPartSymbol)
+        {
             FunctionCall randomPartCall = FunctionCallBuilder.resolve(session, this.metadata)
                     .setName(QualifiedName.of("random"))
                     .addArgument(IntegerType.INTEGER, maxReplicationFactor)
@@ -313,10 +335,11 @@ public class SkewJoinOptimizer
             return new ProjectNode(idAllocator.getNextId(), probe, assignments);
         }
 
-        private UnnestNode unnestBuildSide(PlanNode build, SymbolReference skewedRightKey, List<Expression> inSkewedValues, Symbol partSymbol) {
+        private UnnestNode unnestBuildSide(PlanNode build, SymbolReference skewedRightKey, List<Expression> inSkewedValues, Symbol partSymbol)
+        {
             Symbol partitionerSymbol = symbolAllocator.newSymbol("skewPartitioner", new ArrayType(IntegerType.INTEGER));
 
-            Expression ifSkewedKey = ifContains(skewedRightKey, inSkewedValues, arrayPartitioner, DEFAULT_UNNEST_VALUE);
+            Expression ifSkewedKey = ifContains(skewedRightKey, inSkewedValues, arrayPartitioner, defaultUnnestValue);
 
             Assignments assignments = Assignments.builder()
                     .putIdentities(build.getOutputSymbols())
@@ -335,7 +358,8 @@ public class SkewJoinOptimizer
                     Optional.empty());
         }
 
-        private ProjectNode dropAddedSymbols(JoinNode node, ImmutableSet<Symbol> symbolsToRemove) {
+        private ProjectNode dropAddedSymbols(JoinNode node, ImmutableSet<Symbol> symbolsToRemove)
+        {
             ImmutableList<Symbol> newOutputSymbols = node.getOutputSymbols().stream()
                     .filter(symbol -> !symbolsToRemove.contains(symbol))
                     .collect(toImmutableList());
@@ -345,11 +369,13 @@ public class SkewJoinOptimizer
             return new ProjectNode(idAllocator.getNextId(), node, assignments);
         }
 
-        private JoinNode rewriteJoinClause(JoinNode node, ProjectNode leftSource, Symbol leftKey, UnnestNode rightSource, Symbol rightKey) {
+        private JoinNode rewriteJoinClause(JoinNode node, ProjectNode leftSource, Symbol leftKey, UnnestNode rightSource, Symbol rightKey)
+        {
             return rewriteJoin(node, leftSource, rightSource, Stream.of(new JoinNode.EquiJoinClause(leftKey, rightKey)));
         }
 
-        public JoinNode rewriteJoin(JoinNode node, PlanNode leftSource, PlanNode rightSource, Stream<JoinNode.EquiJoinClause> additionalClause) {
+        public JoinNode rewriteJoin(JoinNode node, PlanNode leftSource, PlanNode rightSource, Stream<JoinNode.EquiJoinClause> additionalClause)
+        {
             List<JoinNode.EquiJoinClause> criteria = Stream
                     .concat(node.getCriteria().stream(), additionalClause)
                     .collect(Collectors.toUnmodifiableList());
@@ -372,7 +398,8 @@ public class SkewJoinOptimizer
                     node.getReorderJoinStatsAndCost());
         }
 
-        public PlanNode rewriteSkewedJoin(JoinNode joinNode, JoinNode.EquiJoinClause skewedClause, SkewedContext context) {
+        public PlanNode rewriteSkewedJoin(JoinNode joinNode, JoinNode.EquiJoinClause skewedClause, SkewedContext context)
+        {
             if (joinNode.getDistributionType().isEmpty() || joinNode.getDistributionType().get() != JoinNode.DistributionType.PARTITIONED) {
                 // Only optimize partitioned joins
                 return joinNode;

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SkewJoinOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SkewJoinOptimizer.java
@@ -1,0 +1,442 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.optimizations;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.trino.Session;
+import io.trino.cost.TableStatsProvider;
+import io.trino.execution.warnings.WarningCollector;
+import io.trino.metadata.Metadata;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.IntegerType;
+import io.trino.sql.planner.FunctionCallBuilder;
+import io.trino.sql.planner.PlanNodeIdAllocator;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.SymbolAllocator;
+import io.trino.sql.planner.TypeProvider;
+import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.ExchangeNode;
+import io.trino.sql.planner.plan.FilterNode;
+import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.PlanVisitor;
+import io.trino.sql.planner.plan.ProjectNode;
+import io.trino.sql.planner.plan.SortNode;
+import io.trino.sql.planner.plan.TableScanNode;
+import io.trino.sql.planner.plan.UnnestNode;
+import io.trino.sql.tree.Cast;
+import io.trino.sql.tree.DataType;
+import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.FunctionCall;
+import io.trino.sql.tree.GenericLiteral;
+import io.trino.sql.tree.IfExpression;
+import io.trino.sql.tree.InListExpression;
+import io.trino.sql.tree.InPredicate;
+import io.trino.sql.tree.LongLiteral;
+import io.trino.sql.tree.QualifiedName;
+import io.trino.sql.tree.StringLiteral;
+import io.trino.sql.tree.SymbolReference;
+import oshi.util.tuples.Pair;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.SystemSessionProperties.getSkewedJoinMetadata;
+import static io.trino.SystemSessionProperties.getSkewedJoinReplicationFactor;
+import static io.trino.sql.analyzer.TypeSignatureTranslator.toSqlType;
+import static io.trino.sql.planner.plan.ChildReplacer.replaceChildren;
+import static java.util.Objects.requireNonNull;
+
+public class SkewJoinOptimizer
+        implements PlanOptimizer
+{
+    private final Metadata metadata;
+
+    public SkewJoinOptimizer(Metadata metadata)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
+    @Override
+    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, TableStatsProvider statsProvider)
+    {
+        List<List<String>> skewedJoinMetadata = getSkewedJoinMetadata(session);
+
+        if (skewedJoinMetadata.size() == 0) {
+            // No session information found, nothing to do.
+            return plan;
+        }
+
+        Map<String, SkewJoinConfig> skewedTables = skewedJoinMetadata.stream()
+                .map(SkewJoinConfig::valueOf)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toMap(SkewJoinConfig::getTableName, Function.identity()));
+
+        JoinRewriter rewriter = new JoinRewriter(metadata, idAllocator, symbolAllocator, session);
+
+        return plan.accept(new PlanRewriter(session, metadata, skewedTables, rewriter), new HashMap<>());
+    }
+
+    private static class SkewedContext
+    {
+        public final DataType keyType;
+        public final List<String> values;
+
+        public SkewedContext(List<String> values, DataType keyType)
+        {
+            this.keyType = keyType;
+            this.values = values;
+        }
+    }
+
+    private static class PlanRewriter
+            extends PlanVisitor<PlanNode, Map<Symbol, SkewedContext>>
+    {
+        private final Session session;
+        private final Metadata metadata;
+        private final JoinRewriter joinRewriter;
+        private final Map<String, SkewJoinConfig> skewedTables;
+
+        public PlanRewriter(Session session, Metadata metadata, Map<String, SkewJoinConfig> skewedTables, JoinRewriter rewriter)
+        {
+            this.session = requireNonNull(session, "session is null");
+            this.metadata = requireNonNull(metadata, "metadata is null");
+            this.skewedTables = requireNonNull(skewedTables, "skewedTables is null");
+            this.joinRewriter = requireNonNull(rewriter, "rewriter is null");
+        }
+
+        public PlanNode passThrough(PlanNode node, Map<Symbol, SkewedContext> context)
+        {
+            List<PlanNode> rewrittenChildren = node.getSources().stream()
+                    .map(child -> child.accept(this, context))
+                    .collect(Collectors.toList());
+            return replaceChildren(node, rewrittenChildren);
+        }
+
+        @Override
+        public PlanNode visitJoin(JoinNode node, Map<Symbol, SkewedContext> context)
+        {
+            // TODO : how do range joins behave ?
+            Map<Symbol, SkewedContext> leftCtx = new HashMap<>();
+            Map<Symbol, SkewedContext> rightCtx = new HashMap<>();
+
+            PlanNode leftReWritten = node.getLeft().accept(this, leftCtx);
+            PlanNode rightReWritten = node.getRight().accept(this, rightCtx);
+
+            JoinNode newJoin = this.joinRewriter.rewriteJoin(node, leftReWritten, rightReWritten, Stream.empty());
+
+            // TODO: Currently we only handle the case when the skewed symbol is on the probe side. lets also handle the stream side.
+            if (leftCtx.size() > 0) {
+                Optional<JoinNode.EquiJoinClause> maybeClause = newJoin.getCriteria().stream()
+                        .filter(clause -> leftCtx.containsKey(clause.getLeft()))
+                        .findFirst();
+
+                if (maybeClause.isPresent()) {
+                    JoinNode.EquiJoinClause skewedClause = maybeClause.get();
+                    return this.joinRewriter.rewriteSkewedJoin(newJoin, skewedClause, leftCtx.get(skewedClause.getLeft()));
+                }
+            }
+
+            return newJoin;
+        }
+
+        @Override
+        public PlanNode visitFilter(FilterNode node, Map<Symbol, SkewedContext> context)
+        {
+            return passThrough(node, context);
+        }
+
+        @Override
+        public PlanNode visitSort(SortNode node, Map<Symbol, SkewedContext> context)
+        {
+            return passThrough(node, context);
+        }
+
+        @Override
+        public PlanNode visitExchange(ExchangeNode node, Map<Symbol, SkewedContext> context)
+        {
+
+            throw new IllegalStateException("Unexpected node: ExchangeNode , SkewJoin optimizer should be run before adding exchanges.");
+        }
+
+        @Override
+        public PlanNode visitProject(ProjectNode node, Map<Symbol, SkewedContext> context)
+        {
+            // If any symbol assignments refers to a skewed symbol then add that symbol to the set of skewed symbols.
+            PlanNode child = node.getSource().accept(this, context);
+
+            // Symbols that will be removed by this projection.
+            Set<Symbol> outputSymbols = new HashSet<>(node.getOutputSymbols());
+            Set<Symbol> symbolsToRemove = new HashSet<>(node.getSource().getOutputSymbols());
+            symbolsToRemove.removeAll(outputSymbols);
+
+            // Add all symbols that refer to a skewed symbol.
+            node.getAssignments().entrySet()
+                    .forEach(entry -> {
+                        Expression value = entry.getValue();
+                        if (entry.getValue() instanceof SymbolReference) {
+                            Symbol skewedSymbol = Symbol.from(value);
+                            if (context.containsKey(Symbol.from(value)) && !context.containsKey(entry.getKey())) {
+                                context.put(entry.getKey(), context.get(skewedSymbol));
+                            }
+                        }
+                    });
+
+            // Remove symbols that are dropped in the projection
+            context.keySet().removeAll(symbolsToRemove);
+
+            return replaceChildren(node, ImmutableList.of(child));
+        }
+
+        @Override
+        protected PlanNode visitPlan(PlanNode node, Map<Symbol, SkewedContext> context)
+        {
+            // For all other nodes, don't let the context pass through.
+            List<PlanNode> children = node.getSources().stream()
+                    .map(child -> child.accept(this, new HashMap<>()))
+                    .collect(Collectors.toList());
+            return replaceChildren(node, children);
+        }
+
+        @Override
+        public PlanNode visitTableScan(TableScanNode node, Map<Symbol, SkewedContext> context)
+        {
+            String qualifiedTableName = metadata.getTableMetadata(session, node.getTable()).getQualifiedName().toString();
+
+            if (skewedTables.containsKey(qualifiedTableName)) {
+                SkewJoinConfig skewConfig = skewedTables.get(qualifiedTableName);
+                Optional<Pair<Symbol, ColumnMetadata>> symbolAndMetadata = node.getAssignments().entrySet().stream()
+                        .map(entry -> new Pair<>(entry.getKey(), metadata.getColumnMetadata(session, node.getTable(), entry.getValue())))
+                        .filter(entry -> entry.getB().getName().equals(skewConfig.getColumnName()))
+                        .findFirst();
+                symbolAndMetadata.ifPresent(metadata -> {
+                    context.putIfAbsent(metadata.getA(), new SkewedContext(skewConfig.values, toSqlType(metadata.getB().getType())));
+                });
+            }
+
+            return node;
+        }
+    }
+
+    // Parses and validates the user supplied session data.
+    private static class SkewJoinConfig
+    {
+        private final String tableName;
+        private final String columnName;
+        private final List<String> values;
+
+        private static final int TABLE_INDEX = 0;
+        private static final int COLUMN_INDEX = 1;
+        private static final int VALUE_INDEX = 2;
+        private static final int MIN_SIZE = 3;
+
+        private SkewJoinConfig(List<String> rawMetadata)
+        {
+            tableName = rawMetadata.get(TABLE_INDEX);
+            columnName = rawMetadata.get(COLUMN_INDEX);
+            values = ImmutableList.copyOf(rawMetadata.subList(VALUE_INDEX, rawMetadata.size()));
+        }
+
+        public String getTableName()
+        {
+            return tableName;
+        }
+
+        public String getColumnName()
+        {
+            return columnName;
+        }
+
+        public static Optional<SkewJoinConfig> valueOf(List<String> rawMetadata)
+        {
+            if (rawMetadata.size() < MIN_SIZE) {
+                return Optional.empty();
+            }
+
+            return Optional.of(new SkewJoinConfig(rawMetadata));
+        }
+    }
+
+    private static class JoinRewriter
+    {
+        private static final GenericLiteral DEFAULT_PROJECT_VALUE = new GenericLiteral("TINYINT", "0");
+        private final Expression DEFAULT_UNNEST_VALUE;
+
+        private final LongLiteral maxReplicationFactor;
+        private final Expression arrayPartitioner;
+        private final Metadata metadata;
+        private final PlanNodeIdAllocator idAllocator;
+        private final SymbolAllocator symbolAllocator;
+        private final Session session;
+
+        public JoinRewriter(Metadata metadata, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
+        {
+            this.metadata = requireNonNull(metadata, "metadata is null");
+            this.idAllocator = requireNonNull(idAllocator, "id allocator is null");
+            this.symbolAllocator = requireNonNull(symbolAllocator, "symbol allocator is null");
+            this.session = requireNonNull(session, "session is null");
+            this.DEFAULT_UNNEST_VALUE = toArrayExpression(ImmutableList.of(DEFAULT_PROJECT_VALUE));
+
+            int maxReplicas = getSkewedJoinReplicationFactor(session) - 1;
+            checkArgument(maxReplicas > 0, "skew_join_replication_factor should be >= 2");
+
+            this.maxReplicationFactor = new LongLiteral(Integer.toString(maxReplicas));
+            this.arrayPartitioner = toArrayExpression(IntStream.rangeClosed(0, maxReplicas)
+                    .boxed()
+                    .map(i -> new GenericLiteral("TINYINT", Integer.toString(i)))
+                    .collect(Collectors.toList())
+            );
+        }
+
+        private Expression toArrayExpression(List<GenericLiteral> partitions) {
+            FunctionCallBuilder builder = FunctionCallBuilder.resolve(session, metadata)
+                    .setName(QualifiedName.of("$array"));
+
+            partitions.forEach(partition -> builder.addArgument(IntegerType.INTEGER, partition));
+
+            return builder.build();
+        }
+
+        private Expression ifContains(SymbolReference keyColumn, List<Expression> skewedValues, Expression then, Expression otherWise)
+        {
+            return new IfExpression(
+                    new InPredicate(keyColumn, new InListExpression(skewedValues)),
+                    then,
+                    otherWise);
+        }
+
+        private ProjectNode projectProbeSide(PlanNode probe, SymbolReference skewedLeftKey, List<Expression> inSkewedValues, Symbol randomPartSymbol)
+        {
+            FunctionCall randomPartCall = FunctionCallBuilder.resolve(session, this.metadata)
+                    .setName(QualifiedName.of("random"))
+                    .addArgument(IntegerType.INTEGER, maxReplicationFactor)
+                    .build();
+
+            Expression ifSkewedKey = ifContains(skewedLeftKey, inSkewedValues, randomPartCall, DEFAULT_PROJECT_VALUE);
+
+            Assignments assignments = Assignments.builder()
+                    .putIdentities(probe.getOutputSymbols())
+                    .put(randomPartSymbol, ifSkewedKey)
+                    .build();
+
+            return new ProjectNode(idAllocator.getNextId(), probe, assignments);
+        }
+
+        private UnnestNode unnestBuildSide(PlanNode build, SymbolReference skewedRightKey, List<Expression> inSkewedValues, Symbol partSymbol)
+        {
+            Symbol partitionerSymbol = symbolAllocator.newSymbol("skewPartitioner", new ArrayType(IntegerType.INTEGER));
+
+            Expression ifSkewedKey = ifContains(skewedRightKey, inSkewedValues, arrayPartitioner, DEFAULT_UNNEST_VALUE);
+
+            Assignments assignments = Assignments.builder()
+                    .putIdentities(build.getOutputSymbols())
+                    .put(partitionerSymbol, ifSkewedKey)
+                    .build();
+
+            ProjectNode setPartitionArray = new ProjectNode(idAllocator.getNextId(), build, assignments);
+
+            return new UnnestNode(
+                    idAllocator.getNextId(),
+                    setPartitionArray,
+                    build.getOutputSymbols(),
+                    ImmutableList.of(new UnnestNode.Mapping(partitionerSymbol, ImmutableList.of(partSymbol))),
+                    Optional.empty(),
+                    JoinNode.Type.INNER,
+                    Optional.empty());
+        }
+
+        private ProjectNode dropAddedSymbols(JoinNode node, ImmutableSet<Symbol> symbolsToRemove)
+        {
+            ImmutableList<Symbol> newOutputSymbols = node.getOutputSymbols().stream()
+                    .filter(symbol -> !symbolsToRemove.contains(symbol))
+                    .collect(toImmutableList());
+
+            Assignments assignments = Assignments.builder().putIdentities(newOutputSymbols).build();
+
+            return new ProjectNode(idAllocator.getNextId(), node, assignments);
+        }
+
+        private JoinNode rewriteJoinClause(JoinNode node, ProjectNode leftSource, Symbol leftKey, UnnestNode rightSource, Symbol rightKey)
+        {
+            return rewriteJoin(node, leftSource, rightSource, Stream.of(new JoinNode.EquiJoinClause(leftKey, rightKey)));
+        }
+
+        public JoinNode rewriteJoin(JoinNode node, PlanNode leftSource, PlanNode rightSource, Stream<JoinNode.EquiJoinClause> additionalClause)
+        {
+            List<JoinNode.EquiJoinClause> criteria = Stream
+                    .concat(node.getCriteria().stream(), additionalClause)
+                    .collect(Collectors.toUnmodifiableList());
+
+            return new JoinNode(
+                    idAllocator.getNextId(),
+                    node.getType(),
+                    leftSource,
+                    rightSource,
+                    criteria,
+                    node.getLeftOutputSymbols(),
+                    node.getRightOutputSymbols(),
+                    node.isMaySkipOutputDuplicates(),
+                    node.getFilter(),
+                    node.getLeftHashSymbol(),
+                    node.getRightHashSymbol(),
+                    node.getDistributionType(),
+                    node.isSpillable(),
+                    node.getDynamicFilters(),
+                    node.getReorderJoinStatsAndCost());
+        }
+
+        public PlanNode rewriteSkewedJoin(JoinNode joinNode, JoinNode.EquiJoinClause skewedClause, SkewedContext context)
+        {
+            if (joinNode.getDistributionType().isEmpty() || joinNode.getDistributionType().get() != JoinNode.DistributionType.PARTITIONED) {
+                // Only optimize partitioned joins
+                return joinNode;
+            }
+
+            if (joinNode.getType() != JoinNode.Type.INNER && joinNode.getType() != JoinNode.Type.LEFT) {
+                // Only support left and inner joins since they won't cause row duplication.
+                return joinNode;
+            }
+
+            SymbolReference skewedLeftKey = skewedClause.getLeft().toSymbolReference();
+            SymbolReference skewedRightKey = skewedClause.getRight().toSymbolReference();
+            List<Expression> skewedExpressionValues = context.values.stream()
+                    .map(StringLiteral::new)
+                    .map(literal -> new Cast(literal, context.keyType))
+                    .collect(Collectors.toList());
+
+            Symbol randomPartSymbol = symbolAllocator.newSymbol("randPart", IntegerType.INTEGER);
+            Symbol partSymbol = symbolAllocator.newSymbol("skewPart", IntegerType.INTEGER);
+
+            ProjectNode newLeftNode = projectProbeSide(joinNode.getLeft(), skewedLeftKey, skewedExpressionValues, randomPartSymbol);
+            UnnestNode newRightNode = unnestBuildSide(joinNode.getRight(), skewedRightKey, skewedExpressionValues, partSymbol);
+
+            JoinNode newJoinNode = rewriteJoinClause(joinNode, newLeftNode, randomPartSymbol, newRightNode, partSymbol);
+
+            return dropAddedSymbols(newJoinNode, ImmutableSet.of(randomPartSymbol, partSymbol));
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/TestExpressionVerifier.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/TestExpressionVerifier.java
@@ -125,6 +125,28 @@ public class TestExpressionVerifier
         assertTrue(verifier.process(expression("y IS DISTINCT FROM x"), expression("b IS DISTINCT FROM a")));
     }
 
+    @Test
+    public void testArrayConstructor()
+    {
+        SymbolAliases symbolAliases = SymbolAliases.builder()
+                .put("a", new SymbolReference("x"))
+                .put("b", new SymbolReference("y"))
+                .build();
+
+        ExpressionVerifier verifier = new ExpressionVerifier(symbolAliases);
+
+        // Complete match flat
+        assertTrue(verifier.process(expression("ARRAY[1,2,3]"), expression("ARRAY[1,2,3]")));
+        // Complete match nested
+        assertTrue(verifier.process(expression("ARRAY[ARRAY[1,2,3]]"), expression("ARRAY[ARRAY[1,2,3]]")));
+        // Different value on right
+        assertFalse(verifier.process(expression("ARRAY[ARRAY[1,2,3]]"), expression("ARRAY[ARRAY[1,2,4]]")));
+        // Different value on left
+        assertFalse(verifier.process(expression("ARRAY[ARRAY[1,2,4]]"), expression("ARRAY[ARRAY[1,2,3]]")));
+        // Different size
+        assertFalse(verifier.process(expression("ARRAY[ARRAY[1,2]]"), expression("ARRAY[ARRAY[1,2,3]]")));
+    }
+
     private Expression expression(String sql)
     {
         return rewriteIdentifiersToSymbolReferences(parser.createExpression(sql, new ParsingOptions()));

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestSkewJoinOptimizer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestSkewJoinOptimizer.java
@@ -1,0 +1,291 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.sql.planner.optimizations;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.cost.CachingTableStatsProvider;
+import io.trino.cost.StatsAndCosts;
+import io.trino.execution.warnings.WarningCollector;
+import io.trino.metadata.Metadata;
+import io.trino.metadata.TableHandle;
+import io.trino.plugin.tpch.TpchColumnHandle;
+import io.trino.plugin.tpch.TpchTableHandle;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.planner.Plan;
+import io.trino.sql.planner.PlanNodeIdAllocator;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.SymbolAllocator;
+import io.trino.sql.planner.assertions.BasePlanTest;
+import io.trino.sql.planner.assertions.PlanAssert;
+import io.trino.sql.planner.assertions.PlanMatchPattern;
+import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
+import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.TableScanNode;
+import io.trino.testing.TestingTransactionHandle;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.trino.SessionTestUtils.TEST_SESSION;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.UnnestMapping.unnestMapping;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.sort;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.unnest;
+import static io.trino.testing.TestingHandles.TEST_CATALOG_HANDLE;
+
+@Test(singleThreaded = true)
+public class TestSkewJoinOptimizer
+        extends BasePlanTest
+{
+    private PlannerContext plannerContext;
+    private Metadata metadata;
+    private PlanBuilder builder;
+    private Symbol lineitemOrderKeySymbol;
+    private TableScanNode lineitemTableScanNode;
+    private TableHandle lineitemTableHandle;
+    private Symbol ordersOrderKeySymbol;
+    private TableScanNode ordersTableScanNode;
+
+    public TestSkewJoinOptimizer()
+    {
+        super(ImmutableMap.of(
+                "skewed_join_metadata", String.format("[[\"%s.sf1.orders\", \"orderkey\", \"11\", \"42\"]]", TEST_CATALOG_HANDLE.getCatalogName())));
+    }
+
+    @BeforeClass
+    public void setup()
+    {
+        plannerContext = getQueryRunner().getPlannerContext();
+        metadata = plannerContext.getMetadata();
+        builder = new PlanBuilder(new PlanNodeIdAllocator(), metadata, TEST_SESSION);
+        lineitemTableHandle = new TableHandle(
+                TEST_CATALOG_HANDLE,
+                new TpchTableHandle("sf1", "lineitem", 1.0),
+                TestingTransactionHandle.create());
+        lineitemOrderKeySymbol = builder.symbol("LINEITEM_OK", BIGINT);
+        lineitemTableScanNode = builder.tableScan(lineitemTableHandle, ImmutableList.of(lineitemOrderKeySymbol), ImmutableMap.of(lineitemOrderKeySymbol, new TpchColumnHandle("orderkey", BIGINT)));
+
+        TableHandle ordersTableHandle = new TableHandle(
+                TEST_CATALOG_HANDLE,
+                new TpchTableHandle("sf1", "orders", 1.0),
+                TestingTransactionHandle.create());
+        ordersOrderKeySymbol = builder.symbol("ORDERS_OK", BIGINT);
+        ordersTableScanNode = builder.tableScan(ordersTableHandle, ImmutableList.of(ordersOrderKeySymbol), ImmutableMap.of(ordersOrderKeySymbol, new TpchColumnHandle("orderkey", BIGINT)));
+    }
+
+    @Test
+    public void testSkewJoinOptimizer()
+    {
+        PlanNode actualQuery = builder.join(
+                JoinNode.Type.INNER,
+                ordersTableScanNode,
+                lineitemTableScanNode,
+                ImmutableList.of(new JoinNode.EquiJoinClause(ordersOrderKeySymbol, lineitemOrderKeySymbol)),
+                ordersTableScanNode.getOutputSymbols(),
+                lineitemTableScanNode.getOutputSymbols(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(JoinNode.DistributionType.PARTITIONED),
+                ImmutableMap.of());
+
+        assertPlan(optimizeSkewedJoins(actualQuery),
+                project(
+                        ImmutableMap.of("ORDERS_OK", expression("ORDERS_OK")),
+                        join(
+                                JoinNode.Type.INNER, builder -> builder
+                                        .equiCriteria(ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK"), equiJoinClause("randPart", "skewPart")))
+                                        .left(
+                                                project(ImmutableMap.of("randPart", expression("IF((\"ORDERS_OK\" IN (CAST('11' AS bigint), CAST('42' AS bigint))), random(2), TINYINT '0')"), "ORDERS_OK", expression("ORDERS_OK")),
+                                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))))
+                                        .right(
+                                                unnest(
+                                                        ImmutableList.of("LINEITEM_OK"),
+                                                        ImmutableList.of(unnestMapping("skewPartitioner", ImmutableList.of("skewPart"))),
+                                                        project(ImmutableMap.of("skewPartitioner", expression("IF((\"LINEITEM_OK\" IN (CAST('11' AS bigint), CAST('42' AS bigint))), \"$array\"(TINYINT '0', TINYINT '1', TINYINT '2'), \"$array\"(TINYINT '0'))"), "LINEITEM_OK", expression("LINEITEM_OK")),
+                                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))))));
+    }
+
+    @Test
+    public void testSkewJoinOptimizerPassesThroughNodes()
+    {
+        PlanNode leftSort = builder.sort(ImmutableList.of(ordersOrderKeySymbol), ordersTableScanNode);
+
+        PlanNode rightFilterProject = builder.filter(PlanBuilder.expression("LINEITEM_OK > 10"), builder.project(
+                Assignments.of(builder.symbol("LINEITEM_OK"), PlanBuilder.expression("orderkey")),
+                lineitemTableScanNode));
+
+        PlanNode actualQuery = builder.join(
+                JoinNode.Type.INNER,
+                leftSort,
+                rightFilterProject,
+                ImmutableList.of(new JoinNode.EquiJoinClause(ordersOrderKeySymbol, lineitemOrderKeySymbol)),
+                ordersTableScanNode.getOutputSymbols(),
+                lineitemTableScanNode.getOutputSymbols(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(JoinNode.DistributionType.PARTITIONED),
+                ImmutableMap.of());
+
+        PlanMatchPattern expectedLeftSort = sort(tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")));
+        PlanMatchPattern expectedRightFilterProject = filter("LINEITEM_OK > 10", project(tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))));
+
+        assertPlan(optimizeSkewedJoins(actualQuery),
+                project(
+                        ImmutableMap.of("ORDERS_OK", expression("ORDERS_OK")),
+                        join(JoinNode.Type.INNER, builder -> builder
+                                .equiCriteria(ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK"), equiJoinClause("randPart", "skewPart")))
+                                .left(
+                                        project(ImmutableMap.of("randPart", expression("IF((\"ORDERS_OK\" IN (CAST('11' AS bigint), CAST('42' AS bigint))), random(2), TINYINT '0')"), "ORDERS_OK", expression("ORDERS_OK")),
+                                                expectedLeftSort))
+                                .right(
+                                        unnest(
+                                                ImmutableList.of("LINEITEM_OK"),
+                                                ImmutableList.of(unnestMapping("skewPartitioner", ImmutableList.of("skewPart"))),
+                                                project(ImmutableMap.of("skewPartitioner", expression("IF((\"LINEITEM_OK\" IN (CAST('11' AS bigint), CAST('42' AS bigint))), \"$array\"(TINYINT '0', TINYINT '1', TINYINT '2'), \"$array\"(TINYINT '0'))"), "LINEITEM_OK", expression("LINEITEM_OK")),
+                                                        expectedRightFilterProject))))));
+    }
+
+    @Test
+    public void testSkewJoinOptimizerReplicatedJoinsNotOptimized()
+    {
+        PlanNode actualQuery = builder.join(
+                JoinNode.Type.INNER,
+                ordersTableScanNode,
+                lineitemTableScanNode,
+                ImmutableList.of(new JoinNode.EquiJoinClause(ordersOrderKeySymbol, lineitemOrderKeySymbol)),
+                ordersTableScanNode.getOutputSymbols(),
+                lineitemTableScanNode.getOutputSymbols(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(JoinNode.DistributionType.REPLICATED),
+                ImmutableMap.of());
+
+        assertPlan(optimizeSkewedJoins(actualQuery),
+                join(JoinNode.Type.INNER, builder -> builder
+                        .equiCriteria("ORDERS_OK", "LINEITEM_OK")
+                        .left(tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))
+                        .right(tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))));
+    }
+
+    @Test
+    public void testSkewJoinOptimizerRightJoinsNotOptimized()
+    {
+        PlanNode actualQuery = builder.join(
+                JoinNode.Type.RIGHT,
+                ordersTableScanNode,
+                lineitemTableScanNode,
+                ImmutableList.of(new JoinNode.EquiJoinClause(ordersOrderKeySymbol, lineitemOrderKeySymbol)),
+                ordersTableScanNode.getOutputSymbols(),
+                lineitemTableScanNode.getOutputSymbols(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(JoinNode.DistributionType.PARTITIONED),
+                ImmutableMap.of());
+
+        assertPlan(optimizeSkewedJoins(actualQuery),
+                join(JoinNode.Type.RIGHT, builder -> builder
+                        .equiCriteria("ORDERS_OK", "LINEITEM_OK")
+                        .left(tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))
+                        .right(tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))));
+    }
+
+    @Test
+    public void testSkewJoinOptimizerNestedJoin()
+    {
+        PlanNode childJoin = builder.join(
+                JoinNode.Type.INNER,
+                ordersTableScanNode,
+                lineitemTableScanNode,
+                ImmutableList.of(new JoinNode.EquiJoinClause(ordersOrderKeySymbol, lineitemOrderKeySymbol)),
+                ordersTableScanNode.getOutputSymbols(),
+                lineitemTableScanNode.getOutputSymbols(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(JoinNode.DistributionType.PARTITIONED),
+                ImmutableMap.of());
+
+        PlanNode actualQuery = builder.join(
+                JoinNode.Type.INNER,
+                childJoin,
+                lineitemTableScanNode,
+                ImmutableList.of(new JoinNode.EquiJoinClause(ordersOrderKeySymbol, lineitemOrderKeySymbol)),
+                childJoin.getOutputSymbols(),
+                lineitemTableScanNode.getOutputSymbols(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(JoinNode.DistributionType.PARTITIONED),
+                ImmutableMap.of());
+
+        assertPlan(optimizeSkewedJoins(actualQuery),
+                join(JoinNode.Type.INNER, builder -> builder
+                        .equiCriteria("ORDERS_OK", "LINEITEM_OK")
+                        .left(
+                                project(
+                                        ImmutableMap.of("ORDERS_OK", expression("ORDERS_OK")),
+                                        join(JoinNode.Type.INNER, childBuilder -> childBuilder
+                                                .equiCriteria(ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK"), equiJoinClause("randPart", "skewPart")))
+                                                .left(
+                                                        project(ImmutableMap.of("randPart", expression("IF((\"ORDERS_OK\" IN (CAST('11' AS bigint), CAST('42' AS bigint))), random(2), TINYINT '0')"), "ORDERS_OK", expression("ORDERS_OK")),
+                                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))))
+                                                .right(
+                                                        unnest(
+                                                                ImmutableList.of("LINEITEM_OK"),
+                                                                ImmutableList.of(unnestMapping("skewPartitioner", ImmutableList.of("skewPart"))),
+                                                                project(ImmutableMap.of("skewPartitioner", expression("IF((\"LINEITEM_OK\" IN (CAST('11' AS bigint), CAST('42' AS bigint))), \"$array\"(TINYINT '0', TINYINT '1', TINYINT '2'), \"$array\"(TINYINT '0'))"), "LINEITEM_OK", expression("LINEITEM_OK")),
+                                                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))))))
+                        .right(tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))));
+    }
+
+    private PlanNode optimizeSkewedJoins(PlanNode root)
+    {
+        return getQueryRunner().inTransaction(session -> {
+            // metadata.getCatalogHandle() registers the catalog for the transaction
+            session.getCatalog().ifPresent(catalog -> metadata.getCatalogHandle(session, catalog));
+            return new SkewJoinOptimizer(metadata).optimize(root, session, builder.getTypes(), new SymbolAllocator(), new PlanNodeIdAllocator(), WarningCollector.NOOP, new CachingTableStatsProvider(metadata, session));
+        });
+    }
+
+    void assertPlan(PlanNode actual, PlanMatchPattern pattern)
+    {
+        getQueryRunner().inTransaction(session -> {
+            // metadata.getCatalogHandle() registers the catalog for the transaction
+            session.getCatalog().ifPresent(catalog -> metadata.getCatalogHandle(session, catalog));
+            PlanAssert.assertPlan(
+                    session,
+                    metadata,
+                    getQueryRunner().getFunctionManager(),
+                    getQueryRunner().getStatsCalculator(),
+                    new Plan(actual, builder.getTypes(), StatsAndCosts.empty()),
+                    pattern);
+            return null;
+        });
+    }
+}

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestSkewJoinQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestSkewJoinQueries.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.tests;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.tests.tpch.TpchQueryRunnerBuilder;
+import org.testng.annotations.Test;
+
+public class TestSkewJoinQueries
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return TpchQueryRunnerBuilder.builder()
+                .setCoordinatorProperties(ImmutableMap.of("optimizer.join-reordering-strategy", "NONE"))
+                .amendSession(builder -> builder.setSystemProperty("skewed_join_metadata", "[[\"tpch.tiny.orders\", \"orderkey\", \"1\"]]"))
+                .build();
+    }
+
+    @Test
+    public void testEnsureSkewedKeyExists()
+    {
+        assertQuery("SELECT orderkey FROM orders WHERE orderkey = 1 LIMIT 1", "VALUES 1");
+    }
+
+    @Test
+    public void testSkewedLeftJoin()
+    {
+        String sql = """
+                SELECT o.orderkey, SUM(l.suppkey) FROM orders o LEFT JOIN lineitem l ON o.orderkey = l.orderkey
+                WHERE l.suppkey > 10 GROUP BY o.orderkey ORDER BY 2 DESC LIMIT 10
+                """;
+        assertExplain("EXPLAIN " + sql, "\\QInnerJoin[criteria = (\"orderkey\" = \"orderkey_1\") AND (\"randpart\" = \"skewpart\"), hash");
+        assertQuery(sql);
+    }
+
+    @Test
+    public void testSkewedInnerJoin()
+    {
+        String sql = """
+                SELECT o.orderkey, SUM(l.suppkey) FROM orders o INNER JOIN lineitem l ON o.orderkey = l.orderkey
+                WHERE l.suppkey > 10 GROUP BY o.orderkey ORDER BY 2 DESC LIMIT 10
+                """;
+        assertExplain("EXPLAIN " + sql, "\\QInnerJoin[criteria = (\"orderkey\" = \"orderkey_1\") AND (\"randpart\" = \"skewpart\"), hash");
+        assertQuery(sql);
+    }
+
+    @Test
+    public void testNestedInnerJoin()
+    {
+        assertQuery("""
+            SELECT o.orderkey, SUM(l.suppkey) FROM orders o INNER JOIN lineitem l ON o.orderkey = l.orderkey
+            WHERE l.suppkey > 10 GROUP BY o.orderkey ORDER BY 2 DESC LIMIT 10""");
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Overview
This PR introduces a new optimization rule to handle joins where keys have a skewed distribution (some keys are much more frequent than others) using the salted join technique.

<img width="727" alt="image" src="https://user-images.githubusercontent.com/422763/181656656-5f23c57b-5428-476d-a0cc-f0635e1cd4b4.png">


here are the steps for breaking up skew in the optimizer:

- User provides the name of the skewed column that they want to join on and the values of keys that are skewed.
- On the left side a new column is created called `randPart`, for the skewed rows `randPart=random(N)` where N is the number of buckets to partition skew. for non-skewed rows `randPart=0` 
- On the right side we create N copies of rows with skewed values and assign them a `skewPart` of 0,1,..N respectively
- Add an additional condition to the join clause to join on `left.randPart = right.skewPart`
- Drop `randPart` column after the join 

see https://github.com/trinodb/trino/issues/1261 for further discussion

## Assumptions 

- The rule only applies to inner joins and left joins, other join types will have errors because of the duplicate rows on the right side.
- I'm only considering partitioned joins because there won't be much benefit for replicated joins as they are fast enough.
- For now i've made the decision to not handle the case where the skew is on the right side. but i think in the future we can generalize the optimizer to handle skew in either side.
- The optimizer traverses the plan to find all symbols that reference skewed symbols and propagates this information through nodes. it does not propagate skewed symbols through JoinNodes, so a join on a skewed join will not be rewritten even if it references a skewed symbol. Nested joins are currently out of scope because it is possible for joins to alter the distribution of skewness. However nesting joins against a skewed fact table is a popular pattern in queries. We should tackle this in future extensions to this work.


## Details of the changes

**SystemSessionProperties.java** 

Introduces two new session variables

- SKEWED_JOIN_METADATA: This is an array of arrays of the form Array[Array[tablename, skewedcolumn, skewedvalue, skewedvalue]]
- SKEWED_JOIN_REPLICATION_FACTOR: The number of buckets to partition skewed rows by, defaults to 3.

**SkewJoinOptimizer.java**

- SkewJoinConfig: Parses the session variables for and extracts the table, column and skewed values.
- PlanRewriter: Traverses the plan and finds all skewed symbols that might reference the user specified skewed column. When it finds a join that uses a skewed symbol it rewrites it.
- JoinRewriter: Rewrites skewed joins with a new join that has its left side projected with a random symbol and the right side unnested to produce duplicated rows, also modifies the join clause to include the random symbols.

## Future work
- Use a hint framework to specify the configuration rather than session variables, that way we don't need to traverse the plan to find join nodes and symbols.
- Handle skew on the right side as well.
- Handle nested joins.
- We can extend a similar pattern to handle range joins, im going to be exploring this angle.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

related to: https://github.com/trinodb/trino/issues/1261

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Introduced a skew join optimizer. ({issue} https://github.com/trinodb/trino/issues/1261)
```

cc: @amoghmargoor 