### PR TITLE
Add comments explaining why use Multimap in DynamicFilters#extractSourceSymbols

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/DynamicFilters.java
+++ b/core/trino-main/src/main/java/io/trino/sql/DynamicFilters.java
@@ -133,6 +133,20 @@ public final class DynamicFilters
 
     public static Multimap<DynamicFilterId, Descriptor> extractSourceSymbols(List<DynamicFilters.Descriptor> dynamicFilters)
     {
+        // Let's imagine if the probe-side is a union, and we need to match multiple
+        // probe-side symbols to the dynamic filter. For example, the following SQL:
+        // ```
+        // SELECT b.orderkey
+        // FROM (
+        //    SELECT custkey FROM tpch.sf1.customer WHERE custkey = 1
+        //    UNION
+        //    SELECT custkey FROM tpch.sf1.customer WHERE custkey = 2
+        // ) a
+        // JOIN tpch.sf1.orders b ON a.custkey = b.custkey
+        // ```
+        // We need to pass the dynamic filter generated from "tpch.sf1.orders" to the two
+        // "tpch.sf1.customer" in the union, so we use `Multimap` here to match the case
+        // where there may be one dynamic filter for multiple symbols on the probe-side.
         return dynamicFilters.stream()
                 .collect(toImmutableListMultimap(
                         DynamicFilters.Descriptor::getId,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalDynamicFiltersCollector.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalDynamicFiltersCollector.java
@@ -162,7 +162,7 @@ public class LocalDynamicFiltersCollector
             this.futuresLeft = predicateFutures.size();
             this.isBlocked = predicateFutures.isEmpty() ? NOT_BLOCKED : new CompletableFuture<>();
             this.currentPredicate = TupleDomain.all();
-            predicateFutures.stream().forEach(future -> addSuccessCallback(future, this::update, directExecutor()));
+            predicateFutures.forEach(future -> addSuccessCallback(future, this::update, directExecutor()));
         }
 
         private void update(TupleDomain<ColumnHandle> predicate)


### PR DESCRIPTION
Related https://github.com/trinodb/trino/pull/931/commits/d57a180437a7d07be593a0c4476f111af0965e43#r327738515

## Documentation

(x) No documentation is needed.

## Release notes

(x) No release notes entries required.
