### PR TITLE
Revert "Improve Iceberg deletes when an entire file can be removed"

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/CommitTaskData.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/CommitTaskData.java
@@ -32,8 +32,6 @@ public class CommitTaskData
     private final Optional<String> partitionDataJson;
     private final FileContent content;
     private final Optional<String> referencedDataFile;
-    private final Optional<Long> fileRecordCount;
-    private final Optional<Long> deletedRowCount;
 
     @JsonCreator
     public CommitTaskData(
@@ -44,9 +42,7 @@ public class CommitTaskData
             @JsonProperty("partitionSpecJson") String partitionSpecJson,
             @JsonProperty("partitionDataJson") Optional<String> partitionDataJson,
             @JsonProperty("content") FileContent content,
-            @JsonProperty("referencedDataFile") Optional<String> referencedDataFile,
-            @JsonProperty("fileRecordCount") Optional<Long> fileRecordCount,
-            @JsonProperty("deletedRowCount") Optional<Long> deletedRowCount)
+            @JsonProperty("referencedDataFile") Optional<String> referencedDataFile)
     {
         this.path = requireNonNull(path, "path is null");
         this.fileFormat = requireNonNull(fileFormat, "fileFormat is null");
@@ -56,11 +52,6 @@ public class CommitTaskData
         this.partitionDataJson = requireNonNull(partitionDataJson, "partitionDataJson is null");
         this.content = requireNonNull(content, "content is null");
         this.referencedDataFile = requireNonNull(referencedDataFile, "referencedDataFile is null");
-        this.fileRecordCount = requireNonNull(fileRecordCount, "fileRecordCount is null");
-        fileRecordCount.ifPresent(rowCount -> checkArgument(rowCount >= 0, "fileRecordCount cannot be negative"));
-        this.deletedRowCount = requireNonNull(deletedRowCount, "deletedRowCount is null");
-        deletedRowCount.ifPresent(rowCount -> checkArgument(rowCount >= 0, "deletedRowCount cannot be negative"));
-        checkArgument(fileRecordCount.isPresent() == deletedRowCount.isPresent(), "fileRecordCount and deletedRowCount must be specified together");
         checkArgument(fileSizeInBytes >= 0, "fileSizeInBytes is negative");
     }
 
@@ -110,17 +101,5 @@ public class CommitTaskData
     public Optional<String> getReferencedDataFile()
     {
         return referencedDataFile;
-    }
-
-    @JsonProperty
-    public Optional<Long> getFileRecordCount()
-    {
-        return fileRecordCount;
-    }
-
-    @JsonProperty
-    public Optional<Long> getDeletedRowCount()
-    {
-        return deletedRowCount;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergColumnHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergColumnHandle.java
@@ -40,7 +40,6 @@ public class IcebergColumnHandle
     public static final int TRINO_MERGE_ROW_ID = Integer.MIN_VALUE + 1;
     public static final String TRINO_ROW_ID_NAME = "$row_id";
 
-    public static final int TRINO_MERGE_FILE_RECORD_COUNT = Integer.MIN_VALUE + 2;
     public static final int TRINO_MERGE_PARTITION_SPEC_ID = Integer.MIN_VALUE + 3;
     public static final int TRINO_MERGE_PARTITION_DATA = Integer.MIN_VALUE + 4;
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -94,8 +94,6 @@ import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.DeleteFile;
-import org.apache.iceberg.DeleteFiles;
-import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileMetadata;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.IsolationLevel;
@@ -122,7 +120,6 @@ import org.apache.iceberg.expressions.Term;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types.IntegerType;
-import org.apache.iceberg.types.Types.LongType;
 import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.types.Types.StringType;
 import org.apache.iceberg.types.Types.StructType;
@@ -151,8 +148,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
@@ -168,7 +163,6 @@ import static io.trino.plugin.hive.HiveApplyProjectionUtil.replaceWithNewVariabl
 import static io.trino.plugin.hive.util.HiveUtil.isStructuralType;
 import static io.trino.plugin.iceberg.ConstraintExtractor.extractTupleDomain;
 import static io.trino.plugin.iceberg.ExpressionConverter.toIcebergExpression;
-import static io.trino.plugin.iceberg.IcebergColumnHandle.TRINO_MERGE_FILE_RECORD_COUNT;
 import static io.trino.plugin.iceberg.IcebergColumnHandle.TRINO_MERGE_PARTITION_DATA;
 import static io.trino.plugin.iceberg.IcebergColumnHandle.TRINO_MERGE_PARTITION_SPEC_ID;
 import static io.trino.plugin.iceberg.IcebergColumnHandle.TRINO_MERGE_ROW_ID;
@@ -224,9 +218,7 @@ import static io.trino.spi.type.UuidType.UUID;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
-import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.joining;
-import static org.apache.iceberg.FileContent.POSITION_DELETES;
 import static org.apache.iceberg.ReachableFileUtil.metadataFileLocations;
 import static org.apache.iceberg.ReachableFileUtil.versionHintLocation;
 import static org.apache.iceberg.SnapshotSummary.DELETED_RECORDS_PROP;
@@ -1492,7 +1484,6 @@ public class IcebergMetadata
         StructType type = StructType.of(ImmutableList.<NestedField>builder()
                 .add(MetadataColumns.FILE_PATH)
                 .add(MetadataColumns.ROW_POSITION)
-                .add(NestedField.required(TRINO_MERGE_FILE_RECORD_COUNT, "file_record_count", LongType.get()))
                 .add(NestedField.required(TRINO_MERGE_PARTITION_SPEC_ID, "partition_spec_id", IntegerType.get()))
                 .add(NestedField.required(TRINO_MERGE_PARTITION_DATA, "partition_data", StringType.get()))
                 .build());
@@ -1561,141 +1552,83 @@ public class IcebergMetadata
 
         Schema schema = SchemaParser.fromJson(table.getTableSchemaJson());
 
-        Map<String, List<CommitTaskData>> deletesByFilePath = commitTasks.stream()
-                .filter(task -> task.getContent() == POSITION_DELETES)
-                .collect(groupingBy(task -> task.getReferencedDataFile().orElseThrow()));
-        Map<String, List<CommitTaskData>> fullyDeletedFiles = deletesByFilePath
-                .entrySet().stream()
-                .filter(entry -> fileIsFullyDeleted(entry.getValue()))
-                .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
-
-        if (!deletesByFilePath.keySet().equals(fullyDeletedFiles.keySet()) || commitTasks.stream().anyMatch(task -> task.getContent() == FileContent.DATA)) {
-            RowDelta rowDelta = transaction.newRowDelta();
-            table.getSnapshotId().map(icebergTable::snapshot).ifPresent(s -> rowDelta.validateFromSnapshot(s.snapshotId()));
-            if (!table.getEnforcedPredicate().isAll()) {
-                rowDelta.conflictDetectionFilter(toIcebergExpression(table.getEnforcedPredicate()));
-            }
-
-            IsolationLevel isolationLevel = IsolationLevel.fromName(icebergTable.properties().getOrDefault(DELETE_ISOLATION_LEVEL, DELETE_ISOLATION_LEVEL_DEFAULT));
-            if (isolationLevel == IsolationLevel.SERIALIZABLE) {
-                rowDelta.validateNoConflictingDataFiles();
-            }
-
-            if (runUpdateValidations) {
-                // Ensure a row that is updated by this commit was not deleted by a separate commit
-                rowDelta.validateDeletedFiles();
-                rowDelta.validateNoConflictingDeleteFiles();
-            }
-
-            ImmutableSet.Builder<String> writtenFiles = ImmutableSet.builder();
-            ImmutableSet.Builder<String> referencedDataFiles = ImmutableSet.builder();
-            for (CommitTaskData task : commitTasks) {
-                PartitionSpec partitionSpec = PartitionSpecParser.fromJson(schema, task.getPartitionSpecJson());
-                Type[] partitionColumnTypes = partitionSpec.fields().stream()
-                        .map(field -> field.transform().getResultType(icebergTable.schema().findType(field.sourceId())))
-                        .toArray(Type[]::new);
-                switch (task.getContent()) {
-                    case POSITION_DELETES:
-                        if (fullyDeletedFiles.containsKey(task.getReferencedDataFile().orElseThrow())) {
-                            continue;
-                        }
-
-                        FileMetadata.Builder deleteBuilder = FileMetadata.deleteFileBuilder(partitionSpec)
-                                .withPath(task.getPath())
-                                .withFormat(task.getFileFormat().toIceberg())
-                                .ofPositionDeletes()
-                                .withFileSizeInBytes(task.getFileSizeInBytes())
-                                .withMetrics(task.getMetrics().metrics());
-
-                        if (!partitionSpec.fields().isEmpty()) {
-                            String partitionDataJson = task.getPartitionDataJson()
-                                    .orElseThrow(() -> new VerifyException("No partition data for partitioned table"));
-                            deleteBuilder.withPartition(PartitionData.fromJson(partitionDataJson, partitionColumnTypes));
-                        }
-
-                        rowDelta.addDeletes(deleteBuilder.build());
-                        writtenFiles.add(task.getPath());
-                        task.getReferencedDataFile().ifPresent(referencedDataFiles::add);
-                        break;
-                    case DATA:
-                        DataFiles.Builder builder = DataFiles.builder(partitionSpec)
-                                .withPath(task.getPath())
-                                .withFormat(task.getFileFormat().toIceberg())
-                                .withFileSizeInBytes(task.getFileSizeInBytes())
-                                .withMetrics(task.getMetrics().metrics());
-
-                        if (!icebergTable.spec().fields().isEmpty()) {
-                            String partitionDataJson = task.getPartitionDataJson()
-                                    .orElseThrow(() -> new VerifyException("No partition data for partitioned table"));
-                            builder.withPartition(PartitionData.fromJson(partitionDataJson, partitionColumnTypes));
-                        }
-                        rowDelta.addRows(builder.build());
-                        writtenFiles.add(task.getPath());
-                        break;
-                    default:
-                        throw new UnsupportedOperationException("Unsupported task content: " + task.getContent());
-                }
-            }
-
-            // try to leave as little garbage as possible behind
-            if (table.getRetryMode() != NO_RETRIES) {
-                cleanExtraOutputFiles(session, writtenFiles.build());
-            }
-
-            rowDelta.validateDataFilesExist(referencedDataFiles.build());
-            try {
-                rowDelta.commit();
-            }
-            catch (ValidationException e) {
-                throw new TrinoException(ICEBERG_COMMIT_ERROR, "Failed to commit Iceberg update to table: " + table.getSchemaTableName(), e);
-            }
+        RowDelta rowDelta = transaction.newRowDelta();
+        table.getSnapshotId().map(icebergTable::snapshot).ifPresent(s -> rowDelta.validateFromSnapshot(s.snapshotId()));
+        if (!table.getEnforcedPredicate().isAll()) {
+            rowDelta.conflictDetectionFilter(toIcebergExpression(table.getEnforcedPredicate()));
         }
 
-        if (!fullyDeletedFiles.isEmpty()) {
-            try {
-                FileSystem fileSystem = hdfsEnvironment.getFileSystem(new HdfsContext(session), new Path(table.getTableLocation()));
-                for (List<CommitTaskData> commitTasksToCleanUp : fullyDeletedFiles.values()) {
-                    for (CommitTaskData commitTaskData : commitTasksToCleanUp) {
-                        if (!fileSystem.delete(new Path(commitTaskData.getPath()), false)) {
-                            log.warn("Failed to clean up uncommitted position delete file: %s", commitTaskData.getPath());
-                        }
+        IsolationLevel isolationLevel = IsolationLevel.fromName(icebergTable.properties().getOrDefault(DELETE_ISOLATION_LEVEL, DELETE_ISOLATION_LEVEL_DEFAULT));
+        if (isolationLevel == IsolationLevel.SERIALIZABLE) {
+            rowDelta.validateNoConflictingDataFiles();
+        }
+
+        if (runUpdateValidations) {
+            // Ensure a row that is updated by this commit was not deleted by a separate commit
+            rowDelta.validateDeletedFiles();
+            rowDelta.validateNoConflictingDeleteFiles();
+        }
+
+        ImmutableSet.Builder<String> writtenFiles = ImmutableSet.builder();
+        ImmutableSet.Builder<String> referencedDataFiles = ImmutableSet.builder();
+        for (CommitTaskData task : commitTasks) {
+            PartitionSpec partitionSpec = PartitionSpecParser.fromJson(schema, task.getPartitionSpecJson());
+            Type[] partitionColumnTypes = partitionSpec.fields().stream()
+                    .map(field -> field.transform().getResultType(icebergTable.schema().findType(field.sourceId())))
+                    .toArray(Type[]::new);
+            switch (task.getContent()) {
+                case POSITION_DELETES:
+                    FileMetadata.Builder deleteBuilder = FileMetadata.deleteFileBuilder(partitionSpec)
+                            .withPath(task.getPath())
+                            .withFormat(task.getFileFormat().toIceberg())
+                            .ofPositionDeletes()
+                            .withFileSizeInBytes(task.getFileSizeInBytes())
+                            .withMetrics(task.getMetrics().metrics());
+
+                    if (!partitionSpec.fields().isEmpty()) {
+                        String partitionDataJson = task.getPartitionDataJson()
+                                .orElseThrow(() -> new VerifyException("No partition data for partitioned table"));
+                        deleteBuilder.withPartition(PartitionData.fromJson(partitionDataJson, partitionColumnTypes));
                     }
-                }
-            }
-            catch (IOException e) {
-                log.warn(e, "Failed to clean up uncommitted position delete files");
+
+                    rowDelta.addDeletes(deleteBuilder.build());
+                    writtenFiles.add(task.getPath());
+                    task.getReferencedDataFile().ifPresent(referencedDataFiles::add);
+                    break;
+                case DATA:
+                    DataFiles.Builder builder = DataFiles.builder(partitionSpec)
+                            .withPath(task.getPath())
+                            .withFormat(task.getFileFormat().toIceberg())
+                            .withFileSizeInBytes(task.getFileSizeInBytes())
+                            .withMetrics(task.getMetrics().metrics());
+
+                    if (!icebergTable.spec().fields().isEmpty()) {
+                        String partitionDataJson = task.getPartitionDataJson()
+                                .orElseThrow(() -> new VerifyException("No partition data for partitioned table"));
+                        builder.withPartition(PartitionData.fromJson(partitionDataJson, partitionColumnTypes));
+                    }
+                    rowDelta.addRows(builder.build());
+                    writtenFiles.add(task.getPath());
+                    break;
+                default:
+                    throw new UnsupportedOperationException("Unsupported task content: " + task.getContent());
             }
         }
 
+        // try to leave as little garbage as possible behind
+        if (table.getRetryMode() != NO_RETRIES) {
+            cleanExtraOutputFiles(session, writtenFiles.build());
+        }
+
+        rowDelta.validateDataFilesExist(referencedDataFiles.build());
         try {
-            if (!fullyDeletedFiles.isEmpty()) {
-                DeleteFiles deleteFiles = transaction.newDelete();
-                fullyDeletedFiles.keySet().forEach(deleteFiles::deleteFile);
-                deleteFiles.commit();
-            }
+            rowDelta.commit();
             transaction.commitTransaction();
         }
         catch (ValidationException e) {
             throw new TrinoException(ICEBERG_COMMIT_ERROR, "Failed to commit Iceberg update to table: " + table.getSchemaTableName(), e);
         }
         transaction = null;
-    }
-
-    private static boolean fileIsFullyDeleted(List<CommitTaskData> positionDeletes)
-    {
-        checkArgument(!positionDeletes.isEmpty(), "Cannot call fileIsFullyDeletes with an empty list");
-        String referencedDataFile = positionDeletes.get(0).getReferencedDataFile().orElseThrow();
-        long fileRecordCount = positionDeletes.get(0).getFileRecordCount().orElseThrow();
-        checkArgument(positionDeletes.stream().allMatch(positionDelete ->
-                        positionDelete.getReferencedDataFile().orElseThrow().equals(referencedDataFile) &&
-                                positionDelete.getFileRecordCount().orElseThrow() == fileRecordCount),
-                "All position deletes must be for the same file and have the same fileRecordCount");
-        long deletedRowCount = positionDeletes.stream()
-                .map(CommitTaskData::getDeletedRowCount)
-                .mapToLong(Optional::orElseThrow)
-                .sum();
-        checkState(deletedRowCount <= fileRecordCount, "Found more deleted rows than exist in the file");
-        return fileRecordCount == deletedRowCount;
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
@@ -325,8 +325,6 @@ public class IcebergPageSink
                 PartitionSpecParser.toJson(partitionSpec),
                 writeContext.getPartitionData().map(PartitionData::toJson),
                 DATA,
-                Optional.empty(),
-                Optional.empty(),
                 Optional.empty());
 
         commitTasks.add(wrappedBuffer(jsonCodec.toJsonBytes(task)));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplit.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplit.java
@@ -40,7 +40,6 @@ public class IcebergSplit
     private final long start;
     private final long length;
     private final long fileSize;
-    private final long fileRecordCount;
     private final IcebergFileFormat fileFormat;
     private final List<HostAddress> addresses;
     private final String partitionSpecJson;
@@ -55,7 +54,6 @@ public class IcebergSplit
             @JsonProperty("start") long start,
             @JsonProperty("length") long length,
             @JsonProperty("fileSize") long fileSize,
-            @JsonProperty("fileRecordCount") long fileRecordCount,
             @JsonProperty("fileFormat") IcebergFileFormat fileFormat,
             @JsonProperty("addresses") List<HostAddress> addresses,
             @JsonProperty("partitionSpecJson") String partitionSpecJson,
@@ -68,7 +66,6 @@ public class IcebergSplit
         this.start = start;
         this.length = length;
         this.fileSize = fileSize;
-        this.fileRecordCount = fileRecordCount;
         this.fileFormat = requireNonNull(fileFormat, "fileFormat is null");
         this.addresses = ImmutableList.copyOf(requireNonNull(addresses, "addresses is null"));
         this.partitionSpecJson = requireNonNull(partitionSpecJson, "partitionSpecJson is null");
@@ -113,12 +110,6 @@ public class IcebergSplit
     public long getFileSize()
     {
         return fileSize;
-    }
-
-    @JsonProperty
-    public long getFileRecordCount()
-    {
-        return fileRecordCount;
     }
 
     @JsonProperty
@@ -186,12 +177,9 @@ public class IcebergSplit
         ToStringHelper helper = toStringHelper(this)
                 .addValue(path)
                 .add("start", start)
-                .add("length", length)
-                .add("records", fileRecordCount);
+                .add("length", length);
         if (!deletes.isEmpty()) {
             helper.add("deleteFiles", deletes.size());
-            helper.add("deleteRecords", deletes.stream()
-                    .mapToLong(DeleteFile::recordCount).sum());
         }
         return helper.toString();
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
@@ -397,7 +397,6 @@ public class IcebergSplitSource
                 task.start(),
                 task.length(),
                 task.file().fileSizeInBytes(),
-                task.file().recordCount(),
                 IcebergFileFormat.fromIceberg(task.file().format()),
                 ImmutableList.of(),
                 PartitionSpecParser.toJson(task.spec()),

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/DeleteFile.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/DeleteFile.java
@@ -41,7 +41,6 @@ public final class DeleteFile
     private final FileContent content;
     private final String path;
     private final FileFormat format;
-    private final long recordCount;
     private final long fileSizeInBytes;
     private final List<Integer> equalityFieldIds;
     private final Map<Integer, byte[]> lowerBounds;
@@ -58,7 +57,6 @@ public final class DeleteFile
                 deleteFile.content(),
                 deleteFile.path().toString(),
                 deleteFile.format(),
-                deleteFile.recordCount(),
                 deleteFile.fileSizeInBytes(),
                 Optional.ofNullable(deleteFile.equalityFieldIds()).orElseGet(ImmutableList::of),
                 lowerBounds,
@@ -70,7 +68,6 @@ public final class DeleteFile
             FileContent content,
             String path,
             FileFormat format,
-            long recordCount,
             long fileSizeInBytes,
             List<Integer> equalityFieldIds,
             Map<Integer, byte[]> lowerBounds,
@@ -79,7 +76,6 @@ public final class DeleteFile
         this.content = requireNonNull(content, "content is null");
         this.path = requireNonNull(path, "path is null");
         this.format = requireNonNull(format, "format is null");
-        this.recordCount = recordCount;
         this.fileSizeInBytes = fileSizeInBytes;
         this.equalityFieldIds = ImmutableList.copyOf(requireNonNull(equalityFieldIds, "equalityFieldIds is null"));
         this.lowerBounds = ImmutableMap.copyOf(requireNonNull(lowerBounds, "lowerBounds is null"));
@@ -102,12 +98,6 @@ public final class DeleteFile
     public FileFormat format()
     {
         return format;
-    }
-
-    @JsonProperty
-    public long recordCount()
-    {
-        return recordCount;
     }
 
     @JsonProperty
@@ -148,7 +138,6 @@ public final class DeleteFile
     {
         return toStringHelper(this)
                 .addValue(path)
-                .add("records", recordCount)
                 .toString();
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/IcebergPositionDeletePageSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/IcebergPositionDeletePageSink.java
@@ -62,11 +62,9 @@ public class IcebergPositionDeletePageSink
     private final JsonCodec<CommitTaskData> jsonCodec;
     private final IcebergFileWriter writer;
     private final IcebergFileFormat fileFormat;
-    private final long fileRecordCount;
 
     private long validationCpuNanos;
     private boolean writtenData;
-    private long deletedRowCount;
 
     public IcebergPositionDeletePageSink(
             String dataFilePath,
@@ -80,15 +78,13 @@ public class IcebergPositionDeletePageSink
             JsonCodec<CommitTaskData> jsonCodec,
             ConnectorSession session,
             IcebergFileFormat fileFormat,
-            Map<String, String> storageProperties,
-            long fileRecordCount)
+            Map<String, String> storageProperties)
     {
         this.dataFilePath = requireNonNull(dataFilePath, "dataFilePath is null");
         this.jsonCodec = requireNonNull(jsonCodec, "jsonCodec is null");
         this.partitionSpec = requireNonNull(partitionSpec, "partitionSpec is null");
         this.partition = requireNonNull(partition, "partition is null");
         this.fileFormat = requireNonNull(fileFormat, "fileFormat is null");
-        this.fileRecordCount = fileRecordCount;
         // prepend query id to a file name so we can determine which files were written by which query. This is needed for opportunistic cleanup of extra files
         // which may be present for successfully completing query in presence of failure recovery mechanisms.
         String fileName = fileFormat.toIceberg().addExtension(session.getQueryId() + "-" + randomUUID());
@@ -128,7 +124,6 @@ public class IcebergPositionDeletePageSink
         writer.appendRows(new Page(blocks));
 
         writtenData = true;
-        deletedRowCount += page.getPositionCount();
         return NOT_BLOCKED;
     }
 
@@ -146,9 +141,7 @@ public class IcebergPositionDeletePageSink
                     PartitionSpecParser.toJson(partitionSpec),
                     partition.map(PartitionData::toJson),
                     FileContent.POSITION_DELETES,
-                    Optional.of(dataFilePath),
-                    Optional.of(fileRecordCount),
-                    Optional.of(deletedRowCount));
+                    Optional.of(dataFilePath));
             Long recordCount = task.getMetrics().recordCount();
             if (recordCount != null && recordCount > 0) {
                 commitTasks.add(wrappedBuffer(jsonCodec.toJsonBytes(task)));

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -5269,6 +5269,22 @@ public abstract class BaseIcebergConnectorTest
     }
 
     @Test
+    public void testDeleteRetainsTableHistory()
+    {
+        String tableName = "test_delete_retains_table_history_" + randomTableSuffix();
+        assertUpdate("CREATE TABLE " + tableName + "(c1 INT, c2 INT)");
+        assertUpdate("INSERT INTO " + tableName + " VALUES (1, 1), (2, 2), (3, 3)", 3);
+        assertUpdate("INSERT INTO " + tableName + " VALUES (3, 3), (4, 4), (5, 5)", 3);
+        List<Long> snapshots = getTableHistory(tableName);
+
+        assertUpdate("DELETE FROM " + tableName + " WHERE c1 < 4", 4);
+        List<Long> snapshotsAfterDelete = getTableHistory(tableName);
+        assertThat(snapshotsAfterDelete.size()).isGreaterThan(snapshots.size());
+        assertThat(snapshotsAfterDelete).containsAll(snapshots);
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
     public void testMergeSimpleSelectPartitioned()
     {
         String targetTable = "merge_simple_target_" + randomTableSuffix();
@@ -5606,6 +5622,14 @@ public abstract class BaseIcebergConnectorTest
                 .getOnlyColumn()
                 .map(Long.class::cast)
                 .collect(toUnmodifiableList());
+    }
+
+    private List<Long> getTableHistory(String tableName)
+    {
+        return getQueryRunner().execute(format("SELECT snapshot_id FROM \"%s$history\"", tableName))
+                .getOnlyColumn()
+                .map(Long.class::cast)
+                .collect(toImmutableList());
     }
 
     private long getCurrentSnapshotId(String tableName)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -1411,6 +1411,7 @@ public abstract class BaseIcebergConnectorTest
 
         // The old partition scheme is no longer used so pushdown using the hour transform is allowed
         assertUpdate("DELETE FROM " + tableName + " WHERE year(d) = 1969", 3);
+        assertUpdate("ALTER TABLE " + tableName + " EXECUTE optimize");
         assertUpdate("INSERT INTO " + tableName + " VALUES " + initialValues, 3);
         assertThat(query(selectQuery))
                 .containsAll("VALUES 1, 8, 9, 10")

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
@@ -156,7 +156,6 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                 0,
                 outputFile.length(),
                 outputFile.length(),
-                0, // This is incorrect, but the value is only used for delete operations
                 ORC,
                 ImmutableList.of(),
                 PartitionSpecParser.toJson(PartitionSpec.unpartitioned()),

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
@@ -380,7 +380,7 @@ public class TestIcebergV2
         assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(2);
         assertUpdate("DELETE FROM " + tableName + " WHERE regionkey <= 2", "SELECT count(*) FROM nation WHERE regionkey <= 2");
         assertQuery("SELECT * FROM " + tableName, "SELECT * FROM nation WHERE regionkey > 2");
-        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(1);
+        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(2);
     }
 
     @Test
@@ -394,7 +394,7 @@ public class TestIcebergV2
         assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(4);
         assertUpdate("DELETE FROM " + tableName + " WHERE b % 2 = 0", 6);
         assertQuery("SELECT * FROM " + tableName, "VALUES (1, 1), (1, 3), (1, 5), (2, 1), (2, 3), (2, 5)");
-        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(2);
+        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(4);
     }
 
     @Test
@@ -408,7 +408,7 @@ public class TestIcebergV2
         assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(2);
         assertUpdate("DELETE FROM " + tableName + " WHERE regionkey % 2 = 1", "SELECT count(*) FROM nation WHERE regionkey % 2 = 1");
         assertQuery("SELECT * FROM " + tableName, "SELECT * FROM nation WHERE regionkey % 2 = 0");
-        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(1);
+        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(2);
     }
 
     @Test
@@ -428,7 +428,7 @@ public class TestIcebergV2
         long parentSnapshotId = (long) computeScalar("SELECT parent_id FROM \"" + tableName + "$snapshots\" ORDER BY committed_at DESC FETCH FIRST 1 ROW WITH TIES");
         assertEquals(initialSnapshotId, parentSnapshotId);
         assertThat(query("SELECT * FROM " + tableName)).returnsEmptyResult();
-        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(0);
+        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(1);
     }
 
     @Test


### PR DESCRIPTION
## Description

This reverts commit 9ddaa60df18f74247d299cf0ce4c81d9383cfb9d.

Including both a RowDelta and a DeleteFiles commit in the same Iceberg transaction
results in the table history being cleared. Instead only write RowDeltas,
even in the case where a file can be fully removed.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Iceberg connector

> How would you describe this change to a non-technical end user or system administrator?

Ensures Trino does not clear Iceberg table history when it's not expected.

## Related issues, pull requests, and links

Quick fix for: https://github.com/trinodb/trino/issues/12843

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Iceberg
* Fix delete transactions to ensure table history remain intact.
```

Fixes https://github.com/trinodb/trino/issues/12843 