### PR TITLE
Fix more deprecated Parquet API usage

### DIFF
--- a/lib/trino-parquet/src/test/java/io/trino/parquet/TestParquetTimestampUtils.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/TestParquetTimestampUtils.java
@@ -42,7 +42,7 @@ public class TestParquetTimestampUtils
     {
         try {
             byte[] invalidLengthBinaryTimestamp = new byte[8];
-            decodeInt96Timestamp(Binary.fromByteArray(invalidLengthBinaryTimestamp));
+            decodeInt96Timestamp(Binary.fromConstantByteArray(invalidLengthBinaryTimestamp));
         }
         catch (TrinoException e) {
             assertEquals(e.getErrorCode(), NOT_SUPPORTED.toErrorCode());

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/predicate/BenchmarkTupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/predicate/BenchmarkTupleDomainParquetPredicate.java
@@ -19,6 +19,7 @@ import io.trino.parquet.DictionaryPage;
 import io.trino.parquet.ParquetEncoding;
 import io.trino.spi.predicate.Domain;
 import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.schema.Types;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -91,7 +92,7 @@ public class BenchmarkTupleDomainParquetPredicate
             }
 
             return new DictionaryDescriptor(
-                    new ColumnDescriptor(new String[] {"path"}, INT64, 0, 0),
+                    new ColumnDescriptor(new String[] {"path"}, Types.optional(INT64).named("Test column"), 0, 0),
                     Optional.of(
                             new DictionaryPage(
                                     slice,

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/predicate/TestPredicateUtils.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/predicate/TestPredicateUtils.java
@@ -17,7 +17,10 @@ import com.google.common.collect.ImmutableSet;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.EncodingStats;
 import org.apache.parquet.column.statistics.BinaryStatistics;
+import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
 import org.testng.annotations.Test;
 
 import java.util.Set;
@@ -108,7 +111,9 @@ public class TestPredicateUtils
                 .addDictEncoding(PLAIN)
                 .addDataEncodings(ImmutableSet.copyOf(dataEncodings)).build();
 
-        return ColumnChunkMetaData.get(fromDotString("column"), BINARY, UNCOMPRESSED, encodingStats, encodingStats.getDataEncodings(), new BinaryStatistics(), 0, 0, 1, 1, 1);
+        PrimitiveType type = Types.optional(BINARY).named("");
+        Statistics<?> stats = Statistics.createStats(type);
+        return ColumnChunkMetaData.get(fromDotString("column"), type, UNCOMPRESSED, encodingStats, encodingStats.getDataEncodings(), stats, 0, 0, 1, 1, 1);
     }
 
     @SuppressWarnings("deprecation")

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnReader.java
@@ -22,11 +22,12 @@ import io.trino.parquet.RichColumnDescriptor;
 import io.trino.spi.block.Block;
 import org.apache.parquet.bytes.HeapByteBufferAllocator;
 import org.apache.parquet.column.ColumnDescriptor;
-import org.apache.parquet.column.statistics.IntStatistics;
+import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.column.values.plain.PlainValuesWriter;
 import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridEncoder;
 import org.apache.parquet.internal.filter2.columnindex.RowRanges;
 import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -248,7 +249,7 @@ public class TestColumnReader
                     Slices.wrappedBuffer(encodePlainValues(values)),
                     valueCount * 4,
                     OptionalLong.of(start),
-                    new IntStatistics(),
+                    Statistics.createStats(Types.optional(INT32).named("TestColumn")),
                     false);
         }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix more deprecated Parquet API usage:
- `Binary`
- `ColumnChunkMetadata`
- `ColumnDescriptor`
- `Statistics`

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

`lib/trino-parquet` and `plugin/trino-hive` connector

> How would you describe this change to a non-technical end user or system administrator?

Fix deprecated API usage

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

Part of #1802

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
