### PR TITLE
Fix deprecated Parquet OriginalType

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
@@ -21,8 +21,8 @@ import org.apache.parquet.io.GroupColumnIO;
 import org.apache.parquet.io.MessageColumnIO;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.io.PrimitiveColumnIO;
-import org.apache.parquet.schema.DecimalMetadata;
 import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.LogicalTypeAnnotation.DecimalLogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 
 import javax.annotation.Nullable;
@@ -34,7 +34,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static org.apache.parquet.schema.OriginalType.DECIMAL;
 import static org.apache.parquet.schema.Type.Repetition.REPEATED;
 
 public final class ParquetTypeUtils
@@ -80,7 +79,7 @@ public final class ParquetTypeUtils
          *  }
          */
         if (columnIO instanceof GroupColumnIO &&
-                columnIO.getType().getOriginalType() == null &&
+                columnIO.getType().getLogicalTypeAnnotation() == null &&
                 ((GroupColumnIO) columnIO).getChildrenCount() == 1 &&
                 !columnIO.getName().equals("array") &&
                 !columnIO.getName().equals(columnIO.getParent().getName() + "_tuple")) {
@@ -221,11 +220,11 @@ public final class ParquetTypeUtils
 
     public static Optional<DecimalType> createDecimalType(RichColumnDescriptor descriptor)
     {
-        if (descriptor.getPrimitiveType().getOriginalType() != DECIMAL) {
+        if (!(descriptor.getPrimitiveType().getLogicalTypeAnnotation() instanceof DecimalLogicalTypeAnnotation)) {
             return Optional.empty();
         }
-        DecimalMetadata decimalMetadata = descriptor.getPrimitiveType().getDecimalMetadata();
-        return Optional.of(DecimalType.createDecimalType(decimalMetadata.getPrecision(), decimalMetadata.getScale()));
+        DecimalLogicalTypeAnnotation decimalLogicalType = (DecimalLogicalTypeAnnotation) descriptor.getPrimitiveType().getLogicalTypeAnnotation();
+        return Optional.of(DecimalType.createDecimalType(decimalLogicalType.getPrecision(), decimalLogicalType.getScale()));
     }
 
     /**

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PrimitiveColumnReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PrimitiveColumnReader.java
@@ -35,8 +35,8 @@ import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridDecoder;
 import org.apache.parquet.internal.filter2.columnindex.RowRanges;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.TimeLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.TimestampLogicalTypeAnnotation;
-import org.apache.parquet.schema.OriginalType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.joda.time.DateTimeZone;
 
@@ -105,13 +105,16 @@ public abstract class PrimitiveColumnReader
             case INT32:
                 return createDecimalColumnReader(descriptor).orElse(new IntColumnReader(descriptor));
             case INT64:
-                if (descriptor.getPrimitiveType().getOriginalType() == OriginalType.TIME_MICROS) {
+                if (descriptor.getPrimitiveType().getLogicalTypeAnnotation() instanceof TimeLogicalTypeAnnotation &&
+                        ((TimeLogicalTypeAnnotation) descriptor.getPrimitiveType().getLogicalTypeAnnotation()).getUnit() == LogicalTypeAnnotation.TimeUnit.MICROS) {
                     return new TimeMicrosColumnReader(descriptor);
                 }
-                if (descriptor.getPrimitiveType().getOriginalType() == OriginalType.TIMESTAMP_MICROS) {
+                if (descriptor.getPrimitiveType().getLogicalTypeAnnotation() instanceof TimestampLogicalTypeAnnotation &&
+                        ((TimestampLogicalTypeAnnotation) descriptor.getPrimitiveType().getLogicalTypeAnnotation()).getUnit() == LogicalTypeAnnotation.TimeUnit.MICROS) {
                     return new TimestampMicrosColumnReader(descriptor);
                 }
-                if (descriptor.getPrimitiveType().getOriginalType() == OriginalType.TIMESTAMP_MILLIS) {
+                if (descriptor.getPrimitiveType().getLogicalTypeAnnotation() instanceof TimestampLogicalTypeAnnotation &&
+                        ((TimestampLogicalTypeAnnotation) descriptor.getPrimitiveType().getLogicalTypeAnnotation()).getUnit() == LogicalTypeAnnotation.TimeUnit.MILLIS) {
                     return new Int64TimestampMillisColumnReader(descriptor);
                 }
                 if (descriptor.getPrimitiveType().getLogicalTypeAnnotation() instanceof TimestampLogicalTypeAnnotation &&

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetSchemaConverter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetSchemaConverter.java
@@ -28,7 +28,6 @@ import io.trino.spi.type.VarcharType;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.OriginalType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type.Repetition;
 import org.apache.parquet.schema.Types;
@@ -143,7 +142,7 @@ public class ParquetSchemaConverter
                     .named(name);
         }
         if (DATE.equals(type)) {
-            return Types.primitive(PrimitiveType.PrimitiveTypeName.INT32, repetition).as(OriginalType.DATE).named(name);
+            return Types.primitive(PrimitiveType.PrimitiveTypeName.INT32, repetition).as(LogicalTypeAnnotation.dateType()).named(name);
         }
         if (BIGINT.equals(type)) {
             return Types.primitive(PrimitiveType.PrimitiveTypeName.INT64, repetition).named(name);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetTypeVisitor.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetTypeVisitor.java
@@ -15,8 +15,8 @@ package io.trino.parquet.writer;
 
 import com.google.common.collect.Lists;
 import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.OriginalType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
 
@@ -24,8 +24,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static org.apache.parquet.schema.OriginalType.LIST;
-import static org.apache.parquet.schema.OriginalType.MAP;
 import static org.apache.parquet.schema.Type.Repetition.REPEATED;
 
 // Code from iceberg
@@ -44,8 +42,8 @@ public class ParquetTypeVisitor<T>
         else {
             // if not a primitive, the typeId must be a group
             GroupType group = type.asGroupType();
-            OriginalType annotation = group.getOriginalType();
-            if (annotation == LIST) {
+            LogicalTypeAnnotation annotation = group.getLogicalTypeAnnotation();
+            if (LogicalTypeAnnotation.listType().equals(annotation)) {
                 checkArgument(!group.isRepetition(REPEATED),
                         "Invalid list: top-level group is repeated: " + group);
                 checkArgument(group.getFieldCount() == 1,
@@ -70,7 +68,7 @@ public class ParquetTypeVisitor<T>
                     visitor.fieldNames.pop();
                 }
             }
-            else if (annotation == MAP) {
+            else if (LogicalTypeAnnotation.mapType().equals(annotation)) {
                 checkArgument(!group.isRepetition(REPEATED),
                         "Invalid map: top-level group is repeated: " + group);
                 checkArgument(group.getFieldCount() == 1,

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriters.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriters.java
@@ -47,9 +47,9 @@ import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.TimeLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.TimestampLogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.OriginalType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.joda.time.DateTimeZone;
 
@@ -215,7 +215,7 @@ final class ParquetWriters
             return new DateValueWriter(valuesWriter, parquetType);
         }
         if (TIME_MICROS.equals(type)) {
-            verifyParquetType(type, parquetType, OriginalType.TIME_MICROS);
+            verifyParquetType(type, parquetType, TimeLogicalTypeAnnotation.class, isTime(LogicalTypeAnnotation.TimeUnit.MICROS));
             return new TimeMicrosValueWriter(valuesWriter, parquetType);
         }
         if (type instanceof TimestampType) {
@@ -224,28 +224,23 @@ final class ParquetWriters
                 return new Int96TimestampValueWriter(valuesWriter, type, parquetType, parquetTimeZone.get());
             }
             if (TIMESTAMP_MILLIS.equals(type)) {
-                verifyParquetType(type, parquetType, OriginalType.TIMESTAMP_MILLIS);
                 verifyParquetType(type, parquetType, TimestampLogicalTypeAnnotation.class, isTimestamp(LogicalTypeAnnotation.TimeUnit.MILLIS));
                 return new TimestampMillisValueWriter(valuesWriter, type, parquetType);
             }
             if (TIMESTAMP_MICROS.equals(type)) {
-                verifyParquetType(type, parquetType, OriginalType.TIMESTAMP_MICROS);
                 verifyParquetType(type, parquetType, TimestampLogicalTypeAnnotation.class, isTimestamp(LogicalTypeAnnotation.TimeUnit.MICROS));
                 return new BigintValueWriter(valuesWriter, type, parquetType);
             }
             if (TIMESTAMP_NANOS.equals(type)) {
-                verifyParquetType(type, parquetType, (OriginalType) null); // no OriginalType for timestamp NANOS
                 verifyParquetType(type, parquetType, TimestampLogicalTypeAnnotation.class, isTimestamp(LogicalTypeAnnotation.TimeUnit.NANOS));
                 return new TimestampNanosValueWriter(valuesWriter, type, parquetType);
             }
         }
 
         if (TIMESTAMP_TZ_MILLIS.equals(type)) {
-            verifyParquetType(type, parquetType, OriginalType.TIMESTAMP_MILLIS);
             return new TimestampTzMillisValueWriter(valuesWriter, parquetType);
         }
         if (TIMESTAMP_TZ_MICROS.equals(type)) {
-            verifyParquetType(type, parquetType, OriginalType.TIMESTAMP_MICROS);
             return new TimestampTzMicrosValueWriter(valuesWriter, parquetType);
         }
         if (DOUBLE.equals(type)) {
@@ -264,17 +259,20 @@ final class ParquetWriters
         throw new TrinoException(NOT_SUPPORTED, format("Unsupported type for Parquet writer: %s", type));
     }
 
-    private static void verifyParquetType(Type type, PrimitiveType parquetType, OriginalType originalType)
-    {
-        checkArgument(parquetType.getOriginalType() == originalType, "Wrong Parquet type '%s' for Trino type '%s'", parquetType, type);
-    }
-
     private static <T> void verifyParquetType(Type type, PrimitiveType parquetType, Class<T> annotationType, Predicate<T> predicate)
     {
         checkArgument(
                 annotationType.isInstance(parquetType.getLogicalTypeAnnotation()) &&
                         predicate.test(annotationType.cast(parquetType.getLogicalTypeAnnotation())),
                 "Wrong Parquet type '%s' for Trino type '%s'", parquetType, type);
+    }
+
+    private static Predicate<TimeLogicalTypeAnnotation> isTime(LogicalTypeAnnotation.TimeUnit precision)
+    {
+        requireNonNull(precision, "precision is null");
+        return annotation -> annotation.getUnit() == precision &&
+                // isAdjustedToUTC=false indicates Local semantics (timestamps not normalized to UTC)
+                !annotation.isAdjustedToUTC();
     }
 
     private static Predicate<TimestampLogicalTypeAnnotation> isTimestamp(LogicalTypeAnnotation.TimeUnit precision)

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnIndexBuilder.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnIndexBuilder.java
@@ -24,6 +24,7 @@ import org.apache.parquet.internal.column.columnindex.BoundaryOrder;
 import org.apache.parquet.internal.column.columnindex.ColumnIndex;
 import org.apache.parquet.internal.column.columnindex.ColumnIndexBuilder;
 import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Types;
 import org.testng.annotations.Test;
@@ -51,9 +52,6 @@ import static org.apache.parquet.filter2.predicate.FilterApi.ltEq;
 import static org.apache.parquet.filter2.predicate.FilterApi.notEq;
 import static org.apache.parquet.filter2.predicate.FilterApi.userDefined;
 import static org.apache.parquet.filter2.predicate.LogicalInverter.invert;
-import static org.apache.parquet.schema.OriginalType.DECIMAL;
-import static org.apache.parquet.schema.OriginalType.UINT_8;
-import static org.apache.parquet.schema.OriginalType.UTF8;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BOOLEAN;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.DOUBLE;
@@ -265,7 +263,7 @@ public class TestColumnIndexBuilder
     @Test
     public void testBuildBinaryDecimal()
     {
-        PrimitiveType type = Types.required(BINARY).as(DECIMAL).precision(12).scale(2).named("test_binary_decimal");
+        PrimitiveType type = Types.required(BINARY).as(LogicalTypeAnnotation.decimalType(2, 12)).named("test_binary_decimal");
         ColumnIndexBuilder builder = ColumnIndexBuilder.getBuilder(type, Integer.MAX_VALUE);
         //assertThat(builder, instanceOf(BinaryColumnIndexBuilder.class));
         assertNull(builder.build());
@@ -409,7 +407,7 @@ public class TestColumnIndexBuilder
     @Test
     public void testBuildBinaryUtf8()
     {
-        PrimitiveType type = Types.required(BINARY).as(UTF8).named("test_binary_utf8");
+        PrimitiveType type = Types.required(BINARY).as(LogicalTypeAnnotation.stringType()).named("test_binary_utf8");
         ColumnIndexBuilder builder = ColumnIndexBuilder.getBuilder(type, Integer.MAX_VALUE);
         //assertThat(builder, instanceOf(BinaryColumnIndexBuilder.class));
         assertNull(builder.build());
@@ -554,7 +552,7 @@ public class TestColumnIndexBuilder
     public void testStaticBuildBinary()
     {
         ColumnIndex columnIndex = ColumnIndexBuilder.build(
-                Types.required(BINARY).as(UTF8).named("test_binary_utf8"),
+                Types.required(BINARY).as(LogicalTypeAnnotation.stringType()).named("test_binary_utf8"),
                 BoundaryOrder.ASCENDING,
                 asList(true, true, false, false, true, false, true, false),
                 asList(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L),
@@ -603,7 +601,7 @@ public class TestColumnIndexBuilder
     public void testFilterWithoutNullCounts()
     {
         ColumnIndex columnIndex = ColumnIndexBuilder.build(
-                Types.required(BINARY).as(UTF8).named("test_binary_utf8"),
+                Types.required(BINARY).as(LogicalTypeAnnotation.stringType()).named("test_binary_utf8"),
                 BoundaryOrder.ASCENDING,
                 asList(true, true, false, false, true, false, true, false),
                 null,
@@ -1137,7 +1135,7 @@ public class TestColumnIndexBuilder
     @Test
     public void testBuildUInt8()
     {
-        PrimitiveType type = Types.required(INT32).as(UINT_8).named("test_uint8");
+        PrimitiveType type = Types.required(INT32).as(LogicalTypeAnnotation.intType(8, false)).named("test_uint8");
         ColumnIndexBuilder builder = ColumnIndexBuilder.getBuilder(type, Integer.MAX_VALUE);
         //assertThat(builder, instanceOf(IntColumnIndexBuilder.class));
         assertNull(builder.build());
@@ -1352,7 +1350,7 @@ public class TestColumnIndexBuilder
     {
         ColumnIndexBuilder builder = ColumnIndexBuilder.getNoOpBuilder();
         StatsBuilder sb = new StatsBuilder();
-        builder.add(sb.stats(Types.required(BINARY).as(UTF8).named("test_binary_utf8"), stringBinary("Jeltz"),
+        builder.add(sb.stats(Types.required(BINARY).as(LogicalTypeAnnotation.stringType()).named("test_binary_utf8"), stringBinary("Jeltz"),
                 stringBinary("Slartibartfast"), null, null));
         builder.add(sb.stats(Types.required(BOOLEAN).named("test_boolean"), true, true, null, null));
         builder.add(sb.stats(Types.required(DOUBLE).named("test_double"), null, null, null));

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestMetadataReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestMetadataReader.java
@@ -20,8 +20,9 @@ import org.apache.parquet.column.statistics.FloatStatistics;
 import org.apache.parquet.column.statistics.IntStatistics;
 import org.apache.parquet.column.statistics.LongStatistics;
 import org.apache.parquet.format.Statistics;
-import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -403,7 +404,7 @@ public class TestMetadataReader
         if (max != null) {
             statistics.setMax(max.getBytes(UTF_8));
         }
-        assertThat(MetadataReader.readStats(fileCreatedBy, Optional.of(statistics), new PrimitiveType(OPTIONAL, BINARY, "Test column", OriginalType.UTF8)))
+        assertThat(MetadataReader.readStats(fileCreatedBy, Optional.of(statistics), Types.optional(BINARY).as(LogicalTypeAnnotation.stringType()).named("Test column")))
                 .isInstanceOfSatisfying(BinaryStatistics.class, columnStatistics -> {
                     assertFalse(columnStatistics.isEmpty());
 
@@ -437,7 +438,7 @@ public class TestMetadataReader
     @Test(dataProvider = "allCreatedBy")
     public void testReadStatsBinaryUtf8(Optional<String> fileCreatedBy)
     {
-        PrimitiveType varchar = new PrimitiveType(OPTIONAL, BINARY, "Test column", OriginalType.UTF8);
+        PrimitiveType varchar = Types.optional(BINARY).as(LogicalTypeAnnotation.stringType()).named("Test column");
         Statistics statistics;
 
         // Stats written by Parquet after https://issues.apache.org/jira/browse/PARQUET-1025
@@ -477,7 +478,7 @@ public class TestMetadataReader
                         columnStatistics -> assertTrue(columnStatistics.isEmpty()));
 
         // varchar
-        assertThat(MetadataReader.readStats(fileCreatedBy, Optional.empty(), new PrimitiveType(OPTIONAL, BINARY, "Test column", OriginalType.UTF8)))
+        assertThat(MetadataReader.readStats(fileCreatedBy, Optional.empty(), Types.optional(BINARY).as(LogicalTypeAnnotation.stringType()).named("Test column")))
                 .isInstanceOfSatisfying(
                         BinaryStatistics.class,
                         columnStatistics -> assertTrue(columnStatistics.isEmpty()));

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/write/SingleLevelArrayMapKeyValuesSchemaConverter.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/write/SingleLevelArrayMapKeyValuesSchemaConverter.java
@@ -23,8 +23,8 @@ import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.OriginalType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Type;
 import org.apache.parquet.schema.Type.Repetition;
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Locale;
 
 import static com.google.common.base.Preconditions.checkState;
-import static org.apache.parquet.schema.OriginalType.MAP_KEY_VALUE;
 
 /**
  * This class is copied from org.apache.hadoop.hive.ql.io.parquet.convert.HiveSchemaConverter
@@ -70,7 +69,7 @@ public final class SingleLevelArrayMapKeyValuesSchemaConverter
     {
         if (typeInfo.getCategory() == Category.PRIMITIVE) {
             if (typeInfo.equals(TypeInfoFactory.stringTypeInfo)) {
-                return Types.primitive(PrimitiveTypeName.BINARY, repetition).as(OriginalType.UTF8)
+                return Types.primitive(PrimitiveTypeName.BINARY, repetition).as(LogicalTypeAnnotation.stringType())
                         .named(name);
             }
             if (typeInfo.equals(TypeInfoFactory.intTypeInfo) ||
@@ -102,16 +101,16 @@ public final class SingleLevelArrayMapKeyValuesSchemaConverter
             if (typeInfo.getTypeName().toLowerCase(Locale.ENGLISH).startsWith(
                     serdeConstants.CHAR_TYPE_NAME)) {
                 if (repetition == Repetition.OPTIONAL) {
-                    return Types.optional(PrimitiveTypeName.BINARY).as(OriginalType.UTF8).named(name);
+                    return Types.optional(PrimitiveTypeName.BINARY).as(LogicalTypeAnnotation.stringType()).named(name);
                 }
-                return Types.repeated(PrimitiveTypeName.BINARY).as(OriginalType.UTF8).named(name);
+                return Types.repeated(PrimitiveTypeName.BINARY).as(LogicalTypeAnnotation.stringType()).named(name);
             }
             if (typeInfo.getTypeName().toLowerCase(Locale.ENGLISH).startsWith(
                     serdeConstants.VARCHAR_TYPE_NAME)) {
                 if (repetition == Repetition.OPTIONAL) {
-                    return Types.optional(PrimitiveTypeName.BINARY).as(OriginalType.UTF8).named(name);
+                    return Types.optional(PrimitiveTypeName.BINARY).as(LogicalTypeAnnotation.stringType()).named(name);
                 }
-                return Types.repeated(PrimitiveTypeName.BINARY).as(OriginalType.UTF8).named(name);
+                return Types.repeated(PrimitiveTypeName.BINARY).as(LogicalTypeAnnotation.stringType()).named(name);
             }
             if (typeInfo instanceof DecimalTypeInfo) {
                 DecimalTypeInfo decimalTypeInfo = (DecimalTypeInfo) typeInfo;
@@ -119,12 +118,12 @@ public final class SingleLevelArrayMapKeyValuesSchemaConverter
                 int scale = decimalTypeInfo.scale();
                 int bytes = ParquetHiveSerDe.PRECISION_TO_BYTE_COUNT[prec - 1];
                 if (repetition == Repetition.OPTIONAL) {
-                    return Types.optional(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY).length(bytes).as(OriginalType.DECIMAL).scale(scale).precision(prec).named(name);
+                    return Types.optional(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY).length(bytes).as(LogicalTypeAnnotation.decimalType(scale, prec)).named(name);
                 }
-                return Types.repeated(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY).length(bytes).as(OriginalType.DECIMAL).scale(scale).precision(prec).named(name);
+                return Types.repeated(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY).length(bytes).as(LogicalTypeAnnotation.decimalType(scale, prec)).named(name);
             }
             if (typeInfo.equals(TypeInfoFactory.dateTypeInfo)) {
-                return Types.primitive(PrimitiveTypeName.INT32, repetition).as(OriginalType.DATE).named(name);
+                return Types.primitive(PrimitiveTypeName.INT32, repetition).as(LogicalTypeAnnotation.dateType()).named(name);
             }
             if (typeInfo.equals(TypeInfoFactory.unknownTypeInfo)) {
                 throw new UnsupportedOperationException("Unknown type not implemented");
@@ -150,7 +149,7 @@ public final class SingleLevelArrayMapKeyValuesSchemaConverter
     private static GroupType convertArrayType(String name, ListTypeInfo typeInfo, Repetition repetition)
     {
         TypeInfo subType = typeInfo.getListElementTypeInfo();
-        return listWrapper(name, OriginalType.LIST, convertType("array_element", subType, Repetition.REPEATED), repetition);
+        return listWrapper(name, LogicalTypeAnnotation.listType(), convertType("array_element", subType, Repetition.REPEATED), repetition);
     }
 
     // An optional group containing multiple elements
@@ -179,7 +178,7 @@ public final class SingleLevelArrayMapKeyValuesSchemaConverter
             return listWrapper(
                     repetition,
                     alias,
-                    MAP_KEY_VALUE,
+                    LogicalTypeAnnotation.MapKeyValueTypeAnnotation.getInstance(),
                     new GroupType(
                             Repetition.REPEATED,
                             mapAlias,
@@ -191,7 +190,7 @@ public final class SingleLevelArrayMapKeyValuesSchemaConverter
         return listWrapper(
                 repetition,
                 alias,
-                MAP_KEY_VALUE,
+                LogicalTypeAnnotation.MapKeyValueTypeAnnotation.getInstance(),
                 new GroupType(
                         Repetition.REPEATED,
                         mapAlias,
@@ -199,16 +198,16 @@ public final class SingleLevelArrayMapKeyValuesSchemaConverter
                         valueType));
     }
 
-    private static GroupType listWrapper(Repetition repetition, String alias, OriginalType originalType, Type nested)
+    private static GroupType listWrapper(Repetition repetition, String alias, LogicalTypeAnnotation logicalType, Type nested)
     {
         if (!nested.isRepetition(Repetition.REPEATED)) {
             throw new IllegalArgumentException("Nested type should be repeated: " + nested);
         }
-        return new GroupType(repetition, alias, originalType, nested);
+        return Types.buildGroup(repetition).as(logicalType).addField(nested).named(alias);
     }
 
-    private static GroupType listWrapper(String name, OriginalType originalType, Type elementType, Repetition repetition)
+    private static GroupType listWrapper(String name, LogicalTypeAnnotation logicalType, Type elementType, Repetition repetition)
     {
-        return new GroupType(repetition, name, originalType, elementType);
+        return Types.buildGroup(repetition).as(logicalType).addField(elementType).named(name);
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/write/TestDataWritableWriter.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/write/TestDataWritableWriter.java
@@ -43,7 +43,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.io.api.RecordConsumer;
 import org.apache.parquet.schema.GroupType;
-import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.Type;
 import org.joda.time.DateTimeZone;
 
@@ -140,9 +140,9 @@ public class TestDataWritableWriter
         }
         else {
             GroupType groupType = type.asGroupType();
-            OriginalType originalType = type.getOriginalType();
+            LogicalTypeAnnotation logicalType = type.getLogicalTypeAnnotation();
 
-            if (OriginalType.LIST == originalType) {
+            if (LogicalTypeAnnotation.listType().equals(logicalType)) {
                 checkInspectorCategory(inspector, ObjectInspector.Category.LIST);
                 if (singleLevelArray) {
                     writeSingleLevelArray(value, (ListObjectInspector) inspector, groupType);
@@ -151,7 +151,7 @@ public class TestDataWritableWriter
                     writeArray(value, (ListObjectInspector) inspector, groupType);
                 }
             }
-            else if (originalType != null && (originalType == OriginalType.MAP || originalType == OriginalType.MAP_KEY_VALUE)) {
+            else if (LogicalTypeAnnotation.mapType().equals(logicalType) || LogicalTypeAnnotation.MapKeyValueTypeAnnotation.getInstance().equals(logicalType)) {
                 checkInspectorCategory(inspector, ObjectInspector.Category.MAP);
                 writeMap(value, (MapObjectInspector) inspector, groupType);
             }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Replace deprecated Parquet `OriginalType` with `LogicalTypeAnnotation`

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

`lib/trino-parquet` and `plugin/trino-hive` connector

> How would you describe this change to a non-technical end user or system administrator?

Fix deprecated Parquet API usage

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

Part of #1802

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text: