### PR TITLE
Add config exchange.azure.max-error-retries

### DIFF
--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
@@ -410,7 +410,7 @@ the property may be configured for:
    * - ``exchange.s3.max-error-retries``
      - Maximum number of times the exchange manager's S3 client should retry
        a request.
-     - ``3``
+     - ``10``
      - Any S3-compatible storage
    * - ``exchange.s3.upload.part-size``
      - Part size for S3 multi-part upload.
@@ -434,6 +434,11 @@ the property may be configured for:
    * - ``exchange.azure.block-size``
      - Block size for Azure block blob parallel upload.
      - ``4MB``
+     - Azure Blob Storage
+   * - ``exchange.azure.max-error-retries``
+     - Maximum number of times the exchange manager's Azure client should
+       retry a request.
+     - ``10``
      - Azure Blob Storage
 
 It is recommended to set the ``exchange.compression-enabled`` property to

--- a/plugin/trino-exchange-filesystem/pom.xml
+++ b/plugin/trino-exchange-filesystem/pom.xml
@@ -112,6 +112,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-storage-common</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.api</groupId>
             <artifactId>gax</artifactId>
             <version>2.17.0</version>

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/azure/AzureBlobFileSystemExchangeStorage.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/azure/AzureBlobFileSystemExchangeStorage.java
@@ -27,6 +27,8 @@ import com.azure.storage.blob.models.CustomerProvidedKey;
 import com.azure.storage.blob.models.DeleteSnapshotsOptionType;
 import com.azure.storage.blob.models.ListBlobsOptions;
 import com.azure.storage.blob.specialized.BlockBlobAsyncClient;
+import com.azure.storage.common.policy.RequestRetryOptions;
+import com.azure.storage.common.policy.RetryPolicyType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Lists;
@@ -96,9 +98,10 @@ public class AzureBlobFileSystemExchangeStorage
     {
         requireNonNull(config, "config is null");
         this.blockSize = toIntExact(config.getAzureStorageBlockSize().toBytes());
-        Optional<String> connectionString = config.getAzureStorageConnectionString();
 
-        BlobServiceClientBuilder blobServiceClientBuilder = new BlobServiceClientBuilder();
+        BlobServiceClientBuilder blobServiceClientBuilder = new BlobServiceClientBuilder()
+                .retryOptions(new RequestRetryOptions(RetryPolicyType.EXPONENTIAL, config.getMaxErrorRetries(), (Integer) null, null, null, null));
+        Optional<String> connectionString = config.getAzureStorageConnectionString();
         if (connectionString.isPresent()) {
             blobServiceClientBuilder.connectionString(connectionString.get());
         }

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/azure/ExchangeAzureConfig.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/azure/ExchangeAzureConfig.java
@@ -20,6 +20,7 @@ import io.airlift.units.DataSize;
 import io.airlift.units.MaxDataSize;
 import io.airlift.units.MinDataSize;
 
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import java.util.Optional;
@@ -30,6 +31,7 @@ public class ExchangeAzureConfig
 {
     private Optional<String> azureStorageConnectionString = Optional.empty();
     private DataSize azureStorageBlockSize = DataSize.of(4, MEGABYTE);
+    private int maxErrorRetries = 10;
 
     public Optional<String> getAzureStorageConnectionString()
     {
@@ -57,6 +59,19 @@ public class ExchangeAzureConfig
     public ExchangeAzureConfig setAzureStorageBlockSize(DataSize azureStorageBlockSize)
     {
         this.azureStorageBlockSize = azureStorageBlockSize;
+        return this;
+    }
+
+    @Min(0)
+    public int getMaxErrorRetries()
+    {
+        return maxErrorRetries;
+    }
+
+    @Config("exchange.azure.max-error-retries")
+    public ExchangeAzureConfig setMaxErrorRetries(int maxErrorRetries)
+    {
+        this.maxErrorRetries = maxErrorRetries;
         return this;
     }
 }

--- a/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/azure/TestExchangeAzureConfig.java
+++ b/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/azure/TestExchangeAzureConfig.java
@@ -31,7 +31,8 @@ public class TestExchangeAzureConfig
     {
         assertRecordedDefaults(recordDefaults(ExchangeAzureConfig.class)
                 .setAzureStorageConnectionString(null)
-                .setAzureStorageBlockSize(DataSize.of(4, MEGABYTE)));
+                .setAzureStorageBlockSize(DataSize.of(4, MEGABYTE))
+                .setMaxErrorRetries(10));
     }
 
     @Test
@@ -40,11 +41,13 @@ public class TestExchangeAzureConfig
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("exchange.azure.connection-string", "connection")
                 .put("exchange.azure.block-size", "8MB")
+                .put("exchange.azure.max-error-retries", "8")
                 .buildOrThrow();
 
         ExchangeAzureConfig expected = new ExchangeAzureConfig()
                 .setAzureStorageConnectionString("connection")
-                .setAzureStorageBlockSize(DataSize.of(8, MEGABYTE));
+                .setAzureStorageBlockSize(DataSize.of(8, MEGABYTE))
+                .setMaxErrorRetries(8);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

New config

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

trino-exchange-filesystem plugin

> How would you describe this change to a non-technical end user or system administrator?

This PR allows users to configure the maximum number of request error retries fro Azure-based spooling. Default was 4, now 10.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
