### PR TITLE
Minor code cleanup

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/type/SmallintType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/SmallintType.java
@@ -138,7 +138,7 @@ public final class SmallintType
     @Override
     public long getLong(Block block, int position)
     {
-        return (long) block.getShort(position, 0);
+        return block.getShort(position, 0);
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TinyintType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TinyintType.java
@@ -138,7 +138,7 @@ public final class TinyintType
     @Override
     public long getLong(Block block, int position)
     {
-        return (long) block.getByte(position, 0);
+        return block.getByte(position, 0);
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPageSink.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPageSink.java
@@ -61,10 +61,10 @@ public class JdbcPageSink
         }
 
         try {
-            // According to JDBC javaodcs "If a connection is in auto-commit mode, then all its SQL statements will be
+            // According to JDBC javadocs "If a connection is in auto-commit mode, then all its SQL statements will be
             // executed and committed as individual transactions." Notably MySQL and SQL Server respect this which
             // leads to multiple commits when we close the connection leading to slow performance. Explicit commits
-            // where needed ensure that all of the submitted statements are committed as a single transaction and
+            // where needed to ensure that all the submitted statements are committed as a single transaction and
             // performs better.
             connection.setAutoCommit(false);
         }
@@ -183,7 +183,7 @@ public class JdbcPageSink
             throw new TrinoException(JDBC_NON_TRANSIENT_ERROR, e);
         }
         catch (SQLException e) {
-            // Convert chained SQLExceptions to suppressed exceptions so they are visible in the stack trace
+            // Convert chained SQLExceptions to suppressed exceptions, so they are visible in the stack trace
             SQLException nextException = e.getNextException();
             while (nextException != null) {
                 if (e != nextException) {


### PR DESCRIPTION
- Remove redundant cast from SmallintType and TinyintType
- Fix grammar and typo in JdbcPageSink

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
