### PR TITLE
Support decoding varbinary in Pinot broker queries

### DIFF
--- a/docs/src/main/sphinx/connector/pinot.rst
+++ b/docs/src/main/sphinx/connector/pinot.rst
@@ -166,6 +166,7 @@ Pinot                        Trino
 ``FLOAT``                    ``REAL``
 ``DOUBLE``                   ``DOUBLE``
 ``STRING``                   ``VARCHAR``
+``BYTES``                    ``VARBINARY``
 ``INT_ARRAY``                ``VARCHAR``
 ``LONG_ARRAY``               ``VARCHAR``
 ``FLOAT_ARRAY``              ``VARCHAR``

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotSegmentPageSource.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotSegmentPageSource.java
@@ -26,8 +26,6 @@ import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
-import org.apache.commons.codec.DecoderException;
-import org.apache.commons.codec.binary.Hex;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 
@@ -39,6 +37,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static io.trino.plugin.pinot.PinotErrorCode.PINOT_DECODE_ERROR;
 import static io.trino.plugin.pinot.PinotErrorCode.PINOT_UNSUPPORTED_COLUMN_TYPE;
+import static io.trino.plugin.pinot.decoders.VarbinaryDecoder.toBytes;
 import static java.lang.Float.floatToIntBits;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -330,16 +329,6 @@ public class PinotSegmentPageSource
             return Slices.wrappedBuffer(toBytes(currentDataTable.getDataTable().getString(rowIndex, columnIndex)));
         }
         return Slices.EMPTY_SLICE;
-    }
-
-    private static byte[] toBytes(String stringValue)
-    {
-        try {
-            return Hex.decodeHex(stringValue.toCharArray());
-        }
-        catch (DecoderException e) {
-            throw new IllegalArgumentException("Value: " + stringValue + " is not Hex encoded", e);
-        }
     }
 
     private Slice getUtf8Slice(String value)

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/decoders/DecoderFactory.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/decoders/DecoderFactory.java
@@ -22,6 +22,7 @@ import io.trino.spi.type.FixedWidthType;
 import io.trino.spi.type.IntegerType;
 import io.trino.spi.type.RealType;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.VarbinaryType;
 
 import java.util.Optional;
 
@@ -59,6 +60,9 @@ public class DecoderFactory
         }
         else if (type instanceof ArrayType) {
             return new ArrayDecoder(type);
+        }
+        else if (type instanceof VarbinaryType) {
+            return new VarbinaryDecoder();
         }
         else {
             return new VarcharDecoder();

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/decoders/VarbinaryDecoder.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/decoders/VarbinaryDecoder.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.pinot.decoders;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.BlockBuilder;
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
+
+import java.util.function.Supplier;
+
+import static io.trino.spi.StandardErrorCode.TYPE_MISMATCH;
+import static java.lang.String.format;
+
+public class VarbinaryDecoder
+        implements Decoder
+{
+    @Override
+    public void decode(Supplier<Object> getter, BlockBuilder output)
+    {
+        Object value = getter.get();
+        if (value == null) {
+            output.appendNull();
+        }
+        else if (value instanceof String) {
+            Slice slice = Slices.wrappedBuffer(toBytes((String) value));
+            output.writeBytes(slice, 0, slice.length()).closeEntry();
+        }
+        else {
+            throw new TrinoException(TYPE_MISMATCH, format("Expected a string value of type VARBINARY: %s [%s]", value, value.getClass().getSimpleName()));
+        }
+    }
+
+    public static byte[] toBytes(String stringValue)
+    {
+        try {
+            return Hex.decodeHex(stringValue.toCharArray());
+        }
+        catch (DecoderException e) {
+            throw new IllegalArgumentException("Value: " + stringValue + " is not Hex encoded", e);
+        }
+    }
+}

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/AbstractPinotIntegrationSmokeTest.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/AbstractPinotIntegrationSmokeTest.java
@@ -2183,4 +2183,24 @@ public abstract class AbstractPinotIntegrationSmokeTest
                         "(56, VARCHAR 'string_8400', BIGINT '1')," +
                         "(1000, VARCHAR 'string1_8401', BIGINT '1')");
     }
+
+    @Test
+    public void testVarbinary()
+    {
+        String expectedValues = "VALUES (X'')," +
+                "  (X'73 74 72 69 6e 67 5f 30')," +
+                "  (X'73 74 72 69 6e 67 5f 31 32 30 30')," +
+                "  (X'73 74 72 69 6e 67 5f 32 34 30 30')," +
+                "  (X'73 74 72 69 6e 67 5f 33 36 30 30')," +
+                "  (X'73 74 72 69 6e 67 5f 34 38 30 30')," +
+                "  (X'73 74 72 69 6e 67 5f 36 30 30 30')," +
+                "  (X'73 74 72 69 6e 67 5f 37 32 30 30')," +
+                "  (X'73 74 72 69 6e 67 5f 38 34 30 30')," +
+                "  (X'73 74 72 69 6e 67 5f 39 36 30 30')";
+        // The filter on string_col is to have a deterministic result set: the default limit for broker queries is 10 rows.
+        assertThat(query("SELECT bytes_col FROM alltypes WHERE string_col != 'array_null'"))
+                .matches(expectedValues);
+        assertThat(query("SELECT bytes_col FROM \"SELECT bytes_col, string_col FROM alltypes\" WHERE string_col != 'array_null'"))
+                .matches(expectedValues);
+    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->
Varbinary columns were not properly rendered when returned from a broker query. This could happen in passthrough queries or pushdown queries.
<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) Sufficient documentation is included in this PR.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# Pinot
* Add support for `bytes` type. ({issue}`13427`)
```
