### PR TITLE
Ensure memory is freed in SpoolingExchangeOutputBuffer

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/buffer/SpoolingExchangeOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/SpoolingExchangeOutputBuffer.java
@@ -203,7 +203,7 @@ public class SpoolingExchangeOutputBuffer
                 stateMachine.finish();
             }
             exchangeSink = null;
-            updateMemoryUsage(0);
+            forceFreeMemory();
         });
     }
 
@@ -234,7 +234,7 @@ public class SpoolingExchangeOutputBuffer
                 log.warn(failure, "Error aborting exchange sink");
             }
             exchangeSink = null;
-            updateMemoryUsage(0);
+            forceFreeMemory();
         });
     }
 
@@ -269,6 +269,14 @@ public class SpoolingExchangeOutputBuffer
             if (peakMemoryUsage.compareAndSet(currentValue, bytes)) {
                 return;
             }
+        }
+    }
+
+    private void forceFreeMemory()
+    {
+        LocalMemoryContext context = getSystemMemoryContextOrNull();
+        if (context != null) {
+            context.close();
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

Close memory context to prevent race condition when memory is reserved
in enqueuePage after output buffer destroy following the pattern used in
other output buffers

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core engine

> How would you describe this change to a non-technical end user or system administrator?

`N/A`

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

https://github.com/trinodb/trino/issues/13362

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(X) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(X) No release notes entries required.
( ) Release notes entries required with the following suggested text:

