### PR TITLE
Avoid writing to Hive an empty list of column stats because Hive 2.x fails

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -689,7 +689,9 @@ public class ThriftHiveMetastore
         verify(!dateStatistics.isEmpty() && metastoreSupportsDateStatistics.equals(Optional.empty()));
 
         try (ThriftMetastoreClient client = createMetastoreClient()) {
-            saveColumnStatistics.call(client, statisticsExceptDate);
+            if (!statisticsExceptDate.isEmpty()) {
+                saveColumnStatistics.call(client, statisticsExceptDate);
+            }
 
             try {
                 saveColumnStatistics.call(client, dateStatistics);


### PR DESCRIPTION
Issue happens on hive2.3.
Sending empty stats will generate empty columns list that will [return null value](https://github.com/apache/hive/blob/a3e807af67fb708acc5f6ab7d63575125615de3d/metastore/src/java/org/apache/hadoop/hive/metastore/ObjectStore.java#L7189-L7191) and will make [this](https://github.com/apache/hive/blob/a3e807af67fb708acc5f6ab7d63575125615de3d/metastore/src/java/org/apache/hadoop/hive/metastore/ObjectStore.java#L7060-L7063) to fail on  `java.lang.NullPointerException: Cannot invoke "java.util.List.iterator()" because "stats" is null`

On hive3 issue doesn't happen since empty column list result with [empty list](https://github.com/apache/hive/blob/8b312d54ea206461cb50450ac95ec267aba60b21/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java#L9938-L9940)

On `387` the issue happens only when it's the first write before any other "mixed" table with both date and non-date columns - that's why it's hard to catch it, since most of tables contains both date and non-date columns.

On `388+`  it seems to constantly happen.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
