### PR TITLE
Minor improvement in Pinot config classes

### DIFF
--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotConfig.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotConfig.java
@@ -23,6 +23,7 @@ import io.airlift.units.Duration;
 import io.airlift.units.MinDuration;
 
 import javax.annotation.PostConstruct;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
 import java.net.URI;
@@ -64,7 +65,7 @@ public class PinotConfig
     private boolean grpcEnabled = true;
     private DataSize targetSegmentPageSize = DataSize.of(1, MEGABYTE);
 
-    @NotNull
+    @NotEmpty(message = "pinot.controller-urls cannot be empty")
     public List<URI> getControllerUrls()
     {
         return controllerUrls;

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotClient.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotClient.java
@@ -90,7 +90,6 @@ import static io.airlift.json.JsonCodec.mapJsonCodec;
 import static io.trino.collect.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.plugin.pinot.PinotErrorCode.PINOT_AMBIGUOUS_TABLE_NAME;
 import static io.trino.plugin.pinot.PinotErrorCode.PINOT_EXCEPTION;
-import static io.trino.plugin.pinot.PinotErrorCode.PINOT_INVALID_CONFIGURATION;
 import static io.trino.plugin.pinot.PinotErrorCode.PINOT_UNABLE_TO_FIND_BROKER;
 import static io.trino.plugin.pinot.PinotMetadata.SCHEMA_NAME;
 import static java.lang.String.format;
@@ -152,9 +151,6 @@ public class PinotClient
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)).jsonCodec(Schema.class);
         this.brokerResponseCodec = requireNonNull(brokerResponseCodec, "brokerResponseCodec is null");
         requireNonNull(config, "config is null");
-        if (config.getControllerUrls() == null || config.getControllerUrls().isEmpty()) {
-            throw new PinotException(PINOT_INVALID_CONFIGURATION, Optional.empty(), "No pinot controllers specified");
-        }
         this.pinotHostMapper = requireNonNull(pinotHostMapper, "pinotHostMapper is null");
 
         this.controllerUrls = config.getControllerUrls();

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotGrpcServerQueryClientTlsConfig.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotGrpcServerQueryClientTlsConfig.java
@@ -14,14 +14,21 @@
 package io.trino.plugin.pinot;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.inject.ConfigurationException;
 import io.airlift.configuration.testing.ConfigAssertions;
 import io.trino.plugin.pinot.client.PinotGrpcServerQueryClientTlsConfig;
 import org.testng.annotations.Test;
 
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 
 import static io.trino.plugin.pinot.client.PinotKeystoreTrustStoreType.JKS;
 import static io.trino.plugin.pinot.client.PinotKeystoreTrustStoreType.PKCS12;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestPinotGrpcServerQueryClientTlsConfig
 {
@@ -41,24 +48,68 @@ public class TestPinotGrpcServerQueryClientTlsConfig
 
     @Test
     public void testExplicitPropertyMappings()
+            throws Exception
     {
+        Path keystoreFile = Files.createTempFile(null, null);
+        Path truststoreFile = Files.createTempFile(null, null);
+
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("pinot.grpc.tls.keystore-type", "PKCS12")
-                .put("pinot.grpc.tls.keystore-path", "/root")
+                .put("pinot.grpc.tls.keystore-path", keystoreFile.toString())
                 .put("pinot.grpc.tls.keystore-password", "password")
                 .put("pinot.grpc.tls.truststore-type", "PKCS12")
-                .put("pinot.grpc.tls.truststore-path", "/root")
+                .put("pinot.grpc.tls.truststore-path", truststoreFile.toString())
                 .put("pinot.grpc.tls.truststore-password", "password")
                 .put("pinot.grpc.tls.ssl-provider", "OPENSSL")
                 .buildOrThrow();
         PinotGrpcServerQueryClientTlsConfig expected = new PinotGrpcServerQueryClientTlsConfig()
                 .setKeystoreType(PKCS12)
-                .setKeystorePath("/root")
+                .setKeystorePath(keystoreFile.toFile())
                 .setKeystorePassword("password")
                 .setTruststoreType(PKCS12)
-                .setTruststorePath("/root")
+                .setTruststorePath(truststoreFile.toFile())
                 .setTruststorePassword("password")
                 .setSslProvider("OPENSSL");
         ConfigAssertions.assertFullMapping(properties, expected);
+    }
+
+    @Test
+    public void testFailOnMissingKeystorePasswordWithKeystorePathSet()
+            throws Exception
+    {
+        String secret = "pinot";
+        Path keystorePath = Files.createTempFile("keystore", ".p12");
+
+        writeToFile(keystorePath, secret);
+
+        PinotGrpcServerQueryClientTlsConfig config = new PinotGrpcServerQueryClientTlsConfig();
+        config.setKeystorePath(keystorePath.toFile());
+        assertThatThrownBy(config::validate)
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageContaining("pinot.grpc.tls.keystore-password must set when pinot.grpc.tls.keystore-path is given");
+    }
+
+    @Test
+    public void testFailOnMissingTruststorePasswordWithTruststorePathSet()
+            throws Exception
+    {
+        String secret = "pinot";
+        Path truststorePath = Files.createTempFile("truststore", ".p12");
+
+        writeToFile(truststorePath, secret);
+
+        PinotGrpcServerQueryClientTlsConfig config = new PinotGrpcServerQueryClientTlsConfig();
+        config.setTruststorePath(truststorePath.toFile());
+        assertThatThrownBy(config::validate)
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageContaining("pinot.grpc.tls.truststore-password must set when pinot.grpc.tls.truststore-path is given");
+    }
+
+    private void writeToFile(Path filepath, String content)
+            throws IOException
+    {
+        try (FileWriter writer = new FileWriter(filepath.toFile(), UTF_8)) {
+            writer.write(content);
+        }
     }
 }


### PR DESCRIPTION
## Description

Minor improvement in Pinot config classes

## Documentation

(x) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# Pinot
* Redact the value of `pinot.grpc.tls.keystore-password` and `pinot.grpc.tls.truststore-password` in the server log. ({issue}`13422`)
```
