### PR TITLE
Add predicate to ParquetReader constructor in Iceberg

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
@@ -285,7 +285,7 @@ public class ParquetPageSourceFactory
                     timeZone,
                     newSimpleAggregatedMemoryContext(),
                     options,
-                    parquetPredicate,
+                    Optional.of(parquetPredicate),
                     columnIndexes.build());
 
             ConnectorPageSource parquetPageSource = new ParquetPageSource(

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -1058,7 +1058,8 @@ public class IcebergPageSourceProvider
                     dataSource,
                     UTC,
                     memoryContext,
-                    options);
+                    options,
+                    Optional.empty());
 
             return new ReaderPageSourceWithRowPositions(
                     new ReaderPageSource(


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Make `parquetPredicate` parameter Optional in `ParquetReader` constructor and pass `Optional.empty()` from Iceberg to `ParquetReader` constructor. Add `requireNonNull` to `parquetPredicate` and `columnIndexStore` in `ParquetReader` constructor since they can no longer be null.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(X) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(X) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
```
