### PR TITLE
Highlight the environment configuration in the database example

### DIFF
--- a/docs/src/main/sphinx/admin/resource-groups.rst
+++ b/docs/src/main/sphinx/admin/resource-groups.rst
@@ -283,16 +283,13 @@ Database resource group manager
 
 This example is for a MySQL database.
 
-As stated above, the environment ``'test'`` in the example should match ``node.environment`` property from
-:ref:`node_properties`.
-
 .. code-block:: sql
 
     -- global properties
     INSERT INTO resource_groups_global_properties (name, value) VALUES ('cpu_quota_period', '1h');
 
-    -- Every row in resource_groups table indicates a resource group. The parent-child relationship
-    -- is indicated by the ID in 'parent' column.
+    -- Every row in resource_groups table indicates a resource group. The enviroment name is 'test'.
+    -- The parent-child relationship is indicated by the ID in 'parent' column. 
 
     -- create a root group 'global' with NULL parent
     INSERT INTO resource_groups (name, soft_memory_limit, hard_concurrency_limit, max_queued, scheduling_policy, jmx_export, environment) VALUES ('global', '80%', 100, 1000, 'weighted', true, 'test');

--- a/docs/src/main/sphinx/admin/resource-groups.rst
+++ b/docs/src/main/sphinx/admin/resource-groups.rst
@@ -288,48 +288,49 @@ This example is for a MySQL database.
     -- global properties
     INSERT INTO resource_groups_global_properties (name, value) VALUES ('cpu_quota_period', '1h');
 
-    -- Every row in resource_groups table indicates a resource group. The enviroment name is 'test'.
+    -- Every row in resource_groups table indicates a resource group. 
+    -- The enviroment name is 'test_environment', make sure it matches `node.environment` in your cluster.
     -- The parent-child relationship is indicated by the ID in 'parent' column. 
 
     -- create a root group 'global' with NULL parent
-    INSERT INTO resource_groups (name, soft_memory_limit, hard_concurrency_limit, max_queued, scheduling_policy, jmx_export, environment) VALUES ('global', '80%', 100, 1000, 'weighted', true, 'test');
+    INSERT INTO resource_groups (name, soft_memory_limit, hard_concurrency_limit, max_queued, scheduling_policy, jmx_export, environment) VALUES ('global', '80%', 100, 1000, 'weighted', true, 'test_environment');
 
     -- get ID of 'global' group
     SELECT resource_group_id FROM resource_groups WHERE name = 'global';  -- 1
     -- create two new groups with 'global' as parent
-    INSERT INTO resource_groups (name, soft_memory_limit, hard_concurrency_limit, max_queued, scheduling_weight, environment, parent) VALUES ('data_definition', '10%', 5, 100, 1, 'test', 1);
-    INSERT INTO resource_groups (name, soft_memory_limit, hard_concurrency_limit, max_queued, scheduling_weight, environment, parent) VALUES ('adhoc', '10%', 50, 1, 10, 'test', 1);
+    INSERT INTO resource_groups (name, soft_memory_limit, hard_concurrency_limit, max_queued, scheduling_weight, environment, parent) VALUES ('data_definition', '10%', 5, 100, 1, 'test_environment', 1);
+    INSERT INTO resource_groups (name, soft_memory_limit, hard_concurrency_limit, max_queued, scheduling_weight, environment, parent) VALUES ('adhoc', '10%', 50, 1, 10, 'test_environment', 1);
 
     -- get ID of 'adhoc' group
     SELECT resource_group_id FROM resource_groups WHERE name = 'adhoc';   -- 3
     -- create 'other' group with 'adhoc' as parent
-    INSERT INTO resource_groups (name, soft_memory_limit, hard_concurrency_limit, max_queued, scheduling_weight, scheduling_policy, environment, parent) VALUES ('other', '10%', 2, 1, 10, 'weighted_fair', 'test', 3);
+    INSERT INTO resource_groups (name, soft_memory_limit, hard_concurrency_limit, max_queued, scheduling_weight, scheduling_policy, environment, parent) VALUES ('other', '10%', 2, 1, 10, 'weighted_fair', 'test_environment', 3);
 
     -- get ID of 'other' group
     SELECT resource_group_id FROM resource_groups WHERE name = 'other';  -- 4
     -- create '${USER}' group with 'other' as parent.
-    INSERT INTO resource_groups (name, soft_memory_limit, hard_concurrency_limit, max_queued, environment, parent) VALUES ('${USER}', '10%', 1, 100, 'test', 4);
+    INSERT INTO resource_groups (name, soft_memory_limit, hard_concurrency_limit, max_queued, environment, parent) VALUES ('${USER}', '10%', 1, 100, 'test_environment', 4);
 
     -- create 'bi-${toolname}' group with 'adhoc' as parent
-    INSERT INTO resource_groups (name, soft_memory_limit, hard_concurrency_limit, max_queued, scheduling_weight, scheduling_policy, environment, parent) VALUES ('bi-${toolname}', '10%', 10, 100, 10, 'weighted_fair', 'test', 3);
+    INSERT INTO resource_groups (name, soft_memory_limit, hard_concurrency_limit, max_queued, scheduling_weight, scheduling_policy, environment, parent) VALUES ('bi-${toolname}', '10%', 10, 100, 10, 'weighted_fair', 'test_environment', 3);
 
     -- get ID of 'bi-${toolname}' group
     SELECT resource_group_id FROM resource_groups WHERE name = 'bi-${toolname}';  -- 6
     -- create '${USER}' group with 'bi-${toolname}' as parent. This indicates
     -- nested group 'global.adhoc.bi-${toolname}.${USER}', and will have a
     -- different ID than 'global.adhoc.other.${USER}' created above.
-    INSERT INTO resource_groups (name, soft_memory_limit, hard_concurrency_limit, max_queued,  environment, parent) VALUES ('${USER}', '10%', 3, 10, 'test', 6);
+    INSERT INTO resource_groups (name, soft_memory_limit, hard_concurrency_limit, max_queued,  environment, parent) VALUES ('${USER}', '10%', 3, 10, 'test_environment', 6);
 
     -- create 'pipeline' group with 'global' as parent
-    INSERT INTO resource_groups (name, soft_memory_limit, hard_concurrency_limit, max_queued, scheduling_weight, jmx_export, environment, parent) VALUES ('pipeline', '80%', 45, 100, 1, true, 'test', 1);
+    INSERT INTO resource_groups (name, soft_memory_limit, hard_concurrency_limit, max_queued, scheduling_weight, jmx_export, environment, parent) VALUES ('pipeline', '80%', 45, 100, 1, true, 'test_environment', 1);
 
     -- get ID of 'pipeline' group
     SELECT resource_group_id FROM resource_groups WHERE name = 'pipeline'; -- 8
     -- create 'pipeline_${USER}' group with 'pipeline' as parent
-    INSERT INTO resource_groups (name, soft_memory_limit, hard_concurrency_limit, max_queued,  environment, parent) VALUES ('pipeline_${USER}', '50%', 5, 100, 'test', 8);
+    INSERT INTO resource_groups (name, soft_memory_limit, hard_concurrency_limit, max_queued,  environment, parent) VALUES ('pipeline_${USER}', '50%', 5, 100, 'test_environment', 8);
 
     -- create a root group 'admin' with NULL parent
-    INSERT INTO resource_groups (name, soft_memory_limit, hard_concurrency_limit, max_queued, scheduling_policy, environment, jmx_export) VALUES ('admin', '100%', 50, 100, 'query_priority', 'test', true);
+    INSERT INTO resource_groups (name, soft_memory_limit, hard_concurrency_limit, max_queued, scheduling_policy, environment, jmx_export) VALUES ('admin', '100%', 50, 100, 'query_priority', 'test_environment', true);
 
 
     -- Selectors

--- a/docs/src/main/sphinx/admin/resource-groups.rst
+++ b/docs/src/main/sphinx/admin/resource-groups.rst
@@ -283,6 +283,9 @@ Database resource group manager
 
 This example is for a MySQL database.
 
+As stated above, the environment ``'test'`` in the example should match ``node.environment`` property from
+:ref:`node_properties`.
+
 .. code-block:: sql
 
     -- global properties


### PR DESCRIPTION
Leaving a note since `environment` is not apparent initially, is crucial to make the example configuration work and figuring out why the example is not picked up can be frustrating.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
docs enhancement
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
no, docs
> How would you describe this change to a non-technical end user or system administrator?
improve readability
## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
() Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
