### PR TITLE
Fix extension point in IcebergPageSourceProvider

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -1359,7 +1359,7 @@ public class IcebergPageSourceProvider
         return new TrinoException(ICEBERG_CURSOR_ERROR, format("Failed to read ORC file: %s", dataSourceId), exception);
     }
 
-    private static final class ReaderPageSourceWithRowPositions
+    public static final class ReaderPageSourceWithRowPositions
     {
         private final ReaderPageSource readerPageSource;
         private final Optional<Long> startRowPosition;


### PR DESCRIPTION
## Description

`createDataPageSource` is an extension point for the page source provider, so its return type should not be private.

> Is this change a fix, improvement, new feature, refactoring, or other?

Refactoring

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Iceberg connector

> How would you describe this change to a non-technical end user or system administrator?

Allows for extending the features of the Iceberg connector

## Related issues, pull requests, and links

Extension point added by https://github.com/trinodb/trino/pull/13378

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text: