### PR TITLE
Allow method move to a superclass in TestSpiBackwardCompatibility

### DIFF
--- a/core/trino-spi/src/test/java/io/trino/spi/TestSpiBackwardCompatibility.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/TestSpiBackwardCompatibility.java
@@ -26,6 +26,9 @@ import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -33,7 +36,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
+import java.util.Arrays;
 import java.util.Set;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -59,8 +65,8 @@ public class TestSpiBackwardCompatibility
             // example
             .put("123", "Field: public java.util.List<io.trino.spi.predicate.Range> io.trino.spi.predicate.BenchmarkSortedRangeSet$Data.ranges")
             // changes
-            .put("393", "Method: public abstract io.trino.spi.connector.ConnectorBucketNodeMap io.trino.spi.connector.ConnectorNodePartitioningProvider.getBucketNodeMap(io.trino.spi.connector.ConnectorTransactionHandle,io.trino.spi.connector.ConnectorSession,io.trino.spi.connector.ConnectorPartitioningHandle)")
-            .put("393", "Method: public abstract java.util.function.ToIntFunction<io.trino.spi.connector.ConnectorSplit> io.trino.spi.connector.ConnectorNodePartitioningProvider.getSplitBucketFunction(io.trino.spi.connector.ConnectorTransactionHandle,io.trino.spi.connector.ConnectorSession,io.trino.spi.connector.ConnectorPartitioningHandle)")
+            .put("393", "Method: public io.trino.spi.connector.ConnectorBucketNodeMap io.trino.spi.connector.ConnectorNodePartitioningProvider.getBucketNodeMap(io.trino.spi.connector.ConnectorTransactionHandle,io.trino.spi.connector.ConnectorSession,io.trino.spi.connector.ConnectorPartitioningHandle)")
+            .put("393", "Method: public java.util.function.ToIntFunction<io.trino.spi.connector.ConnectorSplit> io.trino.spi.connector.ConnectorNodePartitioningProvider.getSplitBucketFunction(io.trino.spi.connector.ConnectorTransactionHandle,io.trino.spi.connector.ConnectorSession,io.trino.spi.connector.ConnectorPartitioningHandle)")
             .put("394", "Method: public abstract io.trino.spi.exchange.Exchange io.trino.spi.exchange.ExchangeManager.createExchange(io.trino.spi.exchange.ExchangeContext,int)")
             .put("394", "Method: public abstract io.trino.spi.exchange.ExchangeSink io.trino.spi.exchange.ExchangeManager.createSink(io.trino.spi.exchange.ExchangeSinkInstanceHandle,boolean)")
             .build();
@@ -159,7 +165,7 @@ public class TestSpiBackwardCompatibility
             }
             entities.add("Constructor: " + constructor.toGenericString());
         }
-        for (Method method : clazz.getDeclaredMethods()) {
+        for (Method method : clazz.getMethods()) {
             if (isExperimental(method, "method " + method)) {
                 continue;
             }
@@ -169,7 +175,7 @@ public class TestSpiBackwardCompatibility
             if (!includeDeprecated && method.isAnnotationPresent(Deprecated.class)) {
                 continue;
             }
-            entities.add("Method: " + method.toGenericString());
+            entities.add("Method: " + new MethodPrinter(clazz, method));
         }
         for (Field field : clazz.getDeclaredFields()) {
             if (isExperimental(field, "field " + field)) {
@@ -206,5 +212,89 @@ public class TestSpiBackwardCompatibility
     private static boolean isOriginalPtfClass(Class<?> clazz, boolean includeDeprecated)
     {
         return !includeDeprecated && clazz.getName().startsWith("io.trino.spi.ptf.");
+    }
+
+    private static class MethodPrinter
+    {
+        private static final int RELEVANT_METHOD_MODIFIERS = Modifier.PUBLIC | Modifier.PROTECTED | Modifier.PRIVATE | Modifier.STATIC;
+        private final Class<?> clazz;
+        private final Method method;
+
+        private MethodPrinter(Class<?> clazz, Method method)
+        {
+            this.clazz = clazz;
+            this.method = method;
+        }
+
+        // Based on java.lang.reflect.Executable.sharedToGenericString
+        // Two changes. Outputs only modifiers relevant to the compatibility check
+        // and uses specified class name instead of class where the method was declared in.
+        public String toString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            printModifiersIfNonzero(sb);
+
+            TypeVariable<?>[] typeparms = method.getTypeParameters();
+            if (typeparms.length > 0) {
+                sb.append(Arrays.stream(typeparms)
+                        .map(MethodPrinter::typeVarBounds)
+                        .collect(Collectors.joining(",", "<", "> ")));
+            }
+
+            specificToGenericStringHeader(sb);
+
+            sb.append('(');
+            StringJoiner sj = new StringJoiner(",");
+            Type[] params = method.getGenericParameterTypes();
+            for (int j = 0; j < params.length; j++) {
+                String param = params[j].getTypeName();
+                if (method.isVarArgs() && (j == params.length - 1)) { // replace T[] with T...
+                    param = param.replaceFirst("\\[\\]$", "...");
+                }
+                sj.add(param);
+            }
+            sb.append(sj);
+            sb.append(')');
+
+            Type[] exceptionTypes = method.getGenericExceptionTypes();
+            if (exceptionTypes.length > 0) {
+                sb.append(Arrays.stream(exceptionTypes)
+                        .map(Type::getTypeName)
+                        .collect(Collectors.joining(",", " throws ", "")));
+            }
+            return sb.toString();
+        }
+
+        void specificToGenericStringHeader(StringBuilder sb)
+        {
+            Type genRetType = method.getGenericReturnType();
+            sb.append(genRetType.getTypeName()).append(' ');
+            sb.append(clazz.getTypeName()).append('.');
+            sb.append(method.getName());
+        }
+
+        static String typeVarBounds(TypeVariable<?> typeVar)
+        {
+            Type[] bounds = typeVar.getBounds();
+            if (bounds.length == 1 && bounds[0].equals(Object.class)) {
+                return typeVar.getName();
+            }
+            else {
+                return typeVar.getName() + " extends " +
+                        Arrays.stream(bounds)
+                                .map(Type::getTypeName)
+                                .collect(Collectors.joining(" & "));
+            }
+        }
+
+        void printModifiersIfNonzero(StringBuilder sb)
+        {
+            int mod = method.getModifiers() & RELEVANT_METHOD_MODIFIERS;
+
+            if (mod != 0) {
+                sb.append(Modifier.toString(mod)).append(' ');
+            }
+        }
     }
 }


### PR DESCRIPTION
Moving public method implementation to a superclass or interface
does not break backward compatibility

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

improvement
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

spi tests
> How would you describe this change to a non-technical end user or system administrator?

improve spi backward compatibility tests so support backward compatible changes
## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

* unblocks https://github.com/trinodb/trino/pull/12512
<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( X) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(X ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
