### PR TITLE
Fix typo in event listeners docs

### DIFF
--- a/docs/src/main/sphinx/admin/event-listeners-http.rst
+++ b/docs/src/main/sphinx/admin/event-listeners-http.rst
@@ -65,7 +65,7 @@ Configuration properties
     - ``false``
 
   * - http-event-listener.log-completed
-    - Enable the plugin to log ``QueryCcompletedEvent`` events
+    - Enable the plugin to log ``QueryCompletedEvent`` events
     - ``false``
 
   * - http-event-listener.log-split


### PR DESCRIPTION
## Description

A typo fix in the HTTP event listeners docs

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:
