### PR TITLE
Add table functions support to File-based access control

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AccessControlRules.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AccessControlRules.java
@@ -26,16 +26,19 @@ public class AccessControlRules
     private final List<SchemaAccessControlRule> schemaRules;
     private final List<TableAccessControlRule> tableRules;
     private final List<SessionPropertyAccessControlRule> sessionPropertyRules;
+    private final List<FunctionAccessControlRule> functionRules;
 
     @JsonCreator
     public AccessControlRules(
             @JsonProperty("schemas") Optional<List<SchemaAccessControlRule>> schemaRules,
             @JsonProperty("tables") Optional<List<TableAccessControlRule>> tableRules,
-            @JsonProperty("session_properties") @JsonAlias("sessionProperties") Optional<List<SessionPropertyAccessControlRule>> sessionPropertyRules)
+            @JsonProperty("session_properties") @JsonAlias("sessionProperties") Optional<List<SessionPropertyAccessControlRule>> sessionPropertyRules,
+            @JsonProperty("functions") Optional<List<FunctionAccessControlRule>> functionRules)
     {
         this.schemaRules = schemaRules.orElse(ImmutableList.of(SchemaAccessControlRule.ALLOW_ALL));
         this.tableRules = tableRules.orElse(ImmutableList.of(TableAccessControlRule.ALLOW_ALL));
         this.sessionPropertyRules = sessionPropertyRules.orElse(ImmutableList.of(SessionPropertyAccessControlRule.ALLOW_ALL));
+        this.functionRules = functionRules.orElse(ImmutableList.of(FunctionAccessControlRule.ALLOW_ALL));
     }
 
     public List<SchemaAccessControlRule> getSchemaRules()
@@ -53,10 +56,16 @@ public class AccessControlRules
         return sessionPropertyRules;
     }
 
+    public List<FunctionAccessControlRule> getFunctionRules()
+    {
+        return functionRules;
+    }
+
     public boolean hasRoleRules()
     {
         return schemaRules.stream().anyMatch(rule -> rule.getRoleRegex().isPresent()) ||
                 tableRules.stream().anyMatch(rule -> rule.getRoleRegex().isPresent()) ||
-                sessionPropertyRules.stream().anyMatch(rule -> rule.getRoleRegex().isPresent());
+                sessionPropertyRules.stream().anyMatch(rule -> rule.getRoleRegex().isPresent()) ||
+                functionRules.stream().anyMatch(rule -> rule.getRoleRegex().isPresent());
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/CatalogFunctionAccessControlRule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/CatalogFunctionAccessControlRule.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.security;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.plugin.base.security.FunctionAccessControlRule.FunctionPrivilege;
+import io.trino.spi.connector.CatalogSchemaRoutineName;
+import io.trino.spi.function.FunctionKind;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.trino.spi.function.FunctionKind.TABLE;
+import static java.util.Objects.requireNonNull;
+
+public class CatalogFunctionAccessControlRule
+{
+    public static final CatalogFunctionAccessControlRule ALLOW_ALL = new CatalogFunctionAccessControlRule(
+            Optional.empty(),
+            FunctionAccessControlRule.ALLOW_ALL);
+
+    private final Optional<Pattern> catalogRegex;
+    private final FunctionAccessControlRule functionAccessControlRule;
+
+    @JsonCreator
+    public CatalogFunctionAccessControlRule(
+            @JsonProperty("privileges") Set<FunctionPrivilege> privileges,
+            @JsonProperty("user") Optional<Pattern> userRegex,
+            @JsonProperty("role") Optional<Pattern> roleRegex,
+            @JsonProperty("group") Optional<Pattern> groupRegex,
+            @JsonProperty("catalog") Optional<Pattern> catalogRegex,
+            @JsonProperty("schema") Optional<Pattern> schemaRegex,
+            @JsonProperty("function") Optional<Pattern> tableFunctionRegex,
+            @JsonProperty("function_kinds") @JsonAlias("functionKinds") Set<FunctionKind> functionKinds)
+    {
+        this(catalogRegex, new FunctionAccessControlRule(privileges, userRegex, roleRegex, groupRegex, schemaRegex, tableFunctionRegex, functionKinds));
+    }
+
+    private CatalogFunctionAccessControlRule(Optional<Pattern> catalogRegex, FunctionAccessControlRule functionAccessControlRule)
+    {
+        this.catalogRegex = requireNonNull(catalogRegex, "catalogRegex is null");
+        this.functionAccessControlRule = requireNonNull(functionAccessControlRule, "functionAccessControlRule is null");
+        // TODO when every function is tied to connectors then remove this check
+        checkState(functionAccessControlRule.getFunctionKinds().equals(Set.of(TABLE)) || catalogRegex.isEmpty(), "Cannot define catalog for others function kinds than TABLE");
+    }
+
+    public boolean matches(String user, Set<String> roles, Set<String> groups, String functionName)
+    {
+        return functionAccessControlRule.matches(user, roles, groups, functionName);
+    }
+
+    public boolean matches(String user, Set<String> roles, Set<String> groups, FunctionKind functionKind, CatalogSchemaRoutineName functionName)
+    {
+        if (!catalogRegex.map(regex -> regex.matcher(functionName.getCatalogName()).matches()).orElse(true)) {
+            return false;
+        }
+        return functionAccessControlRule.matches(user, roles, groups, functionKind, functionName.getSchemaRoutineName());
+    }
+
+    Optional<AnyCatalogPermissionsRule> toAnyCatalogPermissionsRule()
+    {
+        if (functionAccessControlRule.getPrivileges().isEmpty() ||
+                // TODO when every function is tied to connectors then remove this check
+                !functionAccessControlRule.getFunctionKinds().contains(TABLE)) {
+            return Optional.empty();
+        }
+        return Optional.of(new AnyCatalogPermissionsRule(
+                functionAccessControlRule.getUserRegex(),
+                functionAccessControlRule.getRoleRegex(),
+                functionAccessControlRule.getGroupRegex(),
+                catalogRegex));
+    }
+
+    Optional<AnyCatalogSchemaPermissionsRule> toAnyCatalogSchemaPermissionsRule()
+    {
+        if (functionAccessControlRule.getPrivileges().isEmpty() ||
+                // TODO when every function is tied to connectors then remove this check
+                !functionAccessControlRule.getFunctionKinds().contains(TABLE)) {
+            return Optional.empty();
+        }
+        return Optional.of(new AnyCatalogSchemaPermissionsRule(
+                functionAccessControlRule.getUserRegex(),
+                functionAccessControlRule.getRoleRegex(),
+                functionAccessControlRule.getGroupRegex(),
+                catalogRegex,
+                functionAccessControlRule.getSchemaRegex()));
+    }
+
+    public boolean canExecuteFunction()
+    {
+        return functionAccessControlRule.canExecuteFunction();
+    }
+
+    public boolean canGrantExecuteFunction()
+    {
+        return functionAccessControlRule.canGrantExecuteFunction();
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControlRules.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControlRules.java
@@ -31,6 +31,7 @@ public class FileBasedSystemAccessControlRules
     private final Optional<List<CatalogTableAccessControlRule>> tableRules;
     private final Optional<List<SessionPropertyAccessControlRule>> sessionPropertyRules;
     private final Optional<List<CatalogSessionPropertyAccessControlRule>> catalogSessionPropertyRules;
+    private final Optional<List<CatalogFunctionAccessControlRule>> functionRules;
 
     @JsonCreator
     public FileBasedSystemAccessControlRules(
@@ -42,7 +43,8 @@ public class FileBasedSystemAccessControlRules
             @JsonProperty("schemas") Optional<List<CatalogSchemaAccessControlRule>> schemaAccessControlRules,
             @JsonProperty("tables") Optional<List<CatalogTableAccessControlRule>> tableAccessControlRules,
             @JsonProperty("system_session_properties") Optional<List<SessionPropertyAccessControlRule>> sessionPropertyRules,
-            @JsonProperty("catalog_session_properties") Optional<List<CatalogSessionPropertyAccessControlRule>> catalogSessionPropertyRules)
+            @JsonProperty("catalog_session_properties") Optional<List<CatalogSessionPropertyAccessControlRule>> catalogSessionPropertyRules,
+            @JsonProperty("functions") Optional<List<CatalogFunctionAccessControlRule>> functionRules)
     {
         this.catalogRules = catalogRules.map(ImmutableList::copyOf);
         this.queryAccessRules = queryAccessRules.map(ImmutableList::copyOf);
@@ -53,6 +55,7 @@ public class FileBasedSystemAccessControlRules
         this.tableRules = tableAccessControlRules.map(ImmutableList::copyOf);
         this.sessionPropertyRules = sessionPropertyRules.map(ImmutableList::copyOf);
         this.catalogSessionPropertyRules = catalogSessionPropertyRules.map(ImmutableList::copyOf);
+        this.functionRules = functionRules.map(ImmutableList::copyOf);
     }
 
     public Optional<List<CatalogAccessControlRule>> getCatalogRules()
@@ -98,5 +101,10 @@ public class FileBasedSystemAccessControlRules
     public Optional<List<CatalogSessionPropertyAccessControlRule>> getCatalogSessionPropertyRules()
     {
         return catalogSessionPropertyRules;
+    }
+
+    public Optional<List<CatalogFunctionAccessControlRule>> getFunctionRules()
+    {
+        return functionRules;
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FunctionAccessControlRule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FunctionAccessControlRule.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.security;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableSet;
+import io.trino.spi.connector.SchemaRoutineName;
+import io.trino.spi.function.FunctionKind;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.trino.plugin.base.security.FunctionAccessControlRule.FunctionPrivilege.EXECUTE;
+import static io.trino.plugin.base.security.FunctionAccessControlRule.FunctionPrivilege.GRANT_EXECUTE;
+import static io.trino.spi.function.FunctionKind.AGGREGATE;
+import static io.trino.spi.function.FunctionKind.SCALAR;
+import static io.trino.spi.function.FunctionKind.TABLE;
+import static io.trino.spi.function.FunctionKind.WINDOW;
+import static java.util.Objects.requireNonNull;
+
+public class FunctionAccessControlRule
+{
+    public static final FunctionAccessControlRule ALLOW_ALL = new FunctionAccessControlRule(
+            ImmutableSet.copyOf(FunctionPrivilege.values()),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            ImmutableSet.copyOf(FunctionKind.values()));
+
+    private final Set<FunctionPrivilege> privileges;
+    private final Optional<Pattern> userRegex;
+    private final Optional<Pattern> roleRegex;
+    private final Optional<Pattern> groupRegex;
+    private final Optional<Pattern> schemaRegex;
+    private final Optional<Pattern> functionRegex;
+    private final Set<FunctionKind> functionKinds;
+    private final boolean globalScopeFunctionKind;
+
+    @JsonCreator
+    public FunctionAccessControlRule(
+            @JsonProperty("privileges") Set<FunctionPrivilege> privileges,
+            @JsonProperty("user") Optional<Pattern> userRegex,
+            @JsonProperty("role") Optional<Pattern> roleRegex,
+            @JsonProperty("group") Optional<Pattern> groupRegex,
+            @JsonProperty("schema") Optional<Pattern> schemaRegex,
+            @JsonProperty("function") Optional<Pattern> functionRegex,
+            @JsonProperty("function_kinds") @JsonAlias("functionKinds") Set<FunctionKind> functionKinds)
+    {
+        this.privileges = ImmutableSet.copyOf(requireNonNull(privileges, "privileges is null"));
+        this.userRegex = requireNonNull(userRegex, "userRegex is null");
+        this.roleRegex = requireNonNull(roleRegex, "roleRegex is null");
+        this.groupRegex = requireNonNull(groupRegex, "groupRegex is null");
+        this.schemaRegex = requireNonNull(schemaRegex, "schemaRegex is null");
+        this.functionRegex = requireNonNull(functionRegex, "functionRegex is null");
+        this.functionKinds = requireNonNull(functionKinds, "functionKinds is null");
+        checkState(!functionKinds.isEmpty(), "functionKinds cannot be empty, provide at least one function kind " + Arrays.toString(FunctionKind.values()));
+        globalScopeFunctionKind = functionKinds.contains(SCALAR) || functionKinds.contains(AGGREGATE) || functionKinds.contains(WINDOW);
+        // TODO when every function is tied to connectors then remove this check
+        checkState(functionKinds.equals(Set.of(TABLE)) || schemaRegex.isEmpty(), "Cannot define schema for others function kinds than TABLE");
+    }
+
+    public boolean matches(String user, Set<String> roles, Set<String> groups, String functionName)
+    {
+        return globalScopeFunctionKind &&
+                userRegex.map(regex -> regex.matcher(user).matches()).orElse(true) &&
+                roleRegex.map(regex -> roles.stream().anyMatch(role -> regex.matcher(role).matches())).orElse(true) &&
+                groupRegex.map(regex -> groups.stream().anyMatch(group -> regex.matcher(group).matches())).orElse(true) &&
+                functionRegex.map(regex -> regex.matcher(functionName).matches()).orElse(true);
+    }
+
+    public boolean matches(String user, Set<String> roles, Set<String> groups, FunctionKind functionKind, SchemaRoutineName functionName)
+    {
+        return this.functionKinds.contains(functionKind) &&
+                userRegex.map(regex -> regex.matcher(user).matches()).orElse(true) &&
+                roleRegex.map(regex -> roles.stream().anyMatch(role -> regex.matcher(role).matches())).orElse(true) &&
+                groupRegex.map(regex -> groups.stream().anyMatch(group -> regex.matcher(group).matches())).orElse(true) &&
+                schemaRegex.map(regex -> regex.matcher(functionName.getSchemaName()).matches()).orElse(true) &&
+                functionRegex.map(regex -> regex.matcher(functionName.getRoutineName()).matches()).orElse(true);
+    }
+
+    public boolean canExecuteFunction()
+    {
+        return privileges.contains(EXECUTE) || canGrantExecuteFunction();
+    }
+
+    public boolean canGrantExecuteFunction()
+    {
+        return privileges.contains(GRANT_EXECUTE);
+    }
+
+    Optional<AnySchemaPermissionsRule> toAnySchemaPermissionsRule()
+    {
+        if (privileges.isEmpty() ||
+                // TODO when every function is tied to connectors then remove this check
+                !functionKinds.contains(TABLE)) {
+            return Optional.empty();
+        }
+        return Optional.of(new AnySchemaPermissionsRule(userRegex, roleRegex, groupRegex, schemaRegex));
+    }
+
+    Set<FunctionPrivilege> getPrivileges()
+    {
+        return privileges;
+    }
+
+    Optional<Pattern> getUserRegex()
+    {
+        return userRegex;
+    }
+
+    Optional<Pattern> getRoleRegex()
+    {
+        return roleRegex;
+    }
+
+    Optional<Pattern> getGroupRegex()
+    {
+        return groupRegex;
+    }
+
+    Optional<Pattern> getSchemaRegex()
+    {
+        return schemaRegex;
+    }
+
+    Set<FunctionKind> getFunctionKinds()
+    {
+        return functionKinds;
+    }
+
+    public enum FunctionPrivilege
+    {
+        EXECUTE, GRANT_EXECUTE
+    }
+}

--- a/lib/trino-plugin-toolkit/src/test/resources/disallow-function-rule-combination-without-table.json
+++ b/lib/trino-plugin-toolkit/src/test/resources/disallow-function-rule-combination-without-table.json
@@ -1,0 +1,16 @@
+{
+    "functions": [
+        {
+            "schema": "sample_schema",
+            "function_kinds": [
+                "SCALAR",
+                "AGGREGATE",
+                "WINDOW"
+            ],
+            "privileges": [
+                "EXECUTE",
+                "GRANT_EXECUTE"
+            ]
+        }
+    ]
+}

--- a/lib/trino-plugin-toolkit/src/test/resources/disallow-function-rule-combination.json
+++ b/lib/trino-plugin-toolkit/src/test/resources/disallow-function-rule-combination.json
@@ -1,0 +1,17 @@
+{
+    "functions": [
+        {
+            "schema": "sample_schema",
+            "function_kinds": [
+                "SCALAR",
+                "AGGREGATE",
+                "WINDOW",
+                "TABLE"
+            ],
+            "privileges": [
+                "EXECUTE",
+                "GRANT_EXECUTE"
+            ]
+        }
+    ]
+}

--- a/lib/trino-plugin-toolkit/src/test/resources/empty-functions-kind.json
+++ b/lib/trino-plugin-toolkit/src/test/resources/empty-functions-kind.json
@@ -1,0 +1,12 @@
+{
+    "functions": [
+        {
+            "function_kinds": [
+            ],
+            "privileges": [
+                "EXECUTE",
+                "GRANT_EXECUTE"
+            ]
+        }
+    ]
+}

--- a/lib/trino-plugin-toolkit/src/test/resources/file-based-disallow-function-rule-combination-without-table.json
+++ b/lib/trino-plugin-toolkit/src/test/resources/file-based-disallow-function-rule-combination-without-table.json
@@ -1,0 +1,16 @@
+{
+    "functions": [
+        {
+            "catalog": "sample_catalog",
+            "function_kinds": [
+                "SCALAR",
+                "AGGREGATE",
+                "WINDOW"
+            ],
+            "privileges": [
+                "EXECUTE",
+                "GRANT_EXECUTE"
+            ]
+        }
+    ]
+}

--- a/lib/trino-plugin-toolkit/src/test/resources/file-based-disallow-function-rule-combination.json
+++ b/lib/trino-plugin-toolkit/src/test/resources/file-based-disallow-function-rule-combination.json
@@ -1,0 +1,17 @@
+{
+    "functions": [
+        {
+            "catalog": "sample_catalog",
+            "function_kinds": [
+                "SCALAR",
+                "AGGREGATE",
+                "TABLE",
+                "WINDOW"
+            ],
+            "privileges": [
+                "EXECUTE",
+                "GRANT_EXECUTE"
+            ]
+        }
+    ]
+}

--- a/lib/trino-plugin-toolkit/src/test/resources/file-based-system-access-visibility.json
+++ b/lib/trino-plugin-toolkit/src/test/resources/file-based-system-access-visibility.json
@@ -37,6 +37,11 @@
         {
             "catalog": ".*session.*",
             "allow": "read-only"
+        },
+        {
+            "user": "alice",
+            "catalog": "ptf-catalog",
+            "allow": "all"
         }
     ],
     "schemas": [
@@ -118,6 +123,34 @@
             "catalog": "bob-catalog-session",
             "property": "safe",
             "allow": true
+        }
+    ],
+    "functions": [
+        {
+            "user": "alice",
+            "catalog": "ptf-catalog",
+            "schema": "ptf_schema",
+            "function_kinds": [
+                "TABLE"
+            ],
+            "function": "some_table_function",
+            "privileges": [
+                "EXECUTE",
+                "GRANT_EXECUTE"
+            ]
+        },
+        {
+            "user": "bob",
+            "function_kinds": [
+                "SCALAR",
+                "AGGREGATE",
+                "WINDOW"
+            ],
+            "function": "some_function",
+            "privileges": [
+                "EXECUTE",
+                "GRANT_EXECUTE"
+            ]
         }
     ]
 }

--- a/lib/trino-plugin-toolkit/src/test/resources/file-based-system-no-access.json
+++ b/lib/trino-plugin-toolkit/src/test/resources/file-based-system-no-access.json
@@ -2,5 +2,7 @@
   "schemas": [
   ],
   "tables": [
+  ],
+  "functions": [
   ]
 }

--- a/lib/trino-plugin-toolkit/src/test/resources/no-access.json
+++ b/lib/trino-plugin-toolkit/src/test/resources/no-access.json
@@ -2,5 +2,7 @@
   "schemas": [
   ],
   "tables": [
+  ],
+  "functions": [
   ]
 }

--- a/lib/trino-plugin-toolkit/src/test/resources/visibility.json
+++ b/lib/trino-plugin-toolkit/src/test/resources/visibility.json
@@ -45,5 +45,32 @@
                 "SELECT"
             ]
         }
+    ],
+    "functions": [
+        {
+            "user": "alice",
+            "schema": "ptf_schema",
+            "function_kinds": [
+                "TABLE"
+            ],
+            "function": "some_table_function",
+            "privileges": [
+                "EXECUTE",
+                "GRANT_EXECUTE"
+            ]
+        },
+        {
+            "user": "bob",
+            "function_kinds": [
+                "SCALAR",
+                "AGGREGATE",
+                "WINDOW"
+            ],
+            "function": "some_function",
+            "privileges": [
+                "EXECUTE",
+                "GRANT_EXECUTE"
+            ]
+        }
     ]
 }

--- a/testing/trino-tests/src/test/java/io/trino/security/TestFunctionsInViewsWithFileBasedSystemAccessControl.java
+++ b/testing/trino-tests/src/test/java/io/trino/security/TestFunctionsInViewsWithFileBasedSystemAccessControl.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.security;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.trino.Session;
+import io.trino.connector.MockConnectorFactory;
+import io.trino.connector.MockConnectorPlugin;
+import io.trino.connector.TestingTableFunctions;
+import io.trino.plugin.base.security.FileBasedSystemAccessControl;
+import io.trino.plugin.blackhole.BlackHolePlugin;
+import io.trino.spi.connector.TableFunctionApplicationResult;
+import io.trino.spi.security.Identity;
+import io.trino.spi.security.SystemAccessControl;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.google.common.io.Resources.getResource;
+import static io.trino.plugin.base.security.FileBasedAccessControlConfig.SECURITY_CONFIG_FILE;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+
+public class TestFunctionsInViewsWithFileBasedSystemAccessControl
+        extends AbstractTestQueryFramework
+{
+    public static final Session ALICE_USER = user("alice"); // can create views && can query views && can execute and grant execute functions
+    public static final Session BOB_USER = user("bob"); // can create views && can query views && can execute functions
+    public static final Session CHARLIE_USER = user("charlie"); // can query views
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        String securityConfigFile = getResource("file-based-system-functions-access.json").getPath();
+        SystemAccessControl accessControl = new FileBasedSystemAccessControl.Factory().create(ImmutableMap.of(SECURITY_CONFIG_FILE, securityConfigFile));
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(testSessionBuilder()
+                        .setCatalog(Optional.empty())
+                        .setSchema(Optional.empty())
+                        .build())
+                .setNodeCount(1)
+                .setSystemAccessControl(accessControl)
+                .build();
+        queryRunner.installPlugin(new BlackHolePlugin());
+        queryRunner.createCatalog("blackhole", "blackhole");
+        queryRunner.installPlugin(new MockConnectorPlugin(MockConnectorFactory.builder()
+                .withTableFunctions(ImmutableSet.of(new TestingTableFunctions.SimpleTableFunction()))
+                .withApplyTableFunction((session, handle) -> {
+                    if (handle instanceof TestingTableFunctions.SimpleTableFunction.SimpleTableFunctionHandle functionHandle) {
+                        return Optional.of(new TableFunctionApplicationResult<>(functionHandle.getTableHandle(), functionHandle.getTableHandle().getColumns().orElseThrow()));
+                    }
+                    throw new IllegalStateException("Unsupported table function handle: " + handle.getClass().getSimpleName());
+                })
+                .build()));
+        queryRunner.createCatalog("mock", "mock");
+        return queryRunner;
+    }
+
+    @Test
+    public void testPtfSecurityDefinerViewCreatedByAlice()
+    {
+        assertQuerySucceeds(ALICE_USER, "CREATE VIEW blackhole.default.view_ptf_alice_security_definer SECURITY DEFINER AS SELECT * FROM TABLE(mock.system.simple_table_function())");
+        String securityDefinerQuery = "SELECT * FROM blackhole.default.view_ptf_alice_security_definer";
+        assertQuerySucceeds(ALICE_USER, securityDefinerQuery);
+        assertQuerySucceeds(BOB_USER, securityDefinerQuery);
+        assertQuerySucceeds(CHARLIE_USER, securityDefinerQuery);
+    }
+
+    @Test
+    public void testPtfSecurityInvokerViewCreatedByAlice()
+    {
+        assertQuerySucceeds(ALICE_USER, "CREATE VIEW blackhole.default.view_ptf_alice_security_invoker SECURITY INVOKER AS SELECT * FROM TABLE(mock.system.simple_table_function())");
+        String securityInvokerQuery = "SELECT * FROM blackhole.default.view_ptf_alice_security_invoker";
+        assertQuerySucceeds(ALICE_USER, securityInvokerQuery);
+        assertQuerySucceeds(BOB_USER, securityInvokerQuery);
+        assertAccessDenied(CHARLIE_USER, securityInvokerQuery, "Cannot access catalog mock");
+    }
+
+    @Test
+    public void testFunctionSecurityDefinerViewCreatedByAlice()
+    {
+        assertQuerySucceeds(ALICE_USER, "CREATE VIEW blackhole.default.view_function_alice_security_definer SECURITY DEFINER AS SELECT now() AS t");
+        String securityDefinerQuery = "SELECT * FROM blackhole.default.view_function_alice_security_definer";
+        assertQuerySucceeds(ALICE_USER, securityDefinerQuery);
+        assertQuerySucceeds(BOB_USER, securityDefinerQuery);
+        assertQuerySucceeds(CHARLIE_USER, securityDefinerQuery);
+    }
+
+    @Test
+    public void testFunctionSecurityInvokerViewCreatedByAlice()
+    {
+        assertQuerySucceeds(ALICE_USER, "CREATE VIEW blackhole.default.view_function_alice_security_invoker SECURITY INVOKER AS SELECT now() AS t");
+        String securityInvokerQuery = "SELECT * FROM blackhole.default.view_function_alice_security_invoker";
+        assertQuerySucceeds(ALICE_USER, securityInvokerQuery);
+        assertQuerySucceeds(BOB_USER, securityInvokerQuery);
+        assertAccessDenied(CHARLIE_USER, securityInvokerQuery, "Cannot execute function now");
+    }
+
+    @Test
+    public void testPtfSecurityDefinerViewCreatedByBob()
+    {
+        assertQuerySucceeds(BOB_USER, "CREATE VIEW blackhole.default.view_ptf_bob_security_definer SECURITY DEFINER AS SELECT * FROM TABLE(mock.system.simple_table_function())");
+        String securityDefinerQuery = "SELECT * FROM blackhole.default.view_ptf_bob_security_definer";
+        assertAccessDenied(ALICE_USER, securityDefinerQuery, "View owner does not have sufficient privileges: 'bob' cannot grant 'mock\\.system\\.simple_table_function' execution to user 'alice'");
+        assertQuerySucceeds(BOB_USER, securityDefinerQuery);
+        assertAccessDenied(CHARLIE_USER, securityDefinerQuery, "View owner does not have sufficient privileges: 'bob' cannot grant 'mock\\.system\\.simple_table_function' execution to user 'charlie'");
+    }
+
+    @Test
+    public void testPtfSecurityInvokerViewCreatedByBob()
+    {
+        assertQuerySucceeds(BOB_USER, "CREATE VIEW blackhole.default.view_ptf_bob_security_invoker SECURITY INVOKER AS SELECT * FROM TABLE(mock.system.simple_table_function())");
+        String securityInvokerQuery = "SELECT * FROM blackhole.default.view_ptf_bob_security_invoker";
+        assertQuerySucceeds(ALICE_USER, securityInvokerQuery);
+        assertQuerySucceeds(BOB_USER, securityInvokerQuery);
+        assertAccessDenied(CHARLIE_USER, securityInvokerQuery, "Cannot access catalog mock");
+    }
+
+    @Test
+    public void testFunctionSecurityDefinerViewCreatedByBob()
+    {
+        assertQuerySucceeds(BOB_USER, "CREATE VIEW blackhole.default.view_function_bob_security_definer SECURITY DEFINER AS SELECT now() AS t");
+        String securityDefinerQuery = "SELECT * FROM blackhole.default.view_function_bob_security_definer";
+        assertAccessDenied(ALICE_USER, securityDefinerQuery, "View owner does not have sufficient privileges: 'bob' cannot grant 'now' execution to user 'alice'");
+        assertQuerySucceeds(BOB_USER, securityDefinerQuery);
+        assertAccessDenied(CHARLIE_USER, securityDefinerQuery, "View owner does not have sufficient privileges: 'bob' cannot grant 'now' execution to user 'charlie'");
+    }
+
+    @Test
+    public void testFunctionSecurityInvokerViewCreatedByBob()
+    {
+        assertQuerySucceeds(BOB_USER, "CREATE VIEW blackhole.default.view_function_bob_security_invoker SECURITY INVOKER AS SELECT now() AS t");
+        String securityInvokerQuery = "SELECT * FROM blackhole.default.view_function_bob_security_invoker";
+        assertQuerySucceeds(ALICE_USER, securityInvokerQuery);
+        assertQuerySucceeds(BOB_USER, securityInvokerQuery);
+        assertAccessDenied(CHARLIE_USER, securityInvokerQuery, "Cannot execute function now");
+    }
+
+    private static Session user(String user)
+    {
+        return testSessionBuilder()
+                .setIdentity(Identity.ofUser(user))
+                .build();
+    }
+}

--- a/testing/trino-tests/src/test/resources/file-based-system-functions-access.json
+++ b/testing/trino-tests/src/test/resources/file-based-system-functions-access.json
@@ -1,0 +1,85 @@
+{
+    "catalogs": [
+        {
+            "user": "alice|bob",
+            "catalog": "blackhole|mock",
+            "allow": "all"
+        },
+        {
+            "user": "charlie",
+            "catalog": "blackhole",
+            "allow": "read-only"
+        }
+    ],
+    "tables": [
+        {
+            "user": "alice|bob",
+            "catalog": "blackhole",
+            "schema": "default",
+            "table": "view_.*",
+            "privileges": [
+                "SELECT",
+                "OWNERSHIP"
+            ]
+        },
+        {
+            "user": "charlie",
+            "catalog": "blackhole",
+            "schema": "default",
+            "table": "view_.*",
+            "privileges": [
+                "SELECT"
+            ]
+        }
+    ],
+    "functions": [
+        {
+            "user": "alice",
+            "function_kinds": [
+                "SCALAR",
+                "AGGREGATE",
+                "WINDOW"
+            ],
+            "privileges": [
+                "EXECUTE",
+                "GRANT_EXECUTE"
+            ]
+        },
+        {
+            "user": "alice",
+            "catalog": "mock",
+            "schema": "system",
+            "function": "simple_table_function",
+            "function_kinds": [
+                "TABLE"
+            ],
+            "privileges": [
+                "EXECUTE",
+                "GRANT_EXECUTE"
+            ]
+        },
+        {
+            "user": "bob",
+            "function_kinds": [
+                "SCALAR",
+                "AGGREGATE",
+                "WINDOW"
+            ],
+            "privileges": [
+                "EXECUTE"
+            ]
+        },
+        {
+            "user": "bob",
+            "catalog": "mock",
+            "schema": "system",
+            "function": "simple_table_function",
+            "function_kinds": [
+                "TABLE"
+            ],
+            "privileges": [
+                "EXECUTE"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Description

This PR adds File-based access control support for table functions.
Before this PR with File-based access control enabled every table functions was denied.

By default every rule kind (access to catalogs, schemas, tables) is allow when user does not specify any rule.
The same behavior is also here. **After upgrading Trino to newer version and without making any changes to access rules, access to every table function will change and by default it will be `allow`.** To restore previous behavior user needs to add:
```
{
    "functions": [
        {
            "function_kinds": [
                "SCALAR",
                "AGGREGATE",
                "WINDOW"
            ],
            "privileges": [
                "EXECUTE",
                "GRANT_EXECUTE"
            ]
        },
        {
            "function_kinds": [
                "TABLE"
            ],
            "privileges": []
        }
    ]
}
```

Examples System-level access control file
1. Allow `postgresql.system.query` for `admin` user.
```
{
    "functions": [
        {
            "function_kinds": [
                "SCALAR",
                "AGGREGATE",
                "WINDOW"
            ],
            "privileges": [
                "EXECUTE",
                "GRANT_EXECUTE"
            ]
        },
        {
            "user": "admin",
            "catalog": "postgresql",
            "schema": "system",
            "function_kinds": [
                "TABLE"
            ],
            "function": "query",
            "privileges": [
                "EXECUTE",
                "GRANT_EXECUTE"
            ]
        }
    ]
}
```

2. Allow `query` table function from every catalog & schema for `admin` user.
```
{
    "functions": [
        {
            "function_kinds": [
                "SCALAR",
                "AGGREGATE",
                "WINDOW"
            ],
            "privileges": [
                "EXECUTE",
                "GRANT_EXECUTE"
            ]
        },
        {
            "user": "admin",
            "function_kinds": [
                "TABLE"
            ],
            "function": "query",
            "privileges": [
                "EXECUTE",
                "GRANT_EXECUTE"
            ]
        }
    ]
}
```

3. Deny `mysql.system.query` for anyone.
```
{
    "functions": [
        {
            "function_kinds": [
                "SCALAR",
                "AGGREGATE",
                "WINDOW"
            ],
            "privileges": [
                "EXECUTE",
                "GRANT_EXECUTE"
            ]
        },
        {
            "catalog": "mysql",
            "schema": "system",
            "function_kinds": [
                "TABLE"
            ],
            "function": "query",
            "privileges": []
        }
    ]
}
```

- Possible `privileges` values: `EXECUTE` and `GRANT_EXECUTE` - the second one allows to execute a function from `SECURITY DEFINER` view
- Possible `function_kinds` values: `SCALAR`, `AGGREGATE`, `WINDOW` and `TABLES`, it's required to provide at least one value, also when user define a rule for `AGGREGATE`, `SCALAR` or `WINDOW` function, `catalog` and `schema` are disallowed

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
(x) Documentation PR is available with #13713.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Section
* Add support for PTF in File-based access control. ({issue}`13713`)
```
