### PR TITLE
Fix Iceberg delete with metadata filter

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1564,8 +1564,9 @@ public class IcebergMetadata
 
         RowDelta rowDelta = transaction.newRowDelta();
         table.getSnapshotId().map(icebergTable::snapshot).ifPresent(s -> rowDelta.validateFromSnapshot(s.snapshotId()));
-        if (!table.getEnforcedPredicate().isAll()) {
-            rowDelta.conflictDetectionFilter(toIcebergExpression(table.getEnforcedPredicate()));
+        TupleDomain<IcebergColumnHandle> dataColumnPredicate = table.getEnforcedPredicate().filter((column, domain) -> !isMetadataColumnId(column.getId()));
+        if (!dataColumnPredicate.isAll()) {
+            rowDelta.conflictDetectionFilter(toIcebergExpression(dataColumnPredicate));
         }
 
         IsolationLevel isolationLevel = IsolationLevel.fromName(icebergTable.properties().getOrDefault(DELETE_ISOLATION_LEVEL, DELETE_ISOLATION_LEVEL_DEFAULT));


### PR DESCRIPTION
Fix deletes with filter on a metadata column like `$path`, or
`$file_modified_time`.

This fixes
`BaseIcebergConnectorTest#testDeleteWithFileModifiedTimeColumn` which
was failing due to a logical merge conflict.
