### PR TITLE
Add support for table rename for delta lake with glue

### DIFF
--- a/plugin/trino-delta-lake/pom.xml
+++ b/plugin/trino-delta-lake/pom.xml
@@ -408,6 +408,7 @@
                                 <exclude>**/TestDeltaLakeCleanUpGlueMetastore.java</exclude>
                                 <exclude>**/TestDeltaLakeSharedGlueMetastoreWithTableRedirections.java</exclude>
                                 <exclude>**/TestDeltaLakeTableWithCustomLocationUsingGlueMetastore.java</exclude>
+                                <exclude>**/TestDeltaLakeRenameToWithGlueMetastore.java</exclude>
                                 <exclude>**/TestDeltaLakeGcsConnectorSmokeTest.java</exclude>
                             </excludes>
                         </configuration>
@@ -457,6 +458,7 @@
                                 <include>**/TestDeltaLakeCleanUpGlueMetastore.java</include>
                                 <include>**/TestDeltaLakeSharedGlueMetastoreWithTableRedirections.java</include>
                                 <include>**/TestDeltaLakeTableWithCustomLocationUsingGlueMetastore.java</include>
+                                <include>**/TestDeltaLakeRenameToWithGlueMetastore.java</include>
                             </includes>
                         </configuration>
                     </plugin>

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -1998,7 +1998,8 @@ public class DeltaLakeMetadata
         DeltaLakeTableHandle handle = (DeltaLakeTableHandle) tableHandle;
         Table table = metastore.getTable(handle.getSchemaName(), handle.getTableName())
                 .orElseThrow(() -> new TableNotFoundException(handle.getSchemaTableName()));
-        if (table.getTableType().equals(MANAGED_TABLE.name()) && !metastoreType.equalsIgnoreCase("glue")) {
+        if (table.getTableType().equals(MANAGED_TABLE.name()) &&
+                !(metastoreType.equalsIgnoreCase("glue") || metastoreType.equalsIgnoreCase("file"))) {
             throw new TrinoException(NOT_SUPPORTED, format("Renaming managed tables is not supported for %s metastore", metastoreType));
         }
         metastore.renameTable(session, handle.getSchemaTableName(), newTableName);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadataFactory.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadataFactory.java
@@ -22,6 +22,7 @@ import io.trino.plugin.deltalake.transactionlog.TransactionLogAccess;
 import io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointWriterManager;
 import io.trino.plugin.deltalake.transactionlog.writer.TransactionLogWriterFactory;
 import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
+import io.trino.plugin.hive.metastore.MetastoreTypeConfig;
 import io.trino.plugin.hive.metastore.cache.CachingHiveMetastore;
 import io.trino.spi.NodeManager;
 import io.trino.spi.security.ConnectorIdentity;
@@ -58,6 +59,8 @@ public class DeltaLakeMetadataFactory
     private final boolean deleteSchemaLocationsFallback;
     private final boolean useUniqueTableLocation;
 
+    private final String metastoreType;
+
     @Inject
     public DeltaLakeMetadataFactory(
             HiveMetastoreFactory hiveMetastoreFactory,
@@ -74,7 +77,8 @@ public class DeltaLakeMetadataFactory
             NodeManager nodeManager,
             CheckpointWriterManager checkpointWriterManager,
             DeltaLakeRedirectionsProvider deltaLakeRedirectionsProvider,
-            CachingExtendedStatisticsAccess statisticsAccess)
+            CachingExtendedStatisticsAccess statisticsAccess,
+            MetastoreTypeConfig metastoreTypeConfig)
     {
         this.hiveMetastoreFactory = requireNonNull(hiveMetastoreFactory, "hiveMetastore is null");
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
@@ -98,6 +102,8 @@ public class DeltaLakeMetadataFactory
         this.perTransactionMetastoreCacheMaximumSize = deltaLakeConfig.getPerTransactionMetastoreCacheMaximumSize();
         this.deleteSchemaLocationsFallback = deltaLakeConfig.isDeleteSchemaLocationsFallback();
         this.useUniqueTableLocation = deltaLakeConfig.isUniqueTableLocation();
+        requireNonNull(metastoreTypeConfig, "metastoreTypeConfig is null");
+        this.metastoreType = requireNonNull(metastoreTypeConfig.getMetastoreType(), "metastoreType is null");
     }
 
     public DeltaLakeMetadata create(ConnectorIdentity identity)
@@ -131,6 +137,7 @@ public class DeltaLakeMetadataFactory
                 deleteSchemaLocationsFallback,
                 deltaLakeRedirectionsProvider,
                 statisticsAccess,
-                useUniqueTableLocation);
+                useUniqueTableLocation,
+                metastoreType);
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -632,7 +632,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     public void testRenameTable()
     {
         assertThatThrownBy(super::testRenameTable)
-                .hasMessage("Renaming managed tables is not supported")
+                .hasMessage("Renaming managed tables is not supported for thrift metastore")
                 .hasStackTraceContaining("SQL: ALTER TABLE test_rename_");
     }
 
@@ -668,7 +668,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     public void testRenameTableAcrossSchemas()
     {
         assertThatThrownBy(super::testRenameTableAcrossSchemas)
-                .hasMessage("Renaming managed tables is not supported")
+                .hasMessage("Renaming managed tables is not supported for thrift metastore")
                 .hasStackTraceContaining("SQL: ALTER TABLE test_rename_");
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeMinioConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeMinioConnectorTest.java
@@ -312,7 +312,7 @@ public abstract class BaseDeltaLakeMinioConnectorTest
     public void testRenameTable()
     {
         assertThatThrownBy(super::testRenameTable)
-                .hasMessage("Renaming managed tables is not supported")
+                .hasMessage("Renaming managed tables is not supported for thrift metastore")
                 .hasStackTraceContaining("SQL: ALTER TABLE test_rename_");
     }
 
@@ -323,7 +323,7 @@ public abstract class BaseDeltaLakeMinioConnectorTest
     public void testRenameTableAcrossSchema()
     {
         assertThatThrownBy(super::testRenameTableAcrossSchema)
-                .hasMessage("Renaming managed tables is not supported")
+                .hasMessage("Renaming managed tables is not supported for thrift metastore")
                 .hasStackTraceContaining("SQL: ALTER TABLE test_rename_");
     }
 
@@ -331,7 +331,7 @@ public abstract class BaseDeltaLakeMinioConnectorTest
     public void testRenameTableToUnqualifiedPreservesSchema()
     {
         assertThatThrownBy(super::testRenameTableToUnqualifiedPreservesSchema)
-                .hasMessage("Renaming managed tables is not supported")
+                .hasMessage("Renaming managed tables is not supported for thrift metastore")
                 .hasStackTraceContaining("SQL: ALTER TABLE test_source_schema_");
     }
 
@@ -339,7 +339,7 @@ public abstract class BaseDeltaLakeMinioConnectorTest
     public void testRenameTableToLongTableName()
     {
         assertThatThrownBy(super::testRenameTableToLongTableName)
-                .hasMessage("Renaming managed tables is not supported")
+                .hasMessage("Renaming managed tables is not supported for thrift metastore")
                 .hasStackTraceContaining("SQL: ALTER TABLE test_rename_");
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaLakeRenameToWithGlueMetastore.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaLakeRenameToWithGlueMetastore.java
@@ -117,8 +117,30 @@ public class TestDeltaLakeRenameToWithGlueMetastore
         }
     }
 
+    @Test
+    public void testRenameOfManagedTable()
+    {
+        String oldTable = "test_table_managed_to_be_renamed_" + randomTableSuffix();
+        String newTable = "test_table_managed_renamed_" + randomTableSuffix();
+        try {
+            assertUpdate(format("CREATE TABLE %s AS SELECT 1 AS val ", oldTable), 1);
+            String oldLocation = (String) computeScalar("SELECT \"$path\" FROM " + oldTable);
+            assertQuery("SELECT val FROM " + oldTable, "VALUES (1)");
+
+            assertUpdate("ALTER TABLE " + oldTable + " RENAME TO " + newTable);
+            assertQueryReturnsEmptyResult("SHOW TABLES LIKE '" + oldTable + "'");
+            assertQuery("SELECT val FROM " + newTable, "VALUES (1)");
+            assertQuery("SELECT \"$path\" FROM " + newTable, "SELECT '" + oldLocation + "'");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + oldTable);
+            assertUpdate("DROP TABLE IF EXISTS " + newTable);
+        }
+    }
+
     @AfterClass
-    public void cleanup() {
+    public void cleanup()
+    {
         assertUpdate("DROP SCHEMA IF EXISTS " + SCHEMA);
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaLakeRenameToWithGlueMetastore.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaLakeRenameToWithGlueMetastore.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake.metastore.glue;
+
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.trino.Session;
+import io.trino.hdfs.DynamicHdfsConfiguration;
+import io.trino.hdfs.HdfsConfig;
+import io.trino.hdfs.HdfsConfigurationInitializer;
+import io.trino.hdfs.HdfsEnvironment;
+import io.trino.hdfs.authentication.NoHdfsAuthentication;
+import io.trino.plugin.deltalake.DeltaLakePlugin;
+import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.plugin.hive.metastore.glue.DefaultGlueColumnStatisticsProviderFactory;
+import io.trino.plugin.hive.metastore.glue.GlueHiveMetastore;
+import io.trino.plugin.hive.metastore.glue.GlueHiveMetastoreConfig;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Optional;
+
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static io.trino.plugin.deltalake.DeltaLakeConnectorFactory.CONNECTOR_NAME;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static java.lang.String.format;
+
+public class TestDeltaLakeRenameToWithGlueMetastore
+        extends AbstractTestQueryFramework
+{
+    protected static final String SCHEMA = "test_delta_lake_rename_to_with_glue_" + randomTableSuffix();
+    protected static final String CATALOG_NAME = "test_delta_lake_rename_to_with_glue";
+    protected File metastoreDir;
+    protected HiveMetastore metastore;
+    protected HdfsEnvironment hdfsEnvironment;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session deltaLakeSession = testSessionBuilder()
+                .setCatalog(CATALOG_NAME)
+                .setSchema(SCHEMA)
+                .build();
+
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(deltaLakeSession).build();
+
+        this.metastoreDir = new File(queryRunner.getCoordinator().getBaseDataDir().resolve("delta_lake_data").toString());
+        this.metastoreDir.deleteOnExit();
+
+        queryRunner.installPlugin(new DeltaLakePlugin());
+        queryRunner.createCatalog(
+                CATALOG_NAME,
+                CONNECTOR_NAME,
+                ImmutableMap.<String, String>builder()
+                        .put("hive.metastore", "glue")
+                        .put("hive.metastore.glue.region", "us-east-2")
+                        .put("hive.metastore.glue.default-warehouse-dir", metastoreDir.getPath())
+                        .buildOrThrow());
+
+        HdfsConfig hdfsConfig = new HdfsConfig();
+        hdfsEnvironment = new HdfsEnvironment(
+                new DynamicHdfsConfiguration(new HdfsConfigurationInitializer(hdfsConfig), ImmutableSet.of()),
+                hdfsConfig,
+                new NoHdfsAuthentication());
+        GlueHiveMetastoreConfig glueConfig = new GlueHiveMetastoreConfig()
+                .setGlueRegion("us-east-2");
+        metastore = new GlueHiveMetastore(
+                hdfsEnvironment,
+                glueConfig,
+                DefaultAWSCredentialsProviderChain.getInstance(),
+                directExecutor(),
+                new DefaultGlueColumnStatisticsProviderFactory(directExecutor(), directExecutor()),
+                Optional.empty(),
+                table -> true);
+
+        queryRunner.execute("CREATE SCHEMA " + SCHEMA + " WITH (location = '" + metastoreDir.getPath() + "')");
+        return queryRunner;
+    }
+
+    @Test
+    public void testRenameOfExternalTable()
+    {
+        String oldTable = "test_table_external_to_be_renamed_" + randomTableSuffix();
+        String newTable = "test_table_external_renamed_" + randomTableSuffix();
+        String location = metastoreDir.getAbsolutePath() + "/tableLocation/";
+        try {
+            assertUpdate(format("CREATE TABLE %s WITH (location = '%s') AS SELECT 1 AS val ", oldTable, location), 1);
+            String oldLocation = (String) computeScalar("SELECT \"$path\" FROM " + oldTable);
+            assertQuery("SELECT val FROM " + oldTable, "VALUES (1)");
+
+            assertUpdate("ALTER TABLE " + oldTable + " RENAME TO " + newTable);
+            assertQueryReturnsEmptyResult("SHOW TABLES LIKE '" + oldTable + "'");
+            assertQuery("SELECT val FROM " + newTable, "VALUES (1)");
+            assertQuery("SELECT \"$path\" FROM " + newTable, "SELECT '" + oldLocation + "'");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + oldTable);
+            assertUpdate("DROP TABLE IF EXISTS " + newTable);
+        }
+    }
+
+    @AfterClass
+    public void cleanup() {
+        assertUpdate("DROP SCHEMA IF EXISTS " + SCHEMA);
+    }
+}

--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/s3select/S3SelectTestHelper.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/s3select/S3SelectTestHelper.java
@@ -48,6 +48,7 @@ import io.trino.plugin.hive.aws.athena.PartitionProjectionService;
 import io.trino.plugin.hive.fs.FileSystemDirectoryLister;
 import io.trino.plugin.hive.metastore.HiveMetastoreConfig;
 import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
+import io.trino.plugin.hive.metastore.MetastoreTypeConfig;
 import io.trino.plugin.hive.metastore.thrift.BridgingHiveMetastore;
 import io.trino.plugin.hive.s3.HiveS3Config;
 import io.trino.plugin.hive.s3.TrinoS3ConfigurationInitializer;
@@ -150,7 +151,8 @@ public class S3SelectTestHelper
                 new DefaultHiveMaterializedViewMetadataFactory(),
                 SqlStandardAccessControlMetadata::new,
                 new FileSystemDirectoryLister(),
-                new PartitionProjectionService(this.hiveConfig, ImmutableMap.of(), new TestingTypeManager()));
+                new PartitionProjectionService(this.hiveConfig, ImmutableMap.of(), new TestingTypeManager()),
+                new MetastoreTypeConfig());
         transactionManager = new HiveTransactionManager(metadataFactory);
 
         splitManager = new HiveSplitManager(

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -371,6 +371,7 @@ public class HiveMetadata
     private final AccessControlMetadata accessControlMetadata;
     private final DirectoryLister directoryLister;
     private final PartitionProjectionService partitionProjectionService;
+    private final String metastoreType;
 
     public HiveMetadata(
             CatalogName catalogName,
@@ -394,7 +395,8 @@ public class HiveMetadata
             HiveMaterializedViewMetadata hiveMaterializedViewMetadata,
             AccessControlMetadata accessControlMetadata,
             DirectoryLister directoryLister,
-            PartitionProjectionService partitionProjectionService)
+            PartitionProjectionService partitionProjectionService,
+            String metastoreType)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.metastore = requireNonNull(metastore, "metastore is null");
@@ -418,6 +420,7 @@ public class HiveMetadata
         this.accessControlMetadata = requireNonNull(accessControlMetadata, "accessControlMetadata is null");
         this.directoryLister = requireNonNull(directoryLister, "directoryLister is null");
         this.partitionProjectionService = requireNonNull(partitionProjectionService, "partitionProjectionService is null");
+        this.metastoreType = requireNonNull(metastoreType, "metastoreType is null");
     }
 
     @Override
@@ -1263,6 +1266,9 @@ public class HiveMetadata
     @Override
     public void renameTable(ConnectorSession session, ConnectorTableHandle tableHandle, SchemaTableName newTableName)
     {
+        if (metastoreType.equalsIgnoreCase("glue")) {
+            throw new TrinoException(NOT_SUPPORTED, "Table rename is not yet supported by Glue service");
+        }
         HiveTableHandle handle = (HiveTableHandle) tableHandle;
         metastore.renameTable(handle.getSchemaName(), handle.getTableName(), newTableName.getSchemaName(), newTableName.getTableName());
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadataFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadataFactory.java
@@ -23,6 +23,7 @@ import io.trino.plugin.hive.fs.DirectoryLister;
 import io.trino.plugin.hive.fs.TransactionScopeCachingDirectoryLister;
 import io.trino.plugin.hive.metastore.HiveMetastoreConfig;
 import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
+import io.trino.plugin.hive.metastore.MetastoreTypeConfig;
 import io.trino.plugin.hive.metastore.SemiTransactionalHiveMetastore;
 import io.trino.plugin.hive.security.AccessControlMetadataFactory;
 import io.trino.plugin.hive.statistics.MetastoreHiveStatisticsProvider;
@@ -75,6 +76,7 @@ public class HiveMetadataFactory
     private final DirectoryLister directoryLister;
     private final long perTransactionFileStatusCacheMaximumSize;
     private final PartitionProjectionService partitionProjectionService;
+    private final String metastoreType;
 
     @Inject
     public HiveMetadataFactory(
@@ -96,7 +98,8 @@ public class HiveMetadataFactory
             HiveMaterializedViewMetadataFactory hiveMaterializedViewMetadataFactory,
             AccessControlMetadataFactory accessControlMetadataFactory,
             DirectoryLister directoryLister,
-            PartitionProjectionService partitionProjectionService)
+            PartitionProjectionService partitionProjectionService,
+            MetastoreTypeConfig metastoreTypeConfig)
     {
         this(
                 catalogName,
@@ -129,7 +132,8 @@ public class HiveMetadataFactory
                 accessControlMetadataFactory,
                 directoryLister,
                 hiveConfig.getPerTransactionFileStatusCacheMaximumSize(),
-                partitionProjectionService);
+                partitionProjectionService,
+                metastoreTypeConfig);
     }
 
     public HiveMetadataFactory(
@@ -163,7 +167,8 @@ public class HiveMetadataFactory
             AccessControlMetadataFactory accessControlMetadataFactory,
             DirectoryLister directoryLister,
             long perTransactionFileStatusCacheMaximumSize,
-            PartitionProjectionService partitionProjectionService)
+            PartitionProjectionService partitionProjectionService,
+            MetastoreTypeConfig metastoreTypeConfig)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.skipDeletionForAlter = skipDeletionForAlter;
@@ -203,6 +208,8 @@ public class HiveMetadataFactory
         this.directoryLister = requireNonNull(directoryLister, "directoryLister is null");
         this.perTransactionFileStatusCacheMaximumSize = perTransactionFileStatusCacheMaximumSize;
         this.partitionProjectionService = requireNonNull(partitionProjectionService, "partitionProjectionService is null");
+        requireNonNull(metastoreTypeConfig, "metastoreTypeConfig is null");
+        this.metastoreType = requireNonNull(metastoreTypeConfig.getMetastoreType(), "metastoreType is null");
     }
 
     @Override
@@ -248,6 +255,7 @@ public class HiveMetadataFactory
                 hiveMaterializedViewMetadataFactory.create(hiveMetastoreClosure),
                 accessControlMetadataFactory.create(metastore),
                 directoryLister,
-                partitionProjectionService);
+                partitionProjectionService,
+                metastoreType);
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastoreModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastoreModule.java
@@ -42,6 +42,9 @@ public class HiveMetastoreModule
     {
         if (metastore.isPresent()) {
             binder.bind(HiveMetastoreFactory.class).annotatedWith(RawHiveMetastoreFactory.class).toInstance(HiveMetastoreFactory.ofInstance(metastore.get()));
+            MetastoreTypeConfig metastoreTypeConfig = new MetastoreTypeConfig();
+            metastoreTypeConfig.setMetastoreType("provided");
+            binder.bind(MetastoreTypeConfig.class).toInstance(metastoreTypeConfig);
         }
         else {
             bindMetastoreModule("thrift", new ThriftMetastoreModule());

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -630,7 +630,50 @@ public class GlueHiveMetastore
     @Override
     public void renameTable(String databaseName, String tableName, String newDatabaseName, String newTableName)
     {
-        throw new TrinoException(NOT_SUPPORTED, "Table rename is not yet supported by Glue service");
+        boolean newTableCreated = false;
+        try {
+            GetTableRequest getTableRequest = new GetTableRequest().withDatabaseName(databaseName)
+                    .withName(tableName);
+            GetTableResult glueTable = glueClient.getTable(getTableRequest);
+            TableInput tableInput = convertGlueTableToTableInput(glueTable.getTable(), newTableName);
+            CreateTableRequest createTableRequest = new CreateTableRequest()
+                    .withDatabaseName(newDatabaseName)
+                    .withTableInput(tableInput);
+            stats.getCreateTable().call(() -> glueClient.createTable(createTableRequest));
+            newTableCreated = true;
+            dropTable(databaseName, tableName, false);
+        }
+        catch (RuntimeException e) {
+            if (newTableCreated) {
+                try {
+                    dropTable(databaseName, tableName, false);
+                }
+                catch (RuntimeException cleanupException) {
+                    if (!cleanupException.equals(e)) {
+                        e.addSuppressed(cleanupException);
+                    }
+                }
+            }
+            throw e;
+        }
+    }
+
+    private TableInput convertGlueTableToTableInput(com.amazonaws.services.glue.model.Table glueTable, String newTableName)
+    {
+        return new TableInput()
+                .withName(newTableName)
+                .withDescription(glueTable.getDescription())
+                .withOwner(glueTable.getOwner())
+                .withLastAccessTime(glueTable.getLastAccessTime())
+                .withLastAnalyzedTime(glueTable.getLastAnalyzedTime())
+                .withRetention(glueTable.getRetention())
+                .withStorageDescriptor(glueTable.getStorageDescriptor())
+                .withPartitionKeys(glueTable.getPartitionKeys())
+                .withViewOriginalText(glueTable.getViewOriginalText())
+                .withViewExpandedText(glueTable.getViewExpandedText())
+                .withTableType(glueTable.getTableType())
+                .withTargetTable(glueTable.getTargetTable())
+                .withParameters(glueTable.getParameters());
     }
 
     @Override

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -41,6 +41,7 @@ import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
 import io.trino.plugin.hive.metastore.HivePrincipal;
 import io.trino.plugin.hive.metastore.HivePrivilegeInfo;
 import io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege;
+import io.trino.plugin.hive.metastore.MetastoreTypeConfig;
 import io.trino.plugin.hive.metastore.Partition;
 import io.trino.plugin.hive.metastore.PartitionWithStatistics;
 import io.trino.plugin.hive.metastore.PrincipalPrivileges;
@@ -872,7 +873,8 @@ public abstract class AbstractTestHive
                 SqlStandardAccessControlMetadata::new,
                 countingDirectoryLister,
                 1000,
-                new PartitionProjectionService(hiveConfig, ImmutableMap.of(), new TestingTypeManager()));
+                new PartitionProjectionService(hiveConfig, ImmutableMap.of(), new TestingTypeManager()),
+                new MetastoreTypeConfig());
         transactionManager = new HiveTransactionManager(metadataFactory);
         splitManager = new HiveSplitManager(
                 transactionManager,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
@@ -40,6 +40,7 @@ import io.trino.plugin.hive.metastore.ForwardingHiveMetastore;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.HiveMetastoreConfig;
 import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
+import io.trino.plugin.hive.metastore.MetastoreTypeConfig;
 import io.trino.plugin.hive.metastore.PrincipalPrivileges;
 import io.trino.plugin.hive.metastore.StorageFormat;
 import io.trino.plugin.hive.metastore.Table;
@@ -214,7 +215,8 @@ public abstract class AbstractTestHiveFileSystem
                 new DefaultHiveMaterializedViewMetadataFactory(),
                 SqlStandardAccessControlMetadata::new,
                 new FileSystemDirectoryLister(),
-                new PartitionProjectionService(config, ImmutableMap.of(), new TestingTypeManager()));
+                new PartitionProjectionService(config, ImmutableMap.of(), new TestingTypeManager()),
+                new MetastoreTypeConfig());
         transactionManager = new HiveTransactionManager(metadataFactory);
         splitManager = new HiveSplitManager(
                 transactionManager,


### PR DESCRIPTION
## Description
> Is this change a fix, improvement, new feature, refactoring, or other?

new feature

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

a connector

> How would you describe this change to a non-technical end user or system administrator?

ALTER TABLE RENAME TO can be used with glue as a metastore for delta lake

## Related issues, pull requests, and links
Fixes: https://github.com/trinodb/trino/issues/12985

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Delta Lake
* Add support for `ALTER TABLE ... RENAME TO` statement on Glue metastore. ({issue}`12985`)
```
