### PR TITLE
Minor improvements to ClickHouse doc

### DIFF
--- a/docs/src/main/sphinx/connector/clickhouse.rst
+++ b/docs/src/main/sphinx/connector/clickhouse.rst
@@ -38,6 +38,16 @@ appropriate for your setup:
     connection-user=exampleuser
     connection-password=examplepassword
 
+The ``connection-url`` defines the connection information and parameters to pass
+to the ClickHouse JDBC driver. The supported parameters for the URL are
+available in the `ClickHouse JDBC driver configuration
+<https://github.com/ClickHouse/clickhouse-jdbc/tree/master/clickhouse-jdbc#Configuration>`_.
+
+The ``connection-user`` and ``connection-password`` are typically required and
+determine the user credentials for the connection, often a service user. You can
+use :doc:`secrets </security/secrets>` to avoid actual values in the catalog
+properties files.
+
 .. note::
 
     Trino uses the new ClickHouse driver(``com.clickhouse.jdbc.ClickHouseDriver``)


### PR DESCRIPTION
Previously, ClickHouse documentation did not explicitly state: 
1. what parameters users can set via `connection-url`
2. how to secretly set `connection-password`

So this pr: 
- Reference to the parameters supported by `connection-url`
- Reference to use secret way to configure `connection-password`

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Doc improvements.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

ClickHouse doc.

> How would you describe this change to a non-technical end user or system administrator?

N/A.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->
Fixes #13527

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) Sufficient documentation is included in this PR.

## Release notes

(x) No release notes entries required.
