### PR TITLE
Fix flaky testFailStuckSplitTasks unit test

### DIFF
--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskManager.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskManager.java
@@ -49,11 +49,15 @@ import io.trino.version.EmbedVersion;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
+import javax.annotation.concurrent.GuardedBy;
+
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
@@ -249,6 +253,7 @@ public class TestSqlTaskManager
 
     @Test
     public void testFailStuckSplitTasks()
+            throws InterruptedException, ExecutionException, TimeoutException
     {
         TestingTicker ticker = new TestingTicker();
 
@@ -265,6 +270,9 @@ public class TestSqlTaskManager
         taskExecutor.enqueueSplits(taskHandle, false, ImmutableList.of(mockSplitRunner));
         taskExecutor.start();
 
+        // wait for the task executor to start processing the split
+        mockSplitRunner.waitForStart();
+
         TaskManagerConfig taskManagerConfig = new TaskManagerConfig()
                 .setInterruptStuckSplitTasksEnabled(true)
                 .setInterruptStuckSplitTasksDetectionInterval(new Duration(10, SECONDS))
@@ -272,11 +280,21 @@ public class TestSqlTaskManager
                 .setInterruptStuckSplitTasksTimeout(new Duration(10, SECONDS));
 
         try (SqlTaskManager sqlTaskManager = createSqlTaskManager(taskManagerConfig, new NodeMemoryConfig(), taskExecutor, stackTraceElements -> true)) {
+            sqlTaskManager.addStateChangeListener(TASK_ID, (state) -> {
+                if (state.isDone()) {
+                    taskExecutor.removeTask(taskHandle);
+                }
+            });
+
             ticker.increment(30, SECONDS);
             sqlTaskManager.failStuckSplitTasks();
 
+            mockSplitRunner.waitForFinish();
             assertEquals(sqlTaskManager.getAllTaskInfo().size(), 1);
             assertEquals(sqlTaskManager.getAllTaskInfo().get(0).getTaskStatus().getState(), TaskState.FAILED);
+        }
+        finally {
+            taskExecutor.stop();
         }
     }
 
@@ -444,17 +462,45 @@ public class TestSqlTaskManager
     private static class MockSplitRunner
             implements SplitRunner
     {
-        private SettableFuture<Boolean> interrupted = SettableFuture.create();
+        private final SettableFuture<Void> startedFuture = SettableFuture.create();
+        private final SettableFuture<Void> finishedFuture = SettableFuture.create();
+
+        @GuardedBy("this")
+        private Thread runnerThread;
+        @GuardedBy("this")
+        private boolean closed;
+
+        public void waitForStart()
+                throws ExecutionException, InterruptedException, TimeoutException
+        {
+            startedFuture.get(10, SECONDS);
+        }
+
+        public void waitForFinish()
+                throws ExecutionException, InterruptedException, TimeoutException
+        {
+            finishedFuture.get(10, SECONDS);
+        }
 
         @Override
-        public boolean isFinished()
+        public synchronized boolean isFinished()
         {
-            return interrupted.isDone();
+            return closed;
         }
 
         @Override
         public ListenableFuture<Void> processFor(Duration duration)
         {
+            startedFuture.set(null);
+            synchronized (this) {
+                runnerThread = Thread.currentThread();
+
+                if (closed) {
+                    finishedFuture.set(null);
+                    return immediateVoidFuture();
+                }
+            }
+
             while (true) {
                 try {
                     Thread.sleep(100000);
@@ -463,19 +509,29 @@ public class TestSqlTaskManager
                     break;
                 }
             }
-            interrupted.set(true);
+
+            synchronized (this) {
+                closed = true;
+            }
+            finishedFuture.set(null);
+
             return immediateVoidFuture();
         }
 
         @Override
         public String getInfo()
         {
-            return "";
+            return "MockSplitRunner";
         }
 
         @Override
-        public void close()
+        public synchronized void close()
         {
+            closed = true;
+
+            if (runnerThread != null) {
+                runnerThread.interrupt();
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->
Fix flaky testFailStuckSplitTasks unit test.

1. Added wait for task executors to pick up tasks
2. Close task executor after the unit test finished. 

There is a race condition between unit test thread and the task executor thread. Added checking via settableFuture in the unit test thread to ensure task executor to process splits first.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Query Engine

> How would you describe this change to a non-technical end user or system administrator?

Fix flaky testFailStuckSplitTasks unit test.

## Related issues, pull requests, and links
https://github.com/trinodb/trino/pull/12392
https://github.com/trinodb/trino/issues/13437

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
