### PR TITLE
Schedule source stages in sequence in FixedSourcePartitionedScheduler

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/FixedSourcePartitionedScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/FixedSourcePartitionedScheduler.java
@@ -80,8 +80,6 @@ public class FixedSourcePartitionedScheduler
 
         ArrayList<SourceScheduler> sourceSchedulers = new ArrayList<>();
 
-        boolean firstPlanNode = true;
-
         partitionIdAllocator = new PartitionIdAllocator();
         scheduledTasks = new HashMap<>();
         for (PlanNodeId planNodeId : schedulingOrder) {
@@ -101,10 +99,6 @@ public class FixedSourcePartitionedScheduler
                     scheduledTasks);
 
             sourceSchedulers.add(sourceScheduler);
-
-            if (firstPlanNode) {
-                firstPlanNode = false;
-            }
         }
         this.sourceSchedulers = new ArrayDeque<>(sourceSchedulers);
     }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/ScheduleResult.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/ScheduleResult.java
@@ -34,23 +34,6 @@ public class ScheduleResult
         WAITING_FOR_SOURCE,
         MIXED_SPLIT_QUEUES_FULL_AND_WAITING_FOR_SOURCE,
         /**/;
-
-        public BlockedReason combineWith(BlockedReason other)
-        {
-            switch (this) {
-                case WRITER_SCALING:
-                    throw new IllegalArgumentException("cannot be combined");
-                case NO_ACTIVE_DRIVER_GROUP:
-                    return other;
-                case SPLIT_QUEUES_FULL:
-                    return other == SPLIT_QUEUES_FULL || other == NO_ACTIVE_DRIVER_GROUP ? SPLIT_QUEUES_FULL : MIXED_SPLIT_QUEUES_FULL_AND_WAITING_FOR_SOURCE;
-                case WAITING_FOR_SOURCE:
-                    return other == WAITING_FOR_SOURCE || other == NO_ACTIVE_DRIVER_GROUP ? WAITING_FOR_SOURCE : MIXED_SPLIT_QUEUES_FULL_AND_WAITING_FOR_SOURCE;
-                case MIXED_SPLIT_QUEUES_FULL_AND_WAITING_FOR_SOURCE:
-                    return MIXED_SPLIT_QUEUES_FULL_AND_WAITING_FOR_SOURCE;
-            }
-            throw new IllegalArgumentException("Unknown blocked reason: " + other);
-        }
     }
 
     private final Set<RemoteTask> newTasks;

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestBucketedQueryWithManySplits.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestBucketedQueryWithManySplits.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.testng.annotations.Test;
+
+import static java.lang.String.format;
+
+public class TestBucketedQueryWithManySplits
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return HiveQueryRunner.builder()
+                .setNodeCount(1)
+                .setExtraProperties(ImmutableMap.of(
+                        "query.schedule-split-batch-size", "1",
+                        "node-scheduler.max-splits-per-node", "1",
+                        "node-scheduler.max-pending-splits-per-task", "1"))
+                .build();
+    }
+
+    @Test(timeOut = 120_000)
+    public void testBucketedQueryWithManySplits()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        queryRunner.execute("CREATE TABLE tbl_a (col bigint, bucket bigint) WITH (bucketed_by=array['bucket'], bucket_count=10)");
+        queryRunner.execute("CREATE TABLE tbl_b (col bigint, bucket bigint) WITH (bucketed_by=array['bucket'], bucket_count=10)");
+
+        for (int i = 0; i < 50; i++) {
+            queryRunner.execute(format("INSERT INTO tbl_a VALUES (%s, %s)", i, i));
+            queryRunner.execute(format("INSERT INTO tbl_b VALUES (%s, %s)", i, i));
+        }
+
+        // query should not deadlock
+        assertQuery("" +
+                        "WITH test_data AS" +
+                        "  (SELECT bucket" +
+                        "   FROM" +
+                        "     (SELECT" +
+                        "        bucket" +
+                        "      FROM tbl_a" +
+                        "      UNION ALL" +
+                        "      SELECT" +
+                        "        bucket" +
+                        "      FROM tbl_b) " +
+                        "   GROUP BY bucket) " +
+                        "SELECT COUNT(1) FROM test_data",
+                "VALUES 50");
+
+        assertUpdate("DROP TABLE tbl_a");
+        assertUpdate("DROP TABLE tbl_b");
+    }
+}


### PR DESCRIPTION
Before grouped execution was added, source stages in FixedSourcePartitionedScheduler
were scheduled in sequence. When grouped execution got removed
that logic was lost. This PR restores the logic so that
partitioned queries don't get deadlocked

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core (scheduler)

> How would you describe this change to a non-technical end user or system administrator?

Prevent queries from deadlocking which was introduced when grouped execution was removed

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

Fixes https://github.com/trinodb/trino/issues/13652

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Prevent queries on bucketed tables from deadlocking ({issue}`issuenumber`)
```
