### PR TITLE
Simplify pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,29 +2,7 @@
 
 ## Description
 
-<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->
-
-<!-- Answer the following questions to help reviewers and maintainers
-understand this PR's scope at a glance:
--->
-
-> Is this change a fix, improvement, new feature, refactoring, or other?
-
-> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
-
-> How would you describe this change to a non-technical end user or system administrator?
-
-## Related issues, pull requests, and links
-
-<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
-* Fixes #issuenumber
-* Related documentation in #issuenumber
-* [Some release notes](http://usefulinfo.example.com)
--->
-
-<!-- The following sections are filled in by the maintainer with input from the contributor:
-Use :white_check_mark: or (x) to signal selection.
--->
+....
 
 ## Documentation
 


### PR DESCRIPTION
It's apparently not filled in in majority of the PRs, also including
once authored by maintainers. As a result, reviewers spend time
eyeballing the template's text to check whether this is just a raw
template or there is any information added.
