### PR TITLE
Speedup analyze hive table with many partitions

### DIFF
--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -572,6 +572,14 @@ Property Name                              Description
    * - ``hive.metastore.thrift.delete-files-on-drop``
      - Actively delete the files for drop table operations, for cases when the
        metastore does not delete the files. Default is ``false``.
+   * - ``hive.metastore.thrift.update-partition-statistics.batch.enabled``
+     - Update partition statistics using Hive thrift batch API. This can be
+       used to speed up the analysis of partitioned tables. Default is ``true``.
+   * - ``hive.metastore.thrift.update-partition-statistics.batch-size``
+     - The batch size of partitions to set statistics in one thrift request.
+       If the hive metastore connection timeout occurs when analyzing partitioned
+       table, you can increase ``hive.metastore-timeout`` or decrease this configuration.
+       Default is ``30``.
 
 .. _hive-glue-metastore:
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/FailureAwareThriftMetastoreClient.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/FailureAwareThriftMetastoreClient.java
@@ -196,6 +196,13 @@ public class FailureAwareThriftMetastoreClient
     }
 
     @Override
+    public void setPartitionColumnStatisticsBatch(String databaseName, String tableName, Map<String, List<ColumnStatisticsObj>> partitionStatistics)
+            throws TException
+    {
+        runWithHandle(() -> delegate.setPartitionColumnStatisticsBatch(databaseName, tableName, partitionStatistics));
+    }
+
+    @Override
     public void deletePartitionColumnStatistics(String databaseName, String tableName, String partitionName, String columnName)
             throws TException
     {
@@ -424,6 +431,13 @@ public class FailureAwareThriftMetastoreClient
             throws TException
     {
         runWithHandle(() -> delegate.alterPartitions(dbName, tableName, partitions, writeId));
+    }
+
+    @Override
+    public void alterPartitions(String dbName, String tableName, List<Partition> partitions)
+            throws TException
+    {
+        runWithHandle(() -> delegate.alterPartitions(dbName, tableName, partitions));
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreFactory.java
@@ -42,6 +42,8 @@ public class ThriftHiveMetastoreFactory
     private final boolean deleteFilesOnDrop;
     private final boolean translateHiveViews;
     private final boolean assumeCanonicalPartitionKeys;
+    private final boolean updatePartitionStatisticsBatchEnabled;
+    private final int updatePartitionStatisticsBatchSize;
     private final ThriftMetastoreStats stats = new ThriftMetastoreStats();
 
     @Inject
@@ -66,6 +68,8 @@ public class ThriftHiveMetastoreFactory
         this.maxWaitForLock = thriftConfig.getMaxWaitForTransactionLock();
 
         this.assumeCanonicalPartitionKeys = thriftConfig.isAssumeCanonicalPartitionKeys();
+        this.updatePartitionStatisticsBatchEnabled = thriftConfig.isUpdatePartitionStatisticsBatchEnabled();
+        this.updatePartitionStatisticsBatchSize = thriftConfig.getUpdatePartitionStatisticsBatchSize();
     }
 
     @Managed
@@ -97,6 +101,8 @@ public class ThriftHiveMetastoreFactory
                 deleteFilesOnDrop,
                 translateHiveViews,
                 assumeCanonicalPartitionKeys,
+                updatePartitionStatisticsBatchEnabled,
+                updatePartitionStatisticsBatchSize,
                 stats);
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastore.java
@@ -94,6 +94,8 @@ public interface ThriftMetastore
 
     void updatePartitionStatistics(Table table, String partitionName, Function<PartitionStatistics, PartitionStatistics> update);
 
+    void updatePartitionStatistics(Table table, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates);
+
     void createRole(String role, String grantor);
 
     void dropRole(String role);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreClient.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreClient.java
@@ -96,6 +96,9 @@ public interface ThriftMetastoreClient
     void setPartitionColumnStatistics(String databaseName, String tableName, String partitionName, List<ColumnStatisticsObj> statistics)
             throws TException;
 
+    void setPartitionColumnStatisticsBatch(String databaseName, String tableName, Map<String, List<ColumnStatisticsObj>> partitionStatistics)
+            throws TException;
+
     void deletePartitionColumnStatistics(String databaseName, String tableName, String partitionName, String columnName)
             throws TException;
 
@@ -199,6 +202,9 @@ public interface ThriftMetastoreClient
             throws TException;
 
     void alterPartitions(String dbName, String tableName, List<Partition> partitions, long writeId)
+            throws TException;
+
+    void alterPartitions(String dbName, String tableName, List<Partition> partitions)
             throws TException;
 
     void addDynamicPartitions(String dbName, String tableName, List<String> partitionNames, long transactionId, long writeId, AcidOperation operation)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreConfig.java
@@ -51,6 +51,9 @@ public class ThriftMetastoreConfig
     private String trustStorePassword;
     private boolean assumeCanonicalPartitionKeys;
 
+    private boolean updatePartitionStatisticsBatchEnabled = true;
+    private int updatePartitionStatisticsBatchSize = 30;
+
     @NotNull
     public Duration getMetastoreTimeout()
     {
@@ -295,6 +298,30 @@ public class ThriftMetastoreConfig
     public ThriftMetastoreConfig setAssumeCanonicalPartitionKeys(boolean assumeCanonicalPartitionKeys)
     {
         this.assumeCanonicalPartitionKeys = assumeCanonicalPartitionKeys;
+        return this;
+    }
+
+    public boolean isUpdatePartitionStatisticsBatchEnabled()
+    {
+        return updatePartitionStatisticsBatchEnabled;
+    }
+
+    @Config("hive.metastore.thrift.update-partition-statistics.batch.enabled")
+    public ThriftMetastoreConfig setUpdatePartitionStatisticsBatchEnabled(boolean updatePartitionStatisticsBatchEnabled)
+    {
+        this.updatePartitionStatisticsBatchEnabled = updatePartitionStatisticsBatchEnabled;
+        return this;
+    }
+
+    public int getUpdatePartitionStatisticsBatchSize()
+    {
+        return updatePartitionStatisticsBatchSize;
+    }
+
+    @Config("hive.metastore.thrift.update-partition-statistics.batch-size")
+    public ThriftMetastoreConfig setUpdatePartitionStatisticsBatchSize(int updatePartitionStatisticsBatchSize)
+    {
+        this.updatePartitionStatisticsBatchSize = updatePartitionStatisticsBatchSize;
         return this;
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/InMemoryThriftMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/InMemoryThriftMetastore.java
@@ -494,6 +494,12 @@ public class InMemoryThriftMetastore
     }
 
     @Override
+    public synchronized void updatePartitionStatistics(Table table, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
+    {
+        updates.forEach((partitionName, update) -> updatePartitionStatistics(table, partitionName, update));
+    }
+
+    @Override
     public void createRole(String role, String grantor)
     {
         throw new UnsupportedOperationException();

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
@@ -233,6 +233,13 @@ public class MockThriftMetastoreClient
     }
 
     @Override
+    public void setPartitionColumnStatisticsBatch(String databaseName, String tableName, Map<String, List<ColumnStatisticsObj>> partitionStatistics)
+            throws TException
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void deletePartitionColumnStatistics(String databaseName, String tableName, String partitionName, String columnName)
     {
         throw new UnsupportedOperationException();
@@ -510,6 +517,13 @@ public class MockThriftMetastoreClient
 
     @Override
     public void alterPartitions(String dbName, String tableName, List<Partition> partitions, long writeId)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void alterPartitions(String dbName, String tableName, List<Partition> partitions)
+            throws TException
     {
         throw new UnsupportedOperationException();
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
@@ -234,9 +234,9 @@ public class MockThriftMetastoreClient
 
     @Override
     public void setPartitionColumnStatisticsBatch(String databaseName, String tableName, Map<String, List<ColumnStatisticsObj>> partitionStatistics)
-            throws TException
     {
-        throw new UnsupportedOperationException();
+        accessCount.incrementAndGet();
+        // No-op
     }
 
     @Override
@@ -523,9 +523,9 @@ public class MockThriftMetastoreClient
 
     @Override
     public void alterPartitions(String dbName, String tableName, List<Partition> partitions)
-            throws TException
     {
-        throw new UnsupportedOperationException();
+        accessCount.incrementAndGet();
+        // No-op
     }
 
     @Override

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftMetastoreConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftMetastoreConfig.java
@@ -54,7 +54,9 @@ public class TestThriftMetastoreConfig
                 .setDelegationTokenCacheMaximumSize(1000)
                 .setDeleteFilesOnDrop(false)
                 .setMaxWaitForTransactionLock(new Duration(10, MINUTES))
-                .setAssumeCanonicalPartitionKeys(false));
+                .setAssumeCanonicalPartitionKeys(false)
+                .setUpdatePartitionStatisticsBatchEnabled(true)
+                .setUpdatePartitionStatisticsBatchSize(30));
     }
 
     @Test
@@ -83,6 +85,8 @@ public class TestThriftMetastoreConfig
                 .put("hive.metastore.thrift.delete-files-on-drop", "true")
                 .put("hive.metastore.thrift.txn-lock-max-wait", "5m")
                 .put("hive.metastore.thrift.assume-canonical-partition-keys", "true")
+                .put("hive.metastore.thrift.update-partition-statistics.batch.enabled", "false")
+                .put("hive.metastore.thrift.update-partition-statistics.batch-size", "100")
                 .buildOrThrow();
 
         ThriftMetastoreConfig expected = new ThriftMetastoreConfig()
@@ -103,7 +107,9 @@ public class TestThriftMetastoreConfig
                 .setDelegationTokenCacheMaximumSize(9999)
                 .setDeleteFilesOnDrop(true)
                 .setMaxWaitForTransactionLock(new Duration(5, MINUTES))
-                .setAssumeCanonicalPartitionKeys(true);
+                .setAssumeCanonicalPartitionKeys(true)
+                .setUpdatePartitionStatisticsBatchEnabled(false)
+                .setUpdatePartitionStatisticsBatchSize(100);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

Using the following hive metastore thrift **batch** API to speedup updating partition statistics:
* `alter_partitions`
* `set_aggr_stats_for`

I have tested it on TPC-DS `web_returns` table which has 2185 partitions. When I enabled batch optimization, total duration of analyzing commit was reduced from 1415623 ms (23.6 min) to 243509 ms (4.1 min).

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

hive connector

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

* https://github.com/trinodb/trino/issues/2493
* [improve the columns stats update speed for all the partitions of a table](https://issues.apache.org/jira/browse/HIVE-7736)

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) Sufficient documentation is included in this PR.