### PR TITLE
Quote reserved identifiers

### DIFF
--- a/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
@@ -120,6 +120,7 @@ import java.util.function.Function;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.sql.ReservedIdentifiers.reserved;
 import static io.trino.sql.RowPatternFormatter.formatPattern;
 import static io.trino.sql.SqlFormatter.formatName;
 import static io.trino.sql.SqlFormatter.formatSql;
@@ -401,12 +402,10 @@ public final class ExpressionFormatter
         @Override
         protected String visitIdentifier(Identifier node, Void context)
         {
-            if (!node.isDelimited()) {
-                return node.getValue();
-            }
-            else {
+            if (node.isDelimited() || reserved(node.getValue())) {
                 return '"' + node.getValue().replace("\"", "\"\"") + '"';
             }
+            return node.getValue();
         }
 
         @Override

--- a/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.sql.tree.ColumnDefinition;
+import io.trino.sql.tree.CreateTable;
+import io.trino.sql.tree.GenericDataType;
+import io.trino.sql.tree.Identifier;
+import io.trino.sql.tree.NodeLocation;
+import io.trino.sql.tree.QualifiedName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+import static io.trino.sql.SqlFormatter.formatSql;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestSqlFormatter
+{
+    @Test
+    public void testIdentifiers()
+    {
+        // Reserved keyword
+        assertThat(formatSql(new Identifier("exists", false))).isEqualTo("\"exists\"");
+        assertThat(formatSql(new Identifier("exists", true))).isEqualTo("\"exists\"");
+        assertThat(formatSql(new Identifier("\"exists\"", true))).isEqualTo("\"\"\"exists\"\"\"");
+
+        // Non-reserved keyword
+        assertThat(formatSql(new Identifier("analyze", false))).isEqualTo("analyze");
+        assertThat(formatSql(new Identifier("analyze", true))).isEqualTo("\"analyze\"");
+        assertThat(formatSql(new Identifier("\"analyze\"", true))).isEqualTo("\"\"\"analyze\"\"\"");
+
+        // ANSI-compliant identifier
+        assertThat(formatSql(new Identifier("account", false))).isEqualTo("account");
+        assertThat(formatSql(new Identifier("account", true))).isEqualTo("\"account\"");
+        assertThat(formatSql(new Identifier("\"account\"", true))).isEqualTo("\"\"\"account\"\"\"");
+
+        // Non-ANSI compliant identifier
+        assertThat(formatSql(new Identifier("1", true))).isEqualTo("\"1\"");
+        assertThat(formatSql(new Identifier("\"1\"", true))).isEqualTo("\"\"\"1\"\"\"");
+    }
+
+    @Test
+    public void testCreateTable()
+    {
+        BiFunction<String, String, CreateTable> createTable = (tableName, columnName) -> {
+            NodeLocation location = new NodeLocation(1, 1);
+            Identifier type = new Identifier(location, "VARCHAR", false);
+            return new CreateTable(
+                    QualifiedName.of(ImmutableList.of(new Identifier(tableName, false))),
+                    ImmutableList.of(new ColumnDefinition(
+                            new Identifier(columnName, false),
+                            new GenericDataType(location, type, ImmutableList.of()),
+                            true,
+                            ImmutableList.of(),
+                            Optional.empty())),
+                    false,
+                    ImmutableList.of(),
+                    Optional.empty());
+        };
+        String createTableSql = "CREATE TABLE %s (\n   %s VARCHAR\n)";
+
+        assertThat(formatSql(createTable.apply("table_name", "column_name")))
+                .isEqualTo(String.format(createTableSql, "table_name", "column_name"));
+        assertThat(formatSql(createTable.apply("exists", "exists")))
+                .isEqualTo(String.format(createTableSql, "\"exists\"", "\"exists\""));
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

Fix #13483, quote reserved keywords in `SHOW CREATE TABLE`

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core query engine

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

Fixes #13483

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
