### PR TITLE
Fix typo in file-based access control doc

### DIFF
--- a/docs/src/main/sphinx/security/file-system-access-control.rst
+++ b/docs/src/main/sphinx/security/file-system-access-control.rst
@@ -388,7 +388,7 @@ management is denied. Each rule is composed of the following fields:
 
     Users always have permission to view or kill their own queries.
 
-    A rule that includes ``owner`` may not include the ``execute`` access mode.
+    A rule that includes ``queryOwner`` may not include the ``execute`` access mode.
     Queries are only owned by a user once their execution has begun.
 
 For example, if you want to allow the role ``admin`` full query access, allow


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Fix a typo in documentation.

Ref:
https://github.com/trinodb/trino/blob/44555a0e5d3ec5d20eca92edfe6af264c4486d6a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/QueryAccessRule.java#L55-L57

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

