### PR TITLE
Re-enable comparison type match check in DomainTranslator

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
@@ -550,8 +550,7 @@ public final class DomainTranslator
             Type leftType = expressionTypes.get(NodeRef.of(comparison.getLeft()));
             Type rightType = expressionTypes.get(NodeRef.of(comparison.getRight()));
 
-            // TODO: re-enable this check once we fix the type coercions in the optimizers
-            // checkArgument(leftType.equals(rightType), "left and right type do not match in comparison expression (%s)", comparison);
+            checkArgument(leftType.equals(rightType), "left and right type do not match in comparison expression (%s)", comparison);
 
             if (left instanceof Expression == right instanceof Expression) {
                 // we expect one side to be expression and other to be value.

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushFilterThroughCountAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushFilterThroughCountAggregation.java
@@ -146,7 +146,7 @@ public class TestPushFilterThroughCountAggregation
                     Symbol mask = p.symbol("mask");
                     Symbol count = p.symbol("count");
                     return p.filter(
-                            PlanBuilder.expression("count < 0 AND count > 0"),
+                            PlanBuilder.expression("count < BIGINT '0' AND count > BIGINT '0'"),
                             p.aggregation(builder -> builder
                                     .singleGroupingSet(g)
                                     .addAggregation(count, PlanBuilder.expression("count()"), ImmutableList.of(), mask)
@@ -183,7 +183,7 @@ public class TestPushFilterThroughCountAggregation
                     Symbol mask = p.symbol("mask");
                     Symbol count = p.symbol("count");
                     return p.filter(
-                            PlanBuilder.expression("(count < 0 OR count >= 0) AND g = 5"),
+                            PlanBuilder.expression("(count < BIGINT '0' OR count >= BIGINT '0') AND g = BIGINT '5'"),
                             p.aggregation(builder -> builder
                                     .singleGroupingSet(g)
                                     .addAggregation(count, PlanBuilder.expression("count()"), ImmutableList.of(), mask)
@@ -201,7 +201,7 @@ public class TestPushFilterThroughCountAggregation
                     Symbol mask = p.symbol("mask");
                     Symbol count = p.symbol("count");
                     return p.filter(
-                            PlanBuilder.expression("count > 0"),
+                            PlanBuilder.expression("count > BIGINT '0'"),
                             p.aggregation(builder -> builder
                                     .singleGroupingSet(g)
                                     .addAggregation(count, PlanBuilder.expression("count()"), ImmutableList.of(), mask)
@@ -224,7 +224,7 @@ public class TestPushFilterThroughCountAggregation
                     Symbol mask = p.symbol("mask");
                     Symbol count = p.symbol("count");
                     return p.filter(
-                            PlanBuilder.expression("count > 0 AND g > 5"),
+                            PlanBuilder.expression("count > BIGINT '0' AND g > BIGINT '5'"),
                             p.aggregation(builder -> builder
                                     .singleGroupingSet(g)
                                     .addAggregation(count, PlanBuilder.expression("count()"), ImmutableList.of(), mask)
@@ -232,7 +232,7 @@ public class TestPushFilterThroughCountAggregation
                 })
                 .matches(
                         filter(
-                                "g > 5",
+                                "g > BIGINT '5'",
                                 aggregation(
                                         ImmutableMap.of("count", functionCall("count", ImmutableList.of())),
                                         filter(
@@ -245,7 +245,7 @@ public class TestPushFilterThroughCountAggregation
                     Symbol mask = p.symbol("mask");
                     Symbol count = p.symbol("count");
                     return p.filter(
-                            PlanBuilder.expression("count > 0 AND count % 2 = 0"),
+                            PlanBuilder.expression("count > BIGINT '0' AND count % 2 = BIGINT '0'"),
                             p.aggregation(builder -> builder
                                     .singleGroupingSet(g)
                                     .addAggregation(count, PlanBuilder.expression("count()"), ImmutableList.of(), mask)
@@ -253,7 +253,7 @@ public class TestPushFilterThroughCountAggregation
                 })
                 .matches(
                         filter(
-                                "count % 2 = 0",
+                                "count % 2 = BIGINT '0'",
                                 aggregation(
                                         ImmutableMap.of("count", functionCall("count", ImmutableList.of())),
                                         filter(
@@ -270,7 +270,7 @@ public class TestPushFilterThroughCountAggregation
                     Symbol mask = p.symbol("mask");
                     Symbol count = p.symbol("count");
                     return p.filter(
-                            PlanBuilder.expression("count > 5"),
+                            PlanBuilder.expression("count > BIGINT '5'"),
                             p.aggregation(builder -> builder
                                     .singleGroupingSet(g)
                                     .addAggregation(count, PlanBuilder.expression("count()"), ImmutableList.of(), mask)
@@ -278,7 +278,7 @@ public class TestPushFilterThroughCountAggregation
                 })
                 .matches(
                         filter(
-                                "count > 5",
+                                "count > BIGINT '5'",
                                 aggregation(
                                         ImmutableMap.of("count", functionCall("count", ImmutableList.of())),
                                         filter(
@@ -295,7 +295,7 @@ public class TestPushFilterThroughCountAggregation
                     Symbol mask = p.symbol("mask");
                     Symbol count = p.symbol("count");
                     return p.filter(
-                            PlanBuilder.expression("count > 0"),
+                            PlanBuilder.expression("count > BIGINT '0'"),
                             p.project(
                                     Assignments.identity(count),
                                     p.aggregation(builder -> builder
@@ -318,7 +318,7 @@ public class TestPushFilterThroughCountAggregation
                     Symbol mask = p.symbol("mask");
                     Symbol count = p.symbol("count");
                     return p.filter(
-                            PlanBuilder.expression("count > 0 AND g > 5"),
+                            PlanBuilder.expression("count > BIGINT '0' AND g > BIGINT '5'"),
                             p.project(
                                     Assignments.identity(count, g),
                                     p.aggregation(builder -> builder
@@ -328,7 +328,7 @@ public class TestPushFilterThroughCountAggregation
                 })
                 .matches(
                         filter(
-                                "g > 5",
+                                "g > BIGINT '5'",
                                 project(
                                         ImmutableMap.of("count", expression("count"), "g", expression("g")),
                                         aggregation(
@@ -343,7 +343,7 @@ public class TestPushFilterThroughCountAggregation
                     Symbol mask = p.symbol("mask");
                     Symbol count = p.symbol("count");
                     return p.filter(
-                            PlanBuilder.expression("count > 5"),
+                            PlanBuilder.expression("count > BIGINT '5'"),
                             p.project(
                                     Assignments.identity(count),
                                     p.aggregation(builder -> builder
@@ -353,7 +353,7 @@ public class TestPushFilterThroughCountAggregation
                 })
                 .matches(
                         filter(
-                                "count > 5",
+                                "count > BIGINT '5'",
                                 project(
                                         ImmutableMap.of("count", expression("count")),
                                         aggregation(

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushPredicateIntoTableScan.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushPredicateIntoTableScan.java
@@ -362,7 +362,7 @@ public class TestPushPredicateIntoTableScan
                 .build();
         assertThatThrownBy(() -> tester().assertThat(pushPredicateIntoTableScan)
                 .withSession(session)
-                .on(p -> p.filter(expression("col = 'G'"),
+                .on(p -> p.filter(expression("col = VARCHAR 'G'"),
                         p.tableScan(
                                 PARTITIONED_TABLE_HANDLE_TO_UNPARTITIONED,
                                 ImmutableList.of(p.symbol("col", VARCHAR)),
@@ -373,7 +373,7 @@ public class TestPushPredicateIntoTableScan
 
         tester().assertThat(pushPredicateIntoTableScan)
                 .withSession(session)
-                .on(p -> p.filter(expression("col = 'G'"),
+                .on(p -> p.filter(expression("col = VARCHAR 'G'"),
                         p.tableScan(
                                 PARTITIONED_TABLE_HANDLE,
                                 ImmutableList.of(p.symbol("col", VARCHAR)),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushPredicateThroughProjectIntoRowNumber.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushPredicateThroughProjectIntoRowNumber.java
@@ -62,7 +62,7 @@ public class TestPushPredicateThroughProjectIntoRowNumber
                     Symbol a = p.symbol("a");
                     Symbol rowNumber = p.symbol("row_number");
                     return p.filter(
-                            PlanBuilder.expression("a = 1"),
+                            PlanBuilder.expression("a = BIGINT '1'"),
                             p.project(
                                     Assignments.identity(a, rowNumber),
                                     p.rowNumber(
@@ -82,7 +82,7 @@ public class TestPushPredicateThroughProjectIntoRowNumber
                     Symbol a = p.symbol("a");
                     Symbol rowNumber = p.symbol("row_number");
                     return p.filter(
-                            PlanBuilder.expression("a = 1 AND row_number < -10"),
+                            PlanBuilder.expression("a = BIGINT '1' AND row_number < BIGINT '-10'"),
                             p.project(
                                     Assignments.identity(a, rowNumber),
                                     p.rowNumber(
@@ -102,7 +102,7 @@ public class TestPushPredicateThroughProjectIntoRowNumber
                     Symbol a = p.symbol("a");
                     Symbol rowNumber = p.symbol("row_number");
                     return p.filter(
-                            PlanBuilder.expression("row_number > 2 AND row_number < 5"),
+                            PlanBuilder.expression("row_number > BIGINT '2' AND row_number < BIGINT '5'"),
                             p.project(
                                     Assignments.identity(rowNumber),
                                     p.rowNumber(
@@ -112,7 +112,7 @@ public class TestPushPredicateThroughProjectIntoRowNumber
                                             p.values(a))));
                 })
                 .matches(filter(
-                        "row_number > 2 AND row_number < 5",
+                        "row_number > BIGINT '2' AND row_number < BIGINT '5'",
                         project(
                                 ImmutableMap.of("row_number", expression("row_number")),
                                 rowNumber(
@@ -130,7 +130,7 @@ public class TestPushPredicateThroughProjectIntoRowNumber
                     Symbol a = p.symbol("a");
                     Symbol rowNumber = p.symbol("row_number");
                     return p.filter(
-                            PlanBuilder.expression("row_number > 2 AND row_number < 5"),
+                            PlanBuilder.expression("row_number > BIGINT '2' AND row_number < BIGINT '5'"),
                             p.project(
                                     Assignments.identity(rowNumber),
                                     p.rowNumber(
@@ -150,7 +150,7 @@ public class TestPushPredicateThroughProjectIntoRowNumber
                     Symbol a = p.symbol("a");
                     Symbol rowNumber = p.symbol("row_number");
                     return p.filter(
-                            PlanBuilder.expression("row_number < 5"),
+                            PlanBuilder.expression("row_number < BIGINT '5'"),
                             p.project(
                                     Assignments.identity(rowNumber),
                                     p.rowNumber(
@@ -172,7 +172,7 @@ public class TestPushPredicateThroughProjectIntoRowNumber
                     Symbol a = p.symbol("a");
                     Symbol rowNumber = p.symbol("row_number");
                     return p.filter(
-                            PlanBuilder.expression("row_number < 3"),
+                            PlanBuilder.expression("row_number < BIGINT '3'"),
                             p.project(
                                     Assignments.identity(rowNumber),
                                     p.rowNumber(
@@ -198,7 +198,7 @@ public class TestPushPredicateThroughProjectIntoRowNumber
                     Symbol a = p.symbol("a");
                     Symbol rowNumber = p.symbol("row_number");
                     return p.filter(
-                            PlanBuilder.expression("row_number < 5 AND a > 0"),
+                            PlanBuilder.expression("row_number < BIGINT '5' AND a > BIGINT '0'"),
                             p.project(
                                     Assignments.identity(rowNumber, a),
                                     p.rowNumber(
@@ -208,7 +208,7 @@ public class TestPushPredicateThroughProjectIntoRowNumber
                                             p.values(a))));
                 })
                 .matches(filter(
-                        "a > 0",
+                        "a > BIGINT '0'",
                         project(
                                 ImmutableMap.of("row_number", expression("row_number"), "a", expression("a")),
                                 rowNumber(
@@ -222,7 +222,7 @@ public class TestPushPredicateThroughProjectIntoRowNumber
                     Symbol a = p.symbol("a");
                     Symbol rowNumber = p.symbol("row_number");
                     return p.filter(
-                            PlanBuilder.expression("row_number < 5 AND row_number % 2 = 0"),
+                            PlanBuilder.expression("row_number < BIGINT '5' AND row_number % 2 = BIGINT '0'"),
                             p.project(
                                     Assignments.identity(rowNumber),
                                     p.rowNumber(
@@ -232,7 +232,7 @@ public class TestPushPredicateThroughProjectIntoRowNumber
                                             p.values(a))));
                 })
                 .matches(filter(
-                        "row_number % 2 = 0",
+                        "row_number % 2 = BIGINT '0'",
                         project(
                                 ImmutableMap.of("row_number", expression("row_number")),
                                 rowNumber(

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushPredicateThroughProjectIntoWindow.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushPredicateThroughProjectIntoWindow.java
@@ -86,7 +86,7 @@ public class TestPushPredicateThroughProjectIntoWindow
                     Symbol a = p.symbol("a");
                     Symbol ranking = p.symbol("ranking");
                     return p.filter(
-                            PlanBuilder.expression("a = 1"),
+                            PlanBuilder.expression("a = BIGINT '1'"),
                             p.project(
                                     Assignments.identity(a, ranking),
                                     p.window(
@@ -113,7 +113,7 @@ public class TestPushPredicateThroughProjectIntoWindow
                     Symbol a = p.symbol("a");
                     Symbol ranking = p.symbol("ranking");
                     return p.filter(
-                            PlanBuilder.expression("a = 1 AND ranking < -10"),
+                            PlanBuilder.expression("a = BIGINT '1' AND ranking < BIGINT '-10'"),
                             p.project(
                                     Assignments.identity(a, ranking),
                                     p.window(
@@ -140,7 +140,7 @@ public class TestPushPredicateThroughProjectIntoWindow
                     Symbol a = p.symbol("a");
                     Symbol ranking = p.symbol("ranking");
                     return p.filter(
-                            PlanBuilder.expression("ranking > 2 AND ranking < 5"),
+                            PlanBuilder.expression("ranking > BIGINT '2' AND ranking < BIGINT '5'"),
                             p.project(
                                     Assignments.identity(ranking),
                                     p.window(
@@ -151,7 +151,7 @@ public class TestPushPredicateThroughProjectIntoWindow
                                             p.values(a))));
                 })
                 .matches(filter(
-                        "ranking > 2 AND ranking < 5",
+                        "ranking > BIGINT '2' AND ranking < BIGINT '5'",
                         project(
                                 ImmutableMap.of("ranking", expression("ranking")),
                                 topNRanking(
@@ -181,7 +181,7 @@ public class TestPushPredicateThroughProjectIntoWindow
                     Symbol a = p.symbol("a");
                     Symbol ranking = p.symbol("ranking");
                     return p.filter(
-                            PlanBuilder.expression("ranking < 5"),
+                            PlanBuilder.expression("ranking < BIGINT '5'"),
                             p.project(
                                     Assignments.identity(ranking),
                                     p.window(
@@ -220,7 +220,7 @@ public class TestPushPredicateThroughProjectIntoWindow
                     Symbol a = p.symbol("a");
                     Symbol ranking = p.symbol("ranking");
                     return p.filter(
-                            PlanBuilder.expression("ranking < 5 AND a > 0"),
+                            PlanBuilder.expression("ranking < BIGINT '5' AND a > BIGINT '0'"),
                             p.project(
                                     Assignments.identity(ranking, a),
                                     p.window(
@@ -231,7 +231,7 @@ public class TestPushPredicateThroughProjectIntoWindow
                                             p.values(a))));
                 })
                 .matches(filter(
-                        "a > 0",
+                        "a > BIGINT '0'",
                         project(
                                 ImmutableMap.of("ranking", expression("ranking"), "a", expression("a")),
                                 topNRanking(
@@ -251,7 +251,7 @@ public class TestPushPredicateThroughProjectIntoWindow
                     Symbol a = p.symbol("a");
                     Symbol ranking = p.symbol("ranking");
                     return p.filter(
-                            PlanBuilder.expression("ranking < 5 AND ranking % 2 = 0"),
+                            PlanBuilder.expression("ranking < BIGINT '5' AND ranking % 2 = BIGINT '0'"),
                             p.project(
                                     Assignments.identity(ranking),
                                     p.window(
@@ -262,7 +262,7 @@ public class TestPushPredicateThroughProjectIntoWindow
                                             p.values(a))));
                 })
                 .matches(filter(
-                        "ranking % 2 = 0",
+                        "ranking % 2 = BIGINT '0'",
                         project(
                                 ImmutableMap.of("ranking", expression("ranking")),
                                 topNRanking(

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushdownFilterIntoRowNumber.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushdownFilterIntoRowNumber.java
@@ -94,7 +94,7 @@ public class TestPushdownFilterIntoRowNumber
                     Symbol a = p.symbol("a");
                     Symbol rowNumberSymbol = p.symbol("row_number_1");
                     return p.filter(
-                            expression("row_number_1 < cast(5 as bigint) and a = 1"),
+                            expression("row_number_1 < cast(5 as bigint) and a = BIGINT '1'"),
                             p.rowNumber(
                                     ImmutableList.of(a),
                                     Optional.of(10),
@@ -103,7 +103,7 @@ public class TestPushdownFilterIntoRowNumber
                 })
                 .matches(
                         filter(
-                                "a = 1",
+                                "a = BIGINT '1'",
                                 rowNumber(rowNumber -> rowNumber
                                                 .maxRowCountPerPartition(Optional.of(4))
                                                 .partitionBy(ImmutableList.of("a")),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushdownFilterIntoWindow.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushdownFilterIntoWindow.java
@@ -106,13 +106,13 @@ public class TestPushdownFilterIntoWindow
                     OrderingScheme orderingScheme = new OrderingScheme(
                             ImmutableList.of(a),
                             ImmutableMap.of(a, SortOrder.ASC_NULLS_FIRST));
-                    return p.filter(expression("row_number_1 < cast(100 as bigint) and a = 1"), p.window(
+                    return p.filter(expression("row_number_1 < cast(100 as bigint) and a = BIGINT '1'"), p.window(
                             new WindowNode.Specification(ImmutableList.of(a), Optional.of(orderingScheme)),
                             ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(ranking, a)),
                             p.values(p.symbol("a"))));
                 })
                 .matches(filter(
-                        "a = 1",
+                        "a = BIGINT '1'",
                         topNRanking(pattern -> pattern
                                         .partial(false)
                                         .maxRankingPerPartition(99)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/sanity/TestValidateLimitWithPresortedInput.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/sanity/TestValidateLimitWithPresortedInput.java
@@ -149,7 +149,7 @@ public class TestValidateLimitWithPresortedInput
                         true,
                         ImmutableList.of(p.symbol("a", BIGINT)),
                         p.filter(
-                                expression("a = 1"),
+                                expression("a = BIGINT '1'"),
                                 p.values(
                                         ImmutableList.of(p.symbol("a", BIGINT)),
                                         ImmutableList.of(


### PR DESCRIPTION
It was temporarily disabled in March 2017 in commit
a103a639e396608d6e75f68d0b039597cd352f35.
