### PR TITLE
Disable DynamicFilteringMultiJoinOnBucketedTables for broadcast join

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeDynamicPartitionPruningTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeDynamicPartitionPruningTest.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.deltalake;
 
 import com.google.common.collect.ImmutableMap;
-import io.trino.sql.planner.OptimizerConfig.JoinDistributionType;
 import io.trino.testing.BaseDynamicPartitionPruningTest;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
@@ -49,7 +48,7 @@ public class TestDeltaLakeDynamicPartitionPruningTest
     }
 
     @Override
-    public void testJoinDynamicFilteringMultiJoinOnBucketedTables(JoinDistributionType joinDistributionType)
+    public void testJoinDynamicFilteringMultiJoinOnBucketedTables()
     {
         throw new SkipException("Delta Lake does not support bucketing");
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergDynamicPartitionPruningTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergDynamicPartitionPruningTest.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.iceberg;
 
-import io.trino.sql.planner.OptimizerConfig.JoinDistributionType;
 import io.trino.testing.BaseDynamicPartitionPruningTest;
 import io.trino.testing.QueryRunner;
 import org.intellij.lang.annotations.Language;
@@ -40,7 +39,7 @@ public class TestIcebergDynamicPartitionPruningTest
     }
 
     @Override
-    public void testJoinDynamicFilteringMultiJoinOnBucketedTables(JoinDistributionType joinDistributionType)
+    public void testJoinDynamicFilteringMultiJoinOnBucketedTables()
     {
         throw new SkipException("Iceberg does not support bucketing");
     }

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseDynamicPartitionPruningTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseDynamicPartitionPruningTest.java
@@ -442,8 +442,9 @@ public abstract class BaseDynamicPartitionPruningTest
         testJoinDynamicFilteringMultiJoin(joinDistributionType, "t0_part", "t1_part", "t2_part");
     }
 
-    @Test(timeOut = 30_000, dataProvider = "joinDistributionTypes")
-    public void testJoinDynamicFilteringMultiJoinOnBucketedTables(JoinDistributionType joinDistributionType)
+    // TODO: use joinDistributionTypeProvider when https://github.com/trinodb/trino/issues/4713 is done as currently waiting for BROADCAST DFs doesn't work for bucketed tables
+    @Test(timeOut = 30_000)
+    public void testJoinDynamicFilteringMultiJoinOnBucketedTables()
     {
         assertUpdate("DROP TABLE IF EXISTS t0_bucketed");
         assertUpdate("DROP TABLE IF EXISTS t1_bucketed");
@@ -454,7 +455,7 @@ public abstract class BaseDynamicPartitionPruningTest
         assertUpdate("INSERT INTO t0_bucketed VALUES (1.0, 1), (1.0, 2)", 2);
         assertUpdate("INSERT INTO t1_bucketed VALUES (2.0, 10), (2.0, 20)", 2);
         assertUpdate("INSERT INTO t2_bucketed VALUES (3.0, 1, 1), (3.0, 2, 2)", 2);
-        testJoinDynamicFilteringMultiJoin(joinDistributionType, "t0_bucketed", "t1_bucketed", "t2_bucketed");
+        testJoinDynamicFilteringMultiJoin(PARTITIONED, "t0_bucketed", "t1_bucketed", "t2_bucketed");
     }
 
     private void testJoinDynamicFilteringMultiJoin(JoinDistributionType joinDistributionType, String t0, String t1, String t2)


### PR DESCRIPTION
Fixes https://github.com/trinodb/trino/issues/13322

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

> How would you describe this change to a non-technical end user or system administrator?

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
