### PR TITLE
Remove redundant singleThreaded-ness annotation from TestConnectorEventListener

### DIFF
--- a/testing/trino-tests/src/test/java/io/trino/execution/TestConnectorEventListener.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestConnectorEventListener.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 
 import static io.trino.SessionTestUtils.TEST_SESSION;
 
-@Test(singleThreaded = true)
 public class TestConnectorEventListener
 {
     private final EventsCollector generatedEvents = new EventsCollector();


### PR DESCRIPTION
The class does not seem to have any mutable state besides
`EventsCollector`, which is `@ThreadSafe` and differentiates between
queries by the query id since b370bf8f30789cb4b45affceb3c01edaaa8b2a89 (https://github.com/trinodb/trino/pull/13274).

Not related to https://github.com/trinodb/trino/issues/3364 because the class currently has single test method anyway.