### PR TITLE
[WIP] Store query type in trino-cli StatementClient

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/Query.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/Query.java
@@ -53,6 +53,7 @@ import static io.trino.cli.CsvPrinter.CsvOutputFormat.NO_HEADER_AND_QUOTES;
 import static io.trino.cli.CsvPrinter.CsvOutputFormat.NO_QUOTES;
 import static io.trino.cli.CsvPrinter.CsvOutputFormat.STANDARD;
 import static io.trino.cli.TerminalUtils.isRealTerminal;
+import static io.trino.client.QueryType.EXPLAIN_ANALYZE;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
@@ -163,6 +164,12 @@ public class Query
             QueryStatusInfo results = client.isRunning() ? client.currentStatusInfo() : client.finalStatusInfo();
             if (results.getUpdateType() != null) {
                 renderUpdate(errorChannel, results);
+                if (client.getQueryType().equals(EXPLAIN_ANALYZE)) {
+                    renderResults(out, outputFormat, usePager, results.getColumns());
+                }
+                else {
+                    discardResults();
+                }
             }
             else if (results.getColumns() == null) {
                 errorChannel.printf("Query %s has no columns\n", results.getId());
@@ -228,7 +235,6 @@ public class Query
             status += format(": %s row%s", count, (count != 1) ? "s" : "");
         }
         out.println(status);
-        discardResults();
     }
 
     private void discardResults()

--- a/client/trino-client/src/main/java/io/trino/client/QueryType.java
+++ b/client/trino-client/src/main/java/io/trino/client/QueryType.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client;
+
+public enum QueryType
+{
+    EXPLAIN_ANALYZE,
+    OTHER,
+}

--- a/client/trino-client/src/main/java/io/trino/client/StatementClient.java
+++ b/client/trino-client/src/main/java/io/trino/client/StatementClient.java
@@ -26,6 +26,8 @@ public interface StatementClient
 {
     String getQuery();
 
+    QueryType getQueryType();
+
     ZoneId getTimeZone();
 
     boolean isRunning();

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/cli/TestTrinoCli.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/cli/TestTrinoCli.java
@@ -403,6 +403,20 @@ public class TestTrinoCli
         assertThat(trimLines(trino.readLinesUntilPrompt())).doesNotContain("admin");
     }
 
+    @Test(groups = CLI, timeOut = TIMEOUT)
+    public void shouldPrintExplainAnalyzePlan()
+            throws Exception
+    {
+        launchTrinoCliWithServerArgument();
+        trino.waitForPrompt();
+        trino.getProcessInput().println("EXPLAIN ANALYZE CREATE TABLE hive.default.test_table AS SELECT * FROM hive.default.nation;");
+        List<String> lines = trimLines(trino.readLinesUntilPrompt());
+        assertThat(lines).contains("CREATE TABLE", "Query Plan");
+        trino.getProcessInput().println("EXPLAIN ANALYZE INSERT INTO hive.default.test_table VALUES(100, 'URUGUAY', 3, 'test comment');");
+        lines = trimLines(trino.readLinesUntilPrompt());
+        assertThat(lines).contains("INSERT", "Query Plan");
+    }
+
     private void launchTrinoCliWithServerArgument(String... arguments)
             throws IOException
     {


### PR DESCRIPTION
## Description
The goal of this PR is to fix trino-cli to show plan when `EXPLAIN ANALYZE` is called. 
I came up with 3 different approaches to solve this, see:
- https://github.com/trinodb/trino/pull/13898
- https://github.com/trinodb/trino/pull/13899
- https://github.com/trinodb/trino/pull/13900

Test should show the biggest difference.
In this PR, trino-cli extract information that the query is EXPLAIN ANALYZE and uses it during displaying the results. The displayed results contains name of the operation, like `CREATE TABLE` or `INSERT` and entire plan.

> Is this change a fix, improvement, new feature, refactoring, or other?
a fix
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
a library ?
> How would you describe this change to a non-technical end user or system administrator?
Results of `EXPLAIN ANALYZE` queries are described correctly.

## Related issues, pull requests, and links

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

() No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# trino-cli
* Display results of EXPLAIN ANALYZE correctly ({issue}`issuenumber`)
```
