### PR TITLE
Remove redundant TODO about date format

### DIFF
--- a/core/trino-main/src/main/java/io/trino/util/DateTimeUtils.java
+++ b/core/trino-main/src/main/java/io/trino/util/DateTimeUtils.java
@@ -61,10 +61,6 @@ public final class DateTimeUtils
 
     public static int parseDate(String value)
     {
-        // in order to follow the standard, we should validate the value:
-        // - the required format is 'YYYY-MM-DD'
-        // - all components should be unsigned numbers
-        // https://github.com/trinodb/trino/issues/10677
         return toIntExact(TimeUnit.MILLISECONDS.toDays(DATE_FORMATTER.parseMillis(value)));
     }
 


### PR DESCRIPTION
The existing behavior is specwise.

Fixes https://github.com/trinodb/trino/issues/10677