### PR TITLE
Enhance timeout message in EventsAwaitingQueries

### DIFF
--- a/testing/trino-tests/src/test/java/io/trino/execution/EventsCollector.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/EventsCollector.java
@@ -139,7 +139,12 @@ final class EventsCollector
 
             boolean finished = latch.await(timeout.toMillis(), MILLISECONDS);
             if (!finished) {
-                throw new TimeoutException("Query did not complete in " + timeout);
+                synchronized (this) {
+                    TimeoutException exception = new TimeoutException("Query did not complete in %s. Currently, queryCreatedEvent=%s queryCompletedEvent=%s queryCompleteLatch=%s"
+                                    .formatted(timeout, queryCreatedEvent, queryCompletedEvent, queryCompleteLatch));
+                    failures.forEach(exception::addSuppressed);
+                    throw exception;
+                }
             }
         }
 


### PR DESCRIPTION
This is to help understand why `TestConnectorEventListener` sometimes
times out.

For https://github.com/trinodb/trino/issues/3364