### PR TITLE
Unblock driver when one of the operator finishes

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/Driver.java
+++ b/core/trino-main/src/main/java/io/trino/operator/Driver.java
@@ -463,6 +463,11 @@ public class Driver
             }
 
             if (!blockedFutures.isEmpty()) {
+                // allow for operators to unblock drivers when they become finished
+                for (Operator operator : activeOperators) {
+                    operator.getOperatorContext().getFinishedFuture().ifPresent(blockedFutures::add);
+                }
+
                 // unblock when the first future is complete
                 ListenableFuture<Void> blocked = firstFinishedFuture(blockedFutures);
                 // driver records serial blocked time

--- a/core/trino-main/src/main/java/io/trino/operator/OperatorContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OperatorContext.java
@@ -97,6 +97,7 @@ public class OperatorContext
     private final AtomicReference<SettableFuture<Void>> memoryFuture;
     private final AtomicReference<SettableFuture<Void>> revocableMemoryFuture;
     private final AtomicReference<BlockedMonitor> blockedMonitor = new AtomicReference<>();
+    private final AtomicReference<ListenableFuture<Void>> finishedFuture = new AtomicReference<>();
     private final AtomicLong blockedWallNanos = new AtomicLong();
 
     private final OperationTiming finishTiming = new OperationTiming();
@@ -239,6 +240,16 @@ public class OperatorContext
     public void setLatestConnectorMetrics(Metrics metrics)
     {
         this.connectorMetrics.set(metrics);
+    }
+
+    Optional<ListenableFuture<Void>> getFinishedFuture()
+    {
+        return Optional.ofNullable(finishedFuture.get());
+    }
+
+    public void setFinishedFuture(ListenableFuture<Void> finishedFuture)
+    {
+        checkState(this.finishedFuture.getAndSet(requireNonNull(finishedFuture, "finishedFuture is null")) == null, "finishedFuture already set");
     }
 
     public void recordPhysicalWrittenData(long sizeInBytes)

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchangeSinkOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchangeSinkOperator.java
@@ -89,6 +89,7 @@ public class LocalExchangeSinkOperator
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
         this.sink = requireNonNull(sink, "sink is null");
         this.pagePreprocessor = requireNonNull(pagePreprocessor, "pagePreprocessor is null");
+        operatorContext.setFinishedFuture(sink.isFinished());
     }
 
     @Override
@@ -106,7 +107,7 @@ public class LocalExchangeSinkOperator
     @Override
     public boolean isFinished()
     {
-        return sink.isFinished();
+        return sink.isFinished().isDone();
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/operator/TestDriver.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestDriver.java
@@ -193,7 +193,6 @@ public class TestDriver
 
     @Test
     public void testBrokenOperatorCloseWhileProcessing()
-            throws Exception
     {
         BrokenOperator brokenOperator = new BrokenOperator(driverContext.addOperatorContext(0, new PlanNodeId("test"), "source"), false);
         Driver driver = Driver.createDriver(driverContext, brokenOperator, createSinkOperator(ImmutableList.of()));
@@ -257,7 +256,6 @@ public class TestDriver
 
     @Test
     public void testBrokenOperatorAddSource()
-            throws Exception
     {
         PlanNodeId sourceId = new PlanNodeId("source");
         List<Type> types = ImmutableList.of(VARCHAR, BIGINT, BIGINT);

--- a/core/trino-main/src/test/java/io/trino/operator/exchange/TestLocalExchange.java
+++ b/core/trino-main/src/test/java/io/trino/operator/exchange/TestLocalExchange.java
@@ -584,8 +584,14 @@ public class TestLocalExchange
             sinkFactory.noMoreSinkFactories();
             LocalExchangeSink sinkA = sinkFactory.createSink();
             assertSinkCanWrite(sinkA);
+            ListenableFuture<Void> sinkAFinished = sinkA.isFinished();
+            assertFalse(sinkAFinished.isDone());
+
             LocalExchangeSink sinkB = sinkFactory.createSink();
             assertSinkCanWrite(sinkB);
+            ListenableFuture<Void> sinkBFinished = sinkB.isFinished();
+            assertFalse(sinkBFinished.isDone());
+
             sinkFactory.close();
 
             LocalExchangeSource sourceA = exchange.getSource(0);
@@ -620,6 +626,8 @@ public class TestLocalExchange
 
             assertTrue(sinkAFuture.isDone());
             assertTrue(sinkBFuture.isDone());
+            assertTrue(sinkAFinished.isDone());
+            assertTrue(sinkBFinished.isDone());
 
             assertSinkFinished(sinkA);
             assertSinkFinished(sinkB);
@@ -692,13 +700,13 @@ public class TestLocalExchange
 
     private static void assertSinkCanWrite(LocalExchangeSink sink)
     {
-        assertFalse(sink.isFinished());
+        assertFalse(sink.isFinished().isDone());
         assertTrue(sink.waitForWriting().isDone());
     }
 
     private static ListenableFuture<Void> assertSinkWriteBlocked(LocalExchangeSink sink)
     {
-        assertFalse(sink.isFinished());
+        assertFalse(sink.isFinished().isDone());
         ListenableFuture<Void> writeFuture = sink.waitForWriting();
         assertFalse(writeFuture.isDone());
         return writeFuture;
@@ -706,12 +714,12 @@ public class TestLocalExchange
 
     private static void assertSinkFinished(LocalExchangeSink sink)
     {
-        assertTrue(sink.isFinished());
+        assertTrue(sink.isFinished().isDone());
         assertTrue(sink.waitForWriting().isDone());
 
         // this will be ignored
         sink.addPage(createPage(0));
-        assertTrue(sink.isFinished());
+        assertTrue(sink.isFinished().isDone());
         assertTrue(sink.waitForWriting().isDone());
     }
 

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/TestDistributedFaultTolerantEngineOnlyQueries.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/TestDistributedFaultTolerantEngineOnlyQueries.java
@@ -23,6 +23,7 @@ import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.FaultTolerantExecutionConnectorTestHelper;
 import io.trino.testing.QueryRunner;
 import io.trino.tpch.TpchTable;
+import org.testng.annotations.Test;
 
 import static io.airlift.testing.Closeables.closeAllSuppress;
 
@@ -57,5 +58,12 @@ public class TestDistributedFaultTolerantEngineOnlyQueries
             throw closeAllSuppress(e, queryRunner);
         }
         return queryRunner;
+    }
+
+    @Override
+    @Test(enabled = false)
+    public void testSelectiveLimit()
+    {
+        // FTE mode does not terminate query when limit is reached
     }
 }

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractDistributedEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractDistributedEngineOnlyQueries.java
@@ -350,4 +350,16 @@ public abstract class AbstractDistributedEngineOnlyQueries
 
         assertThatThrownBy(queryFuture::get).hasMessageContaining("Query was canceled");
     }
+
+    @Test(timeOut = 30_000)
+    public void testSelectiveLimit()
+    {
+        assertQuery("" +
+                        "SELECT * FROM (" +
+                        "   (SELECT orderkey AS a FROM tpch.sf10000.orders WHERE orderkey=-1)" +
+                        " UNION ALL SELECT * FROM (values -1) AS t(a))" +
+                        "WHERE a=-1 " +
+                        "LIMIT 1",
+                "VALUES -1");
+    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

    As described in https://github.com/trinodb/trino/issues/4065
    highly selective limit queries might not finish when
    required number of rows is produced. This is due to the
    case described in https://github.com/prestodb/presto/issues/9357.
    This problem is solved by allowing LocalExchangeSinkOperator to
    notify driver when operator becomes finished.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

improvment

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core engine

> How would you describe this change to a non-technical end user or system administrator?

Highly selective LIMIT queries will finish as soon as required number of rows is processed

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

Fixes https://github.com/trinodb/trino/issues/4065

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Make highly selective queries finish as soon as required number of rows is produced ({issue}`issuenumber`)
```
