### PR TITLE
Document named zone support for timestamp with time zone

### DIFF
--- a/docs/src/main/sphinx/language/types.rst
+++ b/docs/src/main/sphinx/language/types.rst
@@ -262,11 +262,27 @@ The following examples illustrate the behavior::
 Instant in time that includes the date and time of day with ``P`` digits of
 precision for the fraction of seconds and with a time zone. Values of this
 type are rendered using the time zone from the value.
-Time zones are expressed as the numeric UTC offset value::
+Time zones can be expressed in the following ways:
 
-    TIMESTAMP '2001-08-22 03:04:05.321 -08:00';
-    -- 2001-08-22 03:04:05.321-08:00
+* ``UTC``, with ``GMT``, ``Z``, or ``UT`` usable as aliases for UTC.
+* ``+hh:mm`` or ``-hh:mm`` with ``hh:mm`` as an hour and minute offset from UTC.
+  Can be written with or without ``UTC``, ``GMT``, or ``UT`` as an alias for
+  UTC.
+* An `IANA time zone name <https://www.iana.org/time-zones>`_.
 
+The following examples demonstrate some of these syntax options::
+
+    SELECT TIMESTAMP '2001-08-22 03:04:05.321 UTC';
+    -- 2001-08-22 03:04:05.321 UTC
+
+    SELECT TIMESTAMP '2001-08-22 03:04:05.321 -08:30';
+    -- 2001-08-22 03:04:05.321 -08:30
+
+    SELECT TIMESTAMP '2001-08-22 03:04:05.321 GMT-08:30';
+    -- 2001-08-22 03:04:05.321 -08:30
+
+    SELECT TIMESTAMP '2001-08-22 03:04:05.321 America/New_York';
+    -- 2001-08-22 03:04:05.321 America/New_York
 
 ``INTERVAL YEAR TO MONTH``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

Describe how a named time zone is supported by the `timestamp(p) with time zone` type with an example

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Type documentation

> How would you describe this change to a non-technical end user or system administrator?

Describe an additional supported use of Trino types

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

Follow up on discussion in https://github.com/trinodb/trino/pull/7912#discussion_r958645602

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(x) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
