### PR TITLE
Fix running all ES plugin tests in the same JVM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -418,7 +418,6 @@ jobs:
             - { modules: plugin/trino-hive }
             - { modules: plugin/trino-hive, profile: test-parquet }
             - { modules: plugin/trino-elasticsearch }
-            - { modules: plugin/trino-elasticsearch, profile: test-stats }
             - { modules: plugin/trino-mongodb }
             - { modules: plugin/trino-kafka }
             - { modules: plugin/trino-pinot }

--- a/plugin/trino-elasticsearch/pom.xml
+++ b/plugin/trino-elasticsearch/pom.xml
@@ -400,48 +400,4 @@
             </plugins>
         </pluginManagement>
     </build>
-
-    <profiles>
-        <profile>
-            <id>default</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludes>
-                                <!-- You can only bind one statistics bean per JVM, otherwise you'll see problems with statistics being 0 despite backpressure handling -->
-                                <!-- This test should be run in isolation, to avoid the possibility of some other test also registering statistic beans -->
-                                <exclude>**/TestElasticsearchBackpressure*</exclude>
-                            </excludes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>test-stats</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <includes>
-                                <include>**/TestElasticsearchBackpressure*</include>
-                            </includes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearchBackpressure.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearchBackpressure.java
@@ -50,7 +50,9 @@ public class TestElasticsearchBackpressure
                 ImmutableMap.of(),
                 // This test can only run on a single node, otherwise each node exports its own stats beans and they override each other
                 // You can only bind one such bean per JVM, so this causes problems with statistics being 0 despite backpressure handling
-                1);
+                1,
+                // Use a unique catalog name to make sure JMX stats beans are unique and not affected by other tests
+                "elasticsearch-backpressure");
     }
 
     @AfterClass(alwaysRun = true)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Test `io.trino.plugin.elasticsearch.TestElasticsearchBackpressure` is currently being run in a separate CI job, because the JMX stats bean that is used verify backpressure would be overriden by other tests.

To make this test work with all the others, we can rename the elasticsearch catalog in this test to a unique name, so that the JMX bean receives a unique name.

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Tests of Elasticsearch connector

> How would you describe this change to a non-technical end user or system administrator?

N/A

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text: