### PR TITLE
Align flush_metadata_cache procedure named args with other procedures

### DIFF
--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -1097,7 +1097,7 @@ The following procedures are available:
   Flush Hive metadata caches entries connected with selected table.
   Procedure requires named parameters to be passed
 
-* ``system.flush_metadata_cache(schema_name => ..., table_name => ..., partition_column => ARRAY[...], partition_value => ARRAY[...])``
+* ``system.flush_metadata_cache(schema_name => ..., table_name => ..., partition_columns => ARRAY[...], partition_values => ARRAY[...])``
 
   Flush Hive metadata cache entries connected with selected partition.
   Procedure requires named parameters to be passed

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/procedure/FlushHiveMetastoreCacheProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/procedure/FlushHiveMetastoreCacheProcedure.java
@@ -42,8 +42,13 @@ public class FlushHiveMetastoreCacheProcedure
 
     private static final String PARAM_SCHEMA_NAME = "SCHEMA_NAME";
     private static final String PARAM_TABLE_NAME = "TABLE_NAME";
+    // Other procedures use plural naming, but it's kept for backward compatibility
+    @Deprecated
     private static final String PARAM_PARTITION_COLUMN = "PARTITION_COLUMN";
+    @Deprecated
     private static final String PARAM_PARTITION_VALUE = "PARTITION_VALUE";
+    private static final String PARAM_PARTITION_COLUMNS = "PARTITION_COLUMNS";
+    private static final String PARAM_PARTITION_VALUES = "PARTITION_VALUES";
 
     private static final String PROCEDURE_USAGE_EXAMPLES = format(
             "Valid usages:%n" +
@@ -54,6 +59,13 @@ public class FlushHiveMetastoreCacheProcedure
             // Use lowercase parameter names per convention. In the usage example the names are not delimited.
             PARAM_SCHEMA_NAME.toLowerCase(ENGLISH),
             PARAM_TABLE_NAME.toLowerCase(ENGLISH),
+            PARAM_PARTITION_COLUMNS.toLowerCase(ENGLISH),
+            PARAM_PARTITION_VALUES.toLowerCase(ENGLISH));
+
+    private static final String INVALID_PARTITION_PARAMS_ERROR_MESSAGE = format(
+            "Procedure should only be invoked with single pair of partition definition named params: %1$s and %2$s or %3$s and %4$s",
+            PARAM_PARTITION_COLUMNS.toLowerCase(ENGLISH),
+            PARAM_PARTITION_VALUES.toLowerCase(ENGLISH),
             PARAM_PARTITION_COLUMN.toLowerCase(ENGLISH),
             PARAM_PARTITION_VALUE.toLowerCase(ENGLISH));
 
@@ -61,7 +73,8 @@ public class FlushHiveMetastoreCacheProcedure
 
     static {
         try {
-            FLUSH_HIVE_METASTORE_CACHE = lookup().unreflect(FlushHiveMetastoreCacheProcedure.class.getMethod("flushMetadataCache", String.class, String.class, List.class, List.class));
+            FLUSH_HIVE_METASTORE_CACHE = lookup().unreflect(FlushHiveMetastoreCacheProcedure.class.getMethod(
+                    "flushMetadataCache", String.class, String.class, List.class, List.class, List.class, List.class));
         }
         catch (ReflectiveOperationException e) {
             throw new AssertionError(e);
@@ -85,20 +98,37 @@ public class FlushHiveMetastoreCacheProcedure
                 ImmutableList.of(
                         new Procedure.Argument(PARAM_SCHEMA_NAME, VARCHAR, false, null),
                         new Procedure.Argument(PARAM_TABLE_NAME, VARCHAR, false, null),
+                        new Procedure.Argument(PARAM_PARTITION_COLUMNS, new ArrayType(VARCHAR), false, null),
+                        new Procedure.Argument(PARAM_PARTITION_VALUES, new ArrayType(VARCHAR), false, null),
                         new Procedure.Argument(PARAM_PARTITION_COLUMN, new ArrayType(VARCHAR), false, null),
                         new Procedure.Argument(PARAM_PARTITION_VALUE, new ArrayType(VARCHAR), false, null)),
                 FLUSH_HIVE_METASTORE_CACHE.bindTo(this),
                 true);
     }
 
-    public void flushMetadataCache(String schemaName, String tableName, List<String> partitionColumn, List<String> partitionValue)
+    public void flushMetadataCache(
+            String schemaName,
+            String tableName,
+            List<String> partitionColumns,
+            List<String> partitionValues,
+            List<String> partitionColumn,
+            List<String> partitionValue)
     {
+        Optional<List<String>> optionalPartitionColumns = Optional.ofNullable(partitionColumns);
+        Optional<List<String>> optionalPartitionValues = Optional.ofNullable(partitionValues);
+        Optional<List<String>> optionalPartitionColumn = Optional.ofNullable(partitionColumn);
+        Optional<List<String>> optionalPartitionValue = Optional.ofNullable(partitionValue);
+        checkState(partitionParamsUsed(optionalPartitionColumns, optionalPartitionValues, optionalPartitionColumn, optionalPartitionValue)
+                        || deprecatedPartitionParamsUsed(optionalPartitionColumns, optionalPartitionValues, optionalPartitionColumn, optionalPartitionValue)
+                        || partitionParamsNotUsed(optionalPartitionColumns, optionalPartitionValues, optionalPartitionColumn, optionalPartitionValue),
+                INVALID_PARTITION_PARAMS_ERROR_MESSAGE);
+
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
             doFlushMetadataCache(
                     Optional.ofNullable(schemaName),
                     Optional.ofNullable(tableName),
-                    Optional.ofNullable(partitionColumn).orElse(ImmutableList.of()),
-                    Optional.ofNullable(partitionValue).orElse(ImmutableList.of()));
+                    optionalPartitionColumns.or(() -> optionalPartitionColumn).orElse(ImmutableList.of()),
+                    optionalPartitionValues.or(() -> optionalPartitionValue).orElse(ImmutableList.of()));
         }
     }
 
@@ -127,5 +157,35 @@ public class FlushHiveMetastoreCacheProcedure
                     HiveErrorCode.HIVE_METASTORE_ERROR,
                     "Illegal parameter set passed. " + PROCEDURE_USAGE_EXAMPLES);
         }
+    }
+
+    private boolean partitionParamsNotUsed(
+            Optional<List<String>> partitionColumns,
+            Optional<List<String>> partitionValues,
+            Optional<List<String>> partitionColumn,
+            Optional<List<String>> partitionValue)
+    {
+        return partitionColumns.isEmpty() && partitionValues.isEmpty()
+                && partitionColumn.isEmpty() && partitionValue.isEmpty();
+    }
+
+    private boolean partitionParamsUsed(
+            Optional<List<String>> partitionColumns,
+            Optional<List<String>> partitionValues,
+            Optional<List<String>> partitionColumn,
+            Optional<List<String>> partitionValue)
+    {
+        return (partitionColumns.isPresent() || partitionValues.isPresent())
+                && partitionColumn.isEmpty() && partitionValue.isEmpty();
+    }
+
+    private boolean deprecatedPartitionParamsUsed(
+            Optional<List<String>> partitionColumns,
+            Optional<List<String>> partitionValues,
+            Optional<List<String>> partitionColumn,
+            Optional<List<String>> partitionValue)
+    {
+        return (partitionColumn.isPresent() || partitionValue.isPresent())
+                && partitionColumns.isEmpty() && partitionValues.isEmpty();
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveOnDataLake.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveOnDataLake.java
@@ -204,6 +204,37 @@ public abstract class BaseTestHiveOnDataLake
         String fullyQualifiedTestTableName = getFullyQualifiedTestTableName(tableName);
         String partitionColumn = "regionkey";
 
+        testFlushPartitionCache(
+                tableName,
+                fullyQualifiedTestTableName,
+                partitionColumn,
+                format(
+                        "CALL system.flush_metadata_cache(schema_name => '%s', table_name => '%s', partition_columns => ARRAY['%s'], partition_values => ARRAY['0'])",
+                        HIVE_TEST_SCHEMA,
+                        tableName,
+                        partitionColumn));
+    }
+
+    @Test
+    public void testFlushPartitionCacheWithDeprecatedPartitionParams()
+    {
+        String tableName = "nation_" + randomTableSuffix();
+        String fullyQualifiedTestTableName = getFullyQualifiedTestTableName(tableName);
+        String partitionColumn = "regionkey";
+
+        testFlushPartitionCache(
+                tableName,
+                fullyQualifiedTestTableName,
+                partitionColumn,
+                format(
+                        "CALL system.flush_metadata_cache(schema_name => '%s', table_name => '%s', partition_column => ARRAY['%s'], partition_value => ARRAY['0'])",
+                        HIVE_TEST_SCHEMA,
+                        tableName,
+                        partitionColumn));
+    }
+
+    private void testFlushPartitionCache(String tableName, String fullyQualifiedTestTableName, String partitionColumn, String flushCacheProcedureSql)
+    {
         // Create table with partition on regionkey
         computeActual(getCreateTableStatement(
                 fullyQualifiedTestTableName,
@@ -230,13 +261,8 @@ public abstract class BaseTestHiveOnDataLake
         assertQueryReturnsEmptyResult(queryUsingPartitionCacheForValue1);
         assertQueryReturnsEmptyResult(queryUsingPartitionCacheForValue2);
 
-        // Refresh cache for schema_name => 'dummy_schema', table_name => 'dummy_table', partition_column =>
-        getQueryRunner().execute(format(
-                "CALL system.flush_metadata_cache(schema_name => '%s', table_name => '%s', partition_column => ARRAY['%s'], partition_value => ARRAY['%s'])",
-                HIVE_TEST_SCHEMA,
-                tableName,
-                partitionColumn,
-                partitionValue1));
+        // Refresh cache
+        getQueryRunner().execute(flushCacheProcedureSql);
 
         // Should return expected rows as we refresh cache
         assertQuery(queryUsingPartitionCacheForValue1, expectedQueryResultForValue1);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastoreWithQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastoreWithQueryRunner.java
@@ -146,7 +146,7 @@ public class TestCachingHiveMetastoreWithQueryRunner
         String illegalParameterMessage = "Illegal parameter set passed. Valid usages:\n" +
                 " - 'flush_metadata_cache()'\n" +
                 " - flush_metadata_cache(schema_name => ..., table_name => ...)" +
-                " - flush_metadata_cache(schema_name => ..., table_name => ..., partition_column => ARRAY['...'], partition_value => ARRAY['...'])";
+                " - flush_metadata_cache(schema_name => ..., table_name => ..., partition_columns => ARRAY['...'], partition_values => ARRAY['...'])";
 
         assertThatThrownBy(() -> getQueryRunner().execute("CALL system.flush_metadata_cache('dummy_schema')"))
                 .hasMessageContaining("Only named arguments are allowed for this procedure");
@@ -156,6 +156,17 @@ public class TestCachingHiveMetastoreWithQueryRunner
 
         assertThatThrownBy(() -> getQueryRunner().execute("CALL system.flush_metadata_cache(schema_name => 'dummy_schema', table_name => 'dummy_table', partition_column => ARRAY['dummy_partition'])"))
                 .hasMessage("Parameters partition_column and partition_value should have same length");
+
+        assertThatThrownBy(
+                () -> getQueryRunner().execute("CALL system.flush_metadata_cache(" +
+                        "partition_columns => ARRAY['example'], " +
+                        "partition_values => ARRAY['0'], " +
+                        "partition_column => ARRAY['example'], " +
+                        "partition_value => ARRAY['0']" +
+                        ")"))
+                .hasMessage(
+                        "Procedure should only be invoked with single pair of partition definition named params: " +
+                                "partition_columns and partition_values or partition_column and partition_value");
     }
 
     @Test


### PR DESCRIPTION

## Description
Follow up to @colebow PR https://github.com/trinodb/trino/pull/13398 
syncing `flush_metadata_cache` named args with other procedures.

## Related issues, pull requests, and links
* PR https://github.com/trinodb/trino/pull/13398 

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Hive
* Align `flush_metadata_cache` named args to other procedures
```
