### PR TITLE
Upgrade MySQL docker image in tests to 8.0.30

### DIFF
--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlAutomaticJoinPushdown.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlAutomaticJoinPushdown.java
@@ -36,7 +36,7 @@ public class TestMySqlAutomaticJoinPushdown
     {
         // Using MySQL 8.0.15 because test is sensitive to quality of NDV estimation and 5.5.46 we use
         // in other places does very poor job; for 10000 row table with 1000 distinct keys it estimates NDV at ~2500
-        mySqlServer = closeAfterClass(new TestingMySqlServer("mysql:8.0.15", false));
+        mySqlServer = closeAfterClass(new TestingMySqlServer("mysql:8.0.30", false));
 
         return createMySqlQueryRunner(
                 mySqlServer,

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTableStatisticsMySql8Histograms.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTableStatisticsMySql8Histograms.java
@@ -32,7 +32,7 @@ public class TestMySqlTableStatisticsMySql8Histograms
 {
     public TestMySqlTableStatisticsMySql8Histograms()
     {
-        super("mysql:8.0.15",
+        super("mysql:8.0.30",
                 Function.identity(),
                 Function.identity());
     }

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTableStatisticsMySql8IndexStatistics.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTableStatisticsMySql8IndexStatistics.java
@@ -20,7 +20,7 @@ public class TestMySqlTableStatisticsMySql8IndexStatistics
 {
     public TestMySqlTableStatisticsMySql8IndexStatistics()
     {
-        super("mysql:8.0.15");
+        super("mysql:8.0.30");
     }
 
     @Override

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestingMySqlServer.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestingMySqlServer.java
@@ -30,7 +30,7 @@ import static org.testcontainers.containers.MySQLContainer.MYSQL_PORT;
 public class TestingMySqlServer
         implements AutoCloseable
 {
-    public static final String DEFAULT_IMAGE = "mysql:8.0.29-oracle";
+    public static final String DEFAULT_IMAGE = "mysql:8.0.30";
     public static final String LEGACY_IMAGE = "mysql:5.7.35";
 
     private final MySQLContainer<?> container;

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/TestRaptorMySqlConnectorTest.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/TestRaptorMySqlConnectorTest.java
@@ -36,7 +36,7 @@ public class TestRaptorMySqlConnectorTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        mysqlContainer = new MySQLContainer<>("mysql:8.0.29-oracle");
+        mysqlContainer = new MySQLContainer<>("mysql:8.0.30");
         mysqlContainer.start();
         return createRaptorMySqlQueryRunner(getJdbcUrl(mysqlContainer));
     }

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupsMysqlFlywayMigration.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupsMysqlFlywayMigration.java
@@ -25,7 +25,7 @@ public class TestDbResourceGroupsMysqlFlywayMigration
     @Override
     protected final JdbcDatabaseContainer<?> startContainer()
     {
-        JdbcDatabaseContainer<?> container = new MySQLContainer<>("mysql:8.0.29-oracle");
+        JdbcDatabaseContainer<?> container = new MySQLContainer<>("mysql:8.0.30");
         container.start();
         return container;
     }

--- a/plugin/trino-session-property-managers/src/test/java/io/trino/plugin/session/db/TestingMySqlContainer.java
+++ b/plugin/trino-session-property-managers/src/test/java/io/trino/plugin/session/db/TestingMySqlContainer.java
@@ -20,7 +20,7 @@ public class TestingMySqlContainer
 {
     public TestingMySqlContainer()
     {
-        super("mysql:8.0.29-oracle");
+        super("mysql:8.0.30");
     }
 
     @Override

--- a/service/trino-verifier/src/test/java/io/trino/verifier/TestDatabaseEventClient.java
+++ b/service/trino-verifier/src/test/java/io/trino/verifier/TestDatabaseEventClient.java
@@ -101,7 +101,7 @@ public class TestDatabaseEventClient
     @BeforeClass
     public void setup()
     {
-        mysqlContainer = new MySQLContainer<>("mysql:8.0.29-oracle");
+        mysqlContainer = new MySQLContainer<>("mysql:8.0.30");
         mysqlContainer.start();
         mysqlContainerUrl = getJdbcUrl(mysqlContainer);
         codec = new JsonCodecFactory().listJsonCodec(String.class);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Newer MySQL docker image releases contain an image based on oracle
linux with support for ARM64 architecture, which is needed for running
on M1 MacBook.

Since release 8.0.29 the image based on oracle linux is the default.

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement of developer experience

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Tests

> How would you describe this change to a non-technical end user or system administrator?

N/A

## Related issues, pull requests, and links

https://github.com/trinodb/trino/pull/12608

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text: