### PR TITLE
Pushdown DATE, TIMESTAMP, and TIMESTAMP_TZ_MILLIS predicates in MongoDB

### DIFF
--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
@@ -521,7 +521,7 @@ public class MongoSession
         }
 
         if (type == TIMESTAMP_TZ_MILLIS) {
-            return Optional.of(new Date(unpackMillisUtc((Long) trinoNativeValue)));
+            return Optional.of(new Date(unpackMillisUtc((long) trinoNativeValue)));
         }
 
         if (type instanceof ObjectIdType) {

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
@@ -66,6 +66,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -78,9 +79,12 @@ import static io.trino.plugin.mongodb.ObjectIdType.OBJECT_ID;
 import static io.trino.spi.HostAddress.fromParts;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
+import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
@@ -506,6 +510,18 @@ public class MongoSession
 
         if (type == BIGINT) {
             return Optional.of(trinoNativeValue);
+        }
+
+        if (type == DATE) {
+            return Optional.of(new Date(TimeUnit.DAYS.toMillis((Long) trinoNativeValue)));
+        }
+
+        if (type == TIMESTAMP_MILLIS) {
+            return Optional.of(new Date(TimeUnit.MILLISECONDS.convert((Long) trinoNativeValue, TimeUnit.MICROSECONDS)));
+        }
+
+        if (type == TIMESTAMP_TZ_MILLIS) {
+            return Optional.of(new Date(unpackMillisUtc((Long) trinoNativeValue)));
         }
 
         if (type instanceof ObjectIdType) {

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoTypeMapping.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoTypeMapping.java
@@ -251,6 +251,9 @@ public class TestMongoTypeMapping
                 .addRoundTrip("time", "TIME '23:59:59.9'", createTimeType(3), "TIME '23:59:59.900'")
                 .addRoundTrip("time", "TIME '23:59:59.99'", createTimeType(3), "TIME '23:59:59.990'")
                 .addRoundTrip("time", "TIME '23:59:59.999'", createTimeType(3), "TIME '23:59:59.999'")
+                .addRoundTrip("time", "TIME '23:59:59.9999'", createTimeType(4), "TIME '23:59:59.9999'")
+                .addRoundTrip("time", "TIME '23:59:59.99999'", createTimeType(5), "TIME '23:59:59.99999'")
+                .addRoundTrip("time", "TIME '23:59:59.999999'", createTimeType(6), "TIME '23:59:59.999999'")
                 .execute(getQueryRunner(), trinoCreateAsSelect("test_time"))
                 .execute(getQueryRunner(), trinoCreateAndInsert("test_time"));
     }


### PR DESCRIPTION
Resolves: #5658
Superseeds: #5682, because it seems that the developer is not active in the moment.

This PR takes all changes as in #5682 and implement additional the proposed changes from discussion.