### PR TITLE
Support snapshot queries on Iceberg system tables - IcebergSystemTableHandle is a ConnectorTableHandle with custom `instanceof` handling in IcebergMetadata

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HistoryTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HistoryTable.java
@@ -15,6 +15,7 @@ package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableMetadata;
@@ -22,17 +23,23 @@ import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.InMemoryRecordSet;
 import io.trino.spi.connector.RecordCursor;
 import io.trino.spi.connector.SchemaTableName;
-import io.trino.spi.connector.SystemTable;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.TimeZoneKey;
 import org.apache.iceberg.HistoryEntry;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.SnapshotUtil;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.trino.plugin.iceberg.ColumnIdentity.createColumnIdentity;
+import static io.trino.plugin.iceberg.IcebergUtil.createColumnHandle;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
@@ -40,17 +47,24 @@ import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static java.util.Objects.requireNonNull;
 
 public class HistoryTable
-        implements SystemTable
+        implements IcebergSystemTable
 {
     private final ConnectorTableMetadata tableMetadata;
     private final Table icebergTable;
 
-    private static final List<ColumnMetadata> COLUMNS = ImmutableList.<ColumnMetadata>builder()
-            .add(new ColumnMetadata("made_current_at", TIMESTAMP_TZ_MILLIS))
-            .add(new ColumnMetadata("snapshot_id", BIGINT))
-            .add(new ColumnMetadata("parent_id", BIGINT))
-            .add(new ColumnMetadata("is_current_ancestor", BOOLEAN))
+    private static final List<IcebergColumnHandle> COLUMNS_HANDLES_LIST = ImmutableList.<IcebergColumnHandle>builder()
+            .add(createColumnHandle(createColumnIdentity(Types.NestedField.required(1, "made_current_at", Types.TimestampType.withZone())), TIMESTAMP_TZ_MILLIS))
+            .add(createColumnHandle(createColumnIdentity(Types.NestedField.required(2, "snapshot_id", Types.LongType.get())), BIGINT))
+            .add(createColumnHandle(createColumnIdentity(Types.NestedField.optional(3, "parent_id", Types.LongType.get())), BIGINT))
+            .add(createColumnHandle(createColumnIdentity(Types.NestedField.required(4, "is_current_ancestor", Types.BooleanType.get())), BOOLEAN))
             .build();
+
+    private static final List<ColumnMetadata> COLUMNS = COLUMNS_HANDLES_LIST.stream()
+            .map(icebergColumnHandle -> new ColumnMetadata(icebergColumnHandle.getName(), icebergColumnHandle.getType()))
+            .collect(Collectors.toUnmodifiableList());
+
+    private static final Map<String, ColumnHandle> COLUMN_HANDLES_MAP = COLUMNS_HANDLES_LIST.stream()
+                .collect(toImmutableMap(IcebergColumnHandle::getName, Function.identity()));
 
     public HistoryTable(SchemaTableName tableName, Table icebergTable)
     {
@@ -59,15 +73,15 @@ public class HistoryTable
     }
 
     @Override
-    public Distribution getDistribution()
-    {
-        return Distribution.SINGLE_COORDINATOR;
-    }
-
-    @Override
     public ConnectorTableMetadata getTableMetadata()
     {
         return tableMetadata;
+    }
+
+    @Override
+    public Map<String, ColumnHandle> getColumnHandles()
+    {
+        return COLUMN_HANDLES_MAP;
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSystemSplit.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSystemSplit.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.HostAddress;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.predicate.TupleDomain;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.List;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static java.util.Objects.requireNonNull;
+
+public class IcebergSystemSplit
+        implements ConnectorSplit
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(IcebergSystemSplit.class).instanceSize();
+
+    private static final int INSTANCE_COLUMN_HANDLE_SIZE = ClassLayout.parseClass(IcebergColumnHandle.class).instanceSize();
+
+    private final List<HostAddress> addresses;
+
+    private final TupleDomain<ColumnHandle> constraint;
+
+    public IcebergSystemSplit(HostAddress address, TupleDomain<ColumnHandle> constraint)
+    {
+        this(ImmutableList.of(requireNonNull(address, "address is null")), constraint);
+    }
+
+    @JsonCreator
+    public IcebergSystemSplit(
+            @JsonProperty("addresses") List<HostAddress> addresses,
+            @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint)
+    {
+        requireNonNull(addresses, "addresses is null");
+        checkArgument(!addresses.isEmpty(), "addresses is empty");
+        this.addresses = ImmutableList.copyOf(addresses);
+        this.constraint = requireNonNull(constraint, "constraint is null");
+    }
+
+    @Override
+    public boolean isRemotelyAccessible()
+    {
+        return false;
+    }
+
+    @Override
+    @JsonProperty
+    public List<HostAddress> getAddresses()
+    {
+        return addresses;
+    }
+
+    @JsonProperty
+    public TupleDomain<ColumnHandle> getConstraint()
+    {
+        return constraint;
+    }
+
+    @Override
+    public Object getInfo()
+    {
+        return this;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE
+                + estimatedSizeOf(addresses, HostAddress::getRetainedSizeInBytes)
+                + constraint.getRetainedSizeInBytes(columnHandle -> getRetainedSizeInBytes((IcebergColumnHandle) columnHandle));
+    }
+
+    private long getRetainedSizeInBytes(IcebergColumnHandle icebergColumnHandle)
+    {
+        return INSTANCE_COLUMN_HANDLE_SIZE
+                + estimatedSizeOf(icebergColumnHandle.getName());
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("addresses", addresses)
+                .toString();
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSystemTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSystemTable.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.RecordCursor;
+import io.trino.spi.predicate.TupleDomain;
+
+import java.util.Map;
+
+/**
+ * Exactly one of {@link #cursor} or {@link #pageSource} must be implemented.
+ */
+public interface IcebergSystemTable
+{
+    ConnectorTableMetadata getTableMetadata();
+
+    Map<String, ColumnHandle> getColumnHandles();
+
+    /**
+     * Create a cursor for the data in this table.
+     *
+     * @param session the session to use for creating the data
+     * @param constraint the constraints for the table columns (indexed from 0)
+     */
+    default RecordCursor cursor(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Create a page source for the data in this table.
+     *
+     * @param session the session to use for creating the data
+     * @param constraint the constraints for the table columns (indexed from 0)
+     */
+    default ConnectorPageSource pageSource(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSystemTableHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSystemTableHandle.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.predicate.TupleDomain;
+
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.Verify.verify;
+import static io.trino.plugin.iceberg.TableType.DATA;
+import static java.util.Objects.requireNonNull;
+
+public class IcebergSystemTableHandle
+        implements ConnectorTableHandle
+{
+    private final String schemaName;
+    private final String tableName;
+    private final TableType tableType;
+    private final Optional<Long> snapshotId;
+
+    private final TupleDomain<ColumnHandle> constraint;
+
+    @JsonCreator
+    public IcebergSystemTableHandle(
+            @JsonProperty("schemaName") String schemaName,
+            @JsonProperty("tableName") String tableName,
+            @JsonProperty("tableType") TableType tableType,
+            @JsonProperty("snapshotId") Optional<Long> snapshotId,
+            @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint)
+    {
+        requireNonNull(tableType, "tableType is null");
+        verify(tableType != DATA, "tableType DATA cannot be used by system tables");
+
+        this.schemaName = requireNonNull(schemaName, "schemaName is null");
+        this.tableName = requireNonNull(tableName, "tableName is null");
+        this.tableType = tableType;
+        this.snapshotId = requireNonNull(snapshotId, "snapshotId is null");
+        this.constraint = requireNonNull(constraint, "constraint is null");
+    }
+
+    @JsonProperty
+    public String getSchemaName()
+    {
+        return schemaName;
+    }
+
+    @JsonProperty
+    public String getTableName()
+    {
+        return tableName;
+    }
+
+    @JsonProperty
+    public TableType getTableType()
+    {
+        return tableType;
+    }
+
+    @JsonProperty
+    public Optional<Long> getSnapshotId()
+    {
+        return snapshotId;
+    }
+
+    @JsonProperty
+    public TupleDomain<ColumnHandle> getConstraint()
+    {
+        return constraint;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(schemaName, tableName, constraint);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        IcebergSystemTableHandle other = (IcebergSystemTableHandle) obj;
+        return Objects.equals(this.schemaName, other.schemaName) &&
+                Objects.equals(this.tableName, other.tableName) &&
+                Objects.equals(this.tableType, other.tableType) &&
+                Objects.equals(this.snapshotId, other.snapshotId) &&
+                Objects.equals(this.constraint, other.constraint);
+    }
+
+    @Override
+    public String toString()
+    {
+        return getSchemaTableNameWithType() + snapshotId.map(v -> "@" + v).orElse("");
+    }
+
+    public SchemaTableName getSchemaTableName()
+    {
+        return new SchemaTableName(schemaName, tableName);
+    }
+
+    private SchemaTableName getSchemaTableNameWithType()
+    {
+        return new SchemaTableName(schemaName, tableName + "$" + tableType.name().toLowerCase(Locale.ROOT));
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -653,4 +653,14 @@ public final class IcebergUtil
             throw new TrinoException(INVALID_TABLE_PROPERTY, format("Orc bloom filter columns %s not present in schema", Sets.difference(ImmutableSet.copyOf(orcBloomFilterColumns), allColumns)));
         }
     }
+
+    public static IcebergColumnHandle createColumnHandle(ColumnIdentity columnIdentity, io.trino.spi.type.Type type)
+    {
+        return new IcebergColumnHandle(
+                columnIdentity,
+                type,
+                ImmutableList.of(),
+                type,
+                Optional.empty());
+    }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/SnapshotsTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/SnapshotsTable.java
@@ -16,6 +16,7 @@ package io.trino.plugin.iceberg;
 import com.google.common.collect.ImmutableList;
 import io.trino.plugin.iceberg.util.PageListBuilder;
 import io.trino.spi.Page;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.ConnectorSession;
@@ -23,24 +24,31 @@ import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.FixedPageSource;
 import io.trino.spi.connector.SchemaTableName;
-import io.trino.spi.connector.SystemTable;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.TimeZoneKey;
 import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.TypeSignature;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.types.Types;
 
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.trino.plugin.iceberg.ColumnIdentity.createColumnIdentity;
+import static io.trino.plugin.iceberg.IcebergUtil.createColumnHandle;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.util.Objects.requireNonNull;
 
 public class SnapshotsTable
-        implements SystemTable
+        implements IcebergSystemTable
 {
     private final ConnectorTableMetadata tableMetadata;
+    private final Map<String, ColumnHandle> columnHandles;
     private final Table icebergTable;
 
     public SnapshotsTable(SchemaTableName tableName, TypeManager typeManager, Table icebergTable)
@@ -48,27 +56,37 @@ public class SnapshotsTable
         requireNonNull(typeManager, "typeManager is null");
 
         this.icebergTable = requireNonNull(icebergTable, "icebergTable is null");
+        List<IcebergColumnHandle> columnHandlesList = ImmutableList.<IcebergColumnHandle>builder()
+                .add(createColumnHandle(createColumnIdentity(Types.NestedField.required(1, "committed_at", Types.TimestampType.withZone())), TIMESTAMP_TZ_MILLIS))
+                .add(createColumnHandle(createColumnIdentity(Types.NestedField.required(2, "snapshot_id", Types.LongType.get())), BIGINT))
+                .add(createColumnHandle(createColumnIdentity(Types.NestedField.optional(3, "parent_id", Types.LongType.get())), BIGINT))
+                .add(createColumnHandle(createColumnIdentity(Types.NestedField.optional(4, "operation", Types.StringType.get())), VARCHAR))
+                .add(createColumnHandle(createColumnIdentity(Types.NestedField.optional(5, "manifest_list", Types.StringType.get())), VARCHAR))
+                .add(createColumnHandle(
+                        createColumnIdentity(Types.NestedField.optional(
+                                6,
+                                "summary",
+                                Types.MapType.ofRequired(7, 8, Types.StringType.get(), Types.StringType.get()))),
+                        typeManager.getType(TypeSignature.mapType(VARCHAR.getTypeSignature(), VARCHAR.getTypeSignature()))))
+                .build();
+        columnHandles = columnHandlesList.stream()
+                .collect(toImmutableMap(IcebergColumnHandle::getName, Function.identity()));
         tableMetadata = new ConnectorTableMetadata(requireNonNull(tableName, "tableName is null"),
-                ImmutableList.<ColumnMetadata>builder()
-                        .add(new ColumnMetadata("committed_at", TIMESTAMP_TZ_MILLIS))
-                        .add(new ColumnMetadata("snapshot_id", BIGINT))
-                        .add(new ColumnMetadata("parent_id", BIGINT))
-                        .add(new ColumnMetadata("operation", VARCHAR))
-                        .add(new ColumnMetadata("manifest_list", VARCHAR))
-                        .add(new ColumnMetadata("summary", typeManager.getType(TypeSignature.mapType(VARCHAR.getTypeSignature(), VARCHAR.getTypeSignature()))))
-                        .build());
-    }
-
-    @Override
-    public Distribution getDistribution()
-    {
-        return Distribution.SINGLE_COORDINATOR;
+                columnHandlesList.stream()
+                        .map(icebergColumnHandle -> new ColumnMetadata(icebergColumnHandle.getName(), icebergColumnHandle.getType()))
+                        .collect(Collectors.toUnmodifiableList()));
     }
 
     @Override
     public ConnectorTableMetadata getTableMetadata()
     {
         return tableMetadata;
+    }
+
+    @Override
+    public Map<String, ColumnHandle> getColumnHandles()
+    {
+        return columnHandles;
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
@@ -263,37 +263,37 @@ public class TestIcebergMetastoreAccessOperations
         // select from $history
         assertMetastoreInvocations("SELECT * FROM \"test_select_snapshots$history\"",
                 ImmutableMultiset.builder()
-                        .addCopies(GET_TABLE, 1)
+                        .addCopies(GET_TABLE, 3)
                         .build());
 
         // select from $snapshots
         assertMetastoreInvocations("SELECT * FROM \"test_select_snapshots$snapshots\"",
                 ImmutableMultiset.builder()
-                        .addCopies(GET_TABLE, 1)
+                        .addCopies(GET_TABLE, 3)
                         .build());
 
         // select from $manifests
         assertMetastoreInvocations("SELECT * FROM \"test_select_snapshots$manifests\"",
                 ImmutableMultiset.builder()
-                        .addCopies(GET_TABLE, 1)
+                        .addCopies(GET_TABLE, 3)
                         .build());
 
         // select from $partitions
         assertMetastoreInvocations("SELECT * FROM \"test_select_snapshots$partitions\"",
                 ImmutableMultiset.builder()
-                        .addCopies(GET_TABLE, 1)
+                        .addCopies(GET_TABLE, 3)
                         .build());
 
         // select from $files
         assertMetastoreInvocations("SELECT * FROM \"test_select_snapshots$files\"",
                 ImmutableMultiset.builder()
-                        .addCopies(GET_TABLE, 1)
+                        .addCopies(GET_TABLE, 3)
                         .build());
 
         // select from $properties
         assertMetastoreInvocations("SELECT * FROM \"test_select_snapshots$properties\"",
                 ImmutableMultiset.builder()
-                        .addCopies(GET_TABLE, 1)
+                        .addCopies(GET_TABLE, 3)
                         .build());
 
         // This test should get updated if a new system table is added.

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.json.JsonCodecFactory;
 import io.airlift.testing.TempFile;
+import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
 import io.trino.metadata.TableHandle;
 import io.trino.operator.GroupByHashPageIndexerFactory;
@@ -26,14 +27,20 @@ import io.trino.orc.OrcWriter;
 import io.trino.orc.OrcWriterOptions;
 import io.trino.orc.OrcWriterStats;
 import io.trino.orc.OutputStreamOrcDataSink;
+import io.trino.plugin.base.CatalogName;
 import io.trino.plugin.hive.FileFormatDataSourceStats;
 import io.trino.plugin.hive.HiveTransactionHandle;
 import io.trino.plugin.hive.NodeVersion;
 import io.trino.plugin.hive.metastore.Column;
+import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.orc.OrcReaderConfig;
 import io.trino.plugin.hive.orc.OrcWriterConfig;
 import io.trino.plugin.hive.parquet.ParquetReaderConfig;
 import io.trino.plugin.hive.parquet.ParquetWriterConfig;
+import io.trino.plugin.iceberg.catalog.IcebergTableOperationsProvider;
+import io.trino.plugin.iceberg.catalog.TrinoCatalogFactory;
+import io.trino.plugin.iceberg.catalog.file.FileMetastoreTableOperationsProvider;
+import io.trino.plugin.iceberg.catalog.hms.TrinoHiveCatalog;
 import io.trino.spi.Page;
 import io.trino.spi.SplitWeight;
 import io.trino.spi.block.BlockBuilder;
@@ -43,6 +50,7 @@ import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.connector.RetryMode;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.TestingTypeManager;
 import io.trino.spi.type.Type;
 import io.trino.sql.gen.JoinCompiler;
 import io.trino.testing.TestingConnectorSession;
@@ -52,22 +60,29 @@ import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.types.Types;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.trino.orc.metadata.CompressionKind.NONE;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static io.trino.plugin.hive.HiveType.HIVE_INT;
 import static io.trino.plugin.hive.HiveType.HIVE_STRING;
+import static io.trino.plugin.hive.metastore.cache.CachingHiveMetastore.memoizeMetastore;
+import static io.trino.plugin.hive.metastore.file.FileHiveMetastore.createTestingFileHiveMetastore;
 import static io.trino.plugin.iceberg.ColumnIdentity.TypeCategory.PRIMITIVE;
 import static io.trino.plugin.iceberg.IcebergFileFormat.ORC;
 import static io.trino.spi.type.IntegerType.INTEGER;
@@ -82,6 +97,8 @@ import static org.testng.Assert.assertNull;
 
 public class TestIcebergNodeLocalDynamicSplitPruning
 {
+    private File metastoreDir;
+    private HiveMetastore metastore;
     private static final String SCHEMA_NAME = "test";
     private static final String TABLE_NAME = "test";
     private static final Column KEY_COLUMN = new Column("a_integer", HIVE_INT, Optional.empty());
@@ -99,6 +116,22 @@ public class TestIcebergNodeLocalDynamicSplitPruning
     private static final OrcWriterConfig ORC_WRITER_CONFIG = new OrcWriterConfig();
     private static final ParquetReaderConfig PARQUET_READER_CONFIG = new ParquetReaderConfig();
     private static final ParquetWriterConfig PARQUET_WRITER_CONFIG = new ParquetWriterConfig();
+
+    @BeforeClass
+    public void setup()
+            throws IOException
+    {
+        File tempDir = Files.createTempDirectory("test_iceberg_split_source").toFile();
+        metastoreDir = new File(tempDir, "iceberg_data");
+        metastore = createTestingFileHiveMetastore(metastoreDir);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+            throws IOException
+    {
+        deleteRecursively(metastoreDir.getParentFile().toPath(), ALLOW_INSECURE);
+    }
 
     @Test
     public void testDynamicSplitPruning()
@@ -150,7 +183,7 @@ public class TestIcebergNodeLocalDynamicSplitPruning
         }
     }
 
-    private static ConnectorPageSource createTestingPageSource(HiveTransactionHandle transaction, IcebergConfig icebergConfig, File outputFile, DynamicFilter dynamicFilter)
+    private ConnectorPageSource createTestingPageSource(HiveTransactionHandle transaction, IcebergConfig icebergConfig, File outputFile, DynamicFilter dynamicFilter)
     {
         IcebergSplit split = new IcebergSplit(
                 "file:///" + outputFile.getAbsolutePath(),
@@ -188,6 +221,20 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                 transaction);
 
         FileFormatDataSourceStats stats = new FileFormatDataSourceStats();
+        TrinoCatalogFactory hiveCatalogFactory = identity -> {
+            TrinoFileSystemFactory fileSystemFactory = new HdfsFileSystemFactory(HDFS_ENVIRONMENT);
+            IcebergTableOperationsProvider operationsProvider = new FileMetastoreTableOperationsProvider(fileSystemFactory);
+            return new TrinoHiveCatalog(
+                    new CatalogName("hive"),
+                    memoizeMetastore(metastore, 1000),
+                    fileSystemFactory,
+                    new TestingTypeManager(),
+                    operationsProvider,
+                    "test",
+                    false,
+                    false,
+                    false);
+        };
         IcebergPageSourceProvider provider = new IcebergPageSourceProvider(
                 new HdfsFileSystemFactory(HDFS_ENVIRONMENT),
                 stats,
@@ -197,6 +244,7 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                 new JsonCodecFactory().jsonCodec(CommitTaskData.class),
                 new IcebergFileWriterFactory(TESTING_TYPE_MANAGER, new NodeVersion("trino_test"), stats, ORC_WRITER_CONFIG),
                 new GroupByHashPageIndexerFactory(new JoinCompiler(TESTING_TYPE_MANAGER.getTypeOperators()), new BlockTypeOperators()),
+                hiveCatalogFactory,
                 icebergConfig);
 
         return provider.createPageSource(

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergReadVersionedTable.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergReadVersionedTable.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.iceberg;
 
+import io.trino.Session;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.DistributedQueryRunner;
 import org.testng.annotations.BeforeClass;
@@ -25,6 +26,7 @@ import java.time.format.DateTimeFormatter;
 import static io.trino.plugin.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
 import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
+import static org.testng.Assert.assertEquals;
 
 public class TestIcebergReadVersionedTable
         extends AbstractTestQueryFramework
@@ -94,11 +96,18 @@ public class TestIcebergReadVersionedTable
     }
 
     @Test
-    public void testSystemTables()
+    public void testSelectFromSystemTablesWithEndSnapshotId()
     {
-        // TODO https://github.com/trinodb/trino/issues/12920
-        assertQueryFails("SELECT * FROM \"test_iceberg_read_versioned_table$partitions\" FOR VERSION AS OF " + v1SnapshotId,
-                "This connector does not support versioned tables");
+        assertQuery("SELECT * FROM \"test_iceberg_read_versioned_table$data\" FOR VERSION AS OF " + v1SnapshotId, "VALUES ('a', 1)");
+        assertQuerySucceeds("SELECT * FROM \"test_iceberg_read_versioned_table$properties\" FOR VERSION AS OF " + v1SnapshotId);
+        assertQueryFails("SELECT * FROM \"test_iceberg_read_versioned_table$history\" FOR VERSION AS OF " + v1SnapshotId, "Versioning not supported for metadata table\\: tpch.test_iceberg_read_versioned_table\\$history");
+        assertQueryFails("SELECT * FROM \"test_iceberg_read_versioned_table$snapshots\" FOR VERSION AS OF " + v1SnapshotId, "Versioning not supported for metadata table\\: tpch.test_iceberg_read_versioned_table\\$snapshots");
+        Session allowLegacySnapshotSession = Session.builder(getSession())
+                .setCatalogSessionProperty("iceberg", "allow_legacy_snapshot_syntax", "true")
+                .build();
+        assertEquals(computeActual(allowLegacySnapshotSession, "SELECT * FROM \"test_iceberg_read_versioned_table$files@" + v1SnapshotId + "\"").getRowCount(), 1);
+        assertEquals(computeActual("SELECT * FROM \"test_iceberg_read_versioned_table$files\" FOR VERSION AS OF " + v1SnapshotId).getRowCount(), 1);
+        assertEquals(computeActual("SELECT * FROM \"test_iceberg_read_versioned_table$files\" FOR VERSION AS OF " + v2SnapshotId).getRowCount(), 2);
     }
 
     private long getLatestSnapshotId(String tableName)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergHiveTablesCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergHiveTablesCompatibility.java
@@ -48,7 +48,7 @@ public class TestIcebergHiveTablesCompatibility
                 .hasMessageMatching("Query failed \\(#\\w+\\):\\Q Not an Iceberg table: default." + tableName);
 
         assertQueryFailure(() -> onTrino().executeQuery("SELECT * FROM iceberg.default.\"" + tableName + "$files\""))
-                .hasMessageMatching("Query failed \\(#\\w+\\):\\Q line 1:15: Table 'iceberg.default." + tableName + "$files' does not exist");
+                .hasMessageMatching("Query failed \\(#\\w+\\):\\Q Not an Iceberg table: default." + tableName);
 
         onTrino().executeQuery("DROP TABLE hive.default." + tableName);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Use `IcebergSystemTableHandle` for dealing with system tables
because it encodes for the table being queried also:

- snapshot id
- table type

NOTE that this change reuses `IcebergMetadata` columns for performing queries related to system tables.

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Bugfix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Iceberg connector

> How would you describe this change to a non-technical end user or system administrator?

The metadata tables exposed by the Iceberg connector for its tables should support snapshot/versioned queries in the same fashion as the Iceberg tables.

```
SELECT * FROM table1$files FOR VERSION AS OF 1242141
SELECT * FROM table1$files FOR TIMESTAMP AS OF TIMESTAMP '2022-01-01'
```

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

Fixes #12736


This PR is built on top of https://github.com/trinodb/trino/pull/12737  and uses `IcebergSystemTableHandle` for dealing with system tables, instead of `IcebergTableHandle`.

This PR could pave the way to the functionality of having distributed `$files` calculation. See https://github.com/trinodb/trino/pull/4840

Having a distributed retrieval for `$files` could be beneficial in debugging scenarios when dealing with tables with a lot of files. Probably other scenarios could follow.


<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

() No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Iceberg
* Support snapshot queries on Iceberg system tables
```
