### PR TITLE
Add query clause information to function analysis

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/CallTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CallTask.java
@@ -26,6 +26,7 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.eventlistener.ClauseInfo;
 import io.trino.spi.eventlistener.RoutineInfo;
 import io.trino.spi.procedure.Procedure;
 import io.trino.spi.procedure.Procedure.Argument;
@@ -202,7 +203,7 @@ public class CallTask
         }
 
         accessControl.checkCanExecuteProcedure(session.toSecurityContext(), procedureName);
-        stateMachine.setRoutines(ImmutableList.of(new RoutineInfo(procedureName.getObjectName(), session.getUser())));
+        stateMachine.setRoutines(ImmutableList.of(new RoutineInfo(procedureName.getObjectName(), session.getUser(), ClauseInfo.CALL)));
 
         try {
             procedure.getMethodHandle().invokeWithArguments(arguments);

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -37,6 +37,7 @@ import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnSchema;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.eventlistener.ClauseInfo;
 import io.trino.spi.eventlistener.ColumnDetail;
 import io.trino.spi.eventlistener.ColumnInfo;
 import io.trino.spi.eventlistener.RoutineInfo;
@@ -644,9 +645,9 @@ public class Analysis
         return resolvedFunctions.get(NodeRef.of(node)).getFunction();
     }
 
-    public void addResolvedFunction(Expression node, ResolvedFunction function, String authorization)
+    public void addResolvedFunction(Expression node, ResolvedFunction function, String authorization, ClauseInfo clauseInfo)
     {
-        resolvedFunctions.put(NodeRef.of(node), new RoutineEntry(function, authorization));
+        resolvedFunctions.put(NodeRef.of(node), new RoutineEntry(function, authorization, clauseInfo));
     }
 
     public Set<NodeRef<Expression>> getColumnReferences()
@@ -1136,7 +1137,7 @@ public class Analysis
     public List<RoutineInfo> getRoutines()
     {
         return resolvedFunctions.entrySet().stream()
-                .map(entry -> new RoutineInfo(entry.getValue().function.getSignature().getName(), entry.getValue().getAuthorization()))
+                .map(entry -> new RoutineInfo(entry.getValue().function.getSignature().getName(), entry.getValue().getAuthorization(), entry.getValue().getClauseInfo()))
                 .collect(toImmutableList());
     }
 
@@ -1959,11 +1960,13 @@ public class Analysis
     {
         private final ResolvedFunction function;
         private final String authorization;
+        private final ClauseInfo clauseInfo;
 
-        public RoutineEntry(ResolvedFunction function, String authorization)
+        public RoutineEntry(ResolvedFunction function, String authorization, ClauseInfo clauseInfo)
         {
             this.function = requireNonNull(function, "function is null");
             this.authorization = requireNonNull(authorization, "authorization is null");
+            this.clauseInfo = requireNonNull(clauseInfo, "clauseInfo is null");
         }
 
         public ResolvedFunction getFunction()
@@ -1974,6 +1977,11 @@ public class Analysis
         public String getAuthorization()
         {
             return authorization;
+        }
+
+        public ClauseInfo getClauseInfo()
+        {
+            return clauseInfo;
         }
     }
 

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -189,6 +189,10 @@
                                     <code>java.method.addedToInterface</code>
                                     <new>method io.trino.spi.block.BlockBuilder io.trino.spi.block.BlockBuilder::newBlockBuilderLike(int, io.trino.spi.block.BlockBuilderStatus)</new>
                                 </item>
+                                <item>
+                                    <code>java.annotation.removed</code>
+                                    <old>method void io.trino.spi.eventlistener.RoutineInfo::&lt;init>(java.lang.String, java.lang.String)</old>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/ClauseInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/ClauseInfo.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.eventlistener;
+
+public enum ClauseInfo
+{
+    SELECT,
+    FROM,
+    WHERE,
+    GROUP_BY,
+    HAVING,
+    WINDOW,
+    ORDER_BY,
+    OFFSET,
+    LIMIT,
+    JOIN,
+    UNNEST,
+    UPDATE,
+    MERGE,
+    ROW_FILTER,
+    COLUMN_MASK,
+    VALUES,
+    PATTERN_RECOGNITION,
+    CALL
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/RoutineInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/RoutineInfo.java
@@ -16,6 +16,8 @@ package io.trino.spi.eventlistener;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Optional;
+
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -25,14 +27,34 @@ public class RoutineInfo
 {
     private final String routine;
     private final String authorization;
+    private final Optional<ClauseInfo> clauseInfo;
+
+    @Deprecated
+    public RoutineInfo(String routine, String authorization)
+    {
+        this(
+                routine,
+                authorization,
+                Optional.empty());
+    }
+
+    public RoutineInfo(String routine, String authorization, ClauseInfo clauseInfo)
+    {
+        this(
+                routine,
+                authorization,
+                Optional.of(requireNonNull(clauseInfo, "clauseInfo is null")));
+    }
 
     @JsonCreator
     public RoutineInfo(
             @JsonProperty("routine") String routine,
-            @JsonProperty("authorization") String authorization)
+            @JsonProperty("authorization") String authorization,
+            @JsonProperty("clauseInfo") Optional<ClauseInfo> clauseInfo)
     {
         this.routine = requireNonNull(routine, "routine is null");
         this.authorization = requireNonNull(authorization, "authorization is null");
+        this.clauseInfo = requireNonNull(clauseInfo, "clauseInfo is null");
     }
 
     @JsonProperty
@@ -45,5 +67,11 @@ public class RoutineInfo
     public String getAuthorization()
     {
         return authorization;
+    }
+
+    @JsonProperty
+    public Optional<ClauseInfo> getClauseInfo()
+    {
+        return clauseInfo;
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Add the information from which query clause each function was called. This information can be valuable to subscribers of the event listener because each query clause has different characteristics - some are pushed down, some affect performance more than others, and so on.

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

- core query engine (Analyzer)
- SPI (`RoutineInfo` which is part of `QueryMetadata` that exposed through the event listener)
> How would you describe this change to a non-technical end user or system administrator?

Trino exposes some telemetry about queries. In particular, which functions were used. This change adds the information from which query clause each function was called.

<!-- ## Related issues, pull requests, and links -->

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(X) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(?) Release notes entries required with the following suggested text:

```markdown
# SPI
* Add query clause information (`ClauseInfo`) to `io.trino.spi.eventlistener.RoutineInfo`. (#13885)
```
