### PR TITLE
Added BaseConnectorSmokeTest as a base class for Pinot SmokeTest

### DIFF
--- a/plugin/trino-pinot/pom.xml
+++ b/plugin/trino-pinot/pom.xml
@@ -547,6 +547,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino.tpch</groupId>
+            <artifactId>tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>testing</artifactId>
             <scope>test</scope>

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/AbstractPinotIntegrationSmokeTest.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/AbstractPinotIntegrationSmokeTest.java
@@ -142,6 +142,30 @@ public abstract class AbstractPinotIntegrationSmokeTest
         TestingPinotCluster pinot = closeAfterClass(new TestingPinotCluster(kafka.getNetwork(), isSecured(), getPinotImageName()));
         pinot.start();
 
+        createAndPopulateAllTypesTopic(kafka, pinot);
+        createAndPopulateMixedCaseTableAndTopic(kafka, pinot);
+        createAndPopulateMixedCaseDistinctTableAndTopic(kafka, pinot);
+        createAndPopulateTooManyRowsTable(kafka, pinot);
+        createAndPopulateTooManyBrokerRowsTableAndTopic(kafka, pinot);
+        createTheDuplicateTablesAndTopics(kafka, pinot);
+        createAndPopulateDateTimeFieldsTableAndTopic(kafka, pinot);
+        createAndPopulateJsonTypeTable(kafka, pinot);
+        createAndPopulateJsonTable(kafka, pinot);
+        createAndPopulateMixedCaseHybridTablesAndTopic(kafka, pinot);
+        createAndPopulateTableHavingReservedKeywordColumnNames(kafka, pinot);
+        createAndPopulateHavingQuotesInColumnNames(kafka, pinot);
+        createAndPopulateHavingMultipleColumnsWithDuplicateValues(kafka, pinot);
+
+        return PinotQueryRunner.createPinotQueryRunner(
+                ImmutableMap.of(),
+                pinotProperties(pinot),
+                Optional.of(binder -> newOptionalBinder(binder, PinotHostMapper.class).setBinding()
+                        .toInstance(new TestingPinotHostMapper(pinot.getBrokerHostAndPort(), pinot.getServerHostAndPort(), pinot.getServerGrpcHostAndPort()))));
+    }
+
+    private void createAndPopulateAllTypesTopic(TestingKafka kafka, TestingPinotCluster pinot)
+            throws Exception
+    {
         // Create and populate the all_types topic and table
         kafka.createTopic(ALL_TYPES_TABLE);
 
@@ -165,7 +189,11 @@ public abstract class AbstractPinotIntegrationSmokeTest
 
         pinot.createSchema(getClass().getClassLoader().getResourceAsStream("alltypes_schema.json"), ALL_TYPES_TABLE);
         pinot.addRealTimeTable(getClass().getClassLoader().getResourceAsStream("alltypes_realtimeSpec.json"), ALL_TYPES_TABLE);
+    }
 
+    private void createAndPopulateMixedCaseTableAndTopic(TestingKafka kafka, TestingPinotCluster pinot)
+            throws Exception
+    {
         // Create and populate mixed case table and topic
         kafka.createTopic(MIXED_CASE_COLUMN_NAMES_TABLE);
         Schema mixedCaseAvroSchema = SchemaBuilder.record(MIXED_CASE_COLUMN_NAMES_TABLE).fields()
@@ -200,7 +228,11 @@ public abstract class AbstractPinotIntegrationSmokeTest
         kafka.sendMessages(mixedCaseProducerRecords.stream(), schemaRegistryAwareProducer(kafka));
         pinot.createSchema(getClass().getClassLoader().getResourceAsStream("mixed_case_schema.json"), MIXED_CASE_COLUMN_NAMES_TABLE);
         pinot.addRealTimeTable(getClass().getClassLoader().getResourceAsStream("mixed_case_realtimeSpec.json"), MIXED_CASE_COLUMN_NAMES_TABLE);
+    }
 
+    private void createAndPopulateMixedCaseDistinctTableAndTopic(TestingKafka kafka, TestingPinotCluster pinot)
+            throws Exception
+    {
         // Create and populate mixed case distinct table and topic
         kafka.createTopic(MIXED_CASE_DISTINCT_TABLE);
         Schema mixedCaseDistinctAvroSchema = SchemaBuilder.record(MIXED_CASE_DISTINCT_TABLE).fields()
@@ -234,7 +266,11 @@ public abstract class AbstractPinotIntegrationSmokeTest
         // Create mixed case table name, populated from the mixed case topic
         pinot.createSchema(getClass().getClassLoader().getResourceAsStream("mixed_case_table_name_schema.json"), MIXED_CASE_TABLE_NAME);
         pinot.addRealTimeTable(getClass().getClassLoader().getResourceAsStream("mixed_case_table_name_realtimeSpec.json"), MIXED_CASE_TABLE_NAME);
+    }
 
+    private void createAndPopulateTooManyRowsTable(TestingKafka kafka, TestingPinotCluster pinot)
+            throws Exception
+    {
         // Create and populate too many rows table and topic
         kafka.createTopic(TOO_MANY_ROWS_TABLE);
         Schema tooManyRowsAvroSchema = SchemaBuilder.record(TOO_MANY_ROWS_TABLE).fields()
@@ -255,7 +291,11 @@ public abstract class AbstractPinotIntegrationSmokeTest
         kafka.sendMessages(tooManyRowsRecordsBuilder.build().stream(), schemaRegistryAwareProducer(kafka));
         pinot.createSchema(getClass().getClassLoader().getResourceAsStream("too_many_rows_schema.json"), TOO_MANY_ROWS_TABLE);
         pinot.addRealTimeTable(getClass().getClassLoader().getResourceAsStream("too_many_rows_realtimeSpec.json"), TOO_MANY_ROWS_TABLE);
+    }
 
+    private void createAndPopulateTooManyBrokerRowsTableAndTopic(TestingKafka kafka, TestingPinotCluster pinot)
+            throws Exception
+    {
         // Create and populate too many broker rows table and topic
         kafka.createTopic(TOO_MANY_BROKER_ROWS_TABLE);
         Schema tooManyBrokerRowsAvroSchema = SchemaBuilder.record(TOO_MANY_BROKER_ROWS_TABLE).fields()
@@ -273,7 +313,11 @@ public abstract class AbstractPinotIntegrationSmokeTest
         kafka.sendMessages(tooManyBrokerRowsRecordsBuilder.build().stream(), schemaRegistryAwareProducer(kafka));
         pinot.createSchema(getClass().getClassLoader().getResourceAsStream("too_many_broker_rows_schema.json"), TOO_MANY_BROKER_ROWS_TABLE);
         pinot.addRealTimeTable(getClass().getClassLoader().getResourceAsStream("too_many_broker_rows_realtimeSpec.json"), TOO_MANY_BROKER_ROWS_TABLE);
+    }
 
+    private void createTheDuplicateTablesAndTopics(TestingKafka kafka, TestingPinotCluster pinot)
+            throws Exception
+    {
         // Create the duplicate tables and topics
         kafka.createTopic(DUPLICATE_TABLE_LOWERCASE);
         pinot.createSchema(getClass().getClassLoader().getResourceAsStream("dup_table_lower_case_schema.json"), DUPLICATE_TABLE_LOWERCASE);
@@ -282,7 +326,11 @@ public abstract class AbstractPinotIntegrationSmokeTest
         kafka.createTopic(DUPLICATE_TABLE_MIXED_CASE);
         pinot.createSchema(getClass().getClassLoader().getResourceAsStream("dup_table_mixed_case_schema.json"), DUPLICATE_TABLE_MIXED_CASE);
         pinot.addRealTimeTable(getClass().getClassLoader().getResourceAsStream("dup_table_mixed_case_realtimeSpec.json"), DUPLICATE_TABLE_MIXED_CASE);
+    }
 
+    private void createAndPopulateDateTimeFieldsTableAndTopic(TestingKafka kafka, TestingPinotCluster pinot)
+            throws Exception
+    {
         // Create and populate date time fields table and topic
         kafka.createTopic(DATE_TIME_FIELDS_TABLE);
         Schema dateTimeFieldsAvroSchema = SchemaBuilder.record(DATE_TIME_FIELDS_TABLE).fields()
@@ -310,7 +358,11 @@ public abstract class AbstractPinotIntegrationSmokeTest
         kafka.sendMessages(dateTimeFieldsProducerRecords.stream(), schemaRegistryAwareProducer(kafka));
         pinot.createSchema(getClass().getClassLoader().getResourceAsStream("date_time_fields_schema.json"), DATE_TIME_FIELDS_TABLE);
         pinot.addRealTimeTable(getClass().getClassLoader().getResourceAsStream("date_time_fields_realtimeSpec.json"), DATE_TIME_FIELDS_TABLE);
+    }
 
+    private void createAndPopulateJsonTypeTable(TestingKafka kafka, TestingPinotCluster pinot)
+            throws Exception
+    {
         // Create json type table
         kafka.createTopic(JSON_TYPE_TABLE);
 
@@ -332,7 +384,11 @@ public abstract class AbstractPinotIntegrationSmokeTest
         pinot.createSchema(getClass().getClassLoader().getResourceAsStream("json_schema.json"), JSON_TYPE_TABLE);
         pinot.addRealTimeTable(getClass().getClassLoader().getResourceAsStream("json_realtimeSpec.json"), JSON_TYPE_TABLE);
         pinot.addOfflineTable(getClass().getClassLoader().getResourceAsStream("json_offlineSpec.json"), JSON_TYPE_TABLE);
+    }
 
+    private void createAndPopulateJsonTable(TestingKafka kafka, TestingPinotCluster pinot)
+            throws Exception
+    {
         // Create json table
         kafka.createTopic(JSON_TABLE);
         long key = 0L;
@@ -347,7 +403,11 @@ public abstract class AbstractPinotIntegrationSmokeTest
 
         pinot.createSchema(getClass().getClassLoader().getResourceAsStream("schema.json"), JSON_TABLE);
         pinot.addRealTimeTable(getClass().getClassLoader().getResourceAsStream("realtimeSpec.json"), JSON_TABLE);
+    }
 
+    private void createAndPopulateMixedCaseHybridTablesAndTopic(TestingKafka kafka, TestingPinotCluster pinot)
+            throws Exception
+    {
         // Create and populate mixed case table and topic
         kafka.createTopic(HYBRID_TABLE_NAME);
         Schema hybridAvroSchema = SchemaBuilder.record(HYBRID_TABLE_NAME).fields()
@@ -433,7 +493,11 @@ public abstract class AbstractPinotIntegrationSmokeTest
         }
 
         kafka.sendMessages(hybridProducerRecords.stream(), schemaRegistryAwareProducer(kafka));
+    }
 
+    private void createAndPopulateTableHavingReservedKeywordColumnNames(TestingKafka kafka, TestingPinotCluster pinot)
+            throws Exception
+    {
         // Create a table having reserved keyword column names
         kafka.createTopic(RESERVED_KEYWORD_TABLE);
         Schema reservedKeywordAvroSchema = SchemaBuilder.record(RESERVED_KEYWORD_TABLE).fields()
@@ -447,7 +511,11 @@ public abstract class AbstractPinotIntegrationSmokeTest
         kafka.sendMessages(reservedKeywordRecordsBuilder.build().stream(), schemaRegistryAwareProducer(kafka));
         pinot.createSchema(getClass().getClassLoader().getResourceAsStream("reserved_keyword_schema.json"), RESERVED_KEYWORD_TABLE);
         pinot.addRealTimeTable(getClass().getClassLoader().getResourceAsStream("reserved_keyword_realtimeSpec.json"), RESERVED_KEYWORD_TABLE);
+    }
 
+    private void createAndPopulateHavingQuotesInColumnNames(TestingKafka kafka, TestingPinotCluster pinot)
+            throws Exception
+    {
         // Create a table having quotes in column names
         kafka.createTopic(QUOTES_IN_COLUMN_NAME_TABLE);
         Schema quotesInColumnNameAvroSchema = SchemaBuilder.record(QUOTES_IN_COLUMN_NAME_TABLE).fields()
@@ -460,7 +528,11 @@ public abstract class AbstractPinotIntegrationSmokeTest
         kafka.sendMessages(quotesInColumnNameRecordsBuilder.build().stream(), schemaRegistryAwareProducer(kafka));
         pinot.createSchema(getClass().getClassLoader().getResourceAsStream("quotes_in_column_name_schema.json"), QUOTES_IN_COLUMN_NAME_TABLE);
         pinot.addRealTimeTable(getClass().getClassLoader().getResourceAsStream("quotes_in_column_name_realtimeSpec.json"), QUOTES_IN_COLUMN_NAME_TABLE);
+    }
 
+    private void createAndPopulateHavingMultipleColumnsWithDuplicateValues(TestingKafka kafka, TestingPinotCluster pinot)
+            throws Exception
+    {
         // Create a table having multiple columns with duplicate values
         kafka.createTopic(DUPLICATE_VALUES_IN_COLUMNS_TABLE);
         Schema duplicateValuesInColumnsAvroSchema = SchemaBuilder.record(DUPLICATE_VALUES_IN_COLUMNS_TABLE).fields()
@@ -523,12 +595,6 @@ public abstract class AbstractPinotIntegrationSmokeTest
         kafka.sendMessages(duplicateValuesInColumnsRecordsBuilder.build().stream(), schemaRegistryAwareProducer(kafka));
         pinot.createSchema(getClass().getClassLoader().getResourceAsStream("duplicate_values_in_columns_schema.json"), DUPLICATE_VALUES_IN_COLUMNS_TABLE);
         pinot.addRealTimeTable(getClass().getClassLoader().getResourceAsStream("duplicate_values_in_columns_realtimeSpec.json"), DUPLICATE_VALUES_IN_COLUMNS_TABLE);
-
-        return PinotQueryRunner.createPinotQueryRunner(
-                ImmutableMap.of(),
-                pinotProperties(pinot),
-                Optional.of(binder -> newOptionalBinder(binder, PinotHostMapper.class).setBinding()
-                        .toInstance(new TestingPinotHostMapper(pinot.getBrokerHostAndPort(), pinot.getServerHostAndPort(), pinot.getServerGrpcHostAndPort()))));
     }
 
     private Map<String, String> pinotProperties(TestingPinotCluster pinot)

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/PinotQueryRunner.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/PinotQueryRunner.java
@@ -43,7 +43,6 @@ public class PinotQueryRunner
             throws Exception
     {
         DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(createSession("default"))
-                .setNodeCount(2)
                 .setExtraProperties(extraProperties)
                 .build();
         queryRunner.installPlugin(new PinotPlugin(extension));

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotWithoutAuthenticationIntegrationConnectorConnectorSmokeTest.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotWithoutAuthenticationIntegrationConnectorConnectorSmokeTest.java
@@ -13,25 +13,11 @@
  */
 package io.trino.plugin.pinot;
 
-import static io.trino.plugin.pinot.TestingPinotCluster.PINOT_LATEST_IMAGE_NAME;
-
-public class TestPinotWithoutAuthenticationIntegrationSmokeTestLatestVersionNoGrpc
-        extends AbstractPinotIntegrationSmokeTest
+public class TestPinotWithoutAuthenticationIntegrationConnectorConnectorSmokeTest
+        extends BasePinotIntegrationConnectorSmokeTest
 {
     @Override
     protected boolean isSecured()
-    {
-        return false;
-    }
-
-    @Override
-    protected String getPinotImageName()
-    {
-        return PINOT_LATEST_IMAGE_NAME;
-    }
-
-    @Override
-    protected boolean isGrpcEnabled()
     {
         return false;
     }

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotWithoutAuthenticationIntegrationLatestVersionConnectorConnectorSmokeTest.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotWithoutAuthenticationIntegrationLatestVersionConnectorConnectorSmokeTest.java
@@ -13,12 +13,20 @@
  */
 package io.trino.plugin.pinot;
 
-public class TestPinotWithoutAuthenticationIntegrationSmokeTest
-        extends AbstractPinotIntegrationSmokeTest
+import static io.trino.plugin.pinot.TestingPinotCluster.PINOT_LATEST_IMAGE_NAME;
+
+public class TestPinotWithoutAuthenticationIntegrationLatestVersionConnectorConnectorSmokeTest
+        extends BasePinotIntegrationConnectorSmokeTest
 {
     @Override
     protected boolean isSecured()
     {
         return false;
+    }
+
+    @Override
+    protected String getPinotImageName()
+    {
+        return PINOT_LATEST_IMAGE_NAME;
     }
 }

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotWithoutAuthenticationIntegrationLatestVersionNoGrpcConnectorSmokeTest.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotWithoutAuthenticationIntegrationLatestVersionNoGrpcConnectorSmokeTest.java
@@ -15,8 +15,8 @@ package io.trino.plugin.pinot;
 
 import static io.trino.plugin.pinot.TestingPinotCluster.PINOT_LATEST_IMAGE_NAME;
 
-public class TestPinotWithoutAuthenticationIntegrationSmokeTestLatestVersion
-        extends AbstractPinotIntegrationSmokeTest
+public class TestPinotWithoutAuthenticationIntegrationLatestVersionNoGrpcConnectorSmokeTest
+        extends BasePinotIntegrationConnectorSmokeTest
 {
     @Override
     protected boolean isSecured()
@@ -28,5 +28,11 @@ public class TestPinotWithoutAuthenticationIntegrationSmokeTestLatestVersion
     protected String getPinotImageName()
     {
         return PINOT_LATEST_IMAGE_NAME;
+    }
+
+    @Override
+    protected boolean isGrpcEnabled()
+    {
+        return false;
     }
 }

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestSecuredPinotIntegrationConnectorSmokeTest.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestSecuredPinotIntegrationConnectorSmokeTest.java
@@ -19,8 +19,8 @@ import java.util.Map;
 
 import static io.trino.plugin.pinot.auth.PinotAuthenticationType.PASSWORD;
 
-public class TestSecuredPinotIntegrationSmokeTest
-        extends AbstractPinotIntegrationSmokeTest
+public class TestSecuredPinotIntegrationConnectorSmokeTest
+        extends BasePinotIntegrationConnectorSmokeTest
 {
     @Override
     protected boolean isSecured()

--- a/plugin/trino-pinot/src/test/resources/nation_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/nation_realtimeSpec.json
@@ -1,0 +1,46 @@
+{
+    "tableName": "nation",
+    "tableType": "REALTIME",
+    "segmentsConfig": {
+        "timeColumnName": "updated_at_seconds",
+        "retentionTimeUnit": "DAYS",
+        "retentionTimeValue": "365",
+        "segmentPushType": "APPEND",
+        "segmentPushFrequency": "daily",
+        "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
+        "schemaName": "nation",
+        "replicasPerPartition": "1"
+    },
+    "tenants": {
+        "broker": "DefaultTenant",
+        "server": "DefaultTenant"
+    },
+    "tableIndexConfig": {
+        "loadMode": "MMAP",
+        "noDictionaryColumns": [],
+        "sortedColumn": [
+            "updated_at_seconds"
+        ],
+        "aggregateMetrics": "false",
+        "nullHandlingEnabled": "true",
+        "streamConfigs": {
+            "streamType": "kafka",
+            "stream.kafka.consumer.type": "lowLevel",
+            "stream.kafka.topic.name": "nation",
+            "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.avro.confluent.KafkaConfluentSchemaRegistryAvroMessageDecoder",
+            "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+            "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
+            "stream.kafka.zk.broker.url": "zookeeper:2181/",
+            "stream.kafka.broker.list": "kafka:9092",
+            "realtime.segment.flush.threshold.time": "1m",
+            "realtime.segment.flush.threshold.size": "0",
+            "realtime.segment.flush.desired.size": "1M",
+            "isolation.level": "read_committed",
+            "stream.kafka.consumer.prop.auto.offset.reset": "smallest",
+            "stream.kafka.consumer.prop.group.id": "pinot_nation"
+        }
+    },
+    "metadata": {
+        "customConfigs": {}
+    }
+}

--- a/plugin/trino-pinot/src/test/resources/nation_schema.json
+++ b/plugin/trino-pinot/src/test/resources/nation_schema.json
@@ -1,0 +1,31 @@
+{
+    "schemaName": "nation",
+    "dimensionFieldSpecs": [
+        {
+            "name": "nationkey",
+            "dataType": "LONG"
+        },
+        {
+            "name": "name",
+            "dataType": "STRING"
+        },
+        {
+            "name": "comment",
+            "dataType": "STRING"
+        },
+        {
+            "name": "regionkey",
+            "dataType": "LONG"
+        }
+    ],
+    "dateTimeFieldSpecs": [
+        {
+            "name": "updated_at_seconds",
+            "dataType": "LONG",
+            "defaultNullValue": 0,
+            "format": "1:SECONDS:EPOCH",
+            "transformFunction": "toEpochSeconds(updated_at)",
+            "granularity": "1:SECONDS"
+        }
+    ]
+}

--- a/plugin/trino-pinot/src/test/resources/region_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/region_realtimeSpec.json
@@ -1,0 +1,46 @@
+{
+    "tableName": "region",
+    "tableType": "REALTIME",
+    "segmentsConfig": {
+        "timeColumnName": "updated_at_seconds",
+        "retentionTimeUnit": "DAYS",
+        "retentionTimeValue": "365",
+        "segmentPushType": "APPEND",
+        "segmentPushFrequency": "daily",
+        "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
+        "schemaName": "region",
+        "replicasPerPartition": "1"
+    },
+    "tenants": {
+        "broker": "DefaultTenant",
+        "server": "DefaultTenant"
+    },
+    "tableIndexConfig": {
+        "loadMode": "MMAP",
+        "noDictionaryColumns": [],
+        "sortedColumn": [
+            "updated_at_seconds"
+        ],
+        "aggregateMetrics": "false",
+        "nullHandlingEnabled": "true",
+        "streamConfigs": {
+            "streamType": "kafka",
+            "stream.kafka.consumer.type": "lowLevel",
+            "stream.kafka.topic.name": "region",
+            "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.avro.confluent.KafkaConfluentSchemaRegistryAvroMessageDecoder",
+            "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+            "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
+            "stream.kafka.zk.broker.url": "zookeeper:2181/",
+            "stream.kafka.broker.list": "kafka:9092",
+            "realtime.segment.flush.threshold.time": "1m",
+            "realtime.segment.flush.threshold.size": "0",
+            "realtime.segment.flush.desired.size": "1M",
+            "isolation.level": "read_committed",
+            "stream.kafka.consumer.prop.auto.offset.reset": "smallest",
+            "stream.kafka.consumer.prop.group.id": "pinot_region"
+        }
+    },
+    "metadata": {
+        "customConfigs": {}
+    }
+}

--- a/plugin/trino-pinot/src/test/resources/region_schema.json
+++ b/plugin/trino-pinot/src/test/resources/region_schema.json
@@ -1,0 +1,27 @@
+{
+    "schemaName": "region",
+    "dimensionFieldSpecs": [
+        {
+            "name": "regionkey",
+            "dataType": "LONG"
+        },
+        {
+            "name": "name",
+            "dataType": "STRING"
+        },
+        {
+            "name": "comment",
+            "dataType": "STRING"
+        }
+    ],
+    "dateTimeFieldSpecs": [
+        {
+            "name": "updated_at_seconds",
+            "dataType": "LONG",
+            "defaultNullValue": 0,
+            "format": "1:SECONDS:EPOCH",
+            "transformFunction": "toEpochSeconds(updated_at)",
+            "granularity": "1:SECONDS"
+        }
+    ]
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> This change is a refactoring to use BaseConnectorSmokeTest for AbstractPinotIntegration Test class

> This test refactoring is for Apache Pinot 

## Related issues pull requests and links

* Fixes part of #13059

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

 :white_check_mark: No documentation is needed.

## Release notes

 :white_check_mark: No release notes entries required.

```markdown
# Section
* Fix some things. ({issue}`13059`)
```
