### PR TITLE
Add support for not nullable columns in delta lake 

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConnector.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConnector.java
@@ -21,6 +21,7 @@ import io.trino.plugin.base.session.SessionPropertiesProvider;
 import io.trino.plugin.hive.HiveTransactionHandle;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorAccessControl;
+import io.trino.spi.connector.ConnectorCapabilities;
 import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.ConnectorNodePartitioningProvider;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
@@ -41,6 +42,8 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Sets.immutableEnumSet;
+import static io.trino.spi.connector.ConnectorCapabilities.NOT_NULL_COLUMN_CONSTRAINT;
 import static io.trino.spi.transaction.IsolationLevel.READ_COMMITTED;
 import static io.trino.spi.transaction.IsolationLevel.checkConnectorSupports;
 import static java.util.Objects.requireNonNull;
@@ -213,5 +216,11 @@ public class DeltaLakeConnector
     public final void shutdown()
     {
         lifeCycleManager.stop();
+    }
+
+    @Override
+    public Set<ConnectorCapabilities> getCapabilities()
+    {
+        return immutableEnumSet(NOT_NULL_COLUMN_CONSTRAINT);
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksInsertCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksInsertCompatibility.java
@@ -406,34 +406,6 @@ public class TestDeltaLakeDatabricksInsertCompatibility
                                         .collect(toImmutableList())));
     }
 
-    @Test(groups = {DELTA_LAKE_DATABRICKS, PROFILE_SPECIFIC_TESTS})
-    public void testPreventingWritesToTableWithNotNullableColumns()
-    {
-        String tableName = "test_preventing_inserts_into_table_with_not_nullable_columns_" + randomTableSuffix();
-
-        try {
-            onDelta().executeQuery("CREATE TABLE default." + tableName + "( " +
-                    " id INT NOT NULL, " +
-                    " a_number INT) " +
-                    "USING DELTA " +
-                    "LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "'");
-
-            onDelta().executeQuery("INSERT INTO " + tableName + " VALUES(1,1)");
-            assertQueryFailure(() -> onTrino().executeQuery("INSERT INTO " + tableName + " VALUES (2, 2)"))
-                    .hasMessageContaining("Inserts are not supported for tables with non-nullable columns");
-            assertThat(onTrino().executeQuery("SELECT * FROM " + tableName))
-                    .containsOnly(row(1, 1));
-            onDelta().executeQuery("UPDATE " + tableName + " SET a_number = 2 WHERE id = 1");
-            assertQueryFailure(() -> onTrino().executeQuery("UPDATE " + tableName + " SET a_number = 3 WHERE id = 1"))
-                    .hasMessageContaining("Updates are not supported for tables with non-nullable columns");
-            assertThat(onTrino().executeQuery("SELECT * FROM " + tableName))
-                    .containsOnly(row(1, 2));
-        }
-        finally {
-            onDelta().executeQuery("DROP TABLE IF EXISTS " + tableName);
-        }
-    }
-
     @DataProvider
     public Object[][] compressionCodecs()
     {


### PR DESCRIPTION
## Description

In delta lake add support for tables that have non nullable columns.


> Is this change a fix, improvement, new feature, refactoring, or other?

new feature

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

a connector

> How would you describe this change to a non-technical end user or system administrator?

During creation of table you can specify if column can store NULL values.

## Related issues, pull requests, and links

https://github.com/trinodb/trino/issues/12635


## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Delta Lake
* Add support for `NOT NULL` column constraint. ({issue}`13436`)
```
