### PR TITLE
Move MERGE checks for nulls in non nullable columns to planner

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/DeleteAndInsertMergeProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DeleteAndInsertMergeProcessor.java
@@ -15,21 +15,17 @@ package io.trino.operator;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
-import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.ColumnarRow;
 import io.trino.spi.type.Type;
 
 import java.util.List;
-import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
-import static io.trino.spi.StandardErrorCode.CONSTRAINT_VIOLATION;
 import static io.trino.spi.block.ColumnarRow.toColumnarRow;
 import static io.trino.spi.connector.ConnectorMergeSink.DELETE_OPERATION_NUMBER;
 import static io.trino.spi.connector.ConnectorMergeSink.INSERT_OPERATION_NUMBER;
@@ -42,27 +38,22 @@ public class DeleteAndInsertMergeProcessor
         implements MergeRowChangeProcessor
 {
     private final List<Type> dataColumnTypes;
-    private final List<String> dataColumnNames;
     private final Type rowIdType;
     private final int rowIdChannel;
     private final int mergeRowChannel;
     private final List<Integer> dataColumnChannels;
     private final int redistributionColumnCount;
     private final List<Integer> redistributionChannelNumbers;
-    private final Set<Integer> nonNullColumnChannels;
 
     public DeleteAndInsertMergeProcessor(
             List<Type> dataColumnTypes,
-            List<String> dataColumnNames,
             Type rowIdType,
             int rowIdChannel,
             int mergeRowChannel,
             List<Integer> redistributionChannelNumbers,
-            List<Integer> dataColumnChannels,
-            Set<Integer> nonNullColumnChannels)
+            List<Integer> dataColumnChannels)
     {
         this.dataColumnTypes = requireNonNull(dataColumnTypes, "dataColumnTypes is null");
-        this.dataColumnNames = requireNonNull(dataColumnNames, "dataColumnNames is null");
         this.rowIdType = requireNonNull(rowIdType, "rowIdType is null");
         this.rowIdChannel = rowIdChannel;
         this.mergeRowChannel = mergeRowChannel;
@@ -80,7 +71,6 @@ public class DeleteAndInsertMergeProcessor
             }
         }
         this.redistributionChannelNumbers = redistributionChannelNumbersBuilder.build();
-        this.nonNullColumnChannels = ImmutableSet.copyOf(requireNonNull(nonNullColumnChannels, "nonNullColumnChannels is null"));
     }
 
     @JsonProperty
@@ -150,18 +140,6 @@ public class DeleteAndInsertMergeProcessor
         }
 
         Page page = pageBuilder.build();
-        int positionCount = page.getPositionCount();
-        for (int nonNullColumnChannel : nonNullColumnChannels) {
-            Block nonNullBlock = page.getBlock(nonNullColumnChannel);
-            Block operationBlock = page.getBlock(dataColumnChannels.size());
-            if (nonNullBlock.mayHaveNull()) {
-                for (int position = 0; position < positionCount; position++) {
-                    if (TINYINT.getLong(operationBlock, position) == INSERT_OPERATION_NUMBER && nonNullBlock.isNull(position)) {
-                        throw new TrinoException(CONSTRAINT_VIOLATION, "Assigning NULL to non-null MERGE target table column " + dataColumnNames.get(nonNullColumnChannel));
-                    }
-                }
-            }
-        }
         verify(page.getPositionCount() == totalPositions, "page positions (%s) is not equal to (%s)", page.getPositionCount(), totalPositions);
         return page;
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -3444,9 +3444,6 @@ public class LocalExecutionPlanner
             List<Integer> dataColumnChannels = node.getDataColumnSymbols().stream()
                     .map(nodeLayout::get)
                     .collect(toImmutableList());
-            Set<Integer> nonNullColumnChannels = node.getNonNullColumnSymbols().stream()
-                    .map(nodeLayout::get)
-                    .collect(toImmutableSet());
 
             OperatorFactory operatorFactory = MergeProcessorOperator.createOperatorFactory(
                     context.getNextOperatorId(),
@@ -3455,8 +3452,7 @@ public class LocalExecutionPlanner
                     rowIdChannel,
                     mergeRowChannel,
                     redistributionColumns,
-                    dataColumnChannels,
-                    nonNullColumnChannels);
+                    dataColumnChannels);
             return new PhysicalOperation(operatorFactory, nodeLayout, context, source);
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SymbolMapper.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SymbolMapper.java
@@ -471,7 +471,6 @@ public class SymbolMapper
                 map(node.getMergeRowSymbol()),
                 map(node.getDataColumnSymbols()),
                 map(node.getRedistributionColumnSymbols()),
-                map(node.getNonNullColumnSymbols()),
                 newOutputs);
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/MergeProcessorNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/MergeProcessorNode.java
@@ -37,7 +37,6 @@ public class MergeProcessorNode
     private final Symbol mergeRowSymbol;
     private final List<Symbol> dataColumnSymbols;
     private final List<Symbol> redistributionColumnSymbols;
-    private final List<Symbol> nonNullColumnSymbols;
     private final List<Symbol> outputs;
 
     @JsonCreator
@@ -49,7 +48,6 @@ public class MergeProcessorNode
             @JsonProperty("mergeRowSymbol") Symbol mergeRowSymbol,
             @JsonProperty("dataColumnSymbols") List<Symbol> dataColumnSymbols,
             @JsonProperty("redistributionColumnSymbols") List<Symbol> redistributionColumnSymbols,
-            @JsonProperty("nonNullColumnSymbols") List<Symbol> nonNullColumnSymbols,
             @JsonProperty("outputs") List<Symbol> outputs)
     {
         super(id);
@@ -60,7 +58,6 @@ public class MergeProcessorNode
         this.rowIdSymbol = requireNonNull(rowIdSymbol, "rowIdSymbol is null");
         this.dataColumnSymbols = requireNonNull(dataColumnSymbols, "dataColumnSymbols is null");
         this.redistributionColumnSymbols = requireNonNull(redistributionColumnSymbols, "redistributionColumnSymbols is null");
-        this.nonNullColumnSymbols = ImmutableList.copyOf(requireNonNull(nonNullColumnSymbols, "nonNullColumnSymbols is null"));
         this.outputs = ImmutableList.copyOf(requireNonNull(outputs, "outputs is null"));
     }
 
@@ -100,12 +97,6 @@ public class MergeProcessorNode
         return redistributionColumnSymbols;
     }
 
-    @JsonProperty
-    public List<Symbol> getNonNullColumnSymbols()
-    {
-        return nonNullColumnSymbols;
-    }
-
     @JsonProperty("outputs")
     @Override
     public List<Symbol> getOutputSymbols()
@@ -128,6 +119,6 @@ public class MergeProcessorNode
     @Override
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
-        return new MergeProcessorNode(getId(), Iterables.getOnlyElement(newChildren), target, rowIdSymbol, mergeRowSymbol, dataColumnSymbols, redistributionColumnSymbols, nonNullColumnSymbols, outputs);
+        return new MergeProcessorNode(getId(), Iterables.getOnlyElement(newChildren), target, rowIdSymbol, mergeRowSymbol, dataColumnSymbols, redistributionColumnSymbols, outputs);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableWriterNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableWriterNode.java
@@ -726,19 +726,16 @@ public class TableWriterNode
     {
         private final RowChangeParadigm paradigm;
         private final List<Type> columnTypes;
-        private final List<String> columnNames;
         private final Type rowIdType;
 
         @JsonCreator
         public MergeParadigmAndTypes(
                 @JsonProperty("paradigm") RowChangeParadigm paradigm,
                 @JsonProperty("columnTypes") List<Type> columnTypes,
-                @JsonProperty("columnNames") List<String> columnNames,
                 @JsonProperty("rowIdType") Type rowIdType)
         {
             this.paradigm = requireNonNull(paradigm, "paradigm is null");
             this.columnTypes = requireNonNull(columnTypes, "columnTypes is null");
-            this.columnNames = requireNonNull(columnNames, "columnNames is null");
             this.rowIdType = requireNonNull(rowIdType, "rowIdType is null");
         }
 
@@ -752,12 +749,6 @@ public class TableWriterNode
         public List<Type> getColumnTypes()
         {
             return columnTypes;
-        }
-
-        @JsonProperty
-        public List<String> getColumnNames()
-        {
-            return columnNames;
         }
 
         @JsonProperty

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDeleteAndInsertMergeProcessor.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDeleteAndInsertMergeProcessor.java
@@ -14,7 +14,6 @@
 package io.trino.sql.planner;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slices;
 import io.trino.operator.DeleteAndInsertMergeProcessor;
 import io.trino.spi.Page;
@@ -184,7 +183,7 @@ Page[positions=8 0:Dict[VarWidth["Aaron", "Dave", "Dave", "Ed", "Aaron", "Carol"
         List<Type> types = ImmutableList.of(VARCHAR, INTEGER, VARCHAR);
 
         RowType rowIdType = RowType.anonymous(ImmutableList.of(BIGINT, BIGINT, INTEGER));
-        return new DeleteAndInsertMergeProcessor(types, ImmutableList.of(), rowIdType, 0, 1, ImmutableList.of(), ImmutableList.of(0, 1, 2), ImmutableSet.of());
+        return new DeleteAndInsertMergeProcessor(types, rowIdType, 0, 1, ImmutableList.of(), ImmutableList.of(0, 1, 2));
     }
 
     private String getString(Block block, int position)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -835,7 +835,7 @@ public class PlanBuilder
                         TestingTransactionHandle.create()),
                 Optional.empty(),
                 schemaTableName,
-                new MergeParadigmAndTypes(RowChangeParadigm.DELETE_ROW_AND_INSERT_ROW, ImmutableList.of(), ImmutableList.of(), INTEGER));
+                new MergeParadigmAndTypes(RowChangeParadigm.DELETE_ROW_AND_INSERT_ROW, ImmutableList.of(), INTEGER));
     }
 
     public ExchangeNode gatheringExchange(ExchangeNode.Scope scope, PlanNode child)


### PR DESCRIPTION
## Description
> Is this change a fix, improvement, new feature, refactoring, or other?
an improvement
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
core query engine
> How would you describe this change to a non-technical end user or system administrator?
It should not affect end user directly
## Related issues, pull requests, and links
Fixes: https://github.com/trinodb/trino/issues/13795

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# core
* Fix some things. ({issue}`issuenumber`)
```
