### PR TITLE
Refactor list & map wrappers in hive parquet tests

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/write/MapKeyValuesSchemaConverter.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/write/MapKeyValuesSchemaConverter.java
@@ -144,8 +144,12 @@ public final class MapKeyValuesSchemaConverter
     private static GroupType convertArrayType(String name, ListTypeInfo typeInfo)
     {
         TypeInfo subType = typeInfo.getListElementTypeInfo();
-        return listWrapper(name, LogicalTypeAnnotation.listType(), new GroupType(Repetition.REPEATED,
-                ParquetHiveSerDe.ARRAY.toString(), convertType("array_element", subType)));
+        return listWrapper(
+                name,
+                new GroupType(
+                        Repetition.REPEATED,
+                        ParquetHiveSerDe.ARRAY.toString(),
+                        convertType("array_element", subType)));
     }
 
     // An optional group containing multiple elements
@@ -171,10 +175,9 @@ public final class MapKeyValuesSchemaConverter
     {
         //support projection only on key of a map
         if (valueType == null) {
-            return listWrapper(
+            return mapKvWrapper(
                     repetition,
                     alias,
-                    LogicalTypeAnnotation.MapKeyValueTypeAnnotation.getInstance(),
                     new GroupType(
                             Repetition.REPEATED,
                             mapAlias,
@@ -184,10 +187,9 @@ public final class MapKeyValuesSchemaConverter
             if (!valueType.getName().equals("value")) {
                 throw new RuntimeException(valueType.getName() + " should be value");
             }
-            return listWrapper(
+            return mapKvWrapper(
                     repetition,
                     alias,
-                    LogicalTypeAnnotation.MapKeyValueTypeAnnotation.getInstance(),
                     new GroupType(
                             Repetition.REPEATED,
                             mapAlias,
@@ -196,16 +198,16 @@ public final class MapKeyValuesSchemaConverter
         }
     }
 
-    private static GroupType listWrapper(Repetition repetition, String alias, LogicalTypeAnnotation logicalType, Type nested)
+    private static GroupType mapKvWrapper(Repetition repetition, String alias, Type nested)
     {
         if (!nested.isRepetition(Repetition.REPEATED)) {
             throw new IllegalArgumentException("Nested type should be repeated: " + nested);
         }
-        return Types.buildGroup(repetition).as(logicalType).addField(nested).named(alias);
+        return Types.buildGroup(repetition).as(LogicalTypeAnnotation.MapKeyValueTypeAnnotation.getInstance()).addField(nested).named(alias);
     }
 
-    private static GroupType listWrapper(String name, LogicalTypeAnnotation logicalType, GroupType groupType)
+    private static GroupType listWrapper(String name, GroupType groupType)
     {
-        return Types.optionalGroup().as(logicalType).addField(groupType).named(name);
+        return Types.optionalGroup().as(LogicalTypeAnnotation.listType()).addField(groupType).named(name);
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/write/SingleLevelArrayMapKeyValuesSchemaConverter.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/write/SingleLevelArrayMapKeyValuesSchemaConverter.java
@@ -149,7 +149,7 @@ public final class SingleLevelArrayMapKeyValuesSchemaConverter
     private static GroupType convertArrayType(String name, ListTypeInfo typeInfo, Repetition repetition)
     {
         TypeInfo subType = typeInfo.getListElementTypeInfo();
-        return listWrapper(name, LogicalTypeAnnotation.listType(), convertType("array_element", subType, Repetition.REPEATED), repetition);
+        return listWrapper(name, convertType("array_element", subType, Repetition.REPEATED), repetition);
     }
 
     // An optional group containing multiple elements
@@ -175,10 +175,9 @@ public final class SingleLevelArrayMapKeyValuesSchemaConverter
     {
         //support projection only on key of a map
         if (valueType == null) {
-            return listWrapper(
+            return mapKvWrapper(
                     repetition,
                     alias,
-                    LogicalTypeAnnotation.MapKeyValueTypeAnnotation.getInstance(),
                     new GroupType(
                             Repetition.REPEATED,
                             mapAlias,
@@ -187,10 +186,9 @@ public final class SingleLevelArrayMapKeyValuesSchemaConverter
         if (!valueType.getName().equals("value")) {
             throw new RuntimeException(valueType.getName() + " should be value");
         }
-        return listWrapper(
+        return mapKvWrapper(
                 repetition,
                 alias,
-                LogicalTypeAnnotation.MapKeyValueTypeAnnotation.getInstance(),
                 new GroupType(
                         Repetition.REPEATED,
                         mapAlias,
@@ -198,16 +196,16 @@ public final class SingleLevelArrayMapKeyValuesSchemaConverter
                         valueType));
     }
 
-    private static GroupType listWrapper(Repetition repetition, String alias, LogicalTypeAnnotation logicalType, Type nested)
+    private static GroupType mapKvWrapper(Repetition repetition, String alias, Type nested)
     {
         if (!nested.isRepetition(Repetition.REPEATED)) {
             throw new IllegalArgumentException("Nested type should be repeated: " + nested);
         }
-        return Types.buildGroup(repetition).as(logicalType).addField(nested).named(alias);
+        return Types.buildGroup(repetition).as(LogicalTypeAnnotation.MapKeyValueTypeAnnotation.getInstance()).addField(nested).named(alias);
     }
 
-    private static GroupType listWrapper(String name, LogicalTypeAnnotation logicalType, Type elementType, Repetition repetition)
+    private static GroupType listWrapper(String name, Type elementType, Repetition repetition)
     {
-        return Types.buildGroup(repetition).as(logicalType).addField(elementType).named(name);
+        return Types.buildGroup(repetition).as(LogicalTypeAnnotation.listType()).addField(elementType).named(name);
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/write/SingleLevelArraySchemaConverter.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/write/SingleLevelArraySchemaConverter.java
@@ -161,7 +161,7 @@ public final class SingleLevelArraySchemaConverter
     private static GroupType convertArrayType(String name, ListTypeInfo typeInfo, Repetition repetition)
     {
         TypeInfo subType = typeInfo.getListElementTypeInfo();
-        return listWrapper(name, LogicalTypeAnnotation.listType(), convertType("array", subType, Repetition.REPEATED), repetition);
+        return listWrapper(name, convertType("array", subType, Repetition.REPEATED), repetition);
     }
 
     // An optional group containing multiple elements
@@ -183,9 +183,8 @@ public final class SingleLevelArraySchemaConverter
         return ConversionPatterns.mapType(repetition, name, keyType, valueType);
     }
 
-    private static GroupType listWrapper(String name, LogicalTypeAnnotation logicalType,
-            Type elementType, Repetition repetition)
+    private static GroupType listWrapper(String name, Type elementType, Repetition repetition)
     {
-        return Types.buildGroup(repetition).as(logicalType).addField(elementType).named(name);
+        return Types.buildGroup(repetition).as(LogicalTypeAnnotation.listType()).addField(elementType).named(name);
     }
 }


### PR DESCRIPTION
## Description

- Rename overloaded MapKeyValue version for readability
- Inline logical type annotation for list & map key-value

> Is this change a fix, improvement, new feature, refactoring, or other?

Test refactoring

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Hive parquet tests 

> How would you describe this change to a non-technical end user or system administrator?

Refactor Parquet tests in `trino-hive` for better readability

## Related issues, pull requests, and links

Split from https://github.com/trinodb/trino/pull/13549#discussion_r941029424

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:
