### PR TITLE
Disable S3Select pushdown when query not filters data

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3select/S3SelectRecordCursorProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3select/S3SelectRecordCursorProvider.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.hive.s3select;
 
+import com.google.common.collect.ImmutableSet;
 import io.trino.hdfs.HdfsEnvironment;
 import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.plugin.hive.HiveRecordCursorProvider;
@@ -24,19 +25,28 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.TypeManager;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 
 import javax.inject.Inject;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
+import java.util.function.Function;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
 import static io.trino.plugin.hive.HivePageSourceProvider.projectBaseColumns;
 import static io.trino.plugin.hive.util.HiveUtil.getDeserializerClassName;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toUnmodifiableList;
+import static org.apache.hadoop.hive.serde.serdeConstants.COLUMN_NAME_DELIMITER;
+import static org.apache.hadoop.hive.serde.serdeConstants.LIST_COLUMNS;
+import static org.apache.hadoop.hive.serde.serdeConstants.LIST_COLUMN_TYPES;
 
 public class S3SelectRecordCursorProvider
         implements HiveRecordCursorProvider
@@ -80,16 +90,19 @@ public class S3SelectRecordCursorProvider
         // Ignore predicates on partial columns for now.
         effectivePredicate = effectivePredicate.filter((column, domain) -> column.isBaseColumn());
 
+        List<HiveColumnHandle> readerColumns = projectedReaderColumns
+                .map(readColumns -> readColumns.get().stream().map(HiveColumnHandle.class::cast).collect(toImmutableList()))
+                .orElse(columns.stream().collect(toImmutableList()));
+        // Query is not going to filter any data, no need to use S3 Select
+        if (!hasFilters(schema, effectivePredicate, readerColumns)) {
+            return Optional.empty();
+        }
+
         String serdeName = getDeserializerClassName(schema);
         Optional<S3SelectDataType> s3SelectDataTypeOptional = S3SelectSerDeDataTypeMapper.getDataType(serdeName);
 
         if (s3SelectDataTypeOptional.isPresent()) {
             S3SelectDataType s3SelectDataType = s3SelectDataTypeOptional.get();
-
-            List<HiveColumnHandle> readerColumns = projectedReaderColumns
-                    .map(ReaderColumns::get)
-                    .map(readColumns -> readColumns.stream().map(HiveColumnHandle.class::cast).collect(toUnmodifiableList()))
-                    .orElse(columns);
 
             IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(typeManager, s3SelectDataType);
             String ionSqlQuery = queryBuilder.buildSql(readerColumns, effectivePredicate);
@@ -108,5 +121,66 @@ public class S3SelectRecordCursorProvider
             // unsupported serdes
             return Optional.empty();
         }
+    }
+
+    private static boolean hasFilters(
+            Properties schema,
+            TupleDomain<HiveColumnHandle> effectivePredicate,
+            List<HiveColumnHandle> readerColumns)
+    {
+        //There are no effective predicates and readercolumns and columntypes are identical to schema
+        //means getting all data out of S3. We can use S3 GetObject instead of S3 SelectObjectContent in these cases.
+        if (effectivePredicate.isAll()) {
+            return !isEquivalentSchema(readerColumns, schema);
+        }
+        return true;
+    }
+
+    private static boolean isEquivalentSchema(List<HiveColumnHandle> readerColumns, Properties schema)
+    {
+        Set<String> projectedColumnNames = getColumnProperty(readerColumns, HiveColumnHandle::getName);
+        Set<String> projectedColumnTypes = getColumnProperty(readerColumns, column -> column.getHiveType().getTypeInfo().getTypeName());
+        return isEquivalentColumns(projectedColumnNames, schema) && isEquivalentColumnTypes(projectedColumnTypes, schema);
+    }
+
+    private static boolean isEquivalentColumns(Set<String> projectedColumnNames, Properties schema)
+    {
+        Set<String> columnNames;
+        String columnNameProperty = schema.getProperty(LIST_COLUMNS);
+        if (columnNameProperty.length() == 0) {
+            columnNames = ImmutableSet.of();
+        }
+        else {
+            String columnNameDelimiter = (String) schema.getOrDefault(COLUMN_NAME_DELIMITER, ",");
+            columnNames = Arrays.stream(columnNameProperty.split(columnNameDelimiter))
+                    .collect(toImmutableSet());
+        }
+        return projectedColumnNames.equals(columnNames);
+    }
+
+    private static boolean isEquivalentColumnTypes(Set<String> projectedColumnTypes, Properties schema)
+    {
+        String columnTypeProperty = schema.getProperty(LIST_COLUMN_TYPES);
+        Set<String> columnTypes;
+        if (columnTypeProperty.length() == 0) {
+            columnTypes = ImmutableSet.of();
+        }
+        else {
+            columnTypes = TypeInfoUtils.getTypeInfosFromTypeString(columnTypeProperty)
+                    .stream()
+                    .map(TypeInfo::getTypeName)
+                    .collect(toImmutableSet());
+        }
+        return projectedColumnTypes.equals(columnTypes);
+    }
+
+    private static Set<String> getColumnProperty(List<HiveColumnHandle> readerColumns, Function<HiveColumnHandle, String> mapper)
+    {
+        if (readerColumns.isEmpty()) {
+            return ImmutableSet.of();
+        }
+        return readerColumns.stream()
+                .map(mapper)
+                .collect(toImmutableSet());
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3select/TestS3SelectRecordCursor.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3select/TestS3SelectRecordCursor.java
@@ -45,10 +45,10 @@ public class TestS3SelectRecordCursor
 {
     private static final String LAZY_SERDE_CLASS_NAME = LazySimpleSerDe.class.getName();
 
-    private static final HiveColumnHandle ARTICLE_COLUMN = createBaseColumn("article", 1, HIVE_STRING, VARCHAR, REGULAR, Optional.empty());
-    private static final HiveColumnHandle AUTHOR_COLUMN = createBaseColumn("author", 1, HIVE_STRING, VARCHAR, REGULAR, Optional.empty());
-    private static final HiveColumnHandle DATE_ARTICLE_COLUMN = createBaseColumn("date_pub", 1, HIVE_INT, DATE, REGULAR, Optional.empty());
-    private static final HiveColumnHandle QUANTITY_COLUMN = createBaseColumn("quantity", 1, HIVE_INT, INTEGER, REGULAR, Optional.empty());
+    protected static final HiveColumnHandle ARTICLE_COLUMN = createBaseColumn("article", 1, HIVE_STRING, VARCHAR, REGULAR, Optional.empty());
+    protected static final HiveColumnHandle AUTHOR_COLUMN = createBaseColumn("author", 1, HIVE_STRING, VARCHAR, REGULAR, Optional.empty());
+    protected static final HiveColumnHandle DATE_ARTICLE_COLUMN = createBaseColumn("date_pub", 1, HIVE_INT, DATE, REGULAR, Optional.empty());
+    protected static final HiveColumnHandle QUANTITY_COLUMN = createBaseColumn("quantity", 1, HIVE_INT, INTEGER, REGULAR, Optional.empty());
     private static final HiveColumnHandle[] DEFAULT_TEST_COLUMNS = {ARTICLE_COLUMN, AUTHOR_COLUMN, DATE_ARTICLE_COLUMN, QUANTITY_COLUMN};
 
     @Test

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3select/TestS3SelectRecordCursorProvider.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3select/TestS3SelectRecordCursorProvider.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.s3select;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.hadoop.ConfigurationInstantiator;
+import io.trino.plugin.hive.HiveColumnHandle;
+import io.trino.plugin.hive.HiveConfig;
+import io.trino.plugin.hive.HiveRecordCursorProvider.ReaderRecordCursorWithProjections;
+import io.trino.plugin.hive.TestBackgroundHiveSplitLoader.TestingHdfsEnvironment;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
+import io.trino.spi.predicate.SortedRangeSet;
+import io.trino.spi.predicate.TupleDomain;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static io.trino.plugin.hive.HiveTestUtils.SESSION;
+import static io.trino.plugin.hive.s3select.TestS3SelectRecordCursor.ARTICLE_COLUMN;
+import static io.trino.plugin.hive.s3select.TestS3SelectRecordCursor.AUTHOR_COLUMN;
+import static io.trino.plugin.hive.s3select.TestS3SelectRecordCursor.DATE_ARTICLE_COLUMN;
+import static io.trino.plugin.hive.s3select.TestS3SelectRecordCursor.QUANTITY_COLUMN;
+import static io.trino.spi.predicate.TupleDomain.withColumnDomains;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
+import static org.apache.hadoop.hive.serde.serdeConstants.LIST_COLUMNS;
+import static org.apache.hadoop.hive.serde.serdeConstants.LIST_COLUMN_TYPES;
+import static org.apache.hadoop.hive.serde.serdeConstants.SERIALIZATION_LIB;
+import static org.testng.Assert.assertTrue;
+
+public class TestS3SelectRecordCursorProvider
+{
+    @Test
+    public void shouldReturnSelectRecordCursor()
+    {
+        List<HiveColumnHandle> readerColumns = new ArrayList<>();
+        TupleDomain<HiveColumnHandle> effectivePredicate = TupleDomain.all();
+        Optional<ReaderRecordCursorWithProjections> recordCursor =
+                getRecordCursor(effectivePredicate, readerColumns, true);
+        assertTrue(recordCursor.isPresent());
+    }
+
+    @Test
+    public void shouldReturnSelectRecordCursorWhenEffectivePredicateExists()
+    {
+        TupleDomain<HiveColumnHandle> effectivePredicate = withColumnDomains(ImmutableMap.of(QUANTITY_COLUMN,
+                Domain.create(SortedRangeSet.copyOf(BIGINT, ImmutableList.of(Range.equal(BIGINT, 3L))), false)));
+        Optional<ReaderRecordCursorWithProjections> recordCursor =
+                getRecordCursor(effectivePredicate, getAllColumns(), true);
+        assertTrue(recordCursor.isPresent());
+    }
+
+    @Test
+    public void shouldReturnSelectRecordCursorWhenProjectionExists()
+    {
+        TupleDomain<HiveColumnHandle> effectivePredicate = TupleDomain.all();
+        List<HiveColumnHandle> readerColumns = ImmutableList.of(QUANTITY_COLUMN, AUTHOR_COLUMN, ARTICLE_COLUMN);
+        Optional<ReaderRecordCursorWithProjections> recordCursor =
+                getRecordCursor(effectivePredicate, readerColumns, true);
+        assertTrue(recordCursor.isPresent());
+    }
+
+    @Test
+    public void shouldNotReturnSelectRecordCursorWhenPushdownIsDisabled()
+    {
+        List<HiveColumnHandle> readerColumns = new ArrayList<>();
+        TupleDomain<HiveColumnHandle> effectivePredicate = TupleDomain.all();
+        Optional<ReaderRecordCursorWithProjections> recordCursor =
+                getRecordCursor(effectivePredicate, readerColumns, false);
+        assertTrue(recordCursor.isEmpty());
+    }
+
+    @Test
+    public void shouldNotReturnSelectRecordCursorWhenQueryIsNotFiltering()
+    {
+        TupleDomain<HiveColumnHandle> effectivePredicate = TupleDomain.all();
+        Optional<ReaderRecordCursorWithProjections> recordCursor =
+                getRecordCursor(effectivePredicate, getAllColumns(), true);
+        assertTrue(recordCursor.isEmpty());
+    }
+
+    @Test
+    public void shouldNotReturnSelectRecordCursorWhenProjectionOrderIsDifferent()
+    {
+        TupleDomain<HiveColumnHandle> effectivePredicate = TupleDomain.all();
+        List<HiveColumnHandle> readerColumns = ImmutableList.of(DATE_ARTICLE_COLUMN, QUANTITY_COLUMN, ARTICLE_COLUMN, AUTHOR_COLUMN);
+        Optional<ReaderRecordCursorWithProjections> recordCursor =
+                getRecordCursor(effectivePredicate, readerColumns, true);
+        assertTrue(recordCursor.isEmpty());
+    }
+
+    private static Optional<ReaderRecordCursorWithProjections> getRecordCursor(TupleDomain<HiveColumnHandle> effectivePredicate,
+                                                                               List<HiveColumnHandle> readerColumns,
+                                                                               boolean s3SelectPushdownEnabled)
+    {
+        S3SelectRecordCursorProvider s3SelectRecordCursorProvider = new S3SelectRecordCursorProvider(
+                new TestingHdfsEnvironment(new ArrayList<>()),
+                new TrinoS3ClientFactory(new HiveConfig()));
+
+        return s3SelectRecordCursorProvider.createRecordCursor(
+                ConfigurationInstantiator.newEmptyConfiguration(),
+                SESSION,
+                new Path("s3://fakeBucket/fakeObject.gz"),
+                0,
+                10,
+                10,
+                createTestingSchema(),
+                readerColumns,
+                effectivePredicate,
+                TESTING_TYPE_MANAGER,
+                s3SelectPushdownEnabled);
+    }
+
+    private static Properties createTestingSchema()
+    {
+        List<HiveColumnHandle> schemaColumns = getAllColumns();
+        Properties schema = new Properties();
+        String columnNames = buildPropertyFromColumns(schemaColumns, HiveColumnHandle::getName);
+        String columnTypeNames = buildPropertyFromColumns(schemaColumns, column -> column.getHiveType().getTypeInfo().getTypeName());
+        schema.setProperty(LIST_COLUMNS, columnNames);
+        schema.setProperty(LIST_COLUMN_TYPES, columnTypeNames);
+        String deserializerClassName = LazySimpleSerDe.class.getName();
+        schema.setProperty(SERIALIZATION_LIB, deserializerClassName);
+        return schema;
+    }
+
+    private static String buildPropertyFromColumns(List<HiveColumnHandle> columns, Function<HiveColumnHandle, String> mapper)
+    {
+        if (columns.isEmpty()) {
+            return "";
+        }
+        return columns.stream()
+                .map(mapper)
+                .collect(Collectors.joining(","));
+    }
+
+    private static List<HiveColumnHandle> getAllColumns()
+    {
+        return ImmutableList.of(ARTICLE_COLUMN, AUTHOR_COLUMN, DATE_ARTICLE_COLUMN, QUANTITY_COLUMN);
+    }
+}


### PR DESCRIPTION
Enabling S3 Select pushdown for filtering improves performance of queries by reducing the data on the wire. It is most effective when queries pushed down to Select is filtering out some portion of the data residing on S3. This commits disables Select pushdown when query has no predicate, or projection. To retrieve entire object, S3 GetObject is a cheaper option.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

Enabling S3 Select pushdown for filtering improves performance of queries by reducing the data on the wire. It is most effective when queries pushed down to Select is filtering out significant portion  of the data residing on S3. This commit disables Select pushdown  when query has no predicate, or projection. In these cases using S3 GetObject is both cheaper and faster.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

To Trino-Hive connector

> How would you describe this change to a non-technical end user or system administrator?

This commit disables use of S3 Select, when it is not going to improve the performance.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(X) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(X) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
