### PR TITLE
Use physical column name when comparing partition keys in Delta Lake

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSource.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSource.java
@@ -85,9 +85,9 @@ public class DeltaLakePageSource
         Block partitionsBlock = null;
 
         for (DeltaLakeColumnHandle column : columns) {
-            if (partitionKeys.containsKey(column.getName())) {
+            if (partitionKeys.containsKey(column.getPhysicalName())) {
                 Type type = column.getType();
-                Object prefilledValue = deserializePartitionValue(column, partitionKeys.get(column.getName()));
+                Object prefilledValue = deserializePartitionValue(column, partitionKeys.get(column.getPhysicalName()));
                 prefilledBlocks[outputIndex] = Utils.nativeValueToBlock(type, prefilledValue);
                 delegateIndexes[outputIndex] = -1;
             }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeAlterTableCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeAlterTableCompatibility.java
@@ -23,6 +23,7 @@ import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tests.product.TestGroups.DELTA_LAKE_DATABRICKS;
 import static io.trino.tests.product.TestGroups.DELTA_LAKE_EXCLUDE_73;
+import static io.trino.tests.product.TestGroups.DELTA_LAKE_EXCLUDE_91;
 import static io.trino.tests.product.TestGroups.DELTA_LAKE_OSS;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static io.trino.tests.product.deltalake.util.DeltaLakeTestUtils.getColumnCommentOnDelta;
@@ -76,6 +77,71 @@ public class TestDeltaLakeAlterTableCompatibility
         try {
             assertQueryFailure(() -> onTrino().executeQuery("ALTER TABLE delta.default." + tableName + " ADD COLUMN new_col int"))
                     .hasMessageMatching(".* Table .* requires Delta Lake writer version 3 which is not supported");
+        }
+        finally {
+            onDelta().executeQuery("DROP TABLE default." + tableName);
+        }
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_OSS, DELTA_LAKE_EXCLUDE_73, DELTA_LAKE_EXCLUDE_91, PROFILE_SPECIFIC_TESTS})
+    public void testRenameColumn()
+    {
+        String tableName = "test_dl_rename_column_" + randomTableSuffix();
+        String tableDirectory = "databricks-compatibility-test-" + tableName;
+
+        onDelta().executeQuery(format("" +
+                        "CREATE TABLE default.%s (col INT) " +
+                        "USING DELTA LOCATION 's3://%s/%s' " +
+                        "TBLPROPERTIES ('delta.columnMapping.mode'='name')",
+                tableName,
+                bucketName,
+                tableDirectory));
+
+        try {
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES (1)");
+            assertThat(onTrino().executeQuery("SELECT col FROM delta.default." + tableName))
+                    .containsOnly(row(1));
+
+            onDelta().executeQuery("ALTER TABLE default." + tableName + " RENAME COLUMN col TO new_col");
+            assertThat(onTrino().executeQuery("SELECT new_col FROM delta.default." + tableName))
+                    .containsOnly(row(1));
+
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES (2)");
+            assertThat(onTrino().executeQuery("SELECT new_col FROM delta.default." + tableName))
+                    .containsOnly(row(1), row(2));
+        }
+        finally {
+            onDelta().executeQuery("DROP TABLE default." + tableName);
+        }
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_OSS, DELTA_LAKE_EXCLUDE_73, DELTA_LAKE_EXCLUDE_91, PROFILE_SPECIFIC_TESTS})
+    public void testRenamePartitionedColumn()
+    {
+        String tableName = "test_dl_rename_partitioned_column_" + randomTableSuffix();
+        String tableDirectory = "databricks-compatibility-test-" + tableName;
+
+        onDelta().executeQuery(format("" +
+                        "CREATE TABLE default.%s (col INT, part STRING) " +
+                        "USING DELTA LOCATION 's3://%s/%s' " +
+                        "PARTITIONED BY (part) " +
+                        "TBLPROPERTIES ('delta.columnMapping.mode'='name')",
+                tableName,
+                bucketName,
+                tableDirectory));
+
+        try {
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES (1, 'part1')");
+            assertThat(onTrino().executeQuery("SELECT col, part FROM delta.default." + tableName))
+                    .containsOnly(row(1, "part1"));
+
+            onDelta().executeQuery("ALTER TABLE default." + tableName + " RENAME COLUMN part TO new_part");
+            assertThat(onTrino().executeQuery("SELECT col, new_part FROM delta.default." + tableName))
+                    .containsOnly(row(1, "part1"));
+
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES (2, 'part2')");
+            assertThat(onTrino().executeQuery("SELECT col, new_part FROM delta.default." + tableName))
+                    .containsOnly(row(1, "part1"), row(2, "part2"));
         }
         finally {
             onDelta().executeQuery("DROP TABLE default." + tableName);


### PR DESCRIPTION
## Description

Use physical column name when comparing partition keys in Delta Lake
Fixes #13521

## Documentation

(x) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# Delta Lake
* Fix failure when reading a table having partition columns renamed by the remote data source. ({issue}`13521`)
```
