### PR TITLE
Add support for describing table function invocation

### DIFF
--- a/core/trino-main/src/main/java/io/trino/util/StatementUtils.java
+++ b/core/trino-main/src/main/java/io/trino/util/StatementUtils.java
@@ -73,6 +73,7 @@ import io.trino.sql.tree.Delete;
 import io.trino.sql.tree.Deny;
 import io.trino.sql.tree.DescribeInput;
 import io.trino.sql.tree.DescribeOutput;
+import io.trino.sql.tree.DescribeTableFunction;
 import io.trino.sql.tree.DropColumn;
 import io.trino.sql.tree.DropMaterializedView;
 import io.trino.sql.tree.DropRole;
@@ -157,6 +158,7 @@ public final class StatementUtils
             // DESCRIBE
             .add(basicStatement(DescribeInput.class, DESCRIBE))
             .add(basicStatement(DescribeOutput.class, DESCRIBE))
+            .add(basicStatement(DescribeTableFunction.class, DESCRIBE))
             .add(basicStatement(ShowCatalogs.class, DESCRIBE))
             .add(basicStatement(ShowColumns.class, DESCRIBE))
             .add(basicStatement(ShowCreate.class, DESCRIBE))

--- a/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4
+++ b/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4
@@ -161,6 +161,7 @@ statement
     | PREPARE identifier FROM statement                                #prepare
     | DEALLOCATE PREPARE identifier                                    #deallocate
     | EXECUTE identifier (USING expression (',' expression)*)?         #execute
+    | DESCRIBE TABLE '(' tableFunctionCall ')'                         #describeTableFunction
     | DESCRIBE INPUT identifier                                        #describeInput
     | DESCRIBE OUTPUT identifier                                       #describeOutput
     | SET PATH pathSpecification                                       #setPath

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -36,6 +36,7 @@ import io.trino.sql.tree.Delete;
 import io.trino.sql.tree.Deny;
 import io.trino.sql.tree.DescribeInput;
 import io.trino.sql.tree.DescribeOutput;
+import io.trino.sql.tree.DescribeTableFunction;
 import io.trino.sql.tree.DescriptorArgument;
 import io.trino.sql.tree.DropColumn;
 import io.trino.sql.tree.DropMaterializedView;
@@ -376,6 +377,15 @@ public final class SqlFormatter
         {
             append(indent, "DESCRIBE OUTPUT ");
             builder.append(node.getName());
+            return null;
+        }
+
+        @Override
+        protected Void visitDescribeTableFunction(DescribeTableFunction node, Integer indent)
+        {
+            append(indent, "DESCRIBE TABLE(");
+            appendTableFunctionInvocation(node.getInvocation(), indent);
+            builder.append(")");
             return null;
         }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -62,6 +62,7 @@ import io.trino.sql.tree.Deny;
 import io.trino.sql.tree.DereferenceExpression;
 import io.trino.sql.tree.DescribeInput;
 import io.trino.sql.tree.DescribeOutput;
+import io.trino.sql.tree.DescribeTableFunction;
 import io.trino.sql.tree.Descriptor;
 import io.trino.sql.tree.DescriptorField;
 import io.trino.sql.tree.DoubleLiteral;
@@ -887,6 +888,14 @@ class AstBuilder
         return new DescribeInput(
                 getLocation(context),
                 (Identifier) visit(context.identifier()));
+    }
+
+    @Override
+    public Node visitDescribeTableFunction(SqlBaseParser.DescribeTableFunctionContext context)
+    {
+        return new DescribeTableFunction(
+                getLocation(context),
+                (TableFunctionInvocation) visit(context.tableFunctionCall()));
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
@@ -112,6 +112,11 @@ public abstract class AstVisitor<R, C>
         return visitStatement(node, context);
     }
 
+    protected R visitDescribeTableFunction(DescribeTableFunction node, C context)
+    {
+        return visitStatement(node, context);
+    }
+
     protected R visitQuery(Query node, C context)
     {
         return visitStatement(node, context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DescribeTableFunction.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DescribeTableFunction.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+public class DescribeTableFunction
+        extends Statement
+{
+    private final TableFunctionInvocation invocation;
+
+    public DescribeTableFunction(NodeLocation location, TableFunctionInvocation invocation)
+    {
+        this(Optional.of(location), invocation);
+    }
+
+    public DescribeTableFunction(TableFunctionInvocation invocation)
+    {
+        this(Optional.empty(), invocation);
+    }
+
+    private DescribeTableFunction(Optional<NodeLocation> location, TableFunctionInvocation invocation)
+    {
+        super(location);
+        this.invocation = invocation;
+    }
+
+    public TableFunctionInvocation getInvocation()
+    {
+        return invocation;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitDescribeTableFunction(this, context);
+    }
+
+    @Override
+    public List<Node> getChildren()
+    {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(invocation);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        io.trino.sql.tree.DescribeTableFunction o = (io.trino.sql.tree.DescribeTableFunction) obj;
+        return Objects.equals(invocation, o.invocation);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("invocation", invocation)
+                .toString();
+    }
+}

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -53,6 +53,7 @@ import io.trino.sql.tree.Deny;
 import io.trino.sql.tree.DereferenceExpression;
 import io.trino.sql.tree.DescribeInput;
 import io.trino.sql.tree.DescribeOutput;
+import io.trino.sql.tree.DescribeTableFunction;
 import io.trino.sql.tree.Descriptor;
 import io.trino.sql.tree.DescriptorField;
 import io.trino.sql.tree.DoubleLiteral;
@@ -2993,6 +2994,19 @@ public class TestSqlParser
     public void testDescribeInput()
     {
         assertStatement("DESCRIBE INPUT myquery", new DescribeInput(identifier("myquery")));
+    }
+
+    @Test
+    public void testDescribeTableFunction()
+    {
+        assertStatement("DESCRIBE TABLE(some_ptf(input => 1))", new DescribeTableFunction(new TableFunctionInvocation(
+                location(1, 21),
+                qualifiedName(location(1, 21), "some_ptf"),
+                ImmutableList.of(new TableFunctionArgument(
+                        location(1, 30),
+                        Optional.of(new Identifier(location(1, 30), "input", false)),
+                        new LongLiteral(location(1, 39), "1"))),
+                ImmutableList.of())));
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestStatementBuilder.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestStatementBuilder.java
@@ -106,6 +106,8 @@ public class TestStatementBuilder
         printStatement("select sum(distinct x) filter (where x > 4) y, sum(x) filter (where x < 2) z from t");
         printStatement("select sum(x) filter (where x > 4) over (partition by y) z from t");
 
+        printStatement("describe table(some_ptf(some_argument => '1'))");
+
         printStatement("" +
                 "select depname, empno, salary\n" +
                 ", count(*) over ()\n" +

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
@@ -1643,6 +1643,13 @@ public abstract class BaseJdbcConnectorTest
     }
 
     @Test
+    public void testNativeQueryDescribeStatement()
+    {
+        assertQuery(format("DESCRIBE TABLE(system.query(query => 'SELECT name FROM %s.nation'))", getSession().getSchema().orElseThrow()), "VALUES ('name', 'varchar(25)', NULL, NULL)");
+        assertQuery(format("DESCRIBE TABLE(system.query(query => 'SELECT name AS other_name FROM %s.nation'))", getSession().getSchema().orElseThrow()), "VALUES ('other_name', 'varchar(25)', NULL, NULL)");
+    }
+
+    @Test
     public void testNativeQueryInsertStatementTableDoesNotExist()
     {
         assertFalse(getQueryRunner().tableExists(getSession(), "non_existent_table"));


### PR DESCRIPTION
This adds support for describing PTF invocations:

```
❯ ./client/trino-cli/target/trino-cli-392-SNAPSHOT-executable.jar
trino> use postgresql.tpch;
USE
trino:tpch> DESCRIBE TABLE(system.query(query => 'SELECT NOW()'));
 Column |            Type             | Extra | Comment
--------+-----------------------------+-------+---------
 now    | timestamp(6) with time zone | NULL  | NULL
(1 row)

trino:tpch> DESCRIBE TABLE(system.query(query => 'SELECT 1 AS _col2'));
 Column |  Type   | Extra | Comment
--------+---------+-------+---------
 _col2  | integer | NULL  | NULL
(1 row)

trino:tpch> DESCRIBE TABLE(system.query(query => 'SELECT name AS t2, CAST(nationkey  AS DECIMAL(10, 2)) FROM tpch.nation'));
  Column   |     Type      | Extra | Comment
-----------+---------------+-------+---------
 t2        | varchar(25)   | NULL  | NULL
 nationkey | decimal(10,2) | NULL  | NULL
(2 rows)

trino:tpch> DESCRIBE TABLE(system.query(query => 'SELECT name FROM tpch.nation'));
 Column |    Type     | Extra | Comment
--------+-------------+-------+---------
 name   | varchar(25) | NULL  | NULL
(1 row)

trino:tpch> DESCRIBE TABLE(system.query(query => 'SELECT * FROM tpch.nation'));
  Column   |     Type     | Extra | Comment
-----------+--------------+-------+---------
 nationkey | bigint       | NULL  | NULL
 name      | varchar(25)  | NULL  | NULL
 regionkey | bigint       | NULL  | NULL
 comment   | varchar(152) | NULL  | NULL
(4 rows)
```

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
