### PR TITLE
Remove launcher help and debug output from documentation

### DIFF
--- a/docs/src/main/sphinx/installation/deployment.rst
+++ b/docs/src/main/sphinx/installation/deployment.rst
@@ -314,49 +314,8 @@ A number of additional options allow you to specify configuration file and
 directory locations, as well as Java options. Run the launcher with ``--help``
 to see the supported commands and command line options.
 
-.. code-block:: text
-
-   --etc-dir=DIR             Defaults to INSTALL_PATH/etc
-   --launcher-config=FILE    Defaults to INSTALL_PATH/bin/launcher.properties
-   --node-config=FILE        Defaults to ETC_DIR/node.properties
-   --jvm-config=FILE         Defaults to ETC_DIR/jvm.config
-   --config=FILE             Defaults to ETC_DIR/config.properties
-   --log-levels-file=FILE    Defaults to ETC_DIR/log.properties
-   --data-dir=DIR            Defaults to INSTALL_PATH
-   --pid-file=FILE           Defaults to DATA_DIR/var/run/launcher.pid
-   --launcher-log-file=FILE  Defaults to DATA_DIR/var/log/launcher.log (only in
-                             daemon mode)
-   --server-log-file=FILE    Defaults to DATA_DIR/var/log/server.log (only in
-                             daemon mode)
-   -J OPT                    Set a JVM option
-   -D NAME=VALUE             Set a Java system property
-
 The ``-v`` or ``--verbose`` option for each command prepends the server's
-current settings before the command's usual output. For example, you can check
-the status and launcher configuration of a Trino installation in ``/opt/trino``
-and get output similar to the following:
-
-.. code-block:: text
-
-    $ cd /opt/trino
-    $ bin/launcher -v status
-    config_path     = /opt/trino/etc/config.properties
-    data_dir        = /opt/trino
-    etc_dir         = /opt/trino/etc
-    install_path    = /opt/trino
-    jvm_config      = /opt/trino/etc/jvm.config
-    jvm_options     = []
-    launcher_config = /opt/trino/bin/launcher.properties
-    launcher_log    = /opt/trino/var/log/launcher.log
-    log_levels      = /opt/trino/etc/log.properties
-    log_levels_set  = False
-    node_config     = /opt/trino/etc/node.properties
-    pid_file        = /opt/trino/var/run/launcher.pid
-    properties      = {'node.environment': 'demo'}
-    server_log      = /opt/trino/var/log/server.log
-    verbose         = True
-
-    Not running
+current settings before the command's usual output.
 
 Trino can be started as a daemon by running the following:
 


### PR DESCRIPTION
These are distracting and not useful for most users. Advanced users who want to customize the installation can run the help or verbose options to see the output.
