### PR TITLE
Ensure dynamic filters are always delivered to coordinator

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
@@ -448,6 +448,7 @@ public class SqlTask
                             this::notifyStatusChanged);
                     taskHolderReference.compareAndSet(taskHolder, new TaskHolder(taskExecution));
                     needsPlan.set(false);
+                    taskExecution.start();
                 }
             }
 

--- a/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
@@ -451,10 +451,8 @@ public class SqlTask
                 }
             }
 
-            if (taskExecution != null) {
-                taskExecution.addSplitAssignments(splitAssignments);
-                taskExecution.getTaskContext().addDynamicFilter(dynamicFilterDomains);
-            }
+            taskExecution.addSplitAssignments(splitAssignments);
+            taskExecution.getTaskContext().addDynamicFilter(dynamicFilterDomains);
         }
         catch (Error e) {
             failed(e);

--- a/core/trino-main/src/main/java/io/trino/execution/SqlTaskExecutionFactory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTaskExecutionFactory.java
@@ -28,7 +28,6 @@ import io.trino.sql.planner.TypeProvider;
 import java.util.concurrent.Executor;
 
 import static com.google.common.base.Throwables.throwIfUnchecked;
-import static io.trino.execution.SqlTaskExecution.createSqlTaskExecution;
 import static java.util.Objects.requireNonNull;
 
 public class SqlTaskExecutionFactory
@@ -91,13 +90,13 @@ public class SqlTaskExecutionFactory
                 throw new RuntimeException(e);
             }
         }
-        return createSqlTaskExecution(
+        return new SqlTaskExecution(
                 taskStateMachine,
                 taskContext,
                 outputBuffer,
                 localExecutionPlan,
                 taskExecutor,
-                taskNotificationExecutor,
-                splitMonitor);
+                splitMonitor,
+                taskNotificationExecutor);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/DriverFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DriverFactory.java
@@ -16,6 +16,8 @@ package io.trino.operator;
 import com.google.common.collect.ImmutableList;
 import io.trino.sql.planner.plan.PlanNodeId;
 
+import javax.annotation.concurrent.GuardedBy;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -34,7 +36,8 @@ public class DriverFactory
     private final Optional<PlanNodeId> sourceId;
     private final OptionalInt driverInstances;
 
-    private boolean closed;
+    @GuardedBy("this")
+    private boolean noMoreDrivers;
 
     public DriverFactory(int pipelineId, boolean inputDriver, boolean outputDriver, List<OperatorFactory> operatorFactories, OptionalInt driverInstances)
     {
@@ -91,7 +94,7 @@ public class DriverFactory
 
     public synchronized Driver createDriver(DriverContext driverContext)
     {
-        checkState(!closed, "DriverFactory is already closed");
+        checkState(!noMoreDrivers, "noMoreDrivers is already set");
         requireNonNull(driverContext, "driverContext is null");
         ImmutableList.Builder<Operator> operators = ImmutableList.builder();
         for (OperatorFactory operatorFactory : operatorFactories) {
@@ -103,12 +106,17 @@ public class DriverFactory
 
     public synchronized void noMoreDrivers()
     {
-        if (closed) {
+        if (noMoreDrivers) {
             return;
         }
-        closed = true;
+        noMoreDrivers = true;
         for (OperatorFactory operatorFactory : operatorFactories) {
             operatorFactory.noMoreOperators();
         }
+    }
+
+    public synchronized boolean isNoMoreDrivers()
+    {
+        return noMoreDrivers;
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskExecution.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskExecution.java
@@ -135,14 +135,15 @@ public class TestSqlTaskExecution
                             OptionalInt.empty())),
                     ImmutableList.of(TABLE_SCAN_NODE_ID));
             TaskContext taskContext = newTestingTaskContext(taskNotificationExecutor, driverYieldExecutor, taskStateMachine);
-            SqlTaskExecution sqlTaskExecution = SqlTaskExecution.createSqlTaskExecution(
+            SqlTaskExecution sqlTaskExecution = new SqlTaskExecution(
                     taskStateMachine,
                     taskContext,
                     outputBuffer,
                     localExecutionPlan,
                     taskExecutor,
-                    taskNotificationExecutor,
-                    createTestSplitMonitor());
+                    createTestSplitMonitor(),
+                    taskNotificationExecutor);
+            sqlTaskExecution.start();
 
             //
             // test body


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

In certain scenarios dynamic filters were not getting delivered to coordinator as expected. This was causing problems with tests on CI (https://github.com/trinodb/trino/issues/13507).

The tests are configured to wait for dynamic filters indefinitely for consistency reasons. If filters are not delivered the query will never finish. 

Currently dynamic filters are delivered via `DynamicFilterFetcher`. When a `TaskStatus` contains an updated dynamic filter version the `DynamicFilterFetcher` is responsible for fetching the new dynamic filters from a worker.

In certain cases the dynamic filter version was never updated:

1. Task was getting transitioned to finished before the `LocalDynamicFilterConsumer#setPartitionCount` is set (addressed by the `Transition task to FINISHED after noMoreOperators is set` commit).
2. Task was getting blank task status due to a race in SqlTaskExecution creation (addressed by the `Update task holder before starting task execution` commit)


<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core engine

> How would you describe this change to a non-technical end user or system administrator?

`N/A`

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

https://github.com/trinodb/trino/issues/13507
https://github.com/trinodb/trino/pull/12152

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(X) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(X) No release notes entries required.
( ) Release notes entries required with the following suggested text:

