### PR TITLE
Allow GCS-based spooling to pass JSON key as a config

### DIFF
--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
@@ -418,7 +418,13 @@ the property may be configured for:
      - Any S3-compatible storage
    * - ``exchange.gcs.json-key-file-path``
      - Path to the JSON file that contains your Google Cloud Platform
-       service account key.
+       service account key. Not to be set together with
+       ``exchange.gcs.json-key``
+     -
+     - GCS
+   * - ``exchange.gcs.json-key``
+     - Your Google Cloud Platform service account key in JSON format.
+       Not to be set together with ``exchange.gcs.json-key-file-path``
      -
      - GCS
    * - ``exchange.azure.connection-string``

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/s3/ExchangeS3Config.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/s3/ExchangeS3Config.java
@@ -50,6 +50,7 @@ public class ExchangeS3Config
     private int asyncClientMaxPendingConnectionAcquires = 10000;
     private Duration connectionAcquisitionTimeout = new Duration(1, MINUTES);
     private Optional<String> gcsJsonKeyFilePath = Optional.empty();
+    private Optional<String> gcsJsonKey = Optional.empty();
 
     public String getS3AwsAccessKey()
     {
@@ -228,9 +229,24 @@ public class ExchangeS3Config
     }
 
     @Config("exchange.gcs.json-key-file-path")
+    @ConfigDescription("Path to the JSON file that contains your Google Cloud Platform service account key. Not to be set together with `exchange.gcs.json-key`")
     public ExchangeS3Config setGcsJsonKeyFilePath(String gcsJsonKeyFilePath)
     {
         this.gcsJsonKeyFilePath = Optional.ofNullable(gcsJsonKeyFilePath);
+        return this;
+    }
+
+    public Optional<String> getGcsJsonKey()
+    {
+        return gcsJsonKey;
+    }
+
+    @Config("exchange.gcs.json-key")
+    @ConfigDescription("Your Google Cloud Platform service account key in JSON format. Not to be set together with `exchange.gcs.json-key-file-path`")
+    @ConfigSecuritySensitive
+    public ExchangeS3Config setGcsJsonKey(String gcsJsonKey)
+    {
+        this.gcsJsonKey = Optional.ofNullable(gcsJsonKey);
         return this;
     }
 }

--- a/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/s3/TestExchangeS3Config.java
+++ b/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/s3/TestExchangeS3Config.java
@@ -47,7 +47,8 @@ public class TestExchangeS3Config
                 .setAsyncClientConcurrency(100)
                 .setAsyncClientMaxPendingConnectionAcquires(10000)
                 .setConnectionAcquisitionTimeout(new Duration(1, MINUTES))
-                .setGcsJsonKeyFilePath(null));
+                .setGcsJsonKeyFilePath(null)
+                .setGcsJsonKey(null));
     }
 
     @Test
@@ -68,6 +69,7 @@ public class TestExchangeS3Config
                 .put("exchange.s3.async-client-max-pending-connection-acquires", "999")
                 .put("exchange.s3.async-client-connection-acquisition-timeout", "5m")
                 .put("exchange.gcs.json-key-file-path", "/path/to/gcs_keyfile.json")
+                .put("exchange.gcs.json-key", "{}")
                 .buildOrThrow();
 
         ExchangeS3Config expected = new ExchangeS3Config()
@@ -84,7 +86,8 @@ public class TestExchangeS3Config
                 .setAsyncClientConcurrency(202)
                 .setAsyncClientMaxPendingConnectionAcquires(999)
                 .setConnectionAcquisitionTimeout(new Duration(5, MINUTES))
-                .setGcsJsonKeyFilePath("/path/to/gcs_keyfile.json");
+                .setGcsJsonKeyFilePath("/path/to/gcs_keyfile.json")
+                .setGcsJsonKey("{}");
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

trino-exchange-filesystem

> How would you describe this change to a non-technical end user or system administrator?

This allows GCS-based spooling to pass JSON key as a config

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
