### PR TITLE
Fix improper expression aliasing during pushdown

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/NullabilityAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/NullabilityAnalyzer.java
@@ -21,6 +21,7 @@ import io.trino.sql.tree.FunctionCall;
 import io.trino.sql.tree.IfExpression;
 import io.trino.sql.tree.InPredicate;
 import io.trino.sql.tree.NullIfExpression;
+import io.trino.sql.tree.NullLiteral;
 import io.trino.sql.tree.SearchedCaseExpression;
 import io.trino.sql.tree.SimpleCaseExpression;
 import io.trino.sql.tree.SubscriptExpression;
@@ -65,6 +66,7 @@ public final class NullabilityAnalyzer
             // except for the CAST(NULL AS x) case -- we should fix this at some point)
             //
             // Also, try_cast (i.e., safe cast) can return null
+            process(node.getExpression(), result);
             result.compareAndSet(false, node.isSafe() || !node.isTypeOnly());
             return null;
         }
@@ -129,6 +131,13 @@ public final class NullabilityAnalyzer
         protected Void visitFunctionCall(FunctionCall node, AtomicBoolean result)
         {
             // TODO: this should look at whether the return type of the function is annotated with @SqlNullable
+            result.set(true);
+            return null;
+        }
+
+        @Override
+        protected Void visitNullLiteral(NullLiteral node, AtomicBoolean result)
+        {
             result.set(true);
             return null;
         }

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJoin.java
@@ -21,6 +21,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+import java.util.List;
+
+import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.aggregation;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.functionCall;
@@ -109,6 +112,21 @@ public class TestJoin
                 WHERE x = 10 AND z = 'b'
                 """))
                 .matches("VALUES (10, CAST('b' AS varchar(2)))");
+    }
+
+    @Test
+    public void testAliasingOfNullCasts()
+    {
+        // Test for https://github.com/trinodb/trino/issues/13565
+        assertThat(assertions.query("""
+                WITH t AS (
+                    SELECT CAST(null AS varchar) AS x, CAST(null AS varchar) AS y
+                    FROM (VALUES 1) t(a) JOIN (VALUES 1) u(a) USING (a))
+                SELECT * FROM t
+                WHERE CAST(x AS bigint) IS NOT NULL AND y = 'hello'
+                """))
+                .hasOutputTypes(List.of(VARCHAR, VARCHAR))
+                .returnsEmptyResult();
     }
 
     @Test


### PR DESCRIPTION
EqualityInference was considering an expression of the form
`cast(null AS ...)` as an inference candidate, even though it
doens't satisfy the condition of not returning nulls on null
input.

As a result, unrelated expressions were being incorrectly equated
to each other. In particular, for the example in the test,
`CAST(null AS varchar)` was being considered equivalent to `VARCHAR 'hello'`
and then substituted in the expression:

    CAST(CAST(null AS varchar) AS bigint)

to produce the (invalid) expression:

    CAST(VARCHAR 'hello' AS bigint)

Fixes #13565

## Documentation

(x) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# General
* Fix failure potential failure for queries involving joins and implicit or explicit casts of `null` to a concrete type. ({issue}`13565`)
```
