### PR TITLE
[WIP] Return update type EXPLAIN ANALYZE for EXPLAIN ANALIZE

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/Query.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/Query.java
@@ -163,6 +163,12 @@ public class Query
             QueryStatusInfo results = client.isRunning() ? client.currentStatusInfo() : client.finalStatusInfo();
             if (results.getUpdateType() != null) {
                 renderUpdate(errorChannel, results);
+                if (results.getUpdateType().equalsIgnoreCase("EXPLAIN ANALYZE")) {
+                    renderResults(out, outputFormat, usePager, results.getColumns());
+                }
+                else {
+                    discardResults();
+                }
             }
             else if (results.getColumns() == null) {
                 errorChannel.printf("Query %s has no columns\n", results.getId());
@@ -228,7 +234,6 @@ public class Query
             status += format(": %s row%s", count, (count != 1) ? "s" : "");
         }
         out.println(status);
-        discardResults();
     }
 
     private void discardResults()

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -1395,6 +1395,7 @@ class StatementAnalyzer
         protected Scope visitExplainAnalyze(ExplainAnalyze node, Optional<Scope> scope)
         {
             process(node.getStatement(), scope);
+            analysis.setUpdateType("EXPLAIN ANALYZE");
             return createAndAssignScope(node, scope, Field.newUnqualified("Query Plan", VARCHAR));
         }
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/cli/TestTrinoCli.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/cli/TestTrinoCli.java
@@ -403,6 +403,20 @@ public class TestTrinoCli
         assertThat(trimLines(trino.readLinesUntilPrompt())).doesNotContain("admin");
     }
 
+    @Test(groups = CLI, timeOut = TIMEOUT)
+    public void shouldPrintExplainAnalyzeCreateTablePlan()
+            throws Exception
+    {
+        launchTrinoCliWithServerArgument();
+        trino.waitForPrompt();
+        trino.getProcessInput().println("EXPLAIN ANALYZE CREATE TABLE hive.default.test_table AS SELECT * FROM hive.default.nation;");
+        List<String> lines = trimLines(trino.readLinesUntilPrompt());
+        assertThat(lines).contains("EXPLAIN ANALYZE", "Query Plan");
+        trino.getProcessInput().println("EXPLAIN ANALYZE INSERT INTO hive.default.test_table VALUES(100, 'URUGUAY', 3, 'test comment');");
+        lines = trimLines(trino.readLinesUntilPrompt());
+        assertThat(lines).contains("EXPLAIN ANALYZE", "Query Plan");
+    }
+
     private void launchTrinoCliWithServerArgument(String... arguments)
             throws IOException
     {


### PR DESCRIPTION
## Description
The goal of this PR is to fix trino-cli to show plan when `EXPLAIN ANALYZE` is called. 
I came up with 3 different approaches to solve this, see:
- https://github.com/trinodb/trino/pull/13898
- https://github.com/trinodb/trino/pull/13899
- https://github.com/trinodb/trino/pull/13900

Test should show the biggest difference.
In this PR, new type of UpdateType is returned which can be treated differently by trino-cli 

> Is this change a fix, improvement, new feature, refactoring, or other?
a fix
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
a library ?
> How would you describe this change to a non-technical end user or system administrator?
Results of `EXPLAIN ANALYZE` queries are described correctly.

## Related issues, pull requests, and links

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

() No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# trino-cli
* Display results of EXPLAIN ANALYZE correctly ({issue}`issuenumber`)
```
