### PR TITLE
Validate that catalog exists in CreateSchemaTask

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/CreateSchemaTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateSchemaTask.java
@@ -41,6 +41,7 @@ import static io.trino.metadata.MetadataUtil.createCatalogSchemaName;
 import static io.trino.metadata.MetadataUtil.createPrincipal;
 import static io.trino.metadata.MetadataUtil.getRequiredCatalogHandle;
 import static io.trino.spi.StandardErrorCode.ALREADY_EXISTS;
+import static io.trino.spi.StandardErrorCode.CATALOG_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.SCHEMA_ALREADY_EXISTS;
 import static io.trino.sql.ParameterUtils.parameterExtractor;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
@@ -88,7 +89,9 @@ public class CreateSchemaTask
     {
         CatalogSchemaName schema = createCatalogSchemaName(session, statement, Optional.of(statement.getSchemaName()));
 
-        // TODO: validate that catalog exists
+        if (!plannerContext.getMetadata().catalogExists(session, schema.getCatalogName())) {
+            throw semanticException(CATALOG_NOT_FOUND, statement, "Catalog '%s' does not exist", schema.getCatalogName());
+        }
 
         accessControl.checkCanCreateSchema(session.toSecurityContext(), schema);
 

--- a/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
+++ b/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
@@ -238,6 +238,12 @@ public abstract class BaseDataDefinitionTaskTest
         }
 
         @Override
+        public boolean catalogExists(Session session, String catalogName)
+        {
+            return TEST_CATALOG_NAME.equals(catalogName);
+        }
+
+        @Override
         public boolean schemaExists(Session session, CatalogSchemaName schema)
         {
             return schemas.contains(schema);

--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateSchemaTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateSchemaTask.java
@@ -82,6 +82,16 @@ public class TestCreateSchemaTask
                 .withMessage("TEST create schema fail: test-catalog.test_db");
     }
 
+    @Test
+    public void testCreateSchemaOfNonexistentCatalog()
+    {
+        CreateSchemaTask task = getCreateSchemaTask();
+        CreateSchema statement = new CreateSchema(QualifiedName.of("nonexistent_catalog", CATALOG_SCHEMA_NAME.getSchemaName()), false, ImmutableList.of());
+        assertThatExceptionOfType(TrinoException.class)
+                .isThrownBy(() -> getFutureValue(task.execute(statement, queryStateMachine, emptyList(), WarningCollector.NOOP)))
+                .withMessage("Catalog 'nonexistent_catalog' does not exist");
+    }
+
     private CreateSchemaTask getCreateSchemaTask()
     {
         SchemaPropertyManager schemaPropertyManager = new SchemaPropertyManager(CatalogServiceProvider.singleton(TEST_CATALOG_HANDLE, ImmutableMap.of()));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
Validate that catalog exists in CreateSchemaTask.

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->
Implement TODO: validate that catalog exists
<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
improvement
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
a change to the core query engine

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
