### PR TITLE
Verify column name length in PostgreSQL and SQL Server

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -565,6 +565,7 @@ public abstract class BaseJdbcClient
 
             for (ColumnMetadata column : columns) {
                 String columnName = identifierMapping.toRemoteColumnName(connection, column.getName());
+                verifyColumnName(connection.getMetaData(), columnName);
                 columnNames.add(columnName);
                 columnTypes.add(column.getType());
                 columnList.add(getColumnDefinitionSql(session, column, columnName));
@@ -762,6 +763,7 @@ public abstract class BaseJdbcClient
 
         try (Connection connection = connectionFactory.openConnection(session)) {
             String columnName = column.getName();
+            verifyColumnName(connection.getMetaData(), columnName);
             String remoteColumnName = identifierMapping.toRemoteColumnName(connection, columnName);
             String sql = format(
                     "ALTER TABLE %s ADD %s",
@@ -779,6 +781,7 @@ public abstract class BaseJdbcClient
     {
         try (Connection connection = connectionFactory.openConnection(session)) {
             String newRemoteColumnName = identifierMapping.toRemoteColumnName(connection, newColumnName);
+            verifyColumnName(connection.getMetaData(), newRemoteColumnName);
             String sql = renameColumnSql(handle, jdbcColumn, newRemoteColumnName);
             execute(connection, sql);
         }
@@ -1101,6 +1104,12 @@ public abstract class BaseJdbcClient
             throws SQLException
     {
         // expect remote databases throw an exception for unsupported table names
+    }
+
+    protected void verifyColumnName(DatabaseMetaData databaseMetadata, String columnName)
+            throws SQLException
+    {
+        // expect remote databases throw an exception for unsupported column names
     }
 
     protected String quoted(@Nullable String catalog, @Nullable String schema, String table)

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -779,16 +779,21 @@ public abstract class BaseJdbcClient
     {
         try (Connection connection = connectionFactory.openConnection(session)) {
             String newRemoteColumnName = identifierMapping.toRemoteColumnName(connection, newColumnName);
-            String sql = format(
-                    "ALTER TABLE %s RENAME COLUMN %s TO %s",
-                    quoted(handle.asPlainTable().getRemoteTableName()),
-                    jdbcColumn.getColumnName(),
-                    newRemoteColumnName);
+            String sql = renameColumnSql(handle, jdbcColumn, newRemoteColumnName);
             execute(connection, sql);
         }
         catch (SQLException e) {
             throw new TrinoException(JDBC_ERROR, e);
         }
+    }
+
+    protected String renameColumnSql(JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newRemoteColumnName)
+    {
+        return format(
+                "ALTER TABLE %s RENAME COLUMN %s TO %s",
+                quoted(handle.asPlainTable().getRemoteTableName()),
+                jdbcColumn.getColumnName(),
+                newRemoteColumnName);
     }
 
     @Override

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConnectorTest.java
@@ -880,6 +880,19 @@ public class TestBigQueryConnectorTest
                 .hasMessage("Unsupported column type: char(3)");
     }
 
+    @Override
+    protected OptionalInt maxColumnNameLength()
+    {
+        return OptionalInt.of(300);
+    }
+
+    @Override
+    protected void verifyColumnNameLengthFailurePermissible(Throwable e)
+    {
+        assertThat(e)
+                .hasMessageContaining("Fields must contain only letters, numbers, and underscores, start with a letter or underscore, and be at most 300 characters long.");
+    }
+
     private void onBigQuery(@Language("SQL") String sql)
     {
         bigQuerySqlExecutor.execute(sql);

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
@@ -554,6 +554,15 @@ public class TestCassandraConnectorTest
         execute("DROP TABLE test_create_table");
     }
 
+    @Override
+    public void testCreateTableWithLongColumnName()
+    {
+        // TODO: Find the maximum column name length in Cassandra and enable this test.
+        assertThatThrownBy(super::testCreateTableWithLongColumnName)
+                .hasMessageMatching(".* Mutation of .* bytes is too large.*");
+        throw new SkipException("TODO");
+    }
+
     @Test
     public void testCreateTableAs()
     {

--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
@@ -425,19 +425,12 @@ public class ClickHouseClient
     }
 
     @Override
-    public void renameColumn(ConnectorSession session, JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newColumnName)
+    protected String renameColumnSql(JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newRemoteColumnName)
     {
-        try (Connection connection = connectionFactory.openConnection(session)) {
-            String newRemoteColumnName = getIdentifierMapping().toRemoteColumnName(connection, newColumnName);
-            String sql = format("ALTER TABLE %s RENAME COLUMN %s TO %s ",
-                    quoted(handle.getRemoteTableName()),
-                    quoted(jdbcColumn.getColumnName()),
-                    quoted(newRemoteColumnName));
-            execute(connection, sql);
-        }
-        catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
-        }
+        return format("ALTER TABLE %s RENAME COLUMN %s TO %s ",
+                quoted(handle.getRemoteTableName()),
+                quoted(jdbcColumn.getColumnName()),
+                quoted(newRemoteColumnName));
     }
 
     @Override

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseConnectorTest.java
@@ -200,6 +200,20 @@ public abstract class BaseClickHouseConnectorTest
         }
     }
 
+    @Override
+    public void testAlterTableAddLongColumnName()
+    {
+        // TODO: Find the maximum column name length in ClickHouse and enable this test.
+        throw new SkipException("TODO");
+    }
+
+    @Override
+    public void testAlterTableRenameColumnToLongName()
+    {
+        // TODO: Find the maximum column name length in ClickHouse and enable this test.
+        throw new SkipException("TODO");
+    }
+
     @Test
     @Override
     public void testShowCreateTable()

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/BaseDruidConnectorTest.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/BaseDruidConnectorTest.java
@@ -70,6 +70,7 @@ public abstract class BaseDruidConnectorTest
             case SUPPORTS_CREATE_TABLE:
             case SUPPORTS_CREATE_TABLE_WITH_DATA:
             case SUPPORTS_ADD_COLUMN:
+            case SUPPORTS_RENAME_COLUMN:
             case SUPPORTS_RENAME_TABLE:
             case SUPPORTS_COMMENT_ON_COLUMN:
             case SUPPORTS_COMMENT_ON_TABLE:

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
@@ -91,6 +91,7 @@ public abstract class BaseElasticsearchConnectorTest
                 return false;
 
             case SUPPORTS_ADD_COLUMN:
+            case SUPPORTS_RENAME_COLUMN:
                 return false;
 
             case SUPPORTS_CREATE_SCHEMA:

--- a/plugin/trino-mariadb/src/main/java/io/trino/plugin/mariadb/MariaDbClient.java
+++ b/plugin/trino-mariadb/src/main/java/io/trino/plugin/mariadb/MariaDbClient.java
@@ -150,6 +150,9 @@ public class MariaDbClient
     // An empty character means that the table doesn't have a comment in MariaDB
     private static final String NO_COMMENT = "";
 
+    // MariaDB Error Codes https://mariadb.com/kb/en/mariadb-error-codes/
+    private static final int PARSE_ERROR = 1064;
+
     private final AggregateFunctionRewriter<JdbcExpression, String> aggregateFunctionRewriter;
 
     @Inject
@@ -457,7 +460,8 @@ public class MariaDbClient
             execute(connection, sql);
         }
         catch (TrinoException e) {
-            if (e.getCause() instanceof SQLSyntaxErrorException) {
+            // Note: SQLSyntaxErrorException can be thrown also when column name is invalid
+            if (e.getCause() instanceof SQLSyntaxErrorException syntaxError && syntaxError.getErrorCode() == PARSE_ERROR) {
                 throw new TrinoException(NOT_SUPPORTED, "Rename column not supported for the MariaDB server version", e);
             }
             throw e;

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/BaseMariaDbConnectorTest.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/BaseMariaDbConnectorTest.java
@@ -353,4 +353,16 @@ public abstract class BaseMariaDbConnectorTest
     {
         assertThat(e).hasMessageContaining("Incorrect table name");
     }
+
+    @Override
+    protected OptionalInt maxColumnNameLength()
+    {
+        return OptionalInt.of(64);
+    }
+
+    @Override
+    protected void verifyColumnNameLengthFailurePermissible(Throwable e)
+    {
+        assertThat(e).hasMessageMatching("(.*Identifier name '.*' is too long|.*Incorrect column name.*)");
+    }
 }

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbConnectorTest.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbConnectorTest.java
@@ -43,4 +43,11 @@ public class TestMariaDbConnectorTest
         assertThatThrownBy(super::testRenameColumn)
                 .hasMessageContaining("Rename column not supported for the MariaDB server version");
     }
+
+    @Override
+    public void testAlterTableRenameColumnToLongName()
+    {
+        assertThatThrownBy(super::testAlterTableRenameColumnToLongName)
+                .hasMessageContaining("Rename column not supported for the MariaDB server version");
+    }
 }

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlConnectorTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlConnectorTest.java
@@ -408,6 +408,12 @@ public abstract class BaseMySqlConnectorTest
     }
 
     @Override
+    protected OptionalInt maxColumnNameLength()
+    {
+        return OptionalInt.of(64);
+    }
+
+    @Override
     protected SqlExecutor onRemoteDatabase()
     {
         return mySqlServer::execute;

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlConnectorTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlConnectorTest.java
@@ -18,6 +18,7 @@ import io.trino.testing.QueryRunner;
 import org.testng.annotations.Test;
 
 import static io.trino.plugin.mysql.MySqlQueryRunner.createMySqlQueryRunner;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestMySqlConnectorTest
         extends BaseMySqlConnectorTest
@@ -39,5 +40,11 @@ public class TestMySqlConnectorTest
         assertQueryFails(
                 "SELECT * FROM orders WHERE orderdate = DATE '-1996-09-14'",
                 "Incorrect DATE value: '-1996-09-14'");
+    }
+
+    @Override
+    protected void verifyColumnNameLengthFailurePermissible(Throwable e)
+    {
+        assertThat(e).hasMessageMatching("(Incorrect column name '.*'|Identifier name '.*' is too long)");
     }
 }

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlLegacyConnectorTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlLegacyConnectorTest.java
@@ -136,6 +136,14 @@ public class TestMySqlLegacyConnectorTest
     }
 
     @Override
+    public void testAlterTableRenameColumnToLongName()
+    {
+        assertThatThrownBy(super::testAlterTableRenameColumnToLongName)
+                .hasMessageContaining("You have an error in your SQL syntax")
+                .hasStackTraceContaining("RENAME COLUMN x");
+    }
+
+    @Override
     protected Optional<DataMappingTestSetup> filterDataMappingSmokeTestData(DataMappingTestSetup dataMappingTestSetup)
     {
         String typeName = dataMappingTestSetup.getTrinoTypeName();
@@ -144,5 +152,11 @@ public class TestMySqlLegacyConnectorTest
             return Optional.empty();
         }
         return super.filterDataMappingSmokeTestData(dataMappingTestSetup);
+    }
+
+    @Override
+    protected void verifyColumnNameLengthFailurePermissible(Throwable e)
+    {
+        assertThat(e).hasMessageMatching("Identifier name .* is too long");
     }
 }

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorTest.java
@@ -506,6 +506,18 @@ public abstract class BaseOracleConnectorTest
         assertThat(e).hasMessage("ORA-00972: identifier is too long\n");
     }
 
+    @Override
+    protected OptionalInt maxColumnNameLength()
+    {
+        return OptionalInt.of(30);
+    }
+
+    @Override
+    protected void verifyColumnNameLengthFailurePermissible(Throwable e)
+    {
+        assertThat(e).hasMessage("ORA-00972: identifier is too long\n");
+    }
+
     private void predicatePushdownTest(String oracleType, String oracleLiteral, String operator, String filterLiteral)
     {
         String tableName = ("test_pdown_" + oracleType.replaceAll("[^a-zA-Z0-9]", ""))

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
@@ -139,6 +139,15 @@ public class TestPhoenixConnectorTest
     }
 
     @Override
+    public void testAlterTableRenameColumnToLongName()
+    {
+        assertThatThrownBy(super::testAlterTableRenameColumnToLongName)
+                // TODO (https://github.com/trinodb/trino/issues/7205) support column rename in Phoenix
+                .hasMessageContaining("Syntax error. Encountered \"RENAME\"");
+        throw new SkipException("Rename column is not yet supported by Phoenix connector");
+    }
+
+    @Override
     public void testInsert()
     {
         String query = "SELECT orderdate, orderkey, totalprice FROM orders";
@@ -677,6 +686,20 @@ public class TestPhoenixConnectorTest
         // TODO: Find the maximum table name length in Phoenix and enable this test.
         // Table name length with 65536 chars throws "startRow's length must be less than or equal to 32767 to meet the criteria for a row key."
         // 32767 chars still causes the same error and shorter names (e.g. 10000) causes timeout.
+        throw new SkipException("TODO");
+    }
+
+    @Override
+    public void testCreateTableWithLongColumnName()
+    {
+        // TODO: Find the maximum column name length in Phoenix and enable this test.
+        throw new SkipException("TODO");
+    }
+
+    @Override
+    public void testAlterTableAddLongColumnName()
+    {
+        // TODO: Find the maximum column name length in Phoenix and enable this test.
         throw new SkipException("TODO");
     }
 

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -1030,6 +1030,17 @@ public class PostgreSqlClient
         }
     }
 
+    @Override
+    protected void verifyColumnName(DatabaseMetaData databaseMetadata, String columnName)
+            throws SQLException
+    {
+        // PostgreSQL truncates table name to 63 chars silently
+        // PostgreSQL driver caches the max column name length in a DatabaseMetaData object. The cost to call this method per column is low.
+        if (columnName.length() > databaseMetadata.getMaxColumnNameLength()) {
+            throw new TrinoException(NOT_SUPPORTED, format("Column name must be shorter than or equal to '%s' characters but got '%s': '%s'", databaseMetadata.getMaxColumnNameLength(), columnName.length(), columnName));
+        }
+    }
+
     private static ColumnMapping charColumnMapping(int charLength)
     {
         if (charLength > CharType.MAX_LENGTH) {

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -1016,4 +1016,16 @@ public class TestPostgreSqlConnectorTest
     {
         assertThat(e).hasMessage("Table name must be shorter than or equal to '63' characters but got '64'");
     }
+
+    @Override
+    protected OptionalInt maxColumnNameLength()
+    {
+        return OptionalInt.of(63);
+    }
+
+    @Override
+    protected void verifyColumnNameLengthFailurePermissible(Throwable e)
+    {
+        assertThat(e).hasMessageMatching("Column name must be shorter than or equal to '63' characters but got '64': '.*'");
+    }
 }

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/BaseRaptorConnectorTest.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/BaseRaptorConnectorTest.java
@@ -924,6 +924,18 @@ public abstract class BaseRaptorConnectorTest
         assertThat(e).hasMessage("Failed to perform metadata operation");
     }
 
+    @Override
+    protected OptionalInt maxColumnNameLength()
+    {
+        return OptionalInt.of(255);
+    }
+
+    @Override
+    protected void verifyColumnNameLengthFailurePermissible(Throwable e)
+    {
+        assertThat(e).hasMessage("Failed to perform metadata operation");
+    }
+
     @Test
     public void testMergeMultipleOperationsUnbucketed()
     {

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/BaseRedisConnectorTest.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/BaseRedisConnectorTest.java
@@ -37,6 +37,7 @@ public abstract class BaseRedisConnectorTest
                 return false;
 
             case SUPPORTS_ADD_COLUMN:
+            case SUPPORTS_RENAME_COLUMN:
                 return false;
 
             case SUPPORTS_RENAME_TABLE:

--- a/plugin/trino-singlestore/src/main/java/io/trino/plugin/singlestore/SingleStoreClient.java
+++ b/plugin/trino-singlestore/src/main/java/io/trino/plugin/singlestore/SingleStoreClient.java
@@ -334,21 +334,14 @@ public class SingleStoreClient
     }
 
     @Override
-    public void renameColumn(ConnectorSession session, JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newColumnName)
+    protected String renameColumnSql(JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newRemoteColumnName)
     {
-        try (Connection connection = connectionFactory.openConnection(session)) {
-            String newRemoteColumnName = getIdentifierMapping().toRemoteColumnName(connection, newColumnName);
-            // SingleStore versions earlier than 5.7 do not support the CHANGE syntax
-            String sql = format(
-                    "ALTER TABLE %s CHANGE %s %s",
-                    quoted(handle.getCatalogName(), handle.getSchemaName(), handle.getTableName()),
-                    quoted(jdbcColumn.getColumnName()),
-                    quoted(newRemoteColumnName));
-            execute(connection, sql);
-        }
-        catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
-        }
+        // SingleStore versions earlier than 5.7 do not support the CHANGE syntax
+        return format(
+                "ALTER TABLE %s CHANGE %s %s",
+                quoted(handle.getCatalogName(), handle.getSchemaName(), handle.getTableName()),
+                quoted(jdbcColumn.getColumnName()),
+                quoted(newRemoteColumnName));
     }
 
     @Override

--- a/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/TestSingleStoreConnectorTest.java
+++ b/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/TestSingleStoreConnectorTest.java
@@ -411,6 +411,18 @@ public class TestSingleStoreConnectorTest
     }
 
     @Override
+    protected OptionalInt maxColumnNameLength()
+    {
+        return OptionalInt.of(64);
+    }
+
+    @Override
+    protected void verifyColumnNameLengthFailurePermissible(Throwable e)
+    {
+        assertThat(e).hasMessageMatching(".*Identifier name '.*' is too long");
+    }
+
+    @Override
     protected SqlExecutor onRemoteDatabase()
     {
         return singleStoreServer::execute;

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
@@ -308,13 +308,12 @@ public class SqlServerClient
     }
 
     @Override
-    public void renameColumn(ConnectorSession session, JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newColumnName)
+    protected String renameColumnSql(JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newRemoteColumnName)
     {
-        String sql = format(
+        return format(
                 "sp_rename %s, %s, 'COLUMN'",
                 singleQuote(handle.getCatalogName(), handle.getSchemaName(), handle.getTableName(), jdbcColumn.getColumnName()),
-                singleQuote(newColumnName));
-        execute(session, sql);
+                singleQuote(newRemoteColumnName));
     }
 
     @Override

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
@@ -585,6 +585,18 @@ public abstract class BaseSqlServerConnectorTest
         assertThat(e).hasMessageMatching("(The identifier that starts with '.*' is too long. Maximum length is 128.|Table name must be shorter than or equal to '128' characters but got '129')");
     }
 
+    @Override
+    protected OptionalInt maxColumnNameLength()
+    {
+        return OptionalInt.of(128);
+    }
+
+    @Override
+    protected void verifyColumnNameLengthFailurePermissible(Throwable e)
+    {
+        assertThat(e).hasMessageMatching("Column name must be shorter than or equal to '128' characters but got '129': '.*'");
+    }
+
     private String getLongInClause(int start, int length)
     {
         String longValues = range(start, start + length)

--- a/testing/trino-tests/src/test/java/io/trino/tests/tpch/TestTpchConnectorTest.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/tpch/TestTpchConnectorTest.java
@@ -63,6 +63,7 @@ public class TestTpchConnectorTest
                 return false;
 
             case SUPPORTS_ADD_COLUMN:
+            case SUPPORTS_RENAME_COLUMN:
                 return false;
 
             case SUPPORTS_RENAME_TABLE:


### PR DESCRIPTION
## Description

Fixes #12882

## Documentation

(x) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# PostgreSQL
* Prevent using column names with a name which is longer
  than the max length supported by PostgreSQL. Previously, long names were
  truncated to the max length. ({issue}`13742`)
# SQL Server
* Prevent renaming a column to a name which is longer
  than the max length supported by SQL Server. Previously, long names were
  truncated to the max length. ({issue}`13742`)
```
