### PR TITLE
Improve comparison predicate pushdown when varchar column cast to date

### DIFF
--- a/core/trino-main/src/main/java/io/trino/testing/assertions/TestUtil.java
+++ b/core/trino-main/src/main/java/io/trino/testing/assertions/TestUtil.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing.assertions;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
+
+public final class TestUtil
+{
+    private TestUtil() {}
+
+    public static <T> void verifyResultOrFailure(Supplier<T> callback, Consumer<T> verifyResults, Consumer<Throwable> verifyFailure)
+    {
+        requireNonNull(callback, "callback is null");
+        requireNonNull(verifyResults, "verifyResults is null");
+        requireNonNull(verifyFailure, "verifyFailure is null");
+
+        T result;
+        try {
+            result = callback.get();
+        }
+        catch (Throwable t) {
+            verifyFailure.accept(t);
+            return;
+        }
+        verifyResults.accept(result);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/type/DateOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/DateOperators.java
@@ -55,6 +55,8 @@ public final class DateOperators
     @SqlType(StandardTypes.DATE)
     public static long castFromVarchar(@SqlType("varchar(x)") Slice value)
     {
+        // Note: update DomainTranslator.Visitor.createVarcharCastToDateComparisonExtractionResult whenever CAST behavior changes.
+
         try {
             return parseDate(trim(value).toStringUtf8());
         }

--- a/core/trino-main/src/main/java/io/trino/util/DateTimeUtils.java
+++ b/core/trino-main/src/main/java/io/trino/util/DateTimeUtils.java
@@ -61,6 +61,8 @@ public final class DateTimeUtils
 
     public static int parseDate(String value)
     {
+        // Note: update DomainTranslator.Visitor.createVarcharCastToDateComparisonExtractionResult whenever varchar->date conversion (CAST) behavior changes.
+
         // in order to follow the standard, we should validate the value:
         // - the required format is 'YYYY-MM-DD'
         // - all components should be unsigned numbers

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainTranslator.java
@@ -1002,6 +1002,90 @@ public class TestDomainTranslator
     }
 
     @Test
+    public void testPredicateWithVarcharCastToDate()
+    {
+        // =
+        assertPredicateDerives(
+                equal(cast(C_VARCHAR, DATE), new GenericLiteral("DATE", " +2005-9-10  \t")),
+                tupleDomain(C_VARCHAR, Domain.create(ValueSet.ofRanges(
+                                Range.lessThan(VARCHAR, utf8Slice("1")),
+                                Range.range(VARCHAR, utf8Slice("2005-09-10"), true, utf8Slice("2005-09-11"), false),
+                                Range.range(VARCHAR, utf8Slice("2005-9-10"), true, utf8Slice("2005-9-11"), false),
+                                Range.greaterThan(VARCHAR, utf8Slice("9"))),
+                        false)));
+        // = with day ending with 9
+        assertPredicateDerives(
+                equal(cast(C_VARCHAR, DATE), new GenericLiteral("DATE", "2005-09-09")),
+                tupleDomain(C_VARCHAR, Domain.create(ValueSet.ofRanges(
+                                Range.lessThan(VARCHAR, utf8Slice("1")),
+                                Range.range(VARCHAR, utf8Slice("2005-09-09"), true, utf8Slice("2005-09-0:"), false),
+                                Range.range(VARCHAR, utf8Slice("2005-09-9"), true, utf8Slice("2005-09-:"), false),
+                                Range.range(VARCHAR, utf8Slice("2005-9-09"), true, utf8Slice("2005-9-0:"), false),
+                                Range.range(VARCHAR, utf8Slice("2005-9-9"), true, utf8Slice("2005-9-:"), false),
+                                Range.greaterThan(VARCHAR, utf8Slice("9"))),
+                        false)));
+        assertPredicateDerives(
+                equal(cast(C_VARCHAR, DATE), new GenericLiteral("DATE", "2005-09-19")),
+                tupleDomain(C_VARCHAR, Domain.create(ValueSet.ofRanges(
+                                Range.lessThan(VARCHAR, utf8Slice("1")),
+                                Range.range(VARCHAR, utf8Slice("2005-09-19"), true, utf8Slice("2005-09-1:"), false),
+                                Range.range(VARCHAR, utf8Slice("2005-9-19"), true, utf8Slice("2005-9-1:"), false),
+                                Range.greaterThan(VARCHAR, utf8Slice("9"))),
+                        false)));
+
+        // !=
+        assertPredicateDerives(
+                notEqual(cast(C_VARCHAR, DATE), new GenericLiteral("DATE", " +2005-9-10  \t")),
+                tupleDomain(C_VARCHAR, Domain.create(ValueSet.ofRanges(
+                                Range.lessThan(VARCHAR, utf8Slice("2005-09-10")),
+                                Range.range(VARCHAR, utf8Slice("2005-09-11"), true, utf8Slice("2005-9-10"), false),
+                                Range.greaterThanOrEqual(VARCHAR, utf8Slice("2005-9-11"))),
+                        false)));
+
+        // != with single-digit day
+        assertUnsupportedPredicate(
+                notEqual(cast(C_VARCHAR, DATE), new GenericLiteral("DATE", " +2005-9-2  \t")));
+        // != with day ending with 9
+        assertUnsupportedPredicate(
+                notEqual(cast(C_VARCHAR, DATE), new GenericLiteral("DATE", "2005-09-09")));
+        assertPredicateDerives(
+                notEqual(cast(C_VARCHAR, DATE), new GenericLiteral("DATE", "2005-09-19")),
+                tupleDomain(C_VARCHAR, Domain.create(ValueSet.ofRanges(
+                                Range.lessThan(VARCHAR, utf8Slice("2005-09-19")),
+                                Range.range(VARCHAR, utf8Slice("2005-09-1:"), true, utf8Slice("2005-9-19"), false),
+                                Range.greaterThanOrEqual(VARCHAR, utf8Slice("2005-9-1:"))),
+                        false)));
+
+        // <
+        assertPredicateDerives(
+                lessThan(cast(C_VARCHAR, DATE), new GenericLiteral("DATE", " +2005-9-10  \t")),
+                tupleDomain(C_VARCHAR, Domain.create(ValueSet.ofRanges(
+                                Range.lessThan(VARCHAR, utf8Slice("2006")),
+                                Range.greaterThan(VARCHAR, utf8Slice("9"))),
+                        false)));
+
+        // >
+        assertPredicateDerives(
+                greaterThan(cast(C_VARCHAR, DATE), new GenericLiteral("DATE", " +2005-9-10  \t")),
+                tupleDomain(C_VARCHAR, Domain.create(ValueSet.ofRanges(
+                                Range.lessThan(VARCHAR, utf8Slice("1")),
+                                Range.greaterThan(VARCHAR, utf8Slice("2004"))),
+                        false)));
+
+        // BETWEEN
+        assertPredicateTranslates(
+                between(cast(C_VARCHAR, DATE), new GenericLiteral("DATE", "2001-01-31"), new GenericLiteral("DATE", "2005-09-10")),
+                tupleDomain(C_VARCHAR, Domain.create(ValueSet.ofRanges(
+                                Range.lessThan(VARCHAR, utf8Slice("1")),
+                                Range.range(VARCHAR, utf8Slice("2000"), false, utf8Slice("2006"), false),
+                                Range.greaterThan(VARCHAR, utf8Slice("9"))),
+                        false)),
+                and(
+                        greaterThanOrEqual(cast(C_VARCHAR, DATE), new GenericLiteral("DATE", "2001-01-31")),
+                        lessThanOrEqual(cast(C_VARCHAR, DATE), new GenericLiteral("DATE", "2005-09-10"))));
+    }
+
+    @Test
     public void testFromUnprocessableInPredicate()
     {
         assertUnsupportedPredicate(new InPredicate(unprocessableExpression1(C_BIGINT), new InListExpression(ImmutableList.of(TRUE_LITERAL))));
@@ -1909,6 +1993,11 @@ public class TestDomainTranslator
     private void assertPredicateTranslates(Expression expression, TupleDomain<Symbol> tupleDomain)
     {
         assertPredicateTranslates(expression, tupleDomain, TRUE_LITERAL);
+    }
+
+    private void assertPredicateDerives(Expression expression, TupleDomain<Symbol> tupleDomain)
+    {
+        assertPredicateTranslates(expression, tupleDomain, expression);
     }
 
     private void assertPredicateTranslates(Expression expression, TupleDomain<Symbol> tupleDomain, Expression remainingExpression)

--- a/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
@@ -444,7 +444,7 @@ public class QueryAssertions
 
             if (!skipResultsCorrectnessCheckForPushdown) {
                 // Compare the results with pushdown disabled, so that explicit matches() call is not needed
-                verifyResultsWithPushdownDisabled();
+                hasCorrectResultsRegardlessOfPushdown();
             }
             return this;
         }
@@ -511,17 +511,19 @@ public class QueryAssertions
 
             if (!skipResultsCorrectnessCheckForPushdown) {
                 // Compare the results with pushdown disabled, so that explicit matches() call is not needed
-                verifyResultsWithPushdownDisabled();
+                hasCorrectResultsRegardlessOfPushdown();
             }
             return this;
         }
 
-        private void verifyResultsWithPushdownDisabled()
+        @CanIgnoreReturnValue
+        public QueryAssert hasCorrectResultsRegardlessOfPushdown()
         {
             Session withoutPushdown = Session.builder(session)
                     .setSystemProperty("allow_pushdown_into_connectors", "false")
                     .build();
             matches(runner.execute(withoutPushdown, query));
+            return this;
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/type/TestDateTimeOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestDateTimeOperators.java
@@ -303,6 +303,8 @@ public class TestDateTimeOperators
     @Test
     public void testDateCastFromVarchar()
     {
+        // Note: update DomainTranslator.Visitor.createVarcharCastToDateComparisonExtractionResult whenever CAST behavior changes.
+
         assertFunction("CAST('2013-02-02' AS date)", DATE, toDate(new DateTime(2013, 2, 2, 0, 0, 0, 0, UTC)));
         // one digit for month or day
         assertFunction("CAST('2013-2-02' AS date)", DATE, toDate(new DateTime(2013, 2, 2, 0, 0, 0, 0, UTC)));

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduConnectorTest.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduConnectorTest.java
@@ -620,6 +620,15 @@ public class TestKuduConnectorTest
                 .hasStackTraceContaining("Cannot apply operator: varchar = date");
     }
 
+    @Override
+    public void testVarcharCastToDateInPredicate()
+    {
+        assertThatThrownBy(super::testVarcharCastToDateInPredicate)
+                .hasStackTraceContaining("Table partitioning must be specified using setRangePartitionColumns or addHashPartitions");
+
+        throw new SkipException("TODO: implement the test for Kudu");
+    }
+
     @Test
     @Override
     public void testCharVarcharComparison()


### PR DESCRIPTION
Such a cast cannot reasonably be pruned away because the source varchar
value can be any of multiple forms (surrounding whitespace, optional
year sign, optional leading zeros for date components). However, a
usefully narrow `Domain` can be extracted and passed over to connectors
to help connectors prune the data.

Fixes https://github.com/trinodb/trino/issues/12925