### PR TITLE
Share Thrift Metastore data statistic support across identities

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/MetastoreSupportsDateStatistics.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/MetastoreSupportsDateStatistics.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.metastore.thrift;
+
+import io.airlift.units.Duration;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.trino.plugin.hive.metastore.thrift.MetastoreSupportsDateStatistics.DateStatisticsSupport.NOT_SUPPORTED;
+import static io.trino.plugin.hive.metastore.thrift.MetastoreSupportsDateStatistics.DateStatisticsSupport.SUPPORTED;
+import static io.trino.plugin.hive.metastore.thrift.MetastoreSupportsDateStatistics.DateStatisticsSupport.UNKNOWN;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+@ThreadSafe
+class MetastoreSupportsDateStatistics
+{
+    private static final int MAX_SET_DATE_STATISTICS_ATTEMPTS = 100;
+
+    public enum DateStatisticsSupport {
+        SUPPORTED, NOT_SUPPORTED, UNKNOWN
+    }
+
+    private final AtomicReference<DateStatisticsSupport> supported = new AtomicReference<>(UNKNOWN);
+    private final CoalescingCounter failures = new CoalescingCounter(new Duration(1, SECONDS));
+
+    public DateStatisticsSupport isSupported()
+    {
+        return supported.get();
+    }
+
+    public void succeeded()
+    {
+        supported.set(SUPPORTED);
+    }
+
+    public void failed()
+    {
+        // When `dateStatistics.size() > 1` we expect something like "TApplicationException: Required field 'colName' is unset! Struct:ColumnStatisticsObj(colName:null, colType:null, statsData:null)"
+        // When `dateStatistics.size() == 1` we expect something like "TTransportException: java.net.SocketTimeoutException: Read timed out"
+        if (failures.incrementAndGet() >= MAX_SET_DATE_STATISTICS_ATTEMPTS) {
+            supported.set(NOT_SUPPORTED);
+        }
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -172,9 +172,9 @@ public class ThriftHiveMetastore
     private final ThriftMetastoreStats stats;
     private final MetastoreSupportsDateStatistics metastoreSupportsDateStatistics;
 
-    private final AtomicInteger chosenGetTableAlternative = new AtomicInteger(Integer.MAX_VALUE);
-    private final AtomicInteger chosenTableParamAlternative = new AtomicInteger(Integer.MAX_VALUE);
-    private final AtomicInteger chosesGetAllViewsAlternative = new AtomicInteger(Integer.MAX_VALUE);
+    private final AtomicInteger chosenGetTableAlternative;
+    private final AtomicInteger chosenTableParamAlternative;
+    private final AtomicInteger chosesGetAllViewsAlternative;
 
     public ThriftHiveMetastore(
             Optional<ConnectorIdentity> identity,
@@ -190,7 +190,10 @@ public class ThriftHiveMetastore
             boolean translateHiveViews,
             boolean assumeCanonicalPartitionKeys,
             ThriftMetastoreStats stats,
-            MetastoreSupportsDateStatistics metastoreSupportsDateStatistics)
+            MetastoreSupportsDateStatistics metastoreSupportsDateStatistics,
+            AtomicInteger chosenGetTableAlternative,
+            AtomicInteger chosenTableParamAlternative,
+            AtomicInteger chosesGetAllViewsAlternative)
     {
         this.identity = requireNonNull(identity, "identity is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
@@ -206,6 +209,9 @@ public class ThriftHiveMetastore
         this.assumeCanonicalPartitionKeys = assumeCanonicalPartitionKeys;
         this.stats = requireNonNull(stats, "stats is null");
         this.metastoreSupportsDateStatistics = requireNonNull(metastoreSupportsDateStatistics, "metastoreSupportsDateStatistics is null");
+        this.chosenGetTableAlternative = requireNonNull(chosenGetTableAlternative, "chosenGetTableAlternative is null");
+        this.chosenTableParamAlternative = requireNonNull(chosenTableParamAlternative, "chosenTableParamAlternative is null");
+        this.chosesGetAllViewsAlternative = requireNonNull(chosesGetAllViewsAlternative, "chosesGetAllViewsAlternative is null");
     }
 
     @VisibleForTesting

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreFactory.java
@@ -23,6 +23,7 @@ import org.weakref.jmx.Managed;
 import javax.inject.Inject;
 
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
@@ -44,6 +45,9 @@ public class ThriftHiveMetastoreFactory
     private final boolean assumeCanonicalPartitionKeys;
     private final ThriftMetastoreStats stats = new ThriftMetastoreStats();
     private final MetastoreSupportsDateStatistics metastoreSupportsDateStatistics = new MetastoreSupportsDateStatistics();
+    private final AtomicInteger chosenGetTableAlternative = new AtomicInteger(Integer.MAX_VALUE);
+    private final AtomicInteger chosenTableParamAlternative = new AtomicInteger(Integer.MAX_VALUE);
+    private final AtomicInteger chosesGetAllViewsAlternative = new AtomicInteger(Integer.MAX_VALUE);
 
     @Inject
     public ThriftHiveMetastoreFactory(
@@ -99,6 +103,9 @@ public class ThriftHiveMetastoreFactory
                 translateHiveViews,
                 assumeCanonicalPartitionKeys,
                 stats,
-                metastoreSupportsDateStatistics);
+                metastoreSupportsDateStatistics,
+                chosenGetTableAlternative,
+                chosenTableParamAlternative,
+                chosesGetAllViewsAlternative);
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreFactory.java
@@ -43,6 +43,7 @@ public class ThriftHiveMetastoreFactory
     private final boolean translateHiveViews;
     private final boolean assumeCanonicalPartitionKeys;
     private final ThriftMetastoreStats stats = new ThriftMetastoreStats();
+    private final MetastoreSupportsDateStatistics metastoreSupportsDateStatistics = new MetastoreSupportsDateStatistics();
 
     @Inject
     public ThriftHiveMetastoreFactory(
@@ -97,6 +98,7 @@ public class ThriftHiveMetastoreFactory
                 deleteFilesOnDrop,
                 translateHiveViews,
                 assumeCanonicalPartitionKeys,
-                stats);
+                stats,
+                metastoreSupportsDateStatistics);
     }
 }


### PR DESCRIPTION
## Documentation

(X) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(X) Release notes entries required with the following suggested text:

```markdown
# Hive
* Reduce Thrift Metastore communication overhead when impersonation is enabled. ({issue}`13606`)
```
