### PR TITLE
Push varchar non-equality comparisons into PostgreSQL

### DIFF
--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlConfig.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlConfig.java
@@ -22,7 +22,7 @@ public class PostgreSqlConfig
 {
     private ArrayMapping arrayMapping = ArrayMapping.DISABLED;
     private boolean includeSystemTables;
-    private boolean enableStringPushdownWithCollate;
+    private boolean enableStringPushdownWithCollate = true;
 
     public enum ArrayMapping
     {
@@ -62,7 +62,8 @@ public class PostgreSqlConfig
         return enableStringPushdownWithCollate;
     }
 
-    @Config("postgresql.experimental.enable-string-pushdown-with-collate")
+    @Config("postgresql.enable-string-pushdown-with-collate")
+    @LegacyConfig("postgresql.experimental.enable-string-pushdown-with-collate")
     public PostgreSqlConfig setEnableStringPushdownWithCollate(boolean enableStringPushdownWithCollate)
     {
         this.enableStringPushdownWithCollate = enableStringPushdownWithCollate;

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConfig.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConfig.java
@@ -30,7 +30,7 @@ public class TestPostgreSqlConfig
         assertRecordedDefaults(recordDefaults(PostgreSqlConfig.class)
                 .setArrayMapping(PostgreSqlConfig.ArrayMapping.DISABLED)
                 .setIncludeSystemTables(false)
-                .setEnableStringPushdownWithCollate(false));
+                .setEnableStringPushdownWithCollate(true));
     }
 
     @Test
@@ -39,13 +39,13 @@ public class TestPostgreSqlConfig
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("postgresql.array-mapping", "AS_ARRAY")
                 .put("postgresql.include-system-tables", "true")
-                .put("postgresql.experimental.enable-string-pushdown-with-collate", "true")
+                .put("postgresql.enable-string-pushdown-with-collate", "false")
                 .buildOrThrow();
 
         PostgreSqlConfig expected = new PostgreSqlConfig()
                 .setArrayMapping(PostgreSqlConfig.ArrayMapping.AS_ARRAY)
                 .setIncludeSystemTables(true)
-                .setEnableStringPushdownWithCollate(true);
+                .setEnableStringPushdownWithCollate(false);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
This enables by default an existing feature.

Follows https://github.com/trinodb/trino/pull/9746
Relates to https://github.com/trinodb/trino/issues/7496 