### PR TITLE
Handle empty Iceberg tables while executing procedures

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergOptimizeHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergOptimizeHandle.java
@@ -23,6 +23,7 @@ import io.trino.plugin.iceberg.IcebergFileFormat;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
@@ -30,7 +31,7 @@ import static java.util.Objects.requireNonNull;
 public class IcebergOptimizeHandle
         extends IcebergProcedureHandle
 {
-    private final long snapshotId;
+    private final Optional<Long> snapshotId;
     private final String schemaAsJson;
     private final String partitionSpecAsJson;
     private final List<IcebergColumnHandle> tableColumns;
@@ -41,7 +42,7 @@ public class IcebergOptimizeHandle
 
     @JsonCreator
     public IcebergOptimizeHandle(
-            long snapshotId,
+            Optional<Long> snapshotId,
             String schemaAsJson,
             String partitionSpecAsJson,
             List<IcebergColumnHandle> tableColumns,
@@ -61,7 +62,7 @@ public class IcebergOptimizeHandle
     }
 
     @JsonProperty
-    public long getSnapshotId()
+    public Optional<Long> getSnapshotId()
     {
         return snapshotId;
     }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
@@ -1666,6 +1666,28 @@ public class TestIcebergSparkCompatibility
                 .containsOnly(row(1, 2), row(2, 2), row(3, 2), row(11, 12), row(12, 12), row(13, 12));
     }
 
+    @Test(groups = {ICEBERG, PROFILE_SPECIFIC_TESTS})
+    public void testAlterTableExecuteProceduresOnEmptyTable()
+    {
+        String baseTableName = "test_alter_table_execute_procedures_on_empty_table_" + randomTableSuffix();
+        String trinoTableName = trinoTableName(baseTableName);
+        String sparkTableName = sparkTableName(baseTableName);
+
+        onSpark().executeQuery(format(
+                "CREATE TABLE %s (" +
+                        "  _string STRING" +
+                        ", _bigint BIGINT" +
+                        ", _integer INTEGER" +
+                        ") USING ICEBERG",
+                sparkTableName));
+
+        onTrino().executeQuery("ALTER TABLE " + trinoTableName + " EXECUTE optimize");
+        onTrino().executeQuery("ALTER TABLE " + trinoTableName + " EXECUTE expire_snapshots(retention_threshold => '7d')");
+        onTrino().executeQuery("ALTER TABLE " + trinoTableName + " EXECUTE remove_orphan_files(retention_threshold => '7d')");
+
+        assertThat(onTrino().executeQuery("SELECT * FROM " + trinoTableName)).hasNoRows();
+    }
+
     private static String escapeSparkString(String value)
     {
         return value.replace("\\", "\\\\").replace("'", "\\'");


### PR DESCRIPTION
## Description

If a table was just created it may not contain any snapshots. Procedures run on tables that do not contain any snapshots can safely do nothing.

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Iceberg connector

> How would you describe this change to a non-technical end user or system administrator?

Prevent query failure in the edge case where a table is empty and has no history.

## Related issues, pull requests, and links

Related to: https://github.com/trinodb/trino/pull/13576

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Iceberg
* Fix execution of `optimize`, `expire_snapshots`, and `remove_orphan_files` procedures against tables which have empty snapshot histories.
```
