### PR TITLE
Support commenting on table and column in BigQuery

### DIFF
--- a/docs/src/main/sphinx/connector/bigquery.rst
+++ b/docs/src/main/sphinx/connector/bigquery.rst
@@ -219,6 +219,7 @@ the following features:
 * :doc:`/sql/drop-table`
 * :doc:`/sql/create-schema`
 * :doc:`/sql/drop-schema`
+* :doc:`/sql/comment`
 
 Table functions
 ---------------

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
@@ -217,6 +217,18 @@ public class BigQueryClient
         return bigQuery.create(jobInfo);
     }
 
+    public void executeUpdate(QueryJobConfiguration job)
+    {
+        log.debug("Execute query: %s", job.getQuery());
+        try {
+            bigQuery.query(job);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new BigQueryException(BaseHttpServiceException.UNKNOWN_CODE, format("Failed to run the query [%s]", job.getQuery()), e);
+        }
+    }
+
     public TableResult query(String sql, boolean useQueryResultsCache, CreateDisposition createDisposition)
     {
         log.debug("Execute query: %s", sql);

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryFilterQueryBuilder.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryFilterQueryBuilder.java
@@ -26,14 +26,13 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.plugin.bigquery.BigQueryUtil.quote;
 import static io.trino.plugin.bigquery.BigQueryUtil.toBigQueryColumnName;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
 public class BigQueryFilterQueryBuilder
 {
-    private static final String QUOTE = "`";
-    private static final String ESCAPED_QUOTE = "``";
     private final TupleDomain<ColumnHandle> tupleDomain;
 
     public static Optional<String> buildFilter(TupleDomain<ColumnHandle> tupleDomain)
@@ -150,10 +149,5 @@ public class BigQueryFilterQueryBuilder
             return Optional.empty();
         }
         return Optional.of(quote(columnName) + " " + operator + " " + valueAsString.get());
-    }
-
-    private String quote(String name)
-    {
-        return QUOTE + name.replace(QUOTE, ESCAPED_QUOTE) + QUOTE;
     }
 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryUtil.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryUtil.java
@@ -30,6 +30,9 @@ import static com.google.common.base.Throwables.getCausalChain;
 
 public final class BigQueryUtil
 {
+    private static final String QUOTE = "`";
+    private static final String ESCAPED_QUOTE = "``";
+
     private static final Set<String> INTERNAL_ERROR_MESSAGES = ImmutableSet.of(
             "HTTP/2 error code: INTERNAL_ERROR",
             "Connection closed with unknown cause",
@@ -72,5 +75,10 @@ public final class BigQueryUtil
     public static boolean isWildcardTable(TableDefinition.Type type, String tableName)
     {
         return type == TABLE && tableName.contains("*");
+    }
+
+    public static String quote(String name)
+    {
+        return QUOTE + name.replace(QUOTE, ESCAPED_QUOTE) + QUOTE;
     }
 }

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConnectorTest.java
@@ -77,8 +77,6 @@ public class TestBigQueryConnectorTest
             case SUPPORTS_ADD_COLUMN:
             case SUPPORTS_DROP_COLUMN:
             case SUPPORTS_RENAME_COLUMN:
-            case SUPPORTS_COMMENT_ON_TABLE:
-            case SUPPORTS_COMMENT_ON_COLUMN:
             case SUPPORTS_NEGATIVE_DATE:
             case SUPPORTS_ARRAY:
             case SUPPORTS_ROW_TYPE:


### PR DESCRIPTION
## Description

Support commenting on table and column in BigQuery

## Documentation

(x) Sufficient documentation is included in this PR.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# BigQuery
* Add support for [setting comments on tables](/sql/comment). ({issue}`13882`)
* Add support for [setting comments on columns](/sql/comment). ({issue}`13882`)
```
