### PR TITLE
Set size of remote task callbacks thread pool to be adaptive

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
@@ -23,6 +23,7 @@ import com.google.common.net.MediaType;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.concurrent.BoundedExecutor;
 import io.airlift.concurrent.SetThreadName;
 import io.airlift.http.client.FullJsonResponseHandler.JsonResponse;
 import io.airlift.http.client.HttpClient;
@@ -224,7 +225,7 @@ public final class HttpRemoteTask
             this.planFragment = planFragment;
             this.outputBuffers.set(outputBuffers);
             this.httpClient = httpClient;
-            this.executor = executor;
+            this.executor = new BoundedExecutor(executor,  Runtime.getRuntime().availableProcessors() * 2);
             this.errorScheduledExecutor = errorScheduledExecutor;
             this.maxErrorDuration = requireNonNull(maxErrorDuration, "maxErrorDuration is null");
             this.summarizeTaskInfo = summarizeTaskInfo;


### PR DESCRIPTION
We observe a limited throughput scaling with a cluster size scaling. It looks like there are some bottlenecks, this PR relaxes the one of them.  

### Setup
1 coordinator (r5.4xlarge)
40 workers (r5.4xlarge)
### Workload:

99 runs of full set tpcds_sf10
64 concurrent queries

### Before change:

average duration: 26913.5
average througput: 3.35

![image](https://user-images.githubusercontent.com/94364205/185085395-6aec55be-6caf-4bff-8048-904df5f901ed.png)

### After change:

average duration: 20168.34
average througput: 4.81

![image](https://user-images.githubusercontent.com/94364205/185086035-38f287b2-ebaa-409d-8eb5-b0692397ef15.png)

(Results comes from benchto)

It looks like that the thread pool `HttpRemoteTaskFactory.executor` is too big, especially the workload is CPU-bound. Additionally, a lot of threads causes high lock contention on `io.trino.execution.scheduler.PipelinedStageExection`'s monitor and, most probably, a lot of context switches pressure and its side effects. 

The measured throuhput after that change is 30-45% higher. 