### PR TITLE
Fix MERGE bug when join condition is false

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/BeginTableWrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/BeginTableWrite.java
@@ -143,7 +143,7 @@ public class BeginTableWrite
             DeleteTarget deleteTarget = (DeleteTarget) getContextTarget(context);
             return new DeleteNode(
                     node.getId(),
-                    rewriteModifyTableScan(node.getSource(), deleteTarget.getHandleOrElseThrow()),
+                    rewriteModifyTableScan(node.getSource(), deleteTarget.getHandleOrElseThrow(), false),
                     deleteTarget,
                     node.getRowId(),
                     node.getOutputSymbols());
@@ -155,7 +155,7 @@ public class BeginTableWrite
             UpdateTarget updateTarget = (UpdateTarget) getContextTarget(context);
             return new UpdateNode(
                     node.getId(),
-                    rewriteModifyTableScan(node.getSource(), updateTarget.getHandleOrElseThrow()),
+                    rewriteModifyTableScan(node.getSource(), updateTarget.getHandleOrElseThrow(), false),
                     updateTarget,
                     node.getRowId(),
                     node.getColumnValueAndRowIdSymbols(),
@@ -168,7 +168,7 @@ public class BeginTableWrite
             TableExecuteTarget tableExecuteTarget = (TableExecuteTarget) getContextTarget(context);
             return new TableExecuteNode(
                     node.getId(),
-                    rewriteModifyTableScan(node.getSource(), tableExecuteTarget.getSourceHandle().orElseThrow()),
+                    rewriteModifyTableScan(node.getSource(), tableExecuteTarget.getSourceHandle().orElseThrow(), false),
                     tableExecuteTarget,
                     node.getRowCountSymbol(),
                     node.getFragmentSymbol(),
@@ -184,7 +184,7 @@ public class BeginTableWrite
             MergeTarget mergeTarget = (MergeTarget) getContextTarget(context);
             return new MergeWriterNode(
                     mergeNode.getId(),
-                    rewriteModifyTableScan(mergeNode.getSource(), mergeTarget.getHandle()),
+                    rewriteModifyTableScan(mergeNode.getSource(), mergeTarget.getHandle(), true),
                     mergeTarget,
                     mergeNode.getProjectedSymbols(),
                     mergeNode.getPartitioningScheme(),
@@ -365,7 +365,7 @@ public class BeginTableWrite
             throw new IllegalArgumentException("Expected to find exactly one update target TableScanNode in plan but found: " + tableScanNodes);
         }
 
-        private PlanNode rewriteModifyTableScan(PlanNode node, TableHandle handle)
+        private PlanNode rewriteModifyTableScan(PlanNode node, TableHandle handle, boolean tableScanNotFoundIsOk)
         {
             AtomicInteger modifyCount = new AtomicInteger(0);
             PlanNode rewrittenNode = SimplePlanRewriter.rewriteWith(
@@ -393,7 +393,13 @@ public class BeginTableWrite
                     node,
                     null);
 
-            verify(modifyCount.get() == 1, "Expected to find exactly one update target TableScanNode but found %s", modifyCount);
+            int countFound = modifyCount.get();
+            if (tableScanNotFoundIsOk) {
+                verify(countFound == 0 || countFound == 1, "Expected to find zero or one update target TableScanNodes but found %s", countFound);
+            }
+            else {
+                verify(countFound == 1, "Expected to find exactly one update target TableScanNode but found %s", countFound);
+            }
             return rewrittenNode;
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

The bug showed up as an exception in BeginTableWrite.rewriteModifyTableScan
because it can't find the TableScanNode for the target table.  For MERGE,
if the join condition is not false, Some connectors need to find the
TableScanNode to update the table handle in the MergeTarget.  However,
if the join condition is shown by the optimizer to be false, the
MergeTarget handle need not be updated.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
It's a bug fix.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
It's a change to the core query engine.

> How would you describe this change to a non-technical end user or system administrator?
Fix a bug that caused SQL MERGE operations to fail if the optimizer could prove the join conditions was false.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

Fixes #13751

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(X) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(X) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
