### PR TITLE
Change data ownership contract in call of ExchangeSink.add

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/DeduplicatingDirectExchangeBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DeduplicatingDirectExchangeBuffer.java
@@ -26,6 +26,7 @@ import io.airlift.log.Logger;
 import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slices;
 import io.airlift.units.DataSize;
 import io.trino.exchange.ExchangeManagerRegistry;
 import io.trino.execution.StageId;
@@ -579,7 +580,7 @@ public class DeduplicatingDirectExchangeBuffer
                 writeBuffer.writeInt(taskId.getPartitionId());
                 writeBuffer.writeInt(taskId.getAttemptId());
                 writeBuffer.writeBytes(page);
-                exchangeSink.add(0, writeBuffer.slice());
+                exchangeSink.add(0, Slices.copyOf(writeBuffer.slice()));
                 writeBuffer.reset();
                 spilledBytes += page.length();
                 spilledPageCount++;

--- a/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeSink.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeSink.java
@@ -33,8 +33,7 @@ public interface ExchangeSink
 
     /**
      * Appends arbitrary {@code data} to a partition specified by {@code partitionId}.
-     * The engine is free to reuse the {@code data} buffer.
-     * The implementation is expected to copy the buffer as it may be invalidated and recycled.
+     * With method call the {@code data} buffer ownership is passed from caller to callee.
      * This method is guaranteed not to be invoked after {@link #finish()}.
      * This method can be invoked after {@link #abort()}.
      * If this method is invoked after {@link #abort()} the invocation should be ignored.


### PR DESCRIPTION
After the change the contract changes in a way that ownership of data
passed as an argument is passed from caller to callee.
Apart from usage in DeduplicatingDirectExchangeBuffer the Slices passed
as to ExchangeSink.add were single-use and not mutataded/reclaimed
afterwards.

The semantics change allows for simplere and more effective
implementations of ExchangeSinks as no extra data copying is enforced.

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```