### PR TITLE
Use the appropriate link to display MySQL connection parameters

### DIFF
--- a/docs/src/main/sphinx/connector/mysql.rst
+++ b/docs/src/main/sphinx/connector/mysql.rst
@@ -38,7 +38,7 @@ connection properties as appropriate for your setup:
 The ``connection-url`` defines the connection information and parameters to pass
 to the MySQL JDBC driver. The supported parameters for the URL are
 available in the `MySQL Developer Guide
-<https://dev.mysql.com/doc/connector-j/8.0/en/>`_.
+<https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-configuration-properties.html>`_.
 
 For example, the following ``connection-url`` allows you to
 configure the JDBC driver to interpret time values based on UTC as a timezone on


### PR DESCRIPTION
Previously, the link to the available connection parameters in the MySQL
documentation did not point to the appropriate location and required the
user to find the corresponding location, so this commit points the link
directly to the URL where the connection parameters are located,
avoiding the step of manual searching by the user.

## Documentation

(x) Sufficient documentation is included in this PR.

## Release notes

(x) No release notes entries required.
