### PR TITLE
Support predicate pushdown in BigQuery query table function

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryQueryPageSource.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryQueryPageSource.java
@@ -103,9 +103,11 @@ public class BigQueryQueryPageSource
 
     private static String buildSql(BigQueryTableHandle table, String projectId, List<String> columnNames, Optional<String> filter)
     {
-        // TODO: Use filter in query relation handle
-        if (table.getRelationHandle() instanceof BigQueryQueryRelationHandle) {
-            return ((BigQueryQueryRelationHandle) table.getRelationHandle()).getQuery();
+        if (table.getRelationHandle() instanceof BigQueryQueryRelationHandle queryRelationHandle) {
+            if (filter.isEmpty()) {
+                return queryRelationHandle.getQuery();
+            }
+            return "SELECT * FROM (" + queryRelationHandle.getQuery() + " ) WHERE " + filter.get();
         }
         TableId tableId = TableId.of(projectId, table.asPlainTable().getRemoteTableName().getDatasetName(), table.asPlainTable().getRemoteTableName().getTableName());
         return selectSql(tableId, ImmutableList.copyOf(columnNames), filter);

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConnectorTest.java
@@ -770,6 +770,9 @@ public class TestBigQueryConnectorTest
         assertQuery(
                 "SELECT * FROM TABLE(bigquery.system.query(query => 'SELECT name FROM tpch.nation WHERE nationkey = 0'))",
                 "VALUES 'ALGERIA'");
+        assertQuery(
+                "SELECT name FROM TABLE(bigquery.system.query(query => 'SELECT * FROM tpch.nation')) WHERE nationkey = 0",
+                "VALUES 'ALGERIA'");
     }
 
     @Test


### PR DESCRIPTION
## Description

Support predicate pushdown in BigQuery query table function

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
