### PR TITLE
Reduce lock contention in HttpRemoteTask

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
@@ -920,10 +920,10 @@ public final class HttpRemoteTask
                     sentDynamicFiltersVersion.set(currentRequestDynamicFiltersVersion);
                     // Remove dynamic filters which were successfully sent to free up memory
                     outboundDynamicFiltersCollector.acknowledge(currentRequestDynamicFiltersVersion);
+                    sendPlan.set(value.isNeedsPlan());
                     long currentRequestStartNanos;
                     synchronized (HttpRemoteTask.this) {
                         currentRequest = null;
-                        sendPlan.set(value.isNeedsPlan());
                         currentRequestStartNanos = HttpRemoteTask.this.currentRequestStartNanos;
                     }
                     updateStats(currentRequestStartNanos);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

Use separate locks for sending a new request
(which is potentially expensive) and modifying
HttpRemoteTask state.


<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

core

> How would you describe this change to a non-technical end user or system administrator?

Improve throughput for large clusters with higher concurrency

## Related issues, pull requests, and links

Fixes https://github.com/trinodb/trino/issues/10842


<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# General
* Improve throughput for large clusters with higher concurrency. ({issue}`issuenumber`)
```
