### PR TITLE
Improve type mapping documentation for Thrift connector

### DIFF
--- a/docs/src/main/sphinx/connector/thrift.rst
+++ b/docs/src/main/sphinx/connector/thrift.rst
@@ -104,7 +104,7 @@ The following IDL describes the ``TrinoThriftService`` that must be implemented:
 .. literalinclude:: /include/TrinoThriftService.thrift
     :language: thrift
 
-.. _thirft-type-mapping:
+.. _thrift-type-mapping:
 
 Type mapping
 ------------

--- a/docs/src/main/sphinx/connector/thrift.rst
+++ b/docs/src/main/sphinx/connector/thrift.rst
@@ -104,6 +104,13 @@ The following IDL describes the ``TrinoThriftService`` that must be implemented:
 .. literalinclude:: /include/TrinoThriftService.thrift
     :language: thrift
 
+.. _thirft-type-mapping:
+
+Type mapping
+------------
+
+The Thrift service defines data type support and mappings to Trino data types.
+
 .. _thrift-sql-support:
 
 SQL support


### PR DESCRIPTION
## Description

Added a type mapping section that explains the thrift service defines data type support and mappings to Trino data types. The SMEs recommended this verbiage.

> Is this change a fix, improvement, new feature, refactoring, or other?

Documentation improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Thrift connector documentation

> How would you describe this change to a non-technical end user or system administrator?

Added a section about type mapping above SQL support section.


## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

