### PR TITLE
Remove unused method and fix typo in BytecodeUtils

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/gen/BytecodeUtils.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/BytecodeUtils.java
@@ -354,7 +354,7 @@ public final class BytecodeUtils
                         lambdaArgumentIndex++;
                         break;
                     default:
-                        throw new UnsupportedOperationException(format("Unsupported argument conventsion type: %s", invocationConvention.getArgumentConvention(realParameterIndex)));
+                        throw new UnsupportedOperationException(format("Unsupported argument convention type: %s", invocationConvention.getArgumentConvention(realParameterIndex)));
                 }
                 realParameterIndex++;
             }

--- a/core/trino-main/src/main/java/io/trino/sql/gen/BytecodeUtils.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/BytecodeUtils.java
@@ -125,25 +125,6 @@ public final class BytecodeUtils
                 .ifTrue(isNull);
     }
 
-    public static BytecodeNode boxPrimitive(Class<?> type)
-    {
-        BytecodeBlock block = new BytecodeBlock().comment("box primitive");
-        if (type == long.class) {
-            return block.invokeStatic(Long.class, "valueOf", Long.class, long.class);
-        }
-        if (type == double.class) {
-            return block.invokeStatic(Double.class, "valueOf", Double.class, double.class);
-        }
-        if (type == boolean.class) {
-            return block.invokeStatic(Boolean.class, "valueOf", Boolean.class, boolean.class);
-        }
-        if (type.isPrimitive()) {
-            throw new UnsupportedOperationException("not yet implemented: " + type);
-        }
-
-        return NOP;
-    }
-
     public static BytecodeNode unboxPrimitive(Class<?> unboxedType)
     {
         BytecodeBlock block = new BytecodeBlock().comment("unbox primitive");


### PR DESCRIPTION
`BytecodeUtils#boxPrimitiveis` was introduced in commit 654899e and
then the reference to that method was removed in commit 863d4d8, so we
can delete it.

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.