### PR TITLE
Added ppc64le support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         run: $MAVEN clean -pl '!:trino-server,!:trino-cli'
       - uses: docker/setup-qemu-action@v1
         with:
-          platforms: arm64
+          platforms: arm64,ppc64le
       - name: Test Docker Image
         run: core/docker/build.sh
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

Enabled ppc64le (IBM Power architecture) builds by adding an appropriate entry in ci.yml. The complete code was already ready for ppc64le support, so only this minor change was needed.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

New feature (additional architecture support).

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

No.

> How would you describe this change to a non-technical end user or system administrator?

Support for running Trino on IBM Power servers. 

## Documentation

() No documentation is needed.
(X) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(X) Release notes entries required with the following suggested text:
Added support for running Trino on IBM Power servers (ppc64le architecture). 

