### PR TITLE
Move ThriftHiveMetastore alternate calls system to ThriftHiveMetastoreClient

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -371,7 +371,7 @@ public class BridgingHiveMetastore
         return resultBuilder.buildOrThrow();
     }
 
-    private Partition fromMetastoreApiPartition(Table table, org.apache.hadoop.hive.metastore.api.Partition partition)
+    private static Partition fromMetastoreApiPartition(Table table, org.apache.hadoop.hive.metastore.api.Partition partition)
     {
         if (isAvroTableWithSchemaSet(table)) {
             List<FieldSchema> schema = table.getDataColumns().stream()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/CoalescingCounter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/CoalescingCounter.java
@@ -50,7 +50,7 @@ final class CoalescingCounter
         coalescingDurationMillis = requireNonNull(coalescingDuration, "coalescingDuration is null").toMillis();
     }
 
-    public synchronized void increment()
+    private synchronized void increment()
     {
         long now = clock.instant().toEpochMilli();
         if (lastUpdateTime + coalescingDurationMillis >= now) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/DefaultThriftMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/DefaultThriftMetastoreClientFactory.java
@@ -43,6 +43,7 @@ import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.lang.Math.toIntExact;
 import static java.util.Collections.list;
@@ -56,6 +57,11 @@ public class DefaultThriftMetastoreClientFactory
     private final int timeoutMillis;
     private final HiveMetastoreAuthentication metastoreAuthentication;
     private final String hostname;
+
+    private final MetastoreSupportsDateStatistics metastoreSupportsDateStatistics = new MetastoreSupportsDateStatistics();
+    private final AtomicInteger chosenGetTableAlternative = new AtomicInteger(Integer.MAX_VALUE);
+    private final AtomicInteger chosenTableParamAlternative = new AtomicInteger(Integer.MAX_VALUE);
+    private final AtomicInteger chosenGetAllViewsAlternative = new AtomicInteger(Integer.MAX_VALUE);
 
     public DefaultThriftMetastoreClientFactory(
             Optional<SSLContext> sslContext,
@@ -101,7 +107,11 @@ public class DefaultThriftMetastoreClientFactory
     {
         return new ThriftHiveMetastoreClient(
                 transport,
-                hostname);
+                hostname,
+                metastoreSupportsDateStatistics,
+                chosenGetTableAlternative,
+                chosenTableParamAlternative,
+                chosenGetAllViewsAlternative);
     }
 
     private TTransport createTransport(HostAndPort address, Optional<String> delegationToken)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/FailureAwareThriftMetastoreClient.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/FailureAwareThriftMetastoreClient.java
@@ -91,17 +91,17 @@ public class FailureAwareThriftMetastoreClient
     }
 
     @Override
-    public List<String> getTableNamesByFilter(String databaseName, String filter)
+    public List<String> getAllViews(String databaseName)
             throws TException
     {
-        return runWithHandle(() -> delegate.getTableNamesByFilter(databaseName, filter));
+        return runWithHandle(() -> delegate.getAllViews(databaseName));
     }
 
     @Override
-    public List<String> getTableNamesByType(String databaseName, String tableType)
+    public List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue)
             throws TException
     {
-        return runWithHandle(() -> delegate.getTableNamesByType(databaseName, tableType));
+        return runWithHandle(() -> delegate.getTablesWithParameter(databaseName, parameterKey, parameterValue));
     }
 
     @Override
@@ -151,13 +151,6 @@ public class FailureAwareThriftMetastoreClient
             throws TException
     {
         return runWithHandle(() -> delegate.getTable(databaseName, tableName));
-    }
-
-    @Override
-    public Table getTableWithCapabilities(String databaseName, String tableName)
-            throws TException
-    {
-        return runWithHandle(() -> delegate.getTableWithCapabilities(databaseName, tableName));
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/KerberosHiveMetastoreAuthentication.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/KerberosHiveMetastoreAuthentication.java
@@ -131,14 +131,13 @@ public class KerberosHiveMetastoreAuthentication
         public void handle(Callback[] callbacks)
         {
             for (Callback callback : callbacks) {
-                if (callback instanceof NameCallback) {
-                    ((NameCallback) callback).setName(username);
+                if (callback instanceof NameCallback nameCallback) {
+                    nameCallback.setName(username);
                 }
-                if (callback instanceof PasswordCallback) {
-                    ((PasswordCallback) callback).setPassword(password.toCharArray());
+                if (callback instanceof PasswordCallback passwordCallback) {
+                    passwordCallback.setPassword(password.toCharArray());
                 }
-                if (callback instanceof RealmCallback) {
-                    RealmCallback realmCallback = (RealmCallback) callback;
+                if (callback instanceof RealmCallback realmCallback) {
                     realmCallback.setText(realmCallback.getDefaultText());
                 }
             }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/MetastoreSupportsDateStatistics.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/MetastoreSupportsDateStatistics.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.metastore.thrift;
+
+import io.airlift.units.Duration;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.trino.plugin.hive.metastore.thrift.MetastoreSupportsDateStatistics.DateStatisticsSupport.NOT_SUPPORTED;
+import static io.trino.plugin.hive.metastore.thrift.MetastoreSupportsDateStatistics.DateStatisticsSupport.SUPPORTED;
+import static io.trino.plugin.hive.metastore.thrift.MetastoreSupportsDateStatistics.DateStatisticsSupport.UNKNOWN;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+@ThreadSafe
+class MetastoreSupportsDateStatistics
+{
+    private static final int MAX_SET_DATE_STATISTICS_ATTEMPTS = 100;
+
+    public enum DateStatisticsSupport {
+        SUPPORTED, NOT_SUPPORTED, UNKNOWN
+    }
+
+    private final AtomicReference<DateStatisticsSupport> supported = new AtomicReference<>(UNKNOWN);
+    private final CoalescingCounter failures = new CoalescingCounter(new Duration(1, SECONDS));
+
+    public DateStatisticsSupport isSupported()
+    {
+        return supported.get();
+    }
+
+    public void succeeded()
+    {
+        supported.set(SUPPORTED);
+    }
+
+    public void failed()
+    {
+        // When `dateStatistics.size() > 1` we expect something like "TApplicationException: Required field 'colName' is unset! Struct:ColumnStatisticsObj(colName:null, colType:null, statsData:null)"
+        // When `dateStatistics.size() == 1` we expect something like "TTransportException: java.net.SocketTimeoutException: Read timed out"
+        if (failures.incrementAndGet() >= MAX_SET_DATE_STATISTICS_ATTEMPTS) {
+            supported.set(NOT_SUPPORTED);
+        }
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -50,7 +50,6 @@ import io.trino.spi.type.Type;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.metastore.LockComponentBuilder;
 import org.apache.hadoop.hive.metastore.LockRequestBuilder;
-import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
 import org.apache.hadoop.hive.metastore.api.ConfigValSecurityException;
@@ -82,7 +81,6 @@ import org.apache.hadoop.hive.metastore.api.TxnAbortedException;
 import org.apache.hadoop.hive.metastore.api.TxnToWriteId;
 import org.apache.hadoop.hive.metastore.api.UnknownDBException;
 import org.apache.hadoop.hive.metastore.api.UnknownTableException;
-import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TException;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -96,19 +94,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
-import static com.google.common.base.Throwables.propagateIfPossible;
 import static com.google.common.base.Throwables.throwIfUnchecked;
-import static com.google.common.base.Verify.verify;
-import static com.google.common.base.Verify.verifyNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -132,17 +123,12 @@ import static io.trino.plugin.hive.metastore.thrift.ThriftMetastoreUtil.updateSt
 import static io.trino.spi.StandardErrorCode.ALREADY_EXISTS;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.security.PrincipalType.USER;
-import static java.lang.Boolean.FALSE;
-import static java.lang.Boolean.TRUE;
 import static java.lang.String.format;
 import static java.lang.System.nanoTime;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.hadoop.hive.common.FileUtils.makePartName;
 import static org.apache.hadoop.hive.metastore.TableType.MANAGED_TABLE;
 import static org.apache.hadoop.hive.metastore.api.HiveObjectType.TABLE;
-import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.HIVE_FILTER_FIELD_PARAMS;
-import static org.apache.thrift.TApplicationException.UNKNOWN_METHOD;
 
 @ThreadSafe
 public class ThriftHiveMetastore
@@ -150,11 +136,7 @@ public class ThriftHiveMetastore
 {
     private static final Logger log = Logger.get(ThriftHiveMetastore.class);
 
-    private static final int MAX_SET_DATE_STATISTICS_ATTEMPTS = 100;
     private static final String DEFAULT_METASTORE_USER = "presto";
-
-    private static final Pattern TABLE_PARAMETER_SAFE_KEY_PATTERN = Pattern.compile("^[a-zA-Z_]+$");
-    private static final Pattern TABLE_PARAMETER_SAFE_VALUE_PATTERN = Pattern.compile("^[a-zA-Z0-9\\s]*$");
 
     private final HdfsContext hdfsContext = new HdfsContext(ConnectorIdentity.ofUser(DEFAULT_METASTORE_USER));
 
@@ -171,13 +153,6 @@ public class ThriftHiveMetastore
     private final boolean translateHiveViews;
     private final boolean assumeCanonicalPartitionKeys;
     private final ThriftMetastoreStats stats;
-
-    private final AtomicInteger chosenGetTableAlternative = new AtomicInteger(Integer.MAX_VALUE);
-    private final AtomicInteger chosenTableParamAlternative = new AtomicInteger(Integer.MAX_VALUE);
-    private final AtomicInteger chosenGetAllViewsAlternative = new AtomicInteger(Integer.MAX_VALUE);
-
-    private final AtomicReference<Optional<Boolean>> metastoreSupportsDateStatistics = new AtomicReference<>(Optional.empty());
-    private final CoalescingCounter metastoreSetDateStatisticsFailures = new CoalescingCounter(new Duration(1, SECONDS));
 
     public ThriftHiveMetastore(
             Optional<ConnectorIdentity> identity,
@@ -290,8 +265,11 @@ public class ThriftHiveMetastore
             return retry()
                     .stopOn(UnknownDBException.class)
                     .stopOnIllegalExceptions()
-                    .run("getTablesWithParameter", stats.getGetTablesWithParameter().wrap(
-                            () -> doGetTablesWithParameter(databaseName, parameterKey, parameterValue)));
+                    .run("getTablesWithParameter", stats.getGetTablesWithParameter().wrap(() -> {
+                        try (ThriftMetastoreClient client = createMetastoreClient()) {
+                            return client.getTablesWithParameter(databaseName, parameterKey, parameterValue);
+                        }
+                    }));
         }
         catch (UnknownDBException e) {
             return ImmutableList.of();
@@ -312,8 +290,9 @@ public class ThriftHiveMetastore
                     .stopOn(NoSuchObjectException.class)
                     .stopOnIllegalExceptions()
                     .run("getTable", stats.getGetTable().wrap(() -> {
-                        Table table = getTableFromMetastore(databaseName, tableName);
-                        return Optional.of(table);
+                        try (ThriftMetastoreClient client = createMetastoreClient()) {
+                            return Optional.of(client.getTable(databaseName, tableName));
+                        }
                     }));
         }
         catch (NoSuchObjectException e) {
@@ -325,17 +304,6 @@ public class ThriftHiveMetastore
         catch (Exception e) {
             throw propagate(e);
         }
-    }
-
-    private Table getTableFromMetastore(String databaseName, String tableName)
-            throws TException
-    {
-        return alternativeCall(
-                this::createMetastoreClient,
-                ThriftHiveMetastore::defaultIsValidExceptionalResponse,
-                chosenGetTableAlternative,
-                client -> client.getTableWithCapabilities(databaseName, tableName),
-                client -> client.getTable(databaseName, tableName));
     }
 
     @Override
@@ -523,11 +491,10 @@ public class ThriftHiveMetastore
                     .stopOn(NoSuchObjectException.class, InvalidObjectException.class, MetaException.class, InvalidInputException.class)
                     .stopOnIllegalExceptions()
                     .run("setTableColumnStatistics", stats.getSetTableColumnStatistics().wrap(() -> {
-                        setColumnStatistics(
-                                format("table %s.%s", databaseName, tableName),
-                                statistics,
-                                (client, stats) -> client.setTableColumnStatistics(databaseName, tableName, stats));
-                        return null;
+                        try (ThriftMetastoreClient client = createMetastoreClient()) {
+                            client.setTableColumnStatistics(databaseName, tableName, statistics);
+                            return null;
+                        }
                     }));
         }
         catch (NoSuchObjectException e) {
@@ -615,10 +582,9 @@ public class ThriftHiveMetastore
                     .stopOn(NoSuchObjectException.class, InvalidObjectException.class, MetaException.class, InvalidInputException.class)
                     .stopOnIllegalExceptions()
                     .run("setPartitionColumnStatistics", stats.getSetPartitionColumnStatistics().wrap(() -> {
-                        setColumnStatistics(
-                                format("partition of table %s.%s", databaseName, tableName),
-                                statistics,
-                                (client, stats) -> client.setPartitionColumnStatistics(databaseName, tableName, partitionName, stats));
+                        try (ThriftMetastoreClient client = createMetastoreClient()) {
+                            client.setPartitionColumnStatistics(databaseName, tableName, partitionName, statistics);
+                        }
                         return null;
                     }));
         }
@@ -655,58 +621,6 @@ public class ThriftHiveMetastore
         catch (Exception e) {
             throw propagate(e);
         }
-    }
-
-    private void setColumnStatistics(String objectName, List<ColumnStatisticsObj> statistics, Call1<List<ColumnStatisticsObj>> saveColumnStatistics)
-            throws TException
-    {
-        boolean containsDateStatistics = statistics.stream().anyMatch(stats -> stats.getStatsData().isSetDateStats());
-
-        Optional<Boolean> metastoreSupportsDateStatistics = this.metastoreSupportsDateStatistics.get();
-        if (containsDateStatistics && metastoreSupportsDateStatistics.equals(Optional.of(FALSE))) {
-            log.debug("Skipping date statistics for %s because metastore does not support them", objectName);
-            statistics = statistics.stream()
-                    .filter(stats -> !stats.getStatsData().isSetDateStats())
-                    .collect(toImmutableList());
-            containsDateStatistics = false;
-        }
-
-        if (!containsDateStatistics || metastoreSupportsDateStatistics.equals(Optional.of(TRUE))) {
-            try (ThriftMetastoreClient client = createMetastoreClient()) {
-                saveColumnStatistics.call(client, statistics);
-            }
-            return;
-        }
-
-        List<ColumnStatisticsObj> statisticsExceptDate = statistics.stream()
-                .filter(stats -> !stats.getStatsData().isSetDateStats())
-                .collect(toImmutableList());
-
-        List<ColumnStatisticsObj> dateStatistics = statistics.stream()
-                .filter(stats -> stats.getStatsData().isSetDateStats())
-                .collect(toImmutableList());
-
-        verify(!dateStatistics.isEmpty() && metastoreSupportsDateStatistics.equals(Optional.empty()));
-
-        try (ThriftMetastoreClient client = createMetastoreClient()) {
-            if (!statisticsExceptDate.isEmpty()) {
-                saveColumnStatistics.call(client, statisticsExceptDate);
-            }
-
-            try {
-                saveColumnStatistics.call(client, dateStatistics);
-            }
-            catch (TException e) {
-                // When `dateStatistics.size() > 1` we expect something like "TApplicationException: Required field 'colName' is unset! Struct:ColumnStatisticsObj(colName:null, colType:null, statsData:null)"
-                // When `dateStatistics.size() == 1` we expect something like "TTransportException: java.net.SocketTimeoutException: Read timed out"
-                log.warn(e, "Failed to save date statistics for %s. Metastore might not support date statistics", objectName);
-                if (!statisticsExceptDate.isEmpty() && metastoreSetDateStatisticsFailures.incrementAndGet() >= MAX_SET_DATE_STATISTICS_ATTEMPTS) {
-                    this.metastoreSupportsDateStatistics.set(Optional.of(FALSE));
-                }
-                return;
-            }
-        }
-        this.metastoreSupportsDateStatistics.set(Optional.of(TRUE));
     }
 
     @Override
@@ -893,16 +807,12 @@ public class ThriftHiveMetastore
                     .stopOn(UnknownDBException.class)
                     .stopOnIllegalExceptions()
                     .run("getAllViews", stats.getGetAllViews().wrap(() -> {
-                        if (translateHiveViews) {
-                            return alternativeCall(
-                                    this::createMetastoreClient,
-                                    exception -> !isUnknownMethodExceptionalResponse(exception),
-                                    chosenGetAllViewsAlternative,
-                                    client -> client.getTableNamesByType(databaseName, TableType.VIRTUAL_VIEW.name()),
-                                    // fallback to enumerating Presto views only (Hive views will still be executed, but will be listed as tables)
-                                    client -> doGetTablesWithParameter(databaseName, PRESTO_VIEW_FLAG, "true"));
+                        try (ThriftMetastoreClient client = createMetastoreClient()) {
+                            if (translateHiveViews) {
+                                return client.getAllViews(databaseName);
+                            }
+                            return client.getTablesWithParameter(databaseName, PRESTO_VIEW_FLAG, "true");
                         }
-                        return doGetTablesWithParameter(databaseName, PRESTO_VIEW_FLAG, "true");
                     }));
         }
         catch (UnknownDBException e) {
@@ -914,34 +824,6 @@ public class ThriftHiveMetastore
         catch (Exception e) {
             throw propagate(e);
         }
-    }
-
-    private List<String> doGetTablesWithParameter(String databaseName, String parameterKey, String parameterValue)
-            throws TException
-    {
-        checkArgument(TABLE_PARAMETER_SAFE_KEY_PATTERN.matcher(parameterKey).matches(), "Parameter key contains invalid characters: '%s'", parameterKey);
-        /*
-         * The parameter value is restricted to have only alphanumeric characters so that it's safe
-         * to be used against HMS. When using with a LIKE operator, the HMS may want the parameter
-         * value to follow a Java regex pattern or a SQL pattern. And it's hard to predict the
-         * HMS's behavior from outside. Also, by restricting parameter values, we avoid the problem
-         * of how to quote them when passing within the filter string.
-         */
-        checkArgument(TABLE_PARAMETER_SAFE_VALUE_PATTERN.matcher(parameterValue).matches(), "Parameter value contains invalid characters: '%s'", parameterValue);
-        /*
-         * Thrift call `get_table_names_by_filter` may be translated by Metastore to a SQL query against Metastore database.
-         * Hive 2.3 on some databases uses CLOB for table parameter value column and some databases disallow `=` predicate over
-         * CLOB values. At the same time, they allow `LIKE` predicates over them.
-         */
-        String filterWithEquals = HIVE_FILTER_FIELD_PARAMS + parameterKey + " = \"" + parameterValue + "\"";
-        String filterWithLike = HIVE_FILTER_FIELD_PARAMS + parameterKey + " LIKE \"" + parameterValue + "\"";
-
-        return alternativeCall(
-                this::createMetastoreClient,
-                ThriftHiveMetastore::defaultIsValidExceptionalResponse,
-                chosenTableParamAlternative,
-                client -> client.getTableNamesByFilter(databaseName, filterWithEquals),
-                client -> client.getTableNamesByFilter(databaseName, filterWithLike));
     }
 
     @Override
@@ -1950,77 +1832,6 @@ public class ThriftHiveMetastore
                 .anyMatch(privilege -> privilege.getPrivilege().equalsIgnoreCase("all"));
     }
 
-    @SafeVarargs
-    private static <T> T alternativeCall(
-            ClientSupplier clientSupplier,
-            Predicate<Exception> isValidExceptionalResponse,
-            AtomicInteger chosenAlternative,
-            Call<T>... alternatives)
-            throws TException
-    {
-        checkArgument(alternatives.length > 0, "No alternatives");
-        int chosen = chosenAlternative.get();
-        checkArgument(chosen == Integer.MAX_VALUE || (0 <= chosen && chosen < alternatives.length), "Bad chosen alternative value: %s", chosen);
-
-        if (chosen != Integer.MAX_VALUE) {
-            try (ThriftMetastoreClient client = clientSupplier.createMetastoreClient()) {
-                return alternatives[chosen].callOn(client);
-            }
-        }
-
-        Exception firstException = null;
-        for (int i = 0; i < alternatives.length; i++) {
-            int position = i;
-            try (ThriftMetastoreClient client = clientSupplier.createMetastoreClient()) {
-                T result = alternatives[i].callOn(client);
-                chosenAlternative.updateAndGet(currentChosen -> Math.min(currentChosen, position));
-                return result;
-            }
-            catch (TException | RuntimeException exception) {
-                if (isValidExceptionalResponse.test(exception)) {
-                    // This is likely a valid response. We are not settling on an alternative yet.
-                    // We will do it later when we get a more obviously valid response.
-                    throw exception;
-                }
-                if (firstException == null) {
-                    firstException = exception;
-                }
-                else if (firstException != exception) {
-                    firstException.addSuppressed(exception);
-                }
-            }
-        }
-
-        verifyNotNull(firstException);
-        propagateIfPossible(firstException, TException.class);
-        throw propagate(firstException);
-    }
-
-    // TODO we should recognize exceptions which we suppress and try different alternative call
-    // this requires product tests with HDP 3
-    private static boolean defaultIsValidExceptionalResponse(Exception exception)
-    {
-        if (exception instanceof NoSuchObjectException) {
-            return true;
-        }
-
-        if (exception.toString().contains("AccessControlException")) {
-            // e.g. org.apache.hadoop.hive.metastore.api.MetaException: org.apache.hadoop.security.AccessControlException: Permission denied: ...
-            return true;
-        }
-
-        return false;
-    }
-
-    private static boolean isUnknownMethodExceptionalResponse(Exception exception)
-    {
-        if (!(exception instanceof TApplicationException applicationException)) {
-            return false;
-        }
-
-        return applicationException.getType() == UNKNOWN_METHOD;
-    }
-
     private ThriftMetastoreClient createMetastoreClient()
             throws TException
     {
@@ -2042,26 +1853,5 @@ public class ThriftHiveMetastore
         }
         throwIfUnchecked(throwable);
         throw new RuntimeException(throwable);
-    }
-
-    @FunctionalInterface
-    private interface ClientSupplier
-    {
-        ThriftMetastoreClient createMetastoreClient()
-                throws TException;
-    }
-
-    @FunctionalInterface
-    private interface Call<T>
-    {
-        T callOn(ThriftMetastoreClient client)
-                throws TException;
-    }
-
-    @FunctionalInterface
-    private interface Call1<A>
-    {
-        void call(ThriftMetastoreClient client, A arg)
-                throws TException;
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -174,7 +174,7 @@ public class ThriftHiveMetastore
 
     private final AtomicInteger chosenGetTableAlternative = new AtomicInteger(Integer.MAX_VALUE);
     private final AtomicInteger chosenTableParamAlternative = new AtomicInteger(Integer.MAX_VALUE);
-    private final AtomicInteger chosesGetAllViewsAlternative = new AtomicInteger(Integer.MAX_VALUE);
+    private final AtomicInteger chosenGetAllViewsAlternative = new AtomicInteger(Integer.MAX_VALUE);
 
     private final AtomicReference<Optional<Boolean>> metastoreSupportsDateStatistics = new AtomicReference<>(Optional.empty());
     private final CoalescingCounter metastoreSetDateStatisticsFailures = new CoalescingCounter(new Duration(1, SECONDS));
@@ -897,7 +897,7 @@ public class ThriftHiveMetastore
                             return alternativeCall(
                                     this::createMetastoreClient,
                                     exception -> !isUnknownMethodExceptionalResponse(exception),
-                                    chosesGetAllViewsAlternative,
+                                    chosenGetAllViewsAlternative,
                                     client -> client.getTableNamesByType(databaseName, TableType.VIRTUAL_VIEW.name()),
                                     // fallback to enumerating Presto views only (Hive views will still be executed, but will be listed as tables)
                                     client -> doGetTablesWithParameter(databaseName, PRESTO_VIEW_FLAG, "true"));
@@ -2014,11 +2014,10 @@ public class ThriftHiveMetastore
 
     private static boolean isUnknownMethodExceptionalResponse(Exception exception)
     {
-        if (!(exception instanceof TApplicationException)) {
+        if (!(exception instanceof TApplicationException applicationException)) {
             return false;
         }
 
-        TApplicationException applicationException = (TApplicationException) exception;
         return applicationException.getType() == UNKNOWN_METHOD;
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
@@ -45,7 +45,6 @@ import org.apache.hadoop.hive.metastore.api.GetValidWriteIdsRequest;
 import org.apache.hadoop.hive.metastore.api.GrantRevokePrivilegeRequest;
 import org.apache.hadoop.hive.metastore.api.GrantRevokeRoleRequest;
 import org.apache.hadoop.hive.metastore.api.GrantRevokeRoleResponse;
-import org.apache.hadoop.hive.metastore.api.GrantRevokeType;
 import org.apache.hadoop.hive.metastore.api.HeartbeatTxnRangeRequest;
 import org.apache.hadoop.hive.metastore.api.HiveObjectPrivilege;
 import org.apache.hadoop.hive.metastore.api.HiveObjectRef;
@@ -388,7 +387,7 @@ public class ThriftHiveMetastoreClient
             throws TException
     {
         GrantRevokeRoleRequest request = new GrantRevokeRoleRequest();
-        request.setRequestType(GrantRevokeType.GRANT);
+        request.setRequestType(GRANT);
         request.setRoleName(role);
         request.setPrincipalName(granteeName);
         request.setPrincipalType(granteeType);
@@ -491,8 +490,8 @@ public class ThriftHiveMetastoreClient
     public void sendTransactionHeartbeat(long transactionId)
             throws TException
     {
-        HeartbeatTxnRangeRequest rqst = new HeartbeatTxnRangeRequest(transactionId, transactionId);
-        client.heartbeat_txn_range(rqst);
+        HeartbeatTxnRangeRequest request = new HeartbeatTxnRangeRequest(transactionId, transactionId);
+        client.heartbeat_txn_range(request);
     }
 
     @Override
@@ -522,7 +521,7 @@ public class ThriftHiveMetastoreClient
     {
         // Pass currentTxn as 0L to get the recent snapshot of valid transactions in Hive
         // Do not pass currentTransactionId instead as it will break Hive's listing of delta directories if major compaction
-        // deletes deleta directories for valid transactions that existed at the time transaction is opened
+        // deletes delta directories for valid transactions that existed at the time transaction is opened
         ValidTxnList validTransactions = TxnUtils.createValidReadTxnList(client.get_open_txns(), 0L);
         GetValidWriteIdsRequest request = new GetValidWriteIdsRequest(tableList, validTransactions.toString());
         return createValidTxnWriteIdList(
@@ -579,7 +578,7 @@ public class ThriftHiveMetastoreClient
             throws TException
     {
         AddDynamicPartitions request = new AddDynamicPartitions(transactionId, writeId, dbName, tableName, partitionNames);
-        request.setOperationType(operation.getMetastoreOperationType().get());
+        request.setOperationType(operation.getMetastoreOperationType().orElseThrow());
         client.add_dynamic_partitions(request);
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreAuthenticationModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreAuthenticationModule.java
@@ -23,7 +23,6 @@ import io.trino.plugin.hive.HdfsConfigurationInitializer;
 import io.trino.plugin.hive.authentication.HadoopAuthentication;
 import io.trino.plugin.hive.authentication.HiveMetastoreAuthentication;
 import io.trino.plugin.hive.authentication.MetastoreKerberosConfig;
-import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreAuthenticationConfig.ThriftMetastoreAuthenticationType;
 
 import static com.google.inject.Scopes.SINGLETON;
 import static io.airlift.configuration.ConfigBinder.configBinder;
@@ -40,14 +39,10 @@ public class ThriftMetastoreAuthenticationModule
 
     private Module getAuthenticationModule()
     {
-        ThriftMetastoreAuthenticationType type = buildConfigObject(ThriftMetastoreAuthenticationConfig.class).getAuthenticationType();
-        switch (type) {
-            case NONE:
-                return new NoHiveMetastoreAuthenticationModule();
-            case KERBEROS:
-                return new KerberosHiveMetastoreAuthenticationModule();
-        }
-        throw new AssertionError("Unknown authentication type: " + type);
+        return switch (buildConfigObject(ThriftMetastoreAuthenticationConfig.class).getAuthenticationType()) {
+            case NONE -> new NoHiveMetastoreAuthenticationModule();
+            case KERBEROS -> new KerberosHiveMetastoreAuthenticationModule();
+        };
     }
 
     public static class NoHiveMetastoreAuthenticationModule

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreClient.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreClient.java
@@ -51,10 +51,10 @@ public interface ThriftMetastoreClient
     List<String> getAllTables(String databaseName)
             throws TException;
 
-    List<String> getTableNamesByFilter(String databaseName, String filter)
+    List<String> getAllViews(String databaseName)
             throws TException;
 
-    List<String> getTableNamesByType(String databaseName, String tableType)
+    List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue)
             throws TException;
 
     void createDatabase(Database database)
@@ -76,9 +76,6 @@ public interface ThriftMetastoreClient
             throws TException;
 
     Table getTable(String databaseName, String tableName)
-            throws TException;
-
-    Table getTableWithCapabilities(String databaseName, String tableName)
             throws TException;
 
     List<FieldSchema> getFields(String databaseName, String tableName)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
@@ -174,14 +174,14 @@ public class TestCachingHiveMetastore
         assertThatCachingWithDisabledPartitionCache()
                 .whenExecuting(testedMetastore -> {
                     Optional<Table> table = testedMetastore.getTable(TEST_DATABASE, TEST_TABLE);
-                    testedMetastore.getPartition(table.get(), TEST_PARTITION_VALUES1);
+                    testedMetastore.getPartition(table.orElseThrow(), TEST_PARTITION_VALUES1);
                 })
                 .omitsCacheForNumberOfOperations(1);
 
         assertThatCachingWithDisabledPartitionCache()
                 .whenExecuting(testedMetastore -> {
                     Optional<Table> table = testedMetastore.getTable(TEST_DATABASE, TEST_TABLE);
-                    testedMetastore.getPartitionsByNames(table.get(), TEST_PARTITION_VALUES1);
+                    testedMetastore.getPartitionsByNames(table.orElseThrow(), TEST_PARTITION_VALUES1);
                 })
                 .omitsCacheForNumberOfOperations(1);
     }
@@ -279,14 +279,14 @@ public class TestCachingHiveMetastore
     {
         ImmutableList<String> expectedPartitions = ImmutableList.of(TEST_PARTITION1, TEST_PARTITION2);
         assertEquals(mockClient.getAccessCount(), 0);
-        assertEquals(metastore.getPartitionNamesByFilter(TEST_DATABASE, TEST_TABLE, PARTITION_COLUMN_NAMES, TupleDomain.all()).get(), expectedPartitions);
+        assertEquals(metastore.getPartitionNamesByFilter(TEST_DATABASE, TEST_TABLE, PARTITION_COLUMN_NAMES, TupleDomain.all()).orElseThrow(), expectedPartitions);
         assertEquals(mockClient.getAccessCount(), 1);
-        assertEquals(metastore.getPartitionNamesByFilter(TEST_DATABASE, TEST_TABLE, PARTITION_COLUMN_NAMES, TupleDomain.all()).get(), expectedPartitions);
+        assertEquals(metastore.getPartitionNamesByFilter(TEST_DATABASE, TEST_TABLE, PARTITION_COLUMN_NAMES, TupleDomain.all()).orElseThrow(), expectedPartitions);
         assertEquals(mockClient.getAccessCount(), 1);
 
         metastore.flushCache();
 
-        assertEquals(metastore.getPartitionNamesByFilter(TEST_DATABASE, TEST_TABLE, PARTITION_COLUMN_NAMES, TupleDomain.all()).get(), expectedPartitions);
+        assertEquals(metastore.getPartitionNamesByFilter(TEST_DATABASE, TEST_TABLE, PARTITION_COLUMN_NAMES, TupleDomain.all()).orElseThrow(), expectedPartitions);
         assertEquals(mockClient.getAccessCount(), 2);
     }
 
@@ -296,8 +296,8 @@ public class TestCachingHiveMetastore
      * <p>
      * At the moment of writing, CachingHiveMetastore uses HivePartitionName for keys in partition cache.
      * HivePartitionName has a peculiar, semi- value-based equality. HivePartitionName may or may not be missing
-     * a name and it matters for bulk load, but it doesn't matter for single-partition load.
-     * Because of equality semantics, the cache keys may gets mixed during bulk load.
+     * a name, and it matters for bulk load, but it doesn't matter for single-partition load.
+     * Because of equality semantics, the cache keys may get mixed during bulk load.
      */
     @Test
     public void testGetPartitionThenGetPartitions()
@@ -367,16 +367,16 @@ public class TestCachingHiveMetastore
         ImmutableList<String> expectedPartitions = ImmutableList.of(TEST_PARTITION1, TEST_PARTITION2);
 
         assertEquals(mockClient.getAccessCount(), 0);
-        assertEquals(metastore.getPartitionNamesByFilter(TEST_DATABASE, TEST_TABLE, PARTITION_COLUMN_NAMES, TupleDomain.all()).get(), expectedPartitions);
+        assertEquals(metastore.getPartitionNamesByFilter(TEST_DATABASE, TEST_TABLE, PARTITION_COLUMN_NAMES, TupleDomain.all()).orElseThrow(), expectedPartitions);
         assertEquals(mockClient.getAccessCount(), 1);
-        assertEquals(metastore.getPartitionNamesByFilter(TEST_DATABASE, TEST_TABLE, PARTITION_COLUMN_NAMES, TupleDomain.all()).get(), expectedPartitions);
+        assertEquals(metastore.getPartitionNamesByFilter(TEST_DATABASE, TEST_TABLE, PARTITION_COLUMN_NAMES, TupleDomain.all()).orElseThrow(), expectedPartitions);
         assertEquals(mockClient.getAccessCount(), 1);
         assertEquals(metastore.getPartitionFilterStats().getRequestCount(), 2);
         assertEquals(metastore.getPartitionFilterStats().getHitRate(), 0.5);
 
         metastore.flushCache();
 
-        assertEquals(metastore.getPartitionNamesByFilter(TEST_DATABASE, TEST_TABLE, PARTITION_COLUMN_NAMES, TupleDomain.all()).get(), expectedPartitions);
+        assertEquals(metastore.getPartitionNamesByFilter(TEST_DATABASE, TEST_TABLE, PARTITION_COLUMN_NAMES, TupleDomain.all()).orElseThrow(), expectedPartitions);
         assertEquals(mockClient.getAccessCount(), 2);
         assertEquals(metastore.getPartitionFilterStats().getRequestCount(), 3);
         assertEquals(metastore.getPartitionFilterStats().getHitRate(), 1.0 / 3);
@@ -423,14 +423,14 @@ public class TestCachingHiveMetastore
     public void testGetPartitionsByNames()
     {
         assertEquals(mockClient.getAccessCount(), 0);
-        Table table = metastore.getTable(TEST_DATABASE, TEST_TABLE).get();
+        Table table = metastore.getTable(TEST_DATABASE, TEST_TABLE).orElseThrow();
         assertEquals(mockClient.getAccessCount(), 1);
 
         // Select half of the available partitions and load them into the cache
         assertEquals(metastore.getPartitionsByNames(table, ImmutableList.of(TEST_PARTITION1)).size(), 1);
         assertEquals(mockClient.getAccessCount(), 2);
 
-        // Now select all of the partitions
+        // Now select all the partitions
         assertEquals(metastore.getPartitionsByNames(table, ImmutableList.of(TEST_PARTITION1, TEST_PARTITION2)).size(), 2);
         // There should be one more access to fetch the remaining partition
         assertEquals(mockClient.getAccessCount(), 3);
@@ -486,7 +486,7 @@ public class TestCachingHiveMetastore
     {
         assertEquals(mockClient.getAccessCount(), 0);
 
-        Table table = metastore.getTable(TEST_DATABASE, TEST_TABLE).get();
+        Table table = metastore.getTable(TEST_DATABASE, TEST_TABLE).orElseThrow();
         assertEquals(mockClient.getAccessCount(), 1);
 
         assertEquals(metastore.getTableStatistics(table), TEST_STATS);
@@ -504,10 +504,10 @@ public class TestCachingHiveMetastore
     {
         assertEquals(mockClient.getAccessCount(), 0);
 
-        Table table = metastore.getTable(TEST_DATABASE, TEST_TABLE).get();
+        Table table = metastore.getTable(TEST_DATABASE, TEST_TABLE).orElseThrow();
         assertEquals(mockClient.getAccessCount(), 1);
 
-        Partition partition = metastore.getPartition(table, TEST_PARTITION_VALUES1).get();
+        Partition partition = metastore.getPartition(table, TEST_PARTITION_VALUES1).orElseThrow();
         assertEquals(mockClient.getAccessCount(), 2);
 
         assertEquals(metastore.getPartitionStatistics(table, ImmutableList.of(partition)), ImmutableMap.of(TEST_PARTITION1, TEST_STATS));
@@ -530,7 +530,7 @@ public class TestCachingHiveMetastore
 
         HiveMetastoreClosure hiveMetastoreClosure = new HiveMetastoreClosure(metastore);
 
-        Table table = hiveMetastoreClosure.getTable(TEST_DATABASE, TEST_TABLE).get();
+        Table table = hiveMetastoreClosure.getTable(TEST_DATABASE, TEST_TABLE).orElseThrow();
         assertEquals(mockClient.getAccessCount(), 1);
 
         hiveMetastoreClosure.updatePartitionStatistics(table.getDatabaseName(), table.getTableName(), TEST_PARTITION1, identity());
@@ -540,7 +540,7 @@ public class TestCachingHiveMetastore
     @Test
     public void testInvalidGetPartitionsByNames()
     {
-        Table table = metastore.getTable(TEST_DATABASE, TEST_TABLE).get();
+        Table table = metastore.getTable(TEST_DATABASE, TEST_TABLE).orElseThrow();
         Map<String, Optional<Partition>> partitionsByNames = metastore.getPartitionsByNames(table, ImmutableList.of(BAD_PARTITION));
         assertEquals(partitionsByNames.size(), 1);
         Optional<Partition> onlyElement = Iterables.getOnlyElement(partitionsByNames.values());
@@ -695,7 +695,7 @@ public class TestCachingHiveMetastore
                     metastore.getPartitionsByNames(table, partitionNames);
                     getPartitionsByNamesFinishedLatch.countDown(); // 6
 
-                    return (Void) null;
+                    return null;
                 }
                 catch (Throwable e) {
                     log.error(e);
@@ -780,7 +780,7 @@ public class TestCachingHiveMetastore
         private PartitionCachingAssertions()
         {
             thriftClient = new MockThriftMetastoreClient();
-            cachingHiveMetastore = (CachingHiveMetastore) cachingHiveMetastore(
+            cachingHiveMetastore = cachingHiveMetastore(
                     new BridgingHiveMetastore(createThriftHiveMetastore(thriftClient)),
                     listeningDecorator(newCachedThreadPool(daemonThreadsNamed("test-%s"))),
                     new Duration(5, TimeUnit.MINUTES),
@@ -820,9 +820,9 @@ public class TestCachingHiveMetastore
             for (int i = 1; i < 5; i++) {
                 metastoreInteractions.accept(cachingHiveMetastore);
                 int currentAccessCount = thriftClient.getAccessCount();
-                int timesCacheHasBeenOmited = (currentAccessCount - startingAccessCount) / i;
-                assertEquals(timesCacheHasBeenOmited, expectedCacheOmittingOperations, format("Metastore is expected to not use cache %s times, but it does not use it %s times.",
-                        expectedCacheOmittingOperations, timesCacheHasBeenOmited));
+                int timesCacheHasBeenOmitted = (currentAccessCount - startingAccessCount) / i;
+                assertEquals(timesCacheHasBeenOmitted, expectedCacheOmittingOperations, format("Metastore is expected to not use cache %s times, but it does not use it %s times.",
+                        expectedCacheOmittingOperations, timesCacheHasBeenOmitted));
             }
         }
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
@@ -119,6 +119,18 @@ public class MockThriftMetastoreClient
     }
 
     @Override
+    public List<String> getAllViews(String databaseName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Database getDatabase(String name)
             throws TException
     {
@@ -156,12 +168,6 @@ public class MockThriftMetastoreClient
                 "",
                 "",
                 TableType.MANAGED_TABLE.name());
-    }
-
-    @Override
-    public Table getTableWithCapabilities(String databaseName, String tableName)
-    {
-        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -228,18 +234,6 @@ public class MockThriftMetastoreClient
 
     @Override
     public void deletePartitionColumnStatistics(String databaseName, String tableName, String partitionName, String columnName)
-    {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public List<String> getTableNamesByFilter(String databaseName, String filter)
-    {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public List<String> getTableNamesByType(String databaseName, String tableType)
     {
         throw new UnsupportedOperationException();
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
@@ -16,7 +16,6 @@ package io.trino.plugin.hive.metastore.thrift;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import io.trino.plugin.hive.acid.AcidOperation;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.Warehouse;
@@ -47,6 +46,7 @@ import java.util.Map;
 import java.util.OptionalLong;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static org.apache.hadoop.hive.metastore.api.PrincipalType.ROLE;
 import static org.apache.hadoop.hive.metastore.api.PrincipalType.USER;
 
@@ -62,9 +62,9 @@ public class MockThriftMetastoreClient
     public static final String TEST_PARTITION2 = "key=testpartition2";
     public static final String BAD_PARTITION = "key=badpartition1";
     public static final List<String> TEST_PARTITION_VALUES1 = ImmutableList.of("testpartition1");
-    public static final List<String> TEST_PARTITION_VALUES2 = ImmutableList.of("testpartition2");
+    private static final List<String> TEST_PARTITION_VALUES2 = ImmutableList.of("testpartition2");
     public static final List<String> TEST_ROLES = ImmutableList.of("testrole");
-    public static final List<RolePrincipalGrant> TEST_ROLE_GRANTS = ImmutableList.of(
+    private static final List<RolePrincipalGrant> TEST_ROLE_GRANTS = ImmutableList.of(
             new RolePrincipalGrant("role1", "user", USER, false, 0, "grantor1", USER),
             new RolePrincipalGrant("role2", "role1", ROLE, true, 0, "grantor2", ROLE));
     public static final List<String> PARTITION_COLUMN_NAMES = ImmutableList.of(TEST_COLUMN);
@@ -297,14 +297,26 @@ public class MockThriftMetastoreClient
         if (!dbName.equals(TEST_DATABASE) || !tableName.equals(TEST_TABLE) || !ImmutableSet.of(TEST_PARTITION1, TEST_PARTITION2).containsAll(names)) {
             throw new NoSuchObjectException();
         }
-        return Lists.transform(names, name -> {
-            try {
-                return new Partition(ImmutableList.copyOf(Warehouse.getPartValuesFromPartName(name)), TEST_DATABASE, TEST_TABLE, 0, 0, DEFAULT_STORAGE_DESCRIPTOR, ImmutableMap.of());
-            }
-            catch (MetaException e) {
-                throw new RuntimeException(e);
-            }
-        });
+        return names.stream()
+                .map(MockThriftMetastoreClient::getPartitionsByNamesUnchecked)
+                .collect(toImmutableList());
+    }
+
+    private static Partition getPartitionsByNamesUnchecked(String name)
+    {
+        try {
+            return new Partition(
+                    ImmutableList.copyOf(Warehouse.getPartValuesFromPartName(name)),
+                    TEST_DATABASE,
+                    TEST_TABLE,
+                    0,
+                    0,
+                    DEFAULT_STORAGE_DESCRIPTOR,
+                    ImmutableMap.of());
+        }
+        catch (MetaException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override
@@ -422,7 +434,6 @@ public class MockThriftMetastoreClient
 
     @Override
     public List<RolePrincipalGrant> listGrantedPrincipals(String role)
-            throws TException
     {
         throw new UnsupportedOperationException();
     }
@@ -481,7 +492,6 @@ public class MockThriftMetastoreClient
 
     @Override
     public void unlock(long lockId)
-            throws TException
     {
         throw new UnsupportedOperationException();
     }
@@ -500,28 +510,24 @@ public class MockThriftMetastoreClient
 
     @Override
     public void updateTableWriteId(String dbName, String tableName, long transactionId, long writeId, OptionalLong rowCountChange)
-            throws TException
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
     public void alterPartitions(String dbName, String tableName, List<Partition> partitions, long writeId)
-            throws TException
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
     public void addDynamicPartitions(String dbName, String tableName, List<String> partitionNames, long transactionId, long writeId, AcidOperation operation)
-            throws TException
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
     public void alterTransactionalTable(Table table, long transactionId, long writeId, EnvironmentContext context)
-            throws TException
     {
         throw new UnsupportedOperationException();
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestStaticMetastoreLocator.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestStaticMetastoreLocator.java
@@ -220,7 +220,7 @@ public class TestStaticMetastoreLocator
         };
     }
 
-    private void assertEqualHiveClient(ThriftMetastoreClient actual, ThriftMetastoreClient expected)
+    private static void assertEqualHiveClient(ThriftMetastoreClient actual, ThriftMetastoreClient expected)
     {
         if (actual instanceof FailureAwareThriftMetastoreClient) {
             actual = ((FailureAwareThriftMetastoreClient) actual).getDelegate();

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveMetastoreClientFactory.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveMetastoreClientFactory.java
@@ -16,17 +16,26 @@ package io.trino.tests.product.hive;
 import com.google.common.net.HostAndPort;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
+import io.airlift.units.Duration;
+import io.trino.plugin.hive.metastore.thrift.DefaultThriftMetastoreClientFactory;
 import io.trino.plugin.hive.metastore.thrift.NoHiveMetastoreAuthentication;
-import io.trino.plugin.hive.metastore.thrift.ThriftHiveMetastoreClient;
-import io.trino.plugin.hive.metastore.thrift.Transport;
+import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreClient;
+import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreClientFactory;
 import org.apache.thrift.TException;
 
 import java.net.URI;
 import java.util.Optional;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 public final class TestHiveMetastoreClientFactory
 {
-    private static final String LOCALHOST = "localhost";
+    private final ThriftMetastoreClientFactory thriftMetastoreClientFactory = new DefaultThriftMetastoreClientFactory(
+            Optional.empty(),
+            Optional.empty(),
+            new Duration(10, SECONDS),
+            new NoHiveMetastoreAuthentication(),
+            "localhost");
 
     @Inject
     @Named("databases.hive.metastore.host")
@@ -36,17 +45,12 @@ public final class TestHiveMetastoreClientFactory
     @Named("databases.hive.metastore.port")
     private int metastorePort;
 
-    ThriftHiveMetastoreClient createMetastoreClient()
+    public ThriftMetastoreClient createMetastoreClient()
             throws TException
     {
         URI metastore = URI.create("thrift://" + metastoreHost + ":" + metastorePort);
-        return new ThriftHiveMetastoreClient(
-                Transport.create(
-                        HostAndPort.fromParts(metastore.getHost(), metastore.getPort()),
-                        Optional.empty(),
-                        Optional.empty(),
-                        10000,
-                        new NoHiveMetastoreAuthentication(),
-                        Optional.empty()), LOCALHOST);
+        return thriftMetastoreClientFactory.create(
+                HostAndPort.fromParts(metastore.getHost(), metastore.getPort()),
+                Optional.empty());
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTransactionalTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTransactionalTable.java
@@ -18,7 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
-import io.trino.plugin.hive.metastore.thrift.ThriftHiveMetastoreClient;
+import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreClient;
 import io.trino.tempto.assertions.QueryAssert.Row;
 import io.trino.tempto.hadoop.hdfs.HdfsClient;
 import io.trino.tempto.query.QueryExecutor;
@@ -1824,7 +1824,7 @@ public class TestHiveTransactionalTable
                 "STORED AS ORC " +
                 "TBLPROPERTIES ('transactional'='true')");
 
-        ThriftHiveMetastoreClient client = testHiveMetastoreClientFactory.createMetastoreClient();
+        ThriftMetastoreClient client = testHiveMetastoreClientFactory.createMetastoreClient();
         try {
             String selectFromOnePartitionsSql = "SELECT col FROM " + tableName + " ORDER BY COL";
 


### PR DESCRIPTION
## Description

This change moves the logic for discovering and managing alternate Thrift calls for the various version of Hive Metastore to the lowest level ThriftHiveMetastoreClient.  This simplifies callers because they do not need understand complexity of API versions, and instead callers just issue simple commands.

## Documentation

(X) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(X) Release notes entries required with the following suggested text:

```markdown
# Hive
* Reduce Thrift Metastore communication overhead when impersonation is enabled. ({issue}`13606`)
```
