### PR TITLE
Single column bigint join round 2

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/IncrementalLoadFactorHashArraySizeSupplier.java
+++ b/core/trino-main/src/main/java/io/trino/operator/IncrementalLoadFactorHashArraySizeSupplier.java
@@ -24,8 +24,8 @@ public class IncrementalLoadFactorHashArraySizeSupplier
     // Threshold values provide good performance for smaller hash arrays
     // while keeping memory usage limited for larger hash arrays.
     // This is tuned based on TPC-DS SF1000.
-    static final int THRESHOLD_25 = 1 << 16; // 65536
-    static final int THRESHOLD_50 = 1 << 20; // 1048576
+    public static final int THRESHOLD_25 = 1 << 16; // 65536
+    public static final int THRESHOLD_50 = 1 << 20; // 1048576
 
     private final int multiplier;
 

--- a/core/trino-main/src/main/java/io/trino/operator/PagesIndex.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PagesIndex.java
@@ -133,19 +133,25 @@ public class PagesIndex
     {
         public static final TypeOperators TYPE_OPERATORS = new TypeOperators();
         private static final OrderingCompiler ORDERING_COMPILER = new OrderingCompiler(TYPE_OPERATORS);
-        private static final JoinCompiler JOIN_COMPILER = new JoinCompiler(TYPE_OPERATORS);
+        private final JoinCompiler joinCompiler;
         private static final BlockTypeOperators TYPE_OPERATOR_FACTORY = new BlockTypeOperators(TYPE_OPERATORS);
         private final boolean eagerCompact;
 
         public TestingFactory(boolean eagerCompact)
         {
+            this(eagerCompact, true);
+        }
+
+        public TestingFactory(boolean eagerCompact, boolean enableSingleChannelBigintLookupSource)
+        {
             this.eagerCompact = eagerCompact;
+            joinCompiler = new JoinCompiler(TYPE_OPERATORS, enableSingleChannelBigintLookupSource);
         }
 
         @Override
         public PagesIndex newPagesIndex(List<Type> types, int expectedPositions)
         {
-            return new PagesIndex(ORDERING_COMPILER, JOIN_COMPILER, TYPE_OPERATOR_FACTORY, types, expectedPositions, eagerCompact);
+            return new PagesIndex(ORDERING_COMPILER, joinCompiler, TYPE_OPERATOR_FACTORY, types, expectedPositions, eagerCompact);
         }
     }
 
@@ -544,7 +550,8 @@ public class PagesIndex
                 filterFunctionFactory,
                 sortChannel,
                 searchFunctionFactories,
-                hashArraySizeSupplier);
+                hashArraySizeSupplier,
+                OptionalInt.empty());
     }
 
     private static List<Integer> rangeList(int endExclusive)

--- a/core/trino-main/src/main/java/io/trino/operator/join/DefaultPagesHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/DefaultPagesHash.java
@@ -32,9 +32,9 @@ import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 // This implementation assumes arrays used in the hash are always a power of 2
-public final class PagesHash
+public final class DefaultPagesHash
 {
-    private static final int INSTANCE_SIZE = ClassLayout.parseClass(PagesHash.class).instanceSize();
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(DefaultPagesHash.class).instanceSize();
     private static final DataSize CACHE_SIZE = DataSize.of(128, KILOBYTE);
     private final LongArrayList addresses;
     private final PagesHashStrategy pagesHashStrategy;
@@ -50,7 +50,7 @@ public final class PagesHash
     private final long hashCollisions;
     private final double expectedHashCollisions;
 
-    public PagesHash(
+    public DefaultPagesHash(
             LongArrayList addresses,
             PagesHashStrategy pagesHashStrategy,
             PositionLinks.FactoryBuilder positionLinks,

--- a/core/trino-main/src/main/java/io/trino/operator/join/DefaultPagesHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/DefaultPagesHash.java
@@ -31,8 +31,13 @@ import static io.trino.util.HashCollisionsEstimator.estimateNumberOfHashCollisio
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
-// This implementation assumes arrays used in the hash are always a power of 2
+/**
+ * The PagesHash object that handles all cases - single/multi channel joins
+ * with any types.
+ * This implementation assumes arrays used in the hash are always a power of 2
+ */
 public final class DefaultPagesHash
+        implements PagesHash
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(DefaultPagesHash.class).instanceSize();
     private static final DataSize CACHE_SIZE = DataSize.of(128, KILOBYTE);
@@ -124,31 +129,37 @@ public final class DefaultPagesHash
         expectedHashCollisions = estimateNumberOfHashCollisions(addresses.size(), hashSize);
     }
 
+    @Override
     public int getPositionCount()
     {
         return addresses.size();
     }
 
+    @Override
     public long getInMemorySizeInBytes()
     {
         return INSTANCE_SIZE + size;
     }
 
+    @Override
     public long getHashCollisions()
     {
         return hashCollisions;
     }
 
+    @Override
     public double getExpectedHashCollisions()
     {
         return expectedHashCollisions;
     }
 
+    @Override
     public int getAddressIndex(int position, Page hashChannelsPage)
     {
         return getAddressIndex(position, hashChannelsPage, pagesHashStrategy.hashRow(position, hashChannelsPage));
     }
 
+    @Override
     public int getAddressIndex(int rightPosition, Page hashChannelsPage, long rawHash)
     {
         int pos = getHashPosition(rawHash, mask);
@@ -163,6 +174,7 @@ public final class DefaultPagesHash
         return -1;
     }
 
+    @Override
     public void appendTo(long position, PageBuilder pageBuilder, int outputChannelOffset)
     {
         long pageAddress = addresses.getLong(toIntExact(position));

--- a/core/trino-main/src/main/java/io/trino/operator/join/JoinHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/JoinHash.java
@@ -29,7 +29,7 @@ public final class JoinHash
         implements LookupSource
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(JoinHash.class).instanceSize();
-    private final DefaultPagesHash pagesHash;
+    private final PagesHash pagesHash;
 
     // we unwrap Optional<JoinFilterFunction> to actual verifier or null in constructor for performance reasons
     // we do quick check for `filterFunction == null` in `isJoinPositionEligible` to avoid calls to applyFilterFunction
@@ -41,7 +41,7 @@ public final class JoinHash
     @Nullable
     private final PositionLinks positionLinks;
 
-    public JoinHash(DefaultPagesHash pagesHash, Optional<JoinFilterFunction> filterFunction, Optional<PositionLinks> positionLinks)
+    public JoinHash(PagesHash pagesHash, Optional<JoinFilterFunction> filterFunction, Optional<PositionLinks> positionLinks)
     {
         this.pagesHash = requireNonNull(pagesHash, "pagesHash is null");
         this.filterFunction = requireNonNull(filterFunction, "filterFunction cannot be null").orElse(null);

--- a/core/trino-main/src/main/java/io/trino/operator/join/JoinHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/JoinHash.java
@@ -29,7 +29,7 @@ public final class JoinHash
         implements LookupSource
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(JoinHash.class).instanceSize();
-    private final PagesHash pagesHash;
+    private final DefaultPagesHash pagesHash;
 
     // we unwrap Optional<JoinFilterFunction> to actual verifier or null in constructor for performance reasons
     // we do quick check for `filterFunction == null` in `isJoinPositionEligible` to avoid calls to applyFilterFunction
@@ -41,7 +41,7 @@ public final class JoinHash
     @Nullable
     private final PositionLinks positionLinks;
 
-    public JoinHash(PagesHash pagesHash, Optional<JoinFilterFunction> filterFunction, Optional<PositionLinks> positionLinks)
+    public JoinHash(DefaultPagesHash pagesHash, Optional<JoinFilterFunction> filterFunction, Optional<PositionLinks> positionLinks)
     {
         this.pagesHash = requireNonNull(pagesHash, "pagesHash is null");
         this.filterFunction = requireNonNull(filterFunction, "filterFunction cannot be null").orElse(null);

--- a/core/trino-main/src/main/java/io/trino/operator/join/JoinHashSupplier.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/JoinHashSupplier.java
@@ -34,7 +34,7 @@ public class JoinHashSupplier
         implements LookupSourceSupplier
 {
     private final Session session;
-    private final PagesHash pagesHash;
+    private final DefaultPagesHash pagesHash;
     private final LongArrayList addresses;
     private final List<Page> pages;
     private final Optional<PositionLinks.Factory> positionLinks;
@@ -71,7 +71,7 @@ public class JoinHashSupplier
         }
 
         this.pages = channelsToPages(channels);
-        this.pagesHash = new PagesHash(addresses, pagesHashStrategy, positionLinksFactoryBuilder, hashArraySizeSupplier);
+        this.pagesHash = new DefaultPagesHash(addresses, pagesHashStrategy, positionLinksFactoryBuilder, hashArraySizeSupplier);
         this.positionLinks = positionLinksFactoryBuilder.isEmpty() ? Optional.empty() : Optional.of(positionLinksFactoryBuilder.build());
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/join/JoinHashSupplier.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/JoinHashSupplier.java
@@ -34,7 +34,7 @@ public class JoinHashSupplier
         implements LookupSourceSupplier
 {
     private final Session session;
-    private final DefaultPagesHash pagesHash;
+    private final PagesHash pagesHash;
     private final LongArrayList addresses;
     private final List<Page> pages;
     private final Optional<PositionLinks.Factory> positionLinks;

--- a/core/trino-main/src/main/java/io/trino/operator/join/JoinHashSupplier.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/JoinHashSupplier.java
@@ -16,6 +16,7 @@ package io.trino.operator.join;
 import com.google.common.collect.ImmutableList;
 import io.trino.Session;
 import io.trino.operator.HashArraySizeSupplier;
+import io.trino.operator.IncrementalLoadFactorHashArraySizeSupplier;
 import io.trino.operator.PagesHashStrategy;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
@@ -24,6 +25,7 @@ import it.unimi.dsi.fastutil.longs.LongArrayList;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -33,6 +35,12 @@ import static java.util.Objects.requireNonNull;
 public class JoinHashSupplier
         implements LookupSourceSupplier
 {
+    /**
+     * This value is purposefully identical to that of IncrementalLoadFactorHashArraySizeSupplier#THRESHOLD_50,
+     * as higher load factor means more excessive memory consumption
+     */
+    private static final int JOIN_POSITIONS_ARRAY_CUTOFF = IncrementalLoadFactorHashArraySizeSupplier.THRESHOLD_50;
+
     private final Session session;
     private final PagesHash pagesHash;
     private final LongArrayList addresses;
@@ -49,7 +57,8 @@ public class JoinHashSupplier
             Optional<JoinFilterFunctionFactory> filterFunctionFactory,
             Optional<Integer> sortChannel,
             List<JoinFilterFunctionFactory> searchFunctionFactories,
-            HashArraySizeSupplier hashArraySizeSupplier)
+            HashArraySizeSupplier hashArraySizeSupplier,
+            OptionalInt singleBigintJoinChannel)
     {
         this.session = requireNonNull(session, "session is null");
         this.addresses = requireNonNull(addresses, "addresses is null");
@@ -71,7 +80,12 @@ public class JoinHashSupplier
         }
 
         this.pages = channelsToPages(channels);
-        this.pagesHash = new DefaultPagesHash(addresses, pagesHashStrategy, positionLinksFactoryBuilder, hashArraySizeSupplier);
+        if (singleBigintJoinChannel.isPresent() && addresses.size() <= JOIN_POSITIONS_ARRAY_CUTOFF) {
+            this.pagesHash = new BigintPagesHash(addresses, pagesHashStrategy, positionLinksFactoryBuilder, hashArraySizeSupplier, pages, singleBigintJoinChannel.getAsInt());
+        }
+        else {
+            this.pagesHash = new DefaultPagesHash(addresses, pagesHashStrategy, positionLinksFactoryBuilder, hashArraySizeSupplier);
+        }
         this.positionLinks = positionLinksFactoryBuilder.isEmpty() ? Optional.empty() : Optional.of(positionLinksFactoryBuilder.build());
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/join/PagesHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/PagesHash.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.join;
+
+import io.trino.spi.Page;
+import io.trino.spi.PageBuilder;
+
+public interface PagesHash
+{
+    int getPositionCount();
+
+    long getInMemorySizeInBytes();
+
+    long getHashCollisions();
+
+    double getExpectedHashCollisions();
+
+    int getAddressIndex(int position, Page hashChannelsPage);
+
+    int getAddressIndex(int rightPosition, Page hashChannelsPage, long rawHash);
+
+    void appendTo(long position, PageBuilder pageBuilder, int outputChannelOffset);
+}

--- a/core/trino-main/src/main/java/io/trino/operator/join/PagesHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/PagesHash.java
@@ -31,4 +31,22 @@ public interface PagesHash
     int getAddressIndex(int rightPosition, Page hashChannelsPage, long rawHash);
 
     void appendTo(long position, PageBuilder pageBuilder, int outputChannelOffset);
+
+    static int getHashPosition(long rawHash, long mask)
+    {
+        // Avalanches the bits of a long integer by applying the finalisation step of MurmurHash3.
+        //
+        // This function implements the finalisation step of Austin Appleby's <a href="http://sites.google.com/site/murmurhash/">MurmurHash3</a>.
+        // Its purpose is to avalanche the bits of the argument to within 0.25% bias. It is used, among other things, to scramble quickly (but deeply) the hash
+        // values returned by {@link Object#hashCode()}.
+        //
+
+        rawHash ^= rawHash >>> 33;
+        rawHash *= 0xff51afd7ed558ccdL;
+        rawHash ^= rawHash >>> 33;
+        rawHash *= 0xc4ceb9fe1a85ec53L;
+        rawHash ^= rawHash >>> 33;
+
+        return (int) (rawHash & mask);
+    }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/gen/JoinCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/JoinCompiler.java
@@ -36,10 +36,10 @@ import io.trino.Session;
 import io.trino.collect.cache.NonEvictableLoadingCache;
 import io.trino.operator.HashArraySizeSupplier;
 import io.trino.operator.PagesHashStrategy;
+import io.trino.operator.join.DefaultPagesHash;
 import io.trino.operator.join.JoinHash;
 import io.trino.operator.join.JoinHashSupplier;
 import io.trino.operator.join.LookupSourceSupplier;
-import io.trino.operator.join.PagesHash;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.block.Block;
@@ -173,7 +173,7 @@ public class JoinCompiler
                 LookupSourceSupplier.class,
                 JoinHashSupplier.class,
                 JoinHash.class,
-                PagesHash.class);
+                DefaultPagesHash.class);
 
         return new LookupSourceSupplierFactory(joinHashSupplierClass, new PagesHashStrategyFactory(pagesHashStrategyClass));
     }

--- a/core/trino-main/src/main/java/io/trino/sql/gen/JoinCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/JoinCompiler.java
@@ -36,10 +36,13 @@ import io.trino.Session;
 import io.trino.collect.cache.NonEvictableLoadingCache;
 import io.trino.operator.HashArraySizeSupplier;
 import io.trino.operator.PagesHashStrategy;
+import io.trino.operator.join.BigintPagesHash;
 import io.trino.operator.join.DefaultPagesHash;
 import io.trino.operator.join.JoinHash;
 import io.trino.operator.join.JoinHashSupplier;
 import io.trino.operator.join.LookupSourceSupplier;
+import io.trino.operator.join.PagesHash;
+import io.trino.operator.join.unspilled.PartitionedLookupSource;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.block.Block;
@@ -48,6 +51,7 @@ import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
 import io.trino.sql.gen.JoinFilterFunctionCompiler.JoinFilterFunctionFactory;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
+import org.assertj.core.util.VisibleForTesting;
 import org.openjdk.jol.info.ClassLayout;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
@@ -64,6 +68,7 @@ import java.util.OptionalInt;
 import java.util.stream.IntStream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.airlift.bytecode.Access.FINAL;
 import static io.airlift.bytecode.Access.PRIVATE;
 import static io.airlift.bytecode.Access.PUBLIC;
@@ -95,6 +100,7 @@ import static java.util.Objects.requireNonNull;
 public class JoinCompiler
 {
     private final TypeOperators typeOperators;
+    private final boolean enableSingleChannelBigintLookupSource;
 
     private final NonEvictableLoadingCache<CacheKey, LookupSourceSupplierFactory> lookupSourceFactories = buildNonEvictableCache(
             CacheBuilder.newBuilder()
@@ -113,7 +119,14 @@ public class JoinCompiler
     @Inject
     public JoinCompiler(TypeOperators typeOperators)
     {
+        this(typeOperators, true);
+    }
+
+    @VisibleForTesting
+    public JoinCompiler(TypeOperators typeOperators, boolean enableSingleChannelBigintLookupSource)
+    {
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
+        this.enableSingleChannelBigintLookupSource = enableSingleChannelBigintLookupSource;
     }
 
     @Managed
@@ -168,14 +181,23 @@ public class JoinCompiler
     {
         Class<? extends PagesHashStrategy> pagesHashStrategyClass = internalCompileHashStrategy(types, outputChannels, joinChannels, sortChannel);
 
+        OptionalInt singleBigintJoinChannel = OptionalInt.empty();
+        if (enableSingleChannelBigintLookupSource
+                && joinChannels.size() == 1
+                && types.get(getOnlyElement(joinChannels)) == BIGINT) {
+            singleBigintJoinChannel = OptionalInt.of(getOnlyElement(joinChannels));
+        }
+
         Class<? extends LookupSourceSupplier> joinHashSupplierClass = IsolatedClass.isolateClass(
                 new DynamicClassLoader(getClass().getClassLoader()),
                 LookupSourceSupplier.class,
                 JoinHashSupplier.class,
                 JoinHash.class,
-                DefaultPagesHash.class);
-
-        return new LookupSourceSupplierFactory(joinHashSupplierClass, new PagesHashStrategyFactory(pagesHashStrategyClass));
+                PagesHash.class,
+                BigintPagesHash.class,
+                DefaultPagesHash.class,
+                PartitionedLookupSource.class);
+        return new LookupSourceSupplierFactory(joinHashSupplierClass, new PagesHashStrategyFactory(pagesHashStrategyClass), singleBigintJoinChannel);
     }
 
     private static FieldDefinition generateInstanceSize(ClassDefinition definition)
@@ -1019,16 +1041,18 @@ public class JoinCompiler
     {
         private final Constructor<? extends LookupSourceSupplier> constructor;
         private final PagesHashStrategyFactory pagesHashStrategyFactory;
+        private final OptionalInt singleBigintJoinChannel;
 
-        public LookupSourceSupplierFactory(Class<? extends LookupSourceSupplier> joinHashSupplierClass, PagesHashStrategyFactory pagesHashStrategyFactory)
+        public LookupSourceSupplierFactory(Class<? extends LookupSourceSupplier> joinHashSupplierClass, PagesHashStrategyFactory pagesHashStrategyFactory, OptionalInt singleBigintJoinChannel)
         {
             this.pagesHashStrategyFactory = pagesHashStrategyFactory;
             try {
-                constructor = joinHashSupplierClass.getConstructor(Session.class, PagesHashStrategy.class, LongArrayList.class, List.class, Optional.class, Optional.class, List.class, HashArraySizeSupplier.class);
+                constructor = joinHashSupplierClass.getConstructor(Session.class, PagesHashStrategy.class, LongArrayList.class, List.class, Optional.class, Optional.class, List.class, HashArraySizeSupplier.class, OptionalInt.class);
             }
             catch (NoSuchMethodException e) {
                 throw new RuntimeException(e);
             }
+            this.singleBigintJoinChannel = requireNonNull(singleBigintJoinChannel, "singleBigintJoinChannel is null");
         }
 
         public LookupSourceSupplier createLookupSourceSupplier(
@@ -1043,7 +1067,7 @@ public class JoinCompiler
         {
             PagesHashStrategy pagesHashStrategy = pagesHashStrategyFactory.createPagesHashStrategy(channels, hashChannel);
             try {
-                return constructor.newInstance(session, pagesHashStrategy, addresses, channels, filterFunctionFactory, sortChannel, searchFunctionFactories, hashArraySizeSupplier);
+                return constructor.newInstance(session, pagesHashStrategy, addresses, channels, filterFunctionFactory, sortChannel, searchFunctionFactories, hashArraySizeSupplier, singleBigintJoinChannel);
             }
             catch (ReflectiveOperationException e) {
                 throw new RuntimeException(e);

--- a/core/trino-main/src/test/java/io/trino/operator/join/unspilled/JoinTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/unspilled/JoinTestUtils.java
@@ -123,6 +123,17 @@ public final class JoinTestUtils
             RowPagesBuilder buildPages,
             Optional<InternalJoinFilterFunction> filterFunction)
     {
+        return setupBuildSide(nodePartitioningManager, parallelBuild, taskContext, buildPages, filterFunction, true);
+    }
+
+    public static BuildSideSetup setupBuildSide(
+            NodePartitioningManager nodePartitioningManager,
+            boolean parallelBuild,
+            TaskContext taskContext,
+            RowPagesBuilder buildPages,
+            Optional<InternalJoinFilterFunction> filterFunction,
+            boolean enableSingleChannelBigintLookupSource)
+    {
         Optional<JoinFilterFunctionCompiler.JoinFilterFunctionFactory> filterFunctionFactory = filterFunction
                 .map(function -> (session, addresses, pages) -> new StandardJoinFilterFunction(function, addresses, pages));
 
@@ -184,7 +195,7 @@ public final class JoinTestUtils
                 Optional.empty(),
                 ImmutableList.of(),
                 100,
-                new PagesIndex.TestingFactory(false),
+                new PagesIndex.TestingFactory(false, enableSingleChannelBigintLookupSource),
                 incrementalLoadFactorHashArraySizeSupplier(taskContext.getSession()));
         return new BuildSideSetup(lookupSourceFactoryManager, buildOperatorFactory, sourceOperatorFactory, partitionCount);
     }

--- a/core/trino-main/src/test/java/io/trino/operator/join/unspilled/TestHashJoinOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/unspilled/TestHashJoinOperator.java
@@ -189,8 +189,8 @@ public class TestHashJoinOperator
         assertOperatorEquals(joinOperatorFactory, taskContext.addPipelineContext(0, true, true, false).addDriverContext(), probeInput, expected, true, getHashChannels(probePages, buildPages));
     }
 
-    @Test
-    public void testInnerJoinWithRunLengthEncodedProbe()
+    @Test(dataProvider = "singleBigintLookupSourceProvider")
+    public void testInnerJoinWithRunLengthEncodedProbe(boolean singleBigintLookupSource)
     {
         TaskContext taskContext = createTaskContext();
 
@@ -198,7 +198,7 @@ public class TestHashJoinOperator
         RowPagesBuilder buildPages = rowPagesBuilder(false, Ints.asList(0), ImmutableList.of(BIGINT))
                 .addSequencePage(10, 20)
                 .addSequencePage(10, 21);
-        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, false, taskContext, buildPages, Optional.empty());
+        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, false, taskContext, buildPages, Optional.empty(), singleBigintLookupSource);
         JoinBridgeManager<PartitionedLookupSourceFactory> lookupSourceFactory = buildSideSetup.getLookupSourceFactoryManager();
 
         // probe factory
@@ -226,8 +226,8 @@ public class TestHashJoinOperator
         assertOperatorEquals(joinOperatorFactory, taskContext.addPipelineContext(0, true, true, false).addDriverContext(), probeInput, expected, true, getHashChannels(probePages, buildPages));
     }
 
-    @Test
-    public void testUnwrapsLazyBlocks()
+    @Test(dataProvider = "singleBigintLookupSourceProvider")
+    public void testUnwrapsLazyBlocks(boolean singleBigintLookupSource)
     {
         TaskContext taskContext = createTaskContext();
         DriverContext driverContext = taskContext.addPipelineContext(0, true, true, false).addDriverContext();
@@ -240,7 +240,7 @@ public class TestHashJoinOperator
                 }));
 
         RowPagesBuilder buildPages = rowPagesBuilder(false, Ints.asList(0), ImmutableList.of(BIGINT)).addSequencePage(1, 0);
-        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, true, taskContext, buildPages, Optional.of(filterFunction));
+        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, true, taskContext, buildPages, Optional.of(filterFunction), singleBigintLookupSource);
         JoinBridgeManager<PartitionedLookupSourceFactory> lookupSourceFactory = buildSideSetup.getLookupSourceFactoryManager();
 
         RowPagesBuilder probePages = rowPagesBuilder(false, Ints.asList(0), ImmutableList.of(BIGINT, BIGINT));
@@ -276,8 +276,8 @@ public class TestHashJoinOperator
         assertFalse(output.getBlock(1) instanceof LazyBlock);
     }
 
-    @Test
-    public void testYield()
+    @Test(dataProvider = "singleBigintLookupSourceProvider")
+    public void testYield(boolean singleBigintLookupSource)
     {
         // create a filter function that yields for every probe match
         // verify we will yield #match times totally
@@ -298,7 +298,7 @@ public class TestHashJoinOperator
         int entries = 40;
         RowPagesBuilder buildPages = rowPagesBuilder(true, Ints.asList(0), ImmutableList.of(BIGINT))
                 .addSequencePage(entries, 42);
-        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, true, taskContext, buildPages, Optional.of(filterFunction));
+        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, true, taskContext, buildPages, Optional.of(filterFunction), singleBigintLookupSource);
         JoinBridgeManager<PartitionedLookupSourceFactory> lookupSourceFactory = buildSideSetup.getLookupSourceFactoryManager();
 
         // probe matching the above 40 entries
@@ -349,8 +349,8 @@ public class TestHashJoinOperator
         assertEquals(output.getPositionCount(), entries);
     }
 
-    @Test(dataProvider = "hashJoinTestValues")
-    public void testInnerJoinWithNullProbe(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled)
+    @Test(dataProvider = "hashJoinTestValuesAndsingleBigintLookupSourceProvider")
+    public void testInnerJoinWithNullProbe(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled, boolean singleBigintLookupSource)
     {
         TaskContext taskContext = createTaskContext();
 
@@ -360,7 +360,7 @@ public class TestHashJoinOperator
                 .row(1L)
                 .row(2L)
                 .row(3L);
-        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, parallelBuild, taskContext, buildPages, Optional.empty());
+        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, parallelBuild, taskContext, buildPages, Optional.empty(), singleBigintLookupSource);
         JoinBridgeManager<PartitionedLookupSourceFactory> lookupSourceFactory = buildSideSetup.getLookupSourceFactoryManager();
 
         // probe factory
@@ -389,8 +389,8 @@ public class TestHashJoinOperator
         assertOperatorEquals(joinOperatorFactory, taskContext.addPipelineContext(0, true, true, false).addDriverContext(), probeInput, expected, true, getHashChannels(probePages, buildPages));
     }
 
-    @Test(dataProvider = "hashJoinTestValues")
-    public void testInnerJoinWithOutputSingleMatch(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled)
+    @Test(dataProvider = "hashJoinTestValuesAndsingleBigintLookupSourceProvider")
+    public void testInnerJoinWithOutputSingleMatch(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled, boolean singleBigintLookupSource)
     {
         TaskContext taskContext = createTaskContext();
         // build factory
@@ -399,7 +399,7 @@ public class TestHashJoinOperator
                 .row(1L)
                 .row(1L)
                 .row(2L);
-        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, parallelBuild, taskContext, buildPages, Optional.empty());
+        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, parallelBuild, taskContext, buildPages, Optional.empty(), singleBigintLookupSource);
         JoinBridgeManager<PartitionedLookupSourceFactory> lookupSourceFactory = buildSideSetup.getLookupSourceFactoryManager();
 
         // probe factory
@@ -425,8 +425,8 @@ public class TestHashJoinOperator
         assertOperatorEquals(joinOperatorFactory, taskContext.addPipelineContext(0, true, true, false).addDriverContext(), probeInput, expected, true, getHashChannels(probePages, buildPages));
     }
 
-    @Test(dataProvider = "hashJoinTestValues")
-    public void testInnerJoinWithNullBuild(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled)
+    @Test(dataProvider = "hashJoinTestValuesAndsingleBigintLookupSourceProvider")
+    public void testInnerJoinWithNullBuild(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled, boolean singleBigintLookupSource)
     {
         TaskContext taskContext = createTaskContext();
 
@@ -465,8 +465,8 @@ public class TestHashJoinOperator
         assertOperatorEquals(joinOperatorFactory, taskContext.addPipelineContext(0, true, true, false).addDriverContext(), probeInput, expected, true, getHashChannels(probePages, buildPages));
     }
 
-    @Test(dataProvider = "hashJoinTestValues")
-    public void testInnerJoinWithNullOnBothSides(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled)
+    @Test(dataProvider = "hashJoinTestValuesAndsingleBigintLookupSourceProvider")
+    public void testInnerJoinWithNullOnBothSides(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled, boolean singleBigintLookupSource)
     {
         TaskContext taskContext = createTaskContext();
 
@@ -601,8 +601,8 @@ public class TestHashJoinOperator
         assertOperatorEquals(joinOperatorFactory, taskContext.addPipelineContext(0, true, true, false).addDriverContext(), probeInput, expected, true, getHashChannels(probePages, buildPages));
     }
 
-    @Test(dataProvider = "hashJoinTestValues")
-    public void testOuterJoinWithNullProbe(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled)
+    @Test(dataProvider = "hashJoinTestValuesAndsingleBigintLookupSourceProvider")
+    public void testOuterJoinWithNullProbe(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled, boolean singleBigintLookupSource)
     {
         TaskContext taskContext = createTaskContext();
 
@@ -612,7 +612,7 @@ public class TestHashJoinOperator
                 .row(1L)
                 .row(2L)
                 .row(3L);
-        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, parallelBuild, taskContext, buildPages, Optional.empty());
+        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, parallelBuild, taskContext, buildPages, Optional.empty(), singleBigintLookupSource);
         JoinBridgeManager<PartitionedLookupSourceFactory> lookupSourceFactory = buildSideSetup.getLookupSourceFactoryManager();
 
         // probe factory
@@ -643,8 +643,8 @@ public class TestHashJoinOperator
         assertOperatorEquals(joinOperatorFactory, taskContext.addPipelineContext(0, true, true, false).addDriverContext(), probeInput, expected, true, getHashChannels(probePages, buildPages));
     }
 
-    @Test(dataProvider = "hashJoinTestValues")
-    public void testOuterJoinWithNullProbeAndFilterFunction(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled)
+    @Test(dataProvider = "hashJoinTestValuesAndsingleBigintLookupSourceProvider")
+    public void testOuterJoinWithNullProbeAndFilterFunction(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled, boolean singleBigintLookupSource)
     {
         TaskContext taskContext = createTaskContext();
 
@@ -657,7 +657,7 @@ public class TestHashJoinOperator
                 .row(1L)
                 .row(2L)
                 .row(3L);
-        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, parallelBuild, taskContext, buildPages, Optional.of(filterFunction));
+        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, parallelBuild, taskContext, buildPages, Optional.of(filterFunction), singleBigintLookupSource);
         JoinBridgeManager<PartitionedLookupSourceFactory> lookupSourceFactory = buildSideSetup.getLookupSourceFactoryManager();
 
         // probe factory
@@ -688,8 +688,8 @@ public class TestHashJoinOperator
         assertOperatorEquals(joinOperatorFactory, taskContext.addPipelineContext(0, true, true, false).addDriverContext(), probeInput, expected, true, getHashChannels(probePages, buildPages));
     }
 
-    @Test(dataProvider = "hashJoinTestValues")
-    public void testOuterJoinWithNullBuild(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled)
+    @Test(dataProvider = "hashJoinTestValuesAndsingleBigintLookupSourceProvider")
+    public void testOuterJoinWithNullBuild(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled, boolean singleBigintLookupSource)
     {
         TaskContext taskContext = createTaskContext();
 
@@ -701,7 +701,7 @@ public class TestHashJoinOperator
                 .row((String) null)
                 .row(1L)
                 .row(2L);
-        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, parallelBuild, taskContext, buildPages, Optional.empty());
+        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, parallelBuild, taskContext, buildPages, Optional.empty(), singleBigintLookupSource);
         JoinBridgeManager<PartitionedLookupSourceFactory> lookupSourceFactory = buildSideSetup.getLookupSourceFactoryManager();
 
         // probe factory
@@ -729,8 +729,8 @@ public class TestHashJoinOperator
         assertOperatorEquals(joinOperatorFactory, taskContext.addPipelineContext(0, true, true, false).addDriverContext(), probeInput, expected, true, getHashChannels(probePages, buildPages));
     }
 
-    @Test(dataProvider = "hashJoinTestValues")
-    public void testOuterJoinWithNullBuildAndFilterFunction(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled)
+    @Test(dataProvider = "hashJoinTestValuesAndsingleBigintLookupSourceProvider")
+    public void testOuterJoinWithNullBuildAndFilterFunction(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled, boolean singleBigintLookupSource)
     {
         TaskContext taskContext = createTaskContext();
 
@@ -746,7 +746,7 @@ public class TestHashJoinOperator
                 .row((String) null)
                 .row(1L)
                 .row(2L);
-        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, parallelBuild, taskContext, buildPages, Optional.of(filterFunction));
+        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, parallelBuild, taskContext, buildPages, Optional.of(filterFunction), singleBigintLookupSource);
         JoinBridgeManager<PartitionedLookupSourceFactory> lookupSourceFactory = buildSideSetup.getLookupSourceFactoryManager();
 
         // probe factory
@@ -774,8 +774,8 @@ public class TestHashJoinOperator
         assertOperatorEquals(joinOperatorFactory, taskContext.addPipelineContext(0, true, true, false).addDriverContext(), probeInput, expected, true, getHashChannels(probePages, buildPages));
     }
 
-    @Test(dataProvider = "hashJoinTestValues")
-    public void testOuterJoinWithNullOnBothSides(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled)
+    @Test(dataProvider = "hashJoinTestValuesAndsingleBigintLookupSourceProvider")
+    public void testOuterJoinWithNullOnBothSides(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled, boolean singleBigintLookupSource)
     {
         TaskContext taskContext = createTaskContext();
 
@@ -786,7 +786,7 @@ public class TestHashJoinOperator
                 .row((String) null)
                 .row(1L)
                 .row(2L);
-        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, parallelBuild, taskContext, buildPages, Optional.empty());
+        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, parallelBuild, taskContext, buildPages, Optional.empty(), singleBigintLookupSource);
         JoinBridgeManager<PartitionedLookupSourceFactory> lookupSourceFactory = buildSideSetup.getLookupSourceFactoryManager();
 
         // probe factory
@@ -816,8 +816,8 @@ public class TestHashJoinOperator
         assertOperatorEquals(joinOperatorFactory, taskContext.addPipelineContext(0, true, true, false).addDriverContext(), probeInput, expected, true, getHashChannels(probePages, buildPages));
     }
 
-    @Test(dataProvider = "hashJoinTestValues")
-    public void testOuterJoinWithNullOnBothSidesAndFilterFunction(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled)
+    @Test(dataProvider = "hashJoinTestValuesAndsingleBigintLookupSourceProvider")
+    public void testOuterJoinWithNullOnBothSidesAndFilterFunction(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled, boolean singleBigintLookupSource)
     {
         TaskContext taskContext = createTaskContext();
 
@@ -832,7 +832,7 @@ public class TestHashJoinOperator
                 .row((String) null)
                 .row(1L)
                 .row(2L);
-        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, parallelBuild, taskContext, buildPages, Optional.of(filterFunction));
+        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, parallelBuild, taskContext, buildPages, Optional.of(filterFunction), singleBigintLookupSource);
         JoinBridgeManager<PartitionedLookupSourceFactory> lookupSourceFactory = buildSideSetup.getLookupSourceFactoryManager();
 
         // probe factory
@@ -877,15 +877,15 @@ public class TestHashJoinOperator
                 .hasMessageMatching("Query exceeded per-node memory limit of.*");
     }
 
-    @Test(dataProvider = "hashJoinTestValues")
-    public void testInnerJoinWithEmptyLookupSource(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled)
+    @Test(dataProvider = "hashJoinTestValuesAndsingleBigintLookupSourceProvider")
+    public void testInnerJoinWithEmptyLookupSource(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled, boolean singleBigintLookupSource)
     {
         TaskContext taskContext = createTaskContext();
 
         // build factory
         List<Type> buildTypes = ImmutableList.of(BIGINT);
         RowPagesBuilder buildPages = rowPagesBuilder(buildHashEnabled, Ints.asList(0), buildTypes);
-        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, parallelBuild, taskContext, buildPages, Optional.empty());
+        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, parallelBuild, taskContext, buildPages, Optional.empty(), singleBigintLookupSource);
         JoinBridgeManager<PartitionedLookupSourceFactory> lookupSourceFactoryManager = buildSideSetup.getLookupSourceFactoryManager();
 
         // probe factory
@@ -918,15 +918,15 @@ public class TestHashJoinOperator
         assertNull(outputPage);
     }
 
-    @Test(dataProvider = "hashJoinTestValues")
-    public void testLookupOuterJoinWithEmptyLookupSource(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled)
+    @Test(dataProvider = "hashJoinTestValuesAndsingleBigintLookupSourceProvider")
+    public void testLookupOuterJoinWithEmptyLookupSource(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled, boolean singleBigintLookupSource)
     {
         TaskContext taskContext = createTaskContext();
 
         // build factory
         List<Type> buildTypes = ImmutableList.of(BIGINT);
         RowPagesBuilder buildPages = rowPagesBuilder(buildHashEnabled, Ints.asList(0), buildTypes);
-        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, parallelBuild, taskContext, buildPages, Optional.empty());
+        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, parallelBuild, taskContext, buildPages, Optional.empty(), singleBigintLookupSource);
         JoinBridgeManager<PartitionedLookupSourceFactory> lookupSourceFactoryManager = buildSideSetup.getLookupSourceFactoryManager();
 
         // probe factory
@@ -958,15 +958,15 @@ public class TestHashJoinOperator
         assertNull(outputPage);
     }
 
-    @Test(dataProvider = "hashJoinTestValues")
-    public void testProbeOuterJoinWithEmptyLookupSource(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled)
+    @Test(dataProvider = "hashJoinTestValuesAndsingleBigintLookupSourceProvider")
+    public void testProbeOuterJoinWithEmptyLookupSource(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled, boolean singleBigintLookupSource)
     {
         TaskContext taskContext = createTaskContext();
 
         // build factory
         List<Type> buildTypes = ImmutableList.of(BIGINT);
         RowPagesBuilder buildPages = rowPagesBuilder(buildHashEnabled, Ints.asList(0), buildTypes);
-        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, parallelBuild, taskContext, buildPages, Optional.empty());
+        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, parallelBuild, taskContext, buildPages, Optional.empty(), singleBigintLookupSource);
         JoinBridgeManager<PartitionedLookupSourceFactory> lookupSourceFactoryManager = buildSideSetup.getLookupSourceFactoryManager();
 
         // probe factory
@@ -1007,15 +1007,15 @@ public class TestHashJoinOperator
         assertOperatorEquals(joinOperatorFactory, taskContext.addPipelineContext(0, true, true, false).addDriverContext(), probeInput, expected, true, getHashChannels(probePages, buildPages));
     }
 
-    @Test(dataProvider = "hashJoinTestValues")
-    public void testFullOuterJoinWithEmptyLookupSource(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled)
+    @Test(dataProvider = "hashJoinTestValuesAndsingleBigintLookupSourceProvider")
+    public void testFullOuterJoinWithEmptyLookupSource(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled, boolean singleBigintLookupSource)
     {
         TaskContext taskContext = createTaskContext();
 
         // build factory
         List<Type> buildTypes = ImmutableList.of(BIGINT);
         RowPagesBuilder buildPages = rowPagesBuilder(buildHashEnabled, Ints.asList(0), buildTypes);
-        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, parallelBuild, taskContext, buildPages, Optional.empty());
+        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, parallelBuild, taskContext, buildPages, Optional.empty(), singleBigintLookupSource);
         JoinBridgeManager<PartitionedLookupSourceFactory> lookupSourceFactoryManager = buildSideSetup.getLookupSourceFactoryManager();
 
         // probe factory
@@ -1055,8 +1055,8 @@ public class TestHashJoinOperator
         assertOperatorEquals(joinOperatorFactory, taskContext.addPipelineContext(0, true, true, false).addDriverContext(), probeInput, expected, true, getHashChannels(probePages, buildPages));
     }
 
-    @Test(dataProvider = "hashJoinTestValues")
-    public void testInnerJoinWithNonEmptyLookupSourceAndEmptyProbe(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled)
+    @Test(dataProvider = "hashJoinTestValuesAndsingleBigintLookupSourceProvider")
+    public void testInnerJoinWithNonEmptyLookupSourceAndEmptyProbe(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled, boolean singleBigintLookupSource)
     {
         TaskContext taskContext = createTaskContext();
 
@@ -1067,7 +1067,7 @@ public class TestHashJoinOperator
                 .row(2L)
                 .row((String) null)
                 .row(3L);
-        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, parallelBuild, taskContext, buildPages, Optional.empty());
+        BuildSideSetup buildSideSetup = setupBuildSide(nodePartitioningManager, parallelBuild, taskContext, buildPages, Optional.empty(), singleBigintLookupSource);
         JoinBridgeManager<PartitionedLookupSourceFactory> lookupSourceFactoryManager = buildSideSetup.getLookupSourceFactoryManager();
 
         // probe factory
@@ -1303,6 +1303,22 @@ public class TestHashJoinOperator
     public static Object[][] testMemoryLimitProvider()
     {
         return DataProviders.cartesianProduct(
+                new Object[][] {{true}, {false}},
+                new Object[][] {{true}, {false}});
+    }
+
+    @DataProvider(name = "singleBigintLookupSourceProvider")
+    public static Object[][] singleBigintLookupSourceProvider()
+    {
+        return new Object[][] {{true}, {false}};
+    }
+
+    @DataProvider(name = "hashJoinTestValuesAndsingleBigintLookupSourceProvider")
+    public static Object[][] hashJoinTestValuesAndsingleBigintLookupSourceProvider()
+    {
+        return DataProviders.cartesianProduct(
+                new Object[][] {{true}, {false}},
+                new Object[][] {{true}, {false}},
                 new Object[][] {{true}, {false}},
                 new Object[][] {{true}, {false}});
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
This is the next approach to https://github.com/trinodb/trino/pull/13178, which has been reverted due to https://github.com/trinodb/trino/issues/13380.
This time the memory consumption is not so significantly increased. The additionally allocated long array is indexed by page positions, instead of hash buckets making it significantly smaller. Benchmarks show 3x less of an increase in peak memory usage of TPC benchmarks compared to https://github.com/trinodb/trino/pull/13178.
The performance gain should be smaller because of CPUs out-of-order execution is less possible with this approach. However, after merging of https://github.com/trinodb/trino/pull/13352 it should not matter.

For reviewers: The only change between this PR and https://github.com/trinodb/trino/pull/13178 is the addressing of `values` array in `BigintPagesHash` class.

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

improvement
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core query engine
> How would you describe this change to a non-technical end user or system administrator?

Increase the performance of join on single bigint column
## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Section
* Improve performance of joins over a single BIGINT column
```
