### PR TITLE
Increase testReadMetadataWithRelationsConcurrentModifications timeout in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -288,6 +288,14 @@ public abstract class BaseIcebergConnectorTest
                 .hasMessageFindingMatch("(?s)Expecting.*to contain:.*\\Q[(" + viewName + ")]");
     }
 
+    @Override
+    @Test(timeOut = 230_000)
+    public void testReadMetadataWithRelationsConcurrentModifications()
+            throws Exception
+    {
+        testReadMetadataWithRelationsConcurrentModifications(5, 220);
+    }
+
     @Test
     public void testDecimal()
     {


### PR DESCRIPTION


The test frequently fails with timeout on CI. When run locally in
multiple threads, the previous timeout was not sufficient on my laptop.

potentially fixes https://github.com/trinodb/trino/issues/13556, or at least makes it less sever
we still should look into why it takes so long