### PR TITLE
Allow all bucketed table supported types during filter

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketing.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketing.java
@@ -118,14 +118,6 @@ public final class HiveBucketing
     private static final long BUCKETS_EXPLORATION_LIMIT_FACTOR = 4;
     private static final long BUCKETS_EXPLORATION_GUARANTEED_LIMIT = 1000;
 
-    private static final Set<HiveType> SUPPORTED_TYPES_FOR_BUCKET_FILTER = ImmutableSet.of(
-            HiveType.HIVE_BYTE,
-            HiveType.HIVE_SHORT,
-            HiveType.HIVE_INT,
-            HiveType.HIVE_LONG,
-            HiveType.HIVE_BOOLEAN,
-            HiveType.HIVE_STRING);
-
     private HiveBucketing() {}
 
     public static int getHiveBucket(BucketingVersion bucketingVersion, int bucketCount, List<TypeInfo> types, Page page, int position)
@@ -270,7 +262,7 @@ public final class HiveBucketing
             hiveTypes.put(column.getName(), column.getType());
         }
         for (String column : bucketColumns) {
-            if (!SUPPORTED_TYPES_FOR_BUCKET_FILTER.contains(hiveTypes.get(column))) {
+            if (!isTypeSupportedForBucketing(hiveTypes.get(column).getTypeInfo())) {
                 return Optional.empty();
             }
         }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -1775,14 +1775,17 @@ public abstract class AbstractTestHive
 
             assertTableIsBucketed(tableHandle, transaction, session);
 
+            float testFloatValue = 87.1f;
+            double testDoubleValue = 88.2;
+
             ImmutableMap<ColumnHandle, NullableValue> bindings = ImmutableMap.<ColumnHandle, NullableValue>builder()
-                    .put(columnHandles.get(columnIndex.get("t_float")), NullableValue.of(REAL, (long) floatToRawIntBits(87.1f)))
-                    .put(columnHandles.get(columnIndex.get("t_double")), NullableValue.of(DOUBLE, 88.2))
+                    .put(columnHandles.get(columnIndex.get("t_float")), NullableValue.of(REAL, (long) floatToRawIntBits(testFloatValue)))
+                    .put(columnHandles.get(columnIndex.get("t_double")), NullableValue.of(DOUBLE, testDoubleValue))
                     .buildOrThrow();
 
-            // floats and doubles are not supported, so we should see all splits
-            MaterializedResult result = readTable(transaction, tableHandle, columnHandles, session, TupleDomain.fromFixedValues(bindings), OptionalInt.of(32), Optional.empty());
-            assertEquals(result.getRowCount(), 100);
+            MaterializedResult result = readTable(transaction, tableHandle, columnHandles, session, TupleDomain.fromFixedValues(bindings), OptionalInt.of(1), Optional.empty());
+            assertThat(result).anyMatch(row -> testFloatValue == (float) row.getField(columnIndex.get("t_float"))
+                    && testDoubleValue == (double) row.getField(columnIndex.get("t_double")));
         }
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -2102,6 +2102,26 @@ public abstract class BaseHiveConnectorTest
         assertFalse(getQueryRunner().tableExists(session, tableName));
     }
 
+    @Test(dataProvider = "bucketedUnsupportedTypes")
+    public void testBucketedTableUnsupportedTypes(String typeName)
+    {
+        String tableName = "test_bucketed_table_for_unsupported_types_" + randomTableSuffix();
+        assertThatThrownBy(() -> assertUpdate(
+                """
+                CREATE TABLE %s (bucket_key %s, other_data double)
+                WITH (
+                    bucketed_by = ARRAY[ 'bucket_key' ],
+                    bucket_count = 5)
+                """.formatted(tableName, typeName)))
+                .hasMessage("Cannot create a table bucketed on an unsupported type");
+    }
+
+    @DataProvider
+    public final Object[][] bucketedUnsupportedTypes()
+    {
+        return new Object[][] {{"VARBINARY"}, {"TIMESTAMP"}, {"DECIMAL(10,3)"}, {"CHAR"}, {"ROW(id VARCHAR)"}};
+    }
+
     /**
      * Regression test for https://github.com/trinodb/trino/issues/5295
      */


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Fixes https://github.com/trinodb/trino/issues/13472

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

hive connector

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

* Fixes #13472

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Hive
* Add support for hive bucket filtering to float, double, date, list, map and bounded varchar data types. ({issue}`13553`)
```
