### PR TITLE
Do not schedule query on coordinator in Multinode PT

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-tls-kerberos/config-master.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-tls-kerberos/config-master.properties
@@ -3,7 +3,7 @@ node.environment=test
 node.internal-address-source=FQDN
 
 coordinator=true
-node-scheduler.include-coordinator=true
+node-scheduler.include-coordinator=false
 discovery.uri=https://presto-master.docker.cluster:7778
 
 query.max-memory=1GB

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-tls/config-master.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-tls/config-master.properties
@@ -3,7 +3,7 @@ node.environment=test
 node.internal-address-source=FQDN
 
 coordinator=true
-node-scheduler.include-coordinator=true
+node-scheduler.include-coordinator=false
 discovery.uri=https://presto-master.docker.cluster:7778
 
 query.max-memory=1GB


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

improve tests environments

> How would you describe this change to a non-technical end user or system administrator?

If the query could be scheduled on coordinator - it could be enough for successful query execution. The whole environment could pretend that it's multinode but in reality could be singlenode with wrongly configured worker.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
