### PR TITLE
Fix incorrect min and max stats when writing NULL in Delta Lake

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeParquetStatisticsUtils.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeParquetStatisticsUtils.java
@@ -94,7 +94,7 @@ public class DeltaLakeParquetStatisticsUtils
 
     private static Optional<Object> getMin(Type type, Statistics<?> statistics)
     {
-        if (statistics.genericGetMin() == null) {
+        if (statistics.genericGetMin() == null || !statistics.hasNonNullValue()) {
             return Optional.empty();
         }
 
@@ -171,7 +171,7 @@ public class DeltaLakeParquetStatisticsUtils
 
     private static Optional<Object> getMax(Type type, Statistics<?> statistics)
     {
-        if (statistics.genericGetMax() == null) {
+        if (statistics.genericGetMax() == null || !statistics.hasNonNullValue()) {
             return Optional.empty();
         }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeTableStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeTableStatistics.java
@@ -140,4 +140,16 @@ public class TestDeltaLakeTableStatistics
                         "('val_col', null, null, 0.0, null, 23, 26)," +
                         "(null, null, null, null, 3.0, null, null)");
     }
+
+    @Test
+    public void testShowStatsForAllNullColumn()
+    {
+        assertUpdate("CREATE TABLE show_stats_with_null AS SELECT CAST(NULL AS INT) col", 1);
+        assertQuery(
+                "SHOW STATS FOR show_stats_with_null",
+                "VALUES " +
+                        //  column_name | data_size | distinct_values_count | nulls_fraction | row_count | low_value | high_value
+                        "('col', 0.0, null, 1.0, null, null, null)," +
+                        "(null, null, null, null, 1.0, null, null)");
+    }
 }


### PR DESCRIPTION
## Description

Fix incorrect min and max stats when writing NULL in Delta Lake
Fixes #13389

## Documentation

(x) No documentation is needed.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Delta Lake
* Fix storing incorrect min and max stats when writing `NULL`. ({issue}`13389`)
```
