### PR TITLE
Use `Path.toUri` for `hive.metastore.catalog.dir` in DeltaLakeQueryRunner 

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
@@ -106,7 +106,7 @@ public final class DeltaLakeQueryRunner
                 if (!deltaProperties.containsKey("hive.metastore.uri")) {
                     Path dataDir = queryRunner.getCoordinator().getBaseDataDir().resolve(DELTA_CATALOG);
                     deltaProperties.put("hive.metastore", "file");
-                    deltaProperties.put("hive.metastore.catalog.dir", dataDir.toString());
+                    deltaProperties.put("hive.metastore.catalog.dir", dataDir.toUri().toString());
                 }
 
                 queryRunner.createCatalog(catalogName, CONNECTOR_NAME, deltaProperties);


### PR DESCRIPTION
## Description

Use `Path.toUri` for `hive.metastore.catalog.dir` in DeltaLakeQueryRunner 

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
