### PR TITLE
Quote field with reserved key name when reading hive view using coral

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
@@ -47,6 +47,7 @@ import java.util.function.BiFunction;
 
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.linkedin.coral.trino.rel2trino.functions.TrinoKeywordsConverter.quoteWordIfNotQuoted;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_INVALID_VIEW_DATA;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_VIEW_TRANSLATION_ERROR;
 import static io.trino.plugin.hive.HiveMetadata.TABLE_COMMENT;
@@ -245,8 +246,11 @@ public final class ViewReaderUtil
             switch (type.getSqlTypeName()) {
                 case ROW: {
                     verify(type.isStruct(), "expected ROW type to be a struct: %s", type);
+                    // There is no API in RelDataType for Coral to add quotes for rowType.
+                    // We add the Coral function here to parse data types successfully.
+                    // Goal is to use data type mapping instead of translating to strings
                     return type.getFieldList().stream()
-                            .map(field -> field.getName().toLowerCase(Locale.ENGLISH) + " " + getTypeString(field.getType()))
+                            .map(field -> quoteWordIfNotQuoted(field.getName().toLowerCase(Locale.ENGLISH)) + " " + getTypeString(field.getType()))
                             .collect(joining(",", "row(", ")"));
                 }
                 case CHAR:


### PR DESCRIPTION
This fixed issue when reading coral translated hive view with definition such as:
`struct<from:int>`.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->
Quote field with reserved key name when reading hive view using coral.
Enabling Trino to read those hive views.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
Fix.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
Core Query Engine.

> How would you describe this change to a non-technical end user or system administrator?
Enabling Trino to read coral translated hive view that contains columns which itself are of struct type and containing reserved keyword as the struct key.  

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

From the linkedin coral project: https://github.com/linkedin/coral/commit/3aa82062fe8f63b9ab2bc28ba18ec4bdcfd8990a
## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Hive
* Fix failure when reading Hive views having column names with reserved keywords. ({issue}`13450`)
```
