### PR TITLE
Add recording distribution of outputBuffer utilization

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/StageStats.java
+++ b/core/trino-main/src/main/java/io/trino/execution/StageStats.java
@@ -22,12 +22,14 @@ import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.operator.BlockedReason;
 import io.trino.operator.OperatorStats;
+import io.trino.plugin.base.metrics.TDigestHistogram;
 import io.trino.spi.eventlistener.StageGcStatistics;
 import org.joda.time.DateTime;
 
 import javax.annotation.concurrent.Immutable;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.Set;
 
@@ -96,6 +98,7 @@ public class StageStats
     private final Duration failedInputBlockedTime;
 
     private final DataSize bufferedDataSize;
+    private final Optional<TDigestHistogram> outputBufferUtilization;
     private final DataSize outputDataSize;
     private final DataSize failedOutputDataSize;
     private final long outputPositions;
@@ -170,6 +173,7 @@ public class StageStats
             @JsonProperty("failedInputBlockedTime") Duration failedInputBlockedTime,
 
             @JsonProperty("bufferedDataSize") DataSize bufferedDataSize,
+            @JsonProperty("outputBufferUtilization") Optional<TDigestHistogram> outputBufferUtilization,
             @JsonProperty("outputDataSize") DataSize outputDataSize,
             @JsonProperty("failedOutputDataSize") DataSize failedOutputDataSize,
             @JsonProperty("outputPositions") long outputPositions,
@@ -258,6 +262,7 @@ public class StageStats
         this.failedInputBlockedTime = requireNonNull(failedInputBlockedTime, "failedInputBlockedTime is null");
 
         this.bufferedDataSize = requireNonNull(bufferedDataSize, "bufferedDataSize is null");
+        this.outputBufferUtilization = requireNonNull(outputBufferUtilization, "outputBufferUtilization is null");
         this.outputDataSize = requireNonNull(outputDataSize, "outputDataSize is null");
         this.failedOutputDataSize = requireNonNull(failedOutputDataSize, "failedOutputDataSize is null");
         checkArgument(outputPositions >= 0, "outputPositions is negative");
@@ -550,6 +555,12 @@ public class StageStats
     public DataSize getBufferedDataSize()
     {
         return bufferedDataSize;
+    }
+
+    @JsonProperty
+    public Optional<TDigestHistogram> getOutputBufferUtilization()
+    {
+        return outputBufferUtilization;
     }
 
     @JsonProperty

--- a/core/trino-main/src/main/java/io/trino/execution/TaskInfo.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TaskInfo.java
@@ -111,7 +111,7 @@ public class TaskInfo
     public TaskInfo summarize()
     {
         if (taskStatus.getState().isDone()) {
-            return new TaskInfo(taskStatus, lastHeartbeat, outputBuffers.summarize(), noMoreSplits, stats.summarizeFinal(), estimatedMemory, needsPlan);
+            return new TaskInfo(taskStatus, lastHeartbeat, outputBuffers.summarizeFinal(), noMoreSplits, stats.summarizeFinal(), estimatedMemory, needsPlan);
         }
         return new TaskInfo(taskStatus, lastHeartbeat, outputBuffers.summarize(), noMoreSplits, stats.summarize(), estimatedMemory, needsPlan);
     }
@@ -130,7 +130,7 @@ public class TaskInfo
         return new TaskInfo(
                 initialTaskStatus(taskId, location, nodeId),
                 DateTime.now(),
-                new OutputBufferInfo("UNINITIALIZED", OPEN, true, true, 0, 0, 0, 0, bufferStates),
+                new OutputBufferInfo("UNINITIALIZED", OPEN, true, true, 0, 0, 0, 0, bufferStates, Optional.empty()),
                 ImmutableSet.of(),
                 taskStats,
                 Optional.empty(),

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/ArbitraryOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/ArbitraryOutputBuffer.java
@@ -25,6 +25,7 @@ import io.trino.execution.buffer.ClientBuffer.PagesSupplier;
 import io.trino.execution.buffer.OutputBuffers.OutputBufferId;
 import io.trino.execution.buffer.SerializedPageReference.PagesReleasedListener;
 import io.trino.memory.context.LocalMemoryContext;
+import io.trino.plugin.base.metrics.TDigestHistogram;
 
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
@@ -150,7 +151,8 @@ public class ArbitraryOutputBuffer
                 totalBufferedPages,
                 totalRowsAdded.get(),
                 totalPagesAdded.get(),
-                infos.build());
+                infos.build(),
+                Optional.of(new TDigestHistogram(memoryManager.getUtilizationHistogram())));
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/BroadcastOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/BroadcastOutputBuffer.java
@@ -24,6 +24,7 @@ import io.trino.execution.StateMachine.StateChangeListener;
 import io.trino.execution.buffer.OutputBuffers.OutputBufferId;
 import io.trino.execution.buffer.SerializedPageReference.PagesReleasedListener;
 import io.trino.memory.context.LocalMemoryContext;
+import io.trino.plugin.base.metrics.TDigestHistogram;
 
 import javax.annotation.concurrent.GuardedBy;
 
@@ -142,7 +143,8 @@ public class BroadcastOutputBuffer
                 totalPagesAdded.get(),
                 buffers.stream()
                         .map(ClientBuffer::getInfo)
-                        .collect(toImmutableList()));
+                        .collect(toImmutableList()),
+                Optional.of(new TDigestHistogram(memoryManager.getUtilizationHistogram())));
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/LazyOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/LazyOutputBuffer.java
@@ -137,7 +137,8 @@ public class LazyOutputBuffer
                     0,
                     0,
                     0,
-                    ImmutableList.of());
+                    ImmutableList.of(),
+                    Optional.empty());
         }
         return outputBuffer.getInfo();
     }

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/PartitionedOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/PartitionedOutputBuffer.java
@@ -22,6 +22,7 @@ import io.trino.execution.StateMachine.StateChangeListener;
 import io.trino.execution.buffer.OutputBuffers.OutputBufferId;
 import io.trino.execution.buffer.SerializedPageReference.PagesReleasedListener;
 import io.trino.memory.context.LocalMemoryContext;
+import io.trino.plugin.base.metrics.TDigestHistogram;
 
 import java.util.List;
 import java.util.Optional;
@@ -127,7 +128,8 @@ public class PartitionedOutputBuffer
                 totalBufferedPages,
                 totalRowsAdded.get(),
                 totalPagesAdded.get(),
-                infos.build());
+                infos.build(),
+                Optional.of(new TDigestHistogram(memoryManager.getUtilizationHistogram())));
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/SpoolingExchangeOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/SpoolingExchangeOutputBuffer.java
@@ -86,7 +86,8 @@ public class SpoolingExchangeOutputBuffer
                 totalPagesAdded.get(),
                 totalRowsAdded.get(),
                 totalPagesAdded.get(),
-                ImmutableList.of());
+                ImmutableList.of(),
+                Optional.empty());
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/execution/TestingRemoteTaskFactory.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestingRemoteTaskFactory.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.stats.TDigest;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.Session;
@@ -31,6 +32,7 @@ import io.trino.execution.buffer.OutputBuffers;
 import io.trino.metadata.InternalNode;
 import io.trino.metadata.Split;
 import io.trino.operator.TaskStats;
+import io.trino.plugin.base.metrics.TDigestHistogram;
 import io.trino.sql.planner.PlanFragment;
 import io.trino.sql.planner.plan.DynamicFilterId;
 import io.trino.sql.planner.plan.PlanNodeId;
@@ -146,7 +148,8 @@ public class TestingRemoteTaskFactory
                             0,
                             0,
                             0,
-                            ImmutableList.of()),
+                            ImmutableList.of(),
+                            Optional.of(new TDigestHistogram(new TDigest()))),
                     ImmutableSet.copyOf(noMoreSplits),
                     new TaskStats(DateTime.now(), null),
                     Optional.empty(),

--- a/core/trino-main/src/test/java/io/trino/memory/TestLeastWastedEffortTaskLowMemoryKiller.java
+++ b/core/trino-main/src/test/java/io/trino/memory/TestLeastWastedEffortTaskLowMemoryKiller.java
@@ -17,6 +17,7 @@ package io.trino.memory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.airlift.stats.TDigest;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.execution.TaskId;
@@ -26,6 +27,7 @@ import io.trino.execution.TaskStatus;
 import io.trino.execution.buffer.BufferState;
 import io.trino.execution.buffer.OutputBufferInfo;
 import io.trino.operator.TaskStats;
+import io.trino.plugin.base.metrics.TDigestHistogram;
 import org.joda.time.DateTime;
 import org.testng.annotations.Test;
 
@@ -247,7 +249,8 @@ public class TestLeastWastedEffortTaskLowMemoryKiller
                         0,
                         0,
                         0,
-                        ImmutableList.of()),
+                        ImmutableList.of(),
+                        Optional.of(new TDigestHistogram(new TDigest()))),
                 ImmutableSet.of(),
                 new TaskStats(DateTime.now(),
                         null,


### PR DESCRIPTION
This pull request adds the exposure of the distribution of `outputBuffer`'s utilization as the `outputBuffers.utilization` parameter in the operator stats. 