### PR TITLE
Switch Docker to Eclipse Temurin and support ppc64le

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         run: $MAVEN clean -pl '!:trino-server,!:trino-cli'
       - uses: docker/setup-qemu-action@v1
         with:
-          platforms: arm64
+          platforms: arm64,ppc64le
       - name: Test Docker Image
         run: core/docker/build.sh
 

--- a/core/docker/Dockerfile
+++ b/core/docker/Dockerfile
@@ -11,16 +11,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM registry.access.redhat.com/ubi8/ubi
+FROM eclipse-temurin:17.0.4_8-jdk
 
-ENV JAVA_HOME /usr/lib/jvm/zulu17
 RUN \
     set -xeu && \
-    yum -y -q install https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm && \
-    yum -y -q install python3 zulu17-jdk less && \
-    yum -q clean all && \
-    rm -rf /var/cache/yum && \
-    alternatives --set python /usr/bin/python3 && \
+    apt-get update -q && \
+    apt-get install -y -q less python3 && \
+    rm -rf /var/lib/apt/lists/* && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
     groupadd trino --gid 1000 && \
     useradd trino --uid 1000 --gid 1000 --create-home && \
     mkdir -p /usr/lib/trino /data/trino && \
@@ -33,7 +31,6 @@ COPY --chown=trino:trino default/etc /etc/trino
 
 EXPOSE 8080
 USER trino:trino
-ENV LANG en_US.UTF-8
 CMD ["/usr/lib/trino/bin/run-trino"]
 HEALTHCHECK --interval=10s --timeout=5s --start-period=10s \
   CMD /usr/lib/trino/bin/health-check

--- a/core/docker/build.sh
+++ b/core/docker/build.sh
@@ -13,7 +13,7 @@ Builds the Trino Docker image
 EOF
 }
 
-ARCHITECTURES=(amd64 arm64)
+ARCHITECTURES=(amd64 arm64 ppc64le)
 TRINO_VERSION=
 
 while getopts ":a:h:r:" o; do
@@ -87,6 +87,9 @@ echo "🏃 Testing built images"
 source container-test.sh
 
 for arch in "${ARCHITECTURES[@]}"; do
-    test_container "${TAG_PREFIX}-$arch" "linux/$arch"
+    # TODO: remove when https://github.com/multiarch/qemu-user-static/issues/128 is fixed
+    if [[ "$arch" != "ppc64le" ]]; then
+        test_container "${TAG_PREFIX}-$arch" "linux/$arch"
+    fi
     docker image inspect -f '🚀 Built {{.RepoTags}} {{.Id}}' "${TAG_PREFIX}-$arch"
 done


### PR DESCRIPTION
## Description

Use Eclipse Temurin as they have base Docker images for more architectures.

Validation of the ppc64le image is currently disabled due to https://github.com/multiarch/qemu-user-static/issues/128

## Documentation

(x) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# Docker image
* Add image for ppc64le. ({issue}`13522`)
```
