### PR TITLE
Fix trino-cli to display plans for EXPLAIN ANALYZE

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/Query.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/Query.java
@@ -162,8 +162,12 @@ public class Query
         if (client.isRunning() || (client.isFinished() && client.finalStatusInfo().getError() == null)) {
             QueryStatusInfo results = client.isRunning() ? client.currentStatusInfo() : client.finalStatusInfo();
             if (results.getUpdateType() != null) {
-                renderUpdate(errorChannel, results);
+                renderUpdate(errorChannel, results, outputFormat, usePager);
             }
+            // TODO once https://github.com/trinodb/trino/issues/14253 is done this else here should be needed
+            // and should be replaced with just simple:
+            // if there is updateCount print it
+            // if there are columns(resultSet) then print it
             else if (results.getColumns() == null) {
                 errorChannel.printf("Query %s has no columns\n", results.getId());
                 return false;
@@ -220,14 +224,21 @@ public class Query
         warningsPrinter.print(warnings, false, true);
     }
 
-    private void renderUpdate(PrintStream out, QueryStatusInfo results)
+    private void renderUpdate(PrintStream out, QueryStatusInfo results, OutputFormat outputFormat, boolean usePager)
     {
         String status = results.getUpdateType();
         if (results.getUpdateCount() != null) {
             long count = results.getUpdateCount();
             status += format(": %s row%s", count, (count != 1) ? "s" : "");
+            out.println(status);
         }
-        out.println(status);
+        else if (results.getColumns() != null && !results.getColumns().isEmpty()) {
+            out.println(status);
+            renderResults(out, outputFormat, usePager, results.getColumns());
+        }
+        else {
+            out.println(status);
+        }
         discardResults();
     }
 

--- a/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
@@ -49,7 +49,6 @@ import io.trino.spi.QueryId;
 import io.trino.spi.block.BlockEncodingSerde;
 import io.trino.spi.exchange.ExchangeId;
 import io.trino.spi.security.SelectedRole;
-import io.trino.spi.type.BooleanType;
 import io.trino.spi.type.Type;
 import io.trino.transaction.TransactionId;
 
@@ -507,13 +506,11 @@ class Query
 
     private synchronized QueryResultRows removePagesFromExchange(QueryInfo queryInfo, long targetResultBytes)
     {
-        // For queries with no output, return a fake boolean result for clients that require it.
         if (!resultsConsumed && queryInfo.getOutputStage().isEmpty()) {
             return queryResultRowsBuilder(session)
-                    .withSingleBooleanValue(createColumn("result", BooleanType.BOOLEAN, supportsParametricDateTime), true)
+                    .withColumnsAndTypes(ImmutableList.of(), ImmutableList.of())
                     .build();
         }
-
         // Remove as many pages as possible from the exchange until just greater than DESIRED_RESULT_BYTES
         // NOTE: it is critical that query results are created for the pages removed from the exchange
         // client while holding the lock because the query may transition to the finished state when the

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -1026,7 +1026,7 @@ public abstract class BaseIcebergConnectorTest
         String tableName = "partitioning_" + randomTableSuffix();
         @Language("SQL") String sql = format("CREATE TABLE %s (%s bigint) WITH (partitioning = ARRAY['%s'])", tableName, columnName, partitioningField);
         if (success) {
-            assertThat(query(sql)).matches("VALUES (true)");
+            assertUpdate(sql);
             dropTable(tableName);
         }
         else {

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/cli/TestTrinoCli.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/cli/TestTrinoCli.java
@@ -403,6 +403,30 @@ public class TestTrinoCli
         assertThat(trimLines(trino.readLinesUntilPrompt())).doesNotContain("admin");
     }
 
+    @Test(groups = CLI, timeOut = TIMEOUT)
+    public void shouldPrintExplainAnalyzePlan()
+            throws Exception
+    {
+        launchTrinoCliWithServerArgument();
+        trino.waitForPrompt();
+        trino.getProcessInput().println("EXPLAIN ANALYZE CREATE TABLE iceberg.default.test_table AS SELECT * FROM hive.default.nation LIMIT 10;");
+        List<String> lines = trimLines(trino.readLinesUntilPrompt());
+        // TODO once https://github.com/trinodb/trino/issues/14253 is done this should be assertThat(lines).contains("CREATE TABLE: 1 row", "Query Plan");
+        assertThat(lines).contains("CREATE TABLE", "Query Plan");
+        // TODO once https://github.com/trinodb/trino/issues/14253 is done this should be assertThat(lines).contains("INSERT: 1 row", "Query Plan");
+        trino.getProcessInput().println("EXPLAIN ANALYZE INSERT INTO iceberg.default.test_table VALUES(100, 'URUGUAY', 3, 'test comment');");
+        lines = trimLines(trino.readLinesUntilPrompt());
+        assertThat(lines).contains("INSERT", "Query Plan");
+        // TODO once https://github.com/trinodb/trino/issues/14253 is done this should be assertThat(lines).contains("UPDATE: 1 row", "Query Plan");
+        trino.getProcessInput().println("EXPLAIN ANALYZE UPDATE iceberg.default.test_table SET n_comment = 'testValue 5' WHERE n_nationkey = 100;");
+        lines = trimLines(trino.readLinesUntilPrompt());
+        assertThat(lines).contains("UPDATE", "Query Plan");
+        // TODO once https://github.com/trinodb/trino/issues/14253 is done this should be assertThat(lines).contains("DELETE: 1 row", "Query Plan");
+        trino.getProcessInput().println("EXPLAIN ANALYZE DELETE FROM iceberg.default.test_table WHERE n_nationkey = 100;");
+        lines = trimLines(trino.readLinesUntilPrompt());
+        assertThat(lines).contains("DELETE", "Query Plan");
+    }
+
     private void launchTrinoCliWithServerArgument(String... arguments)
             throws IOException
     {

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -5315,35 +5315,35 @@ public abstract class AbstractTestEngineOnlyQueries
     public void testSetSession()
     {
         MaterializedResult result = computeActual("SET SESSION test_string = 'bar'");
-        assertTrue((Boolean) getOnlyElement(result).getField(0));
+        assertNoRelationalResult(result);
         assertEquals(result.getSetSessionProperties(), ImmutableMap.of("test_string", "bar"));
 
         result = computeActual(format("SET SESSION %s.connector_long = 999", TESTING_CATALOG));
-        assertTrue((Boolean) getOnlyElement(result).getField(0));
+        assertNoRelationalResult(result);
         assertEquals(result.getSetSessionProperties(), ImmutableMap.of(TESTING_CATALOG + ".connector_long", "999"));
 
         result = computeActual(format("SET SESSION %s.connector_string = 'baz'", TESTING_CATALOG));
-        assertTrue((Boolean) getOnlyElement(result).getField(0));
+        assertNoRelationalResult(result);
         assertEquals(result.getSetSessionProperties(), ImmutableMap.of(TESTING_CATALOG + ".connector_string", "baz"));
 
         result = computeActual(format("SET SESSION %s.connector_string = 'ban' || 'ana'", TESTING_CATALOG));
-        assertTrue((Boolean) getOnlyElement(result).getField(0));
+        assertNoRelationalResult(result);
         assertEquals(result.getSetSessionProperties(), ImmutableMap.of(TESTING_CATALOG + ".connector_string", "banana"));
 
         result = computeActual(format("SET SESSION %s.connector_long = 444", TESTING_CATALOG));
-        assertTrue((Boolean) getOnlyElement(result).getField(0));
+        assertNoRelationalResult(result);
         assertEquals(result.getSetSessionProperties(), ImmutableMap.of(TESTING_CATALOG + ".connector_long", "444"));
 
         result = computeActual(format("SET SESSION %s.connector_long = 111 + 111", TESTING_CATALOG));
-        assertTrue((Boolean) getOnlyElement(result).getField(0));
+        assertNoRelationalResult(result);
         assertEquals(result.getSetSessionProperties(), ImmutableMap.of(TESTING_CATALOG + ".connector_long", "222"));
 
         result = computeActual(format("SET SESSION %s.connector_boolean = 111 < 3", TESTING_CATALOG));
-        assertTrue((Boolean) getOnlyElement(result).getField(0));
+        assertNoRelationalResult(result);
         assertEquals(result.getSetSessionProperties(), ImmutableMap.of(TESTING_CATALOG + ".connector_boolean", "false"));
 
         result = computeActual(format("SET SESSION %s.connector_double = 11.1", TESTING_CATALOG));
-        assertTrue((Boolean) getOnlyElement(result).getField(0));
+        assertNoRelationalResult(result);
         assertEquals(result.getSetSessionProperties(), ImmutableMap.of(TESTING_CATALOG + ".connector_double", "11.1"));
     }
 
@@ -5351,11 +5351,11 @@ public abstract class AbstractTestEngineOnlyQueries
     public void testResetSession()
     {
         MaterializedResult result = computeActual(getSession(), "RESET SESSION test_string");
-        assertTrue((Boolean) getOnlyElement(result).getField(0));
+        assertNoRelationalResult(result);
         assertEquals(result.getResetSessionProperties(), ImmutableSet.of("test_string"));
 
         result = computeActual(getSession(), format("RESET SESSION %s.connector_string", TESTING_CATALOG));
-        assertTrue((Boolean) getOnlyElement(result).getField(0));
+        assertNoRelationalResult(result);
         assertEquals(result.getResetSessionProperties(), ImmutableSet.of(TESTING_CATALOG + ".connector_string"));
     }
 
@@ -6534,5 +6534,11 @@ public abstract class AbstractTestEngineOnlyQueries
     private static ZonedDateTime zonedDateTime(String value)
     {
         return ZONED_DATE_TIME_FORMAT.parse(value, ZonedDateTime::from);
+    }
+
+    private void assertNoRelationalResult(MaterializedResult result)
+    {
+        assertThat(result.getMaterializedRows()).isEmpty();
+        assertThat(result.getTypes()).isEmpty(); // i.e. no columns
     }
 }

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestGrantOnSchema.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestGrantOnSchema.java
@@ -106,8 +106,8 @@ public class TestGrantOnSchema
         queryRunner.execute(admin, format("GRANT %s ON SCHEMA default TO %s WITH GRANT OPTION", privilege, username));
 
         assertThat(assertions.query(user, "SHOW SCHEMAS FROM local")).matches("VALUES (VARCHAR 'information_schema'), (VARCHAR 'default')");
-        assertThat(assertions.query(user, format("GRANT %s ON SCHEMA default TO %s", privilege, randomUsername()))).matches("VALUES (BOOLEAN 'TRUE')");
-        assertThat(assertions.query(user, format("GRANT %s ON SCHEMA default TO %s WITH GRANT OPTION", privilege, randomUsername()))).matches("VALUES (BOOLEAN 'TRUE')");
+        assertions.query(user, format("GRANT %s ON SCHEMA default TO %s", privilege, randomUsername()));
+        assertions.query(user, format("GRANT %s ON SCHEMA default TO %s WITH GRANT OPTION", privilege, randomUsername()));
     }
 
     @Test(dataProvider = "privileges")

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestGrantOnTable.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestGrantOnTable.java
@@ -33,9 +33,12 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.EnumSet;
+import java.util.Optional;
+import java.util.OptionalLong;
 
 import static io.trino.common.Randoms.randomUsername;
 import static io.trino.spi.security.PrincipalType.USER;
+import static io.trino.testing.QueryAssertions.assertUpdate;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -105,8 +108,8 @@ public class TestGrantOnTable
         queryRunner.execute(admin, format("GRANT %s ON TABLE table_one TO %s WITH GRANT OPTION", privilege, username));
 
         assertThat(assertions.query(user, "SHOW TABLES FROM default")).matches("VALUES (VARCHAR 'table_one')");
-        assertThat(assertions.query(user, format("GRANT %s ON TABLE table_one TO %s", privilege, randomUsername()))).matches("VALUES (BOOLEAN 'TRUE')");
-        assertThat(assertions.query(user, format("GRANT %s ON TABLE table_one TO %s WITH GRANT OPTION", privilege, randomUsername()))).matches("VALUES (BOOLEAN 'TRUE')");
+        assertUpdate(queryRunner, user, format("GRANT %s ON TABLE table_one TO %s", privilege, randomUsername()), OptionalLong.empty(), Optional.empty());
+        assertUpdate(queryRunner, user, format("GRANT %s ON TABLE table_one TO %s WITH GRANT OPTION", privilege, randomUsername()), OptionalLong.empty(), Optional.empty());
     }
 
     @Test(dataProvider = "privileges")


### PR DESCRIPTION

## Description
Previously trino-cli didn't display plans for EXPLAIN ANALYZe

> Is this change a fix, improvement, new feature, refactoring, or other?
a fix
> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
a client library
> How would you describe this change to a non-technical end user or system administrator?
Gives user proper output for EXPLAIN ANALYZe
## Related issues, pull requests, and links

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# cli
* trino-cli displays query plan for EXPLAIN ANALYZE queries ({issue}`issuenumber`)
```
