### PR TITLE
Make functionNullability property consistent in ResolvedFunction

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/ResolvedFunction.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/ResolvedFunction.java
@@ -70,7 +70,7 @@ public class ResolvedFunction
             @JsonProperty("id") FunctionId functionId,
             @JsonProperty("functionKind") FunctionKind functionKind,
             @JsonProperty("deterministic") boolean deterministic,
-            @JsonProperty("nullability") FunctionNullability functionNullability,
+            @JsonProperty("functionNullability") FunctionNullability functionNullability,
             @JsonProperty("typeDependencies") Map<TypeSignature, Type> typeDependencies,
             @JsonProperty("functionDependencies") Set<ResolvedFunction> functionDependencies)
     {
@@ -78,7 +78,7 @@ public class ResolvedFunction
         this.functionId = requireNonNull(functionId, "functionId is null");
         this.functionKind = requireNonNull(functionKind, "functionKind is null");
         this.deterministic = deterministic;
-        this.functionNullability = requireNonNull(functionNullability, "nullability is null");
+        this.functionNullability = requireNonNull(functionNullability, "functionNullability is null");
         this.typeDependencies = ImmutableMap.copyOf(requireNonNull(typeDependencies, "typeDependencies is null"));
         this.functionDependencies = ImmutableSet.copyOf(requireNonNull(functionDependencies, "functionDependencies is null"));
         checkArgument(functionNullability.getArgumentNullable().size() == signature.getArgumentTypes().size(), "signature and functionNullability must have same argument count");


### PR DESCRIPTION
The mismatch of "nullability" and "functionNullability" could cause
failure of JSON deserialization for ResolvedFunction

(This PR is to replace https://github.com/trinodb/trino/pull/13402 which had merge issue)

The symptom is query that involves function usages fails with error message like:
java.lang.IllegalArgumentException: Invalid JSON bytes for [simple type, class io.trino.metadata.ResolvedFunction]

Root cause is https://github.com/trinodb/trino/pull/10183, and specifically https://github.com/trinodb/trino/commit/2c1ebd61f2a017563ba27a2e7a19e51e66ae472d

The problem is exposed starting from https://github.com/trinodb/trino/pull/11217

Repro steps:
1. Create a file-based access control policy for a table with row filter or column mask that uses a function "filter": "name LIKE 'A%'"
2. Run a query against the table

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
core query engine
> How would you describe this change to a non-technical end user or system administrator?
n/a
## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
