### PR TITLE
Update docker-images to v65

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <dep.casandra.version>4.14.0</dep.casandra.version>
         <dep.minio.version>7.1.4</dep.minio.version>
 
-        <dep.docker.images.version>64</dep.docker.images.version>
+        <dep.docker.images.version>65</dep.docker.images.version>
 
         <!--
           America/Bahia_Banderas has:

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkDropTableCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkDropTableCompatibility.java
@@ -80,10 +80,10 @@ public class TestIcebergSparkDropTableCompatibility
         assertFileExistence(tableDirectory, true, "The table directory exists after creating the table");
         List<String> dataFilePaths = getDataFilePaths(tableName);
 
-        tableDropperEngine.queryExecutor().executeQuery("DROP TABLE " + tableName);
+        tableDropperEngine.queryExecutor().executeQuery("DROP TABLE " + tableName); // PURGE option is required to remove data since Iceberg 0.14.0, but the statement hangs in Spark
         boolean expectExists = tableDropperEngine == SPARK; // Note: Spark's behavior is Catalog dependent
         assertFileExistence(tableDirectory, expectExists, format("The table directory %s should be removed after dropping the table", tableDirectory));
-        dataFilePaths.forEach(dataFilePath -> assertFileExistence(dataFilePath, false, format("The data file %s removed after dropping the table", dataFilePath)));
+        dataFilePaths.forEach(dataFilePath -> assertFileExistence(dataFilePath, expectExists, format("The data file %s removed after dropping the table", dataFilePath)));
     }
 
     private String getTableLocation(String tableName)


### PR DESCRIPTION
## Description

Update docker-images to v65
The main change is Iceberg version up (`0.13.2` → `0.14.0`) https://github.com/trinodb/docker-images/pull/137

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
