### PR TITLE
Remove use of deprecated Iceberg API method

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1189,7 +1189,7 @@ public class IcebergMetadata
     private void removeOrphanMetadataFiles(Table table, ConnectorSession session, SchemaTableName schemaTableName, long expireTimestamp)
     {
         ImmutableSet<String> manifests = stream(table.snapshots())
-                .flatMap(snapshot -> snapshot.allManifests().stream())
+                .flatMap(snapshot -> snapshot.allManifests(table.io()).stream())
                 .map(ManifestFile::path)
                 .collect(toImmutableSet());
         List<String> manifestLists = ReachableFileUtil.manifestListLocations(table);
@@ -1721,7 +1721,7 @@ public class IcebergMetadata
             Table icebergTable = catalog.loadTable(session, table.getSchemaTableName());
 
             Long snapshotId = table.getSnapshotId().orElseThrow(() -> new IllegalStateException("Snapshot id must be present"));
-            Set<Integer> partitionSpecIds = icebergTable.snapshot(snapshotId).allManifests().stream()
+            Set<Integer> partitionSpecIds = icebergTable.snapshot(snapshotId).allManifests(icebergTable.io()).stream()
                     .map(ManifestFile::partitionSpecId)
                     .collect(toImmutableSet());
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ManifestsTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ManifestsTable.java
@@ -114,7 +114,7 @@ public class ManifestsTable
 
         Map<Integer, PartitionSpec> partitionSpecsById = icebergTable.specs();
 
-        snapshot.allManifests().forEach(file -> {
+        snapshot.allManifests(icebergTable.io()).forEach(file -> {
             pagesBuilder.beginRow();
             pagesBuilder.appendVarchar(file.path());
             pagesBuilder.appendBigint(file.length());


### PR DESCRIPTION
## Description

Snapshot#allManifests now tables a fileIO parameter, the version previously used has been deprecated.

> Is this change a fix, improvement, new feature, refactoring, or other?

n/a

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Iceberg connector

> How would you describe this change to a non-technical end user or system administrator?

n/a

## Related issues, pull requests, and links

Iceberg API change: https://github.com/apache/iceberg/pull/4873

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text: