### PR TITLE
Fix errors caused by predicates pushdown on MongoDB JSON columns

### DIFF
--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
@@ -40,11 +40,14 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
 import io.trino.spi.connector.SortingProperty;
 import io.trino.spi.connector.TableNotFoundException;
+import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.statistics.ComputedStatistics;
+import io.trino.spi.type.Type;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -55,6 +58,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.mongodb.TypeUtils.isPushdownSupportedType;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.connector.RetryMode.NO_RETRIES;
 import static java.lang.Math.toIntExact;
@@ -339,6 +343,19 @@ public class MongoMetadata
 
         TupleDomain<ColumnHandle> oldDomain = handle.getConstraint();
         TupleDomain<ColumnHandle> newDomain = oldDomain.intersect(constraint.getSummary());
+        Map<ColumnHandle, Domain> domains = newDomain.getDomains().orElseThrow();
+
+        Map<ColumnHandle, Domain> supported = new HashMap<>();
+
+        for (Map.Entry<ColumnHandle, Domain> entry : domains.entrySet()) {
+            Type columnType = ((MongoColumnHandle) entry.getKey()).getType();
+            // TODO: Support predicate pushdown on more types including JSON
+            if (isPushdownSupportedType(columnType)) {
+                supported.put(entry.getKey(), entry.getValue());
+            }
+        }
+        newDomain = TupleDomain.withColumnDomains(supported);
+
         if (oldDomain.equals(newDomain)) {
             return Optional.empty();
         }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/TypeUtils.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/TypeUtils.java
@@ -13,15 +13,31 @@
  */
 package io.trino.plugin.mongodb;
 
+import com.google.common.collect.ImmutableSet;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.MapType;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
 
+import java.util.Set;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.StandardTypes.JSON;
+import static io.trino.spi.type.TinyintType.TINYINT;
 
 public final class TypeUtils
 {
+    private static final Set<Type> PUSHDOWN_SUPPORTED_PRIMITIVE_TYPES = ImmutableSet.of(
+            BOOLEAN,
+            TINYINT,
+            SMALLINT,
+            INTEGER,
+            BIGINT);
+
     private TypeUtils() {}
 
     public static boolean isJsonType(Type type)
@@ -42,5 +58,10 @@ public final class TypeUtils
     public static boolean isRowType(Type type)
     {
         return type instanceof RowType;
+    }
+
+    public static boolean isPushdownSupportedType(Type type)
+    {
+        return type instanceof VarcharType || type instanceof ObjectIdType || PUSHDOWN_SUPPORTED_PRIMITIVE_TYPES.contains(type);
     }
 }

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoTypeMapping.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoTypeMapping.java
@@ -48,6 +48,7 @@ import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createVarcharType;
+import static io.trino.type.JsonType.JSON;
 import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -309,6 +310,17 @@ public class TestMongoTypeMapping
             assertThat(query("SELECT c2 FROM " + table.getName())).matches("VALUES CAST(ARRAY[NULL] AS ARRAY(varchar))");
             assertThat(query("SELECT c3 FROM " + table.getName())).matches("VALUES CAST(ARRAY['foo', NULL, 'bar', NULL] AS ARRAY(varchar))");
         }
+    }
+
+    @Test
+    public void testJson()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("json", "json '{\"id\":0,\"name\":\"user_0\"}'", JSON, "json '{\"id\":0,\"name\":\"user_0\"}'")
+                .addRoundTrip("json", "json '{}'", JSON, "json '{}'")
+                .addRoundTrip("json", "CAST(NULL AS json)", JSON, "CAST(NULL AS json)")
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_json"))
+                .execute(getQueryRunner(), trinoCreateAndInsert("test_json"));
     }
 
     @DataProvider


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->
Fix errors caused by predicates pushdown on MongoDB JSON columns

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
This is a change to the MongoDB connector only

> How would you describe this change to a non-technical end user or system administrator?
The MongoDB connector no longer causes errors on predicates on JSON columns

## Related issues, pull requests, and links
<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #13536
* Related documentation: None needed
* [Some release notes](http://usefulinfo.example.com)
-->

* Fixes #13536
* Related documentation: None needed

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# MongoDB
* Fix failure for queries filtering on columns with `json` type. ({issue}`13536`)
```
