### PR TITLE
Add a test for varchar cast to date predicate

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
@@ -444,7 +444,7 @@ public class QueryAssertions
 
             if (!skipResultsCorrectnessCheckForPushdown) {
                 // Compare the results with pushdown disabled, so that explicit matches() call is not needed
-                verifyResultsWithPushdownDisabled();
+                hasCorrectResultsRegardlessOfPushdown();
             }
             return this;
         }
@@ -511,17 +511,19 @@ public class QueryAssertions
 
             if (!skipResultsCorrectnessCheckForPushdown) {
                 // Compare the results with pushdown disabled, so that explicit matches() call is not needed
-                verifyResultsWithPushdownDisabled();
+                hasCorrectResultsRegardlessOfPushdown();
             }
             return this;
         }
 
-        private void verifyResultsWithPushdownDisabled()
+        @CanIgnoreReturnValue
+        public QueryAssert hasCorrectResultsRegardlessOfPushdown()
         {
             Session withoutPushdown = Session.builder(session)
                     .setSystemProperty("allow_pushdown_into_connectors", "false")
                     .build();
             matches(runner.execute(withoutPushdown, query));
+            return this;
         }
     }
 

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduConnectorTest.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduConnectorTest.java
@@ -620,6 +620,15 @@ public class TestKuduConnectorTest
                 .hasStackTraceContaining("Cannot apply operator: varchar = date");
     }
 
+    @Override
+    public void testVarcharCastToDateInPredicate()
+    {
+        assertThatThrownBy(super::testVarcharCastToDateInPredicate)
+                .hasStackTraceContaining("Table partitioning must be specified using setRangePartitionColumns or addHashPartitions");
+
+        throw new SkipException("TODO: implement the test for Kudu");
+    }
+
     @Test
     @Override
     public void testCharVarcharComparison()


### PR DESCRIPTION
The case where varchar is cast to date and used in a predicate is not
uncommon and it would be worth optimizing for (https://github.com/trinodb/trino/issues/12925).
This involves, however, some edge cases which are easy to forget
about when working on such an optimization (either within the engine,
or on the connector level).

Extracted from https://github.com/trinodb/trino/pull/13567