### PR TITLE
Disallow adding not null columns in Iceberg

### DIFF
--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcConnectorTest.java
@@ -258,6 +258,12 @@ public class TestJdbcConnectorTest
     }
 
     @Override
+    protected void verifyAddNotNullColumnToNonEmptyTableFailurePermissible(Throwable e)
+    {
+        assertThat(e).hasMessageContaining("NULL not allowed for column");
+    }
+
+    @Override
     public void testAddColumnConcurrently()
     {
         // TODO: Difficult to determine whether the exception is concurrent issue or not from the error message

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeMinioConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeMinioConnectorTest.java
@@ -826,6 +826,14 @@ public abstract class BaseDeltaLakeMinioConnectorTest
     }
 
     @Override
+    public void testAddNotNullColumnToNonEmptyTable()
+    {
+        // TODO https://github.com/trinodb/trino/issues/13587 Disallow adding a new column when the table isn't empty
+        assertThatThrownBy(super::testAddNotNullColumnToNonEmptyTable)
+                .hasMessageContaining("expected [false] but found [true]");
+    }
+
+    @Override
     protected String createSchemaSql(String schemaName)
     {
         return "CREATE SCHEMA " + schemaName + " WITH (location = 's3://" + bucketName + "/" + schemaName + "')";

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1352,6 +1352,10 @@ public class IcebergMetadata
     @Override
     public void addColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnMetadata column)
     {
+        // TODO https://github.com/trinodb/trino/issues/13587 Allow NOT NULL constraint when the table is empty
+        if (!column.isNullable()) {
+            throw new TrinoException(NOT_SUPPORTED, "This connector does not support adding not null columns");
+        }
         Table icebergTable = catalog.loadTable(session, ((IcebergTableHandle) tableHandle).getSchemaTableName());
         icebergTable.updateSchema().addColumn(column.getName(), toIcebergType(column.getType()), column.getComment()).commit();
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -1104,6 +1104,19 @@ public abstract class BaseIcebergConnectorTest
         return "NULL value not allowed for NOT NULL column: " + columnName;
     }
 
+    @Override
+    public void testAddNotNullColumnToNonEmptyTable()
+    {
+        // Override because the connector supports both ADD COLUMN and NOT NULL constraint, but it doesn't support adding NOT NULL columns
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_add_notnull_col", "(a_varchar varchar)")) {
+            String tableName = table.getName();
+
+            assertQueryFails(
+                    "ALTER TABLE " + tableName + " ADD COLUMN b_varchar varchar NOT NULL",
+                    "This connector does not support adding not null columns");
+        }
+    }
+
     @Test
     public void testSchemaEvolution()
     {

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorTest.java
@@ -470,6 +470,12 @@ public abstract class BaseOracleConnectorTest
     }
 
     @Override
+    protected void verifyAddNotNullColumnToNonEmptyTableFailurePermissible(Throwable e)
+    {
+        assertThat(e).hasMessage("ORA-01758: table must be empty to add mandatory (NOT NULL) column\n");
+    }
+
+    @Override
     protected void verifyConcurrentAddColumnFailurePermissible(Exception e)
     {
         assertThat(e)

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -165,6 +165,12 @@ public class TestPostgreSqlConnectorTest
                 "(one bigint, two decimal(50,0), three varchar(10))");
     }
 
+    @Override
+    protected void verifyAddNotNullColumnToNonEmptyTableFailurePermissible(Throwable e)
+    {
+        assertThat(e).hasMessageMatching("ERROR: column \".*\" contains null values");
+    }
+
     @Test
     public void testViews()
     {

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
@@ -180,6 +180,16 @@ public abstract class BaseSqlServerConnectorTest
     }
 
     @Override
+    protected void verifyAddNotNullColumnToNonEmptyTableFailurePermissible(Throwable e)
+    {
+        assertThat(e).hasMessageMatching(
+                "ALTER TABLE only allows columns to be added that can contain nulls, " +
+                        "or have a DEFAULT definition specified, or the column being added is an identity or timestamp column, " +
+                        "or alternatively if none of the previous conditions are satisfied the table must be empty to allow addition of this column\\. " +
+                        "Column '.*' cannot be added to non-empty table '.*' because it does not satisfy these conditions\\.");
+    }
+
+    @Override
     protected void verifyConcurrentAddColumnFailurePermissible(Exception e)
     {
         assertThat(e).hasMessageContaining("was deadlocked on lock resources");


### PR DESCRIPTION
## Description

* Disallow adding not null columns in Iceberg and Delta Lake
* Add test for adding not null column in BaseConnectorTest

Relates to #13587

## Documentation

(x) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# Iceberg
* Disallow specifying `NOT NULL` constraint when adding a new column. Previously, the option was ignored. ({issue}`13673`)
```
