### PR TITLE
Slate Alluxio metastore integration for removal

### DIFF
--- a/docs/src/main/sphinx/connector/hive-alluxio.rst
+++ b/docs/src/main/sphinx/connector/hive-alluxio.rst
@@ -80,7 +80,7 @@ the following:
 .. code-block:: text
 
     connector.name=hive
-    hive.metastore=alluxio
+    hive.metastore=alluxio-deprecated
     hive.metastore.alluxio.master.address=HOSTNAME:PORT
 
 Replace ``HOSTNAME`` with the Alluxio master hostname, and replace ``PORT``

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePlugin.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePlugin.java
@@ -104,6 +104,13 @@ public class TestDeltaLakePlugin
                 new TestingConnectorContext()))
                 .hasMessageMatching("(?s)Unable to create injector, see the following errors:.*" +
                         "Explicit bindings are required and HiveMetastoreFactory .* is not explicitly bound.*");
+
+        assertThatThrownBy(() -> factory.create(
+                "test",
+                ImmutableMap.of("hive.metastore", "alluxio-deprecated"),
+                new TestingConnectorContext()))
+                .hasMessageMatching("(?s)Unable to create injector, see the following errors:.*" +
+                        "Explicit bindings are required and HiveMetastoreFactory .* is not explicitly bound.*");
     }
 
     @Test

--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHivePlugin.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHivePlugin.java
@@ -134,7 +134,7 @@ public class TestHivePlugin
         factory.create(
                 "test",
                 ImmutableMap.of(
-                        "hive.metastore", "alluxio",
+                        "hive.metastore", "alluxio-deprecated",
                         "hive.metastore.alluxio.master.address", "dummy:1234"),
                 new TestingConnectorContext())
                 .shutdown();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastoreModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastoreModule.java
@@ -50,7 +50,7 @@ public class HiveMetastoreModule
             // Load Alluxio metastore support through reflection. This makes Alluxio effectively an optional dependency
             // and allows deploying Trino without the Alluxio jar. Can be useful if the integration is unused and is flagged
             // by a security scanner.
-            bindMetastoreModule("alluxio", deferredModule("io.trino.plugin.hive.metastore.alluxio.AlluxioMetastoreModule"));
+            bindMetastoreModule("alluxio-deprecated", deferredModule("io.trino.plugin.hive.metastore.alluxio.AlluxioMetastoreModule"));
         }
 
         install(new DecoratedHiveMetastoreModule());


### PR DESCRIPTION
The Alluxio integration does not seem actively maintained and seems to
have quite small user base (for example, searching for Alluxio
over Trino Slack discussions since Jan 2022 didn't return any users
using Alluxio). Yet, as any integration, it causes problems as security
scanners sometimes flag Alluxio shaded client jar as being affected by
some CVE vulnerabilities.

Mark Alluxio integration as deprecated.
