### PR TITLE
Remove redundant `iceberg.compression-codec` in product test

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg/iceberg.properties
@@ -1,3 +1,2 @@
 connector.name=iceberg
 hive.metastore.uri=thrift://hadoop-master:9083
-iceberg.compression-codec=SNAPPY

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
@@ -1277,8 +1277,8 @@ public class TestIcebergSparkCompatibility
         assertThat(onTrino().executeQuery("SHOW SESSION LIKE 'iceberg.compression_codec'"))
                 .containsOnly(row(
                         "iceberg.compression_codec",
-                        "SNAPPY",
-                        "SNAPPY",
+                        "ZSTD",
+                        "ZSTD",
                         "varchar",
                         "Compression codec to use when writing files. Possible values: " + compressionCodecs()));
     }


### PR DESCRIPTION
## Description

Remove redundant `iceberg.compression-codec` in product test

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
