### PR TITLE
Support extra http headers in pinot controller/broker requests

### DIFF
--- a/docs/src/main/sphinx/connector/pinot.rst
+++ b/docs/src/main/sphinx/connector/pinot.rst
@@ -74,6 +74,11 @@ Property name                                             Required   Description
 ``pinot.aggregation-pushdown.enabled``                    No         Push down aggregation queries, default is ``true``.
 ``pinot.count-distinct-pushdown.enabled``                 No         Push down count distinct queries to Pinot, default is ``true``.
 ``pinot.target-segment-page-size``                        No         Max allowed page size for segment query, default is ``1MB``.
+``pinot.extra-http-headers``                              No         Extra headers when sending HTTP based pinot requests to Pinot controller/broker.
+                                                                     Headers are comma-separated, and each header key value pair is colon-separated,
+                                                                     e.g. ``k1:v1,k2:v2,k3:v3 with space`` with space, default is an empty map. Note
+                                                                     that if controller/broker authentications is enabled and ``Authorization`` header
+                                                                     is set, an exception will raise.
 ========================================================= ========== ==============================================================================
 
 If ``pinot.controller.authentication.type`` is set to ``PASSWORD`` then both ``pinot.controller.authentication.user`` and

--- a/plugin/trino-pinot/pom.xml
+++ b/plugin/trino-pinot/pom.xml
@@ -164,6 +164,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.8</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.helix</groupId>
             <artifactId>helix-core</artifactId>
             <version>0.9.8</version>
@@ -458,13 +464,6 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.8</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotConfig.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotConfig.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.configuration.testing.ConfigAssertions;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.trino.testing.assertions.Assert;
 import org.testng.annotations.Test;
 
 import java.util.Map;
@@ -47,7 +48,8 @@ public class TestPinotConfig
                         .setAggregationPushdownEnabled(true)
                         .setCountDistinctPushdownEnabled(true)
                         .setGrpcEnabled(true)
-                        .setTargetSegmentPageSize(DataSize.of(1, MEGABYTE)));
+                        .setTargetSegmentPageSize(DataSize.of(1, MEGABYTE))
+                        .setExtraHttpHeaders(""));
     }
 
     @Test
@@ -68,6 +70,7 @@ public class TestPinotConfig
                 .put("pinot.count-distinct-pushdown.enabled", "false")
                 .put("pinot.grpc.enabled", "false")
                 .put("pinot.target-segment-page-size", "2MB")
+                .put("pinot.extra-http-headers", "k1:v1,k2:v2,k3:some random v3")
                 .buildOrThrow();
 
         PinotConfig expected = new PinotConfig()
@@ -84,9 +87,19 @@ public class TestPinotConfig
                 .setAggregationPushdownEnabled(false)
                 .setCountDistinctPushdownEnabled(false)
                 .setGrpcEnabled(false)
-                .setTargetSegmentPageSize(DataSize.of(2, MEGABYTE));
+                .setTargetSegmentPageSize(DataSize.of(2, MEGABYTE))
+                .setExtraHttpHeaders("k1:v1,k2:v2,k3:some random v3");
 
         ConfigAssertions.assertFullMapping(properties, expected);
+    }
+
+    @Test
+    public void testExtraHttpMetadata()
+    {
+        PinotConfig pinotConfig = new PinotConfig().setExtraHttpHeaders("k1:v1,k2:v2,k3:some random v3");
+        Assert.assertEquals("v1", pinotConfig.getExtraHttpHeaders().get("k1"));
+        Assert.assertEquals("v2", pinotConfig.getExtraHttpHeaders().get("k2"));
+        Assert.assertEquals("some random v3", pinotConfig.getExtraHttpHeaders().get("k3"));
     }
 
     @Test


### PR DESCRIPTION
## Description
Allow users to add customized HTTP headers for controller/broker requests.
This is useful for users who require customization, tracing, or tag information. 

## Documentation

( ) No documentation is needed.
(X) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(X) Release notes entries required with the following suggested text:

```markdown
# Pinot
* Support extra HTTP headers in pinot controller/broker requests.
```
