### PR TITLE
Improve Iceberg Glue table caching

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -62,8 +62,10 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.Transaction;
+import org.apache.iceberg.io.FileIO;
 
 import java.time.Duration;
 import java.util.List;
@@ -98,12 +100,14 @@ import static io.trino.plugin.iceberg.catalog.glue.GlueIcebergUtil.getMaterializ
 import static io.trino.plugin.iceberg.catalog.glue.GlueIcebergUtil.getTableInput;
 import static io.trino.plugin.iceberg.catalog.glue.GlueIcebergUtil.getViewTableInput;
 import static io.trino.spi.StandardErrorCode.ALREADY_EXISTS;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.UNSUPPORTED_TABLE_TYPE;
 import static io.trino.spi.connector.SchemaTableName.schemaTableName;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.apache.hadoop.hive.metastore.TableType.VIRTUAL_VIEW;
+import static org.apache.iceberg.BaseMetastoreTableOperations.METADATA_LOCATION_PROP;
 import static org.apache.iceberg.CatalogUtil.dropTableData;
 
 public class TrinoGlueCatalog
@@ -117,6 +121,8 @@ public class TrinoGlueCatalog
     private final GlueMetastoreStats stats;
 
     private final Map<SchemaTableName, TableMetadata> tableMetadataCache = new ConcurrentHashMap<>();
+    private final Map<SchemaTableName, ConnectorViewDefinition> viewCache = new ConcurrentHashMap<>();
+    private final Map<SchemaTableName, ConnectorMaterializedViewDefinition> materializedViewCache = new ConcurrentHashMap<>();
 
     public TrinoGlueCatalog(
             CatalogName catalogName,
@@ -278,6 +284,10 @@ public class TrinoGlueCatalog
     @Override
     public Table loadTable(ConnectorSession session, SchemaTableName table)
     {
+        if (viewCache.containsKey(table) || materializedViewCache.containsKey(table)) {
+            throw new TableNotFoundException(table);
+        }
+
         TableMetadata metadata = tableMetadataCache.computeIfAbsent(
                 table,
                 ignore -> {
@@ -338,7 +348,7 @@ public class TrinoGlueCatalog
     {
         boolean newTableCreated = false;
         try {
-            com.amazonaws.services.glue.model.Table table = getTable(from)
+            com.amazonaws.services.glue.model.Table table = getTable(session, from)
                     .orElseThrow(() -> new TableNotFoundException(from));
             TableInput tableInput = getTableInput(to.getTableName(), Optional.ofNullable(table.getOwner()), table.getParameters());
             CreateTableRequest createTableRequest = new CreateTableRequest()
@@ -363,15 +373,69 @@ public class TrinoGlueCatalog
         }
     }
 
-    private Optional<com.amazonaws.services.glue.model.Table> getTable(SchemaTableName schemaTableName)
+    private Optional<com.amazonaws.services.glue.model.Table> getTable(ConnectorSession session, SchemaTableName schemaTableName)
     {
         try {
-            return Optional.of(
-                    stats.getGetTable().call(() ->
-                            glueClient.getTable(new GetTableRequest()
+            com.amazonaws.services.glue.model.Table table = stats.getGetTable().call(() ->
+                    glueClient.getTable(new GetTableRequest()
                                     .withDatabaseName(schemaTableName.getSchemaName())
                                     .withName(schemaTableName.getTableName()))
-                                    .getTable()));
+                            .getTable());
+
+            if (isIcebergTable(table.getParameters()) && !tableMetadataCache.containsKey(schemaTableName)) {
+                if (viewCache.containsKey(schemaTableName) || materializedViewCache.containsKey(schemaTableName)) {
+                    throw new TrinoException(GENERIC_INTERNAL_ERROR, "Glue table cache inconsistency. Table cannot also be a view/materialized view");
+                }
+
+                String metadataLocation = table.getParameters().get(METADATA_LOCATION_PROP);
+                try {
+                    // Cache the TableMetadata while we have the Table retrieved anyway
+                    TableOperations operations = tableOperationsProvider.createTableOperations(
+                            this,
+                            session,
+                            schemaTableName.getSchemaName(),
+                            schemaTableName.getTableName(),
+                            Optional.empty(),
+                            Optional.empty());
+                    FileIO io = operations.io();
+                    tableMetadataCache.put(schemaTableName, TableMetadataParser.read(io, io.newInputFile(metadataLocation)));
+                }
+                catch (RuntimeException e) {
+                    LOG.warn(e, "Failed to cache table metadata from table at %s", metadataLocation);
+                }
+            }
+            else if (isTrinoMaterializedView(table.getTableType(), table.getParameters())) {
+                if (viewCache.containsKey(schemaTableName) || tableMetadataCache.containsKey(schemaTableName)) {
+                    throw new TrinoException(GENERIC_INTERNAL_ERROR, "Glue table cache inconsistency. Materialized View cannot also be a table or view");
+                }
+
+                try {
+                    createMaterializedViewDefinition(session, schemaTableName, table)
+                            .ifPresent(materializedView -> materializedViewCache.put(schemaTableName, materializedView));
+                }
+                catch (RuntimeException e) {
+                    LOG.warn(e, "Failed to cache materialized view from %s", schemaTableName);
+                }
+            }
+            else if (isPrestoView(table.getParameters()) && !viewCache.containsKey(schemaTableName)) {
+                if (materializedViewCache.containsKey(schemaTableName) || tableMetadataCache.containsKey(schemaTableName)) {
+                    throw new TrinoException(GENERIC_INTERNAL_ERROR, "Glue table cache inconsistency. View cannot also be a materialized view or table");
+                }
+
+                try {
+                    getView(schemaTableName,
+                            Optional.ofNullable(table.getViewOriginalText()),
+                            table.getTableType(),
+                            table.getParameters(),
+                            Optional.ofNullable(table.getOwner()))
+                            .ifPresent(viewDefinition -> viewCache.put(schemaTableName, viewDefinition));
+                }
+                catch (RuntimeException e) {
+                    LOG.warn(e, "Failed to cache view from %s", schemaTableName);
+                }
+            }
+
+            return Optional.of(table);
         }
         catch (EntityNotFoundException e) {
             return Optional.empty();
@@ -441,12 +505,12 @@ public class TrinoGlueCatalog
                 .withMaxRetries(3)
                 .withDelay(Duration.ofMillis(100))
                 .abortIf(throwable -> !replace || throwable instanceof ViewAlreadyExistsException))
-                .run(() -> doCreateView(schemaViewName, viewTableInput, replace));
+                .run(() -> doCreateView(session, schemaViewName, viewTableInput, replace));
     }
 
-    private void doCreateView(SchemaTableName schemaViewName, TableInput viewTableInput, boolean replace)
+    private void doCreateView(ConnectorSession session, SchemaTableName schemaViewName, TableInput viewTableInput, boolean replace)
     {
-        Optional<com.amazonaws.services.glue.model.Table> existing = getTable(schemaViewName);
+        Optional<com.amazonaws.services.glue.model.Table> existing = getTable(session, schemaViewName);
         if (existing.isPresent()) {
             if (!replace || !isPrestoView(existing.get().getParameters())) {
                 // TODO: ViewAlreadyExists is misleading if the name is used by a table https://github.com/trinodb/trino/issues/10037
@@ -476,9 +540,9 @@ public class TrinoGlueCatalog
     {
         boolean newTableCreated = false;
         try {
-            com.amazonaws.services.glue.model.Table existingView = getTable(source)
+            com.amazonaws.services.glue.model.Table existingView = getTable(session, source)
                     .orElseThrow(() -> new TableNotFoundException(source));
-
+            viewCache.remove(source);
             TableInput viewTableInput = getViewTableInput(
                     target.getTableName(),
                     existingView.getViewOriginalText(),
@@ -520,6 +584,7 @@ public class TrinoGlueCatalog
         }
 
         try {
+            viewCache.remove(schemaViewName);
             deleteTable(schemaViewName.getSchemaName(), schemaViewName.getTableName());
         }
         catch (AmazonServiceException e) {
@@ -561,7 +626,17 @@ public class TrinoGlueCatalog
     @Override
     public Optional<ConnectorViewDefinition> getView(ConnectorSession session, SchemaTableName viewName)
     {
-        Optional<com.amazonaws.services.glue.model.Table> table = getTable(viewName);
+        ConnectorViewDefinition cachedView = viewCache.get(viewName);
+        if (cachedView != null) {
+            return Optional.of(cachedView);
+        }
+
+        if (tableMetadataCache.containsKey(viewName) || materializedViewCache.containsKey(viewName)) {
+            // Entries in these caches are not views
+            return Optional.empty();
+        }
+
+        Optional<com.amazonaws.services.glue.model.Table> table = getTable(session, viewName);
         if (table.isEmpty()) {
             return Optional.empty();
         }
@@ -640,7 +715,7 @@ public class TrinoGlueCatalog
             boolean replace,
             boolean ignoreExisting)
     {
-        Optional<com.amazonaws.services.glue.model.Table> existing = getTable(viewName);
+        Optional<com.amazonaws.services.glue.model.Table> existing = getTable(session, viewName);
 
         if (existing.isPresent()) {
             if (!isTrinoMaterializedView(existing.get().getTableType(), existing.get().getParameters())) {
@@ -692,12 +767,13 @@ public class TrinoGlueCatalog
     @Override
     public void dropMaterializedView(ConnectorSession session, SchemaTableName viewName)
     {
-        com.amazonaws.services.glue.model.Table view = getTable(viewName)
+        com.amazonaws.services.glue.model.Table view = getTable(session, viewName)
                 .orElseThrow(() -> new MaterializedViewNotFoundException(viewName));
 
         if (!isTrinoMaterializedView(view.getTableType(), view.getParameters())) {
             throw new TrinoException(UNSUPPORTED_TABLE_TYPE, "Not a Materialized View: " + view.getDatabaseName() + "." + view.getName());
         }
+        materializedViewCache.remove(viewName);
         dropStorageTable(session, view);
         deleteTable(view.getDatabaseName(), view.getName());
     }
@@ -720,7 +796,17 @@ public class TrinoGlueCatalog
     @Override
     protected Optional<ConnectorMaterializedViewDefinition> doGetMaterializedView(ConnectorSession session, SchemaTableName viewName)
     {
-        Optional<com.amazonaws.services.glue.model.Table> maybeTable = getTable(viewName);
+        ConnectorMaterializedViewDefinition materializedViewDefinition = materializedViewCache.get(viewName);
+        if (materializedViewDefinition != null) {
+            return Optional.of(materializedViewDefinition);
+        }
+
+        if (tableMetadataCache.containsKey(viewName) || viewCache.containsKey(viewName)) {
+            // Entries in these caches are not materialized views.
+            return Optional.empty();
+        }
+
+        Optional<com.amazonaws.services.glue.model.Table> maybeTable = getTable(session, viewName);
         if (maybeTable.isEmpty()) {
             return Optional.empty();
         }
@@ -730,6 +816,14 @@ public class TrinoGlueCatalog
             return Optional.empty();
         }
 
+        return createMaterializedViewDefinition(session, viewName, table);
+    }
+
+    private Optional<ConnectorMaterializedViewDefinition> createMaterializedViewDefinition(
+            ConnectorSession session,
+            SchemaTableName viewName,
+            com.amazonaws.services.glue.model.Table table)
+    {
         Map<String, String> materializedViewParameters = table.getParameters();
         String storageTable = materializedViewParameters.get(STORAGE_TABLE);
         checkState(storageTable != null, "Storage table missing in definition of materialized view " + viewName);
@@ -766,8 +860,9 @@ public class TrinoGlueCatalog
     {
         boolean newTableCreated = false;
         try {
-            com.amazonaws.services.glue.model.Table glueTable = getTable(source)
+            com.amazonaws.services.glue.model.Table glueTable = getTable(session, source)
                     .orElseThrow(() -> new TableNotFoundException(source));
+            materializedViewCache.remove(source);
             if (!isTrinoMaterializedView(glueTable.getTableType(), glueTable.getParameters())) {
                 throw new TrinoException(UNSUPPORTED_TABLE_TYPE, "Not a Materialized View: " + source);
             }
@@ -813,7 +908,7 @@ public class TrinoGlueCatalog
                 tableName.getSchemaName(),
                 tableName.getTableName().substring(0, metadataMarkerIndex));
 
-        Optional<com.amazonaws.services.glue.model.Table> table = getTable(new SchemaTableName(tableNameBase.getSchemaName(), tableNameBase.getTableName()));
+        Optional<com.amazonaws.services.glue.model.Table> table = getTable(session, new SchemaTableName(tableNameBase.getSchemaName(), tableNameBase.getTableName()));
 
         if (table.isEmpty() || VIRTUAL_VIEW.name().equals(table.get().getTableType())) {
             return Optional.empty();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogAccessOperations.java
@@ -59,7 +59,10 @@ import static io.trino.plugin.iceberg.TableType.MANIFESTS;
 import static io.trino.plugin.iceberg.TableType.PARTITIONS;
 import static io.trino.plugin.iceberg.TableType.PROPERTIES;
 import static io.trino.plugin.iceberg.TableType.SNAPSHOTS;
-import static io.trino.plugin.iceberg.catalog.glue.GlueMetastoreMethod.*;
+import static io.trino.plugin.iceberg.catalog.glue.GlueMetastoreMethod.CREATE_TABLE;
+import static io.trino.plugin.iceberg.catalog.glue.GlueMetastoreMethod.GET_DATABASE;
+import static io.trino.plugin.iceberg.catalog.glue.GlueMetastoreMethod.GET_TABLE;
+import static io.trino.plugin.iceberg.catalog.glue.GlueMetastoreMethod.UPDATE_TABLE;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
@@ -158,7 +161,7 @@ public class TestIcebergGlueCatalogAccessOperations
 
             assertGlueMetastoreApiInvocations("SELECT * FROM test_select_from",
                     ImmutableMultiset.builder()
-                            .addCopies(GET_TABLE, 3)
+                            .add(GET_TABLE)
                             .build());
         }
         finally {
@@ -174,7 +177,7 @@ public class TestIcebergGlueCatalogAccessOperations
 
             assertGlueMetastoreApiInvocations("SELECT * FROM test_select_from_where WHERE age = 2",
                     ImmutableMultiset.builder()
-                            .addCopies(GET_TABLE, 3)
+                            .add(GET_TABLE)
                             .build());
         }
         finally {
@@ -191,7 +194,7 @@ public class TestIcebergGlueCatalogAccessOperations
 
             assertGlueMetastoreApiInvocations("SELECT * FROM test_select_view_view",
                     ImmutableMultiset.builder()
-                            .addCopies(GET_TABLE, 5)
+                            .addCopies(GET_TABLE, 2)
                             .build());
         }
         finally {
@@ -209,7 +212,7 @@ public class TestIcebergGlueCatalogAccessOperations
 
             assertGlueMetastoreApiInvocations("SELECT * FROM test_select_view_where_view WHERE age = 2",
                     ImmutableMultiset.builder()
-                            .addCopies(GET_TABLE, 5)
+                            .addCopies(GET_TABLE, 2)
                             .build());
         }
         finally {
@@ -227,7 +230,7 @@ public class TestIcebergGlueCatalogAccessOperations
 
             assertGlueMetastoreApiInvocations("SELECT * FROM test_select_mview_view",
                     ImmutableMultiset.builder()
-                            .addCopies(GET_TABLE, 6)
+                            .addCopies(GET_TABLE, 3)
                             .build());
         }
         finally {
@@ -245,7 +248,7 @@ public class TestIcebergGlueCatalogAccessOperations
 
             assertGlueMetastoreApiInvocations("SELECT * FROM test_select_mview_where_view WHERE age = 2",
                     ImmutableMultiset.builder()
-                            .addCopies(GET_TABLE, 6)
+                            .addCopies(GET_TABLE, 3)
                             .build());
         }
         finally {
@@ -263,7 +266,7 @@ public class TestIcebergGlueCatalogAccessOperations
 
             assertGlueMetastoreApiInvocations("REFRESH MATERIALIZED VIEW test_refresh_mview_view",
                     ImmutableMultiset.builder()
-                            .addCopies(GET_TABLE, 12)
+                            .addCopies(GET_TABLE, 9)
                             .addCopies(UPDATE_TABLE, 2)
                             .build());
         }
@@ -282,7 +285,7 @@ public class TestIcebergGlueCatalogAccessOperations
 
             assertGlueMetastoreApiInvocations("SELECT name, age FROM test_join_t1 JOIN test_join_t2 ON test_join_t2.id = test_join_t1.id",
                     ImmutableMultiset.builder()
-                            .addCopies(GET_TABLE, 6)
+                            .addCopies(GET_TABLE, 2)
                             .build());
         }
         finally {
@@ -299,7 +302,7 @@ public class TestIcebergGlueCatalogAccessOperations
 
             assertGlueMetastoreApiInvocations("SELECT child.age, parent.age FROM test_self_join_table child JOIN test_self_join_table parent ON child.parent = parent.id",
                     ImmutableMultiset.builder()
-                            .addCopies(GET_TABLE, 5)
+                            .add(GET_TABLE)
                             .build());
         }
         finally {
@@ -315,7 +318,7 @@ public class TestIcebergGlueCatalogAccessOperations
 
             assertGlueMetastoreApiInvocations("EXPLAIN SELECT * FROM test_explain",
                     ImmutableMultiset.builder()
-                            .addCopies(GET_TABLE, 3)
+                            .add(GET_TABLE)
                             .build());
         }
         finally {
@@ -331,7 +334,7 @@ public class TestIcebergGlueCatalogAccessOperations
 
             assertGlueMetastoreApiInvocations("SHOW STATS FOR test_show_stats",
                     ImmutableMultiset.builder()
-                            .addCopies(GET_TABLE, 3)
+                            .add(GET_TABLE)
                             .build());
         }
         finally {
@@ -347,7 +350,7 @@ public class TestIcebergGlueCatalogAccessOperations
 
             assertGlueMetastoreApiInvocations("SHOW STATS FOR (SELECT * FROM test_show_stats_with_filter where age >= 2)",
                     ImmutableMultiset.builder()
-                            .addCopies(GET_TABLE, 3)
+                            .addCopies(GET_TABLE, 1)
                             .build());
         }
         finally {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogAccessOperations.java
@@ -59,9 +59,7 @@ import static io.trino.plugin.iceberg.TableType.MANIFESTS;
 import static io.trino.plugin.iceberg.TableType.PARTITIONS;
 import static io.trino.plugin.iceberg.TableType.PROPERTIES;
 import static io.trino.plugin.iceberg.TableType.SNAPSHOTS;
-import static io.trino.plugin.iceberg.catalog.glue.GlueMetastoreMethod.CREATE_TABLE;
-import static io.trino.plugin.iceberg.catalog.glue.GlueMetastoreMethod.GET_DATABASE;
-import static io.trino.plugin.iceberg.catalog.glue.GlueMetastoreMethod.GET_TABLE;
+import static io.trino.plugin.iceberg.catalog.glue.GlueMetastoreMethod.*;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
@@ -220,7 +218,7 @@ public class TestIcebergGlueCatalogAccessOperations
         }
     }
 
-    @Test(enabled = false)
+    @Test
     public void testSelectFromMaterializedView()
     {
         try {
@@ -229,7 +227,7 @@ public class TestIcebergGlueCatalogAccessOperations
 
             assertGlueMetastoreApiInvocations("SELECT * FROM test_select_mview_view",
                     ImmutableMultiset.builder()
-                            .addCopies(GET_TABLE, 3)
+                            .addCopies(GET_TABLE, 6)
                             .build());
         }
         finally {
@@ -238,7 +236,7 @@ public class TestIcebergGlueCatalogAccessOperations
         }
     }
 
-    @Test(enabled = false)
+    @Test
     public void testSelectFromMaterializedViewWithFilter()
     {
         try {
@@ -247,7 +245,7 @@ public class TestIcebergGlueCatalogAccessOperations
 
             assertGlueMetastoreApiInvocations("SELECT * FROM test_select_mview_where_view WHERE age = 2",
                     ImmutableMultiset.builder()
-                            .addCopies(GET_TABLE, 3)
+                            .addCopies(GET_TABLE, 6)
                             .build());
         }
         finally {
@@ -256,7 +254,7 @@ public class TestIcebergGlueCatalogAccessOperations
         }
     }
 
-    @Test(enabled = false)
+    @Test
     public void testRefreshMaterializedView()
     {
         try {
@@ -265,7 +263,8 @@ public class TestIcebergGlueCatalogAccessOperations
 
             assertGlueMetastoreApiInvocations("REFRESH MATERIALIZED VIEW test_refresh_mview_view",
                     ImmutableMultiset.builder()
-                            .addCopies(GET_TABLE, 5)
+                            .addCopies(GET_TABLE, 12)
+                            .addCopies(UPDATE_TABLE, 2)
                             .build());
         }
         finally {


### PR DESCRIPTION
## Description

Reduce the number of getTable calls by caching metadata any time a table is retrieved from Glue.

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Iceberg connector with Glue

> How would you describe this change to a non-technical end user or system administrator?

Reduce the number of repeated API calls

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Iceberg
* Reduce the number of redundant API calls to AWS Glue.
```
