### PR TITLE
Improve type mapping documentation for BigQuery connector

### DIFF
--- a/docs/src/main/sphinx/connector/bigquery.rst
+++ b/docs/src/main/sphinx/connector/bigquery.rst
@@ -141,30 +141,110 @@ Property                                              Description               
                                                       <https://cloud.google.com/bigquery/docs/cached-results>`_      ``false``
 ===================================================== ============================================================== ======================================================
 
-Data types
-----------
+.. _bigquery-type-mapping:
 
-With a few exceptions, all BigQuery types are mapped directly to their Trino
-counterparts. Here are all the mappings:
+Type mapping
+------------
 
-============== =============================== =============================================================================================================
-BigQuery       Trino                           Notes
-============== =============================== =============================================================================================================
-``ARRAY``      ``ARRAY``
-``BOOLEAN``    ``BOOLEAN``
-``BYTES``      ``VARBINARY``
-``DATE``       ``DATE``
-``DATETIME``   ``TIMESTAMP(6)``
-``FLOAT``      ``DOUBLE``
-``GEOGRAPHY``  ``VARCHAR``                     In `Well-known text (WKT) <https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry>`_ format
-``INTEGER``    ``BIGINT``
-``NUMERIC``    ``DECIMAL(P,S)``                Defaults to ``38`` as precision and ``9`` as scale
-``BIGNUMERIC`` ``DECIMAL(P,S)``                Precision > 38 is not supported. Note that the default precision and scale of BIGNUMERIC is ``(77, 38)``.
-``RECORD``     ``ROW``
-``STRING``     ``VARCHAR``
-``TIME``       ``TIME(6)``
-``TIMESTAMP``  ``TIMESTAMP(6) WITH TIME ZONE`` Time zone is UTC
-============== =============================== =============================================================================================================
+Because Trino and BigQuery each support types that the other does not, this
+connector modifies some types when reading or writing data. Data types may not
+map the same way in both directions between Trino and the data source. Refer to
+the following sections for type mapping in each direction.
+
+BigQuery type to Trino type mapping
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The connector maps BigQuery types to the corresponding Trino types according
+to the following table:
+
+.. list-table:: BigQuery type to Trino type mapping
+  :widths: 30, 30, 50
+  :header-rows: 1
+
+  * - BigQuery type
+    - Trino type
+    - Notes
+  * - ``BOOLEAN``
+    - ``BOOLEAN``
+    -
+  * - ``INT64``
+    - ``BIGINT``
+    - ``INT``, ``SMALLINT``, ``INTEGER``, ``BIGINT``, ``TINYINT``, and
+      ``BYTEINT`` are aliases for ``INT64`` in BigQuery.
+  * - ``FLOAT64``
+    - ``DOUBLE``
+    -
+  * - ``NUMERIC``
+    - ``DECIMAL(P,S)``
+    - The default precision and scale of ``NUMERIC`` is ``(38, 9)``.
+  * - ``BIGNUMERIC``
+    - ``DECIMAL(P,S)``
+    - Precision > 38 is not supported. The default precision and scale of
+      ``BIGNUMERIC`` is ``(77, 38)``.
+  * - ``DATE``
+    - ``DATE``
+    -
+  * - ``DATETIME``
+    - ``TIMESTAMP(6)``
+    -
+  * - ``STRING``
+    - ``VARCHAR``
+    -
+  * - ``BYTES``
+    - ``VARBINARY``
+    -
+  * - ``TIME``
+    - ``TIME(6)``
+    -
+  * - ``TIMESTAMP``
+    - ``TIMESTAMP(6) WITH TIME ZONE``
+    - Time zone is UTC
+  * - ``GEOGRAPHY``
+    - ``VARCHAR``
+    - In `Well-known text (WKT) <https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry>`_ format
+  * - ``ARRAY``
+    - ``ARRAY``
+    -
+  * - ``RECORD``
+    - ``ROW``
+    -
+
+No other types are supported.
+
+Trino type to BigQuery type mapping
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The connector maps Trino types to the corresponding BigQuery types according
+to the following table:
+
+.. list-table:: Trino type to BigQuery type mapping
+  :widths: 30, 30, 50
+  :header-rows: 1
+
+  * - Trino type
+    - BigQuery type
+    - Notes
+  * - ``BOOLEAN``
+    - ``BOOLEAN``
+    -
+  * - ``VARBINARY``
+    - ``BYTES``
+    -
+  * - ``DATE``
+    - ``DATE``
+    -
+  * - ``DOUBLE``
+    - ``FLOAT``
+    -
+  * - ``BIGINT``
+    - ``INT64``
+    - ``INT``, ``SMALLINT``, ``INTEGER``, ``BIGINT``, ``TINYINT``, and
+      ``BYTEINT`` are aliases for ``INT64`` in BigQuery.
+  * - ``VARCHAR``
+    - ``STRING``
+    -
+
+No other types are supported.
 
 System tables
 -------------


### PR DESCRIPTION
## Description

Improve type mapping documentation for BigQuery connector.

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement to  BigQuery connector documentation

> How would you describe this change to a non-technical end user or system administrator?

Added data type mapping for write direction (Trino --> BigQuery); reformatted table for better wrapping; added boilerplate headings and verbiage for consistency.

**Question for SMEs**: I wasn't sure about the new write table. To avoid 1:m mapping in write direction, I chose ``BIGNUMERIC`` for ``DECIMAL(P,S)`` instead of ``NUMERIC``. I was not sure which one to choose for ``VARCHAR`` (``STRING`` or ``GEOGRAPHY``), so left them both. Please advise.

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

