### PR TITLE
Ensure operators are always closed

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/Driver.java
+++ b/core/trino-main/src/main/java/io/trino/operator/Driver.java
@@ -48,6 +48,7 @@ import java.util.function.Supplier;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.throwIfUnchecked;
+import static com.google.common.base.Verify.verify;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.trino.operator.Operator.NOT_BLOCKED;
@@ -698,22 +699,21 @@ public class Driver
             return Optional.empty();
         }
 
-        Optional<T> result;
+        T result = null;
+        Throwable failure = null;
+
         try {
-            result = Optional.of(task.get());
+            result = task.get();
+
+            // opportunistic check to avoid unnecessary lock reacquisition
+            processNewSources();
+            destroyIfNecessary();
+        }
+        catch (Throwable t) {
+            failure = t;
         }
         finally {
-            try {
-                try {
-                    processNewSources();
-                }
-                finally {
-                    destroyIfNecessary();
-                }
-            }
-            finally {
-                exclusiveLock.unlock();
-            }
+            exclusiveLock.unlock();
         }
 
         // If there are more assignment updates available, attempt to reacquire the lock and process them.
@@ -727,8 +727,25 @@ public class Driver
                 try {
                     processNewSources();
                 }
-                finally {
+                catch (Throwable t) {
+                    if (failure == null) {
+                        failure = t;
+                    }
+                    else if (failure != t) {
+                        failure.addSuppressed(t);
+                    }
+                }
+
+                try {
                     destroyIfNecessary();
+                }
+                catch (Throwable t) {
+                    if (failure == null) {
+                        failure = t;
+                    }
+                    else if (failure != t) {
+                        failure.addSuppressed(t);
+                    }
                 }
             }
             finally {
@@ -736,7 +753,14 @@ public class Driver
             }
         }
 
-        return result;
+        if (failure != null) {
+            throwIfUnchecked(failure);
+            // should never happen
+            throw new AssertionError(failure);
+        }
+
+        verify(result != null, "result is null");
+        return Optional.of(result);
     }
 
     private static class DriverLock


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

Due to a race condition in Driver#tryWithLock there was a chance an
operator might have end up not being properly closed upon completion.

- Driver#process executes an operator under the Driver#exclusiveLock
- An operator throws an exception and triggers a task failure
- A TaskStateMachine listener closes all drivers calling Driver#close
- Driver#close is not able to acquire the Driver#exclusiveLock and
  assumes the driver will be terminated by the lock owner
- The lock owner throws an exception and never runs post
  execution code in Driver#tryWithLock that was expected to close
  the operators

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core engine

> How would you describe this change to a non-technical end user or system administrator?

`N/A`

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

https://github.com/trinodb/trino/issues/11275

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(X) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(X) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
