### PR TITLE
In errorprone CI job build trino-spi with dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           # Run Error Prone on one module with a retry to ensure all runtime dependencies are fetched
-          $RETRY $MAVEN ${MAVEN_TEST} -T C1 clean verify -DskipTests -P gib,errorprone-compiler -pl ':trino-spi'
+          $RETRY $MAVEN ${MAVEN_TEST} -T C1 clean verify -DskipTests -P gib,errorprone-compiler -am -pl ':trino-spi'
           # The main Error Prone run
           $MAVEN ${MAVEN_TEST} -T C1 clean verify -DskipTests -P gib,errorprone-compiler \
             -pl '!:trino-docs,!:trino-server,!:trino-server-rpm'


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->
A follow-up for #13367. When there's no cache, building `trino-spi` also requires building its dependencies. 

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
ci

> How would you describe this change to a non-technical end user or system administrator?
n/a

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
