### PR TITLE
Support for mutil-value audience claims in JWT token

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/jwt/InvalidClaimException.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/jwt/InvalidClaimException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.security.jwt;
+
+import io.jsonwebtoken.JwtException;
+
+public class InvalidClaimException
+        extends JwtException
+{
+    public InvalidClaimException(String message)
+    {
+        super(message);
+    }
+
+    public InvalidClaimException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtAuthenticator.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtAuthenticator.java
@@ -77,11 +77,11 @@ public class JwtAuthenticator
 
     private void validateAudience(Claims claims)
     {
-        Object tokenAudience = claims.get(AUDIENCE);
         if (requiredAudience.isEmpty()) {
             return;
         }
 
+        Object tokenAudience = claims.get(AUDIENCE);
         if (tokenAudience == null) {
             throw new InvalidClaimException(format("Expected %s claim to be: %s, but was not present in the JWT claims.", AUDIENCE, requiredAudience.get()));
         }

--- a/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtAuthenticator.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtAuthenticator.java
@@ -13,6 +13,7 @@
  */
 package io.trino.server.security.jwt;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtParser;
 import io.jsonwebtoken.JwtParserBuilder;
 import io.jsonwebtoken.SigningKeyResolver;
@@ -26,10 +27,13 @@ import io.trino.spi.security.Identity;
 import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
 
+import java.util.Collection;
 import java.util.Optional;
 
+import static io.jsonwebtoken.Claims.AUDIENCE;
 import static io.trino.server.security.UserMapping.createUserMapping;
 import static io.trino.server.security.jwt.JwtUtil.newJwtParserBuilder;
+import static java.lang.String.format;
 
 public class JwtAuthenticator
         extends AbstractBearerAuthenticator
@@ -37,20 +41,19 @@ public class JwtAuthenticator
     private final JwtParser jwtParser;
     private final String principalField;
     private final UserMapping userMapping;
+    private final String requiredAudience;
 
     @Inject
     public JwtAuthenticator(JwtAuthenticatorConfig config, @ForJwt SigningKeyResolver signingKeyResolver)
     {
         principalField = config.getPrincipalField();
+        requiredAudience = config.getRequiredAudience();
 
         JwtParserBuilder jwtParser = newJwtParserBuilder()
                 .setSigningKeyResolver(signingKeyResolver);
 
         if (config.getRequiredIssuer() != null) {
             jwtParser.requireIssuer(config.getRequiredIssuer());
-        }
-        if (config.getRequiredAudience() != null) {
-            jwtParser.requireAudience(config.getRequiredAudience());
         }
         this.jwtParser = jwtParser.build();
         userMapping = createUserMapping(config.getUserMappingPattern(), config.getUserMappingFile());
@@ -60,15 +63,42 @@ public class JwtAuthenticator
     protected Optional<Identity> createIdentity(String token)
             throws UserMappingException
     {
-        Optional<String> principal = Optional.ofNullable(jwtParser.parseClaimsJws(token)
-                .getBody()
-                .get(principalField, String.class));
+        Claims claims = jwtParser.parseClaimsJws(token).getBody();
+        validateAudience(claims);
+
+        Optional<String> principal = Optional.ofNullable(claims.get(principalField, String.class));
         if (principal.isEmpty()) {
             return Optional.empty();
         }
         return Optional.of(Identity.forUser(userMapping.mapUser(principal.get()))
                 .withPrincipal(new BasicPrincipal(principal.get()))
                 .build());
+    }
+
+    private void validateAudience(Claims claims)
+    {
+        Object tokenAudience = claims.get(AUDIENCE);
+        if (requiredAudience == null) {
+            return;
+        }
+
+        if (tokenAudience == null) {
+            throw new InvalidClaimException(format("Expected %s claim to be: %s, but was not present in the JWT claims.", AUDIENCE, requiredAudience));
+        }
+
+        if (tokenAudience instanceof String) {
+            if (!requiredAudience.equals((String) tokenAudience)) {
+                throw new InvalidClaimException(format("Invalid Audience: %s. Allowed audiences: %s", tokenAudience, requiredAudience));
+            }
+        }
+        else if (tokenAudience instanceof Collection) {
+            if (((Collection<?>) tokenAudience).stream().map(String.class::cast).noneMatch(requiredAudience::equals)) {
+                throw new InvalidClaimException(format("Invalid Audience: %s. Allowed audiences: %s", tokenAudience, requiredAudience));
+            }
+        }
+        else {
+            throw new InvalidClaimException(format("Invalid Audience: %s", tokenAudience));
+        }
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
@@ -97,6 +97,7 @@ import static com.google.common.net.HttpHeaders.AUTHORIZATION;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
 import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
+import static io.jsonwebtoken.Claims.AUDIENCE;
 import static io.jsonwebtoken.security.Keys.hmacShaKeyFor;
 import static io.trino.client.OkHttpUtil.setupSsl;
 import static io.trino.client.ProtocolHeaders.TRINO_HEADERS;
@@ -148,6 +149,9 @@ public class TestResourceSecurity
     private static final String HMAC_KEY = Resources.getResource("hmac_key.txt").getPath();
     private static final String JWK_KEY_ID = "test-rsa";
     private static final String GROUPS_CLAIM = "groups";
+    private static final String TRINO_AUDIENCE = "trino-client";
+    private static final String ADDITIONAL_AUDIENCE = "https://external-service.com";
+    private static final String UNTRUSTED_CLIENT_AUDIENCE = "https://untrusted.com";
     private static final PrivateKey JWK_PRIVATE_KEY;
     private static final PublicKey JWK_PUBLIC_KEY;
     private static final ObjectMapper json = new ObjectMapper();
@@ -460,11 +464,13 @@ public class TestResourceSecurity
     public void testJwtAuthenticator()
             throws Exception
     {
-        verifyJwtAuthenticator(Optional.empty());
-        verifyJwtAuthenticator(Optional.of("custom-principal"));
+        verifyJwtAuthenticator(Optional.empty(), Optional.empty());
+        verifyJwtAuthenticator(Optional.of("custom-principal"), Optional.empty());
+        verifyJwtAuthenticator(Optional.empty(), Optional.of(TRINO_AUDIENCE));
+        verifyJwtAuthenticator(Optional.empty(), Optional.of(ImmutableList.of(TRINO_AUDIENCE, ADDITIONAL_AUDIENCE)));
     }
 
-    private void verifyJwtAuthenticator(Optional<String> principalField)
+    private void verifyJwtAuthenticator(Optional<String> principalField, Optional<Object> audience)
             throws Exception
     {
         try (TestingTrinoServer server = TestingTrinoServer.builder()
@@ -473,6 +479,7 @@ public class TestResourceSecurity
                         .put("http-server.authentication.type", "jwt")
                         .put("http-server.authentication.jwt.key-file", HMAC_KEY)
                         .put("http-server.authentication.jwt.principal-field", principalField.orElse("sub"))
+                        .put("http-server.authentication.jwt.required-audience", TRINO_AUDIENCE)
                         .buildOrThrow())
                 .build()) {
             server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(TestSystemAccessControl.NO_IMPERSONATION);
@@ -485,10 +492,17 @@ public class TestResourceSecurity
                     .signWith(hmac)
                     .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()));
             if (principalField.isPresent()) {
-                tokenBuilder.claim(principalField.get(), "test-user");
+                tokenBuilder.claim(principalField.get(), TEST_USER);
             }
             else {
-                tokenBuilder.setSubject("test-user");
+                tokenBuilder.setSubject(TEST_USER);
+            }
+
+            if (audience.isPresent()) {
+                tokenBuilder.claim(AUDIENCE, audience.get());
+            }
+            else {
+                tokenBuilder.setAudience(TRINO_AUDIENCE);
             }
             String token = tokenBuilder.compact();
 
@@ -535,6 +549,34 @@ public class TestResourceSecurity
         }
         finally {
             jwkServer.stop();
+        }
+    }
+
+    @Test
+    public void testJwtAuthenticatorWithInvalidAudience()
+            throws Exception
+    {
+        try (TestingTrinoServer server = TestingTrinoServer.builder()
+                .setProperties(ImmutableMap.<String, String>builder()
+                        .putAll(SECURE_PROPERTIES)
+                        .put("http-server.authentication.type", "jwt")
+                        .put("http-server.authentication.jwt.key-file", HMAC_KEY)
+                        .put("http-server.authentication.jwt.required-audience", TRINO_AUDIENCE)
+                        .buildOrThrow())
+                .build()) {
+            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(TestSystemAccessControl.NO_IMPERSONATION);
+            HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
+
+            SecretKey hmac = hmacShaKeyFor(Base64.getDecoder().decode(Files.readString(Paths.get(HMAC_KEY)).trim()));
+            JwtBuilder tokenBuilder = newJwtBuilder()
+                    .signWith(hmac)
+                    .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()))
+                    .claim(AUDIENCE, ImmutableList.of(ADDITIONAL_AUDIENCE, UNTRUSTED_CLIENT_AUDIENCE));
+            String token = tokenBuilder.compact();
+
+            OkHttpClient clientWithJwt = this.client.newBuilder()
+                    .build();
+            assertResponseCode(clientWithJwt, getAuthorizedUserLocation(httpServerInfo.getHttpsUri()), SC_UNAUTHORIZED, Headers.of(AUTHORIZATION, "Bearer " + token));
         }
     }
 


### PR DESCRIPTION
## Description

`requiredAudience` validation fails if `aud` claim contains multiple audiences in JWT token.

- Remove `jwtParser.requireAudience(config.getRequiredAudience());` to not to validate `aud` during `parseClaimsJws`.
- Add `validateAudience` method and call it from `createIdentity`

> Is this change a fix, improvement, new feature, refactoring, or other?

a fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

JWT Authentication

> How would you describe this change to a non-technical end user or system administrator?

Support for mutil-value audience claims in JWT token

## Related issues, pull requests, and links

#13442

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( *) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# JWT Authentication
* Support for mutil-value audience claims in JWT token. ({issue}`13442 `)
```
