### PR TITLE
Optimize decimal state serializers for small value case

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowAndLongStateSerializer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowAndLongStateSerializer.java
@@ -18,7 +18,6 @@ import io.airlift.slice.Slices;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.function.AccumulatorStateSerializer;
-import io.trino.spi.type.Int128;
 import io.trino.spi.type.Type;
 
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
@@ -26,8 +25,6 @@ import static io.trino.spi.type.VarbinaryType.VARBINARY;
 public class LongDecimalWithOverflowAndLongStateSerializer
         implements AccumulatorStateSerializer<LongDecimalWithOverflowAndLongState>
 {
-    private static final int SERIALIZED_SIZE = (Long.BYTES * 2) + Int128.SIZE;
-
     @Override
     public Type getSerializedType()
     {
@@ -42,7 +39,27 @@ public class LongDecimalWithOverflowAndLongStateSerializer
             long overflow = state.getOverflow();
             long[] decimal = state.getDecimalArray();
             int offset = state.getDecimalArrayOffset();
-            VARBINARY.writeSlice(out, Slices.wrappedLongArray(count, overflow, decimal[offset], decimal[offset + 1]));
+            long[] buffer = new long[4];
+            long high = decimal[offset];
+            long low = decimal[offset + 1];
+
+            buffer[0] = low;
+            buffer[1] = high;
+            // if high = 0, the count will overwrite it
+            int countOffset = 1 + (high == 0 ? 0 : 1);
+            // append count, overflow
+            buffer[countOffset] = count;
+            buffer[countOffset + 1] = overflow;
+
+            // cases
+            // high == 0 (countOffset = 1)
+            //    overflow == 0 & count == 1  -> bufferLength = 1
+            //    overflow != 0 || count != 1 -> bufferLength = 3
+            // high != 0 (countOffset = 2)
+            //    overflow == 0 & count == 1  -> bufferLength = 2
+            //    overflow != 0 || count != 1 -> bufferLength = 4
+            int bufferLength = countOffset + ((overflow == 0 & count == 1) ? 0 : 2);
+            VARBINARY.writeSlice(out, Slices.wrappedLongArray(buffer, 0, bufferLength));
         }
         else {
             out.appendNull();
@@ -54,20 +71,33 @@ public class LongDecimalWithOverflowAndLongStateSerializer
     {
         if (!block.isNull(index)) {
             Slice slice = VARBINARY.getSlice(block, index);
-            if (slice.length() != SERIALIZED_SIZE) {
-                throw new IllegalStateException("Unexpected serialized state size: " + slice.length());
-            }
-
-            long count = slice.getLong(0);
-            long overflow = slice.getLong(Long.BYTES);
-
-            state.setLong(count);
-            state.setOverflow(overflow);
-            state.setNotNull();
             long[] decimal = state.getDecimalArray();
             int offset = state.getDecimalArrayOffset();
-            decimal[offset] = slice.getLong(Long.BYTES * 2);
-            decimal[offset + 1] = slice.getLong(Long.BYTES * 3);
+
+            int sliceLength = slice.length();
+            long low = slice.getLong(0);
+            long high = 0;
+            long overflow = 0;
+            long count = 1;
+
+            switch (sliceLength) {
+                case 4 * Long.BYTES:
+                    overflow = slice.getLong(Long.BYTES * 3);
+                    count = slice.getLong(Long.BYTES * 2);
+                    // fall through
+                case 2 * Long.BYTES:
+                    high = slice.getLong(Long.BYTES);
+                    break;
+                case 3 * Long.BYTES:
+                    overflow = slice.getLong(Long.BYTES * 2);
+                    count = slice.getLong(Long.BYTES);
+            }
+
+            decimal[offset + 1] = low;
+            decimal[offset] = high;
+            state.setOverflow(overflow);
+            state.setLong(count);
+            state.setNotNull();
         }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/state/TestLongDecimalWithOverflowAndLongStateSerializer.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/state/TestLongDecimalWithOverflowAndLongStateSerializer.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation.state;
+
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.VariableWidthBlockBuilder;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestLongDecimalWithOverflowAndLongStateSerializer
+{
+    private static final LongDecimalWithOverflowAndLongStateFactory STATE_FACTORY = new LongDecimalWithOverflowAndLongStateFactory();
+
+    @Test(dataProvider = "input")
+    public void testSerde(long low, long high, long overflow, long count, int expectedLength)
+    {
+        LongDecimalWithOverflowAndLongState state = STATE_FACTORY.createSingleState();
+        state.getDecimalArray()[0] = high;
+        state.getDecimalArray()[1] = low;
+        state.setOverflow(overflow);
+        state.setLong(count);
+        state.setNotNull();
+
+        LongDecimalWithOverflowAndLongState outState = roundTrip(state, expectedLength);
+
+        assertTrue(outState.isNotNull());
+        assertEquals(outState.getDecimalArray()[0], high);
+        assertEquals(outState.getDecimalArray()[1], low);
+        assertEquals(outState.getOverflow(), overflow);
+        assertEquals(outState.getLong(), count);
+    }
+
+    @Test
+    public void testNullSerde()
+    {
+        // state is created null
+        LongDecimalWithOverflowAndLongState state = STATE_FACTORY.createSingleState();
+
+        LongDecimalWithOverflowAndLongState outState = roundTrip(state, 0);
+
+        assertFalse(outState.isNotNull());
+    }
+
+    private LongDecimalWithOverflowAndLongState roundTrip(LongDecimalWithOverflowAndLongState state, int expectedLength)
+    {
+        LongDecimalWithOverflowAndLongStateSerializer serializer = new LongDecimalWithOverflowAndLongStateSerializer();
+        BlockBuilder out = new VariableWidthBlockBuilder(null, 1, 0);
+
+        serializer.serialize(state, out);
+
+        Block serialized = out.build();
+        assertEquals(serialized.getSliceLength(0), expectedLength * Long.BYTES);
+        LongDecimalWithOverflowAndLongState outState = STATE_FACTORY.createSingleState();
+        serializer.deserialize(serialized, 0, outState);
+        return outState;
+    }
+
+    @DataProvider
+    public Object[][] input()
+    {
+        return new Object[][] {
+                {3, 0, 0, 1, 1},
+                {3, 5, 0, 1, 2},
+                {3, 5, 7, 1, 4},
+                {3, 0, 0, 2, 3},
+                {3, 5, 0, 2, 4},
+                {3, 5, 7, 2, 4},
+                {3, 0, 7, 1, 3},
+                {3, 0, 7, 2, 3},
+                {0, 0, 0, 1, 1},
+                {0, 5, 0, 1, 2},
+                {0, 5, 7, 1, 4},
+                {0, 0, 0, 2, 3},
+                {0, 5, 0, 2, 4},
+                {0, 5, 7, 2, 4},
+                {0, 0, 7, 1, 3},
+                {0, 0, 7, 2, 3}
+        };
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/state/TestLongDecimalWithOverflowStateSerializer.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/state/TestLongDecimalWithOverflowStateSerializer.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation.state;
+
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.VariableWidthBlockBuilder;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestLongDecimalWithOverflowStateSerializer
+{
+    private static final LongDecimalWithOverflowStateFactory STATE_FACTORY = new LongDecimalWithOverflowStateFactory();
+
+    @Test(dataProvider = "input")
+    public void testSerde(long low, long high, long overflow, int expectedLength)
+    {
+        LongDecimalWithOverflowState state = STATE_FACTORY.createSingleState();
+        state.getDecimalArray()[0] = high;
+        state.getDecimalArray()[1] = low;
+        state.setOverflow(overflow);
+        state.setNotNull();
+
+        LongDecimalWithOverflowState outState = roundTrip(state, expectedLength);
+
+        assertTrue(outState.isNotNull());
+        assertEquals(outState.getDecimalArray()[0], high);
+        assertEquals(outState.getDecimalArray()[1], low);
+        assertEquals(outState.getOverflow(), overflow);
+    }
+
+    @Test
+    public void testNullSerde()
+    {
+        // state is created null
+        LongDecimalWithOverflowState state = STATE_FACTORY.createSingleState();
+
+        LongDecimalWithOverflowState outState = roundTrip(state, 0);
+
+        assertFalse(outState.isNotNull());
+    }
+
+    private LongDecimalWithOverflowState roundTrip(LongDecimalWithOverflowState state, int expectedLength)
+    {
+        LongDecimalWithOverflowStateSerializer serializer = new LongDecimalWithOverflowStateSerializer();
+        BlockBuilder out = new VariableWidthBlockBuilder(null, 1, 0);
+
+        serializer.serialize(state, out);
+
+        Block serialized = out.build();
+        assertEquals(serialized.getSliceLength(0), expectedLength * Long.BYTES);
+        LongDecimalWithOverflowState outState = STATE_FACTORY.createSingleState();
+        serializer.deserialize(serialized, 0, outState);
+        return outState;
+    }
+
+    @DataProvider
+    public Object[][] input()
+    {
+        return new Object[][] {
+                {3, 0, 0, 1},
+                {3, 5, 0, 2},
+                {3, 5, 7, 3},
+                {3, 0, 7, 3},
+                {0, 0, 0, 1},
+                {0, 5, 0, 2},
+                {0, 5, 7, 3},
+                {0, 0, 7, 3}
+        };
+    }
+}

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestAggregations.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestAggregations.java
@@ -1400,4 +1400,16 @@ public abstract class AbstractTestAggregations
         assertEquals(actual1.getMaterializedRows().get(2).getFields().get(0), "c");
         assertEquals(actual1.getMaterializedRows().get(2).getFields().get(1), ImmutableMap.of("C", 2L));
     }
+
+    @Test
+    public void testLongDecimalAggregations()
+    {
+        assertQuery("""
+                SELECT avg(value_big), sum(value_big), avg(value_small), sum(value_small)
+                FROM (
+                    SELECT orderkey as id, CAST(power(2, 65) as DECIMAL(38, 0)) as value_big, CAST(1 as DECIMAL(38, 0)) as value_small
+                    FROM orders
+                    LIMIT 10)
+                GROUP BY id""");
+    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->
Given that many decimal aggregations (sum, avg) stay in the `long` range, aggregation state serializer can be optimized for this case, limiting the number of bytes per position significantly (3-4X).

#### tpch/tpcds benchmarks
![image](https://user-images.githubusercontent.com/8080198/183679547-d0d2f9af-7035-4cfd-adc8-adf94423075d.png)

[Benchmarks_decimal_aggr_serde_simple_case.pdf](https://github.com/trinodb/trino/files/9291809/Benchmarks_decimal_aggr_serde_simple_case.pdf)


<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

improvement
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core query engine (`sum`, `avg` aggregation state serialization)
> How would you describe this change to a non-technical end user or system administrator?

improve performance of queries with `sum` or `avg` aggregations
## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( X) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(X ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
