### PR TITLE
Avoid retaining LocalExecutionPlanContext for collecting DF domains

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -3164,7 +3164,7 @@ public class LocalExecutionPlanner
             return new PhysicalOperation(operator, outputMappings, context, probeSource);
         }
 
-        private Set<DynamicFilterId> getCoordinatorDynamicFilters(Set<DynamicFilterId> dynamicFilters, PlanNode node, TaskId taskId)
+        private static Set<DynamicFilterId> getCoordinatorDynamicFilters(Set<DynamicFilterId> dynamicFilters, PlanNode node, TaskId taskId)
         {
             if (!isBuildSideReplicated(node) || taskId.getPartitionId() == 0) {
                 // replicated dynamic filters are collected by single stage task only


### PR DESCRIPTION
## Description

Avoid retaining LocalExecutionPlanContext for collecting DF domains

> Is this change a fix, improvement, new feature, refactoring, or other?

improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core query engine
> How would you describe this change to a non-technical end user or system administrator?

minor internal refactoring 

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text: