### PR TITLE
Update build requirements to Java 17 in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ information about reporting vulnerabilities.
 ## Build requirements
 
 * Mac OS X or Linux
-* Java 11.0.11+, 64-bit
+* Java 17.0.4+, 64-bit
 * Docker
 
 ## Building Trino


### PR DESCRIPTION
## Description

After we upgrade the language to Java 17 (#13200), we also need Java 17 when building, so `README.md` needs to be updated as well.

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
