### PR TITLE
Ensure test table contains multiple active files

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/AbstractTestDeltaLakeCreateTableStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/AbstractTestDeltaLakeCreateTableStatistics.java
@@ -433,36 +433,6 @@ public abstract class AbstractTestDeltaLakeCreateTableStatistics
     }
 
     @Test
-    public void testMultiFileTable()
-            throws Exception
-    {
-        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle("name", createUnboundedVarcharType(), "name", createUnboundedVarcharType(), REGULAR);
-        Session session = testSessionBuilder()
-                .setCatalog(DELTA_CATALOG)
-                .setSystemProperty("scale_writers", "false")
-                .setSchema(SCHEMA)
-                .build();
-        try (TestTable table = new TestTable(
-                "test_partitioned_table_",
-                ImmutableList.of(),
-                ImmutableList.of(),
-                "SELECT name FROM tpch.tiny.nation UNION select name from tpch.tiny.customer",
-                session)) {
-            List<AddFileEntry> addFileEntries = getAddFileEntries(table.getName());
-            assertThat(addFileEntries.size()).isGreaterThan(1);
-
-            List<DeltaLakeFileStatistics> statistics = addFileEntries.stream().map(entry -> entry.getStats().get()).collect(toImmutableList());
-
-            List<Object> minValues = statistics.stream().map(stat -> stat.getMinColumnValue(columnHandle).get()).collect(toImmutableList());
-            List<Object> maxValues = statistics.stream().map(stat -> stat.getMaxColumnValue(columnHandle).get()).collect(toImmutableList());
-
-            // All values in the table are distinct, so the min and max values should all be different
-            assertEquals(minValues.size(), minValues.stream().distinct().count());
-            assertEquals(maxValues.size(), maxValues.stream().distinct().count());
-        }
-    }
-
-    @Test
     public void testMultiFileTableWithNaNValue()
             throws Exception
     {

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/AbstractTestDeltaLakeCreateTableStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/AbstractTestDeltaLakeCreateTableStatistics.java
@@ -57,8 +57,6 @@ import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.testing.TestingConnectorSession.SESSION;
-import static io.trino.testing.TestingSession.testSessionBuilder;
-import static io.trino.testing.assertions.Assert.assertEventually;
 import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.POSITIVE_INFINITY;
@@ -81,8 +79,9 @@ public abstract class AbstractTestDeltaLakeCreateTableStatistics
         this.bucketName = "delta-test-create-table-statistics-" + randomTableSuffix();
         HiveMinioDataLake hiveMinioDataLake = closeAfterClass(new HiveMinioDataLake(bucketName));
         hiveMinioDataLake.start();
-        ImmutableMap.Builder<String, String> queryRunnerProperties = ImmutableMap.builder();
-        queryRunnerProperties.putAll(additionalProperties());
+        ImmutableMap.Builder<String, String> queryRunnerProperties = ImmutableMap.<String, String>builder()
+                .put("delta.enable-non-concurrent-writes", "true")
+                .putAll(additionalProperties());
         return DeltaLakeQueryRunner.createS3DeltaLakeQueryRunner(
                 DELTA_CATALOG,
                 SCHEMA,
@@ -436,32 +435,24 @@ public abstract class AbstractTestDeltaLakeCreateTableStatistics
     public void testMultiFileTableWithNaNValue()
             throws Exception
     {
-        // assertEventually because sometimes write from tpch.tiny.orders creates one file only and the test requires at least two files
-        assertEventually(() -> {
-            String columnName = "orderkey";
-            DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, columnName, DoubleType.DOUBLE, REGULAR);
-            Session session = testSessionBuilder()
-                    .setCatalog(DELTA_CATALOG)
-                    .setSchema(SCHEMA)
-                    .setSystemProperty("scale_writers", "false")
-                    .build();
-            try (TestTable table = new TestTable(
-                    "test_partitioned_table_",
-                    ImmutableList.of(columnName),
-                    ImmutableList.of(),
-                    "SELECT IF(orderkey = 50597, nan(), CAST(orderkey AS double)) FROM tpch.tiny.orders",
-                    session)) {
-                List<AddFileEntry> addFileEntries = getAddFileEntries(table.getName());
-                assertThat(addFileEntries.size()).isGreaterThan(1);
+        String columnName = "key";
+        DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(columnName, DoubleType.DOUBLE, columnName, DoubleType.DOUBLE, REGULAR);
+        try (TestTable table = new TestTable(
+                "test_multi_file_table_nan_value_",
+                ImmutableList.of(columnName),
+                ImmutableList.of(),
+                "SELECT IF(custkey = 1143, nan(), CAST(custkey AS double)) FROM tpch.tiny.customer")) {
+            assertUpdate("INSERT INTO %s SELECT CAST(nationkey AS double) FROM tpch.tiny.nation".formatted(table.getName()), 25);
+            List<AddFileEntry> addFileEntries = getAddFileEntries(table.getName());
+            assertThat(addFileEntries.size()).isGreaterThan(1);
 
-                List<DeltaLakeFileStatistics> statistics = addFileEntries.stream().map(entry -> entry.getStats().get()).collect(toImmutableList());
+            List<DeltaLakeFileStatistics> statistics = addFileEntries.stream().map(entry -> entry.getStats().get()).collect(toImmutableList());
 
-                assertEquals(statistics.stream().filter(stat -> stat.getMinColumnValue(columnHandle).isEmpty() && stat.getMaxColumnValue(columnHandle).isEmpty()).count(), 1);
-                assertEquals(
-                        statistics.stream().filter(stat -> stat.getMinColumnValue(columnHandle).isPresent() && stat.getMaxColumnValue(columnHandle).isPresent()).count(),
-                        statistics.size() - 1);
-            }
-        });
+            assertEquals(statistics.stream().filter(stat -> stat.getMinColumnValue(columnHandle).isEmpty() && stat.getMaxColumnValue(columnHandle).isEmpty()).count(), 1);
+            assertEquals(
+                    statistics.stream().filter(stat -> stat.getMinColumnValue(columnHandle).isPresent() && stat.getMaxColumnValue(columnHandle).isPresent()).count(),
+                    statistics.size() - 1);
+        }
     }
 
     protected class TestTable


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

Ensure that the table created in the test does indeed have multiple files by partitioning the table.
Assuming that an unpartitioned table will have multiple files after being created with a CTAS statement can lead to flakiness in the tests. 

This change is related to test infrastructure and doesn't change the existing functionality of the production code.


## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

Fixes https://github.com/trinodb/trino/issues/13107

