### PR TITLE
Make reservedIdentifiers & sqlKeywords static

### DIFF
--- a/core/trino-parser/src/main/java/io/trino/sql/ReservedIdentifiers.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/ReservedIdentifiers.java
@@ -44,6 +44,27 @@ public final class ReservedIdentifiers
 
     private static final SqlParser PARSER = new SqlParser();
 
+    private static final Set<String> SQL_KEYWORDS;
+
+    private static final Set<String> RESERVED_IDENTIFIERS;
+
+    static {
+        ImmutableSet.Builder<String> names = ImmutableSet.builder();
+        Vocabulary vocabulary = SqlBaseLexer.VOCABULARY;
+        for (int i = 0; i <= vocabulary.getMaxTokenType(); i++) {
+            String name = nullToEmpty(vocabulary.getLiteralName(i));
+            Matcher matcher = IDENTIFIER.matcher(name);
+            if (matcher.matches()) {
+                names.add(matcher.group(1));
+            }
+        }
+        SQL_KEYWORDS = names.build();
+        RESERVED_IDENTIFIERS = SQL_KEYWORDS.stream()
+                .filter(ReservedIdentifiers::reserved)
+                .sorted()
+                .collect(toImmutableSet());
+    }
+
     private ReservedIdentifiers() {}
 
     @SuppressWarnings("CallToPrintStackTrace")
@@ -121,24 +142,12 @@ public final class ReservedIdentifiers
 
     public static Set<String> reservedIdentifiers()
     {
-        return sqlKeywords().stream()
-                .filter(ReservedIdentifiers::reserved)
-                .sorted()
-                .collect(toImmutableSet());
+        return RESERVED_IDENTIFIERS;
     }
 
     public static Set<String> sqlKeywords()
     {
-        ImmutableSet.Builder<String> names = ImmutableSet.builder();
-        Vocabulary vocabulary = SqlBaseLexer.VOCABULARY;
-        for (int i = 0; i <= vocabulary.getMaxTokenType(); i++) {
-            String name = nullToEmpty(vocabulary.getLiteralName(i));
-            Matcher matcher = IDENTIFIER.matcher(name);
-            if (matcher.matches()) {
-                names.add(matcher.group(1));
-            }
-        }
-        return names.build();
+        return SQL_KEYWORDS;
     }
 
     public static boolean reserved(String name)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Initialize `reservedIdentifiers` & `sqlKeywords` in `ReservedIdentifiers` statically

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Performance improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core query engine

> How would you describe this change to a non-technical end user or system administrator?

Improve SQL parser performance when checking if a token is a reserved identifier or SQL keyword.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

Related to #13611

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
