### PR TITLE
Fix leak in SqlQueryManager

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/SqlQueryManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlQueryManager.java
@@ -241,9 +241,11 @@ public class SqlQueryManager
             throw new TrinoException(GENERIC_INTERNAL_ERROR, format("Query %s already registered", queryExecution.getQueryId()));
         }
 
-        queryExecution.addFinalQueryInfoListener(finalQueryInfo -> {
-            // execution MUST be added to the expiration queue or there will be a leak
-            queryTracker.expireQuery(queryExecution.getQueryId());
+        queryExecution.addStateChangeListener(newState -> {
+            if (newState.isDone()) {
+                // execution MUST be added to the expiration queue or there will be a leak
+                queryTracker.expireQuery(queryExecution.getQueryId());
+            }
         });
 
         queryExecution.start();


### PR DESCRIPTION
Final query info notification is not guaranteed to be fired for FAILED state

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
A fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
the core query engine

> How would you describe this change to a non-technical end user or system administrator?
Fix memory leak

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix memory leak in qeuery manager. ({issue}`issuenumber`)
```
