### PR TITLE
Remove LIKE operator reference from regexp_like doc

### DIFF
--- a/docs/src/main/sphinx/functions/regexp.rst
+++ b/docs/src/main/sphinx/functions/regexp.rst
@@ -82,11 +82,10 @@ with a few notable exceptions:
     Evaluates the regular expression ``pattern`` and determines if it is
     contained within ``string``.
 
-    This function is similar to the ``LIKE`` operator, except that the
-    pattern only needs to be contained within ``string``, rather than
-    needing to match all of ``string``. In other words, this performs a
-    *contains* operation rather than a *match* operation. You can match
-    the entire string by anchoring the pattern using ``^`` and ``$``::
+    The ``pattern`` only needs to be contained within
+    ``string``, rather than needing to match all of ``string``. In other words,
+    this performs a *contains* operation rather than a *match* operation. You can
+    match the entire string by anchoring the pattern using ``^`` and ``$``::
 
         SELECT regexp_like('1a 2b 14m', '\d+b'); -- true
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Regular expressions documentation

> How would you describe this change to a non-technical end user or system administrator?

Removes references to the LIKE operator which can cause confusion for those who are familiar with the RLIKE operator from Hive and MySQL.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
