### PR TITLE
Set `hive.metastore-timeout` as 1m in Delta Lake and Iceberg tests

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
@@ -167,6 +167,7 @@ public final class DeltaLakeQueryRunner
                         .put("hive.s3.aws-secret-key", MINIO_SECRET_KEY)
                         .put("hive.s3.endpoint", minioAddress)
                         .put("hive.s3.path-style-access", "true")
+                        .put("hive.metastore-timeout", "1m") // read timed out sometimes happens with the default timeout
                         .putAll(connectorProperties)
                         .buildOrThrow(),
                 testingHadoop,

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePerTransactionMetastoreCache.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePerTransactionMetastoreCache.java
@@ -144,6 +144,7 @@ public class TestDeltaLakePerTransactionMetastoreCache
         deltaLakeProperties.put("hive.s3.endpoint", hiveMinioDataLake.getMinioAddress());
         deltaLakeProperties.put("hive.s3.path-style-access", "true");
         deltaLakeProperties.put("hive.metastore", "test"); // use test value so we do not get clash with default bindings)
+        deltaLakeProperties.put("hive.metastore-timeout", "1m"); // read timed out sometimes happens with the default timeout
         if (!enablePerTransactionHiveMetastoreCaching) {
             // almost disable the cache; 0 is not allowed as config property value
             deltaLakeProperties.put("delta.per-transaction-metastore-cache-maximum-size", "1");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMinioConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMinioConnectorSmokeTest.java
@@ -55,6 +55,7 @@ public abstract class BaseIcebergMinioConnectorSmokeTest
                                 .put("iceberg.file-format", format.name())
                                 .put("iceberg.catalog.type", "HIVE_METASTORE")
                                 .put("hive.metastore.uri", "thrift://" + hiveMinioDataLake.getHiveHadoop().getHiveMetastoreEndpoint())
+                                .put("hive.metastore-timeout", "1m") // read timed out sometimes happens with the default timeout
                                 .put("hive.s3.aws-access-key", MINIO_ACCESS_KEY)
                                 .put("hive.s3.aws-secret-key", MINIO_SECRET_KEY)
                                 .put("hive.s3.endpoint", "http://" + hiveMinioDataLake.getMinio().getMinioApiEndpoint())


### PR DESCRIPTION
## Description

Fixes #13348

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
