### PR TITLE
Include jvmkill in Docker image

### DIFF
--- a/core/docker/Dockerfile
+++ b/core/docker/Dockerfile
@@ -11,6 +11,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+FROM eclipse-temurin:17-jdk AS builder
+
+RUN \
+    set -xeu && \
+    echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries && \
+    echo 'Acquire::http::Timeout "15";' > /etc/apt/apt.conf.d/80-timeouts && \
+    apt-get update -q && \
+    apt-get install -y -q git gcc make && \
+    git clone https://github.com/airlift/jvmkill /tmp/jvmkill && \
+    make -C /tmp/jvmkill
+
 FROM eclipse-temurin:17-jdk
 
 RUN \
@@ -30,6 +41,7 @@ ARG TRINO_VERSION
 COPY trino-cli-${TRINO_VERSION}-executable.jar /usr/bin/trino
 COPY --chown=trino:trino trino-server-${TRINO_VERSION} /usr/lib/trino
 COPY --chown=trino:trino default/etc /etc/trino
+COPY --chown=trino:trino --from=builder /tmp/jvmkill/libjvmkill.so /usr/lib/trino/bin
 
 EXPOSE 8080
 USER trino:trino

--- a/core/docker/Dockerfile
+++ b/core/docker/Dockerfile
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM eclipse-temurin:17.0.4_8-jdk
+FROM eclipse-temurin:17-jdk
 
 RUN \
     set -xeu && \

--- a/core/docker/default/etc/jvm.config
+++ b/core/docker/default/etc/jvm.config
@@ -1,4 +1,5 @@
 -server
+-agentpath:/usr/lib/trino/bin/libjvmkill.so
 -XX:InitialRAMPercentage=80
 -XX:MaxRAMPercentage=80
 -XX:G1HeapRegionSize=32M


### PR DESCRIPTION
## Description

Include the [jvmkill](https://github.com/airlift/jvmkill) agent to ensure the JVM is terminated on any resource exhaustion event, such as unable to create a native thread. This is important, because various code such as `BoundedExecutor` can become unusable after this occurs.

## Documentation

(x) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# Docker image
* Terminate the JVM if unable to create a native thread. ({issue}`13736`)
```
