### PR TITLE
Add curl as explicit dependency in Dockerfile

### DIFF
--- a/core/docker/Dockerfile
+++ b/core/docker/Dockerfile
@@ -16,7 +16,7 @@ FROM eclipse-temurin:17.0.4_8-jdk
 RUN \
     set -xeu && \
     apt-get update -q && \
-    apt-get install -y -q less python3 && \
+    apt-get install -y -q less python3 curl && \
     rm -rf /var/lib/apt/lists/* && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
     groupadd trino --gid 1000 && \


### PR DESCRIPTION
Even though the base image being used already contains curl it's useful
to be explicit about what dependencies are needed to make it easier when
migrating to a different base image.