### PR TITLE
Added all_files system table to the Iceberg connector

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -928,6 +928,83 @@ The output of the query has the following columns:
     - Metadata about the encryption key used to encrypt this file, if applicable
   * - ``split_offsets``
     - ``array(bigint)``
+    - List of recommended split locations.
+  * - ``equality_ids``
+    - ``array(integer)``
+    - The set of field IDs used for equality comparison in equality delete files
+
+``$all_files`` table
+^^^^^^^^^^^^^^^^^^^^
+
+The ``$all_files`` table exposes the valid data files of the Iceberg table.
+A valid data file is one that is readable from any snapshot currently tracked by the table.
+
+To retrieve the information about the data files from all the snapshots of the Iceberg table ``test_table`` use the following query::
+
+    SELECT * FROM "test_table$all_files"
+
+The output of the query has the columns, which is similar to the ``$files`` metadata table.
+
+.. code-block:: text
+
+     content  | file_path                                                                                                                     | record_count    | file_format   | file_size_in_bytes   |  column_sizes        |  value_counts     |  null_value_counts | nan_value_counts  | lower_bounds                |  upper_bounds               |  key_metadata  | split_offsets  |  equality_ids
+    ----------+-------------------------------------------------------------------------------------------------------------------------------+-----------------+---------------+----------------------+----------------------+-------------------+--------------------+-------------------+-----------------------------+-----------------------------+----------------+----------------+---------------
+     0        | hdfs://hadoop-master:9000/user/hive/warehouse/test_table/data/c1=3/c2=2021-01-14/af9872b2-40f3-428f-9c87-186d2750d84e.parquet |  1              |  PARQUET      |  442                 | {1=40, 2=40, 3=44}   |  {1=1, 2=1, 3=1}  |  {1=0, 2=0, 3=0}   | <null>            |  {1=3, 2=2021-01-14, 3=1.3} |  {1=3, 2=2021-01-14, 3=1.3} |  <null>        | <null>         |   <null>
+     0        | hdfs://hadoop-master:9000/user/hive/warehouse/test_table/data/c1=3/c2=2021-01-14/af9872b2-40f3-428f-9c87-186d2750d84e.parquet |  1              |  PARQUET      |  442                 | {1=40, 2=40, 3=44}   |  {1=1, 2=1, 3=1}  |  {1=0, 2=0, 3=0}   | <null>            |  {1=3, 2=2021-01-14, 3=1.3} |  {1=3, 2=2021-01-14, 3=1.2} |  <null>        | <null>         |   <null>
+     0        | hdfs://hadoop-master:9000/user/hive/warehouse/test_table/data/c1=3/c2=2021-01-15/af9872b2-40f3-428f-9c87-186d2718d90f.parquet |  1              |  PARQUET      |  256                 | {1=40, 2=40, 3=40}   |  {1=1, 2=0, 3=1}  |  {1=0, 2=0, 3=0}   | <null>            |  {1=3, 2=2021-01-15, 3=1.3} |  {1=3, 2=2021-01-14, 3=1.3} |  <null>        | <null>         |   <null>
+
+The output of the query has the following columns:
+
+.. list-table:: Files columns
+  :widths: 25, 30, 45
+  :header-rows: 1
+
+  * - Name
+    - Type
+    - Description
+  * - ``content``
+    - ``integer``
+    - Type of content stored in the file.
+      The supported content types in Iceberg are:
+
+      * ``DATA(0)``
+      * ``POSITION_DELETES(1)``
+      * ``EQUALITY_DELETES(2)``
+  * - ``file_path``
+    - ``varchar``
+    - The data file location
+  * - ``file_format``
+    - ``varchar``
+    - The format of the data file
+  * - ``record_count``
+    - ``bigint``
+    - The number of entries contained in the data file
+  * - ``file_size_in_bytes``
+    - ``bigint``
+    - The data file size
+  * - ``column_sizes``
+    - ``map(integer, bigint)``
+    - Mapping between the Iceberg column ID and its corresponding size in the file
+  * - ``value_counts``
+    - ``map(integer, bigint)``
+    - Mapping between the Iceberg column ID and its corresponding count of entries in the file
+  * - ``null_value_counts``
+    - ``map(integer, bigint)``
+    - Mapping between the Iceberg column ID and its corresponding count of ``NULL`` values in the file
+  * - ``nan_value_counts``
+    - ``map(integer, bigint)``
+    - Mapping between the Iceberg column ID and its corresponding count of non numerical values in the file
+  * - ``lower_bounds``
+    - ``map(integer, bigint)``
+    - Mapping between the Iceberg column ID and its corresponding lower bound in the file
+  * - ``upper_bounds``
+    - ``map(integer, bigint)``
+    - Mapping between the Iceberg column ID and its corresponding upper bound in the file
+  * - ``key_metadata``
+    - ``varbinary``
+    - Metadata about the encryption key used to encrypt this file, if applicable
+  * - ``split_offsets``
+    - ``array(bigint)``
     - List of recommended split locations
   * - ``equality_ids``
     - ``array(integer)``

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/AbstractFilesTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/AbstractFilesTable.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slices;
+import io.trino.plugin.iceberg.util.PageListBuilder;
+import io.trino.spi.Page;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.FixedPageSource;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.SystemTable;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.TypeManager;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.transforms.Transforms;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.TypeSignature.mapType;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.util.Objects.requireNonNull;
+
+public abstract class AbstractFilesTable
+        implements SystemTable
+{
+    private final ConnectorTableMetadata tableMetadata;
+    private final Table icebergTable;
+
+    public AbstractFilesTable(SchemaTableName tableName, TypeManager typeManager, Table icebergTable)
+    {
+        requireNonNull(tableName, "tableName is null");
+        requireNonNull(typeManager, "typeManager is null");
+        this.tableMetadata = tableMetadata(tableName, typeManager);
+        this.icebergTable = requireNonNull(icebergTable, "icebergTable is null");
+    }
+
+    @Override
+    public Distribution getDistribution()
+    {
+        return Distribution.SINGLE_COORDINATOR;
+    }
+
+    @Override
+    public ConnectorTableMetadata getTableMetadata()
+    {
+        return tableMetadata;
+    }
+
+    @Override
+    public ConnectorPageSource pageSource(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
+    {
+        return new FixedPageSource(buildPages());
+    }
+
+    protected abstract TableScan buildTableScan();
+
+    protected Table getIcebergTable()
+    {
+        return icebergTable;
+    }
+
+    private List<Page> buildPages()
+    {
+        PageListBuilder pagesBuilder = PageListBuilder.forTable(tableMetadata);
+        Map<Integer, Type> idToTypeMapping = getIcebergIdToTypeMapping(icebergTable.schema());
+        TableScan tableScan = buildTableScan();
+
+        tableScan.planFiles().forEach(fileScanTask -> {
+            addRow(pagesBuilder, idToTypeMapping, fileScanTask.file());
+        });
+
+        return pagesBuilder.build();
+    }
+
+    private void addRow(PageListBuilder pagesBuilder, Map<Integer, Type> idToTypeMapping, DataFile dataFile)
+    {
+        pagesBuilder.beginRow();
+        pagesBuilder.appendInteger(dataFile.content().id());
+        pagesBuilder.appendVarchar(dataFile.path().toString());
+        pagesBuilder.appendVarchar(dataFile.format().name());
+        pagesBuilder.appendBigint(dataFile.recordCount());
+        pagesBuilder.appendBigint(dataFile.fileSizeInBytes());
+        if (checkNonNull(dataFile.columnSizes(), pagesBuilder)) {
+            pagesBuilder.appendIntegerBigintMap(dataFile.columnSizes());
+        }
+        if (checkNonNull(dataFile.valueCounts(), pagesBuilder)) {
+            pagesBuilder.appendIntegerBigintMap(dataFile.valueCounts());
+        }
+        if (checkNonNull(dataFile.nullValueCounts(), pagesBuilder)) {
+            pagesBuilder.appendIntegerBigintMap(dataFile.nullValueCounts());
+        }
+        if (checkNonNull(dataFile.nanValueCounts(), pagesBuilder)) {
+            pagesBuilder.appendIntegerBigintMap(dataFile.nanValueCounts());
+        }
+        if (checkNonNull(dataFile.lowerBounds(), pagesBuilder)) {
+            pagesBuilder.appendIntegerVarcharMap(dataFile.lowerBounds().entrySet().stream()
+                    .filter(entry -> idToTypeMapping.containsKey(entry.getKey()))
+                    .collect(toImmutableMap(
+                            Map.Entry<Integer, ByteBuffer>::getKey,
+                            entry -> Transforms.identity(idToTypeMapping.get(entry.getKey())).toHumanString(
+                                    Conversions.fromByteBuffer(idToTypeMapping.get(entry.getKey()), entry.getValue())))));
+        }
+        if (checkNonNull(dataFile.upperBounds(), pagesBuilder)) {
+            pagesBuilder.appendIntegerVarcharMap(dataFile.upperBounds().entrySet().stream()
+                    .filter(entry -> idToTypeMapping.containsKey(entry.getKey()))
+                    .collect(toImmutableMap(
+                            Map.Entry<Integer, ByteBuffer>::getKey,
+                            entry -> Transforms.identity(idToTypeMapping.get(entry.getKey())).toHumanString(
+                                    Conversions.fromByteBuffer(idToTypeMapping.get(entry.getKey()), entry.getValue())))));
+        }
+        if (checkNonNull(dataFile.keyMetadata(), pagesBuilder)) {
+            pagesBuilder.appendVarbinary(Slices.wrappedBuffer(dataFile.keyMetadata()));
+        }
+        if (checkNonNull(dataFile.splitOffsets(), pagesBuilder)) {
+            pagesBuilder.appendBigintArray(dataFile.splitOffsets());
+        }
+        if (checkNonNull(dataFile.equalityFieldIds(), pagesBuilder)) {
+            pagesBuilder.appendIntegerArray(dataFile.equalityFieldIds());
+        }
+        pagesBuilder.endRow();
+    }
+
+    private ConnectorTableMetadata tableMetadata(SchemaTableName tableName, TypeManager typeManager)
+    {
+        return new ConnectorTableMetadata(requireNonNull(tableName, "tableName is null"),
+                ImmutableList.<ColumnMetadata>builder()
+                        .add(new ColumnMetadata("content", INTEGER))
+                        .add(new ColumnMetadata("file_path", VARCHAR))
+                        .add(new ColumnMetadata("file_format", VARCHAR))
+                        .add(new ColumnMetadata("record_count", BIGINT))
+                        .add(new ColumnMetadata("file_size_in_bytes", BIGINT))
+                        .add(new ColumnMetadata("column_sizes", typeManager.getType(mapType(INTEGER.getTypeSignature(), BIGINT.getTypeSignature()))))
+                        .add(new ColumnMetadata("value_counts", typeManager.getType(mapType(INTEGER.getTypeSignature(), BIGINT.getTypeSignature()))))
+                        .add(new ColumnMetadata("null_value_counts", typeManager.getType(mapType(INTEGER.getTypeSignature(), BIGINT.getTypeSignature()))))
+                        .add(new ColumnMetadata("nan_value_counts", typeManager.getType(mapType(INTEGER.getTypeSignature(), BIGINT.getTypeSignature()))))
+                        .add(new ColumnMetadata("lower_bounds", typeManager.getType(mapType(INTEGER.getTypeSignature(), VARCHAR.getTypeSignature()))))
+                        .add(new ColumnMetadata("upper_bounds", typeManager.getType(mapType(INTEGER.getTypeSignature(), VARCHAR.getTypeSignature()))))
+                        .add(new ColumnMetadata("key_metadata", VARBINARY))
+                        .add(new ColumnMetadata("split_offsets", new ArrayType(BIGINT)))
+                        .add(new ColumnMetadata("equality_ids", new ArrayType(INTEGER)))
+                        .build());
+    }
+
+    private static boolean checkNonNull(Object object, PageListBuilder pagesBuilder)
+    {
+        if (object == null) {
+            pagesBuilder.appendNull();
+            return false;
+        }
+        return true;
+    }
+
+    private static Map<Integer, Type> getIcebergIdToTypeMapping(Schema schema)
+    {
+        ImmutableMap.Builder<Integer, Type> icebergIdToTypeMapping = ImmutableMap.builder();
+        for (Types.NestedField field : schema.columns()) {
+            populateIcebergIdToTypeMapping(field, icebergIdToTypeMapping);
+        }
+        return icebergIdToTypeMapping.buildOrThrow();
+    }
+
+    private static void populateIcebergIdToTypeMapping(Types.NestedField field, ImmutableMap.Builder<Integer, Type> icebergIdToTypeMapping)
+    {
+        Type type = field.type();
+        icebergIdToTypeMapping.put(field.fieldId(), type);
+        if (type instanceof Type.NestedType) {
+            type.asNestedType().fields().forEach(child -> populateIcebergIdToTypeMapping(child, icebergIdToTypeMapping));
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/AllFilesTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/AllFilesTable.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.type.TypeManager;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableScan;
+
+import static org.apache.iceberg.MetadataTableType.ALL_DATA_FILES;
+import static org.apache.iceberg.MetadataTableUtils.createMetadataTableInstance;
+
+public class AllFilesTable
+        extends AbstractFilesTable
+{
+    public AllFilesTable(SchemaTableName tableName, TypeManager typeManager, Table icebergTable)
+    {
+        super(tableName, typeManager, icebergTable);
+    }
+
+    @Override
+    protected TableScan buildTableScan()
+    {
+        Table filesTable = createMetadataTableInstance(getIcebergTable(), ALL_DATA_FILES);
+
+        TableScan tableScan = filesTable
+                .newScan()
+                .includeColumnStats();
+        return tableScan;
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/FilesTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/FilesTable.java
@@ -14,84 +14,29 @@
 package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import io.airlift.slice.Slices;
-import io.trino.plugin.iceberg.util.PageListBuilder;
-import io.trino.spi.Page;
-import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.ConnectorSession;
-import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.FixedPageSource;
 import io.trino.spi.connector.SchemaTableName;
-import io.trino.spi.connector.SystemTable;
 import io.trino.spi.predicate.TupleDomain;
-import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.TypeManager;
-import org.apache.iceberg.DataFile;
-import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableScan;
-import org.apache.iceberg.transforms.Transforms;
-import org.apache.iceberg.types.Conversions;
-import org.apache.iceberg.types.Type;
-import org.apache.iceberg.types.Types;
 
-import java.nio.ByteBuffer;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static io.trino.spi.type.BigintType.BIGINT;
-import static io.trino.spi.type.IntegerType.INTEGER;
-import static io.trino.spi.type.TypeSignature.mapType;
-import static io.trino.spi.type.VarbinaryType.VARBINARY;
-import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.util.Objects.requireNonNull;
 
 public class FilesTable
-        implements SystemTable
+        extends AbstractFilesTable
 {
-    private final ConnectorTableMetadata tableMetadata;
-    private final Table icebergTable;
     private final Optional<Long> snapshotId;
 
     public FilesTable(SchemaTableName tableName, TypeManager typeManager, Table icebergTable, Optional<Long> snapshotId)
     {
-        this.icebergTable = requireNonNull(icebergTable, "icebergTable is null");
-
-        tableMetadata = new ConnectorTableMetadata(requireNonNull(tableName, "tableName is null"),
-                ImmutableList.<ColumnMetadata>builder()
-                        .add(new ColumnMetadata("content", INTEGER))
-                        .add(new ColumnMetadata("file_path", VARCHAR))
-                        .add(new ColumnMetadata("file_format", VARCHAR))
-                        .add(new ColumnMetadata("record_count", BIGINT))
-                        .add(new ColumnMetadata("file_size_in_bytes", BIGINT))
-                        .add(new ColumnMetadata("column_sizes", typeManager.getType(mapType(INTEGER.getTypeSignature(), BIGINT.getTypeSignature()))))
-                        .add(new ColumnMetadata("value_counts", typeManager.getType(mapType(INTEGER.getTypeSignature(), BIGINT.getTypeSignature()))))
-                        .add(new ColumnMetadata("null_value_counts", typeManager.getType(mapType(INTEGER.getTypeSignature(), BIGINT.getTypeSignature()))))
-                        .add(new ColumnMetadata("nan_value_counts", typeManager.getType(mapType(INTEGER.getTypeSignature(), BIGINT.getTypeSignature()))))
-                        .add(new ColumnMetadata("lower_bounds", typeManager.getType(mapType(INTEGER.getTypeSignature(), VARCHAR.getTypeSignature()))))
-                        .add(new ColumnMetadata("upper_bounds", typeManager.getType(mapType(INTEGER.getTypeSignature(), VARCHAR.getTypeSignature()))))
-                        .add(new ColumnMetadata("key_metadata", VARBINARY))
-                        .add(new ColumnMetadata("split_offsets", new ArrayType(BIGINT)))
-                        .add(new ColumnMetadata("equality_ids", new ArrayType(INTEGER)))
-                        .build());
+        super(tableName, typeManager, icebergTable);
         this.snapshotId = requireNonNull(snapshotId, "snapshotId is null");
-    }
-
-    @Override
-    public Distribution getDistribution()
-    {
-        return Distribution.SINGLE_COORDINATOR;
-    }
-
-    @Override
-    public ConnectorTableMetadata getTableMetadata()
-    {
-        return tableMetadata;
     }
 
     @Override
@@ -100,94 +45,14 @@ public class FilesTable
         if (snapshotId.isEmpty()) {
             return new FixedPageSource(ImmutableList.of());
         }
-        return new FixedPageSource(buildPages(tableMetadata, icebergTable, snapshotId.get()));
+        return super.pageSource(transactionHandle, session, constraint);
     }
 
-    private static List<Page> buildPages(ConnectorTableMetadata tableMetadata, Table icebergTable, long snapshotId)
+    @Override
+    protected TableScan buildTableScan()
     {
-        PageListBuilder pagesBuilder = PageListBuilder.forTable(tableMetadata);
-        Map<Integer, Type> idToTypeMapping = getIcebergIdToTypeMapping(icebergTable.schema());
-
-        TableScan tableScan = icebergTable.newScan()
-                .useSnapshot(snapshotId)
+        return getIcebergTable().newScan()
+                .useSnapshot(snapshotId.get())
                 .includeColumnStats();
-
-        tableScan.planFiles().forEach(fileScanTask -> {
-            DataFile dataFile = fileScanTask.file();
-
-            pagesBuilder.beginRow();
-            pagesBuilder.appendInteger(dataFile.content().id());
-            pagesBuilder.appendVarchar(dataFile.path().toString());
-            pagesBuilder.appendVarchar(dataFile.format().name());
-            pagesBuilder.appendBigint(dataFile.recordCount());
-            pagesBuilder.appendBigint(dataFile.fileSizeInBytes());
-            if (checkNonNull(dataFile.columnSizes(), pagesBuilder)) {
-                pagesBuilder.appendIntegerBigintMap(dataFile.columnSizes());
-            }
-            if (checkNonNull(dataFile.valueCounts(), pagesBuilder)) {
-                pagesBuilder.appendIntegerBigintMap(dataFile.valueCounts());
-            }
-            if (checkNonNull(dataFile.nullValueCounts(), pagesBuilder)) {
-                pagesBuilder.appendIntegerBigintMap(dataFile.nullValueCounts());
-            }
-            if (checkNonNull(dataFile.nanValueCounts(), pagesBuilder)) {
-                pagesBuilder.appendIntegerBigintMap(dataFile.nanValueCounts());
-            }
-            if (checkNonNull(dataFile.lowerBounds(), pagesBuilder)) {
-                pagesBuilder.appendIntegerVarcharMap(dataFile.lowerBounds().entrySet().stream()
-                        .filter(entry -> idToTypeMapping.containsKey(entry.getKey()))
-                        .collect(toImmutableMap(
-                                Map.Entry<Integer, ByteBuffer>::getKey,
-                                entry -> Transforms.identity(idToTypeMapping.get(entry.getKey())).toHumanString(
-                                        Conversions.fromByteBuffer(idToTypeMapping.get(entry.getKey()), entry.getValue())))));
-            }
-            if (checkNonNull(dataFile.upperBounds(), pagesBuilder)) {
-                pagesBuilder.appendIntegerVarcharMap(dataFile.upperBounds().entrySet().stream()
-                        .filter(entry -> idToTypeMapping.containsKey(entry.getKey()))
-                        .collect(toImmutableMap(
-                                Map.Entry<Integer, ByteBuffer>::getKey,
-                                entry -> Transforms.identity(idToTypeMapping.get(entry.getKey())).toHumanString(
-                                        Conversions.fromByteBuffer(idToTypeMapping.get(entry.getKey()), entry.getValue())))));
-            }
-            if (checkNonNull(dataFile.keyMetadata(), pagesBuilder)) {
-                pagesBuilder.appendVarbinary(Slices.wrappedBuffer(dataFile.keyMetadata()));
-            }
-            if (checkNonNull(dataFile.splitOffsets(), pagesBuilder)) {
-                pagesBuilder.appendBigintArray(dataFile.splitOffsets());
-            }
-            if (checkNonNull(dataFile.equalityFieldIds(), pagesBuilder)) {
-                pagesBuilder.appendIntegerArray(dataFile.equalityFieldIds());
-            }
-            pagesBuilder.endRow();
-        });
-
-        return pagesBuilder.build();
-    }
-
-    private static boolean checkNonNull(Object object, PageListBuilder pagesBuilder)
-    {
-        if (object == null) {
-            pagesBuilder.appendNull();
-            return false;
-        }
-        return true;
-    }
-
-    private static Map<Integer, Type> getIcebergIdToTypeMapping(Schema schema)
-    {
-        ImmutableMap.Builder<Integer, Type> icebergIdToTypeMapping = ImmutableMap.builder();
-        for (Types.NestedField field : schema.columns()) {
-            populateIcebergIdToTypeMapping(field, icebergIdToTypeMapping);
-        }
-        return icebergIdToTypeMapping.buildOrThrow();
-    }
-
-    private static void populateIcebergIdToTypeMapping(Types.NestedField field, ImmutableMap.Builder<Integer, Type> icebergIdToTypeMapping)
-    {
-        Type type = field.type();
-        icebergIdToTypeMapping.put(field.fieldId(), type);
-        if (type instanceof Type.NestedType) {
-            type.asNestedType().fields().forEach(child -> populateIcebergIdToTypeMapping(child, icebergIdToTypeMapping));
-        }
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/FilesTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/FilesTable.java
@@ -27,6 +27,8 @@ import org.apache.iceberg.TableScan;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
+import static org.apache.iceberg.MetadataTableType.FILES;
+import static org.apache.iceberg.MetadataTableUtils.createMetadataTableInstance;
 
 public class FilesTable
         extends AbstractFilesTable
@@ -51,8 +53,12 @@ public class FilesTable
     @Override
     protected TableScan buildTableScan()
     {
-        return getIcebergTable().newScan()
+        Table filesTable = createMetadataTableInstance(getIcebergTable(), FILES);
+
+        TableScan tableScan = filesTable
+                .newScan()
                 .useSnapshot(snapshotId.get())
                 .includeColumnStats();
+        return tableScan;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -416,6 +416,8 @@ public class IcebergMetadata
                 return Optional.of(new ManifestsTable(systemTableName, table, getSnapshotId(table, name.getSnapshotId(), isAllowLegacySnapshotSyntax(session))));
             case FILES:
                 return Optional.of(new FilesTable(systemTableName, typeManager, table, getSnapshotId(table, name.getSnapshotId(), isAllowLegacySnapshotSyntax(session))));
+            case ALL_FILES:
+                return Optional.of(new AllFilesTable(systemTableName, typeManager, table));
             case PROPERTIES:
                 return Optional.of(new PropertiesTable(systemTableName, table));
         }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TableType.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TableType.java
@@ -21,5 +21,6 @@ public enum TableType
     MANIFESTS,
     PARTITIONS,
     FILES,
+    ALL_FILES,
     PROPERTIES,
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
@@ -44,6 +44,7 @@ import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Methods
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Methods.GET_DATABASE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Methods.GET_TABLE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Methods.REPLACE_TABLE;
+import static io.trino.plugin.iceberg.TableType.ALL_FILES;
 import static io.trino.plugin.iceberg.TableType.DATA;
 import static io.trino.plugin.iceberg.TableType.FILES;
 import static io.trino.plugin.iceberg.TableType.HISTORY;
@@ -296,9 +297,15 @@ public class TestIcebergMetastoreAccessOperations
                         .addCopies(GET_TABLE, 1)
                         .build());
 
+        // select from $all_files
+        assertMetastoreInvocations("SELECT * FROM \"test_select_snapshots$all_files\"",
+                ImmutableMultiset.builder()
+                        .addCopies(GET_TABLE, 1)
+                        .build());
+
         // This test should get updated if a new system table is added.
         assertThat(TableType.values())
-                .containsExactly(DATA, HISTORY, SNAPSHOTS, MANIFESTS, PARTITIONS, FILES, PROPERTIES);
+                .containsExactly(DATA, HISTORY, SNAPSHOTS, MANIFESTS, PARTITIONS, FILES, ALL_FILES, PROPERTIES);
     }
 
     private void assertMetastoreInvocations(String query, Multiset<?> expectedInvocations)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

- This is to add `$all_files` system table support.
- Spark already supports the iceberg's `$data_files` and `$all_data_files` metadata tables. Trino is already supporting `$files`.
- `$all_files` table will include data_files from all the available snapshots to a table where the `$files` metadata table includes only the current snapshot one.

**Use cases**

- This can be used when the user is debugging data issue. As in case when Trino/Spark is used for metadata/data [optimization](https://iceberg.apache.org/docs/latest/maintenance/), then it can modify the metadata and data. 

- Another case is when snapshot is rolled back/future from Trino/Spark and now trying to understand what all data-files are present, and is there any implication because of the optimization/rollback operations.

- This and `$all_manifests` can also be used to add the optimization features in Trino like purging orphan files or identifying partitions modified since last time, to implement moving window data-compaction feature. [detail ](https://github.com/apache/iceberg/pull/805)
Where we need to identify the 

**Design**
Adding a new class `AllFilesTable` and used it as a parent for `FilesTable`, as both will be implementing similar responsibility,.

**Testing**
Added a test case in the existing `TestIcebergSystemTable`.
Thought of using `rollback` to show case that `$all_files` can give all the data_files, but then history was getting updated and `testHistoryTable` depends on the order and operations happen in the `testAllFilesTable` test. So have not used it. If we think, I can add it.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
NA

> How would you describe this change to a non-technical end user or system administrator?
allows user to access all the data-files referred by the table ( rolled back snapshots, old snapshots). This is helpful for debugging issues like why my query is showing certain data and not current one (in case snapshots are rolled back)

syntax:
`select * from "table$all_files"`


## Related issues, pull requests, and links

* Fixes [11172](https://github.com/trinodb/trino/issues/11172)

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Adds support for `all_files` metadata table, supported by Spark as well. ({issue}`11172`)
```
