### PR TITLE
Rename variables for readability

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
@@ -1104,9 +1104,9 @@ public final class SortedRangeSet
         @Override
         public int compareTo(RangeView that)
         {
-            int compare = compareLowBound(that);
-            if (compare != 0) {
-                return compare;
+            int lowBoundCompare = compareLowBound(that);
+            if (lowBoundCompare != 0) {
+                return lowBoundCompare;
             }
             return compareHighBound(that);
         }


### PR DESCRIPTION
Now this variable only holds the result of the low bound comparison, so
it could be renamed.

Related to https://github.com/trinodb/trino/pull/13734#discussion_r953054473

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
