### PR TITLE
Register catalogs with backup coordinator in DistributedQueryRunner

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
@@ -432,6 +432,7 @@ public class DistributedQueryRunner
     {
         long start = System.nanoTime();
         coordinator.createCatalog(catalogName, connectorName, properties);
+        backupCoordinator.ifPresent(backup -> backup.createCatalog(catalogName, connectorName, properties));
         log.info("Created catalog %s in %s", catalogName, nanosSince(start));
     }
 


### PR DESCRIPTION
## Description

New test catalogs were not being registered with the backup coordinator in DistributedQueryRunner.

This is simply a fix in the testing package

## Related issues, pull requests, and links

* Fixes #13658

## Documentation

(X) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(X) No release notes entries required.
( ) Release notes entries required with the following suggested text:
