### PR TITLE
Improve TestHiveConnectorTest test speed

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -185,10 +185,15 @@ public abstract class BaseHiveConnectorTest
     protected static QueryRunner createHiveQueryRunner(Map<String, String> extraProperties, Consumer<QueryRunner> additionalSetup)
             throws Exception
     {
+        // Use faster compression codec in tests. TODO remove explicit config when default changes
+        verify(new HiveConfig().getHiveCompressionCodec() == HiveCompressionOption.GZIP);
+        String hiveCompressionCodec = HiveCompressionCodec.ZSTD.name();
+
         DistributedQueryRunner queryRunner = HiveQueryRunner.builder()
                 .setExtraProperties(extraProperties)
                 .setAdditionalSetup(additionalSetup)
                 .setHiveProperties(ImmutableMap.of(
+                        "hive.compression-codec", hiveCompressionCodec,
                         "hive.allow-register-partition-procedure", "true",
                         // Reduce writer sort buffer size to ensure SortingFileWriter gets used
                         "hive.writer-sort-buffer-size", "1MB",

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
@@ -248,8 +248,10 @@ public final class HiveQueryRunner
                         .put("hive.max-initial-split-size", "10kB") // so that each bucket has multiple splits
                         .put("hive.max-split-size", "10kB") // so that each bucket has multiple splits
                         .put("hive.storage-format", "TEXTFILE") // so that there's no minimum split size for the file
-                        .put("hive.compression-codec", "NONE") // so that the file is splittable
                         .buildOrThrow();
+                hiveBucketedProperties = new HashMap<>(hiveBucketedProperties);
+                hiveBucketedProperties.put("hive.compression-codec", "NONE"); // so that the file is splittable
+
                 queryRunner.createCatalog(HIVE_CATALOG, "hive", hiveProperties);
                 queryRunner.createCatalog(HIVE_BUCKETED_CATALOG, "hive", hiveBucketedProperties);
 


### PR DESCRIPTION
Writing to tables takes about two thirds of execution time, and
compression is apparently a dominant factor. Switch
`TestHiveConnectorTest` to use ZSTD instead of default GZIP in hope this
improves test execution speed.  Very rough local testing showed about
two-digit percent improvement, but the error margin was high.
