### PR TITLE
Upgrade PostgreSQL JDBC driver to 42.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1751,7 +1751,7 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>42.3.4</version>
+                <version>42.5.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Description

Upgrade PostgreSQL JDBC driver to 42.5.0
https://jdbc.postgresql.org/documentation/changelog.html#version_42.5.0
Closes #13790

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
