### PR TITLE
[WIP] Set EXPLAIN ANALYZE query type to EXPLAIN

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analyzer.java
@@ -19,6 +19,7 @@ import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
 import io.trino.sql.rewrite.StatementRewrite;
+import io.trino.sql.tree.ExplainAnalyze;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.FunctionCall;
 import io.trino.sql.tree.GroupingOperation;
@@ -34,6 +35,7 @@ import static io.trino.spi.StandardErrorCode.EXPRESSION_NOT_SCALAR;
 import static io.trino.sql.analyzer.ExpressionTreeUtils.extractAggregateFunctions;
 import static io.trino.sql.analyzer.ExpressionTreeUtils.extractExpressions;
 import static io.trino.sql.analyzer.ExpressionTreeUtils.extractWindowExpressions;
+import static io.trino.sql.analyzer.QueryType.EXPLAIN;
 import static io.trino.sql.analyzer.QueryType.OTHERS;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
 import static java.util.Objects.requireNonNull;
@@ -68,7 +70,11 @@ public class Analyzer
 
     public Analysis analyze(Statement statement)
     {
-        return analyze(statement, OTHERS);
+        QueryType queryType = OTHERS;
+        if (statement instanceof ExplainAnalyze) {
+            queryType = EXPLAIN;
+        }
+        return analyze(statement, queryType);
     }
 
     public Analysis analyze(Statement statement, QueryType queryType)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/cli/TestTrinoCli.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/cli/TestTrinoCli.java
@@ -403,6 +403,22 @@ public class TestTrinoCli
         assertThat(trimLines(trino.readLinesUntilPrompt())).doesNotContain("admin");
     }
 
+    @Test(groups = CLI, timeOut = TIMEOUT)
+    public void shouldPrintExplainAnalyzePlan()
+            throws Exception
+    {
+        launchTrinoCliWithServerArgument();
+        trino.waitForPrompt();
+        trino.getProcessInput().println("EXPLAIN ANALYZE CREATE TABLE hive.default.test_table AS SELECT * FROM hive.default.nation;");
+        List<String> lines = trimLines(trino.readLinesUntilPrompt());
+        assertThat(lines).contains("Query Plan");
+        assertThat(lines).doesNotContain("CREATE TABLE");
+        trino.getProcessInput().println("EXPLAIN ANALYZE INSERT INTO hive.default.test_table VALUES(100, 'URUGUAY', 3, 'test comment');");
+        lines = trimLines(trino.readLinesUntilPrompt());
+        assertThat(lines).contains("Query Plan");
+        assertThat(lines).doesNotContain("INSERT");
+    }
+
     private void launchTrinoCliWithServerArgument(String... arguments)
             throws IOException
     {


### PR DESCRIPTION
## Description
The goal of this PR is to fix trino-cli to show plan when `EXPLAIN ANALYZE` is called. 
I came up with 3 different approaches to solve this, see:
- https://github.com/trinodb/trino/pull/13898
- https://github.com/trinodb/trino/pull/13899
- https://github.com/trinodb/trino/pull/13900

Test should show the biggest difference.
In this PR, EXPLAIN ANALYZE has QueryType on trino engine site set to EXPLAIN which is displayed differently than other types of queries. The displayed result contains only query plan. 

> Is this change a fix, improvement, new feature, refactoring, or other?
a fix
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
a library ?
> How would you describe this change to a non-technical end user or system administrator?
Results of `EXPLAIN ANALYZE` queries are described correctly.

## Related issues, pull requests, and links

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

() No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# trino-cli
* Display results of EXPLAIN ANALYZE correctly ({issue}`issuenumber`)
```
