### PR TITLE
Add ORC UUIDColumnReader

### DIFF
--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcWriteValidation.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcWriteValidation.java
@@ -101,6 +101,7 @@ import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_NANOS;
 import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.UuidType.UUID;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static java.lang.Math.floorDiv;
 import static java.lang.String.format;
@@ -622,7 +623,7 @@ public class OrcWriteValidation
                 fieldExtractor = ignored -> ImmutableList.of();
                 fieldBuilders = ImmutableList.of();
             }
-            else if (VARBINARY.equals(type)) {
+            else if (VARBINARY.equals(type) || UUID.equals(type)) {
                 statisticsBuilder = new BinaryStatisticsBuilder();
                 fieldExtractor = ignored -> ImmutableList.of();
                 fieldBuilders = ImmutableList.of();

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/OrcType.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/OrcType.java
@@ -13,6 +13,7 @@
  */
 package io.trino.orc.metadata;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.spi.TrinoException;
@@ -29,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -187,8 +189,12 @@ public class OrcType
                 .toString();
     }
 
-    private static List<OrcType> toOrcType(int nextFieldTypeIndex, Type type)
+    private static List<OrcType> toOrcType(int nextFieldTypeIndex, Type type, Optional<Function<Type, Optional<OrcType>>> additionalTypeMapping)
     {
+        Optional<List<OrcType>> orcType = additionalTypeMapping.flatMap(mapping -> mapping.apply(type)).map(ImmutableList::of);
+        if (orcType.isPresent()) {
+            return orcType.get();
+        }
         if (BOOLEAN.equals(type)) {
             return ImmutableList.of(new OrcType(OrcTypeKind.BOOLEAN));
         }
@@ -237,10 +243,10 @@ public class OrcType
             return ImmutableList.of(new OrcType(OrcTypeKind.DECIMAL, decimalType.getPrecision(), decimalType.getScale()));
         }
         if (type instanceof ArrayType) {
-            return createOrcArrayType(nextFieldTypeIndex, type.getTypeParameters().get(0));
+            return createOrcArrayType(nextFieldTypeIndex, type.getTypeParameters().get(0), additionalTypeMapping);
         }
         if (type instanceof MapType) {
-            return createOrcMapType(nextFieldTypeIndex, type.getTypeParameters().get(0), type.getTypeParameters().get(1));
+            return createOrcMapType(nextFieldTypeIndex, type.getTypeParameters().get(0), type.getTypeParameters().get(1), additionalTypeMapping);
         }
         if (type instanceof RowType) {
             List<String> fieldNames = new ArrayList<>();
@@ -250,15 +256,15 @@ public class OrcType
             }
             List<Type> fieldTypes = type.getTypeParameters();
 
-            return createOrcRowType(nextFieldTypeIndex, fieldNames, fieldTypes);
+            return createOrcRowType(nextFieldTypeIndex, fieldNames, fieldTypes, additionalTypeMapping);
         }
         throw new TrinoException(NOT_SUPPORTED, format("Unsupported Hive type: %s", type));
     }
 
-    private static List<OrcType> createOrcArrayType(int nextFieldTypeIndex, Type itemType)
+    private static List<OrcType> createOrcArrayType(int nextFieldTypeIndex, Type itemType, Optional<Function<Type, Optional<OrcType>>> additionalTypeMapping)
     {
         nextFieldTypeIndex++;
-        List<OrcType> itemTypes = toOrcType(nextFieldTypeIndex, itemType);
+        List<OrcType> itemTypes = toOrcType(nextFieldTypeIndex, itemType, additionalTypeMapping);
 
         List<OrcType> orcTypes = new ArrayList<>();
         orcTypes.add(new OrcType(OrcTypeKind.LIST, ImmutableList.of(new OrcColumnId(nextFieldTypeIndex)), ImmutableList.of("item")));
@@ -266,11 +272,11 @@ public class OrcType
         return orcTypes;
     }
 
-    private static List<OrcType> createOrcMapType(int nextFieldTypeIndex, Type keyType, Type valueType)
+    private static List<OrcType> createOrcMapType(int nextFieldTypeIndex, Type keyType, Type valueType, Optional<Function<Type, Optional<OrcType>>> additionalTypeMapping)
     {
         nextFieldTypeIndex++;
-        List<OrcType> keyTypes = toOrcType(nextFieldTypeIndex, keyType);
-        List<OrcType> valueTypes = toOrcType(nextFieldTypeIndex + keyTypes.size(), valueType);
+        List<OrcType> keyTypes = toOrcType(nextFieldTypeIndex, keyType, additionalTypeMapping);
+        List<OrcType> valueTypes = toOrcType(nextFieldTypeIndex + keyTypes.size(), valueType, additionalTypeMapping);
 
         List<OrcType> orcTypes = new ArrayList<>();
         orcTypes.add(new OrcType(
@@ -284,17 +290,23 @@ public class OrcType
 
     public static ColumnMetadata<OrcType> createRootOrcType(List<String> fieldNames, List<Type> fieldTypes)
     {
-        return new ColumnMetadata<>(createOrcRowType(0, fieldNames, fieldTypes));
+        return createRootOrcType(fieldNames, fieldTypes, Optional.empty());
     }
 
-    private static List<OrcType> createOrcRowType(int nextFieldTypeIndex, List<String> fieldNames, List<Type> fieldTypes)
+    @VisibleForTesting
+    public static ColumnMetadata<OrcType> createRootOrcType(List<String> fieldNames, List<Type> fieldTypes, Optional<Function<Type, Optional<OrcType>>> additionalTypeMapping)
+    {
+        return new ColumnMetadata<>(createOrcRowType(0, fieldNames, fieldTypes, additionalTypeMapping));
+    }
+
+    private static List<OrcType> createOrcRowType(int nextFieldTypeIndex, List<String> fieldNames, List<Type> fieldTypes, Optional<Function<Type, Optional<OrcType>>> additionalTypeMapping)
     {
         nextFieldTypeIndex++;
         List<OrcColumnId> fieldTypeIndexes = new ArrayList<>();
         List<List<OrcType>> fieldTypesList = new ArrayList<>();
         for (Type fieldType : fieldTypes) {
             fieldTypeIndexes.add(new OrcColumnId(nextFieldTypeIndex));
-            List<OrcType> fieldOrcTypes = toOrcType(nextFieldTypeIndex, fieldType);
+            List<OrcType> fieldOrcTypes = toOrcType(nextFieldTypeIndex, fieldType, additionalTypeMapping);
             fieldTypesList.add(fieldOrcTypes);
             nextFieldTypeIndex += fieldOrcTypes.size();
         }

--- a/lib/trino-orc/src/main/java/io/trino/orc/reader/ColumnReaders.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/reader/ColumnReaders.java
@@ -21,7 +21,10 @@ import io.trino.orc.OrcReader;
 import io.trino.orc.OrcReader.FieldMapperFactory;
 import io.trino.spi.type.TimeType;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.UuidType;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.orc.metadata.OrcType.OrcTypeKind.BINARY;
 import static io.trino.orc.metadata.OrcType.OrcTypeKind.LONG;
 import static io.trino.orc.reader.ReaderUtils.invalidStreamType;
 import static io.trino.spi.type.IntegerType.INTEGER;
@@ -29,6 +32,8 @@ import static io.trino.spi.type.TimeType.TIME_MICROS;
 
 public final class ColumnReaders
 {
+    public static final String ICEBERG_BINARY_TYPE = "iceberg.binary-type";
+
     private ColumnReaders() {}
 
     public static ColumnReader createColumnReader(
@@ -46,6 +51,14 @@ public final class ColumnReaders
                 throw invalidStreamType(column, type);
             }
             return new TimeColumnReader(type, column, memoryContext.newLocalMemoryContext(ColumnReaders.class.getSimpleName()));
+        }
+        if (type instanceof UuidType) {
+            checkArgument(column.getColumnType() == BINARY, "UUID type can only be read from BINARY column but got " + column);
+            checkArgument(
+                    "UUID".equals(column.getAttributes().get(ICEBERG_BINARY_TYPE)),
+                    "Expected ORC column for UUID data to be annotated with %s=UUID: %s",
+                    ICEBERG_BINARY_TYPE, column);
+            return new UuidColumnReader(column);
         }
 
         switch (column.getColumnType()) {

--- a/lib/trino-orc/src/main/java/io/trino/orc/reader/UuidColumnReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/reader/UuidColumnReader.java
@@ -1,0 +1,271 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.orc.reader;
+
+import io.airlift.units.DataSize;
+import io.trino.orc.OrcColumn;
+import io.trino.orc.OrcCorruptionException;
+import io.trino.orc.metadata.ColumnEncoding;
+import io.trino.orc.metadata.ColumnMetadata;
+import io.trino.orc.stream.BooleanInputStream;
+import io.trino.orc.stream.ByteArrayInputStream;
+import io.trino.orc.stream.InputStreamSource;
+import io.trino.orc.stream.InputStreamSources;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.Int128ArrayBlock;
+import io.trino.spi.block.RunLengthEncodedBlock;
+import org.openjdk.jol.info.ClassLayout;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+import java.time.ZoneId;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.airlift.units.DataSize.Unit.GIGABYTE;
+import static io.trino.orc.metadata.Stream.StreamKind.DATA;
+import static io.trino.orc.metadata.Stream.StreamKind.PRESENT;
+import static io.trino.orc.stream.MissingInputStreamSource.missingStreamSource;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class UuidColumnReader
+        implements ColumnReader
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(UuidColumnReader.class).instanceSize();
+    private static final int ONE_GIGABYTE = toIntExact(DataSize.of(1, GIGABYTE).toBytes());
+
+    private static final VarHandle LONG_ARRAY_HANDLE = MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
+    private final OrcColumn column;
+
+    private int readOffset;
+    private int nextBatchSize;
+
+    private InputStreamSource<BooleanInputStream> presentStreamSource = missingStreamSource(BooleanInputStream.class);
+    @Nullable
+    private BooleanInputStream presentStream;
+
+    private InputStreamSource<ByteArrayInputStream> dataByteSource = missingStreamSource(ByteArrayInputStream.class);
+    @Nullable
+    private ByteArrayInputStream dataStream;
+
+    private boolean rowGroupOpen;
+
+    public UuidColumnReader(OrcColumn column)
+    {
+        this.column = requireNonNull(column, "column is null");
+    }
+
+    @Override
+    public void prepareNextRead(int batchSize)
+    {
+        readOffset += nextBatchSize;
+        nextBatchSize = batchSize;
+    }
+
+    @Override
+    public Block readBlock()
+            throws IOException
+    {
+        if (!rowGroupOpen) {
+            openRowGroup();
+        }
+
+        if (readOffset > 0) {
+            skipToReadOffset();
+            readOffset = 0;
+        }
+
+        if (dataStream == null) {
+            if (presentStream == null) {
+                throw new OrcCorruptionException(column.getOrcDataSourceId(), "Value is null but present stream is missing");
+            }
+            // since dataStream is null, all values are null
+            presentStream.skip(nextBatchSize);
+            Block nullValueBlock = createAllNullsBlock();
+            nextBatchSize = 0;
+            return nullValueBlock;
+        }
+
+        boolean[] isNullVector = null;
+        int nullCount = 0;
+        if (presentStream != null) {
+            isNullVector = new boolean[nextBatchSize];
+            nullCount = presentStream.getUnsetBits(nextBatchSize, isNullVector);
+            if (nullCount == nextBatchSize) {
+                // all nulls
+                Block nullValueBlock = createAllNullsBlock();
+                nextBatchSize = 0;
+                return nullValueBlock;
+            }
+
+            if (nullCount == 0) {
+                isNullVector = null;
+            }
+        }
+
+        int numberOfLongValues = toIntExact(nextBatchSize * 2L);
+        int totalByteLength = toIntExact((long) numberOfLongValues * Long.BYTES);
+
+        int currentBatchSize = nextBatchSize;
+        nextBatchSize = 0;
+        if (totalByteLength == 0) {
+            return new Int128ArrayBlock(currentBatchSize, Optional.empty(), new long[0]);
+        }
+        if (totalByteLength > ONE_GIGABYTE) {
+            throw new TrinoException(GENERIC_INTERNAL_ERROR,
+                    format("Values in column \"%s\" are too large to process for Trino. %s column values are larger than 1GB [%s]", column.getPath(), nextBatchSize, column.getOrcDataSourceId()));
+        }
+        if (dataStream == null) {
+            throw new OrcCorruptionException(column.getOrcDataSourceId(), "Value is not null but data stream is missing");
+        }
+
+        if (isNullVector == null) {
+            long[] values = readNonNullLongs(numberOfLongValues);
+            return new Int128ArrayBlock(currentBatchSize, Optional.empty(), values);
+        }
+
+        int nonNullCount = currentBatchSize - nullCount;
+        long[] values = readNullableLongs(isNullVector, nonNullCount);
+        return new Int128ArrayBlock(currentBatchSize, Optional.of(isNullVector), values);
+    }
+
+    @Override
+    public void startStripe(ZoneId fileTimeZone, InputStreamSources dictionaryStreamSources, ColumnMetadata<ColumnEncoding> encoding)
+    {
+        presentStreamSource = missingStreamSource(BooleanInputStream.class);
+        dataByteSource = missingStreamSource(ByteArrayInputStream.class);
+
+        readOffset = 0;
+        nextBatchSize = 0;
+
+        presentStream = null;
+        dataStream = null;
+
+        rowGroupOpen = false;
+    }
+
+    @Override
+    public void startRowGroup(InputStreamSources dataStreamSources)
+    {
+        presentStreamSource = dataStreamSources.getInputStreamSource(column, PRESENT, BooleanInputStream.class);
+        dataByteSource = dataStreamSources.getInputStreamSource(column, DATA, ByteArrayInputStream.class);
+
+        readOffset = 0;
+        nextBatchSize = 0;
+
+        presentStream = null;
+        dataStream = null;
+
+        rowGroupOpen = false;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .addValue(column)
+                .toString();
+    }
+
+    @Override
+    public void close()
+    {
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE;
+    }
+
+    private void skipToReadOffset()
+            throws IOException
+    {
+        int dataReadOffset = readOffset;
+        if (presentStream != null) {
+            // skip ahead the present bit reader, but count the set bits
+            // and use this as the skip size for the dataStream
+            dataReadOffset = presentStream.countBitsSet(readOffset);
+        }
+        if (dataReadOffset > 0) {
+            if (dataStream == null) {
+                throw new OrcCorruptionException(column.getOrcDataSourceId(), "Value is not null but data stream is missing");
+            }
+            // dataReadOffset deals with positions. Each position is 2 longs in the dataStream.
+            long dataSkipSize = dataReadOffset * 2L * Long.BYTES;
+
+            dataStream.skip(dataSkipSize);
+        }
+    }
+
+    private long[] readNullableLongs(boolean[] isNullVector, int nonNullCount)
+            throws IOException
+    {
+        byte[] data = new byte[nonNullCount * 2 * Long.BYTES];
+
+        dataStream.next(data, 0, data.length);
+
+        int[] offsets = new int[isNullVector.length];
+        int offsetPosition = 0;
+        for (int i = 0; i < isNullVector.length; i++) {
+            offsets[i] = Math.min(offsetPosition * 2 * Long.BYTES, data.length - Long.BYTES * 2);
+            offsetPosition += isNullVector[i] ? 0 : 1;
+        }
+
+        long[] values = new long[isNullVector.length * 2];
+
+        for (int i = 0; i < isNullVector.length; i++) {
+            int isNonNull = isNullVector[i] ? 0 : 1;
+            values[i * 2] = (long) LONG_ARRAY_HANDLE.get(data, offsets[i]) * isNonNull;
+            values[i * 2 + 1] = (long) LONG_ARRAY_HANDLE.get(data, offsets[i] + Long.BYTES) * isNonNull;
+        }
+        return values;
+    }
+
+    private long[] readNonNullLongs(int valueCount)
+            throws IOException
+    {
+        byte[] data = new byte[valueCount * Long.BYTES];
+
+        dataStream.next(data, 0, data.length);
+
+        long[] values = new long[valueCount];
+        for (int i = 0; i < valueCount; i++) {
+            values[i] = (long) LONG_ARRAY_HANDLE.get(data, i * Long.BYTES);
+        }
+        return values;
+    }
+
+    private RunLengthEncodedBlock createAllNullsBlock()
+    {
+        return new RunLengthEncodedBlock(new Int128ArrayBlock(1, Optional.of(new boolean[] {true}), new long[2]), nextBatchSize);
+    }
+
+    private void openRowGroup()
+            throws IOException
+    {
+        presentStream = presentStreamSource.openStream();
+        dataStream = dataByteSource.openStream();
+
+        rowGroupOpen = true;
+    }
+}

--- a/lib/trino-orc/src/test/java/io/trino/orc/AbstractTestOrcReader.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/AbstractTestOrcReader.java
@@ -37,6 +37,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.UUID;
 
 import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Iterables.cycle;
@@ -60,11 +61,13 @@ import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MICROS;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_NANOS;
 import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.UuidType.UUID;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.testing.DateTimeTestingUtils.sqlTimestampOf;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.nCopies;
+import static java.util.UUID.randomUUID;
 import static java.util.stream.Collectors.toList;
 import static org.testng.Assert.assertEquals;
 
@@ -505,6 +508,27 @@ public abstract class AbstractTestOrcReader
             throws Exception
     {
         tester.testRoundTrip(VARBINARY, nCopies(30_000, new SqlVarbinary(new byte[0])));
+    }
+
+    @Test
+    public void testUuidDirectSequence()
+            throws Exception
+    {
+        tester.testRoundTrip(
+                UUID,
+                intsBetween(0, 30_000).stream()
+                        .map(i -> randomUUID())
+                        .collect(toList()));
+    }
+
+    @Test
+    public void testUuidDictionarySequence()
+            throws Exception
+    {
+        tester.testRoundTrip(
+                UUID, ImmutableList.copyOf(limit(cycle(ImmutableList.of(1, 3, 5, 7, 11, 13, 17)), 30_000)).stream()
+                        .map(i -> new UUID(i, i))
+                        .collect(toList()));
     }
 
     private static <T> Iterable<T> skipEvery(int n, Iterable<T> iterable)

--- a/lib/trino-orc/src/test/java/io/trino/orc/BenchmarkColumnReaders.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/BenchmarkColumnReaders.java
@@ -22,7 +22,9 @@ import io.trino.spi.block.Block;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.SqlDecimal;
 import io.trino.spi.type.SqlTimestamp;
+import io.trino.spi.type.SqlVarbinary;
 import io.trino.spi.type.Type;
+import io.trino.type.UuidOperators;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -46,6 +48,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
@@ -66,6 +69,8 @@ import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.UuidType.UUID;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static java.nio.file.Files.createTempDirectory;
@@ -330,6 +335,42 @@ public class BenchmarkColumnReaders
         return pages;
     }
 
+    @Benchmark
+    public Object readUuidNoNull(UuidNoNullBenchmarkData data)
+            throws Exception
+    {
+        try (OrcRecordReader recordReader = data.createRecordReader()) {
+            return readFirstColumn(recordReader);
+        }
+    }
+
+    @Benchmark
+    public Object readUuidWithNull(UuidWithNullBenchmarkData data)
+            throws Exception
+    {
+        try (OrcRecordReader recordReader = data.createRecordReader()) {
+            return readFirstColumn(recordReader);
+        }
+    }
+
+    @Benchmark
+    public Object readVarbinaryUuidNoNull(VarbinaryUuidNoNullBenchmarkData data)
+            throws Exception
+    {
+        try (OrcRecordReader recordReader = data.createRecordReader()) {
+            return readFirstColumn(recordReader);
+        }
+    }
+
+    @Benchmark
+    public Object readVarbinaryUuidWithNull(VarbinaryUuidWithNullBenchmarkData data)
+            throws Exception
+    {
+        try (OrcRecordReader recordReader = data.createRecordReader()) {
+            return readFirstColumn(recordReader);
+        }
+    }
+
     private Object readFirstColumn(OrcRecordReader recordReader)
             throws IOException
     {
@@ -416,6 +457,7 @@ public class BenchmarkColumnReaders
 
                 "varchar",
                 "varbinary",
+                "uuid"
         })
         private String typeName;
 
@@ -991,6 +1033,100 @@ public class BenchmarkColumnReaders
                 }
                 else {
                     values.add(null);
+                }
+            }
+            return values.iterator();
+        }
+    }
+
+    @State(Thread)
+    public static class UuidNoNullBenchmarkData
+            extends BenchmarkData
+    {
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            setup(UUID, createValues());
+        }
+
+        private Iterator<?> createValues()
+        {
+            List<UUID> values = new ArrayList<>();
+            for (int i = 0; i < ROWS; ++i) {
+                values.add(java.util.UUID.randomUUID());
+            }
+            return values.iterator();
+        }
+    }
+
+    @State(Thread)
+    public static class UuidWithNullBenchmarkData
+            extends BenchmarkData
+    {
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            setup(UUID, createValues());
+        }
+
+        private Iterator<?> createValues()
+        {
+            List<UUID> values = new ArrayList<>();
+            for (int i = 0; i < ROWS; ++i) {
+                if (random.nextBoolean()) {
+                    values.add(null);
+                }
+                else {
+                    values.add(java.util.UUID.randomUUID());
+                }
+            }
+            return values.iterator();
+        }
+    }
+
+    @State(Thread)
+    public static class VarbinaryUuidNoNullBenchmarkData
+            extends BenchmarkData
+    {
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            setup(VARBINARY, createValues());
+        }
+
+        private Iterator<?> createValues()
+        {
+            List<SqlVarbinary> values = new ArrayList<>();
+            for (int i = 0; i < ROWS; ++i) {
+                values.add(new SqlVarbinary(UuidOperators.uuid().getBytes()));
+            }
+            return values.iterator();
+        }
+    }
+
+    @State(Thread)
+    public static class VarbinaryUuidWithNullBenchmarkData
+            extends BenchmarkData
+    {
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            setup(VARBINARY, createValues());
+        }
+
+        private Iterator<?> createValues()
+        {
+            List<SqlVarbinary> values = new ArrayList<>();
+            for (int i = 0; i < ROWS; ++i) {
+                if (random.nextBoolean()) {
+                    values.add(null);
+                }
+                else {
+                    values.add(new SqlVarbinary(UuidOperators.uuid().getBytes()));
                 }
             }
             return values.iterator();

--- a/lib/trino-orc/src/test/java/io/trino/orc/OrcTester.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/OrcTester.java
@@ -23,6 +23,7 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.airlift.units.DataSize;
 import io.trino.hive.orc.OrcConf;
+import io.trino.orc.metadata.ColumnMetadata;
 import io.trino.orc.metadata.CompressionKind;
 import io.trino.orc.metadata.OrcType;
 import io.trino.spi.Page;
@@ -92,6 +93,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
@@ -104,6 +106,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.IntStream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -124,6 +127,8 @@ import static io.trino.orc.metadata.CompressionKind.NONE;
 import static io.trino.orc.metadata.CompressionKind.SNAPPY;
 import static io.trino.orc.metadata.CompressionKind.ZLIB;
 import static io.trino.orc.metadata.CompressionKind.ZSTD;
+import static io.trino.orc.metadata.OrcType.OrcTypeKind.BINARY;
+import static io.trino.orc.reader.ColumnReaders.ICEBERG_BINARY_TYPE;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.Chars.truncateToLengthAndTrimSpaces;
@@ -148,6 +153,8 @@ import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
 import static io.trino.spi.type.Timestamps.roundDiv;
 import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.UuidType.UUID;
+import static io.trino.spi.type.UuidType.javaUuidToTrinoUuid;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.Varchars.truncateToLength;
 import static io.trino.testing.DateTimeTestingUtils.sqlTimestampOf;
@@ -424,7 +431,7 @@ public class OrcTester
     {
         OrcWriterStats stats = new OrcWriterStats();
         for (CompressionKind compression : compressions) {
-            boolean hiveSupported = (compression != LZ4) && (compression != ZSTD) && !isTimestampTz(writeType) && !isTimestampTz(readType);
+            boolean hiveSupported = (compression != LZ4) && (compression != ZSTD) && !isTimestampTz(writeType) && !isTimestampTz(readType) && !isUuid(writeType) && !isUuid(readType);
 
             for (Format format : formats) {
                 // write Hive, read Trino
@@ -577,6 +584,10 @@ public class OrcTester
                 assertEquals(actualDouble, expectedDouble, 0.001);
             }
         }
+        else if (type.equals(UUID)) {
+            UUID actualUUID = java.util.UUID.fromString((String) actual);
+            assertEquals(actualUUID, expected);
+        }
         else if (!Objects.equals(actual, expected)) {
             assertEquals(actual, expected);
         }
@@ -635,11 +646,25 @@ public class OrcTester
         List<String> columnNames = ImmutableList.of("test");
         List<Type> types = ImmutableList.of(type);
 
+        ColumnMetadata<OrcType> orcType = OrcType.createRootOrcType(columnNames, types, Optional.of(mappedType -> {
+            if (UUID.equals(mappedType)) {
+                return Optional.of(new OrcType(
+                        BINARY,
+                        ImmutableList.of(),
+                        ImmutableList.of(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        ImmutableMap.of(ICEBERG_BINARY_TYPE, "UUID")));
+            }
+            return Optional.empty();
+        }));
+
         OrcWriter writer = new OrcWriter(
                 new OutputStreamOrcDataSink(new FileOutputStream(outputFile)),
                 ImmutableList.of("test"),
                 types,
-                OrcType.createRootOrcType(columnNames, types),
+                orcType,
                 compression,
                 new OrcWriterOptions(),
                 ImmutableMap.of(),
@@ -693,6 +718,9 @@ public class OrcTester
             }
             else if (VARBINARY.equals(type)) {
                 type.writeSlice(blockBuilder, Slices.wrappedBuffer(((SqlVarbinary) value).getBytes()));
+            }
+            else if (UUID.equals(type)) {
+                type.writeSlice(blockBuilder, javaUuidToTrinoUuid((java.util.UUID) value));
             }
             else if (DATE.equals(type)) {
                 long days = ((SqlDate) value).getDays();
@@ -805,7 +833,13 @@ public class OrcTester
             actualValue = ((ByteWritable) actualValue).get();
         }
         else if (actualValue instanceof BytesWritable) {
-            actualValue = new SqlVarbinary(((BytesWritable) actualValue).copyBytes());
+            if (UUID.equals(type)) {
+                ByteBuffer bytes = ByteBuffer.wrap(((BytesWritable) actualValue).copyBytes());
+                actualValue = new UUID(bytes.getLong(), bytes.getLong()).toString();
+            }
+            else {
+                actualValue = new SqlVarbinary(((BytesWritable) actualValue).copyBytes());
+            }
         }
         else if (actualValue instanceof DateWritableV2) {
             actualValue = new SqlDate(((DateWritableV2) actualValue).getDays());
@@ -984,6 +1018,9 @@ public class OrcTester
         if (type instanceof VarbinaryType) {
             return javaByteArrayObjectInspector;
         }
+        if (type.equals(UUID)) {
+            return javaByteArrayObjectInspector;
+        }
         if (type.equals(DATE)) {
             return javaDateObjectInspector;
         }
@@ -1052,6 +1089,9 @@ public class OrcTester
         }
         if (type.equals(VARBINARY)) {
             return ((SqlVarbinary) value).getBytes();
+        }
+        if (type.equals(UUID)) {
+            return javaUuidToTrinoUuid((java.util.UUID) value).getBytes();
         }
         if (type.equals(DATE)) {
             return Date.ofEpochDay(((SqlDate) value).getDays());
@@ -1215,6 +1255,25 @@ public class OrcTester
             return ((RowType) type).getFields().stream()
                     .map(RowType.Field::getType)
                     .anyMatch(OrcTester::isTimestampTz);
+        }
+        return false;
+    }
+
+    private static boolean isUuid(Type type)
+    {
+        if (type.equals(UUID)) {
+            return true;
+        }
+        if (type instanceof ArrayType) {
+            return isUuid(((ArrayType) type).getElementType());
+        }
+        if (type instanceof MapType) {
+            return isUuid(((MapType) type).getKeyType()) || isUuid(((MapType) type).getValueType());
+        }
+        if (type instanceof RowType) {
+            return ((RowType) type).getFields().stream()
+                    .map(RowType.Field::getType)
+                    .anyMatch(OrcTester::isUuid);
         }
         return false;
     }

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestingOrcPredicate.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestingOrcPredicate.java
@@ -59,6 +59,7 @@ import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MICROS;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_NANOS;
 import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.UuidType.UUID;
 import static java.util.stream.Collectors.toList;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -88,7 +89,7 @@ public final class TestingOrcPredicate
         if (REAL.equals(type) || DOUBLE.equals(type)) {
             return new DoubleOrcPredicate(transform(expectedValues, value -> ((Number) value).doubleValue()));
         }
-        if (type instanceof VarbinaryType) {
+        if (type instanceof VarbinaryType || type.equals(UUID)) {
             // binary does not have stats
             return new BasicOrcPredicate<>(expectedValues, Object.class);
         }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -176,7 +176,6 @@ import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
 import static io.trino.spi.type.UuidType.UUID;
-import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
@@ -783,13 +782,6 @@ public class IcebergPageSourceProvider
 
     private static Type getOrcReadType(Type columnType, TypeManager typeManager)
     {
-        if (columnType == UUID) {
-            // ORC spec doesn't have UUID
-            // TODO read into Int128ArrayBlock for better performance when operating on read values
-            // TODO: Validate that the OrcColumn attribute ICEBERG_BINARY_TYPE is equal to "UUID"
-            return VARBINARY;
-        }
-
         if (columnType instanceof ArrayType) {
             return new ArrayType(getOrcReadType(((ArrayType) columnType).getElementType(), typeManager));
         }


### PR DESCRIPTION
Read UUID values to `Int128ArrayBlock` instead of
`VariableWidthBlock` to improve performance and
to use only type preferred by `UUIDType`.

```
Benchmark                                         (compression)  Mode  Cnt  Score   Error  Units
BenchmarkColumnReaders.readUUIDNoNull                      NONE  avgt   20  4.425 ± 0.044  ns/op
BenchmarkColumnReaders.readUUIDNoNull                      ZLIB  avgt   20  4.393 ± 0.051  ns/op
BenchmarkColumnReaders.readUUIDWithNull                    NONE  avgt   20  6.459 ± 0.127  ns/op
BenchmarkColumnReaders.readUUIDWithNull                    ZLIB  avgt   20  6.465 ± 0.103  ns/op
BenchmarkColumnReaders.readVarbinaryUUIDNoNull             NONE  avgt   20  4.965 ± 0.077  ns/op
BenchmarkColumnReaders.readVarbinaryUUIDNoNull             ZLIB  avgt   20  4.932 ± 0.088  ns/op
BenchmarkColumnReaders.readVarbinaryUUIDWithNull           NONE  avgt   20  6.966 ± 0.174  ns/op
BenchmarkColumnReaders.readVarbinaryUUIDWithNull           ZLIB  avgt   20  6.895 ± 0.221  ns/op
```

```
Benchmark                           (compression)  (typeName)  Mode  Cnt  Score   Error  Units
BenchmarkColumnReaders.readAllNull           NONE        uuid  avgt   20  0.197 ± 0.006  ns/op
BenchmarkColumnReaders.readAllNull           NONE   varbinary  avgt   20  0.195 ± 0.003  ns/op
BenchmarkColumnReaders.readAllNull           ZLIB        uuid  avgt   20  0.198 ± 0.008  ns/op
BenchmarkColumnReaders.readAllNull           ZLIB   varbinary  avgt   20  0.212 ± 0.001  ns/op
```

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

improvement
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

orc reader + iceberg connector
> How would you describe this change to a non-technical end user or system administrator?

Make UUID type in orc more efficient
## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->
* part of https://github.com/trinodb/trino/issues/13267

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
