### PR TITLE
Support for reading TIMESTAMP WITH LOCAL TIME ZONE in Hive connector

### DIFF
--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -1673,9 +1673,9 @@ Hive 3-related limitations
 
 * For security reasons, the ``sys`` system catalog is not accessible.
 
-* Hive's ``timestamp with local zone`` data type is not supported.
-  It is possible to read from a table with a column of this type, but the column
-  data is not accessible. Writing to such a table is not supported.
+* Hive's ``timestamp with local zone`` data type is mapped to
+  ``timestamp with time zone`` with UTC timezone. It only supports reading
+  values - writing to tables with columns of this type is not supported.
 
 * Due to Hive issues `HIVE-21002 <https://issues.apache.org/jira/browse/HIVE-21002>`_
   and `HIVE-22167 <https://issues.apache.org/jira/browse/HIVE-22167>`_, Trino does

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveType.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveType.java
@@ -55,6 +55,7 @@ import static io.trino.plugin.hive.util.SerdeConstants.FLOAT_TYPE_NAME;
 import static io.trino.plugin.hive.util.SerdeConstants.INT_TYPE_NAME;
 import static io.trino.plugin.hive.util.SerdeConstants.SMALLINT_TYPE_NAME;
 import static io.trino.plugin.hive.util.SerdeConstants.STRING_TYPE_NAME;
+import static io.trino.plugin.hive.util.SerdeConstants.TIMESTAMPLOCALTZ_TYPE_NAME;
 import static io.trino.plugin.hive.util.SerdeConstants.TIMESTAMP_TYPE_NAME;
 import static io.trino.plugin.hive.util.SerdeConstants.TINYINT_TYPE_NAME;
 import static java.util.Objects.requireNonNull;
@@ -72,6 +73,7 @@ public final class HiveType
     public static final HiveType HIVE_DOUBLE = new HiveType(getPrimitiveTypeInfo(DOUBLE_TYPE_NAME));
     public static final HiveType HIVE_STRING = new HiveType(getPrimitiveTypeInfo(STRING_TYPE_NAME));
     public static final HiveType HIVE_TIMESTAMP = new HiveType(getPrimitiveTypeInfo(TIMESTAMP_TYPE_NAME));
+    public static final HiveType HIVE_TIMESTAMPLOCALTZ = new HiveType(getPrimitiveTypeInfo(TIMESTAMPLOCALTZ_TYPE_NAME));
     public static final HiveType HIVE_DATE = new HiveType(getPrimitiveTypeInfo(DATE_TYPE_NAME));
     public static final HiveType HIVE_BINARY = new HiveType(getPrimitiveTypeInfo(BINARY_TYPE_NAME));
 
@@ -197,10 +199,10 @@ public final class HiveType
                     CHAR,
                     DATE,
                     TIMESTAMP,
+                    TIMESTAMPLOCALTZ,
                     BINARY,
                     DECIMAL -> true;
-            case TIMESTAMPLOCALTZ,
-                    INTERVAL_YEAR_MONTH,
+            case INTERVAL_YEAR_MONTH,
                     INTERVAL_DAY_TIME,
                     VOID,
                     UNKNOWN -> false;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -64,6 +64,7 @@ import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.MapType;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 
@@ -943,7 +944,7 @@ public final class ThriftMetastoreUtil
         if (isNumericType(type) || type.equals(DATE)) {
             return ImmutableSet.of(MIN_VALUE, MAX_VALUE, NUMBER_OF_DISTINCT_VALUES, NUMBER_OF_NON_NULL_VALUES);
         }
-        if (type instanceof TimestampType) {
+        if (type instanceof TimestampType || type instanceof TimestampWithTimeZoneType) {
             // TODO (https://github.com/trinodb/trino/issues/5859) Add support for timestamp MIN_VALUE, MAX_VALUE
             return ImmutableSet.of(NUMBER_OF_DISTINCT_VALUES, NUMBER_OF_NON_NULL_VALUES);
         }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveTypeTranslator.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveTypeTranslator.java
@@ -75,6 +75,7 @@ import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimestampType.createTimestampType;
+import static io.trino.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.TypeSignature.arrayType;
 import static io.trino.spi.type.TypeSignature.mapType;
@@ -261,6 +262,8 @@ public final class HiveTypeTranslator
                 return DATE;
             case TIMESTAMP:
                 return createTimestampType(timestampPrecision.getPrecision());
+            case TIMESTAMPLOCALTZ:
+                return createTimestampWithTimeZoneType(timestampPrecision.getPrecision());
             case BINARY:
                 return VARBINARY;
             case DECIMAL:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Resolves #1240 by mapping Hive TIMESTAMP WITH LOCAL TIME ZONE to TIMESTAMP WITH TIME ZONE with UTC zone. 

Mapping to UTC is a bit of a judgement call (see #1240), but I believe is better than the alternatives (like using session zones) and the direction Trino maintainers want to take (see e.g. #8680). 

In addition to the new automated test, I have tested reading the timestamps from Parquet files. Notably, Hive Avro serde doesn't support TIMESTAMP WITH TIME ZONE.
 
<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

A new feature.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Hive connector

> How would you describe this change to a non-technical end user or system administrator?

Adds support for TIMESTAMP WITH TIME ZONE Trino type to Hive connector. This type is translated to TIMESTAMP WITH LOCAL TIME ZONE - a Hive type that represents an instant of time. There is no explicit time zone associated with Hive TIMESTAMP WITH LOCAL TIME ZONE, so Trino always chooses to represent them in UTC timezone. 

## Related issues, pull requests, and links

* Resolves #1240

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(updated the existing mention of this type in docs, not sure if there are other places I should update)

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Hive connector: support for reading TIMESTAMP WITH LOCAL TIME ZONE values ({issue}`1240`)
```
