### PR TITLE
Fix applyFilter when an Iceberg table does not have any snapshots

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
@@ -117,6 +117,7 @@ public class TestIcebergSparkCompatibility
         // Validate queries on an empty table created by Spark
         assertThat(onTrino().executeQuery(format("SELECT * FROM %s", trinoTableName("\"" + baseTableName + "$snapshots\"")))).hasNoRows();
         assertThat(onTrino().executeQuery(format("SELECT * FROM %s", trinoTableName))).hasNoRows();
+        assertThat(onTrino().executeQuery(format("SELECT * FROM %s WHERE _integer > 0", trinoTableName))).hasNoRows();
 
         onSpark().executeQuery(format(
                 "INSERT INTO %s VALUES (" +


### PR DESCRIPTION
## Description

Tables created by Spark may not have a snapshot committed if they are newly created, empty tables.

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Iceberg connector

> How would you describe this change to a non-technical end user or system administrator?

Fix handling of querying newly created, empty tables.

## Related issues, pull requests, and links

Introduced by: https://github.com/trinodb/trino/pull/13239

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Iceberg
* Fix querying Iceberg tables which are empty and contain no table history.
```
