### PR TITLE
Improve type mapping documentation for Druid connector

### DIFF
--- a/docs/src/main/sphinx/connector/druid.rst
+++ b/docs/src/main/sphinx/connector/druid.rst
@@ -57,6 +57,45 @@ name from the properties file.
 Type mapping
 ------------
 
+Because Trino and Druid each support types that the other does not, this
+connector modifies some types when reading data.
+
+Druid type to Trino type mapping
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The connector maps Druid types to the corresponding Trino types according to the
+following table:
+
+.. list-table:: Druid type to Trino type mapping
+  :widths: 30, 30, 50
+  :header-rows: 1
+
+  * - Druid type
+    - Trino type
+    - Notes
+  * - ``STRING``
+    - ``VARCHAR``
+    -
+  * - ``FLOAT``
+    - ``REAL``
+    -
+  * - ``DOUBLE``
+    - ``DOUBLE``
+    -
+  * - ``LONG``
+    - ``BIGINT``
+    - Except for the special ``_time`` column, which is mapped to ``TIMESTAMP``.
+  * - ``TIMESTAMP``
+    - ``TIMESTAMP``
+    - Only applicable to the special ``_time`` column.
+
+No other data types are supported.
+
+Druid does not have a real ``NULL`` value for any data type. By
+default, Druid treats ``NULL`` as the default value for a data type. For
+example, ``LONG`` would be ``0``, ``DOUBLE`` would be ``0.0``, ``STRING`` would
+be an empty string ``''``, and so forth.
+
 .. include:: jdbc-type-mapping.fragment
 
 .. _druid-sql-support:


### PR DESCRIPTION
## Description

Improve type mapping documentation for Druid connector. Added a type mapping table based on Druid documentation.

> Is this change a fix, improvement, new feature, refactoring, or other?

Docs improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Connector type mapping documentation

> How would you describe this change to a non-technical end user or system administrator?

Added a data type mapping section


<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

