### PR TITLE
Leverage Optional.orElseThrow to increase code readability

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/OutputHandler.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/OutputHandler.java
@@ -94,7 +94,7 @@ public final class OutputHandler
                 if (row == END_TOKEN) {
                     break;
                 }
-                else if (row != null) {
+                if (row != null) {
                     rowBuffer.add(row);
                 }
             }

--- a/core/trino-main/src/main/java/io/trino/cost/CostCalculatorWithEstimatedExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/cost/CostCalculatorWithEstimatedExchanges.java
@@ -280,12 +280,10 @@ public class CostCalculatorWithEstimatedExchanges
             LocalCostEstimate localRepartitionCost = calculateLocalRepartitionCost(buildSizeInBytes);
             return addPartialComponents(replicateCost, localRepartitionCost);
         }
-        else {
-            LocalCostEstimate probeCost = calculateRemoteRepartitionCost(probeSizeInBytes);
-            LocalCostEstimate buildRemoteRepartitionCost = calculateRemoteRepartitionCost(buildSizeInBytes);
-            LocalCostEstimate buildLocalRepartitionCost = calculateLocalRepartitionCost(buildSizeInBytes);
-            return addPartialComponents(probeCost, buildRemoteRepartitionCost, buildLocalRepartitionCost);
-        }
+        LocalCostEstimate probeCost = calculateRemoteRepartitionCost(probeSizeInBytes);
+        LocalCostEstimate buildRemoteRepartitionCost = calculateRemoteRepartitionCost(buildSizeInBytes);
+        LocalCostEstimate buildLocalRepartitionCost = calculateLocalRepartitionCost(buildSizeInBytes);
+        return addPartialComponents(probeCost, buildRemoteRepartitionCost, buildLocalRepartitionCost);
     }
 
     public static LocalCostEstimate calculateJoinInputCost(

--- a/core/trino-main/src/main/java/io/trino/cost/ScalarStatsCalculator.java
+++ b/core/trino-main/src/main/java/io/trino/cost/ScalarStatsCalculator.java
@@ -312,20 +312,18 @@ public class ScalarStatsCalculator
             if (left.getNullsFraction() == 0) {
                 return left;
             }
-            else if (left.getNullsFraction() == 1.0) {
+            if (left.getNullsFraction() == 1.0) {
                 return right;
             }
-            else {
-                return SymbolStatsEstimate.builder()
-                        .setLowValue(min(left.getLowValue(), right.getLowValue()))
-                        .setHighValue(max(left.getHighValue(), right.getHighValue()))
-                        .setDistinctValuesCount(left.getDistinctValuesCount() +
-                                min(right.getDistinctValuesCount(), input.getOutputRowCount() * left.getNullsFraction()))
-                        .setNullsFraction(left.getNullsFraction() * right.getNullsFraction())
-                        // TODO check if dataSize estimation method is correct
-                        .setAverageRowSize(max(left.getAverageRowSize(), right.getAverageRowSize()))
-                        .build();
-            }
+            return SymbolStatsEstimate.builder()
+                    .setLowValue(min(left.getLowValue(), right.getLowValue()))
+                    .setHighValue(max(left.getHighValue(), right.getHighValue()))
+                    .setDistinctValuesCount(left.getDistinctValuesCount() +
+                            min(right.getDistinctValuesCount(), input.getOutputRowCount() * left.getNullsFraction()))
+                    .setNullsFraction(left.getNullsFraction() * right.getNullsFraction())
+                    // TODO check if dataSize estimation method is correct
+                    .setAverageRowSize(max(left.getAverageRowSize(), right.getAverageRowSize()))
+                    .build();
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/dispatcher/QueuedStatementResource.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/QueuedStatementResource.java
@@ -391,15 +391,13 @@ public class QueuedStatementResource
                         DispatchInfo.queued(NO_DURATION, NO_DURATION));
             }
 
-            Optional<DispatchInfo> dispatchInfo = dispatchManager.getDispatchInfo(queryId);
-            if (dispatchInfo.isEmpty()) {
-                // query should always be found, but it may have just been determined to be abandoned
-                throw new WebApplicationException(Response
-                        .status(NOT_FOUND)
-                        .build());
-            }
+            DispatchInfo dispatchInfo = dispatchManager.getDispatchInfo(queryId)
+                    // query should always be found, but it may have just been determined to be abandoned
+                    .orElseThrow(() -> new WebApplicationException(Response
+                            .status(NOT_FOUND)
+                            .build()));
 
-            return createQueryResults(token + 1, uriInfo, dispatchInfo.get());
+            return createQueryResults(token + 1, uriInfo, dispatchInfo);
         }
 
         public void cancel()

--- a/core/trino-main/src/main/java/io/trino/execution/CommentTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CommentTask.java
@@ -30,7 +30,6 @@ import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
@@ -133,12 +132,10 @@ public class CommentTask
 
     private void commentOnColumn(Comment statement, Session session)
     {
-        Optional<QualifiedName> prefix = statement.getName().getPrefix();
-        if (prefix.isEmpty()) {
-            throw semanticException(MISSING_TABLE, statement, "Table must be specified");
-        }
+        QualifiedName prefix = statement.getName().getPrefix()
+                .orElseThrow(() -> semanticException(MISSING_TABLE, statement, "Table must be specified"));
 
-        QualifiedObjectName originalTableName = createQualifiedObjectName(session, statement, prefix.get());
+        QualifiedObjectName originalTableName = createQualifiedObjectName(session, statement, prefix);
         RedirectionAwareTableHandle redirectionAwareTableHandle = metadata.getRedirectionAwareTableHandle(session, originalTableName);
         if (redirectionAwareTableHandle.getTableHandle().isEmpty()) {
             throw semanticException(TABLE_NOT_FOUND, statement, "Table does not exist: " + originalTableName);

--- a/core/trino-main/src/main/java/io/trino/execution/CommitTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CommitTask.java
@@ -54,10 +54,7 @@ public class CommitTask
             WarningCollector warningCollector)
     {
         Session session = stateMachine.getSession();
-        if (session.getTransactionId().isEmpty()) {
-            throw new TrinoException(NOT_IN_TRANSACTION, "No transaction in progress");
-        }
-        TransactionId transactionId = session.getTransactionId().get();
+        TransactionId transactionId = session.getTransactionId().orElseThrow(() -> new TrinoException(NOT_IN_TRANSACTION, "No transaction in progress"));
 
         stateMachine.clearTransactionId();
         return transactionManager.asyncCommit(transactionId);

--- a/core/trino-main/src/main/java/io/trino/execution/DenyTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DenyTask.java
@@ -19,7 +19,6 @@ import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.RedirectionAwareTableHandle;
-import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.security.Privilege;
@@ -97,8 +96,7 @@ public class DenyTask
     {
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getName());
         RedirectionAwareTableHandle redirection = metadata.getRedirectionAwareTableHandle(session, tableName);
-        Optional<TableHandle> tableHandle = redirection.getTableHandle();
-        if (tableHandle.isEmpty()) {
+        if (redirection.getTableHandle().isEmpty()) {
             throw semanticException(TABLE_NOT_FOUND, statement, "Table '%s' does not exist", tableName);
         }
         if (redirection.getRedirectedTableName().isPresent()) {

--- a/core/trino-main/src/main/java/io/trino/execution/GrantTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/GrantTask.java
@@ -19,7 +19,6 @@ import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.RedirectionAwareTableHandle;
-import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.security.Privilege;
@@ -101,8 +100,7 @@ public class GrantTask
     {
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getName());
         RedirectionAwareTableHandle redirection = metadata.getRedirectionAwareTableHandle(session, tableName);
-        Optional<TableHandle> tableHandle = redirection.getTableHandle();
-        if (tableHandle.isEmpty()) {
+        if (redirection.getTableHandle().isEmpty()) {
             throw semanticException(TABLE_NOT_FOUND, statement, "Table '%s' does not exist", tableName);
         }
         if (redirection.getRedirectedTableName().isPresent()) {

--- a/core/trino-main/src/main/java/io/trino/execution/RevokeTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RevokeTask.java
@@ -19,7 +19,6 @@ import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.RedirectionAwareTableHandle;
-import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.security.Privilege;
@@ -101,8 +100,7 @@ public class RevokeTask
     {
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getName());
         RedirectionAwareTableHandle redirection = metadata.getRedirectionAwareTableHandle(session, tableName);
-        Optional<TableHandle> tableHandle = redirection.getTableHandle();
-        if (tableHandle.isEmpty()) {
+        if (redirection.getTableHandle().isEmpty()) {
             throw semanticException(TABLE_NOT_FOUND, statement, "Table '%s' does not exist", tableName);
         }
         if (redirection.getRedirectedTableName().isPresent()) {

--- a/core/trino-main/src/main/java/io/trino/execution/RollbackTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RollbackTask.java
@@ -55,10 +55,7 @@ public class RollbackTask
             WarningCollector warningCollector)
     {
         Session session = stateMachine.getSession();
-        if (session.getTransactionId().isEmpty()) {
-            throw new TrinoException(NOT_IN_TRANSACTION, "No transaction in progress");
-        }
-        TransactionId transactionId = session.getTransactionId().get();
+        TransactionId transactionId = session.getTransactionId().orElseThrow(() -> new TrinoException(NOT_IN_TRANSACTION, "No transaction in progress"));
 
         stateMachine.clearTransactionId();
         transactionManager.asyncAbort(transactionId);

--- a/core/trino-main/src/main/java/io/trino/execution/SetPropertiesTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SetPropertiesTask.java
@@ -118,13 +118,11 @@ public class SetPropertiesTask
             throw semanticException(NOT_SUPPORTED, statement, "Cannot set properties to a view in ALTER TABLE");
         }
 
-        Optional<TableHandle> tableHandle = plannerContext.getMetadata().getTableHandle(session, tableName);
-        if (tableHandle.isEmpty()) {
-            throw semanticException(TABLE_NOT_FOUND, statement, "Table does not exist: %s", tableName);
-        }
+        TableHandle tableHandle = plannerContext.getMetadata().getTableHandle(session, tableName)
+                .orElseThrow(() -> semanticException(TABLE_NOT_FOUND, statement, "Table does not exist: %s", tableName));
 
         accessControl.checkCanSetTableProperties(session.toSecurityContext(), tableName, properties);
-        plannerContext.getMetadata().setTableProperties(session, tableHandle.get(), properties);
+        plannerContext.getMetadata().setTableProperties(session, tableHandle, properties);
     }
 
     private void setMaterializedViewProperties(

--- a/core/trino-main/src/main/java/io/trino/execution/SetTableAuthorizationTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SetTableAuthorizationTask.java
@@ -19,7 +19,6 @@ import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.RedirectionAwareTableHandle;
-import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.sql.tree.Expression;
@@ -71,8 +70,7 @@ public class SetTableAuthorizationTask
 
         getRequiredCatalogHandle(metadata, session, statement, tableName.getCatalogName());
         RedirectionAwareTableHandle redirection = metadata.getRedirectionAwareTableHandle(session, tableName);
-        Optional<TableHandle> tableHandle = redirection.getTableHandle();
-        if (tableHandle.isEmpty()) {
+        if (redirection.getTableHandle().isEmpty()) {
             throw semanticException(TABLE_NOT_FOUND, statement, "Table '%s' does not exist", tableName);
         }
         if (redirection.getRedirectedTableName().isPresent()) {

--- a/core/trino-main/src/main/java/io/trino/execution/SplitAssignment.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SplitAssignment.java
@@ -78,10 +78,8 @@ public class SplitAssignment
                     newSplits,
                     assignment.isNoMoreSplits());
         }
-        else {
-            // the specified assignment is older than this one
-            return this;
-        }
+        // the specified assignment is older than this one
+        return this;
     }
 
     private boolean isNewer(SplitAssignment assignment)

--- a/core/trino-main/src/main/java/io/trino/execution/TruncateTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TruncateTableTask.java
@@ -26,7 +26,6 @@ import io.trino.sql.tree.TruncateTable;
 import javax.inject.Inject;
 
 import java.util.List;
-import java.util.Optional;
 
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
@@ -72,14 +71,12 @@ public class TruncateTableTask
             throw semanticException(NOT_SUPPORTED, statement, "Cannot truncate a view");
         }
 
-        Optional<TableHandle> tableHandle = metadata.getTableHandle(session, tableName);
-        if (tableHandle.isEmpty()) {
-            throw semanticException(TABLE_NOT_FOUND, statement, "Table '%s' does not exist", tableName);
-        }
+        TableHandle tableHandle = metadata.getTableHandle(session, tableName)
+                .orElseThrow(() -> semanticException(TABLE_NOT_FOUND, statement, "Table '%s' does not exist", tableName));
 
         accessControl.checkCanTruncateTable(session.toSecurityContext(), tableName);
 
-        metadata.truncateTable(session, tableHandle.get());
+        metadata.truncateTable(session, tableHandle);
 
         return immediateFuture(null);
     }

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/PagesSerdeUtil.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/PagesSerdeUtil.java
@@ -130,7 +130,7 @@ public final class PagesSerdeUtil
                     context.close(); // Release context buffers
                     return endOfData();
                 }
-                else if (read != headerBuffer.length) {
+                if (read != headerBuffer.length) {
                     throw new EOFException();
                 }
 
@@ -167,7 +167,7 @@ public final class PagesSerdeUtil
                 if (read <= 0) {
                     return endOfData();
                 }
-                else if (read != headerBuffer.length) {
+                if (read != headerBuffer.length) {
                     throw new EOFException();
                 }
 

--- a/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroup.java
+++ b/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroup.java
@@ -234,12 +234,10 @@ public class InternalResourceGroup
             if (canRunMore()) {
                 return CAN_RUN;
             }
-            else if (canQueueMore()) {
+            if (canQueueMore()) {
                 return CAN_QUEUE;
             }
-            else {
-                return FULL;
-            }
+            return FULL;
         }
     }
 
@@ -877,9 +875,7 @@ public class InternalResourceGroup
         if (policy == QUERY_PRIORITY) {
             return group.getHighestQueryPriority();
         }
-        else {
-            return group.computeSchedulingWeight();
-        }
+        return group.computeSchedulingWeight();
     }
 
     private long computeSchedulingWeight()

--- a/core/trino-main/src/main/java/io/trino/execution/resourcegroups/StochasticPriorityQueue.java
+++ b/core/trino-main/src/main/java/io/trino/execution/resourcegroups/StochasticPriorityQueue.java
@@ -257,9 +257,7 @@ final class StochasticPriorityQueue<E>
                 if (left.get().descendants < right.get().descendants) {
                     return left.get().addNode(value, tickets);
                 }
-                else {
-                    return right.get().addNode(value, tickets);
-                }
+                return right.get().addNode(value, tickets);
             }
 
             Node<E> child = new Node<>(Optional.of(this), value);

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/FixedSourcePartitionedScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/FixedSourcePartitionedScheduler.java
@@ -148,10 +148,8 @@ public class FixedSourcePartitionedScheduler
         if (blockedReason != null) {
             return new ScheduleResult(sourceSchedulers.isEmpty(), newTasks, blocked, blockedReason, splitsScheduled);
         }
-        else {
-            checkState(blocked.isDone(), "blockedReason not provided when scheduler is blocked");
-            return new ScheduleResult(sourceSchedulers.isEmpty(), newTasks, splitsScheduled);
-        }
+        checkState(blocked.isDone(), "blockedReason not provided when scheduler is blocked");
+        return new ScheduleResult(sourceSchedulers.isEmpty(), newTasks, splitsScheduled);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/json/PathEvaluationVisitor.java
+++ b/core/trino-main/src/main/java/io/trino/json/PathEvaluationVisitor.java
@@ -528,47 +528,45 @@ class PathEvaluationVisitor
             }
             return jsonNode.longValue();
         }
-        else {
-            TypedValue value = (TypedValue) object;
-            Type type = value.getType();
-            if (type.equals(BIGINT) || type.equals(INTEGER) || type.equals(SMALLINT) || type.equals(TINYINT)) {
-                return value.getLongValue();
-            }
-            if (type.equals(DOUBLE)) {
-                try {
-                    return DoubleOperators.castToLong(value.getDoubleValue());
-                }
-                catch (Exception e) {
-                    throw new PathEvaluationError(e);
-                }
-            }
-            if (type.equals(REAL)) {
-                try {
-                    return RealOperators.castToLong(value.getLongValue());
-                }
-                catch (Exception e) {
-                    throw new PathEvaluationError(e);
-                }
-            }
-            if (type instanceof DecimalType) {
-                DecimalType decimalType = (DecimalType) type;
-                int precision = decimalType.getPrecision();
-                int scale = decimalType.getScale();
-                if (((DecimalType) type).isShort()) {
-                    long tenToScale = longTenToNth(DecimalConversions.intScale(scale));
-                    return DecimalCasts.shortDecimalToBigint(value.getLongValue(), precision, scale, tenToScale);
-                }
-                Int128 tenToScale = Int128Math.powerOfTen(DecimalConversions.intScale(scale));
-                try {
-                    return DecimalCasts.longDecimalToBigint((Int128) value.getObjectValue(), precision, scale, tenToScale);
-                }
-                catch (Exception e) {
-                    throw new PathEvaluationError(e);
-                }
-            }
-
-            throw itemTypeError("NUMBER", type.getDisplayName());
+        TypedValue value = (TypedValue) object;
+        Type type = value.getType();
+        if (type.equals(BIGINT) || type.equals(INTEGER) || type.equals(SMALLINT) || type.equals(TINYINT)) {
+            return value.getLongValue();
         }
+        if (type.equals(DOUBLE)) {
+            try {
+                return DoubleOperators.castToLong(value.getDoubleValue());
+            }
+            catch (Exception e) {
+                throw new PathEvaluationError(e);
+            }
+        }
+        if (type.equals(REAL)) {
+            try {
+                return RealOperators.castToLong(value.getLongValue());
+            }
+            catch (Exception e) {
+                throw new PathEvaluationError(e);
+            }
+        }
+        if (type instanceof DecimalType) {
+            DecimalType decimalType = (DecimalType) type;
+            int precision = decimalType.getPrecision();
+            int scale = decimalType.getScale();
+            if (((DecimalType) type).isShort()) {
+                long tenToScale = longTenToNth(DecimalConversions.intScale(scale));
+                return DecimalCasts.shortDecimalToBigint(value.getLongValue(), precision, scale, tenToScale);
+            }
+            Int128 tenToScale = Int128Math.powerOfTen(DecimalConversions.intScale(scale));
+            try {
+                return DecimalCasts.longDecimalToBigint((Int128) value.getObjectValue(), precision, scale, tenToScale);
+            }
+            catch (Exception e) {
+                throw new PathEvaluationError(e);
+            }
+        }
+
+        throw itemTypeError("NUMBER", type.getDisplayName());
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/metadata/LiteralFunction.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/LiteralFunction.java
@@ -113,9 +113,7 @@ public class LiteralFunction
             if (type instanceof VarcharType) {
                 return type;
             }
-            else {
-                return VARBINARY;
-            }
+            return VARBINARY;
         }
         if (clazz == boolean.class) {
             return BOOLEAN;

--- a/core/trino-main/src/main/java/io/trino/metadata/QualifiedTablePrefix.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/QualifiedTablePrefix.java
@@ -100,12 +100,10 @@ public class QualifiedTablePrefix
         if (schemaName.isEmpty()) {
             return new SchemaTablePrefix();
         }
-        else if (tableName.isEmpty()) {
+        if (tableName.isEmpty()) {
             return new SchemaTablePrefix(schemaName.get());
         }
-        else {
-            return new SchemaTablePrefix(schemaName.get(), tableName.get());
-        }
+        return new SchemaTablePrefix(schemaName.get(), tableName.get());
     }
 
     public Optional<QualifiedObjectName> asQualifiedObjectName()

--- a/core/trino-main/src/main/java/io/trino/metadata/SignatureBinder.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SignatureBinder.java
@@ -690,13 +690,11 @@ public class SignatureBinder
                 }
                 return true;
             }
-            else if (toType instanceof JsonType) {
+            if (toType instanceof JsonType) {
                 return fromType.getTypeParameters().stream()
                         .allMatch(fromTypeParameter -> canCast(fromTypeParameter, toType));
             }
-            else {
-                return false;
-            }
+            return false;
         }
         if (fromType instanceof JsonType) {
             if (toType instanceof RowType) {

--- a/core/trino-main/src/main/java/io/trino/metadata/SignatureBinder.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SignatureBinder.java
@@ -479,11 +479,9 @@ public class SignatureBinder
 
         ImmutableList.Builder<TypeSignature> formalTypeParameterTypeSignatures = ImmutableList.builder();
         for (TypeSignatureParameter formalTypeParameter : formalTypeSignature.getParameters()) {
-            Optional<TypeSignature> typeSignature = formalTypeParameter.getTypeSignatureOrNamedTypeSignature();
-            if (typeSignature.isEmpty()) {
-                throw new UnsupportedOperationException("Types with both type parameters and literal parameters at the same time are not supported");
-            }
-            formalTypeParameterTypeSignatures.add(typeSignature.get());
+            TypeSignature typeSignature = formalTypeParameter.getTypeSignatureOrNamedTypeSignature()
+                    .orElseThrow(() -> new UnsupportedOperationException("Types with both type parameters and literal parameters at the same time are not supported"));
+            formalTypeParameterTypeSignatures.add(typeSignature);
         }
 
         return appendConstraintSolvers(

--- a/core/trino-main/src/main/java/io/trino/operator/DriverContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DriverContext.java
@@ -235,9 +235,7 @@ public class DriverContext
         if (inputOperator != null) {
             return inputOperator.getInputDataSize();
         }
-        else {
-            return new CounterStat();
-        }
+        return new CounterStat();
     }
 
     public CounterStat getInputPositions()
@@ -246,9 +244,7 @@ public class DriverContext
         if (inputOperator != null) {
             return inputOperator.getInputPositions();
         }
-        else {
-            return new CounterStat();
-        }
+        return new CounterStat();
     }
 
     public CounterStat getOutputDataSize()
@@ -257,9 +253,7 @@ public class DriverContext
         if (inputOperator != null) {
             return inputOperator.getOutputDataSize();
         }
-        else {
-            return new CounterStat();
-        }
+        return new CounterStat();
     }
 
     public CounterStat getOutputPositions()
@@ -268,9 +262,7 @@ public class DriverContext
         if (inputOperator != null) {
             return inputOperator.getOutputPositions();
         }
-        else {
-            return new CounterStat();
-        }
+        return new CounterStat();
     }
 
     public long getPhysicalWrittenDataSize()

--- a/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRankAccumulator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRankAccumulator.java
@@ -119,7 +119,7 @@ public class GroupedTopNRankAccumulator
             heapInsert(groupId, newPeerGroupIndex, 1);
             return true;
         }
-        else if (rowReference.compareTo(strategy, peekRootRowId(groupId)) < 0) {
+        if (rowReference.compareTo(strategy, peekRootRowId(groupId)) < 0) {
             // Given that total number of values >= topN, we can only consider values that are less than the root (otherwise topN would be violated)
             long newPeerGroupIndex = peerGroupBuffer.allocateNewNode(rowReference.allocateRowId(), UNKNOWN_INDEX);
             // Rank will increase by +1 after insertion, so only need to pop if root rank is already == topN.
@@ -131,10 +131,8 @@ public class GroupedTopNRankAccumulator
             }
             return true;
         }
-        else {
-            // Row cannot be accepted because the total number of values >= topN, and the row is greater than the root (meaning it's rank would be at least topN+1).
-            return false;
-        }
+        // Row cannot be accepted because the total number of values >= topN, and the row is greater than the root (meaning it's rank would be at least topN+1).
+        return false;
     }
 
     /**

--- a/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRowNumberAccumulator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRowNumberAccumulator.java
@@ -88,13 +88,11 @@ public class GroupedTopNRowNumberAccumulator
             heapInsert(groupId, rowReference.allocateRowId());
             return true;
         }
-        else if (rowReference.compareTo(strategy, heapNodeBuffer.getRowId(heapRootNodeIndex)) < 0) {
+        if (rowReference.compareTo(strategy, heapNodeBuffer.getRowId(heapRootNodeIndex)) < 0) {
             heapPopAndInsert(groupId, rowReference.allocateRowId(), rowIdEvictionListener);
             return true;
         }
-        else {
-            return false;
-        }
+        return false;
     }
 
     /**

--- a/core/trino-main/src/main/java/io/trino/operator/HashAggregationOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/HashAggregationOperator.java
@@ -369,12 +369,10 @@ public class HashAggregationOperator
         if (finishing || outputPages != null) {
             return false;
         }
-        else if (aggregationBuilder != null && aggregationBuilder.isFull()) {
+        if (aggregationBuilder != null && aggregationBuilder.isFull()) {
             return false;
         }
-        else {
-            return unfinishedWork == null;
-        }
+        return unfinishedWork == null;
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/RowReferencePageManager.java
+++ b/core/trino-main/src/main/java/io/trino/operator/RowReferencePageManager.java
@@ -98,10 +98,8 @@ public class RowReferencePageManager
             checkState(currentCursor != null, "No active cursor");
             return currentCursor.getPage();
         }
-        else {
-            int pageId = rowIdBuffer.getPageId(rowId);
-            return pages.get(pageId).getPage();
-        }
+        int pageId = rowIdBuffer.getPageId(rowId);
+        return pages.get(pageId).getPage();
     }
 
     public int getPosition(long rowId)
@@ -111,9 +109,7 @@ public class RowReferencePageManager
             // rowId for cursors only reference the single current position
             return currentCursor.getCurrentPosition();
         }
-        else {
-            return rowIdBuffer.getPosition(rowId);
-        }
+        return rowIdBuffer.getPosition(rowId);
     }
 
     private static boolean isCursorRowId(long rowId)

--- a/core/trino-main/src/main/java/io/trino/operator/ScanFilterAndProjectOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ScanFilterAndProjectOperator.java
@@ -272,10 +272,8 @@ public class ScanFilterAndProjectOperator
                 cursor = ((RecordPageSource) source).getCursor();
                 return ofResult(processColumnSource());
             }
-            else {
-                pageSource = source;
-                return ofResult(processPageSource());
-            }
+            pageSource = source;
+            return ofResult(processPageSource());
         }
 
         WorkProcessor<Page> processColumnSource()
@@ -356,14 +354,12 @@ public class ScanFilterAndProjectOperator
                 outputMemoryContext.setBytes(pageBuilder.getRetainedSizeInBytes());
                 return ProcessState.ofResult(page);
             }
-            else if (finished) {
+            if (finished) {
                 checkState(pageBuilder.isEmpty());
                 return ProcessState.finished();
             }
-            else {
-                outputMemoryContext.setBytes(pageBuilder.getRetainedSizeInBytes());
-                return ProcessState.yielded();
-            }
+            outputMemoryContext.setBytes(pageBuilder.getRetainedSizeInBytes());
+            return ProcessState.yielded();
         }
     }
 
@@ -396,9 +392,7 @@ public class ScanFilterAndProjectOperator
                 if (pageSource.isFinished()) {
                     return ProcessState.finished();
                 }
-                else {
-                    return ProcessState.yielded();
-                }
+                return ProcessState.yielded();
             }
 
             recordMaterializedBytes(page, sizeInBytes -> processedBytes += sizeInBytes);

--- a/core/trino-main/src/main/java/io/trino/operator/TableScanWorkProcessorOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableScanWorkProcessorOperator.java
@@ -291,9 +291,7 @@ public class TableScanWorkProcessorOperator
                 if (pageSource.isFinished()) {
                     return ProcessState.finished();
                 }
-                else {
-                    return ProcessState.yielded();
-                }
+                return ProcessState.yielded();
             }
 
             return ProcessState.ofResult(page);

--- a/core/trino-main/src/main/java/io/trino/operator/TopNRankingOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TopNRankingOperator.java
@@ -246,19 +246,17 @@ public class TopNRankingOperator
         if (partitionChannels.isEmpty()) {
             return Suppliers.ofInstance(new NoChannelGroupByHash());
         }
-        else {
-            checkArgument(expectedPositions > 0, "expectedPositions must be > 0");
-            int[] channels = Ints.toArray(partitionChannels);
-            return () -> createGroupByHash(
-                    session,
-                    partitionTypes,
-                    channels,
-                    hashChannel,
-                    expectedPositions,
-                    joinCompiler,
-                    blockTypeOperators,
-                    updateMemory);
-        }
+        checkArgument(expectedPositions > 0, "expectedPositions must be > 0");
+        int[] channels = Ints.toArray(partitionChannels);
+        return () -> createGroupByHash(
+                session,
+                partitionTypes,
+                channels,
+                hashChannel,
+                expectedPositions,
+                joinCompiler,
+                blockTypeOperators,
+                updateMemory);
     }
 
     private static Supplier<GroupedTopNBuilder> getGroupedTopNBuilderSupplier(
@@ -281,7 +279,7 @@ public class TopNRankingOperator
                     generateRanking,
                     groupByHashSupplier.get());
         }
-        else if (rankingType == RankingType.RANK) {
+        if (rankingType == RankingType.RANK) {
             PageWithPositionComparator comparator = new SimplePageWithPositionComparator(sourceTypes, sortChannels, sortOrders, typeOperators);
             PageWithPositionEqualsAndHash equalsAndHash = new SimplePageWithPositionEqualsAndHash(ImmutableList.copyOf(sourceTypes), sortChannels, blockTypeOperators);
             return () -> new GroupedTopNRankBuilder(
@@ -292,12 +290,10 @@ public class TopNRankingOperator
                     generateRanking,
                     groupByHashSupplier.get());
         }
-        else if (rankingType == RankingType.DENSE_RANK) {
+        if (rankingType == RankingType.DENSE_RANK) {
             throw new UnsupportedOperationException();
         }
-        else {
-            throw new AssertionError("Unknown ranking type: " + rankingType);
-        }
+        throw new AssertionError("Unknown ranking type: " + rankingType);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/Aggregator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/Aggregator.java
@@ -52,9 +52,7 @@ public class Aggregator
         if (step.isOutputPartial()) {
             return intermediateType;
         }
-        else {
-            return finalType;
-        }
+        return finalType;
     }
 
     public void processPage(Page page)

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/DistinctAccumulatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/DistinctAccumulatorFactory.java
@@ -267,9 +267,7 @@ public class DistinctAccumulatorFactory
             if (!mask.isNull(0) && BOOLEAN.getBoolean(mask, 0)) {
                 return page;
             }
-            else {
-                return page.getPositions(new int[0], 0, 0);
-            }
+            return page.getPositions(new int[0], 0, 0);
         }
         boolean mayHaveNull = mask.mayHaveNull();
         int[] ids = new int[positions];

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/GroupedAggregator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/GroupedAggregator.java
@@ -59,9 +59,7 @@ public class GroupedAggregator
         if (step.isOutputPartial()) {
             return intermediateType;
         }
-        else {
-            return finalType;
-        }
+        return finalType;
     }
 
     public void processPage(GroupByIdBlock groupIds, Page page)

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/ParametricAggregationImplementation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/ParametricAggregationImplementation.java
@@ -399,18 +399,12 @@ public class ParametricAggregationImplementation
                 if (isNullable) {
                     return NULLABLE_BLOCK_INPUT_CHANNEL;
                 }
-                else {
-                    return BLOCK_INPUT_CHANNEL;
-                }
+                return BLOCK_INPUT_CHANNEL;
             }
-            else {
-                if (isNullable) {
-                    throw new IllegalArgumentException(methodName + " contains a parameter with @NullablePosition that is not @BlockPosition");
-                }
-                else {
-                    return INPUT_CHANNEL;
-                }
+            if (isNullable) {
+                throw new IllegalArgumentException(methodName + " contains a parameter with @NullablePosition that is not @BlockPosition");
             }
+            return INPUT_CHANNEL;
         }
 
         private static Annotation baseTypeAnnotation(Annotation[] annotations, String methodName)

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/ReduceAggregationFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/ReduceAggregationFunction.java
@@ -99,7 +99,7 @@ public class ReduceAggregationFunction
                     .lambdaInterfaces(BinaryFunctionInterface.class, BinaryFunctionInterface.class)
                     .build();
         }
-        else if (stateType.getJavaType() == double.class) {
+        if (stateType.getJavaType() == double.class) {
             return AggregationImplementation.builder()
                     .inputFunction(normalizeInputMethod(boundSignature, inputType, DOUBLE_STATE_INPUT_FUNCTION))
                     .combineFunction(DOUBLE_STATE_COMBINE_FUNCTION)
@@ -111,7 +111,7 @@ public class ReduceAggregationFunction
                     .lambdaInterfaces(BinaryFunctionInterface.class, BinaryFunctionInterface.class)
                     .build();
         }
-        else if (stateType.getJavaType() == boolean.class) {
+        if (stateType.getJavaType() == boolean.class) {
             return AggregationImplementation.builder()
                     .inputFunction(normalizeInputMethod(boundSignature, inputType, BOOLEAN_STATE_INPUT_FUNCTION))
                     .combineFunction(BOOLEAN_STATE_COMBINE_FUNCTION)
@@ -123,12 +123,10 @@ public class ReduceAggregationFunction
                     .lambdaInterfaces(BinaryFunctionInterface.class, BinaryFunctionInterface.class)
                     .build();
         }
-        else {
-            // State with Slice or Block as native container type is intentionally not supported yet,
-            // as it may result in excessive JVM memory usage of remembered set.
-            // See JDK-8017163.
-            throw new TrinoException(NOT_SUPPORTED, format("State type not supported for %s: %s", NAME, stateType.getDisplayName()));
-        }
+        // State with Slice or Block as native container type is intentionally not supported yet,
+        // as it may result in excessive JVM memory usage of remembered set.
+        // See JDK-8017163.
+        throw new TrinoException(NOT_SUPPORTED, format("State type not supported for %s: %s", NAME, stateType.getDisplayName()));
     }
 
     private static MethodHandle normalizeInputMethod(BoundSignature boundSignature, Type inputType, MethodHandle inputMethodHandle)

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/TypedSet.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/TypedSet.java
@@ -253,9 +253,7 @@ public class TypedSet
         if (block.isNull(position)) {
             return containsNullElement;
         }
-        else {
-            return blockPositionByHash.getInt(getHashPositionOfElement(block, position)) != EMPTY_SLOT;
-        }
+        return blockPositionByHash.getInt(getHashPositionOfElement(block, position)) != EMPTY_SLOT;
     }
 
     /**

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
@@ -138,17 +138,15 @@ public class InMemoryHashAggregationBuilder
         if (groupedAggregators.isEmpty()) {
             return groupByHash.addPage(page);
         }
-        else {
-            return new TransformWork<>(
-                    groupByHash.getGroupIds(page),
-                    groupByIdBlock -> {
-                        for (GroupedAggregator groupedAggregator : groupedAggregators) {
-                            groupedAggregator.processPage(groupByIdBlock, page);
-                        }
-                        // we do not need any output from TransformWork for this case
-                        return null;
-                    });
-        }
+        return new TransformWork<>(
+                groupByHash.getGroupIds(page),
+                groupByIdBlock -> {
+                    for (GroupedAggregator groupedAggregator : groupedAggregators) {
+                        groupedAggregator.processPage(groupByIdBlock, page);
+                    }
+                    // we do not need any output from TransformWork for this case
+                    return null;
+                });
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/builder/SpillableHashAggregationBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/builder/SpillableHashAggregationBuilder.java
@@ -152,9 +152,7 @@ public class SpillableHashAggregationBuilder
             getFutureValue(spillInProgress);
             return true;
         }
-        else {
-            return false;
-        }
+        return false;
     }
 
     @Override
@@ -208,10 +206,8 @@ public class SpillableHashAggregationBuilder
         if (shouldMergeWithMemory(getSizeInMemoryWhenUnspilling())) {
             return mergeFromDiskAndMemory();
         }
-        else {
-            getFutureValue(spillToDisk());
-            return mergeFromDisk();
-        }
+        getFutureValue(spillToDisk());
+        return mergeFromDisk();
     }
 
     /**

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/histogram/GroupedTypedHistogram.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/histogram/GroupedTypedHistogram.java
@@ -436,10 +436,8 @@ public class GroupedTypedHistogram
                 addNewGroup(groupId, block, position, count);
                 return true;
             }
-            else {
-                valueNode.add(count);
-                return false;
-            }
+            valueNode.add(count);
+            return false;
         }
 
         private void addNewGroup(long groupId, Block block, int position, long count)
@@ -488,16 +486,14 @@ public class GroupedTypedHistogram
                 if (nodePointer == EMPTY_BUCKET) {
                     return new BucketDataNode(bucketId, new ValueNode(nextNodePointer), valueHash, valueAndGroupHash, nextNodePointer, true);
                 }
-                else if (groupAndValueMatches(groupId, block, position, nodePointer, valuePositions.get(nodePointer))) {
+                if (groupAndValueMatches(groupId, block, position, nodePointer, valuePositions.get(nodePointer))) {
                     // value match
                     return new BucketDataNode(bucketId, new ValueNode(nodePointer), valueHash, valueAndGroupHash, nodePointer, false);
                 }
-                else {
-                    // keep looking
-                    int probe = nextProbe(probeCount);
-                    bucketId = nextBucketId(originalBucketId, mask, probe);
-                    probeCount++;
-                }
+                // keep looking
+                int probe = nextProbe(probeCount);
+                bucketId = nextBucketId(originalBucketId, mask, probe);
+                probeCount++;
             }
         }
 

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/histogram/ValueStore.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/histogram/ValueStore.java
@@ -98,15 +98,13 @@ public class ValueStore
 
                 return valuePointer;
             }
-            else if (equalOperator.equal(block, position, values, valuePointer)) {
+            if (equalOperator.equal(block, position, values, valuePointer)) {
                 // value at position
                 return valuePointer;
             }
-            else {
-                int probe = nextProbe(probeCount);
-                bucketId = nextBucketId(originalBucketId, mask, probe);
-                probeCount++;
-            }
+            int probe = nextProbe(probeCount);
+            bucketId = nextBucketId(originalBucketId, mask, probe);
+            probeCount++;
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/StateCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/StateCompiler.java
@@ -1151,10 +1151,7 @@ public final class StateCompiler
 
         Type getSqlType()
         {
-            if (sqlType.isEmpty()) {
-                throw new IllegalArgumentException("Unsupported type: " + type);
-            }
-            return sqlType.get();
+            return sqlType.orElseThrow(() -> new IllegalArgumentException("Unsupported type: " + type));
         }
 
         boolean isPrimitiveType()

--- a/core/trino-main/src/main/java/io/trino/operator/join/DefaultPageJoiner.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/DefaultPageJoiner.java
@@ -384,9 +384,7 @@ public class DefaultPageJoiner
         if (joinPosition >= 0) {
             return lookupSourceProvider.withLease(lookupSourceLease -> lookupSourceLease.getLookupSource().joinPositionWithinPartition(joinPosition));
         }
-        else {
-            return -1;
-        }
+        return -1;
     }
 
     private Page buildOutputPage()

--- a/core/trino-main/src/main/java/io/trino/operator/join/NestedLoopJoinOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/NestedLoopJoinOperator.java
@@ -267,15 +267,13 @@ public class NestedLoopJoinOperator
             Page outputPage = new Page(max(probePositions, buildPositions));
             return new PageRepeatingIterator(outputPage, min(probePositions, buildPositions));
         }
-        else if (probeChannels.length == 0 && probePage.getPositionCount() <= buildPage.getPositionCount()) {
+        if (probeChannels.length == 0 && probePage.getPositionCount() <= buildPage.getPositionCount()) {
             return new PageRepeatingIterator(buildPage.getColumns(buildChannels), probePage.getPositionCount());
         }
-        else if (buildChannels.length == 0 && buildPage.getPositionCount() <= probePage.getPositionCount()) {
+        if (buildChannels.length == 0 && buildPage.getPositionCount() <= probePage.getPositionCount()) {
             return new PageRepeatingIterator(probePage.getColumns(probeChannels), buildPage.getPositionCount());
         }
-        else {
-            return new NestedLoopPageBuilder(probePage, buildPage, probeChannels, buildChannels);
-        }
+        return new NestedLoopPageBuilder(probePage, buildPage, probeChannels, buildChannels);
     }
 
     // bi-morphic parent class for the two implementations allowed. Adding a third implementation will make getOutput megamorphic and

--- a/core/trino-main/src/main/java/io/trino/operator/join/PartitionedConsumption.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/PartitionedConsumption.java
@@ -106,9 +106,7 @@ public final class PartitionedConsumption<T>
                 if (next != null) {
                     return next;
                 }
-                else {
-                    return endOfData();
-                }
+                return endOfData();
             }
         };
     }

--- a/core/trino-main/src/main/java/io/trino/operator/join/PartitionedLookupSource.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/PartitionedLookupSource.java
@@ -69,16 +69,14 @@ public class PartitionedLookupSource
                 }
             };
         }
-        else {
-            return TrackingLookupSourceSupplier.nonTracking(
-                    () -> new PartitionedLookupSource(
-                            partitions.stream()
-                                    .map(Supplier::get)
-                                    .collect(toImmutableList()),
-                            hashChannelTypes,
-                            Optional.empty(),
-                            blockTypeOperators));
-        }
+        return TrackingLookupSourceSupplier.nonTracking(
+                () -> new PartitionedLookupSource(
+                        partitions.stream()
+                                .map(Supplier::get)
+                                .collect(toImmutableList()),
+                        hashChannelTypes,
+                        Optional.empty(),
+                        blockTypeOperators));
     }
 
     private final LookupSource[] lookupSources;

--- a/core/trino-main/src/main/java/io/trino/operator/join/SortedPositionLinks.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/SortedPositionLinks.java
@@ -84,16 +84,14 @@ public final class SortedPositionLinks
                 positionLinks.computeIfAbsent(to, key -> new IntArrayList()).add(from);
                 return to;
             }
-            else {
-                // _to_ is larger so, move the chain to _from_
-                IntArrayList links = positionLinks.remove(to);
-                if (links == null) {
-                    links = new IntArrayList();
-                }
-                links.add(to);
-                checkState(positionLinks.put(from, links) == null, "sorted links is corrupted");
-                return from;
+            // _to_ is larger so, move the chain to _from_
+            IntArrayList links = positionLinks.remove(to);
+            if (links == null) {
+                links = new IntArrayList();
             }
+            links.add(to);
+            checkState(positionLinks.put(from, links) == null, "sorted links is corrupted");
+            return from;
         }
 
         private boolean isNull(int position)

--- a/core/trino-main/src/main/java/io/trino/operator/join/unspilled/PartitionedLookupSource.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/unspilled/PartitionedLookupSource.java
@@ -72,16 +72,14 @@ public class PartitionedLookupSource
                 }
             };
         }
-        else {
-            return TrackingLookupSourceSupplier.nonTracking(
-                    () -> new PartitionedLookupSource(
-                            partitions.stream()
-                                    .map(Supplier::get)
-                                    .collect(toImmutableList()),
-                            hashChannelTypes,
-                            Optional.empty(),
-                            blockTypeOperators));
-        }
+        return TrackingLookupSourceSupplier.nonTracking(
+                () -> new PartitionedLookupSource(
+                        partitions.stream()
+                                .map(Supplier::get)
+                                .collect(toImmutableList()),
+                        hashChannelTypes,
+                        Optional.empty(),
+                        blockTypeOperators));
     }
 
     private final LookupSource[] lookupSources;

--- a/core/trino-main/src/main/java/io/trino/operator/project/DictionaryAwarePageProjection.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/DictionaryAwarePageProjection.java
@@ -117,9 +117,7 @@ public class DictionaryAwarePageProjection
             if (produceLazyBlock) {
                 return true;
             }
-            else {
-                return processInternal();
-            }
+            return processInternal();
         }
 
         private boolean processInternal()
@@ -200,10 +198,8 @@ public class DictionaryAwarePageProjection
                     return result.getLoadedBlock();
                 });
             }
-            else {
-                checkState(result != null, "result has not been generated");
-                return result;
-            }
+            checkState(result != null, "result has not been generated");
+            return result;
         }
 
         private void setupDictionaryBlockProjection()

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayJoin.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayJoin.java
@@ -166,27 +166,25 @@ public final class ArrayJoin
                     methodHandle.bindTo(null),
                     Optional.of(STATE_FACTORY));
         }
-        else {
-            try {
-                InvocationConvention convention = new InvocationConvention(ImmutableList.of(BLOCK_POSITION), NULLABLE_RETURN, true, false);
-                MethodHandle cast = functionDependencies.getCastImplementation(type, VARCHAR, convention).getMethodHandle();
+        try {
+            InvocationConvention convention = new InvocationConvention(ImmutableList.of(BLOCK_POSITION), NULLABLE_RETURN, true, false);
+            MethodHandle cast = functionDependencies.getCastImplementation(type, VARCHAR, convention).getMethodHandle();
 
-                // if the cast doesn't take a ConnectorSession, create an adapter that drops the provided session
-                if (cast.type().parameterArray()[0] != ConnectorSession.class) {
-                    cast = MethodHandles.dropArguments(cast, 0, ConnectorSession.class);
-                }
+            // if the cast doesn't take a ConnectorSession, create an adapter that drops the provided session
+            if (cast.type().parameterArray()[0] != ConnectorSession.class) {
+                cast = MethodHandles.dropArguments(cast, 0, ConnectorSession.class);
+            }
 
-                MethodHandle target = MethodHandles.insertArguments(methodHandle, 0, cast);
-                return new ChoicesSpecializedSqlScalarFunction(
-                        boundSignature,
-                        FAIL_ON_NULL,
-                        argumentConventions,
-                        target,
-                        Optional.of(STATE_FACTORY));
-            }
-            catch (TrinoException e) {
-                throw new TrinoException(INVALID_FUNCTION_ARGUMENT, format("Input type %s not supported", type), e);
-            }
+            MethodHandle target = MethodHandles.insertArguments(methodHandle, 0, cast);
+            return new ChoicesSpecializedSqlScalarFunction(
+                    boundSignature,
+                    FAIL_ON_NULL,
+                    argumentConventions,
+                    target,
+                    Optional.of(STATE_FACTORY));
+        }
+        catch (TrinoException e) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, format("Input type %s not supported", type), e);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/BitwiseFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/BitwiseFunctions.java
@@ -202,9 +202,7 @@ public final class BitwiseFunctions
             if (value >= 0) {
                 return 0L;
             }
-            else {
-                return -1L;
-            }
+            return -1L;
         }
         return preserveSign(value, TINYINT_MASK, TINYINT_SIGNED_BIT) >> shift;
     }
@@ -218,9 +216,7 @@ public final class BitwiseFunctions
             if (value >= 0) {
                 return 0L;
             }
-            else {
-                return -1L;
-            }
+            return -1L;
         }
         return preserveSign(value, SMALLINT_MASK, SMALLINT_SIGNED_BIT) >> shift;
     }
@@ -234,9 +230,7 @@ public final class BitwiseFunctions
             if (value >= 0) {
                 return 0L;
             }
-            else {
-                return -1L;
-            }
+            return -1L;
         }
         return preserveSign(value, INTEGER_MASK, INTEGER_SIGNED_BIT) >> shift;
     }
@@ -250,9 +244,7 @@ public final class BitwiseFunctions
             if (value >= 0) {
                 return 0L;
             }
-            else {
-                return -1L;
-            }
+            return -1L;
         }
         return value >> shift;
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/CharacterStringCasts.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/CharacterStringCasts.java
@@ -46,9 +46,7 @@ public final class CharacterStringCasts
         if (x > y) {
             return truncateToLength(slice, y.intValue());
         }
-        else {
-            return slice;
-        }
+        return slice;
     }
 
     @ScalarOperator(OperatorType.CAST)
@@ -59,9 +57,7 @@ public final class CharacterStringCasts
         if (x > y) {
             return truncateToLength(slice, y.intValue());
         }
-        else {
-            return slice;
-        }
+        return slice;
     }
 
     @ScalarOperator(OperatorType.CAST)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ConcatWsFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ConcatWsFunction.java
@@ -74,10 +74,8 @@ public final class ConcatWsFunction
                             if (elements.isNull(i)) {
                                 return null;
                             }
-                            else {
-                                int sliceLength = elements.getSliceLength(i);
-                                return elements.getSlice(i, 0, sliceLength);
-                            }
+                            int sliceLength = elements.getSliceLength(i);
+                            return elements.getSlice(i, 0, sliceLength);
                         }
 
                         @Override

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/JoniRegexpFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/JoniRegexpFunctions.java
@@ -74,14 +74,10 @@ public final class JoniRegexpFunctions
             if (matcher.getBegin() < source.length()) {
                 return matcher.getEnd() + lengthOfCodePointFromStartByte(source.getByte(matcher.getBegin()));
             }
-            else {
-                // last match is empty and we matched end of source, move past the source length to terminate the loop
-                return matcher.getEnd() + 1;
-            }
+            // last match is empty and we matched end of source, move past the source length to terminate the loop
+            return matcher.getEnd() + 1;
         }
-        else {
-            return matcher.getEnd();
-        }
+        return matcher.getEnd();
     }
 
     @Description("Removes substrings matching a regular expression")

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MapToMapCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MapToMapCast.java
@@ -179,21 +179,19 @@ public final class MapToMapCast
         if (javaType == Long.class) {
             return CHECK_LONG_IS_NOT_NULL;
         }
-        else if (javaType == Double.class) {
+        if (javaType == Double.class) {
             return CHECK_DOUBLE_IS_NOT_NULL;
         }
-        else if (javaType == Boolean.class) {
+        if (javaType == Boolean.class) {
             return CHECK_BOOLEAN_IS_NOT_NULL;
         }
-        else if (javaType == Slice.class) {
+        if (javaType == Slice.class) {
             return CHECK_SLICE_IS_NOT_NULL;
         }
-        else if (javaType == Block.class) {
+        if (javaType == Block.class) {
             return CHECK_BLOCK_IS_NOT_NULL;
         }
-        else {
-            throw new IllegalArgumentException("Unknown java type " + javaType);
-        }
+        throw new IllegalArgumentException("Unknown java type " + javaType);
     }
 
     @UsedByGeneratedCode

--- a/core/trino-main/src/main/java/io/trino/server/ServerInfoResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerInfoResource.java
@@ -108,9 +108,7 @@ public class ServerInfoResource
         if (shutdownHandler.isShutdownRequested()) {
             return SHUTTING_DOWN;
         }
-        else {
-            return ACTIVE;
-        }
+        return ACTIVE;
     }
 
     @ResourceSecurity(PUBLIC)

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/JweTokenSerializer.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/JweTokenSerializer.java
@@ -39,7 +39,6 @@ import java.text.ParseException;
 import java.time.Clock;
 import java.util.Date;
 import java.util.Map;
-import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkState;
 import static io.trino.server.security.jwt.JwtUtil.newJwtBuilder;
@@ -122,11 +121,7 @@ public class JweTokenSerializer
     {
         requireNonNull(tokenPair, "tokenPair is null");
 
-        Optional<Map<String, Object>> accessTokenClaims = client.getClaims(tokenPair.getAccessToken());
-        if (accessTokenClaims.isEmpty()) {
-            throw new IllegalArgumentException("Claims are missing");
-        }
-        Map<String, Object> claims = accessTokenClaims.get();
+        Map<String, Object> claims = client.getClaims(tokenPair.getAccessToken()).orElseThrow(() -> new IllegalArgumentException("Claims are missing"));
         if (!claims.containsKey(principalField)) {
             throw new IllegalArgumentException(format("%s field is missing", principalField));
         }

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OidcDiscovery.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OidcDiscovery.java
@@ -97,9 +97,7 @@ public class OidcDiscovery
             if (statusCode < 400 || statusCode >= 500 || statusCode == REQUEST_TIMEOUT.code() || statusCode == TOO_MANY_REQUESTS.code()) {
                 throw new RuntimeException("Invalid response from OpenID Metadata endpoint: " + statusCode);
             }
-            else {
-                throw new IllegalStateException(format("Invalid response from OpenID Metadata endpoint. Expected response code to be %s, but was %s", OK.code(), statusCode));
-            }
+            throw new IllegalStateException(format("Invalid response from OpenID Metadata endpoint. Expected response code to be %s, but was %s", OK.code(), statusCode));
         }
         return readConfiguration(response.getContent());
     }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/CanonicalizationAware.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/CanonicalizationAware.java
@@ -99,7 +99,7 @@ public class CanonicalizationAware<T extends Node>
         if (node instanceof Identifier) {
             return OptionalInt.of(((Identifier) node).getCanonicalValue().hashCode());
         }
-        else if (node.getChildren().isEmpty()) {
+        if (node.getChildren().isEmpty()) {
             return OptionalInt.of(node.hashCode());
         }
         return OptionalInt.empty();

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -1816,9 +1816,7 @@ public class ExpressionAnalyzer
                 if (labelRequired) {
                     throw semanticException(INVALID_ARGUMENTS, node, "Pattern navigation function %s must contain at least one column reference or CLASSIFIER()", name);
                 }
-                else {
-                    return ArgumentLabel.noLabel();
-                }
+                return ArgumentLabel.noLabel();
             }
 
             // Label consistency rules:
@@ -1876,12 +1874,12 @@ public class ExpressionAnalyzer
             if (!inputColumnLabels.isEmpty()) {
                 return ArgumentLabel.explicitLabel(getOnlyElement(inputColumnLabels));
             }
-            else if (!classifierLabels.isEmpty()) {
+            if (!classifierLabels.isEmpty()) {
                 return getOnlyElement(classifierLabels)
                         .map(ArgumentLabel::explicitLabel)
                         .orElse(ArgumentLabel.universalLabel());
             }
-            else if (!unlabeledInputColumns.isEmpty()) {
+            if (!unlabeledInputColumns.isEmpty()) {
                 return ArgumentLabel.universalLabel();
             }
             return ArgumentLabel.noLabel();
@@ -2508,9 +2506,7 @@ public class ExpressionAnalyzer
             if (node.getGroupingColumns().size() <= MAX_NUMBER_GROUPING_ARGUMENTS_INTEGER) {
                 return setExpressionType(node, INTEGER);
             }
-            else {
-                return setExpressionType(node, BIGINT);
-            }
+            return setExpressionType(node, BIGINT);
         }
 
         @Override
@@ -2807,12 +2803,10 @@ public class ExpressionAnalyzer
                     if (UNKNOWN.equals(type) || isCharacterStringType(type)) {
                         yield QualifiedName.of(VARCHAR_TO_JSON);
                     }
-                    else if (isStringType(type)) {
+                    if (isStringType(type)) {
                         yield QualifiedName.of(VARBINARY_TO_JSON);
                     }
-                    else {
-                        throw semanticException(TYPE_MISMATCH, node, format("Cannot read input of type %s as JSON using formatting %s", type, format));
-                    }
+                    throw semanticException(TYPE_MISMATCH, node, format("Cannot read input of type %s as JSON using formatting %s", type, format));
                 }
                 case UTF8 -> QualifiedName.of(VARBINARY_UTF8_TO_JSON);
                 case UTF16 -> QualifiedName.of(VARBINARY_UTF16_TO_JSON);
@@ -2834,12 +2828,10 @@ public class ExpressionAnalyzer
                     if (isCharacterStringType(type)) {
                         yield QualifiedName.of(JSON_TO_VARCHAR);
                     }
-                    else if (isStringType(type)) {
+                    if (isStringType(type)) {
                         yield QualifiedName.of(JSON_TO_VARBINARY);
                     }
-                    else {
-                        throw semanticException(TYPE_MISMATCH, node, format("Cannot output JSON value as %s using formatting %s", type, format));
-                    }
+                    throw semanticException(TYPE_MISMATCH, node, format("Cannot output JSON value as %s using formatting %s", type, format));
                 }
                 case UTF8 -> {
                     if (!VARBINARY.equals(type)) {

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/RelationId.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/RelationId.java
@@ -86,11 +86,9 @@ public class RelationId
                     .addValue(format("x%08x", identityHashCode(this)))
                     .toString();
         }
-        else {
-            return toStringHelper(this)
-                    .addValue(sourceNode.get().getClass().getSimpleName())
-                    .addValue(format("x%08x", identityHashCode(sourceNode.get())))
-                    .toString();
-        }
+        return toStringHelper(this)
+                .addValue(sourceNode.get().getClass().getSimpleName())
+                .addValue(format("x%08x", identityHashCode(sourceNode.get())))
+                .toString();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Scope.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Scope.java
@@ -248,7 +248,7 @@ public class Scope
         if (matches.size() > 1) {
             throw ambiguousAttributeException(node, name);
         }
-        else if (matches.size() == 1) {
+        if (matches.size() == 1) {
             int parentFieldCount = getLocalParent()
                     .map(Scope::getLocalScopeFieldCount)
                     .orElse(0);
@@ -256,18 +256,16 @@ public class Scope
             Field field = getOnlyElement(matches);
             return Optional.of(asResolvedField(field, parentFieldCount, local));
         }
-        else {
-            if (isColumnReference(name, relation)) {
-                return Optional.empty();
-            }
-            if (parent.isPresent()) {
-                if (queryBoundary) {
-                    return parent.get().resolveField(node, name, false);
-                }
-                return parent.get().resolveField(node, name, local);
-            }
+        if (isColumnReference(name, relation)) {
             return Optional.empty();
         }
+        if (parent.isPresent()) {
+            if (queryBoundary) {
+                return parent.get().resolveField(node, name, false);
+            }
+            return parent.get().resolveField(node, name, local);
+        }
+        return Optional.empty();
     }
 
     public ResolvedField getField(int index)

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -913,10 +913,8 @@ class StatementAnalyzer
                     if (layout.getLayout().getPartitioning().isPresent()) {
                         throw new TrinoException(NOT_SUPPORTED, "INSERT must write all distribution columns: " + layout.getPartitionColumns());
                     }
-                    else {
-                        // created table does not contain all columns required by preferred layout
-                        newTableLayout = Optional.empty();
-                    }
+                    // created table does not contain all columns required by preferred layout
+                    newTableLayout = Optional.empty();
                 }
             }
 
@@ -1792,10 +1790,8 @@ class StatementAnalyzer
                             .orElseThrow(() -> semanticException(INVALID_VIEW, table, "Storage table '%s' does not exist", storageTableName));
                     return createScopeForMaterializedView(table, name, scope, optionalMaterializedView.get(), Optional.of(tableHandle));
                 }
-                else {
-                    // This is a stale materialized view and should be expanded like a logical view
-                    return createScopeForMaterializedView(table, name, scope, optionalMaterializedView.get(), Optional.empty());
-                }
+                // This is a stale materialized view and should be expanded like a logical view
+                return createScopeForMaterializedView(table, name, scope, optionalMaterializedView.get(), Optional.empty());
             }
 
             // This could be a reference to a logical view or a table
@@ -4659,9 +4655,7 @@ class StatementAnalyzer
             if (node instanceof FetchFirst) {
                 return analyzeLimit((FetchFirst) node, scope);
             }
-            else {
-                return analyzeLimit((Limit) node, scope);
-            }
+            return analyzeLimit((Limit) node, scope);
         }
 
         private boolean analyzeLimit(FetchFirst node, Scope scope)
@@ -4719,28 +4713,26 @@ class StatementAnalyzer
                 analysis.addCoercion(parameter, BIGINT, false);
                 return OptionalLong.empty();
             }
-            else {
-                // validate parameter index
-                analyzeExpression(parameter, scope);
-                Expression providedValue = analysis.getParameters().get(NodeRef.of(parameter));
-                Object value;
-                try {
-                    value = evaluateConstantExpression(
-                            providedValue,
-                            BIGINT,
-                            plannerContext,
-                            session,
-                            accessControl,
-                            analysis.getParameters());
-                }
-                catch (VerifyException e) {
-                    throw semanticException(INVALID_ARGUMENTS, parameter, "Non constant parameter value for %s: %s", context, providedValue);
-                }
-                if (value == null) {
-                    throw semanticException(INVALID_ARGUMENTS, parameter, "Parameter value provided for %s is NULL: %s", context, providedValue);
-                }
-                return OptionalLong.of((long) value);
+            // validate parameter index
+            analyzeExpression(parameter, scope);
+            Expression providedValue = analysis.getParameters().get(NodeRef.of(parameter));
+            Object value;
+            try {
+                value = evaluateConstantExpression(
+                        providedValue,
+                        BIGINT,
+                        plannerContext,
+                        session,
+                        accessControl,
+                        analysis.getParameters());
             }
+            catch (VerifyException e) {
+                throw semanticException(INVALID_ARGUMENTS, parameter, "Non constant parameter value for %s: %s", context, providedValue);
+            }
+            if (value == null) {
+                throw semanticException(INVALID_ARGUMENTS, parameter, "Parameter value provided for %s is NULL: %s", context, providedValue);
+            }
+            return OptionalLong.of((long) value);
         }
 
         private Scope createAndAssignScope(Node node, Optional<Scope> parentScope)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/DomainCoercer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DomainCoercer.java
@@ -211,9 +211,7 @@ public final class DomainCoercer
             if (originalComparedToCoerced == 0) {
                 return Optional.of(coercedFloorValue);
             }
-            else {
-                return Optional.empty();
-            }
+            return Optional.empty();
         }
 
         private int compareOriginalValueToCoerced(ResolvedFunction castToOriginalTypeOperator, MethodHandle comparisonOperator, Object originalValue, Object coercedValue)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/GroupingOperationRewriter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/GroupingOperationRewriter.java
@@ -51,29 +51,27 @@ public final class GroupingOperationRewriter
         if (groupingSets.size() == 1) {
             return new LongLiteral("0");
         }
-        else {
-            checkState(groupIdSymbol.isPresent(), "groupId symbol is missing");
+        checkState(groupIdSymbol.isPresent(), "groupId symbol is missing");
 
-            RelationId relationId = columnReferenceFields.get(NodeRef.of(expression.getGroupingColumns().get(0))).getFieldId().getRelationId();
+        RelationId relationId = columnReferenceFields.get(NodeRef.of(expression.getGroupingColumns().get(0))).getFieldId().getRelationId();
 
-            List<Integer> columns = expression.getGroupingColumns().stream()
-                    .map(NodeRef::of)
-                    .peek(groupingColumn -> checkState(columnReferenceFields.containsKey(groupingColumn), "the grouping column is not in the columnReferencesField map"))
-                    .map(columnReferenceFields::get)
-                    .map(ResolvedField::getFieldId)
-                    .map(fieldId -> translateFieldToInteger(fieldId, relationId))
-                    .collect(toImmutableList());
+        List<Integer> columns = expression.getGroupingColumns().stream()
+                .map(NodeRef::of)
+                .peek(groupingColumn -> checkState(columnReferenceFields.containsKey(groupingColumn), "the grouping column is not in the columnReferencesField map"))
+                .map(columnReferenceFields::get)
+                .map(ResolvedField::getFieldId)
+                .map(fieldId -> translateFieldToInteger(fieldId, relationId))
+                .collect(toImmutableList());
 
-            List<Expression> groupingResults = groupingSets.stream()
-                    .map(groupingSet -> String.valueOf(calculateGrouping(groupingSet, columns)))
-                    .map(LongLiteral::new)
-                    .collect(toImmutableList());
+        List<Expression> groupingResults = groupingSets.stream()
+                .map(groupingSet -> String.valueOf(calculateGrouping(groupingSet, columns)))
+                .map(LongLiteral::new)
+                .collect(toImmutableList());
 
-            // It is necessary to add a 1 to the groupId because the underlying array is indexed starting at 1
-            return new SubscriptExpression(
-                    new ArrayConstructor(groupingResults),
-                    new ArithmeticBinaryExpression(ADD, groupIdSymbol.get().toSymbolReference(), new GenericLiteral("BIGINT", "1")));
-        }
+        // It is necessary to add a 1 to the groupId because the underlying array is indexed starting at 1
+        return new SubscriptExpression(
+                new ArrayConstructor(groupingResults),
+                new ArithmeticBinaryExpression(ADD, groupIdSymbol.get().toSymbolReference(), new GenericLiteral("BIGINT", "1")));
     }
 
     private static int translateFieldToInteger(FieldId fieldId, RelationId requiredOriginRelationId)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -1944,19 +1944,17 @@ public class LocalExecutionPlanner
 
                     return new PhysicalOperation(operatorFactory, outputMappings, context);
                 }
-                else {
-                    Supplier<PageProcessor> pageProcessor = expressionCompiler.compilePageProcessor(translatedFilter, translatedProjections, Optional.of(context.getStageId() + "_" + planNodeId));
+                Supplier<PageProcessor> pageProcessor = expressionCompiler.compilePageProcessor(translatedFilter, translatedProjections, Optional.of(context.getStageId() + "_" + planNodeId));
 
-                    OperatorFactory operatorFactory = FilterAndProjectOperator.createOperatorFactory(
-                            context.getNextOperatorId(),
-                            planNodeId,
-                            pageProcessor,
-                            getTypes(projections, expressionTypes),
-                            getFilterAndProjectMinOutputPageSize(session),
-                            getFilterAndProjectMinOutputPageRowCount(session));
+                OperatorFactory operatorFactory = FilterAndProjectOperator.createOperatorFactory(
+                        context.getNextOperatorId(),
+                        planNodeId,
+                        pageProcessor,
+                        getTypes(projections, expressionTypes),
+                        getFilterAndProjectMinOutputPageSize(session),
+                        getFilterAndProjectMinOutputPageRowCount(session));
 
-                    return new PhysicalOperation(operatorFactory, outputMappings, context, source);
-                }
+                return new PhysicalOperation(operatorFactory, outputMappings, context, source);
             }
             catch (TrinoException e) {
                 throw e;
@@ -3935,28 +3933,26 @@ public class LocalExecutionPlanner
                         aggregatorFactories,
                         joinCompiler);
             }
-            else {
-                Optional<Integer> hashChannel = hashSymbol.map(channelGetter(source));
-                return new HashAggregationOperatorFactory(
-                        context.getNextOperatorId(),
-                        planNodeId,
-                        groupByTypes,
-                        groupByChannels,
-                        ImmutableList.copyOf(globalGroupingSets),
-                        step,
-                        hasDefaultOutput,
-                        aggregatorFactories,
-                        hashChannel,
-                        groupIdChannel,
-                        expectedGroups,
-                        maxPartialAggregationMemorySize,
-                        spillEnabled,
-                        unspillMemoryLimit,
-                        spillerFactory,
-                        joinCompiler,
-                        blockTypeOperators,
-                        createPartialAggregationController(step, session));
-            }
+            Optional<Integer> hashChannel = hashSymbol.map(channelGetter(source));
+            return new HashAggregationOperatorFactory(
+                    context.getNextOperatorId(),
+                    planNodeId,
+                    groupByTypes,
+                    groupByChannels,
+                    ImmutableList.copyOf(globalGroupingSets),
+                    step,
+                    hasDefaultOutput,
+                    aggregatorFactories,
+                    hashChannel,
+                    groupIdChannel,
+                    expectedGroups,
+                    maxPartialAggregationMemorySize,
+                    spillEnabled,
+                    unspillMemoryLimit,
+                    spillerFactory,
+                    joinCompiler,
+                    blockTypeOperators,
+                    createPartialAggregationController(step, session));
         }
     }
 
@@ -3980,17 +3976,15 @@ public class LocalExecutionPlanner
                     buildOuter,
                     blockTypeOperators);
         }
-        else {
-            return new io.trino.operator.join.unspilled.PartitionedLookupSourceFactory(
-                    buildTypes,
-                    buildOutputTypes,
-                    buildChannels.stream()
-                            .map(buildTypes::get)
-                            .collect(toImmutableList()),
-                    partitionCount,
-                    buildOuter,
-                    blockTypeOperators);
-        }
+        return new io.trino.operator.join.unspilled.PartitionedLookupSourceFactory(
+                buildTypes,
+                buildOutputTypes,
+                buildChannels.stream()
+                        .map(buildTypes::get)
+                        .collect(toImmutableList()),
+                partitionCount,
+                buildOuter,
+                blockTypeOperators);
     }
 
     private static Optional<PartialAggregationController> createPartialAggregationController(AggregationNode.Step step, Session session)
@@ -4073,10 +4067,10 @@ public class LocalExecutionPlanner
             if (target instanceof CreateTarget) {
                 return metadata.finishCreateTable(session, ((CreateTarget) target).getHandle(), fragments, statistics);
             }
-            else if (target instanceof InsertTarget) {
+            if (target instanceof InsertTarget) {
                 return metadata.finishInsert(session, ((InsertTarget) target).getHandle(), fragments, statistics);
             }
-            else if (target instanceof TableWriterNode.RefreshMaterializedViewTarget) {
+            if (target instanceof TableWriterNode.RefreshMaterializedViewTarget) {
                 TableWriterNode.RefreshMaterializedViewTarget refreshTarget = (TableWriterNode.RefreshMaterializedViewTarget) target;
                 return metadata.finishRefreshMaterializedView(
                         session,
@@ -4086,27 +4080,25 @@ public class LocalExecutionPlanner
                         statistics,
                         refreshTarget.getSourceTableHandles());
             }
-            else if (target instanceof DeleteTarget) {
+            if (target instanceof DeleteTarget) {
                 metadata.finishDelete(session, ((DeleteTarget) target).getHandleOrElseThrow(), fragments);
                 return Optional.empty();
             }
-            else if (target instanceof UpdateTarget) {
+            if (target instanceof UpdateTarget) {
                 metadata.finishUpdate(session, ((UpdateTarget) target).getHandleOrElseThrow(), fragments);
                 return Optional.empty();
             }
-            else if (target instanceof TableExecuteTarget) {
+            if (target instanceof TableExecuteTarget) {
                 TableExecuteHandle tableExecuteHandle = ((TableExecuteTarget) target).getExecuteHandle();
                 metadata.finishTableExecute(session, tableExecuteHandle, fragments, tableExecuteContext.getSplitsInfo());
                 return Optional.empty();
             }
-            else if (target instanceof MergeTarget mergeTarget) {
+            if (target instanceof MergeTarget mergeTarget) {
                 MergeHandle mergeHandle = mergeTarget.getMergeHandle().orElseThrow(() -> new IllegalArgumentException("mergeHandle not present"));
                 metadata.finishMerge(session, mergeHandle, fragments, statistics);
                 return Optional.empty();
             }
-            else {
-                throw new AssertionError("Unhandled target type: " + target.getClass().getName());
-            }
+            throw new AssertionError("Unhandled target type: " + target.getClass().getName());
         };
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/Partitioning.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/Partitioning.java
@@ -141,26 +141,20 @@ public final class Partitioning
                 Set<Symbol> mappedColumns = leftToRightMappings.apply(leftArgument.getColumn());
                 return mappedColumns.contains(rightArgument.getColumn());
             }
-            else {
-                // variable == constant
-                // Normally, this would be a false condition, but if we happen to have an external
-                // mapping from the symbol to a constant value and that constant value matches the
-                // right value, then we are co-partitioned.
-                Optional<NullableValue> leftConstant = leftConstantMapping.apply(leftArgument.getColumn());
-                return leftConstant.isPresent() && leftConstant.get().equals(rightArgument.getConstant());
-            }
+            // variable == constant
+            // Normally, this would be a false condition, but if we happen to have an external
+            // mapping from the symbol to a constant value and that constant value matches the
+            // right value, then we are co-partitioned.
+            Optional<NullableValue> leftConstant = leftConstantMapping.apply(leftArgument.getColumn());
+            return leftConstant.isPresent() && leftConstant.get().equals(rightArgument.getConstant());
         }
-        else {
-            if (rightArgument.isConstant()) {
-                // constant == constant
-                return leftArgument.getConstant().equals(rightArgument.getConstant());
-            }
-            else {
-                // constant == variable
-                Optional<NullableValue> rightConstant = rightConstantMapping.apply(rightArgument.getColumn());
-                return rightConstant.isPresent() && rightConstant.get().equals(leftArgument.getConstant());
-            }
+        if (rightArgument.isConstant()) {
+            // constant == constant
+            return leftArgument.getConstant().equals(rightArgument.getConstant());
         }
+        // constant == variable
+        Optional<NullableValue> rightConstant = rightConstantMapping.apply(rightArgument.getColumn());
+        return rightConstant.isPresent() && rightConstant.get().equals(leftArgument.getConstant());
     }
 
     public boolean isPartitionedOn(Collection<Symbol> columns, Set<Symbol> knownConstants)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/ScopeAware.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ScopeAware.java
@@ -138,13 +138,13 @@ public class ScopeAware<T extends Node>
                 }
                 // For references that come from the current query scope or an outer scope of the current
                 // expression, compare by resolved field
-                else if (!leftFieldInSubqueryScope && !rightFieldInSubqueryScope) {
+                if (!leftFieldInSubqueryScope && !rightFieldInSubqueryScope) {
                     return leftField.getFieldId().equals(rightField.getFieldId());
                 }
                 // References come from different scopes
                 return false;
             }
-            else if (leftExpression instanceof Identifier && rightExpression instanceof Identifier) {
+            if (leftExpression instanceof Identifier && rightExpression instanceof Identifier) {
                 return treeEqual(leftExpression, rightExpression, CanonicalizationAware::canonicalizationAwareComparison);
             }
         }
@@ -170,10 +170,10 @@ public class ScopeAware<T extends Node>
 
                 return OptionalInt.of(field.getFieldId().hashCode());
             }
-            else if (expression instanceof Identifier) {
+            if (expression instanceof Identifier) {
                 return OptionalInt.of(treeHash(expression, CanonicalizationAware::canonicalizationAwareHash));
             }
-            else if (node.getChildren().isEmpty()) {
+            if (node.getChildren().isEmpty()) {
                 // Calculate shallow hash since node doesn't have any children
                 return OptionalInt.of(expression.hashCode());
             }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ApplyTableScanRedirection.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ApplyTableScanRedirection.java
@@ -101,15 +101,13 @@ public class ApplyTableScanRedirection
             return Result.empty();
         }
 
-        Optional<TableHandle> destinationTableHandle = plannerContext.getMetadata().getTableHandle(
-                context.getSession(),
-                convertFromSchemaTableName(destinationTable.getCatalogName()).apply(destinationTable.getSchemaTableName()));
-        if (destinationTableHandle.isEmpty()) {
-            throw new TrinoException(TABLE_NOT_FOUND, format("Destination table %s from table scan redirection not found", destinationTable));
-        }
+        TableHandle destinationTableHandle = plannerContext.getMetadata().getTableHandle(
+                        context.getSession(),
+                        convertFromSchemaTableName(destinationTable.getCatalogName()).apply(destinationTable.getSchemaTableName()))
+                .orElseThrow(() -> new TrinoException(TABLE_NOT_FOUND, format("Destination table %s from table scan redirection not found", destinationTable)));
 
         Map<ColumnHandle, String> columnMapping = tableScanRedirectApplicationResult.get().getDestinationColumns();
-        Map<String, ColumnHandle> destinationColumnHandles = plannerContext.getMetadata().getColumnHandles(context.getSession(), destinationTableHandle.get());
+        Map<String, ColumnHandle> destinationColumnHandles = plannerContext.getMetadata().getColumnHandles(context.getSession(), destinationTableHandle);
         ImmutableMap.Builder<Symbol, Cast> casts = ImmutableMap.builder();
         ImmutableMap.Builder<Symbol, ColumnHandle> newAssignmentsBuilder = ImmutableMap.builder();
         for (Map.Entry<Symbol, ColumnHandle> assignment : scanNode.getAssignments().entrySet()) {
@@ -124,7 +122,7 @@ public class ApplyTableScanRedirection
 
             // insert ts if redirected types don't match source types
             Type sourceType = context.getSymbolAllocator().getTypes().get(assignment.getKey());
-            Type redirectedType = plannerContext.getMetadata().getColumnMetadata(context.getSession(), destinationTableHandle.get(), destinationColumnHandle).getType();
+            Type redirectedType = plannerContext.getMetadata().getColumnMetadata(context.getSession(), destinationTableHandle, destinationColumnHandle).getType();
             if (!sourceType.equals(redirectedType)) {
                 Symbol redirectedSymbol = context.getSymbolAllocator().newSymbol(destinationColumn, redirectedType);
                 Cast cast = getCast(
@@ -153,7 +151,7 @@ public class ApplyTableScanRedirection
                     casts.buildOrThrow(),
                     new TableScanNode(
                             scanNode.getId(),
-                            destinationTableHandle.get(),
+                            destinationTableHandle,
                             ImmutableList.copyOf(newAssignments.keySet()),
                             newAssignments,
                             TupleDomain.all(),
@@ -185,7 +183,7 @@ public class ApplyTableScanRedirection
             }
 
             // insert casts if redirected types don't match domain types
-            Type redirectedType = plannerContext.getMetadata().getColumnMetadata(context.getSession(), destinationTableHandle.get(), destinationColumnHandle).getType();
+            Type redirectedType = plannerContext.getMetadata().getColumnMetadata(context.getSession(), destinationTableHandle, destinationColumnHandle).getType();
             if (!domainType.equals(redirectedType)) {
                 Symbol redirectedSymbol = context.getSymbolAllocator().newSymbol(destinationColumn, redirectedType);
                 Cast cast = getCast(
@@ -210,7 +208,7 @@ public class ApplyTableScanRedirection
         Map<Symbol, ColumnHandle> newAssignments = newAssignmentsBuilder.buildOrThrow();
         TableScanNode newScanNode = new TableScanNode(
                 scanNode.getId(),
-                destinationTableHandle.get(),
+                destinationTableHandle,
                 ImmutableList.copyOf(newAssignments.keySet()),
                 newAssignments,
                 TupleDomain.all(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/GatherAndMergeWindows.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/GatherAndMergeWindows.java
@@ -221,9 +221,7 @@ public final class GatherAndMergeWindows
                         restrictOutputs(context.getIdAllocator(), transposedWindows, ImmutableSet.copyOf(parent.getOutputSymbols()))
                                 .orElse(transposedWindows));
             }
-            else {
-                return Optional.empty();
-            }
+            return Optional.empty();
         }
 
         private static int compare(WindowNode o1, WindowNode o2)
@@ -291,11 +289,9 @@ public final class GatherAndMergeWindows
                 if (orderByComparison != 0) {
                     return orderByComparison;
                 }
-                else {
-                    int sortOrderComparison = o1OrderingScheme.getOrdering(symbol1).compareTo(o2OrderingScheme.getOrdering(symbol2));
-                    if (sortOrderComparison != 0) {
-                        return sortOrderComparison;
-                    }
+                int sortOrderComparison = o1OrderingScheme.getOrdering(symbol1).compareTo(o2OrderingScheme.getOrdering(symbol2));
+                if (sortOrderComparison != 0) {
+                    return sortOrderComparison;
                 }
             }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/MergeLimitWithTopN.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/MergeLimitWithTopN.java
@@ -72,9 +72,7 @@ public class MergeLimitWithTopN
             if (parent.getCount() < child.getCount()) {
                 return Result.empty();
             }
-            else {
-                return Result.ofPlanNode(child);
-            }
+            return Result.ofPlanNode(child);
         }
 
         return Result.ofPlanNode(

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneDistinctAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneDistinctAggregation.java
@@ -58,9 +58,7 @@ public class PruneDistinctAggregation
         if (rewriter.isRewritten()) {
             return Result.ofPlanNode(replaceChildren(node, newSources));
         }
-        else {
-            return Result.empty();
-        }
+        return Result.empty();
     }
 
     private static boolean isDistinctOperator(AggregationNode node)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushdownFilterIntoRowNumber.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushdownFilterIntoRowNumber.java
@@ -97,9 +97,7 @@ public class PushdownFilterIntoRowNumber
             if (needRewriteSource) {
                 return Result.ofPlanNode(new FilterNode(node.getId(), source, node.getPredicate()));
             }
-            else {
-                return Result.empty();
-            }
+            return Result.empty();
         }
 
         TupleDomain<Symbol> newTupleDomain = tupleDomain.filter((symbol, domain) -> !symbol.equals(rowNumberSymbol));

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ReplaceRedundantJoinWithProject.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ReplaceRedundantJoinWithProject.java
@@ -82,7 +82,7 @@ public class ReplaceRedundantJoinWithProject
                             context.getIdAllocator(),
                             context.getSymbolAllocator()));
                 }
-                else if (!leftSourceEmpty && rightSourceEmpty) {
+                if (!leftSourceEmpty && rightSourceEmpty) {
                     yield Result.ofPlanNode(appendNulls(
                             node.getLeft(),
                             node.getLeftOutputSymbols(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformCorrelatedInPredicateToJoin.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformCorrelatedInPredicateToJoin.java
@@ -370,9 +370,7 @@ public class TransformCorrelatedInPredicateToJoin
             if (isCorrelatedRecursively(node)) {
                 return Optional.empty();
             }
-            else {
-                return Optional.of(new Decorrelated(ImmutableList.of(), reference));
-            }
+            return Optional.of(new Decorrelated(ImmutableList.of(), reference));
         }
 
         private boolean isCorrelatedRecursively(PlanNode node)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapCastInComparison.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapCastInComparison.java
@@ -227,10 +227,8 @@ public class UnwrapCastInComparison
                         if (!typeHasNaN(sourceType)) {
                             return TRUE_LITERAL;
                         }
-                        else {
-                            // NaN on the right of comparison will be cast to source type later
-                            break;
-                        }
+                        // NaN on the right of comparison will be cast to source type later
+                        break;
                     default:
                         throw new UnsupportedOperationException("Not yet implemented: " + operator);
                 }
@@ -404,13 +402,11 @@ public class UnwrapCastInComparison
                             Double.isNaN(doubleValue) ||
                             (doubleValue > -1L << 53 && doubleValue < 1L << 53); // in (-2^53, 2^53), bigint follows an injective implicit coercion w.r.t double
                 }
-                else {
-                    float realValue = intBitsToFloat(toIntExact((long) value));
-                    return (source.equals(BIGINT) && (realValue > Long.MAX_VALUE || realValue < Long.MIN_VALUE)) ||
-                            (source.equals(INTEGER) && (realValue > Integer.MAX_VALUE || realValue < Integer.MIN_VALUE)) ||
-                            Float.isNaN(realValue) ||
-                            (realValue > -1L << 23 && realValue < 1L << 23); // in (-2^23, 2^23), bigint (and integer) follows an injective implicit coercion w.r.t real
-                }
+                float realValue = intBitsToFloat(toIntExact((long) value));
+                return (source.equals(BIGINT) && (realValue > Long.MAX_VALUE || realValue < Long.MIN_VALUE)) ||
+                        (source.equals(INTEGER) && (realValue > Integer.MAX_VALUE || realValue < Integer.MIN_VALUE)) ||
+                        Float.isNaN(realValue) ||
+                        (realValue > -1L << 23 && realValue < 1L << 23); // in (-2^23, 2^23), bigint (and integer) follows an injective implicit coercion w.r.t real
             }
 
             if (source instanceof DecimalType) {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/ActualProperties.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/ActualProperties.java
@@ -109,9 +109,7 @@ public class ActualProperties
         if (exactly) {
             return global.isStreamPartitionedOnExactly(columns, constants.keySet(), nullsAndAnyReplicated);
         }
-        else {
-            return global.isStreamPartitionedOn(columns, constants.keySet(), nullsAndAnyReplicated);
-        }
+        return global.isStreamPartitionedOn(columns, constants.keySet(), nullsAndAnyReplicated);
     }
 
     public boolean isNodePartitionedOn(Collection<Symbol> columns, boolean exactly)
@@ -124,9 +122,7 @@ public class ActualProperties
         if (exactly) {
             return global.isNodePartitionedOnExactly(columns, constants.keySet(), nullsAndAnyReplicated);
         }
-        else {
-            return global.isNodePartitionedOn(columns, constants.keySet(), nullsAndAnyReplicated);
-        }
+        return global.isNodePartitionedOn(columns, constants.keySet(), nullsAndAnyReplicated);
     }
 
     public boolean isCompatibleTablePartitioningWith(Partitioning partitioning, boolean nullsAndAnyReplicated, Metadata metadata, Session session)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
@@ -780,9 +780,7 @@ public class AddExchanges
 
                 return planReplicatedJoin(node, left);
             }
-            else {
-                return planPartitionedJoin(node, leftSymbols, rightSymbols);
-            }
+            return planPartitionedJoin(node, leftSymbols, rightSymbols);
         }
 
         private PlanWithProperties planPartitionedJoin(JoinNode node, List<Symbol> leftSymbols, List<Symbol> rightSymbols)
@@ -1272,19 +1270,17 @@ public class AddExchanges
                 // instead of "arbitraryPartition".
                 return new PlanWithProperties(node.replaceChildren(partitionedChildren));
             }
-            else {
-                // Trino currently cannot execute stage that has multiple table scans, so in that case
-                // we have to insert REMOTE exchange with FIXED_ARBITRARY_DISTRIBUTION instead of local exchange
-                return new PlanWithProperties(
-                        new ExchangeNode(
-                                idAllocator.getNextId(),
-                                REPARTITION,
-                                REMOTE,
-                                new PartitioningScheme(Partitioning.create(FIXED_ARBITRARY_DISTRIBUTION, ImmutableList.of()), node.getOutputSymbols()),
-                                partitionedChildren,
-                                partitionedOutputLayouts,
-                                Optional.empty()));
-            }
+            // Trino currently cannot execute stage that has multiple table scans, so in that case
+            // we have to insert REMOTE exchange with FIXED_ARBITRARY_DISTRIBUTION instead of local exchange
+            return new PlanWithProperties(
+                    new ExchangeNode(
+                            idAllocator.getNextId(),
+                            REPARTITION,
+                            REMOTE,
+                            new PartitioningScheme(Partitioning.create(FIXED_ARBITRARY_DISTRIBUTION, ImmutableList.of()), node.getOutputSymbols()),
+                            partitionedChildren,
+                            partitionedOutputLayouts,
+                            Optional.empty()));
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/MetadataQueryOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/MetadataQueryOptimizer.java
@@ -162,9 +162,7 @@ public class MetadataQueryOptimizer
                             // partition key does not have a single value, so bail out to be safe
                             return context.defaultRewrite(node);
                         }
-                        else {
-                            rowBuilder.add(literalEncoder.toExpression(session, value.getValue(), type));
-                        }
+                        rowBuilder.add(literalEncoder.toExpression(session, value.getValue(), type));
                     }
                     rowsBuilder.add(new Row(rowBuilder.build()));
                 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PlanNodeSearcher.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PlanNodeSearcher.java
@@ -201,12 +201,10 @@ public class PlanNodeSearcher
             if (sources.isEmpty()) {
                 return node;
             }
-            else if (sources.size() == 1) {
+            if (sources.size() == 1) {
                 return replaceChildren(node, ImmutableList.of(removeFirstRecursive(sources.get(0))));
             }
-            else {
-                throw new IllegalArgumentException("Unable to remove first node when a node has multiple children, use removeAll instead");
-            }
+            throw new IllegalArgumentException("Unable to remove first node when a node has multiple children, use removeAll instead");
         }
         return node;
     }
@@ -248,12 +246,10 @@ public class PlanNodeSearcher
         if (sources.isEmpty()) {
             return node;
         }
-        else if (sources.size() == 1) {
+        if (sources.size() == 1) {
             return replaceChildren(node, ImmutableList.of(replaceFirstRecursive(node, sources.get(0))));
         }
-        else {
-            throw new IllegalArgumentException("Unable to replace first node when a node has multiple children, use replaceAll instead");
-        }
+        throw new IllegalArgumentException("Unable to replace first node when a node has multiple children, use replaceAll instead");
     }
 
     public boolean matches()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
@@ -1154,24 +1154,22 @@ public class PredicatePushDown
                             node.getDynamicFilters(),
                             node.getReorderJoinStatsAndCost());
                 }
-                else {
-                    return new JoinNode(
-                            node.getId(),
-                            canConvertToLeftJoin ? LEFT : RIGHT,
-                            node.getLeft(),
-                            node.getRight(),
-                            node.getCriteria(),
-                            node.getLeftOutputSymbols(),
-                            node.getRightOutputSymbols(),
-                            node.isMaySkipOutputDuplicates(),
-                            node.getFilter(),
-                            node.getLeftHashSymbol(),
-                            node.getRightHashSymbol(),
-                            node.getDistributionType(),
-                            node.isSpillable(),
-                            node.getDynamicFilters(),
-                            node.getReorderJoinStatsAndCost());
-                }
+                return new JoinNode(
+                        node.getId(),
+                        canConvertToLeftJoin ? LEFT : RIGHT,
+                        node.getLeft(),
+                        node.getRight(),
+                        node.getCriteria(),
+                        node.getLeftOutputSymbols(),
+                        node.getRightOutputSymbols(),
+                        node.isMaySkipOutputDuplicates(),
+                        node.getFilter(),
+                        node.getLeftHashSymbol(),
+                        node.getRightHashSymbol(),
+                        node.getDistributionType(),
+                        node.isSpillable(),
+                        node.getDynamicFilters(),
+                        node.getReorderJoinStatsAndCost());
             }
 
             if (node.getType() == JoinNode.Type.LEFT && !canConvertOuterToInner(node.getRight().getOutputSymbols(), inheritedPredicate) ||

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
@@ -964,7 +964,7 @@ public final class PropertyDerivations
             if (equality.getLeft().equals(column) && columns.contains(equality.getRight())) {
                 return Optional.of(equality.getRight());
             }
-            else if (equality.getRight().equals(column) && columns.contains(equality.getLeft())) {
+            if (equality.getRight().equals(column) && columns.contains(equality.getLeft())) {
                 return Optional.of(equality.getLeft());
             }
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/QueryCardinalityUtil.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/QueryCardinalityUtil.java
@@ -183,9 +183,7 @@ public final class QueryCardinalityUtil
             if (sourceCardinalityRange.hasUpperBound()) {
                 return Range.closed(lower, max(sourceCardinalityRange.upperEndpoint() - node.getCount(), 0L));
             }
-            else {
-                return Range.atLeast(lower);
-            }
+            return Range.atLeast(lower);
         }
 
         @Override
@@ -197,9 +195,7 @@ public final class QueryCardinalityUtil
                 if (sourceCardinalityRange.hasUpperBound()) {
                     return Range.closed(lower, sourceCardinalityRange.upperEndpoint());
                 }
-                else {
-                    return Range.atLeast(lower);
-                }
+                return Range.atLeast(lower);
             }
 
             return applyLimit(node.getSource(), node.getCount());

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/StreamPreferredProperties.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/StreamPreferredProperties.java
@@ -183,10 +183,10 @@ public class StreamPreferredProperties
             if (distribution.get() == SINGLE && actualDistribution != SINGLE) {
                 return false;
             }
-            else if (distribution.get() == FIXED && actualDistribution != FIXED) {
+            if (distribution.get() == FIXED && actualDistribution != FIXED) {
                 return false;
             }
-            else if (distribution.get() == MULTIPLE && actualDistribution != FIXED && actualDistribution != MULTIPLE) {
+            if (distribution.get() == MULTIPLE && actualDistribution != FIXED && actualDistribution != MULTIPLE) {
                 return false;
             }
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/CounterBasedAnonymizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/CounterBasedAnonymizer.java
@@ -225,22 +225,22 @@ public class CounterBasedAnonymizer
         if (target instanceof CreateTarget) {
             return anonymize((CreateTarget) target);
         }
-        else if (target instanceof InsertTarget) {
+        if (target instanceof InsertTarget) {
             return anonymize((InsertTarget) target);
         }
-        else if (target instanceof MergeTarget) {
+        if (target instanceof MergeTarget) {
             return anonymize((MergeTarget) target);
         }
-        else if (target instanceof RefreshMaterializedViewTarget) {
+        if (target instanceof RefreshMaterializedViewTarget) {
             return anonymize((RefreshMaterializedViewTarget) target);
         }
-        else if (target instanceof DeleteTarget) {
+        if (target instanceof DeleteTarget) {
             return anonymize((DeleteTarget) target);
         }
-        else if (target instanceof UpdateTarget) {
+        if (target instanceof UpdateTarget) {
             return anonymize((UpdateTarget) target);
         }
-        else if (target instanceof TableExecuteTarget) {
+        if (target instanceof TableExecuteTarget) {
             return anonymize((TableExecuteTarget) target);
         }
         throw new UnsupportedOperationException("Anonymization is not supported for WriterTarget type: " + target.getClass().getSimpleName());

--- a/core/trino-main/src/main/java/io/trino/sql/planner/rowpattern/IrRowPatternFlattener.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/rowpattern/IrRowPatternFlattener.java
@@ -118,9 +118,7 @@ public final class IrRowPatternFlattener
                         if (child instanceof IrAlternation) {
                             return ((IrAlternation) child).getPatterns().stream();
                         }
-                        else {
-                            return Stream.of(child);
-                        }
+                        return Stream.of(child);
                     })
                     .collect(toImmutableList());
 
@@ -174,9 +172,7 @@ public final class IrRowPatternFlattener
                         if (child instanceof IrConcatenation) {
                             return ((IrConcatenation) child).getPatterns().stream();
                         }
-                        else {
-                            return Stream.of(child);
-                        }
+                        return Stream.of(child);
                     })
                     .filter(child -> !(child instanceof IrEmpty))
                     .collect(toImmutableList());

--- a/core/trino-main/src/main/java/io/trino/sql/relational/optimizer/ExpressionOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/relational/optimizer/ExpressionOptimizer.java
@@ -130,9 +130,7 @@ public class ExpressionOptimizer
                             return specialForm.getArguments().get(1).accept(this, context);
                         }
                         // FALSE and NULL
-                        else {
-                            return specialForm.getArguments().get(2).accept(this, context);
-                        }
+                        return specialForm.getArguments().get(2).accept(this, context);
                     }
                     List<RowExpression> arguments = specialForm.getArguments().stream()
                             .map(argument -> argument.accept(this, null))

--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
@@ -373,13 +373,11 @@ public final class ShowQueriesRewrite
                         .collect(toList());
                 return singleColumnValues(rows, "Role");
             }
-            else {
-                accessControl.checkCanShowRoles(session.toSecurityContext(), catalog);
-                List<Expression> rows = metadata.listRoles(session, catalog).stream()
-                        .map(role -> row(new StringLiteral(role)))
-                        .collect(toList());
-                return singleColumnValues(rows, "Role");
-            }
+            accessControl.checkCanShowRoles(session.toSecurityContext(), catalog);
+            List<Expression> rows = metadata.listRoles(session, catalog).stream()
+                    .map(role -> row(new StringLiteral(role)))
+                    .collect(toList());
+            return singleColumnValues(rows, "Role");
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/transaction/InMemoryTransactionManager.java
+++ b/core/trino-main/src/main/java/io/trino/transaction/InMemoryTransactionManager.java
@@ -375,9 +375,7 @@ public class InMemoryTransactionManager
                     // Should not happen normally
                     throw new IllegalStateException("Current transaction already committed");
                 }
-                else {
-                    throw new TrinoException(TRANSACTION_ALREADY_ABORTED, "Current transaction is aborted, commands ignored until end of transaction block");
-                }
+                throw new TrinoException(TRANSACTION_ALREADY_ABORTED, "Current transaction is aborted, commands ignored until end of transaction block");
             }
         }
 

--- a/core/trino-main/src/main/java/io/trino/type/LikeFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/type/LikeFunctions.java
@@ -54,9 +54,7 @@ public final class LikeFunctions
         if (value.hasByteArray()) {
             return matcher.match(value.byteArray(), value.byteArrayOffset(), value.length());
         }
-        else {
-            return matcher.match(value.getBytes(), 0, value.length());
-        }
+        return matcher.match(value.getBytes(), 0, value.length());
     }
 
     @ScalarFunction(value = LIKE_PATTERN_FUNCTION_NAME, hidden = true)

--- a/core/trino-main/src/main/java/io/trino/type/TypeUtils.java
+++ b/core/trino-main/src/main/java/io/trino/type/TypeUtils.java
@@ -113,9 +113,7 @@ public final class TypeUtils
                     if (field.getName().isPresent()) {
                         return field.getName().get() + ' ' + typeDisplayName;
                     }
-                    else {
-                        return typeDisplayName;
-                    }
+                    return typeDisplayName;
                 })
                 .collect(toImmutableList());
 

--- a/core/trino-main/src/main/java/io/trino/util/DateTimeZoneIndex.java
+++ b/core/trino-main/src/main/java/io/trino/util/DateTimeZoneIndex.java
@@ -97,8 +97,6 @@ public final class DateTimeZoneIndex
         if (FIXED_ZONE_OFFSET[zoneKey] == VARIABLE_ZONE) {
             return DATE_TIME_ZONES[zoneKey].getOffset(epochMillis) / 60_000;
         }
-        else {
-            return FIXED_ZONE_OFFSET[zoneKey];
-        }
+        return FIXED_ZONE_OFFSET[zoneKey];
     }
 }

--- a/core/trino-main/src/main/java/io/trino/util/DisjointSet.java
+++ b/core/trino-main/src/main/java/io/trino/util/DisjointSet.java
@@ -120,11 +120,9 @@ public class DisjointSet<T>
         if (value.getParent() == null) {
             return element;
         }
-        else {
-            T root = findInternal(value.getParent());
-            value.setParent(root);
-            return root;
-        }
+        T root = findInternal(value.getParent());
+        value.setParent(root);
+        return root;
     }
 
     public Collection<Set<T>> getEquivalentClasses()

--- a/core/trino-main/src/main/java/io/trino/util/FastutilSetHelper.java
+++ b/core/trino-main/src/main/java/io/trino/util/FastutilSetHelper.java
@@ -65,12 +65,10 @@ public final class FastutilSetHelper
         if (javaElementType == boolean.class) {
             return new BooleanOpenHashSet((Collection<Boolean>) set, 0.25f);
         }
-        else if (!type.getJavaType().isPrimitive()) {
+        if (!type.getJavaType().isPrimitive()) {
             return new ObjectOpenCustomHashSet<>(set, 0.25f, new ObjectStrategy(hashCodeHandle, equalsHandle, type));
         }
-        else {
-            throw new UnsupportedOperationException("Unsupported native type in set: " + type.getJavaType() + " with type " + type.getTypeSignature());
-        }
+        throw new UnsupportedOperationException("Unsupported native type in set: " + type.getJavaType() + " with type " + type.getTypeSignature());
     }
 
     public static boolean in(boolean booleanValue, BooleanOpenHashSet set)

--- a/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
+++ b/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
@@ -133,9 +133,7 @@ public final class JsonUtil
         if (json.length() <= MAX_JSON_LENGTH_IN_ERROR_MESSAGE) {
             return json.toStringUtf8();
         }
-        else {
-            return json.slice(0, MAX_JSON_LENGTH_IN_ERROR_MESSAGE).toStringUtf8() + "...(truncated)";
-        }
+        return json.slice(0, MAX_JSON_LENGTH_IN_ERROR_MESSAGE).toStringUtf8() + "...(truncated)";
     }
 
     public static boolean canCastToJson(Type type)

--- a/core/trino-main/src/main/java/io/trino/util/MoreMath.java
+++ b/core/trino-main/src/main/java/io/trino/util/MoreMath.java
@@ -34,14 +34,12 @@ public final class MoreMath
         if (a == b) { // shortcut, handles infinities
             return true;
         }
-        else if (a == 0 || b == 0 || diff < Double.MIN_NORMAL) {
+        if (a == 0 || b == 0 || diff < Double.MIN_NORMAL) {
             // a or b is zero or both are extremely close to it
             // relative error is less meaningful here
             return diff < (epsilon * Double.MIN_NORMAL);
-        }
-        else { // use relative error
-            return diff / Math.min((absA + absB), Double.MAX_VALUE) < epsilon;
-        }
+        } // use relative error
+        return diff / Math.min((absA + absB), Double.MAX_VALUE) < epsilon;
     }
 
     /**
@@ -56,14 +54,12 @@ public final class MoreMath
         if (a == b) { // shortcut, handles infinities
             return true;
         }
-        else if (a == 0 || b == 0 || diff < Float.MIN_NORMAL) {
+        if (a == 0 || b == 0 || diff < Float.MIN_NORMAL) {
             // a or b is zero or both are extremely close to it
             // relative error is less meaningful here
             return diff < (epsilon * Float.MIN_NORMAL);
-        }
-        else { // use relative error
-            return diff / Math.min((absA + absB), Float.MAX_VALUE) < epsilon;
-        }
+        } // use relative error
+        return diff / Math.min((absA + absB), Float.MAX_VALUE) < epsilon;
     }
 
     public static double min(double... values)

--- a/core/trino-main/src/main/java/io/trino/util/Optionals.java
+++ b/core/trino-main/src/main/java/io/trino/util/Optionals.java
@@ -26,11 +26,9 @@ public final class Optionals
         if (left.isPresent() && right.isPresent()) {
             return Optional.of(combiner.apply(left.get(), right.get()));
         }
-        else if (left.isPresent()) {
+        if (left.isPresent()) {
             return left;
         }
-        else {
-            return right;
-        }
+        return right;
     }
 }

--- a/core/trino-main/src/test/java/io/trino/block/AbstractTestBlock.java
+++ b/core/trino-main/src/test/java/io/trino/block/AbstractTestBlock.java
@@ -404,9 +404,7 @@ public abstract class AbstractTestBlock
             // dictionary blocks might become unwrapped when copyRegion is called on a block that is already compact
             return ((DictionaryBlock) block).compact().getSizeInBytes();
         }
-        else {
-            return copyBlockViaCopyRegion(block).getSizeInBytes();
-        }
+        return copyBlockViaCopyRegion(block).getSizeInBytes();
     }
 
     private static Block copyBlockViaCopyRegion(Block block)

--- a/core/trino-main/src/test/java/io/trino/metadata/TestSignatureBinder.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestSignatureBinder.java
@@ -1239,9 +1239,7 @@ public class TestSignatureBinder
             if (returnType == null) {
                 return signatureBinder.bindVariables(argumentTypes);
             }
-            else {
-                return signatureBinder.bindVariables(argumentTypes, returnType.getTypeSignature());
-            }
+            return signatureBinder.bindVariables(argumentTypes, returnType.getTypeSignature());
         }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkScanFilterAndProjectOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkScanFilterAndProjectOperator.java
@@ -239,9 +239,7 @@ public class BenchmarkScanFilterAndProjectOperator
             if (dictionary) {
                 return SequencePageBuilder.createSequencePageWithDictionaryBlocks(types, positions);
             }
-            else {
-                return SequencePageBuilder.createSequencePage(types, positions);
-            }
+            return SequencePageBuilder.createSequencePage(types, positions);
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/TestExchangeOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestExchangeOperator.java
@@ -292,9 +292,7 @@ public class TestExchangeOperator
                 greaterThanZero = true;
                 break;
             }
-            else {
-                Thread.sleep(10);
-            }
+            Thread.sleep(10);
         }
         assertTrue(greaterThanZero);
 

--- a/core/trino-main/src/test/java/io/trino/operator/TestingExchangeHttpClientHandler.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestingExchangeHttpClientHandler.java
@@ -88,7 +88,7 @@ public class TestingExchangeHttpClientHandler
             output.writeBytes(serializedPage);
             return new TestingResponse(HttpStatus.OK, headers.build(), output.slice().getInput());
         }
-        else if (taskBuffer.isFinished()) {
+        if (taskBuffer.isFinished()) {
             headers.put(TRINO_PAGE_NEXT_TOKEN, String.valueOf(pageToken));
             headers.put(TRINO_BUFFER_COMPLETE, String.valueOf(true));
             DynamicSliceOutput output = new DynamicSliceOutput(8);
@@ -97,10 +97,8 @@ public class TestingExchangeHttpClientHandler
             output.writeInt(0);
             return new TestingResponse(HttpStatus.OK, headers.build(), output.slice().getInput());
         }
-        else {
-            headers.put(TRINO_PAGE_NEXT_TOKEN, String.valueOf(pageToken));
-            headers.put(TRINO_BUFFER_COMPLETE, String.valueOf(false));
-            return new TestingResponse(HttpStatus.NO_CONTENT, headers.build(), new byte[0]);
-        }
+        headers.put(TRINO_PAGE_NEXT_TOKEN, String.valueOf(pageToken));
+        headers.put(TRINO_BUFFER_COMPLETE, String.valueOf(false));
+        return new TestingResponse(HttpStatus.NO_CONTENT, headers.build(), new byte[0]);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/AbstractTestApproximateCountDistinct.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/AbstractTestApproximateCountDistinct.java
@@ -164,11 +164,9 @@ public abstract class AbstractTestApproximateCountDistinct
         if (values.isEmpty()) {
             return new Page(0);
         }
-        else {
-            return new Page(values.size(),
-                    createBlock(getValueType(), values),
-                    createBlock(DOUBLE, ImmutableList.copyOf(Collections.nCopies(values.size(), maxStandardError))));
-        }
+        return new Page(values.size(),
+                createBlock(getValueType(), values),
+                createBlock(DOUBLE, ImmutableList.copyOf(Collections.nCopies(values.size(), maxStandardError))));
     }
 
     /**

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/AbstractTestApproximateSetGeneric.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/AbstractTestApproximateSetGeneric.java
@@ -190,9 +190,7 @@ public abstract class AbstractTestApproximateSetGeneric
         if (values.isEmpty()) {
             return new Page(0);
         }
-        else {
-            return new Page(values.size(), createBlock(getValueType(), values));
-        }
+        return new Page(values.size(), createBlock(getValueType(), values));
     }
 
     /**

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/groupby/GroupByAggregationTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/groupby/GroupByAggregationTestUtils.java
@@ -35,18 +35,16 @@ public final class GroupByAggregationTestUtils
         if (positions == 0) {
             return new Page[] {};
         }
-        else if (positions == 1) {
+        if (positions == 1) {
             return new Page[] {new Page(positions, blocks)};
         }
-        else {
-            int split = positions / 2; // [0, split - 1] goes to first list of blocks; [split, positions - 1] goes to second list of blocks.
-            Block[] blockArray1 = new Block[blocks.length];
-            Block[] blockArray2 = new Block[blocks.length];
-            for (int i = 0; i < blocks.length; i++) {
-                blockArray1[i] = blocks[i].getRegion(0, split);
-                blockArray2[i] = blocks[i].getRegion(split, positions - split);
-            }
-            return new Page[] {new Page(blockArray1), new Page(blockArray2)};
+        int split = positions / 2; // [0, split - 1] goes to first list of blocks; [split, positions - 1] goes to second list of blocks.
+        Block[] blockArray1 = new Block[blocks.length];
+        Block[] blockArray2 = new Block[blocks.length];
+        for (int i = 0; i < blocks.length; i++) {
+            blockArray1[i] = blocks[i].getRegion(0, split);
+            blockArray2[i] = blocks[i].getRegion(split, positions - split);
         }
+        return new Page[] {new Page(blockArray1), new Page(blockArray2)};
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkJsonToArrayCast.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkJsonToArrayCast.java
@@ -141,10 +141,10 @@ public class BenchmarkJsonToArrayCast
             if (valueType == BIGINT) {
                 return Long.toString(ThreadLocalRandom.current().nextLong());
             }
-            else if (valueType == DOUBLE) {
+            if (valueType == DOUBLE) {
                 return Double.toString(ThreadLocalRandom.current().nextDouble());
             }
-            else if (valueType == VARCHAR) {
+            if (valueType == VARCHAR) {
                 String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
 
                 int length = ThreadLocalRandom.current().nextInt(10) + 1;
@@ -156,9 +156,7 @@ public class BenchmarkJsonToArrayCast
                 builder.append('"');
                 return builder.toString();
             }
-            else {
-                throw new UnsupportedOperationException();
-            }
+            throw new UnsupportedOperationException();
         }
 
         public PageProcessor getPageProcessor()

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkJsonToMapCast.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkJsonToMapCast.java
@@ -147,10 +147,10 @@ public class BenchmarkJsonToMapCast
             if (valueType == BIGINT) {
                 return Long.toString(ThreadLocalRandom.current().nextLong());
             }
-            else if (valueType == DOUBLE) {
+            if (valueType == DOUBLE) {
                 return Double.toString(ThreadLocalRandom.current().nextDouble());
             }
-            else if (valueType == VARCHAR) {
+            if (valueType == VARCHAR) {
                 String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
 
                 int length = ThreadLocalRandom.current().nextInt(10) + 1;
@@ -162,9 +162,7 @@ public class BenchmarkJsonToMapCast
                 builder.append('"');
                 return builder.toString();
             }
-            else {
-                throw new UnsupportedOperationException();
-            }
+            throw new UnsupportedOperationException();
         }
 
         public PageProcessor getPageProcessor()

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/FunctionAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/FunctionAssertions.java
@@ -783,21 +783,19 @@ public final class FunctionAssertions
             if (javaType == boolean.class) {
                 return type.getBoolean(block, position);
             }
-            else if (javaType == long.class) {
+            if (javaType == long.class) {
                 return type.getLong(block, position);
             }
-            else if (javaType == double.class) {
+            if (javaType == double.class) {
                 return type.getDouble(block, position);
             }
-            else if (javaType == Slice.class) {
+            if (javaType == Slice.class) {
                 return type.getSlice(block, position);
             }
-            else if (javaType == Block.class || javaType == Int128.class) {
+            if (javaType == Block.class || javaType == Int128.class) {
                 return type.getObject(block, position);
             }
-            else {
-                throw new UnsupportedOperationException("not yet implemented");
-            }
+            throw new UnsupportedOperationException("not yet implemented");
         });
 
         // convert result from stack type to Type ObjectValue
@@ -953,9 +951,7 @@ public final class FunctionAssertions
                         .build();
                 return new RecordPageSource(records);
             }
-            else {
-                return new FixedPageSource(ImmutableList.of(SOURCE_PAGE));
-            }
+            return new FixedPageSource(ImmutableList.of(SOURCE_PAGE));
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/spiller/TestAesSpillCipher.java
+++ b/core/trino-main/src/test/java/io/trino/spiller/TestAesSpillCipher.java
@@ -56,9 +56,7 @@ public class TestAesSpillCipher
         if (output.length == outLength) {
             return output;
         }
-        else {
-            return Arrays.copyOfRange(output, 0, outLength);
-        }
+        return Arrays.copyOfRange(output, 0, outLength);
     }
 
     private static byte[] decryptExact(SpillCipher cipher, byte[] encryptedData)
@@ -68,9 +66,7 @@ public class TestAesSpillCipher
         if (outLength == output.length) {
             return output;
         }
-        else {
-            return Arrays.copyOfRange(output, 0, outLength);
-        }
+        return Arrays.copyOfRange(output, 0, outLength);
     }
 
     private static void assertFailure(ThrowingRunnable runnable, String expectedErrorMessage)

--- a/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkPageProcessor2.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkPageProcessor2.java
@@ -189,9 +189,7 @@ public class BenchmarkPageProcessor2
         if (dictionary) {
             return SequencePageBuilder.createSequencePageWithDictionaryBlocks(types, POSITIONS);
         }
-        else {
-            return SequencePageBuilder.createSequencePage(types, POSITIONS);
-        }
+        return SequencePageBuilder.createSequencePage(types, POSITIONS);
     }
 
     public static void main(String[] args)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestTableScanRedirectionWithPushdown.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestTableScanRedirectionWithPushdown.java
@@ -337,7 +337,7 @@ public class TestTableScanRedirectionWithPushdown
                                 new ColumnMetadata(SOURCE_COLUMN_NAME_C, VARCHAR),
                                 new ColumnMetadata(SOURCE_COLUMN_NAME_D, ROW_TYPE));
                     }
-                    else if (name.equals(DESTINATION_TABLE)) {
+                    if (name.equals(DESTINATION_TABLE)) {
                         return ImmutableList.of(
                                 new ColumnMetadata(DESTINATION_COLUMN_NAME_A, INTEGER),
                                 new ColumnMetadata(DESTINATION_COLUMN_NAME_B, INTEGER),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/CorrelationMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/CorrelationMatcher.java
@@ -72,12 +72,10 @@ public class CorrelationMatcher
         if (node instanceof ApplyNode) {
             return ((ApplyNode) node).getCorrelation();
         }
-        else if (node instanceof CorrelatedJoinNode) {
+        if (node instanceof CorrelatedJoinNode) {
             return ((CorrelatedJoinNode) node).getCorrelation();
         }
-        else {
-            throw new IllegalStateException("Unexpected plan node: " + node);
-        }
+        throw new IllegalStateException("Unexpected plan node: " + node);
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/ExpressionMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/ExpressionMatcher.java
@@ -96,13 +96,11 @@ public class ExpressionMatcher
             ProjectNode projectNode = (ProjectNode) node;
             return projectNode.getAssignments().getMap();
         }
-        else if (node instanceof ApplyNode) {
+        if (node instanceof ApplyNode) {
             ApplyNode applyNode = (ApplyNode) node;
             return applyNode.getSubqueryAssignments().getMap();
         }
-        else {
-            return null;
-        }
+        return null;
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/MatchResult.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/MatchResult.java
@@ -69,8 +69,6 @@ public class MatchResult
         if (matches) {
             return "MATCH";
         }
-        else {
-            return "NO MATCH";
-        }
+        return "NO MATCH";
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
@@ -1389,19 +1389,13 @@ public final class PlanMatchPattern
                 if (nullOrdering == FIRST) {
                     return ASC_NULLS_FIRST;
                 }
-                else {
-                    return ASC_NULLS_LAST;
-                }
+                return ASC_NULLS_LAST;
             }
-            else {
-                checkState(ordering == DESCENDING);
-                if (nullOrdering == FIRST) {
-                    return DESC_NULLS_FIRST;
-                }
-                else {
-                    return DESC_NULLS_LAST;
-                }
+            checkState(ordering == DESCENDING);
+            if (nullOrdering == FIRST) {
+                return DESC_NULLS_FIRST;
             }
+            return DESC_NULLS_LAST;
         }
 
         @Override

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestApplyTableScanRedirection.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestApplyTableScanRedirection.java
@@ -281,7 +281,7 @@ public class TestApplyTableScanRedirection
                                 new ColumnMetadata(SOURCE_COLUMN_NAME_A, VARCHAR),
                                 new ColumnMetadata(SOURCE_COLUMN_NAME_B, VARCHAR));
                     }
-                    else if (schemaTableName.equals(DESTINATION_TABLE)) {
+                    if (schemaTableName.equals(DESTINATION_TABLE)) {
                         return ImmutableList.of(
                                 new ColumnMetadata(DESTINATION_COLUMN_NAME_A, VARCHAR),
                                 new ColumnMetadata(DESTINATION_COLUMN_NAME_B, VARCHAR),

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -3674,15 +3674,13 @@ class AstBuilder
         if (context instanceof SqlBaseParser.SpecifiedPrincipalContext) {
             return new GrantorSpecification(GrantorSpecification.Type.PRINCIPAL, Optional.of(getPrincipalSpecification(((SqlBaseParser.SpecifiedPrincipalContext) context).principal())));
         }
-        else if (context instanceof SqlBaseParser.CurrentUserGrantorContext) {
+        if (context instanceof SqlBaseParser.CurrentUserGrantorContext) {
             return new GrantorSpecification(GrantorSpecification.Type.CURRENT_USER, Optional.empty());
         }
-        else if (context instanceof SqlBaseParser.CurrentRoleGrantorContext) {
+        if (context instanceof SqlBaseParser.CurrentRoleGrantorContext) {
             return new GrantorSpecification(GrantorSpecification.Type.CURRENT_ROLE, Optional.empty());
         }
-        else {
-            throw new IllegalArgumentException("Unsupported grantor: " + context);
-        }
+        throw new IllegalArgumentException("Unsupported grantor: " + context);
     }
 
     private PrincipalSpecification getPrincipalSpecification(SqlBaseParser.PrincipalContext context)
@@ -3690,15 +3688,13 @@ class AstBuilder
         if (context instanceof SqlBaseParser.UnspecifiedPrincipalContext) {
             return new PrincipalSpecification(PrincipalSpecification.Type.UNSPECIFIED, (Identifier) visit(((SqlBaseParser.UnspecifiedPrincipalContext) context).identifier()));
         }
-        else if (context instanceof SqlBaseParser.UserPrincipalContext) {
+        if (context instanceof SqlBaseParser.UserPrincipalContext) {
             return new PrincipalSpecification(PrincipalSpecification.Type.USER, (Identifier) visit(((SqlBaseParser.UserPrincipalContext) context).identifier()));
         }
-        else if (context instanceof SqlBaseParser.RolePrincipalContext) {
+        if (context instanceof SqlBaseParser.RolePrincipalContext) {
             return new PrincipalSpecification(PrincipalSpecification.Type.ROLE, (Identifier) visit(((SqlBaseParser.RolePrincipalContext) context).identifier()));
         }
-        else {
-            throw new IllegalArgumentException("Unsupported principal: " + context);
-        }
+        throw new IllegalArgumentException("Unsupported principal: " + context);
     }
 
     private static void check(boolean condition, String message, ParserRuleContext context)

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/SqlParser.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/SqlParser.java
@@ -124,9 +124,7 @@ public class SqlParser
                     if (nextTokensContext == null) {
                         throw new InputMismatchException(recognizer);
                     }
-                    else {
-                        throw new InputMismatchException(recognizer, nextTokensState, nextTokensContext);
-                    }
+                    throw new InputMismatchException(recognizer, nextTokensState, nextTokensContext);
                 }
             });
 

--- a/core/trino-spi/src/main/java/io/trino/spi/HostAddress.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/HostAddress.java
@@ -221,9 +221,7 @@ public class HostAddress
         if (port < 0) {
             return fromString(host);
         }
-        else {
-            return fromParts(host, port);
-        }
+        return fromParts(host, port);
     }
 
     /**

--- a/core/trino-spi/src/main/java/io/trino/spi/block/AbstractSingleMapBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/AbstractSingleMapBlock.java
@@ -51,9 +51,7 @@ public abstract class AbstractSingleMapBlock
             }
             return false;
         }
-        else {
-            return getRawValueBlock().isNull(position / 2);
-        }
+        return getRawValueBlock().isNull(position / 2);
     }
 
     @Override
@@ -63,9 +61,7 @@ public abstract class AbstractSingleMapBlock
         if (position % 2 == 0) {
             return getRawKeyBlock().getByte(position / 2, offset);
         }
-        else {
-            return getRawValueBlock().getByte(position / 2, offset);
-        }
+        return getRawValueBlock().getByte(position / 2, offset);
     }
 
     @Override
@@ -75,9 +71,7 @@ public abstract class AbstractSingleMapBlock
         if (position % 2 == 0) {
             return getRawKeyBlock().getShort(position / 2, offset);
         }
-        else {
-            return getRawValueBlock().getShort(position / 2, offset);
-        }
+        return getRawValueBlock().getShort(position / 2, offset);
     }
 
     @Override
@@ -87,9 +81,7 @@ public abstract class AbstractSingleMapBlock
         if (position % 2 == 0) {
             return getRawKeyBlock().getInt(position / 2, offset);
         }
-        else {
-            return getRawValueBlock().getInt(position / 2, offset);
-        }
+        return getRawValueBlock().getInt(position / 2, offset);
     }
 
     @Override
@@ -99,9 +91,7 @@ public abstract class AbstractSingleMapBlock
         if (position % 2 == 0) {
             return getRawKeyBlock().getLong(position / 2, offset);
         }
-        else {
-            return getRawValueBlock().getLong(position / 2, offset);
-        }
+        return getRawValueBlock().getLong(position / 2, offset);
     }
 
     @Override
@@ -111,9 +101,7 @@ public abstract class AbstractSingleMapBlock
         if (position % 2 == 0) {
             return getRawKeyBlock().getSlice(position / 2, offset, length);
         }
-        else {
-            return getRawValueBlock().getSlice(position / 2, offset, length);
-        }
+        return getRawValueBlock().getSlice(position / 2, offset, length);
     }
 
     @Override
@@ -123,9 +111,7 @@ public abstract class AbstractSingleMapBlock
         if (position % 2 == 0) {
             return getRawKeyBlock().getSliceLength(position / 2);
         }
-        else {
-            return getRawValueBlock().getSliceLength(position / 2);
-        }
+        return getRawValueBlock().getSliceLength(position / 2);
     }
 
     @Override
@@ -135,9 +121,7 @@ public abstract class AbstractSingleMapBlock
         if (position % 2 == 0) {
             return getRawKeyBlock().compareTo(position / 2, offset, length, otherBlock, otherPosition, otherOffset, otherLength);
         }
-        else {
-            return getRawValueBlock().compareTo(position / 2, offset, length, otherBlock, otherPosition, otherOffset, otherLength);
-        }
+        return getRawValueBlock().compareTo(position / 2, offset, length, otherBlock, otherPosition, otherOffset, otherLength);
     }
 
     @Override
@@ -147,9 +131,7 @@ public abstract class AbstractSingleMapBlock
         if (position % 2 == 0) {
             return getRawKeyBlock().bytesEqual(position / 2, offset, otherSlice, otherOffset, length);
         }
-        else {
-            return getRawValueBlock().bytesEqual(position / 2, offset, otherSlice, otherOffset, length);
-        }
+        return getRawValueBlock().bytesEqual(position / 2, offset, otherSlice, otherOffset, length);
     }
 
     @Override
@@ -159,9 +141,7 @@ public abstract class AbstractSingleMapBlock
         if (position % 2 == 0) {
             return getRawKeyBlock().bytesCompare(position / 2, offset, length, otherSlice, otherOffset, otherLength);
         }
-        else {
-            return getRawValueBlock().bytesCompare(position / 2, offset, length, otherSlice, otherOffset, otherLength);
-        }
+        return getRawValueBlock().bytesCompare(position / 2, offset, length, otherSlice, otherOffset, otherLength);
     }
 
     @Override
@@ -183,9 +163,7 @@ public abstract class AbstractSingleMapBlock
         if (position % 2 == 0) {
             return getRawKeyBlock().equals(position / 2, offset, otherBlock, otherPosition, otherOffset, length);
         }
-        else {
-            return getRawValueBlock().equals(position / 2, offset, otherBlock, otherPosition, otherOffset, length);
-        }
+        return getRawValueBlock().equals(position / 2, offset, otherBlock, otherPosition, otherOffset, length);
     }
 
     @Override
@@ -195,9 +173,7 @@ public abstract class AbstractSingleMapBlock
         if (position % 2 == 0) {
             return getRawKeyBlock().hash(position / 2, offset, length);
         }
-        else {
-            return getRawValueBlock().hash(position / 2, offset, length);
-        }
+        return getRawValueBlock().hash(position / 2, offset, length);
     }
 
     @Override
@@ -207,9 +183,7 @@ public abstract class AbstractSingleMapBlock
         if (position % 2 == 0) {
             return getRawKeyBlock().getObject(position / 2, clazz);
         }
-        else {
-            return getRawValueBlock().getObject(position / 2, clazz);
-        }
+        return getRawValueBlock().getObject(position / 2, clazz);
     }
 
     @Override
@@ -219,9 +193,7 @@ public abstract class AbstractSingleMapBlock
         if (position % 2 == 0) {
             return getRawKeyBlock().getSingleValueBlock(position / 2);
         }
-        else {
-            return getRawValueBlock().getSingleValueBlock(position / 2);
-        }
+        return getRawValueBlock().getSingleValueBlock(position / 2);
     }
 
     @Override
@@ -231,9 +203,7 @@ public abstract class AbstractSingleMapBlock
         if (position % 2 == 0) {
             return getRawKeyBlock().getEstimatedDataSizeForStats(position / 2);
         }
-        else {
-            return getRawValueBlock().getEstimatedDataSizeForStats(position / 2);
-        }
+        return getRawValueBlock().getEstimatedDataSizeForStats(position / 2);
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlockEncoding.java
@@ -111,7 +111,7 @@ public class ByteArrayBlockEncoding
         if (block instanceof ByteArrayBlock) {
             return ((ByteArrayBlock) block).getValuesSlice();
         }
-        else if (block instanceof ByteArrayBlockBuilder) {
+        if (block instanceof ByteArrayBlockBuilder) {
             return ((ByteArrayBlockBuilder) block).getValuesSlice();
         }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlockEncoding.java
@@ -90,7 +90,7 @@ public class Int128ArrayBlockEncoding
         if (block instanceof Int128ArrayBlock) {
             return ((Int128ArrayBlock) block).getValuesSlice();
         }
-        else if (block instanceof Int128ArrayBlockBuilder) {
+        if (block instanceof Int128ArrayBlockBuilder) {
             return ((Int128ArrayBlockBuilder) block).getValuesSlice();
         }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Int96ArrayBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Int96ArrayBlockEncoding.java
@@ -121,7 +121,7 @@ public class Int96ArrayBlockEncoding
         if (block instanceof Int96ArrayBlock) {
             return ((Int96ArrayBlock) block).getHighSlice();
         }
-        else if (block instanceof Int96ArrayBlockBuilder) {
+        if (block instanceof Int96ArrayBlockBuilder) {
             return ((Int96ArrayBlockBuilder) block).getHighSlice();
         }
 
@@ -133,7 +133,7 @@ public class Int96ArrayBlockEncoding
         if (block instanceof Int96ArrayBlock) {
             return ((Int96ArrayBlock) block).getLowSlice();
         }
-        else if (block instanceof Int96ArrayBlockBuilder) {
+        if (block instanceof Int96ArrayBlockBuilder) {
             return ((Int96ArrayBlockBuilder) block).getLowSlice();
         }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlockEncoding.java
@@ -111,7 +111,7 @@ public class IntArrayBlockEncoding
         if (block instanceof IntArrayBlock) {
             return ((IntArrayBlock) block).getValuesSlice();
         }
-        else if (block instanceof IntArrayBlockBuilder) {
+        if (block instanceof IntArrayBlockBuilder) {
             return ((IntArrayBlockBuilder) block).getValuesSlice();
         }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlockEncoding.java
@@ -111,7 +111,7 @@ public class LongArrayBlockEncoding
         if (block instanceof LongArrayBlock) {
             return ((LongArrayBlock) block).getValuesSlice();
         }
-        else if (block instanceof LongArrayBlockBuilder) {
+        if (block instanceof LongArrayBlockBuilder) {
             return ((LongArrayBlockBuilder) block).getValuesSlice();
         }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlockEncoding.java
@@ -111,7 +111,7 @@ public class ShortArrayBlockEncoding
         if (block instanceof ShortArrayBlock) {
             return ((ShortArrayBlock) block).getValuesSlice();
         }
-        else if (block instanceof ShortArrayBlockBuilder) {
+        if (block instanceof ShortArrayBlockBuilder) {
             return ((ShortArrayBlockBuilder) block).getValuesSlice();
         }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/block/SingleRowBlockWriter.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/SingleRowBlockWriter.java
@@ -216,9 +216,7 @@ public class SingleRowBlockWriter
         if (!fieldBlockBuilderReturned) {
             return format("SingleRowBlockWriter{numFields=%d, fieldBlockBuilderReturned=false, positionCount=%d}", fieldBlockBuilders.length, getPositionCount());
         }
-        else {
-            return format("SingleRowBlockWriter{numFields=%d, fieldBlockBuilderReturned=true}", fieldBlockBuilders.length);
-        }
+        return format("SingleRowBlockWriter{numFields=%d, fieldBlockBuilderReturned=true}", fieldBlockBuilders.length);
     }
 
     void setRowIndex(int rowIndex)

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/Domain.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/Domain.java
@@ -146,9 +146,7 @@ public final class Domain
         if (nullAllowed) {
             return values.isNone();
         }
-        else {
-            return values.isSingleValue();
-        }
+        return values.isSingleValue();
     }
 
     public boolean isOnlyNull()
@@ -173,9 +171,7 @@ public final class Domain
         if (nullAllowed) {
             return null;
         }
-        else {
-            return values.getSingleValue();
-        }
+        return values.getSingleValue();
     }
 
     public boolean includesNullableValue(Object value)

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/EquatableValueSet.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/EquatableValueSet.java
@@ -243,15 +243,13 @@ public class EquatableValueSet
         if (inclusive && otherValueSet.inclusive()) {
             return new EquatableValueSet(type, true, intersect(entries, otherValueSet.entries));
         }
-        else if (inclusive) {
+        if (inclusive) {
             return new EquatableValueSet(type, true, subtract(entries, otherValueSet.entries));
         }
-        else if (otherValueSet.inclusive()) {
+        if (otherValueSet.inclusive()) {
             return new EquatableValueSet(type, true, subtract(otherValueSet.entries, entries));
         }
-        else {
-            return new EquatableValueSet(type, false, union(otherValueSet.entries, entries));
-        }
+        return new EquatableValueSet(type, false, union(otherValueSet.entries, entries));
     }
 
     @Override
@@ -262,15 +260,13 @@ public class EquatableValueSet
         if (inclusive && otherValueSet.inclusive()) {
             return setsOverlap(entries, otherValueSet.entries);
         }
-        else if (inclusive) {
+        if (inclusive) {
             return !otherValueSet.entries.containsAll(entries);
         }
-        else if (otherValueSet.inclusive()) {
+        if (otherValueSet.inclusive()) {
             return !entries.containsAll(otherValueSet.entries);
         }
-        else {
-            return true;
-        }
+        return true;
     }
 
     @Override
@@ -281,15 +277,13 @@ public class EquatableValueSet
         if (inclusive && otherValueSet.inclusive()) {
             return new EquatableValueSet(type, true, union(entries, otherValueSet.entries));
         }
-        else if (inclusive) {
+        if (inclusive) {
             return new EquatableValueSet(type, false, subtract(otherValueSet.entries, entries));
         }
-        else if (otherValueSet.inclusive()) {
+        if (otherValueSet.inclusive()) {
             return new EquatableValueSet(type, false, subtract(entries, otherValueSet.entries));
         }
-        else {
-            return new EquatableValueSet(type, false, intersect(otherValueSet.entries, entries));
-        }
+        return new EquatableValueSet(type, false, intersect(otherValueSet.entries, entries));
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/type/ArrayType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ArrayType.java
@@ -195,10 +195,8 @@ public class ArrayType
         if (block instanceof AbstractArrayBlock) {
             return ((AbstractArrayBlock) block).apply((valuesBlock, start, length) -> arrayBlockToObjectValues(session, valuesBlock, start, length), position);
         }
-        else {
-            Block arrayBlock = block.getObject(position, Block.class);
-            return arrayBlockToObjectValues(session, arrayBlock, 0, arrayBlock.getPositionCount());
-        }
+        Block arrayBlock = block.getObject(position, Block.class);
+        return arrayBlockToObjectValues(session, arrayBlock, 0, arrayBlock.getPositionCount());
     }
 
     private List<Object> arrayBlockToObjectValues(ConnectorSession session, Block block, int start, int length)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/Chars.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/Chars.java
@@ -135,9 +135,7 @@ public final class Chars
         if (left.length() < right.length()) {
             return compareCharsShorterToLonger(left, right);
         }
-        else {
-            return -compareCharsShorterToLonger(right, left);
-        }
+        return -compareCharsShorterToLonger(right, left);
     }
 
     private static int compareCharsShorterToLonger(Slice shorter, Slice longer)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/DecimalType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/DecimalType.java
@@ -43,9 +43,7 @@ public abstract class DecimalType
         if (precision <= MAX_SHORT_PRECISION) {
             return new ShortDecimalType(precision, scale);
         }
-        else {
-            return new LongDecimalType(precision, scale);
-        }
+        return new LongDecimalType(precision, scale);
     }
 
     public static DecimalType createDecimalType(int precision)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/Int128.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/Int128.java
@@ -66,7 +66,7 @@ public class Int128
 
             return Int128.valueOf(high, low);
         }
-        else if (bytes.length > 8) {
+        if (bytes.length > 8) {
             // read the last 8 bytes into low
             int offset = bytes.length - Long.BYTES;
             long low = (long) BIG_ENDIAN_LONG_VIEW.get(bytes, offset);
@@ -80,21 +80,19 @@ public class Int128
 
             return Int128.valueOf(high, low);
         }
-        else if (bytes.length == 8) {
+        if (bytes.length == 8) {
             long low = (long) BIG_ENDIAN_LONG_VIEW.get(bytes, 0);
             long high = (low >> 63);
 
             return Int128.valueOf(high, low);
         }
-        else {
-            long high = (bytes[0] >> 7);
-            long low = high;
-            for (int i = 0; i < bytes.length; i++) {
-                low = (low << 8) | (bytes[i] & 0xFF);
-            }
-
-            return Int128.valueOf(high, low);
+        long high = (bytes[0] >> 7);
+        long low = high;
+        for (int i = 0; i < bytes.length; i++) {
+            low = (low << 8) | (bytes[i] & 0xFF);
         }
+
+        return Int128.valueOf(high, low);
     }
 
     public static Int128 valueOf(long[] value)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/SqlVarbinary.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/SqlVarbinary.java
@@ -40,7 +40,7 @@ public final class SqlVarbinary
             if (bytes[i] < obj.bytes[i]) {
                 return -1;
             }
-            else if (bytes[i] > obj.bytes[i]) {
+            if (bytes[i] > obj.bytes[i]) {
                 return 1;
             }
         }

--- a/lib/trino-matching/src/main/java/io/trino/matching/Captures.java
+++ b/lib/trino-matching/src/main/java/io/trino/matching/Captures.java
@@ -45,9 +45,7 @@ public class Captures
         if (this == NIL) {
             return other;
         }
-        else {
-            return new Captures(capture, value, tail.addAll(other));
-        }
+        return new Captures(capture, value, tail.addAll(other));
     }
 
     @SuppressWarnings("unchecked cast")
@@ -56,12 +54,10 @@ public class Captures
         if (this.equals(NIL)) {
             throw new NoSuchElementException("Requested value for unknown Capture. Was it registered in the Pattern?");
         }
-        else if (this.capture.equals(capture)) {
+        if (this.capture.equals(capture)) {
             return (T) value;
         }
-        else {
-            return tail.get(capture);
-        }
+        return tail.get(capture);
     }
 
     @Override

--- a/lib/trino-matching/src/main/java/io/trino/matching/Pattern.java
+++ b/lib/trino-matching/src/main/java/io/trino/matching/Pattern.java
@@ -116,9 +116,7 @@ public abstract class Pattern<T>
             return previous.get().match(object, captures, context)
                     .flatMap(match -> accept(object, match.captures(), context));
         }
-        else {
-            return accept(object, captures, context);
-        }
+        return accept(object, captures, context);
     }
 
     @Override

--- a/lib/trino-orc/src/main/java/io/trino/orc/checkpoint/Checkpoints.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/checkpoint/Checkpoints.java
@@ -144,7 +144,7 @@ public final class Checkpoints
             if (columnEncoding == DICTIONARY_V2) {
                 return new LongStreamV2Checkpoint(0, createInputStreamCheckpoint(0, 0));
             }
-            else if (columnEncoding == DICTIONARY) {
+            if (columnEncoding == DICTIONARY) {
                 return new LongStreamV1Checkpoint(0, createInputStreamCheckpoint(0, 0));
             }
         }

--- a/lib/trino-orc/src/main/java/io/trino/orc/checkpoint/InputStreamCheckpoint.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/checkpoint/InputStreamCheckpoint.java
@@ -32,9 +32,7 @@ public final class InputStreamCheckpoint
         if (compressed) {
             return createInputStreamCheckpoint(positionsList.nextPosition(), positionsList.nextPosition());
         }
-        else {
-            return createInputStreamCheckpoint(0, positionsList.nextPosition());
-        }
+        return createInputStreamCheckpoint(0, positionsList.nextPosition());
     }
 
     public static long createInputStreamCheckpoint(int compressedBlockOffset, int decompressedOffset)
@@ -58,9 +56,7 @@ public final class InputStreamCheckpoint
         if (compressed) {
             return ImmutableList.of(decodeCompressedBlockOffset(inputStreamCheckpoint), decodeDecompressedOffset(inputStreamCheckpoint));
         }
-        else {
-            return ImmutableList.of(decodeDecompressedOffset(inputStreamCheckpoint));
-        }
+        return ImmutableList.of(decodeDecompressedOffset(inputStreamCheckpoint));
     }
 
     public static String inputStreamCheckpointToString(long inputStreamCheckpoint)

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/StringStatisticsBuilder.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/StringStatisticsBuilder.java
@@ -187,9 +187,7 @@ public class StringStatisticsBuilder
             if (isMin) {
                 return StringCompactor.truncateMin(minOrMax, stringStatisticsLimitInBytes);
             }
-            else {
-                return StringCompactor.truncateMax(minOrMax, stringStatisticsLimitInBytes);
-            }
+            return StringCompactor.truncateMax(minOrMax, stringStatisticsLimitInBytes);
         }
 
         // Do not hold the entire slice where the actual stats could be small

--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/DecimalOutputStream.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/DecimalOutputStream.java
@@ -72,10 +72,8 @@ public class DecimalOutputStream
                     buffer.write((byte) lowBits);
                     return;
                 }
-                else {
-                    buffer.write((byte) (0x80 | (lowBits & 0x7f)));
-                    lowBits >>>= 7;
-                }
+                buffer.write((byte) (0x80 | (lowBits & 0x7f)));
+                lowBits >>>= 7;
             }
             value = value.shiftRight(63);
         }

--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/LongDecode.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/LongDecode.java
@@ -49,30 +49,28 @@ public final class LongDecode
         if (n >= ONE.ordinal() && n <= TWENTY_FOUR.ordinal()) {
             return n + 1;
         }
-        else if (n == TWENTY_SIX.ordinal()) {
+        if (n == TWENTY_SIX.ordinal()) {
             return 26;
         }
-        else if (n == TWENTY_EIGHT.ordinal()) {
+        if (n == TWENTY_EIGHT.ordinal()) {
             return 28;
         }
-        else if (n == THIRTY.ordinal()) {
+        if (n == THIRTY.ordinal()) {
             return 30;
         }
-        else if (n == THIRTY_TWO.ordinal()) {
+        if (n == THIRTY_TWO.ordinal()) {
             return 32;
         }
-        else if (n == FORTY.ordinal()) {
+        if (n == FORTY.ordinal()) {
             return 40;
         }
-        else if (n == FORTY_EIGHT.ordinal()) {
+        if (n == FORTY_EIGHT.ordinal()) {
             return 48;
         }
-        else if (n == FIFTY_SIX.ordinal()) {
+        if (n == FIFTY_SIX.ordinal()) {
             return 56;
         }
-        else {
-            return 64;
-        }
+        return 64;
     }
 
     /**
@@ -87,30 +85,28 @@ public final class LongDecode
         if (width >= 1 && width <= 24) {
             return width;
         }
-        else if (width > 24 && width <= 26) {
+        if (width > 24 && width <= 26) {
             return 26;
         }
-        else if (width > 26 && width <= 28) {
+        if (width > 26 && width <= 28) {
             return 28;
         }
-        else if (width > 28 && width <= 30) {
+        if (width > 28 && width <= 30) {
             return 30;
         }
-        else if (width > 30 && width <= 32) {
+        if (width > 30 && width <= 32) {
             return 32;
         }
-        else if (width > 32 && width <= 40) {
+        if (width > 32 && width <= 40) {
             return 40;
         }
-        else if (width > 40 && width <= 48) {
+        if (width > 40 && width <= 48) {
             return 48;
         }
-        else if (width > 48 && width <= 56) {
+        if (width > 48 && width <= 56) {
             return 56;
         }
-        else {
-            return 64;
-        }
+        return 64;
     }
 
     public static long readSignedVInt(OrcInputStream inputStream)
@@ -144,9 +140,7 @@ public final class LongDecode
         if (signed) {
             return readSignedVInt(inputStream);
         }
-        else {
-            return readUnsignedVInt(inputStream);
-        }
+        return readUnsignedVInt(inputStream);
     }
 
     public static long zigzagDecode(long value)
@@ -170,10 +164,8 @@ public final class LongDecode
                 output.write((byte) value);
                 return;
             }
-            else {
-                output.write((byte) (0x80 | (value & 0x7f)));
-                value >>>= 7;
-            }
+            output.write((byte) (0x80 | (value & 0x7f)));
+            value >>>= 7;
         }
     }
 

--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/LongOutputStreamV2.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/LongOutputStreamV2.java
@@ -795,10 +795,8 @@ public class LongOutputStreamV2
                     output.write((byte) value);
                     return;
                 }
-                else {
-                    output.write((byte) (0x80 | (value & 0x7f)));
-                    value >>>= 7;
-                }
+                output.write((byte) (0x80 | (value & 0x7f)));
+                value >>>= 7;
             }
         }
 
@@ -870,30 +868,28 @@ public class LongOutputStreamV2
             if (n >= 1 && n <= 24) {
                 return n;
             }
-            else if (n > 24 && n <= 26) {
+            if (n > 24 && n <= 26) {
                 return 26;
             }
-            else if (n > 26 && n <= 28) {
+            if (n > 26 && n <= 28) {
                 return 28;
             }
-            else if (n > 28 && n <= 30) {
+            if (n > 28 && n <= 30) {
                 return 30;
             }
-            else if (n > 30 && n <= 32) {
+            if (n > 30 && n <= 32) {
                 return 32;
             }
-            else if (n > 32 && n <= 40) {
+            if (n > 32 && n <= 40) {
                 return 40;
             }
-            else if (n > 40 && n <= 48) {
+            if (n > 40 && n <= 48) {
                 return 48;
             }
-            else if (n > 48 && n <= 56) {
+            if (n > 48 && n <= 56) {
                 return 56;
             }
-            else {
-                return 64;
-            }
+            return 64;
         }
 
         public static int getClosestAlignedFixedBits(int n)
@@ -901,36 +897,34 @@ public class LongOutputStreamV2
             if (n == 0 || n == 1) {
                 return 1;
             }
-            else if (n > 1 && n <= 2) {
+            if (n > 1 && n <= 2) {
                 return 2;
             }
-            else if (n > 2 && n <= 4) {
+            if (n > 2 && n <= 4) {
                 return 4;
             }
-            else if (n > 4 && n <= 8) {
+            if (n > 4 && n <= 8) {
                 return 8;
             }
-            else if (n > 8 && n <= 16) {
+            if (n > 8 && n <= 16) {
                 return 16;
             }
-            else if (n > 16 && n <= 24) {
+            if (n > 16 && n <= 24) {
                 return 24;
             }
-            else if (n > 24 && n <= 32) {
+            if (n > 24 && n <= 32) {
                 return 32;
             }
-            else if (n > 32 && n <= 40) {
+            if (n > 32 && n <= 40) {
                 return 40;
             }
-            else if (n > 40 && n <= 48) {
+            if (n > 40 && n <= 48) {
                 return 48;
             }
-            else if (n > 48 && n <= 56) {
+            if (n > 48 && n <= 56) {
                 return 56;
             }
-            else {
-                return 64;
-            }
+            return 64;
         }
 
         enum FixedBitSizes
@@ -955,30 +949,28 @@ public class LongOutputStreamV2
             if (n >= 1 && n <= 24) {
                 return n - 1;
             }
-            else if (n > 24 && n <= 26) {
+            if (n > 24 && n <= 26) {
                 return FixedBitSizes.TWENTY_SIX.ordinal();
             }
-            else if (n > 26 && n <= 28) {
+            if (n > 26 && n <= 28) {
                 return FixedBitSizes.TWENTY_EIGHT.ordinal();
             }
-            else if (n > 28 && n <= 30) {
+            if (n > 28 && n <= 30) {
                 return FixedBitSizes.THIRTY.ordinal();
             }
-            else if (n > 30 && n <= 32) {
+            if (n > 30 && n <= 32) {
                 return FixedBitSizes.THIRTY_TWO.ordinal();
             }
-            else if (n > 32 && n <= 40) {
+            if (n > 32 && n <= 40) {
                 return FixedBitSizes.FORTY.ordinal();
             }
-            else if (n > 40 && n <= 48) {
+            if (n > 40 && n <= 48) {
                 return FixedBitSizes.FORTY_EIGHT.ordinal();
             }
-            else if (n > 48 && n <= 56) {
+            if (n > 48 && n <= 56) {
                 return FixedBitSizes.FIFTY_SIX.ordinal();
             }
-            else {
-                return FixedBitSizes.SIXTY_FOUR.ordinal();
-            }
+            return FixedBitSizes.SIXTY_FOUR.ordinal();
         }
 
         /**
@@ -989,30 +981,28 @@ public class LongOutputStreamV2
             if (n >= FixedBitSizes.ONE.ordinal() && n <= FixedBitSizes.TWENTY_FOUR.ordinal()) {
                 return n + 1;
             }
-            else if (n == FixedBitSizes.TWENTY_SIX.ordinal()) {
+            if (n == FixedBitSizes.TWENTY_SIX.ordinal()) {
                 return 26;
             }
-            else if (n == FixedBitSizes.TWENTY_EIGHT.ordinal()) {
+            if (n == FixedBitSizes.TWENTY_EIGHT.ordinal()) {
                 return 28;
             }
-            else if (n == FixedBitSizes.THIRTY.ordinal()) {
+            if (n == FixedBitSizes.THIRTY.ordinal()) {
                 return 30;
             }
-            else if (n == FixedBitSizes.THIRTY_TWO.ordinal()) {
+            if (n == FixedBitSizes.THIRTY_TWO.ordinal()) {
                 return 32;
             }
-            else if (n == FixedBitSizes.FORTY.ordinal()) {
+            if (n == FixedBitSizes.FORTY.ordinal()) {
                 return 40;
             }
-            else if (n == FixedBitSizes.FORTY_EIGHT.ordinal()) {
+            if (n == FixedBitSizes.FORTY_EIGHT.ordinal()) {
                 return 48;
             }
-            else if (n == FixedBitSizes.FIFTY_SIX.ordinal()) {
+            if (n == FixedBitSizes.FIFTY_SIX.ordinal()) {
                 return 56;
             }
-            else {
-                return 64;
-            }
+            return 64;
         }
 
         void writeInts(long[] input, int offset, int length, int bitSize, SliceOutput output)

--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/ValueStreams.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/ValueStreams.java
@@ -135,11 +135,9 @@ public final class ValueStreams
         if (encoding == DIRECT_V2 || encoding == DICTIONARY_V2) {
             return new LongInputStreamV2(inputStream, signed, false);
         }
-        else if (encoding == DIRECT || encoding == DICTIONARY) {
+        if (encoding == DIRECT || encoding == DICTIONARY) {
             return new LongInputStreamV1(inputStream, signed);
         }
-        else {
-            throw new IllegalArgumentException("Unsupported encoding for long stream: " + encoding);
-        }
+        throw new IllegalArgumentException("Unsupported encoding for long stream: " + encoding);
     }
 }

--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/DictionaryBuilder.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/DictionaryBuilder.java
@@ -103,9 +103,7 @@ public class DictionaryBuilder
         if (block.isNull(position)) {
             return containsNullElement;
         }
-        else {
-            return blockPositionByHash.get(getHashPositionOfElement(block, position)) != EMPTY_SLOT;
-        }
+        return blockPositionByHash.get(getHashPositionOfElement(block, position)) != EMPTY_SLOT;
     }
 
     public int putIfAbsent(Block block, int position)

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestDictionaryCompressionOptimizer.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestDictionaryCompressionOptimizer.java
@@ -622,9 +622,7 @@ public class TestDictionaryCompressionOptimizer
                 direct = true;
                 return OptionalInt.of(toIntExact(directBytes));
             }
-            else {
-                return OptionalInt.empty();
-            }
+            return OptionalInt.empty();
         }
 
         public boolean isDirect()

--- a/lib/trino-orc/src/test/java/io/trino/orc/stream/TestDecimalStream.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/stream/TestDecimalStream.java
@@ -263,10 +263,8 @@ public class TestDecimalStream
                     output.write((byte) lowBits);
                     return;
                 }
-                else {
-                    output.write((byte) (0x80 | (lowBits & 0x7f)));
-                    lowBits >>>= 7;
-                }
+                output.write((byte) (0x80 | (lowBits & 0x7f)));
+                lowBits >>>= 7;
             }
             value = value.shiftRight(63);
         }

--- a/lib/trino-orc/src/test/java/io/trino/orc/stream/TestLongDecode.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/stream/TestLongDecode.java
@@ -111,10 +111,8 @@ public class TestLongDecode
                 output.write((byte) value);
                 return;
             }
-            else {
-                output.write((byte) (0x80 | (value & 0x7f)));
-                value >>>= 7;
-            }
+            output.write((byte) (0x80 | (value & 0x7f)));
+            value >>>= 7;
         }
     }
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/DecimalColumnReaderFactory.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/DecimalColumnReaderFactory.java
@@ -25,8 +25,6 @@ public final class DecimalColumnReaderFactory
         if (parquetDecimalType.isShort()) {
             return new ShortDecimalColumnReader(field, parquetDecimalType);
         }
-        else {
-            return new LongDecimalColumnReader(field, parquetDecimalType);
-        }
+        return new LongDecimalColumnReader(field, parquetDecimalType);
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PageReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PageReader.java
@@ -78,27 +78,25 @@ class PageReader
                         dataPageV1.getDefinitionLevelEncoding(),
                         dataPageV1.getValueEncoding());
             }
-            else {
-                DataPageV2 dataPageV2 = (DataPageV2) compressedPage;
-                if (!dataPageV2.isCompressed()) {
-                    return dataPageV2;
-                }
-                int uncompressedSize = dataPageV2.getUncompressedSize()
-                        - dataPageV2.getDefinitionLevels().length()
-                        - dataPageV2.getRepetitionLevels().length();
-                return new DataPageV2(
-                        dataPageV2.getRowCount(),
-                        dataPageV2.getNullCount(),
-                        dataPageV2.getValueCount(),
-                        dataPageV2.getRepetitionLevels(),
-                        dataPageV2.getDefinitionLevels(),
-                        dataPageV2.getDataEncoding(),
-                        decompress(codec, dataPageV2.getSlice(), uncompressedSize),
-                        dataPageV2.getUncompressedSize(),
-                        firstRowIndex,
-                        dataPageV2.getStatistics(),
-                        false);
+            DataPageV2 dataPageV2 = (DataPageV2) compressedPage;
+            if (!dataPageV2.isCompressed()) {
+                return dataPageV2;
             }
+            int uncompressedSize = dataPageV2.getUncompressedSize()
+                    - dataPageV2.getDefinitionLevels().length()
+                    - dataPageV2.getRepetitionLevels().length();
+            return new DataPageV2(
+                    dataPageV2.getRowCount(),
+                    dataPageV2.getNullCount(),
+                    dataPageV2.getValueCount(),
+                    dataPageV2.getRepetitionLevels(),
+                    dataPageV2.getDefinitionLevels(),
+                    dataPageV2.getDataEncoding(),
+                    decompress(codec, dataPageV2.getSlice(), uncompressedSize),
+                    dataPageV2.getUncompressedSize(),
+                    firstRowIndex,
+                    dataPageV2.getStatistics(),
+                    false);
         }
         catch (IOException e) {
             throw new RuntimeException("Could not decompress page", e);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetColumnChunk.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetColumnChunk.java
@@ -123,9 +123,7 @@ public class ParquetColumnChunk
         if (offsetIndex == null) {
             return valuesCountReadSoFar < descriptor.getColumnChunkMetaData().getValueCount();
         }
-        else {
-            return dataPageCountReadSoFar < offsetIndex.getPageCount();
-        }
+        return dataPageCountReadSoFar < offsetIndex.getPageCount();
     }
 
     private Slice getSlice(int size)

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetSchemaConverter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetSchemaConverter.java
@@ -100,15 +100,13 @@ public class ParquetSchemaConverter
         if (ROW.equals(type.getTypeSignature().getBase())) {
             return getRowType((RowType) type, name, parent, repetition);
         }
-        else if (MAP.equals(type.getTypeSignature().getBase())) {
+        if (MAP.equals(type.getTypeSignature().getBase())) {
             return getMapType((MapType) type, name, parent, repetition);
         }
-        else if (ARRAY.equals(type.getTypeSignature().getBase())) {
+        if (ARRAY.equals(type.getTypeSignature().getBase())) {
             return getArrayType((ArrayType) type, name, parent, repetition);
         }
-        else {
-            return getPrimitiveType(type, name, parent, repetition);
-        }
+        return getPrimitiveType(type, name, parent, repetition);
     }
 
     private org.apache.parquet.schema.Type getPrimitiveType(Type type, String name, List<String> parent, Repetition repetition)

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetTypeVisitor.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetTypeVisitor.java
@@ -36,77 +36,75 @@ public class ParquetTypeVisitor<T>
         if (type instanceof MessageType) {
             return visitor.message((MessageType) type, visitFields(type.asGroupType(), visitor));
         }
-        else if (type.isPrimitive()) {
+        if (type.isPrimitive()) {
             return visitor.primitive(type.asPrimitiveType());
         }
-        else {
-            // if not a primitive, the typeId must be a group
-            GroupType group = type.asGroupType();
-            LogicalTypeAnnotation annotation = group.getLogicalTypeAnnotation();
-            if (LogicalTypeAnnotation.listType().equals(annotation)) {
-                checkArgument(!group.isRepetition(REPEATED),
-                        "Invalid list: top-level group is repeated: " + group);
-                checkArgument(group.getFieldCount() == 1,
-                        "Invalid list: does not contain single repeated field: " + group);
+        // if not a primitive, the typeId must be a group
+        GroupType group = type.asGroupType();
+        LogicalTypeAnnotation annotation = group.getLogicalTypeAnnotation();
+        if (LogicalTypeAnnotation.listType().equals(annotation)) {
+            checkArgument(!group.isRepetition(REPEATED),
+                    "Invalid list: top-level group is repeated: " + group);
+            checkArgument(group.getFieldCount() == 1,
+                    "Invalid list: does not contain single repeated field: " + group);
 
-                GroupType repeatedElement = group.getFields().get(0).asGroupType();
-                checkArgument(repeatedElement.isRepetition(REPEATED),
-                        "Invalid list: inner group is not repeated");
-                checkArgument(repeatedElement.getFieldCount() <= 1,
-                        "Invalid list: repeated group is not a single field: " + group);
+            GroupType repeatedElement = group.getFields().get(0).asGroupType();
+            checkArgument(repeatedElement.isRepetition(REPEATED),
+                    "Invalid list: inner group is not repeated");
+            checkArgument(repeatedElement.getFieldCount() <= 1,
+                    "Invalid list: repeated group is not a single field: " + group);
 
-                visitor.fieldNames.push(repeatedElement.getName());
-                try {
-                    T elementResult = null;
-                    if (repeatedElement.getFieldCount() > 0) {
-                        elementResult = visitField(repeatedElement.getType(0), visitor);
-                    }
-
-                    return visitor.list(group, elementResult);
+            visitor.fieldNames.push(repeatedElement.getName());
+            try {
+                T elementResult = null;
+                if (repeatedElement.getFieldCount() > 0) {
+                    elementResult = visitField(repeatedElement.getType(0), visitor);
                 }
-                finally {
-                    visitor.fieldNames.pop();
-                }
+
+                return visitor.list(group, elementResult);
             }
-            else if (LogicalTypeAnnotation.mapType().equals(annotation)) {
-                checkArgument(!group.isRepetition(REPEATED),
-                        "Invalid map: top-level group is repeated: " + group);
-                checkArgument(group.getFieldCount() == 1,
-                        "Invalid map: does not contain single repeated field: " + group);
-
-                GroupType repeatedKeyValue = group.getType(0).asGroupType();
-                checkArgument(repeatedKeyValue.isRepetition(REPEATED),
-                        "Invalid map: inner group is not repeated");
-                checkArgument(repeatedKeyValue.getFieldCount() <= 2,
-                        "Invalid map: repeated group does not have 2 fields");
-
-                visitor.fieldNames.push(repeatedKeyValue.getName());
-                try {
-                    T keyResult = null;
-                    T valueResult = null;
-                    if (repeatedKeyValue.getFieldCount() == 2) {
-                        keyResult = visitField(repeatedKeyValue.getType(0), visitor);
-                        valueResult = visitField(repeatedKeyValue.getType(1), visitor);
-                    }
-                    else if (repeatedKeyValue.getFieldCount() == 1) {
-                        Type keyOrValue = repeatedKeyValue.getType(0);
-                        if (keyOrValue.getName().equalsIgnoreCase("key")) {
-                            keyResult = visitField(keyOrValue, visitor);
-                            // value result remains null
-                        }
-                        else {
-                            valueResult = visitField(keyOrValue, visitor);
-                            // key result remains null
-                        }
-                    }
-                    return visitor.map(group, keyResult, valueResult);
-                }
-                finally {
-                    visitor.fieldNames.pop();
-                }
+            finally {
+                visitor.fieldNames.pop();
             }
-            return visitor.struct(group, visitFields(group, visitor));
         }
+        if (LogicalTypeAnnotation.mapType().equals(annotation)) {
+            checkArgument(!group.isRepetition(REPEATED),
+                    "Invalid map: top-level group is repeated: " + group);
+            checkArgument(group.getFieldCount() == 1,
+                    "Invalid map: does not contain single repeated field: " + group);
+
+            GroupType repeatedKeyValue = group.getType(0).asGroupType();
+            checkArgument(repeatedKeyValue.isRepetition(REPEATED),
+                    "Invalid map: inner group is not repeated");
+            checkArgument(repeatedKeyValue.getFieldCount() <= 2,
+                    "Invalid map: repeated group does not have 2 fields");
+
+            visitor.fieldNames.push(repeatedKeyValue.getName());
+            try {
+                T keyResult = null;
+                T valueResult = null;
+                if (repeatedKeyValue.getFieldCount() == 2) {
+                    keyResult = visitField(repeatedKeyValue.getType(0), visitor);
+                    valueResult = visitField(repeatedKeyValue.getType(1), visitor);
+                }
+                else if (repeatedKeyValue.getFieldCount() == 1) {
+                    Type keyOrValue = repeatedKeyValue.getType(0);
+                    if (keyOrValue.getName().equalsIgnoreCase("key")) {
+                        keyResult = visitField(keyOrValue, visitor);
+                        // value result remains null
+                    }
+                    else {
+                        valueResult = visitField(keyOrValue, visitor);
+                        // key result remains null
+                    }
+                }
+                return visitor.map(group, keyResult, valueResult);
+            }
+            finally {
+                visitor.fieldNames.pop();
+            }
+        }
+        return visitor.struct(group, visitFields(group, visitor));
     }
 
     private static <T> T visitField(Type field, ParquetTypeVisitor<T> visitor)

--- a/lib/trino-rcfile/src/main/java/io/trino/rcfile/RcFileDecoderUtils.java
+++ b/lib/trino-rcfile/src/main/java/io/trino/rcfile/RcFileDecoderUtils.java
@@ -155,12 +155,10 @@ public final class RcFileDecoderUtils
                     long startOfSyncSequence = offset + position + index;
                     return startOfSyncSequence;
                 }
-                else {
-                    // Otherwise, this is not a match for this region
-                    // Note: this case isn't strictly needed as the loop will exit, but it is
-                    // simpler to explicitly call it out.
-                    return -1;
-                }
+                // Otherwise, this is not a match for this region
+                // Note: this case isn't strictly needed as the loop will exit, but it is
+                // simpler to explicitly call it out.
+                return -1;
             }
         }
         return -1;

--- a/lib/trino-rcfile/src/main/java/io/trino/rcfile/TimestampHolder.java
+++ b/lib/trino-rcfile/src/main/java/io/trino/rcfile/TimestampHolder.java
@@ -62,11 +62,9 @@ public final class TimestampHolder
         if (type.isShort()) {
             return (block, position) -> new TimestampHolder(type.getLong(block, position), 0);
         }
-        else {
-            return (block, position) -> {
-                LongTimestamp longTimestamp = (LongTimestamp) type.getObject(block, position);
-                return new TimestampHolder(longTimestamp.getEpochMicros(), longTimestamp.getPicosOfMicro());
-            };
-        }
+        return (block, position) -> {
+            LongTimestamp longTimestamp = (LongTimestamp) type.getObject(block, position);
+            return new TimestampHolder(longTimestamp.getEpochMicros(), longTimestamp.getPicosOfMicro());
+        };
     }
 }

--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/avro/AvroColumnDecoder.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/avro/AvroColumnDecoder.java
@@ -216,7 +216,7 @@ public class AvroColumnDecoder
             if (value instanceof ByteBuffer) {
                 return Slices.wrappedBuffer((ByteBuffer) value);
             }
-            else if (value instanceof GenericFixed) {
+            if (value instanceof GenericFixed) {
                 return Slices.wrappedBuffer(((GenericFixed) value).bytes());
             }
         }

--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/avro/AvroRowDecoderFactory.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/avro/AvroRowDecoderFactory.java
@@ -61,10 +61,8 @@ public class AvroRowDecoderFactory
             AvroDeserializer<GenericRecord> dataDecoder = avroDeserializerFactory.create(avroReaderSupplier);
             return new GenericRecordRowDecoder(dataDecoder, columns);
         }
-        else {
-            AvroReaderSupplier<Object> avroReaderSupplier = avroReaderSupplierFactory.create(parsedSchema);
-            AvroDeserializer<Object> dataDecoder = avroDeserializerFactory.create(avroReaderSupplier);
-            return new SingleValueRowDecoder(dataDecoder, getOnlyElement(columns));
-        }
+        AvroReaderSupplier<Object> avroReaderSupplier = avroReaderSupplierFactory.create(parsedSchema);
+        AvroDeserializer<Object> dataDecoder = avroDeserializerFactory.create(avroReaderSupplier);
+        return new SingleValueRowDecoder(dataDecoder, getOnlyElement(columns));
     }
 }

--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/csv/CsvColumnDecoder.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/csv/CsvColumnDecoder.java
@@ -84,55 +84,53 @@ public class CsvColumnDecoder
         if (columnIndex >= tokens.length) {
             return nullValueProvider();
         }
-        else {
-            return new FieldValueProvider()
+        return new FieldValueProvider()
+        {
+            @Override
+            public boolean isNull()
             {
-                @Override
-                public boolean isNull()
-                {
-                    return tokens[columnIndex].isEmpty();
-                }
+                return tokens[columnIndex].isEmpty();
+            }
 
-                @SuppressWarnings("SimplifiableConditionalExpression")
-                @Override
-                public boolean getBoolean()
-                {
-                    try {
-                        return Boolean.parseBoolean(tokens[columnIndex].trim());
-                    }
-                    catch (NumberFormatException e) {
-                        throw new TrinoException(DECODER_CONVERSION_NOT_SUPPORTED, format("could not parse value '%s' as '%s' for column '%s'", tokens[columnIndex].trim(), columnType, columnName));
-                    }
+            @SuppressWarnings("SimplifiableConditionalExpression")
+            @Override
+            public boolean getBoolean()
+            {
+                try {
+                    return Boolean.parseBoolean(tokens[columnIndex].trim());
                 }
+                catch (NumberFormatException e) {
+                    throw new TrinoException(DECODER_CONVERSION_NOT_SUPPORTED, format("could not parse value '%s' as '%s' for column '%s'", tokens[columnIndex].trim(), columnType, columnName));
+                }
+            }
 
-                @Override
-                public long getLong()
-                {
-                    try {
-                        return Long.parseLong(tokens[columnIndex].trim());
-                    }
-                    catch (NumberFormatException e) {
-                        throw new TrinoException(DECODER_CONVERSION_NOT_SUPPORTED, format("could not parse value '%s' as '%s' for column '%s'", tokens[columnIndex].trim(), columnType, columnName));
-                    }
+            @Override
+            public long getLong()
+            {
+                try {
+                    return Long.parseLong(tokens[columnIndex].trim());
                 }
+                catch (NumberFormatException e) {
+                    throw new TrinoException(DECODER_CONVERSION_NOT_SUPPORTED, format("could not parse value '%s' as '%s' for column '%s'", tokens[columnIndex].trim(), columnType, columnName));
+                }
+            }
 
-                @Override
-                public double getDouble()
-                {
-                    try {
-                        return Double.parseDouble(tokens[columnIndex].trim());
-                    }
-                    catch (NumberFormatException e) {
-                        throw new TrinoException(DECODER_CONVERSION_NOT_SUPPORTED, format("could not parse value '%s' as '%s' for column '%s'", tokens[columnIndex].trim(), columnType, columnName));
-                    }
+            @Override
+            public double getDouble()
+            {
+                try {
+                    return Double.parseDouble(tokens[columnIndex].trim());
                 }
+                catch (NumberFormatException e) {
+                    throw new TrinoException(DECODER_CONVERSION_NOT_SUPPORTED, format("could not parse value '%s' as '%s' for column '%s'", tokens[columnIndex].trim(), columnType, columnName));
+                }
+            }
 
-                @Override
-                public Slice getSlice()
-                {
-                    return truncateToLength(utf8Slice(tokens[columnIndex]), columnType);
-                }
-            };
-        }
+            @Override
+            public Slice getSlice()
+            {
+                return truncateToLength(utf8Slice(tokens[columnIndex]), columnType);
+            }
+        };
     }
 }

--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloClient.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloClient.java
@@ -852,20 +852,18 @@ public class AccumuloClient
                         location = Optional.of(entry.getValue().toString());
                         break;
                     }
-                    else {
-                        // Chop off some magic nonsense
-                        scannedCompareKey.set(keyBytes, 3, keyBytes.length - 3);
+                    // Chop off some magic nonsense
+                    scannedCompareKey.set(keyBytes, 3, keyBytes.length - 3);
 
-                        // Compare the keys, moving along the tablets until the location is found
-                        if (scannedCompareKey.getLength() > 0) {
-                            int compareTo = splitCompareKey.compareTo(scannedCompareKey);
-                            if (compareTo <= 0) {
-                                location = Optional.of(entry.getValue().toString());
-                            }
-                            else {
-                                // all future tablets will be greater than this key
-                                break;
-                            }
+                    // Compare the keys, moving along the tablets until the location is found
+                    if (scannedCompareKey.getLength() > 0) {
+                        int compareTo = splitCompareKey.compareTo(scannedCompareKey);
+                        if (compareTo <= 0) {
+                            location = Optional.of(entry.getValue().toString());
+                        }
+                        else {
+                            // all future tablets will be greater than this key
+                            break;
                         }
                     }
                 }

--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/index/IndexLookup.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/index/IndexLookup.java
@@ -172,11 +172,9 @@ public class IndexLookup
 
             return true;
         }
-        else {
-            LOG.debug("Use of index metrics is enabled");
-            // Get ranges using the metrics
-            return getRangesWithMetrics(session, schema, table, constraintRanges, rowIdRanges, tabletSplits, auths);
-        }
+        LOG.debug("Use of index metrics is enabled");
+        // Get ranges using the metrics
+        return getRangesWithMetrics(session, schema, table, constraintRanges, rowIdRanges, tabletSplits, auths);
     }
 
     private static Multimap<AccumuloColumnConstraint, Range> getIndexedConstraintRanges(Collection<AccumuloColumnConstraint> constraints, AccumuloRowSerializer serializer)
@@ -279,10 +277,8 @@ public class IndexLookup
             LOG.debug("Number of splits for %s.%s is %d with %d ranges", schema, table, tabletSplits.size(), indexRanges.size());
             return true;
         }
-        else {
-            // We are going to do too much work to use the secondary index, so return false
-            return false;
-        }
+        // We are going to do too much work to use the secondary index, so return false
+        return false;
     }
 
     private static boolean smallestCardAboveThreshold(ConnectorSession session, long numRows, long smallestCardinality)

--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/io/AccumuloPageSink.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/io/AccumuloPageSink.java
@@ -92,16 +92,11 @@ public class AccumuloPageSink
         this.columns = table.getColumns();
 
         // Fetch the row ID ordinal, throwing an exception if not found for safety
-        Optional<Integer> ordinal = columns.stream()
+        this.rowIdOrdinal = columns.stream()
                 .filter(columnHandle -> columnHandle.getName().equals(table.getRowId()))
                 .map(AccumuloColumnHandle::getOrdinal)
-                .findAny();
-
-        if (ordinal.isEmpty()) {
-            throw new TrinoException(FUNCTION_IMPLEMENTATION_ERROR, "Row ID ordinal not found");
-        }
-
-        this.rowIdOrdinal = ordinal.get();
+                .findAny()
+                .orElseThrow(() -> new TrinoException(FUNCTION_IMPLEMENTATION_ERROR, "Row ID ordinal not found"));
         this.serializer = table.getSerializerInstance();
 
         try {

--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/io/AccumuloRecordSet.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/io/AccumuloRecordSet.java
@@ -122,11 +122,9 @@ public class AccumuloRecordSet
             LOG.debug("scan_auths table property set: %s", auths);
             return auths;
         }
-        else {
-            Authorizations auths = connector.securityOperations().getUserAuthorizations(username);
-            LOG.debug("scan_auths table property not set, using user auths: %s", auths);
-            return auths;
-        }
+        Authorizations auths = connector.securityOperations().getUserAuthorizations(username);
+        LOG.debug("scan_auths table property not set, using user auths: %s", auths);
+        return auths;
     }
 
     @Override

--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/serializers/AccumuloRowSerializer.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/serializers/AccumuloRowSerializer.java
@@ -609,16 +609,14 @@ public interface AccumuloRowSerializer
             Type elementType = Types.getElementType(type);
             return getArrayFromBlock(elementType, block.getObject(position, Block.class));
         }
-        else if (Types.isMapType(type)) {
+        if (Types.isMapType(type)) {
             return getMapFromBlock(type, block.getObject(position, Block.class));
         }
-        else {
-            if (type.getJavaType() == Slice.class) {
-                Slice slice = (Slice) TypeUtils.readNativeValue(type, block, position);
-                return type.equals(VarcharType.VARCHAR) ? slice.toStringUtf8() : slice.getBytes();
-            }
-
-            return TypeUtils.readNativeValue(type, block, position);
+        if (type.getJavaType() == Slice.class) {
+            Slice slice = (Slice) TypeUtils.readNativeValue(type, block, position);
+            return type.equals(VarcharType.VARCHAR) ? slice.toStringUtf8() : slice.getBytes();
         }
+
+        return TypeUtils.readNativeValue(type, block, position);
     }
 }

--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/serializers/LexicoderRowSerializer.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/serializers/LexicoderRowSerializer.java
@@ -382,19 +382,17 @@ public class LexicoderRowSerializer
         if (Types.isArrayType(type)) {
             return getListLexicoder(type);
         }
-        else if (Types.isMapType(type)) {
+        if (Types.isMapType(type)) {
             return getMapLexicoder(type);
         }
-        else if (type instanceof VarcharType) {
+        if (type instanceof VarcharType) {
             return LEXICODER_MAP.get(VARCHAR);
         }
-        else {
-            Lexicoder lexicoder = LEXICODER_MAP.get(type);
-            if (lexicoder == null) {
-                throw new TrinoException(NOT_SUPPORTED, "No lexicoder for type " + type);
-            }
-            return lexicoder;
+        Lexicoder lexicoder = LEXICODER_MAP.get(type);
+        if (lexicoder == null) {
+            throw new TrinoException(NOT_SUPPORTED, "No lexicoder for type " + type);
         }
+        return lexicoder;
     }
 
     private static ListLexicoder getListLexicoder(Type elementType)

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
@@ -1307,9 +1307,7 @@ public abstract class BaseJdbcConnectorTest
         if (condition) {
             return queryAssert.isFullyPushedDown();
         }
-        else {
-            return queryAssert.isNotFullyPushedDown(otherwiseExpected);
-        }
+        return queryAssert.isNotFullyPushedDown(otherwiseExpected);
     }
 
     protected void assertConditionallyOrderedPushedDown(

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ReadSessionCreator.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ReadSessionCreator.java
@@ -111,10 +111,8 @@ public class ReadSessionCreator
             // get it from the view
             return client.getCachedTable(viewExpiration, remoteTable, requiredColumns);
         }
-        else {
-            // not regular table or a view
-            throw new TrinoException(NOT_SUPPORTED, format("Table type '%s' of table '%s.%s' is not supported",
-                    tableType, remoteTable.getTableId().getDataset(), remoteTable.getTableId().getTable()));
-        }
+        // not regular table or a view
+        throw new TrinoException(NOT_SUPPORTED, format("Table type '%s' of table '%s.%s' is not supported",
+                tableType, remoteTable.getTableId().getDataset(), remoteTable.getTableId().getTable()));
     }
 }

--- a/plugin/trino-blackhole/src/main/java/io/trino/plugin/blackhole/BlackHolePageSource.java
+++ b/plugin/trino-blackhole/src/main/java/io/trino/plugin/blackhole/BlackHolePageSource.java
@@ -67,10 +67,8 @@ class BlackHolePageSource
         if (pageProcessingDelayInMillis == 0) {
             return page;
         }
-        else {
-            currentPage = toCompletableFuture(executorService.schedule(() -> page, pageProcessingDelayInMillis, MILLISECONDS));
-            return null;
-        }
+        currentPage = toCompletableFuture(executorService.schedule(() -> page, pageProcessingDelayInMillis, MILLISECONDS));
+        return null;
     }
 
     @Override

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraMetadata.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraMetadata.java
@@ -417,11 +417,9 @@ public class CassandraMetadata
     public OptionalLong executeDelete(ConnectorSession session, ConnectorTableHandle deleteHandle)
     {
         CassandraTableHandle handle = (CassandraTableHandle) deleteHandle;
-        Optional<List<CassandraPartition>> partitions = handle.getPartitions();
+        List<CassandraPartition> partitions = handle.getPartitions()
+                .orElseThrow(() -> new TrinoException(NOT_SUPPORTED, "Deleting without partition key is not supported"));
         if (partitions.isEmpty()) {
-            throw new TrinoException(NOT_SUPPORTED, "Deleting without partition key is not supported");
-        }
-        if (partitions.get().isEmpty()) {
             // there are no records of a given partition key
             return OptionalLong.empty();
         }

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSession.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSession.java
@@ -570,17 +570,15 @@ public class CassandraSession
                 if (timeLeft <= 0) {
                     throw e;
                 }
-                else {
-                    long delay = Math.min(schedule.nextDelay().toMillis(), timeLeft);
-                    log.warn(e.getMessage());
-                    log.warn("Reconnecting in %dms", delay);
-                    try {
-                        Thread.sleep(delay);
-                    }
-                    catch (InterruptedException interrupted) {
-                        Thread.currentThread().interrupt();
-                        throw new RuntimeException("interrupted", interrupted);
-                    }
+                long delay = Math.min(schedule.nextDelay().toMillis(), timeLeft);
+                log.warn(e.getMessage());
+                log.warn("Reconnecting in %dms", delay);
+                try {
+                    Thread.sleep(delay);
+                }
+                catch (InterruptedException interrupted) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("interrupted", interrupted);
                 }
             }
         }

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSplit.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSplit.java
@@ -107,17 +107,11 @@ public class CassandraSplit
             if (splitCondition != null) {
                 return " WHERE " + splitCondition;
             }
-            else {
-                return "";
-            }
+            return "";
         }
-        else {
-            if (splitCondition != null) {
-                return " WHERE " + partitionId + " AND " + splitCondition;
-            }
-            else {
-                return " WHERE " + partitionId;
-            }
+        if (splitCondition != null) {
+            return " WHERE " + partitionId + " AND " + splitCondition;
         }
+        return " WHERE " + partitionId;
     }
 }

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/Murmur3PartitionerTokenRing.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/Murmur3PartitionerTokenRing.java
@@ -47,9 +47,7 @@ public final class Murmur3PartitionerTokenRing
             if (start == MIN_TOKEN) {
                 return TOTAL_TOKEN_COUNT;
             }
-            else {
-                return ZERO;
-            }
+            return ZERO;
         }
 
         BigInteger result = BigInteger.valueOf(end).subtract(BigInteger.valueOf(start));

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/RandomPartitionerTokenRing.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/RandomPartitionerTokenRing.java
@@ -50,9 +50,7 @@ public final class RandomPartitionerTokenRing
             if (start.equals(MIN_TOKEN)) {
                 return TOTAL_TOKEN_COUNT;
             }
-            else {
-                return ZERO;
-            }
+            return ZERO;
         }
 
         BigInteger result = end.subtract(start);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaHiveTypeTranslator.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaHiveTypeTranslator.java
@@ -18,7 +18,6 @@ import io.trino.plugin.hive.HiveType;
 import io.trino.spi.TrinoException;
 import io.trino.spi.type.CharType;
 import io.trino.spi.type.DecimalType;
-import io.trino.spi.type.NamedTypeSignature;
 import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.Type;
@@ -149,11 +148,8 @@ public class DeltaHiveTypeTranslator
                 if (!parameter.isNamedTypeSignature()) {
                     throw new IllegalArgumentException(format("Expected all parameters to be named type, but got %s", parameter));
                 }
-                NamedTypeSignature namedTypeSignature = parameter.getNamedTypeSignature();
-                if (namedTypeSignature.getName().isEmpty()) {
-                    throw new TrinoException(NOT_SUPPORTED, format("Anonymous row type is not supported in Hive. Please give each field a name: %s", type));
-                }
-                fieldNames.add(namedTypeSignature.getName().get());
+                fieldNames.add(parameter.getNamedTypeSignature().getName()
+                        .orElseThrow(() -> new TrinoException(NOT_SUPPORTED, format("Anonymous row type is not supported in Hive. Please give each field a name: %s", type))));
             }
             return getStructTypeInfo(
                     fieldNames.build(),

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -668,15 +668,13 @@ public class DeltaLakeMetadata
         boolean external = true;
         String location = getLocation(tableMetadata.getProperties());
         if (location == null) {
-            Optional<String> schemaLocation = getSchemaLocation(schema);
-            if (schemaLocation.isEmpty()) {
-                throw new TrinoException(NOT_SUPPORTED, "The 'location' property must be specified either for the table or the schema");
-            }
+            String schemaLocation = getSchemaLocation(schema)
+                    .orElseThrow(() -> new TrinoException(NOT_SUPPORTED, "The 'location' property must be specified either for the table or the schema"));
             String tableNameForLocation = tableName;
             if (useUniqueTableLocation) {
                 tableNameForLocation += "-" + randomUUID().toString().replace("-", "");
             }
-            location = new Path(schemaLocation.get(), tableNameForLocation).toString();
+            location = new Path(schemaLocation, tableNameForLocation).toString();
             checkPathContainsNoFiles(session, new Path(location));
             external = false;
         }
@@ -802,15 +800,13 @@ public class DeltaLakeMetadata
         boolean external = true;
         String location = getLocation(tableMetadata.getProperties());
         if (location == null) {
-            Optional<String> schemaLocation = getSchemaLocation(schema);
-            if (schemaLocation.isEmpty()) {
-                throw new TrinoException(NOT_SUPPORTED, "The 'location' property must be specified either for the table or the schema");
-            }
+            String schemaLocation = getSchemaLocation(schema)
+                    .orElseThrow(() -> new TrinoException(NOT_SUPPORTED, "The 'location' property must be specified either for the table or the schema"));
             String tableNameForLocation = tableName;
             if (useUniqueTableLocation) {
                 tableNameForLocation += "-" + randomUUID().toString().replace("-", "");
             }
-            location = new Path(schemaLocation.get(), tableNameForLocation).toString();
+            location = new Path(schemaLocation, tableNameForLocation).toString();
             external = false;
         }
         Path targetPath = new Path(location);
@@ -1984,12 +1980,10 @@ public class DeltaLakeMetadata
     {
         DeltaLakeTableHandle handle = (DeltaLakeTableHandle) tableHandle;
 
-        Optional<Table> table = metastore.getTable(handle.getSchemaName(), handle.getTableName());
-        if (table.isEmpty()) {
-            throw new TableNotFoundException(handle.getSchemaTableName());
-        }
+        Table table = metastore.getTable(handle.getSchemaName(), handle.getTableName())
+                .orElseThrow(() -> new TableNotFoundException(handle.getSchemaTableName()));
 
-        metastore.dropTable(session, handle.getSchemaName(), handle.getTableName(), table.get().getTableType().equals(EXTERNAL_TABLE.toString()));
+        metastore.dropTable(session, handle.getSchemaName(), handle.getTableName(), table.getTableType().equals(EXTERNAL_TABLE.toString()));
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeParquetStatisticsUtils.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeParquetStatisticsUtils.java
@@ -110,7 +110,7 @@ public class DeltaLakeParquetStatisticsUtils
                 Instant ts = Instant.ofEpochMilli(((LongStatistics) statistics).genericGetMin());
                 return Optional.of(ISO_INSTANT.format(ZonedDateTime.ofInstant(ts, UTC)));
             }
-            else if (statistics instanceof BinaryStatistics) {
+            if (statistics instanceof BinaryStatistics) {
                 DecodedTimestamp decodedTimestamp = decodeInt96Timestamp(((BinaryStatistics) statistics).genericGetMin());
                 Instant ts = Instant.ofEpochSecond(decodedTimestamp.getEpochSeconds(), decodedTimestamp.getNanosOfSecond());
                 return Optional.of(ISO_INSTANT.format(ZonedDateTime.ofInstant(ts, UTC).truncatedTo(MILLIS)));
@@ -145,11 +145,11 @@ public class DeltaLakeParquetStatisticsUtils
                 min = BigDecimal.valueOf(((IntStatistics) statistics).getMin()).movePointLeft(scale);
                 return Optional.of(min.toPlainString());
             }
-            else if (statistics instanceof LongStatistics) {
+            if (statistics instanceof LongStatistics) {
                 min = BigDecimal.valueOf(((LongStatistics) statistics).getMin()).movePointLeft(scale);
                 return Optional.of(min.toPlainString());
             }
-            else if (statistics instanceof BinaryStatistics) {
+            if (statistics instanceof BinaryStatistics) {
                 BigInteger base = new BigInteger(((BinaryStatistics) statistics).genericGetMin().getBytes());
                 min = new BigDecimal(base, scale);
                 return Optional.of(min.toPlainString());
@@ -187,7 +187,7 @@ public class DeltaLakeParquetStatisticsUtils
                 Instant ts = Instant.ofEpochMilli(((LongStatistics) statistics).genericGetMax());
                 return Optional.of(ISO_INSTANT.format(ZonedDateTime.ofInstant(ts, UTC)));
             }
-            else if (statistics instanceof BinaryStatistics) {
+            if (statistics instanceof BinaryStatistics) {
                 DecodedTimestamp decodedTimestamp = decodeInt96Timestamp(((BinaryStatistics) statistics).genericGetMax());
                 Instant ts = Instant.ofEpochSecond(decodedTimestamp.getEpochSeconds(), decodedTimestamp.getNanosOfSecond());
                 ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(ts, UTC);
@@ -225,11 +225,11 @@ public class DeltaLakeParquetStatisticsUtils
                 max = BigDecimal.valueOf(((IntStatistics) statistics).getMax()).movePointLeft(scale);
                 return Optional.of(max.toPlainString());
             }
-            else if (statistics instanceof LongStatistics) {
+            if (statistics instanceof LongStatistics) {
                 max = BigDecimal.valueOf(((LongStatistics) statistics).getMax()).movePointLeft(scale);
                 return Optional.of(max.toPlainString());
             }
-            else if (statistics instanceof BinaryStatistics) {
+            if (statistics instanceof BinaryStatistics) {
                 BigInteger base = new BigInteger(((BinaryStatistics) statistics).genericGetMax().getBytes());
                 max = new BigDecimal(base, scale);
                 return Optional.of(max.toPlainString());

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogAccess.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogAccess.java
@@ -209,7 +209,7 @@ public class TransactionLogAccess
                 log.warn("Query run with outdated Transaction Log Snapshot, retrieved stale table entries for table: %s and query %s", tableSnapshot.getTable(), session.getQueryId());
                 return loadActiveFiles(tableSnapshot, session);
             }
-            else if (cachedTable.getVersion() < tableSnapshot.getVersion()) {
+            if (cachedTable.getVersion() < tableSnapshot.getVersion()) {
                 DeltaLakeDataFileCacheEntry updatedCacheEntry;
                 try {
                     List<DeltaLakeTransactionLogEntry> newEntries = getJsonEntries(

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TransactionLogTail.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TransactionLogTail.java
@@ -84,9 +84,7 @@ public class TransactionLogTail
                 if (endVersion.isPresent()) {
                     throw new MissingTransactionLogException(path);
                 }
-                else {
-                    endOfTail = true;
-                }
+                endOfTail = true;
             }
 
             if (endVersion.isPresent() && version == endVersion.get()) {
@@ -157,12 +155,10 @@ public class TransactionLogTail
         if (e instanceof FileNotFoundException) {
             return true;
         }
-        else if (e.getMessage().contains("The specified key does not exist")) {
+        if (e.getMessage().contains("The specified key does not exist")) {
             return true;
         }
-        else {
-            return false;
-        }
+        return false;
     }
 
     public List<DeltaLakeTransactionLogEntry> getFileEntries()

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchQueryBuilder.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchQueryBuilder.java
@@ -100,13 +100,12 @@ public final class ElasticsearchQueryBuilder
             queryBuilder.filter(getOnlyElement(shouldClauses));
             return;
         }
-        else if (shouldClauses.size() > 1) {
+        if (shouldClauses.size() > 1) {
             BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
             shouldClauses.forEach(boolQueryBuilder::should);
             queryBuilder.filter(boolQueryBuilder);
             return;
         }
-        return;
     }
 
     private static List<QueryBuilder> getShouldClauses(String columnName, Domain domain, Type type)

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchSplitManager.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchSplitManager.java
@@ -57,12 +57,10 @@ public class ElasticsearchSplitManager
         if (tableHandle.getType().equals(QUERY)) {
             return new FixedSplitSource(ImmutableList.of(new ElasticsearchSplit(tableHandle.getIndex(), 0, Optional.empty())));
         }
-        else {
-            List<ElasticsearchSplit> splits = client.getSearchShards(tableHandle.getIndex()).stream()
-                    .map(shard -> new ElasticsearchSplit(shard.getIndex(), shard.getId(), shard.getAddress()))
-                    .collect(toImmutableList());
+        List<ElasticsearchSplit> splits = client.getSearchShards(tableHandle.getIndex()).stream()
+                .map(shard -> new ElasticsearchSplit(shard.getIndex(), shard.getId(), shard.getAddress()))
+                .collect(toImmutableList());
 
-            return new FixedSplitSource(splits);
-        }
+        return new FixedSplitSource(splits);
     }
 }

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeFutures.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeFutures.java
@@ -33,9 +33,7 @@ public final class FileSystemExchangeFutures
             if (throwable instanceof Error || throwable instanceof IOException) {
                 return immediateFailedFuture(throwable);
             }
-            else {
-                return immediateFailedFuture(new IOException(throwable));
-            }
+            return immediateFailedFuture(new IOException(throwable));
         }, directExecutor()));
     }
 }

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeSinkHandle.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeSinkHandle.java
@@ -64,9 +64,7 @@ public class FileSystemExchangeSinkHandle
         if (secretKey.isPresent() && that.secretKey.isPresent()) {
             return partitionId == that.getPartitionId() && Arrays.equals(secretKey.get(), that.secretKey.get());
         }
-        else {
-            return partitionId == that.getPartitionId() && secretKey.isEmpty() && that.secretKey.isEmpty();
-        }
+        return partitionId == that.getPartitionId() && secretKey.isEmpty() && that.secretKey.isEmpty();
     }
 
     @Override

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeSourceHandle.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeSourceHandle.java
@@ -98,9 +98,7 @@ public class FileSystemExchangeSourceHandle
         if (secretKey.isPresent() && that.secretKey.isPresent()) {
             return partitionId == that.getPartitionId() && Arrays.equals(secretKey.get(), that.secretKey.get());
         }
-        else {
-            return partitionId == that.getPartitionId() && secretKey.isEmpty() && that.secretKey.isEmpty();
-        }
+        return partitionId == that.getPartitionId() && secretKey.isEmpty() && that.secretKey.isEmpty();
     }
 
     @Override

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/local/LocalFileSystemExchangeStorage.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/local/LocalFileSystemExchangeStorage.java
@@ -229,9 +229,7 @@ public class LocalFileSystemExchangeStorage
                     throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to create CipherInputStream: " + e.getMessage(), e);
                 }
             }
-            else {
-                return new InputStreamSliceInput(new FileInputStream(file), BUFFER_SIZE_IN_BYTES);
-            }
+            return new InputStreamSliceInput(new FileInputStream(file), BUFFER_SIZE_IN_BYTES);
         }
     }
 

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsClient.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsClient.java
@@ -158,11 +158,9 @@ public class SheetsClient
     public List<List<Object>> readAllValues(String tableName)
     {
         try {
-            Optional<String> sheetExpression = tableSheetMappingCache.getUnchecked(tableName);
-            if (sheetExpression.isEmpty()) {
-                throw new TrinoException(SHEETS_UNKNOWN_TABLE_ERROR, "Sheet expression not found for table " + tableName);
-            }
-            return sheetDataCache.getUnchecked(sheetExpression.get());
+            String sheetExpression = tableSheetMappingCache.getUnchecked(tableName)
+                    .orElseThrow(() -> new TrinoException(SHEETS_UNKNOWN_TABLE_ERROR, "Sheet expression not found for table " + tableName));
+            return sheetDataCache.getUnchecked(sheetExpression);
         }
         catch (UncheckedExecutionException e) {
             throwIfInstanceOf(e.getCause(), TrinoException.class);

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsSplitManager.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsSplitManager.java
@@ -29,7 +29,6 @@ import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
@@ -53,15 +52,12 @@ public class SheetsSplitManager
             Constraint constraint)
     {
         SheetsTableHandle tableHandle = (SheetsTableHandle) connectorTableHandle;
-        Optional<SheetsTable> table = sheetsClient.getTable(tableHandle.getTableName());
-
-        // this can happen if table is removed during a query
-        if (table.isEmpty()) {
-            throw new TableNotFoundException(tableHandle.toSchemaTableName());
-        }
+        SheetsTable table = sheetsClient.getTable(tableHandle.getTableName())
+                // this can happen if table is removed during a query
+                .orElseThrow(() -> new TableNotFoundException(tableHandle.toSchemaTableName()));
 
         List<ConnectorSplit> splits = new ArrayList<>();
-        splits.add(new SheetsSplit(tableHandle.getSchemaName(), tableHandle.getTableName(), table.get().getValues()));
+        splits.add(new SheetsSplit(tableHandle.getSchemaName(), tableHandle.getTableName(), table.getValues()));
         Collections.shuffle(splits);
         return new FixedSplitSource(splits);
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveApplyProjectionUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveApplyProjectionUtil.java
@@ -72,7 +72,7 @@ public final class HiveApplyProjectionUtil
                 target = (Variable) expression;
                 break;
             }
-            else if (expression instanceof FieldDereference) {
+            if (expression instanceof FieldDereference) {
                 FieldDereference dereference = (FieldDereference) expression;
                 ordinals.add(dereference.getField());
                 expression = dereference.getTarget();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveLocationService.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveLocationService.java
@@ -69,9 +69,7 @@ public class HiveLocationService
             Path writePath = createTemporaryPath(session, context, hdfsEnvironment, targetPath);
             return new LocationHandle(targetPath, writePath, false, STAGE_AND_MOVE_TO_TARGET_DIRECTORY);
         }
-        else {
-            return new LocationHandle(targetPath, targetPath, false, DIRECT_TO_TARGET_NEW_DIRECTORY);
-        }
+        return new LocationHandle(targetPath, targetPath, false, DIRECT_TO_TARGET_NEW_DIRECTORY);
     }
 
     @Override
@@ -84,9 +82,7 @@ public class HiveLocationService
             Path writePath = createTemporaryPath(session, context, hdfsEnvironment, targetPath);
             return new LocationHandle(targetPath, writePath, true, STAGE_AND_MOVE_TO_TARGET_DIRECTORY);
         }
-        else {
-            return new LocationHandle(targetPath, targetPath, true, DIRECT_TO_TARGET_EXISTING_DIRECTORY);
-        }
+        return new LocationHandle(targetPath, targetPath, true, DIRECT_TO_TARGET_EXISTING_DIRECTORY);
     }
 
     @Override
@@ -133,13 +129,11 @@ public class HiveLocationService
             Path writePath = getPartitionWritePath(locationHandle, partitionName, writeMode, targetPath);
             return new WriteInfo(targetPath, writePath, writeMode);
         }
-        else {
-            // new partition
-            return new WriteInfo(
-                    new Path(locationHandle.getTargetPath(), partitionName),
-                    new Path(locationHandle.getWritePath(), partitionName),
-                    locationHandle.getWriteMode());
-        }
+        // new partition
+        return new WriteInfo(
+                new Path(locationHandle.getTargetPath(), partitionName),
+                new Path(locationHandle.getWritePath(), partitionName),
+                locationHandle.getWriteMode());
     }
 
     private Path getPartitionWritePath(LocationHandle locationHandle, String partitionName, WriteMode writeMode, Path targetPath)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -2715,12 +2715,10 @@ public class HiveMetadata
     {
         HiveTableHandle handle = (HiveTableHandle) deleteHandle;
 
-        Optional<Table> table = metastore.getTable(handle.getSchemaName(), handle.getTableName());
-        if (table.isEmpty()) {
-            throw new TableNotFoundException(handle.getSchemaTableName());
-        }
+        Table table = metastore.getTable(handle.getSchemaName(), handle.getTableName())
+                .orElseThrow(() -> new TableNotFoundException(handle.getSchemaTableName()));
 
-        if (table.get().getPartitionColumns().isEmpty()) {
+        if (table.getPartitionColumns().isEmpty()) {
             metastore.truncateUnpartitionedTable(session, handle.getSchemaName(), handle.getTableName());
         }
         else {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitSource.java
@@ -362,9 +362,7 @@ class HiveSplitSource
                 //              But an extra invocation likely doesn't matter.
                 return new ConnectorSplitBatch(splits, splits.isEmpty() && queues.isFinished());
             }
-            else {
-                return new ConnectorSplitBatch(splits, false);
-            }
+            return new ConnectorSplitBatch(splits, false);
         });
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveUpdatablePageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveUpdatablePageSource.java
@@ -257,9 +257,7 @@ public class HiveUpdatablePageSource
             List<Integer> channels = dependencyChannels.orElseThrow(() -> new IllegalArgumentException("dependencyChannels not present"));
             return updateProcessor.removeNonDependencyColumns(page, channels);
         }
-        else {
-            return page;
-        }
+        return page;
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWriterFactory.java
@@ -262,11 +262,8 @@ public class HiveWriterFactory
             writePath = writeInfo.getWritePath();
         }
         else {
-            Optional<Table> table = pageSinkMetadataProvider.getTable();
-            if (table.isEmpty()) {
-                throw new TrinoException(HIVE_INVALID_METADATA, format("Table '%s.%s' was dropped during insert", schemaName, tableName));
-            }
-            this.table = table.get();
+            this.table = pageSinkMetadataProvider.getTable()
+                    .orElseThrow(() -> new TrinoException(HIVE_INVALID_METADATA, format("Table '%s.%s' was dropped during insert", schemaName, tableName)));
             writePath = locationService.getQueryWriteInfo(locationHandle).getWritePath();
         }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/aws/athena/projection/InjectedProjection.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/aws/athena/projection/InjectedProjection.java
@@ -34,10 +34,8 @@ public class InjectedProjection
     @Override
     public List<String> getProjectedValues(Optional<Domain> partitionValueFilter)
     {
-        if (partitionValueFilter.isEmpty()) {
-            throw invalidProjectionException(getColumnName(), "Injected projection requires single predicate for it's column in where clause");
-        }
-        Domain domain = partitionValueFilter.get();
+        Domain domain = partitionValueFilter
+                .orElseThrow(() -> invalidProjectionException(getColumnName(), "Injected projection requires single predicate for it's column in where clause"));
         Type type = domain.getType();
         if (!domain.isNullableSingleValue() || !canConvertSqlTypeToStringForParts(type, true)) {
             throw invalidProjectionException(getColumnName(), "Injected projection requires single predicate for it's column in where clause. Currently provided can't be converted to single partition.");

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/DecimalCoercers.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/DecimalCoercers.java
@@ -49,18 +49,12 @@ public final class DecimalCoercers
             if (toType.isShort()) {
                 return new ShortDecimalToShortDecimalCoercer(fromType, toType);
             }
-            else {
-                return new ShortDecimalToLongDecimalCoercer(fromType, toType);
-            }
+            return new ShortDecimalToLongDecimalCoercer(fromType, toType);
         }
-        else {
-            if (toType.isShort()) {
-                return new LongDecimalToShortDecimalCoercer(fromType, toType);
-            }
-            else {
-                return new LongDecimalToLongDecimalCoercer(fromType, toType);
-            }
+        if (toType.isShort()) {
+            return new LongDecimalToShortDecimalCoercer(fromType, toType);
         }
+        return new LongDecimalToLongDecimalCoercer(fromType, toType);
     }
 
     private static class ShortDecimalToShortDecimalCoercer
@@ -153,9 +147,7 @@ public final class DecimalCoercers
         if (fromType.isShort()) {
             return new ShortDecimalToDoubleCoercer(fromType);
         }
-        else {
-            return new LongDecimalToDoubleCoercer(fromType);
-        }
+        return new LongDecimalToDoubleCoercer(fromType);
     }
 
     private static class ShortDecimalToDoubleCoercer
@@ -198,9 +190,7 @@ public final class DecimalCoercers
         if (fromType.isShort()) {
             return new ShortDecimalToRealCoercer(fromType);
         }
-        else {
-            return new LongDecimalToRealCoercer(fromType);
-        }
+        return new LongDecimalToRealCoercer(fromType);
     }
 
     private static class ShortDecimalToRealCoercer
@@ -243,9 +233,7 @@ public final class DecimalCoercers
         if (toType.isShort()) {
             return new DoubleToShortDecimalCoercer(toType);
         }
-        else {
-            return new DoubleToLongDecimalCoercer(toType);
-        }
+        return new DoubleToLongDecimalCoercer(toType);
     }
 
     private static class DoubleToShortDecimalCoercer
@@ -285,9 +273,7 @@ public final class DecimalCoercers
         if (toType.isShort()) {
             return new RealToShortDecimalCoercer(toType);
         }
-        else {
-            return new RealToLongDecimalCoercer(toType);
-        }
+        return new RealToLongDecimalCoercer(toType);
     }
 
     private static class RealToShortDecimalCoercer

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/CachingDirectoryLister.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/CachingDirectoryLister.java
@@ -127,9 +127,7 @@ public class CachingDirectoryLister
         if (cacheKey.isRecursiveFilesOnly()) {
             return fs.listFiles(cacheKey.getPath(), true);
         }
-        else {
-            return fs.listLocatedStatus(cacheKey.getPath());
-        }
+        return fs.listLocatedStatus(cacheKey.getPath());
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/TransactionScopeCachingDirectoryLister.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/TransactionScopeCachingDirectoryLister.java
@@ -107,9 +107,7 @@ public class TransactionScopeCachingDirectoryLister
         if (cacheKey.isRecursiveFilesOnly()) {
             return delegate.listFilesRecursively(fs, table, cacheKey.getPath());
         }
-        else {
-            return delegate.list(fs, table, cacheKey.getPath());
-        }
+        return delegate.list(fs, table, cacheKey.getPath());
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HivePageSinkMetadataProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HivePageSinkMetadataProvider.java
@@ -54,8 +54,6 @@ public class HivePageSinkMetadataProvider
         if (modifiedPartition == null) {
             return delegate.getPartition(schemaTableName.getSchemaName(), schemaTableName.getTableName(), partitionValues);
         }
-        else {
-            return modifiedPartition;
-        }
+        return modifiedPartition;
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/MetastoreUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/MetastoreUtil.java
@@ -276,9 +276,7 @@ public final class MetastoreUtil
         if (!parameters.containsKey(ProtectMode.PARAMETER_NAME)) {
             return new ProtectMode();
         }
-        else {
-            return getProtectModeFromString(parameters.get(ProtectMode.PARAMETER_NAME));
-        }
+        return getProtectModeFromString(parameters.get(ProtectMode.PARAMETER_NAME));
     }
 
     public static void verifyOnline(SchemaTableName tableName, Optional<String> partitionName, ProtectMode protectMode, Map<String, String> parameters)
@@ -384,29 +382,29 @@ public final class MetastoreUtil
         if (value == null) {
             return nullString;
         }
-        else if (type instanceof CharType) {
+        if (type instanceof CharType) {
             Slice slice = (Slice) value;
             return padSpaces(slice, (CharType) type).toStringUtf8();
         }
-        else if (type instanceof VarcharType) {
+        if (type instanceof VarcharType) {
             Slice slice = (Slice) value;
             return slice.toStringUtf8();
         }
-        else if (type instanceof DecimalType && !((DecimalType) type).isShort()) {
+        if (type instanceof DecimalType && !((DecimalType) type).isShort()) {
             return Decimals.toString((Int128) value, ((DecimalType) type).getScale());
         }
-        else if (type instanceof DecimalType && ((DecimalType) type).isShort()) {
+        if (type instanceof DecimalType && ((DecimalType) type).isShort()) {
             return Decimals.toString((long) value, ((DecimalType) type).getScale());
         }
-        else if (type instanceof DateType) {
+        if (type instanceof DateType) {
             DateTimeFormatter dateTimeFormatter = ISODateTimeFormat.date().withZoneUTC();
             return dateTimeFormatter.print(TimeUnit.DAYS.toMillis((long) value));
         }
-        else if (type instanceof TimestampType) {
+        if (type instanceof TimestampType) {
             // we throw on this type as we don't have timezone. Callers should not ask for this conversion type, but document for possible future work (?)
             throw new TrinoException(NOT_SUPPORTED, "TimestampType conversion to scalar expressions is not supported");
         }
-        else if (type instanceof TinyintType
+        if (type instanceof TinyintType
                 || type instanceof SmallintType
                 || type instanceof IntegerType
                 || type instanceof BigintType
@@ -415,9 +413,7 @@ public final class MetastoreUtil
                 || type instanceof BooleanType) {
             return value.toString();
         }
-        else {
-            throw new TrinoException(NOT_SUPPORTED, format("Unsupported partition key type: %s", type.getDisplayName()));
-        }
+        throw new TrinoException(NOT_SUPPORTED, format("Unsupported partition key type: %s", type.getDisplayName()));
     }
 
     /**

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/alluxio/ProtoUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/alluxio/ProtoUtils.java
@@ -250,9 +250,7 @@ public final class ProtoUtils
                     getTotalSizeInBytes(averageColumnLength, rowCount, nullsCount),
                     nullsCount);
         }
-        else {
-            throw new TrinoException(HIVE_INVALID_METADATA, "Invalid column statistics data: " + columnStatistics);
-        }
+        throw new TrinoException(HIVE_INVALID_METADATA, "Invalid column statistics data: " + columnStatistics);
     }
 
     static Column fromProto(alluxio.grpc.table.FieldSchema column)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/DefaultGlueColumnStatisticsProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/DefaultGlueColumnStatisticsProvider.java
@@ -200,15 +200,15 @@ public class DefaultGlueColumnStatisticsProvider
             DateColumnStatisticsData data = statisticsData.getDateColumnStatisticsData();
             return data.getMaximumValue() != null && data.getMinimumValue() != null;
         }
-        else if (columnType.equals(ColumnStatisticsType.DECIMAL.toString())) {
+        if (columnType.equals(ColumnStatisticsType.DECIMAL.toString())) {
             DecimalColumnStatisticsData data = statisticsData.getDecimalColumnStatisticsData();
             return data.getMaximumValue() != null && data.getMinimumValue() != null;
         }
-        else if (columnType.equals(ColumnStatisticsType.DOUBLE.toString())) {
+        if (columnType.equals(ColumnStatisticsType.DOUBLE.toString())) {
             DoubleColumnStatisticsData data = statisticsData.getDoubleColumnStatisticsData();
             return data.getMaximumValue() != null && data.getMinimumValue() != null;
         }
-        else if (columnType.equals(ColumnStatisticsType.LONG.toString())) {
+        if (columnType.equals(ColumnStatisticsType.LONG.toString())) {
             LongColumnStatisticsData data = statisticsData.getLongColumnStatisticsData();
             return data.getMaximumValue() != null && data.getMinimumValue() != null;
         }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/converter/GlueToTrinoConverter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/converter/GlueToTrinoConverter.java
@@ -117,9 +117,7 @@ public final class GlueToTrinoConverter
             //TODO(https://github.com/trinodb/trino/issues/7240) Add tests
             return new Column(glueColumn.getName(), HiveType.HIVE_STRING, Optional.ofNullable(glueColumn.getComment()));
         }
-        else {
-            return new Column(glueColumn.getName(), HiveType.valueOf(glueColumn.getType().toLowerCase(Locale.ENGLISH)), Optional.ofNullable(glueColumn.getComment()));
-        }
+        return new Column(glueColumn.getName(), HiveType.valueOf(glueColumn.getType().toLowerCase(Locale.ENGLISH)), Optional.ofNullable(glueColumn.getComment()));
     }
 
     private static List<Column> convertColumns(List<com.amazonaws.services.glue.model.Column> glueColumns, String serde)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -216,11 +216,8 @@ public class BridgingHiveMetastore
     @Override
     public void renameTable(String databaseName, String tableName, String newDatabaseName, String newTableName)
     {
-        Optional<org.apache.hadoop.hive.metastore.api.Table> source = delegate.getTable(databaseName, tableName);
-        if (source.isEmpty()) {
-            throw new TableNotFoundException(new SchemaTableName(databaseName, tableName));
-        }
-        org.apache.hadoop.hive.metastore.api.Table table = source.get();
+        org.apache.hadoop.hive.metastore.api.Table table = delegate.getTable(databaseName, tableName)
+                .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(databaseName, tableName)));
         table.setDbName(newDatabaseName);
         table.setTableName(newTableName);
         alterTable(databaseName, tableName, table);
@@ -229,11 +226,8 @@ public class BridgingHiveMetastore
     @Override
     public void commentTable(String databaseName, String tableName, Optional<String> comment)
     {
-        Optional<org.apache.hadoop.hive.metastore.api.Table> source = delegate.getTable(databaseName, tableName);
-        if (source.isEmpty()) {
-            throw new TableNotFoundException(new SchemaTableName(databaseName, tableName));
-        }
-        org.apache.hadoop.hive.metastore.api.Table table = source.get();
+        org.apache.hadoop.hive.metastore.api.Table table = delegate.getTable(databaseName, tableName)
+                .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(databaseName, tableName)));
 
         Map<String, String> parameters = table.getParameters().entrySet().stream()
                 .filter(entry -> !entry.getKey().equals(TABLE_COMMENT))
@@ -265,11 +259,8 @@ public class BridgingHiveMetastore
     @Override
     public void commentColumn(String databaseName, String tableName, String columnName, Optional<String> comment)
     {
-        Optional<org.apache.hadoop.hive.metastore.api.Table> source = delegate.getTable(databaseName, tableName);
-        if (source.isEmpty()) {
-            throw new TableNotFoundException(new SchemaTableName(databaseName, tableName));
-        }
-        org.apache.hadoop.hive.metastore.api.Table table = source.get();
+        org.apache.hadoop.hive.metastore.api.Table table = delegate.getTable(databaseName, tableName)
+                .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(databaseName, tableName)));
 
         for (FieldSchema fieldSchema : table.getSd().getCols()) {
             if (fieldSchema.getName().equals(columnName)) {
@@ -288,11 +279,8 @@ public class BridgingHiveMetastore
     @Override
     public void addColumn(String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
     {
-        Optional<org.apache.hadoop.hive.metastore.api.Table> source = delegate.getTable(databaseName, tableName);
-        if (source.isEmpty()) {
-            throw new TableNotFoundException(new SchemaTableName(databaseName, tableName));
-        }
-        org.apache.hadoop.hive.metastore.api.Table table = source.get();
+        org.apache.hadoop.hive.metastore.api.Table table = delegate.getTable(databaseName, tableName)
+                .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(databaseName, tableName)));
         table.getSd().getCols().add(
                 new FieldSchema(columnName, columnType.getHiveTypeName().toString(), columnComment));
         alterTable(databaseName, tableName, table);
@@ -301,11 +289,8 @@ public class BridgingHiveMetastore
     @Override
     public void renameColumn(String databaseName, String tableName, String oldColumnName, String newColumnName)
     {
-        Optional<org.apache.hadoop.hive.metastore.api.Table> source = delegate.getTable(databaseName, tableName);
-        if (source.isEmpty()) {
-            throw new TableNotFoundException(new SchemaTableName(databaseName, tableName));
-        }
-        org.apache.hadoop.hive.metastore.api.Table table = source.get();
+        org.apache.hadoop.hive.metastore.api.Table table = delegate.getTable(databaseName, tableName)
+                .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(databaseName, tableName)));
         for (FieldSchema fieldSchema : table.getPartitionKeys()) {
             if (fieldSchema.getName().equals(oldColumnName)) {
                 throw new TrinoException(NOT_SUPPORTED, "Renaming partition columns is not supported");

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastore.java
@@ -120,16 +120,14 @@ public interface ThriftMetastore
 
     default Optional<List<FieldSchema>> getFields(String databaseName, String tableName)
     {
-        Optional<Table> table = getTable(databaseName, tableName);
-        if (table.isEmpty()) {
-            throw new TableNotFoundException(new SchemaTableName(databaseName, tableName));
-        }
+        Table table = getTable(databaseName, tableName)
+                .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(databaseName, tableName)));
 
-        if (table.get().getSd() == null) {
+        if (table.getSd() == null) {
             throw new TrinoException(HIVE_INVALID_METADATA, "Table is missing storage descriptor");
         }
 
-        return Optional.of(table.get().getSd().getCols());
+        return Optional.of(table.getSd().getCols());
     }
 
     default long openTransaction(AcidTransactionOwner transactionOwner)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -552,9 +552,7 @@ public final class ThriftMetastoreUtil
                     getTotalSizeInBytes(averageColumnLength, rowCount, nullsCount),
                     nullsCount);
         }
-        else {
-            throw new TrinoException(HIVE_INVALID_METADATA, "Invalid column statistics data: " + columnStatistics);
-        }
+        throw new TrinoException(HIVE_INVALID_METADATA, "Invalid column statistics data: " + columnStatistics);
     }
 
     private static Optional<LocalDate> fromMetastoreDate(Date date)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3select/S3SelectRecordCursorProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3select/S3SelectRecordCursorProvider.java
@@ -117,10 +117,8 @@ public class S3SelectRecordCursorProvider
             RecordCursor cursor = new S3SelectRecordCursor<>(configuration, path, recordReader.get(), length, schema, readerColumns);
             return Optional.of(new ReaderRecordCursorWithProjections(cursor, projectedReaderColumns));
         }
-        else {
-            // unsupported serdes
-            return Optional.empty();
-        }
+        // unsupported serdes
+        return Optional.empty();
     }
 
     private static boolean hasFilters(

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveTypeTranslator.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveTypeTranslator.java
@@ -20,7 +20,6 @@ import io.trino.plugin.hive.HiveTimestampPrecision;
 import io.trino.spi.TrinoException;
 import io.trino.spi.type.CharType;
 import io.trino.spi.type.DecimalType;
-import io.trino.spi.type.NamedTypeSignature;
 import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeSignature;
@@ -163,11 +162,8 @@ public final class HiveTypeTranslator
                 if (!parameter.isNamedTypeSignature()) {
                     throw new IllegalArgumentException(format("Expected all parameters to be named type, but got %s", parameter));
                 }
-                NamedTypeSignature namedTypeSignature = parameter.getNamedTypeSignature();
-                if (namedTypeSignature.getName().isEmpty()) {
-                    throw new TrinoException(NOT_SUPPORTED, format("Anonymous row type is not supported in Hive. Please give each field a name: %s", type));
-                }
-                fieldNames.add(namedTypeSignature.getName().get());
+                fieldNames.add(parameter.getNamedTypeSignature().getName()
+                        .orElseThrow(() -> new TrinoException(NOT_SUPPORTED, format("Anonymous row type is not supported in Hive. Please give each field a name: %s", type))));
             }
             return getStructTypeInfo(
                     fieldNames.build(),

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
@@ -556,12 +556,10 @@ public final class HiveUtil
                 }
                 return NullableValue.of(decimalType, shortDecimalPartitionKey(value, decimalType, partitionName));
             }
-            else {
-                if (value.isEmpty()) {
-                    return NullableValue.of(decimalType, Int128.ZERO);
-                }
-                return NullableValue.of(decimalType, longDecimalPartitionKey(value, decimalType, partitionName));
+            if (value.isEmpty()) {
+                return NullableValue.of(decimalType, Int128.ZERO);
             }
+            return NullableValue.of(decimalType, longDecimalPartitionKey(value, decimalType, partitionName));
         }
 
         if (BOOLEAN.equals(type)) {
@@ -685,9 +683,7 @@ public final class HiveUtil
             int scale = parseInt(matcher.group(DECIMAL_SCALE_GROUP));
             return Optional.of(createDecimalType(precision, scale));
         }
-        else {
-            return Optional.empty();
-        }
+        return Optional.empty();
     }
 
     public static boolean isArrayType(Type type)
@@ -988,50 +984,50 @@ public final class HiveUtil
         if (isHiveNull(bytes)) {
             return NullableValue.asNull(type);
         }
-        else if (type.equals(BOOLEAN)) {
+        if (type.equals(BOOLEAN)) {
             return NullableValue.of(type, booleanPartitionKey(columnValue, name));
         }
-        else if (type.equals(BIGINT)) {
+        if (type.equals(BIGINT)) {
             return NullableValue.of(type, bigintPartitionKey(columnValue, name));
         }
-        else if (type.equals(INTEGER)) {
+        if (type.equals(INTEGER)) {
             return NullableValue.of(type, integerPartitionKey(columnValue, name));
         }
-        else if (type.equals(SMALLINT)) {
+        if (type.equals(SMALLINT)) {
             return NullableValue.of(type, smallintPartitionKey(columnValue, name));
         }
-        else if (type.equals(TINYINT)) {
+        if (type.equals(TINYINT)) {
             return NullableValue.of(type, tinyintPartitionKey(columnValue, name));
         }
-        else if (type.equals(REAL)) {
+        if (type.equals(REAL)) {
             return NullableValue.of(type, floatPartitionKey(columnValue, name));
         }
-        else if (type.equals(DOUBLE)) {
+        if (type.equals(DOUBLE)) {
             return NullableValue.of(type, doublePartitionKey(columnValue, name));
         }
-        else if (type instanceof VarcharType) {
+        if (type instanceof VarcharType) {
             return NullableValue.of(type, varcharPartitionKey(columnValue, name, type));
         }
-        else if (type instanceof CharType) {
+        if (type instanceof CharType) {
             return NullableValue.of(type, charPartitionKey(columnValue, name, type));
         }
-        else if (type.equals(DATE)) {
+        if (type.equals(DATE)) {
             return NullableValue.of(type, datePartitionKey(columnValue, name));
         }
-        else if (type.equals(TIMESTAMP_MILLIS)) {
+        if (type.equals(TIMESTAMP_MILLIS)) {
             return NullableValue.of(type, timestampPartitionKey(columnValue, name));
         }
-        else if (type.equals(TIMESTAMP_TZ_MILLIS)) {
+        if (type.equals(TIMESTAMP_TZ_MILLIS)) {
             // used for $file_modified_time
             return NullableValue.of(type, packDateTimeWithZone(floorDiv(timestampPartitionKey(columnValue, name), MICROSECONDS_PER_MILLISECOND), DateTimeZone.getDefault().getID()));
         }
-        else if (isShortDecimal(type)) {
+        if (isShortDecimal(type)) {
             return NullableValue.of(type, shortDecimalPartitionKey(columnValue, (DecimalType) type, name));
         }
-        else if (isLongDecimal(type)) {
+        if (isLongDecimal(type)) {
             return NullableValue.of(type, longDecimalPartitionKey(columnValue, (DecimalType) type, name));
         }
-        else if (type.equals(VarbinaryType.VARBINARY)) {
+        if (type.equals(VarbinaryType.VARBINARY)) {
             return NullableValue.of(type, utf8Slice(columnValue));
         }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
@@ -448,12 +448,10 @@ public final class HiveWriteUtils
 
     public static Path getTableDefaultLocation(Database database, HdfsContext context, HdfsEnvironment hdfsEnvironment, String schemaName, String tableName)
     {
-        Optional<String> location = database.getLocation();
-        if (location.isEmpty()) {
-            throw new TrinoException(HIVE_DATABASE_LOCATION_ERROR, format("Database '%s' location is not set", schemaName));
-        }
+        String location = database.getLocation()
+                .orElseThrow(() -> new TrinoException(HIVE_DATABASE_LOCATION_ERROR, format("Database '%s' location is not set", schemaName)));
 
-        Path databasePath = new Path(location.get());
+        Path databasePath = new Path(location);
         if (!isS3FileSystem(context, hdfsEnvironment, databasePath)) {
             if (!pathExists(context, hdfsEnvironment, databasePath)) {
                 throw new TrinoException(HIVE_DATABASE_LOCATION_ERROR, format("Database '%s' location does not exist: %s", schemaName, databasePath));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/SerDeUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/SerDeUtils.java
@@ -199,10 +199,8 @@ public final class SerDeUtils
             builder.closeEntry();
             return null;
         }
-        else {
-            Block resultBlock = currentBuilder.build();
-            return resultBlock;
-        }
+        Block resultBlock = currentBuilder.build();
+        return resultBlock;
     }
 
     private static Block serializeMap(Type type, BlockBuilder builder, Object object, MapObjectInspector inspector, boolean filterNullMapKeys)
@@ -240,9 +238,7 @@ public final class SerDeUtils
         if (builderSynthesized) {
             return (Block) type.getObject(builder, 0);
         }
-        else {
-            return null;
-        }
+        return null;
     }
 
     private static Block serializeStruct(Type type, BlockBuilder builder, Object object, StructObjectInspector inspector)
@@ -273,9 +269,7 @@ public final class SerDeUtils
         if (builderSynthesized) {
             return (Block) type.getObject(builder, 0);
         }
-        else {
-            return null;
-        }
+        return null;
     }
 
     // Use row blocks to represent union objects when reading

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileFormats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileFormats.java
@@ -727,9 +727,7 @@ public abstract class AbstractTestHiveFileFormats
             if (decimalType.isShort()) {
                 return BigInteger.valueOf(cursor.getLong(field));
             }
-            else {
-                return ((Int128) cursor.getObject(field)).toBigInteger();
-            }
+            return ((Int128) cursor.getObject(field)).toBigInteger();
         }
         throw new RuntimeException("unknown type");
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
@@ -611,15 +611,13 @@ public abstract class AbstractTestHiveFileSystem
         public void dropTable(String databaseName, String tableName, boolean deleteData)
         {
             try {
-                Optional<Table> table = getTable(databaseName, tableName);
-                if (table.isEmpty()) {
-                    throw new TableNotFoundException(new SchemaTableName(databaseName, tableName));
-                }
+                Table table = getTable(databaseName, tableName)
+                        .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(databaseName, tableName)));
 
                 // hack to work around the metastore not being configured for S3 or other FS
                 List<String> locations = listAllDataPaths(databaseName, tableName);
 
-                Table.Builder tableBuilder = Table.builder(table.get());
+                Table.Builder tableBuilder = Table.builder(table);
                 tableBuilder.getStorageBuilder().setLocation("/");
 
                 // drop table
@@ -641,12 +639,9 @@ public abstract class AbstractTestHiveFileSystem
 
         public void updateTableLocation(String databaseName, String tableName, String location)
         {
-            Optional<Table> table = getTable(databaseName, tableName);
-            if (table.isEmpty()) {
-                throw new TableNotFoundException(new SchemaTableName(databaseName, tableName));
-            }
-
-            Table.Builder tableBuilder = Table.builder(table.get());
+            Table table = getTable(databaseName, tableName)
+                    .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(databaseName, tableName)));
+            Table.Builder tableBuilder = Table.builder(table);
             tableBuilder.getStorageBuilder().setLocation(location);
 
             // NOTE: this clears the permissions

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestReaderProjectionsAdapter.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestReaderProjectionsAdapter.java
@@ -163,12 +163,10 @@ public class TestReaderProjectionsAdapter
         if (type instanceof RowType) {
             return new LazyBlock(data.size(), () -> createRowBlockWithLazyNestedBlocks(data, (RowType) type));
         }
-        else if (BIGINT.equals(type)) {
+        if (BIGINT.equals(type)) {
             return new LazyBlock(positionCount, () -> createLongArrayBlock(data));
         }
-        else {
-            throw new UnsupportedOperationException();
-        }
+        throw new UnsupportedOperationException();
     }
 
     private static Block createRowBlockWithLazyNestedBlocks(List<Object> data, RowType rowType)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/BenchmarkProjectionPushdownHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/BenchmarkProjectionPushdownHive.java
@@ -274,14 +274,14 @@ public class BenchmarkProjectionPushdownHive
 
                 return RowBlock.fromFieldBlocks(rowCount, Optional.empty(), fieldBlocks);
             }
-            else if (type instanceof VarcharType) {
+            if (type instanceof VarcharType) {
                 BlockBuilder builder = VARCHAR.createBlockBuilder(null, rowCount);
                 for (int i = 0; i < rowCount; i++) {
                     VARCHAR.writeString(builder, generateRandomString(random, 500));
                 }
                 return builder.build();
             }
-            else if (type instanceof ArrayType) {
+            if (type instanceof ArrayType) {
                 ArrayType arrayType = (ArrayType) type;
                 Type elementType = arrayType.getElementType();
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/recording/TestRecordingHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/recording/TestRecordingHiveMetastore.java
@@ -311,7 +311,7 @@ public class TestRecordingHiveMetastore
                 if (partitionValues.equals(ImmutableList.of("value"))) {
                     return Optional.of(PARTITION);
                 }
-                else if (partitionValues.equals(ImmutableList.of("other_value"))) {
+                if (partitionValues.equals(ImmutableList.of("other_value"))) {
                     return Optional.of(OTHER_PARTITION);
                 }
             }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/write/MapKeyValuesSchemaConverter.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/write/MapKeyValuesSchemaConverter.java
@@ -71,72 +71,68 @@ public final class MapKeyValuesSchemaConverter
                 return Types.primitive(PrimitiveTypeName.BINARY, repetition).as(LogicalTypeAnnotation.stringType())
                         .named(name);
             }
-            else if (typeInfo.equals(TypeInfoFactory.intTypeInfo) ||
+            if (typeInfo.equals(TypeInfoFactory.intTypeInfo) ||
                     typeInfo.equals(TypeInfoFactory.shortTypeInfo) ||
                     typeInfo.equals(TypeInfoFactory.byteTypeInfo)) {
                 return Types.primitive(PrimitiveTypeName.INT32, repetition).named(name);
             }
-            else if (typeInfo.equals(TypeInfoFactory.longTypeInfo)) {
+            if (typeInfo.equals(TypeInfoFactory.longTypeInfo)) {
                 return Types.primitive(PrimitiveTypeName.INT64, repetition).named(name);
             }
-            else if (typeInfo.equals(TypeInfoFactory.doubleTypeInfo)) {
+            if (typeInfo.equals(TypeInfoFactory.doubleTypeInfo)) {
                 return Types.primitive(PrimitiveTypeName.DOUBLE, repetition).named(name);
             }
-            else if (typeInfo.equals(TypeInfoFactory.floatTypeInfo)) {
+            if (typeInfo.equals(TypeInfoFactory.floatTypeInfo)) {
                 return Types.primitive(PrimitiveTypeName.FLOAT, repetition).named(name);
             }
-            else if (typeInfo.equals(TypeInfoFactory.booleanTypeInfo)) {
+            if (typeInfo.equals(TypeInfoFactory.booleanTypeInfo)) {
                 return Types.primitive(PrimitiveTypeName.BOOLEAN, repetition).named(name);
             }
-            else if (typeInfo.equals(TypeInfoFactory.binaryTypeInfo)) {
+            if (typeInfo.equals(TypeInfoFactory.binaryTypeInfo)) {
                 return Types.primitive(PrimitiveTypeName.BINARY, repetition).named(name);
             }
-            else if (typeInfo.equals(TypeInfoFactory.timestampTypeInfo)) {
+            if (typeInfo.equals(TypeInfoFactory.timestampTypeInfo)) {
                 return Types.primitive(PrimitiveTypeName.INT96, repetition).named(name);
             }
-            else if (typeInfo.equals(TypeInfoFactory.voidTypeInfo)) {
+            if (typeInfo.equals(TypeInfoFactory.voidTypeInfo)) {
                 throw new UnsupportedOperationException("Void type not implemented");
             }
-            else if (typeInfo.getTypeName().toLowerCase(Locale.ENGLISH).startsWith(
+            if (typeInfo.getTypeName().toLowerCase(Locale.ENGLISH).startsWith(
                     serdeConstants.CHAR_TYPE_NAME)) {
                 return Types.optional(PrimitiveTypeName.BINARY).as(LogicalTypeAnnotation.stringType()).named(name);
             }
-            else if (typeInfo.getTypeName().toLowerCase(Locale.ENGLISH).startsWith(
+            if (typeInfo.getTypeName().toLowerCase(Locale.ENGLISH).startsWith(
                     serdeConstants.VARCHAR_TYPE_NAME)) {
                 return Types.optional(PrimitiveTypeName.BINARY).as(LogicalTypeAnnotation.stringType()).named(name);
             }
-            else if (typeInfo instanceof DecimalTypeInfo) {
+            if (typeInfo instanceof DecimalTypeInfo) {
                 DecimalTypeInfo decimalTypeInfo = (DecimalTypeInfo) typeInfo;
                 int prec = decimalTypeInfo.precision();
                 int scale = decimalTypeInfo.scale();
                 int bytes = ParquetHiveSerDe.PRECISION_TO_BYTE_COUNT[prec - 1];
                 return Types.optional(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY).length(bytes).as(LogicalTypeAnnotation.decimalType(scale, prec)).named(name);
             }
-            else if (typeInfo.equals(TypeInfoFactory.dateTypeInfo)) {
+            if (typeInfo.equals(TypeInfoFactory.dateTypeInfo)) {
                 return Types.primitive(PrimitiveTypeName.INT32, repetition).as(LogicalTypeAnnotation.dateType()).named(name);
             }
-            else if (typeInfo.equals(TypeInfoFactory.unknownTypeInfo)) {
+            if (typeInfo.equals(TypeInfoFactory.unknownTypeInfo)) {
                 throw new UnsupportedOperationException("Unknown type not implemented");
             }
-            else {
-                throw new IllegalArgumentException("Unknown type: " + typeInfo);
-            }
-        }
-        else if (typeInfo.getCategory() == Category.LIST) {
-            return convertArrayType(name, (ListTypeInfo) typeInfo);
-        }
-        else if (typeInfo.getCategory() == Category.STRUCT) {
-            return convertStructType(name, (StructTypeInfo) typeInfo);
-        }
-        else if (typeInfo.getCategory() == Category.MAP) {
-            return convertMapType(name, (MapTypeInfo) typeInfo);
-        }
-        else if (typeInfo.getCategory() == Category.UNION) {
-            throw new UnsupportedOperationException("Union type not implemented");
-        }
-        else {
             throw new IllegalArgumentException("Unknown type: " + typeInfo);
         }
+        if (typeInfo.getCategory() == Category.LIST) {
+            return convertArrayType(name, (ListTypeInfo) typeInfo);
+        }
+        if (typeInfo.getCategory() == Category.STRUCT) {
+            return convertStructType(name, (StructTypeInfo) typeInfo);
+        }
+        if (typeInfo.getCategory() == Category.MAP) {
+            return convertMapType(name, (MapTypeInfo) typeInfo);
+        }
+        if (typeInfo.getCategory() == Category.UNION) {
+            throw new UnsupportedOperationException("Union type not implemented");
+        }
+        throw new IllegalArgumentException("Unknown type: " + typeInfo);
     }
 
     // An optional group containing a repeated anonymous group "bag", containing
@@ -183,19 +179,17 @@ public final class MapKeyValuesSchemaConverter
                             mapAlias,
                             keyType));
         }
-        else {
-            if (!valueType.getName().equals("value")) {
-                throw new RuntimeException(valueType.getName() + " should be value");
-            }
-            return mapKvWrapper(
-                    repetition,
-                    alias,
-                    new GroupType(
-                            Repetition.REPEATED,
-                            mapAlias,
-                            keyType,
-                            valueType));
+        if (!valueType.getName().equals("value")) {
+            throw new RuntimeException(valueType.getName() + " should be value");
         }
+        return mapKvWrapper(
+                repetition,
+                alias,
+                new GroupType(
+                        Repetition.REPEATED,
+                        mapAlias,
+                        keyType,
+                        valueType));
     }
 
     private static GroupType mapKvWrapper(Repetition repetition, String alias, Type nested)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/write/SingleLevelArraySchemaConverter.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/write/SingleLevelArraySchemaConverter.java
@@ -74,51 +74,47 @@ public final class SingleLevelArraySchemaConverter
                 return Types.primitive(PrimitiveTypeName.BINARY, repetition).as(LogicalTypeAnnotation.stringType())
                         .named(name);
             }
-            else if (typeInfo.equals(TypeInfoFactory.intTypeInfo) ||
+            if (typeInfo.equals(TypeInfoFactory.intTypeInfo) ||
                     typeInfo.equals(TypeInfoFactory.shortTypeInfo) ||
                     typeInfo.equals(TypeInfoFactory.byteTypeInfo)) {
                 return Types.primitive(PrimitiveTypeName.INT32, repetition).named(name);
             }
-            else if (typeInfo.equals(TypeInfoFactory.longTypeInfo)) {
+            if (typeInfo.equals(TypeInfoFactory.longTypeInfo)) {
                 return Types.primitive(PrimitiveTypeName.INT64, repetition).named(name);
             }
-            else if (typeInfo.equals(TypeInfoFactory.doubleTypeInfo)) {
+            if (typeInfo.equals(TypeInfoFactory.doubleTypeInfo)) {
                 return Types.primitive(PrimitiveTypeName.DOUBLE, repetition).named(name);
             }
-            else if (typeInfo.equals(TypeInfoFactory.floatTypeInfo)) {
+            if (typeInfo.equals(TypeInfoFactory.floatTypeInfo)) {
                 return Types.primitive(PrimitiveTypeName.FLOAT, repetition).named(name);
             }
-            else if (typeInfo.equals(TypeInfoFactory.booleanTypeInfo)) {
+            if (typeInfo.equals(TypeInfoFactory.booleanTypeInfo)) {
                 return Types.primitive(PrimitiveTypeName.BOOLEAN, repetition).named(name);
             }
-            else if (typeInfo.equals(TypeInfoFactory.binaryTypeInfo)) {
+            if (typeInfo.equals(TypeInfoFactory.binaryTypeInfo)) {
                 return Types.primitive(PrimitiveTypeName.BINARY, repetition).named(name);
             }
-            else if (typeInfo.equals(TypeInfoFactory.timestampTypeInfo)) {
+            if (typeInfo.equals(TypeInfoFactory.timestampTypeInfo)) {
                 return Types.primitive(PrimitiveTypeName.INT96, repetition).named(name);
             }
-            else if (typeInfo.equals(TypeInfoFactory.voidTypeInfo)) {
+            if (typeInfo.equals(TypeInfoFactory.voidTypeInfo)) {
                 throw new UnsupportedOperationException("Void type not implemented");
             }
-            else if (typeInfo.getTypeName().toLowerCase(Locale.ENGLISH).startsWith(
+            if (typeInfo.getTypeName().toLowerCase(Locale.ENGLISH).startsWith(
                     serdeConstants.CHAR_TYPE_NAME)) {
                 if (repetition == Repetition.OPTIONAL) {
                     return Types.optional(PrimitiveTypeName.BINARY).as(LogicalTypeAnnotation.stringType()).named(name);
                 }
-                else {
-                    return Types.repeated(PrimitiveTypeName.BINARY).as(LogicalTypeAnnotation.stringType()).named(name);
-                }
+                return Types.repeated(PrimitiveTypeName.BINARY).as(LogicalTypeAnnotation.stringType()).named(name);
             }
-            else if (typeInfo.getTypeName().toLowerCase(Locale.ENGLISH).startsWith(
+            if (typeInfo.getTypeName().toLowerCase(Locale.ENGLISH).startsWith(
                     serdeConstants.VARCHAR_TYPE_NAME)) {
                 if (repetition == Repetition.OPTIONAL) {
                     return Types.optional(PrimitiveTypeName.BINARY).as(LogicalTypeAnnotation.stringType()).named(name);
                 }
-                else {
-                    return Types.repeated(PrimitiveTypeName.BINARY).as(LogicalTypeAnnotation.stringType()).named(name);
-                }
+                return Types.repeated(PrimitiveTypeName.BINARY).as(LogicalTypeAnnotation.stringType()).named(name);
             }
-            else if (typeInfo instanceof DecimalTypeInfo) {
+            if (typeInfo instanceof DecimalTypeInfo) {
                 DecimalTypeInfo decimalTypeInfo = (DecimalTypeInfo) typeInfo;
                 int prec = decimalTypeInfo.precision();
                 int scale = decimalTypeInfo.scale();
@@ -126,35 +122,29 @@ public final class SingleLevelArraySchemaConverter
                 if (repetition == Repetition.OPTIONAL) {
                     return Types.optional(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY).length(bytes).as(LogicalTypeAnnotation.decimalType(scale, prec)).named(name);
                 }
-                else {
-                    return Types.repeated(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY).length(bytes).as(LogicalTypeAnnotation.decimalType(scale, prec)).named(name);
-                }
+                return Types.repeated(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY).length(bytes).as(LogicalTypeAnnotation.decimalType(scale, prec)).named(name);
             }
-            else if (typeInfo.equals(TypeInfoFactory.dateTypeInfo)) {
+            if (typeInfo.equals(TypeInfoFactory.dateTypeInfo)) {
                 return Types.primitive(PrimitiveTypeName.INT32, repetition).as(LogicalTypeAnnotation.dateType()).named(name);
             }
-            else if (typeInfo.equals(TypeInfoFactory.unknownTypeInfo)) {
+            if (typeInfo.equals(TypeInfoFactory.unknownTypeInfo)) {
                 throw new UnsupportedOperationException("Unknown type not implemented");
             }
-            else {
-                throw new IllegalArgumentException("Unknown type: " + typeInfo);
-            }
-        }
-        else if (typeInfo.getCategory() == Category.LIST) {
-            return convertArrayType(name, (ListTypeInfo) typeInfo, repetition);
-        }
-        else if (typeInfo.getCategory() == Category.STRUCT) {
-            return convertStructType(name, (StructTypeInfo) typeInfo, repetition);
-        }
-        else if (typeInfo.getCategory() == Category.MAP) {
-            return convertMapType(name, (MapTypeInfo) typeInfo, repetition);
-        }
-        else if (typeInfo.getCategory() == Category.UNION) {
-            throw new UnsupportedOperationException("Union type not implemented");
-        }
-        else {
             throw new IllegalArgumentException("Unknown type: " + typeInfo);
         }
+        if (typeInfo.getCategory() == Category.LIST) {
+            return convertArrayType(name, (ListTypeInfo) typeInfo, repetition);
+        }
+        if (typeInfo.getCategory() == Category.STRUCT) {
+            return convertStructType(name, (StructTypeInfo) typeInfo, repetition);
+        }
+        if (typeInfo.getCategory() == Category.MAP) {
+            return convertMapType(name, (MapTypeInfo) typeInfo, repetition);
+        }
+        if (typeInfo.getCategory() == Category.UNION) {
+            throw new UnsupportedOperationException("Union type not implemented");
+        }
+        throw new IllegalArgumentException("Unknown type: " + typeInfo);
     }
 
     // 1 anonymous element "array_element"

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -338,11 +338,9 @@ public class TrinoGlueCatalog
     {
         boolean newTableCreated = false;
         try {
-            Optional<com.amazonaws.services.glue.model.Table> table = getTable(from);
-            if (table.isEmpty()) {
-                throw new TableNotFoundException(from);
-            }
-            TableInput tableInput = getTableInput(to.getTableName(), Optional.ofNullable(table.get().getOwner()), table.get().getParameters());
+            com.amazonaws.services.glue.model.Table table = getTable(from)
+                    .orElseThrow(() -> new TableNotFoundException(from));
+            TableInput tableInput = getTableInput(to.getTableName(), Optional.ofNullable(table.getOwner()), table.getParameters());
             CreateTableRequest createTableRequest = new CreateTableRequest()
                     .withDatabaseName(to.getSchemaName())
                     .withTableInput(tableInput);
@@ -478,15 +476,13 @@ public class TrinoGlueCatalog
     {
         boolean newTableCreated = false;
         try {
-            Optional<com.amazonaws.services.glue.model.Table> existingView = getTable(source);
-            if (existingView.isEmpty()) {
-                throw new TableNotFoundException(source);
-            }
+            com.amazonaws.services.glue.model.Table existingView = getTable(source)
+                    .orElseThrow(() -> new TableNotFoundException(source));
 
             TableInput viewTableInput = getViewTableInput(
                     target.getTableName(),
-                    existingView.get().getViewOriginalText(),
-                    existingView.get().getOwner(),
+                    existingView.getViewOriginalText(),
+                    existingView.getOwner(),
                     createViewProperties(session));
             CreateTableRequest createTableRequest = new CreateTableRequest()
                     .withDatabaseName(target.getSchemaName())
@@ -770,11 +766,8 @@ public class TrinoGlueCatalog
     {
         boolean newTableCreated = false;
         try {
-            Optional<com.amazonaws.services.glue.model.Table> table = getTable(source);
-            if (table.isEmpty()) {
-                throw new TableNotFoundException(source);
-            }
-            com.amazonaws.services.glue.model.Table glueTable = table.get();
+            com.amazonaws.services.glue.model.Table glueTable = getTable(source)
+                    .orElseThrow(() -> new TableNotFoundException(source));
             if (!isTrinoMaterializedView(glueTable.getTableType(), glueTable.getParameters())) {
                 throw new TrinoException(UNSUPPORTED_TABLE_TYPE, "Not a Materialized View: " + source);
             }

--- a/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxMetadata.java
+++ b/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxMetadata.java
@@ -204,7 +204,7 @@ public class JmxMetadata
             if (JMX_SCHEMA_NAME.equals(schema)) {
                 return listJmxTables();
             }
-            else if (HISTORY_SCHEMA_NAME.equals(schema)) {
+            if (HISTORY_SCHEMA_NAME.equals(schema)) {
                 return jmxHistoricalData.getTables().stream()
                         .map(tableName -> new SchemaTableName(JmxMetadata.HISTORY_SCHEMA_NAME, tableName))
                         .collect(toList());

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/AvroSchemaConverter.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/AvroSchemaConverter.java
@@ -159,19 +159,19 @@ public class AvroSchemaConverter
                     .filter(type -> type.getType() != NULL)
                     .collect(toImmutableList())));
         }
-        else if (schema.getTypes().size() == 1) {
+        if (schema.getTypes().size() == 1) {
             return convert(getOnlyElement(schema.getTypes()));
         }
-        else if (INTEGRAL_TYPES.containsAll(types)) {
+        if (INTEGRAL_TYPES.containsAll(types)) {
             return Optional.of(BigintType.BIGINT);
         }
-        else if (DECIMAL_TYPES.containsAll(types)) {
+        if (DECIMAL_TYPES.containsAll(types)) {
             return Optional.of(DoubleType.DOUBLE);
         }
-        else if (STRING_TYPES.containsAll(types)) {
+        if (STRING_TYPES.containsAll(types)) {
             return Optional.of(VarcharType.VARCHAR);
         }
-        else if (BINARY_TYPES.containsAll(types)) {
+        if (BINARY_TYPES.containsAll(types)) {
             return Optional.of(VarbinaryType.VARBINARY);
         }
         throw new UnsupportedOperationException(format("Incompatible UNION type: '%s'", schema.toString(true)));

--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisRecordSet.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisRecordSet.java
@@ -241,15 +241,13 @@ public class KinesisRecordSet
             if (listIterator.hasNext()) {
                 return nextRow();
             }
-            else {
-                log.debug("(%s:%s) Read all of the records from the shard:  %d batches and %d messages and %d total bytes.",
-                        split.getStreamName(),
-                        split.getShardId(),
-                        batchesRead,
-                        totalMessages,
-                        totalBytes);
-                return false;
-            }
+            log.debug("(%s:%s) Read all of the records from the shard:  %d batches and %d messages and %d total bytes.",
+                    split.getStreamName(),
+                    split.getShardId(),
+                    batchesRead,
+                    totalMessages,
+                    totalBytes);
+            return false;
         }
 
         private boolean shouldGetMoreRecords()

--- a/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/util/MockKinesisClient.java
+++ b/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/util/MockKinesisClient.java
@@ -169,9 +169,7 @@ public class MockKinesisClient
 
                 return returnArray;
             }
-            else {
-                return new ArrayList<>();
-            }
+            return new ArrayList<>();
         }
 
         public PutRecordResult putRecord(ByteBuffer data, String partitionKey)
@@ -289,9 +287,7 @@ public class MockKinesisClient
         if (theStream != null) {
             return theStream.putRecord(putRecordRequest.getData(), putRecordRequest.getPartitionKey());
         }
-        else {
-            throw new AmazonClientException("This stream does not exist!");
-        }
+        throw new AmazonClientException("This stream does not exist!");
     }
 
     @Override
@@ -328,9 +324,7 @@ public class MockKinesisClient
             result.setRecords(resultList);
             return result;
         }
-        else {
-            throw new AmazonClientException("This stream does not exist!");
-        }
+        throw new AmazonClientException("This stream does not exist!");
     }
 
     @Override

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/properties/KuduTableProperties.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/properties/KuduTableProperties.java
@@ -342,23 +342,21 @@ public final class KuduTableProperties
         if (rangeKey.length == 0) {
             return null;
         }
-        else {
-            Schema schema = table.getSchema();
-            PartitionSchema partitionSchema = table.getPartitionSchema();
-            PartitionSchema.RangeSchema rangeSchema = partitionSchema.getRangeSchema();
-            List<Integer> rangeColumns = rangeSchema.getColumnIds();
+        Schema schema = table.getSchema();
+        PartitionSchema partitionSchema = table.getPartitionSchema();
+        PartitionSchema.RangeSchema rangeSchema = partitionSchema.getRangeSchema();
+        List<Integer> rangeColumns = rangeSchema.getColumnIds();
 
-            int numColumns = rangeColumns.size();
+        int numColumns = rangeColumns.size();
 
-            PartialRow bound = KeyEncoderAccessor.decodeRangePartitionKey(schema, partitionSchema, rangeKey);
+        PartialRow bound = KeyEncoderAccessor.decodeRangePartitionKey(schema, partitionSchema, rangeKey);
 
-            ArrayList<Object> list = new ArrayList<>();
-            for (int i = 0; i < numColumns; i++) {
-                Object obj = toValue(schema, bound, rangeColumns.get(i));
-                list.add(obj);
-            }
-            return new RangeBoundValue(list);
+        ArrayList<Object> list = new ArrayList<>();
+        for (int i = 0; i < numColumns; i++) {
+            Object obj = toValue(schema, bound, rangeColumns.get(i));
+            list.add(obj);
         }
+        return new RangeBoundValue(list);
     }
 
     private static Object toValue(Schema schema, PartialRow bound, Integer idx)
@@ -506,13 +504,11 @@ public final class KuduTableProperties
         if (obj instanceof byte[]) {
             return (byte[]) obj;
         }
-        else if (obj instanceof String) {
+        if (obj instanceof String) {
             return Base64.getDecoder().decode((String) obj);
         }
-        else {
-            handleInvalidValue(name, type, obj);
-            return null;
-        }
+        handleInvalidValue(name, type, obj);
+        return null;
     }
 
     private static boolean toBoolean(Object obj, Type type, String name)
@@ -520,13 +516,11 @@ public final class KuduTableProperties
         if (obj instanceof Boolean) {
             return (Boolean) obj;
         }
-        else if (obj instanceof String) {
+        if (obj instanceof String) {
             return Boolean.valueOf((String) obj);
         }
-        else {
-            handleInvalidValue(name, type, obj);
-            return false;
-        }
+        handleInvalidValue(name, type, obj);
+        return false;
     }
 
     private static long toUnixTimeMicros(Object obj, Type type, String name)
@@ -534,16 +528,14 @@ public final class KuduTableProperties
         if (Number.class.isAssignableFrom(obj.getClass())) {
             return ((Number) obj).longValue();
         }
-        else if (obj instanceof String) {
+        if (obj instanceof String) {
             String s = (String) obj;
             s = s.trim().replace(' ', 'T');
             long millis = ISODateTimeFormat.dateOptionalTimeParser().withZone(DateTimeZone.UTC).parseMillis(s);
             return millis * 1000;
         }
-        else {
-            handleInvalidValue(name, type, obj);
-            return 0;
-        }
+        handleInvalidValue(name, type, obj);
+        return 0;
     }
 
     private static Number toNumber(Object obj, Type type, String name)
@@ -551,13 +543,11 @@ public final class KuduTableProperties
         if (Number.class.isAssignableFrom(obj.getClass())) {
             return (Number) obj;
         }
-        else if (obj instanceof String) {
+        if (obj instanceof String) {
             return new BigDecimal((String) obj);
         }
-        else {
-            handleInvalidValue(name, type, obj);
-            return 0;
-        }
+        handleInvalidValue(name, type, obj);
+        return 0;
     }
 
     private static void handleInvalidValue(String name, Type type, Object obj)

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/properties/RangeBoundValueDeserializer.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/properties/RangeBoundValueDeserializer.java
@@ -36,22 +36,20 @@ public class RangeBoundValueDeserializer
         if (node.isNull()) {
             return null;
         }
-        else {
-            List<Object> list;
-            if (node.isArray()) {
-                list = new ArrayList<>();
-                Iterator<JsonNode> iter = node.elements();
-                while (iter.hasNext()) {
-                    Object v = toValue(iter.next());
-                    list.add(v);
-                }
+        List<Object> list;
+        if (node.isArray()) {
+            list = new ArrayList<>();
+            Iterator<JsonNode> iter = node.elements();
+            while (iter.hasNext()) {
+                Object v = toValue(iter.next());
+                list.add(v);
             }
-            else {
-                Object v = toValue(node);
-                list = ImmutableList.of(v);
-            }
-            return new RangeBoundValue(list);
         }
+        else {
+            Object v = toValue(node);
+            list = ImmutableList.of(v);
+        }
+        return new RangeBoundValue(list);
     }
 
     private Object toValue(JsonNode node)
@@ -60,17 +58,15 @@ public class RangeBoundValueDeserializer
         if (node.isTextual()) {
             return node.asText();
         }
-        else if (node.isNumber()) {
+        if (node.isNumber()) {
             return node.numberValue();
         }
-        else if (node.isBoolean()) {
+        if (node.isBoolean()) {
             return node.asBoolean();
         }
-        else if (node.isBinary()) {
+        if (node.isBinary()) {
             return node.binaryValue();
         }
-        else {
-            throw new IllegalStateException("Unexpected range bound value: " + node);
-        }
+        throw new IllegalStateException("Unexpected range bound value: " + node);
     }
 }

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/properties/RangeBoundValueSerializer.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/properties/RangeBoundValueSerializer.java
@@ -51,7 +51,7 @@ public class RangeBoundValueSerializer
         if (obj == null) {
             throw new IllegalStateException("Unexpected null value");
         }
-        else if (obj instanceof String) {
+        if (obj instanceof String) {
             gen.writeString((String) obj);
         }
         else if (Number.class.isAssignableFrom(obj.getClass())) {

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/schema/NoSchemaEmulation.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/schema/NoSchemaEmulation.java
@@ -33,9 +33,7 @@ public class NoSchemaEmulation
         if (DEFAULT_SCHEMA.equals(schemaName)) {
             throw new SchemaAlreadyExistsException(schemaName);
         }
-        else {
-            throw new TrinoException(GENERIC_USER_ERROR, "Creating schema in Kudu connector not allowed if schema emulation is disabled.");
-        }
+        throw new TrinoException(GENERIC_USER_ERROR, "Creating schema in Kudu connector not allowed if schema emulation is disabled.");
     }
 
     @Override
@@ -44,9 +42,7 @@ public class NoSchemaEmulation
         if (DEFAULT_SCHEMA.equals(schemaName)) {
             throw new TrinoException(GENERIC_USER_ERROR, "Deleting default schema not allowed.");
         }
-        else {
-            throw new SchemaNotFoundException(schemaName);
-        }
+        throw new SchemaNotFoundException(schemaName);
     }
 
     @Override
@@ -67,9 +63,7 @@ public class NoSchemaEmulation
         if (DEFAULT_SCHEMA.equals(schemaTableName.getSchemaName())) {
             return schemaTableName.getTableName();
         }
-        else {
-            throw new SchemaNotFoundException(schemaTableName.getSchemaName());
-        }
+        throw new SchemaNotFoundException(schemaTableName.getSchemaName());
     }
 
     @Override

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/schema/SchemaEmulationByTableNameConvention.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/schema/SchemaEmulationByTableNameConvention.java
@@ -59,16 +59,14 @@ public class SchemaEmulationByTableNameConvention
         if (DEFAULT_SCHEMA.equals(schemaName)) {
             throw new SchemaAlreadyExistsException(schemaName);
         }
-        else {
-            try (KuduOperationApplier operationApplier = KuduOperationApplier.fromKuduClientWrapper(client)) {
-                KuduTable schemasTable = getSchemasTable(client);
-                Upsert upsert = schemasTable.newUpsert();
-                upsert.getRow().addString(0, schemaName);
-                operationApplier.applyOperationAsync(upsert);
-            }
-            catch (KuduException e) {
-                throw new TrinoException(GENERIC_INTERNAL_ERROR, e);
-            }
+        try (KuduOperationApplier operationApplier = KuduOperationApplier.fromKuduClientWrapper(client)) {
+            KuduTable schemasTable = getSchemasTable(client);
+            Upsert upsert = schemasTable.newUpsert();
+            upsert.getRow().addString(0, schemaName);
+            operationApplier.applyOperationAsync(upsert);
+        }
+        catch (KuduException e) {
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, e);
         }
     }
 
@@ -78,10 +76,8 @@ public class SchemaEmulationByTableNameConvention
         if (DEFAULT_SCHEMA.equals(schemaName)) {
             return true;
         }
-        else {
-            List<String> schemas = listSchemaNames(client);
-            return schemas.contains(schemaName);
-        }
+        List<String> schemas = listSchemaNames(client);
+        return schemas.contains(schemaName);
     }
 
     @Override
@@ -90,21 +86,19 @@ public class SchemaEmulationByTableNameConvention
         if (DEFAULT_SCHEMA.equals(schemaName)) {
             throw new TrinoException(GENERIC_USER_ERROR, "Deleting default schema not allowed.");
         }
-        else {
-            try (KuduOperationApplier operationApplier = KuduOperationApplier.fromKuduClientWrapper(client)) {
-                String prefix = getPrefixForTablesOfSchema(schemaName);
-                for (String name : client.getTablesList(prefix).getTablesList()) {
-                    client.deleteTable(name);
-                }
+        try (KuduOperationApplier operationApplier = KuduOperationApplier.fromKuduClientWrapper(client)) {
+            String prefix = getPrefixForTablesOfSchema(schemaName);
+            for (String name : client.getTablesList(prefix).getTablesList()) {
+                client.deleteTable(name);
+            }
 
-                KuduTable schemasTable = getSchemasTable(client);
-                Delete delete = schemasTable.newDelete();
-                delete.getRow().addString(0, schemaName);
-                operationApplier.applyOperationAsync(delete);
-            }
-            catch (KuduException e) {
-                throw new TrinoException(GENERIC_INTERNAL_ERROR, e);
-            }
+            KuduTable schemasTable = getSchemasTable(client);
+            Delete delete = schemasTable.newDelete();
+            delete.getRow().addString(0, schemaName);
+            operationApplier.applyOperationAsync(delete);
+        }
+        catch (KuduException e) {
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, e);
         }
     }
 
@@ -217,9 +211,7 @@ public class SchemaEmulationByTableNameConvention
         if (DEFAULT_SCHEMA.equals(schemaTableName.getSchemaName())) {
             return schemaTableName.getTableName();
         }
-        else {
-            return commonPrefix + schemaTableName.getSchemaName() + "." + schemaTableName.getTableName();
-        }
+        return commonPrefix + schemaTableName.getSchemaName() + "." + schemaTableName.getTableName();
     }
 
     @Override
@@ -256,9 +248,7 @@ public class SchemaEmulationByTableNameConvention
         if (DEFAULT_SCHEMA.equals(schemaName)) {
             return "";
         }
-        else {
-            return commonPrefix + schemaName + ".";
-        }
+        return commonPrefix + schemaName + ".";
     }
 
     @Override

--- a/plugin/trino-local-file/src/main/java/io/trino/plugin/localfile/LocalFileRecordCursor.java
+++ b/plugin/trino-local-file/src/main/java/io/trino/plugin/localfile/LocalFileRecordCursor.java
@@ -198,10 +198,8 @@ public class LocalFileRecordCursor
         if (getType(field).equals(createTimestampWithTimeZoneType(3))) {
             return parseTimestamp(getFieldValue(field));
         }
-        else {
-            checkFieldType(field, BIGINT, INTEGER);
-            return Long.parseLong(getFieldValue(field));
-        }
+        checkFieldType(field, BIGINT, INTEGER);
+        return Long.parseLong(getFieldValue(field));
     }
 
     @Override

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSource.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSource.java
@@ -313,7 +313,7 @@ public class MongoPageSource
                 output.closeEntry();
                 return;
             }
-            else if (value instanceof Map) {
+            if (value instanceof Map) {
                 BlockBuilder builder = output.beginBlockEntry();
                 Map<?, ?> document = (Map<?, ?>) value;
                 for (Map.Entry<?, ?> entry : document.entrySet()) {
@@ -341,7 +341,7 @@ public class MongoPageSource
                 output.closeEntry();
                 return;
             }
-            else if (value instanceof DBRef) {
+            if (value instanceof DBRef) {
                 DBRef dbRefValue = (DBRef) value;
                 BlockBuilder builder = output.beginBlockEntry();
 
@@ -353,7 +353,7 @@ public class MongoPageSource
                 output.closeEntry();
                 return;
             }
-            else if (value instanceof List<?>) {
+            if (value instanceof List<?>) {
                 List<?> listValue = (List<?>) value;
                 BlockBuilder builder = output.beginBlockEntry();
                 for (int index = 0; index < type.getTypeParameters().size(); index++) {

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
@@ -557,17 +557,15 @@ public class MongoSession
             if (!collectionExists(db, tableName)) {
                 throw new TableNotFoundException(new SchemaTableName(schemaName, tableName), format("Table '%s.%s' not found", schemaName, tableName), null);
             }
-            else {
-                Document metadata = new Document(TABLE_NAME_KEY, tableName);
-                metadata.append(FIELDS_KEY, guessTableFields(schemaName, tableName));
-                if (!indexExists(schema)) {
-                    schema.createIndex(new Document(TABLE_NAME_KEY, 1), new IndexOptions().unique(true));
-                }
-
-                schema.insertOne(metadata);
-
-                return metadata;
+            Document metadata = new Document(TABLE_NAME_KEY, tableName);
+            metadata.append(FIELDS_KEY, guessTableFields(schemaName, tableName));
+            if (!indexExists(schema)) {
+                schema.createIndex(new Document(TABLE_NAME_KEY, 1), new IndexOptions().unique(true));
             }
+
+            schema.insertOne(metadata);
+
+            return metadata;
         }
 
         return doc;

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotSegmentPageSource.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotSegmentPageSource.java
@@ -266,9 +266,7 @@ public class PinotSegmentPageSource
         if (dataType.equals(ColumnDataType.FLOAT)) {
             return currentDataTable.getDataTable().getFloat(rowIndex, columnIndex);
         }
-        else {
-            return currentDataTable.getDataTable().getDouble(rowIndex, columnIndex);
-        }
+        return currentDataTable.getDataTable().getDouble(rowIndex, columnIndex);
     }
 
     private Block getArrayBlock(int rowIndex, int columnIndex)
@@ -327,10 +325,10 @@ public class PinotSegmentPageSource
             String field = currentDataTable.getDataTable().getString(rowIndex, columnIndex);
             return getUtf8Slice(field);
         }
-        else if (trinoType instanceof VarbinaryType) {
+        if (trinoType instanceof VarbinaryType) {
             return Slices.wrappedBuffer(toBytes(currentDataTable.getDataTable().getString(rowIndex, columnIndex)));
         }
-        else if (trinoType.getTypeSignature().getBase() == StandardTypes.JSON) {
+        if (trinoType.getTypeSignature().getBase() == StandardTypes.JSON) {
             String field = currentDataTable.getDataTable().getString(rowIndex, columnIndex);
             return jsonParse(getUtf8Slice(field));
         }

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotSplitManager.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotSplitManager.java
@@ -174,9 +174,7 @@ public class PinotSplitManager
             }
             return generateSplitsForSegmentBasedScan(pinotTableHandle, session);
         }
-        else {
-            return generateSplitForBrokerBasedScan(pinotTableHandle);
-        }
+        return generateSplitForBrokerBasedScan(pinotTableHandle);
     }
 
     private static boolean isBrokerQuery(ConnectorSession session, PinotTableHandle tableHandle)

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotClient.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotClient.java
@@ -364,12 +364,10 @@ public class PinotClient
                     if (matcher.matches() && matcher.groupCount() == 2) {
                         return pinotHostMapper.getBrokerHost(matcher.group(1), matcher.group(2));
                     }
-                    else {
-                        throw new PinotException(
-                                PINOT_UNABLE_TO_FIND_BROKER,
-                                Optional.empty(),
-                                format("Cannot parse %s in the broker instance", brokerToParse));
-                    }
+                    throw new PinotException(
+                            PINOT_UNABLE_TO_FIND_BROKER,
+                            Optional.empty(),
+                            format("Cannot parse %s in the broker instance", brokerToParse));
                 })
                 .collect(Collectors.toCollection(ArrayList::new));
         Collections.shuffle(brokers);
@@ -390,9 +388,7 @@ public class PinotClient
             if (throwable instanceof PinotException) {
                 throw (PinotException) throwable;
             }
-            else {
-                throw new PinotException(PINOT_UNABLE_TO_FIND_BROKER, Optional.empty(), "Error when getting brokers for table " + table, throwable);
-            }
+            throw new PinotException(PINOT_UNABLE_TO_FIND_BROKER, Optional.empty(), "Error when getting brokers for table " + table, throwable);
         }
     }
 

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/decoders/DecoderFactory.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/decoders/DecoderFactory.java
@@ -43,33 +43,29 @@ public class DecoderFactory
             if (type instanceof DoubleType) {
                 return new DoubleDecoder();
             }
-            else if (type instanceof RealType) {
+            if (type instanceof RealType) {
                 return new RealDecoder();
             }
-            else if (type instanceof BigintType) {
+            if (type instanceof BigintType) {
                 return new BigintDecoder();
             }
-            else if (type instanceof IntegerType) {
+            if (type instanceof IntegerType) {
                 return new IntegerDecoder();
             }
-            else if (type instanceof BooleanType) {
+            if (type instanceof BooleanType) {
                 return new BooleanDecoder();
             }
-            else {
-                throw new PinotException(PINOT_UNSUPPORTED_COLUMN_TYPE, Optional.empty(), "type '" + type + "' not supported");
-            }
+            throw new PinotException(PINOT_UNSUPPORTED_COLUMN_TYPE, Optional.empty(), "type '" + type + "' not supported");
         }
-        else if (type instanceof ArrayType) {
+        if (type instanceof ArrayType) {
             return new ArrayDecoder(type);
         }
-        else if (type instanceof VarbinaryType) {
+        if (type instanceof VarbinaryType) {
             return new VarbinaryDecoder();
         }
-        else if (type.getTypeSignature().getBase().equals(JSON)) {
+        if (type.getTypeSignature().getBase().equals(JSON)) {
             return new JsonDecoder();
         }
-        else {
-            return new VarcharDecoder();
-        }
+        return new VarcharDecoder();
     }
 }

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/DynamicTableBuilder.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/DynamicTableBuilder.java
@@ -268,9 +268,7 @@ public final class DynamicTableBuilder
         if (queryContext.getOffset() > 0) {
             return OptionalLong.of(queryContext.getOffset());
         }
-        else {
-            return OptionalLong.empty();
-        }
+        return OptionalLong.empty();
     }
 
     private static String stripSuffix(String tableName)
@@ -279,12 +277,10 @@ public final class DynamicTableBuilder
         if (tableName.toUpperCase(ENGLISH).endsWith(OFFLINE_SUFFIX)) {
             return tableName.substring(0, tableName.length() - OFFLINE_SUFFIX.length());
         }
-        else if (tableName.toUpperCase(ENGLISH).endsWith(REALTIME_SUFFIX)) {
+        if (tableName.toUpperCase(ENGLISH).endsWith(REALTIME_SUFFIX)) {
             return tableName.substring(0, tableName.length() - REALTIME_SUFFIX.length());
         }
-        else {
-            return tableName;
-        }
+        return tableName;
     }
 
     private static Optional<String> getSuffix(String tableName)
@@ -293,12 +289,10 @@ public final class DynamicTableBuilder
         if (tableName.toUpperCase(ENGLISH).endsWith(OFFLINE_SUFFIX)) {
             return Optional.of(OFFLINE_SUFFIX);
         }
-        else if (tableName.toUpperCase(ENGLISH).endsWith(REALTIME_SUFFIX)) {
+        if (tableName.toUpperCase(ENGLISH).endsWith(REALTIME_SUFFIX)) {
             return Optional.of(REALTIME_SUFFIX);
         }
-        else {
-            return Optional.empty();
-        }
+        return Optional.empty();
     }
 
     private static class PinotColumnNameAndTrinoType

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/DynamicTablePqlExtractor.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/DynamicTablePqlExtractor.java
@@ -93,15 +93,13 @@ public final class DynamicTablePqlExtractor
         if (tupleFilter.isPresent() && filter.isPresent()) {
             return Optional.of(format("%s AND %s", encloseInParentheses(tupleFilter.get()), encloseInParentheses(filter.get())));
         }
-        else if (filter.isPresent()) {
+        if (filter.isPresent()) {
             return filter;
         }
-        else if (tupleFilter.isPresent()) {
+        if (tupleFilter.isPresent()) {
             return tupleFilter;
         }
-        else {
-            return Optional.empty();
-        }
+        return Optional.empty();
     }
 
     private static String convertOrderByExpressionToPql(OrderByExpression orderByExpression)

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/PinotPatterns.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/PinotPatterns.java
@@ -181,7 +181,7 @@ public class PinotPatterns
             if (predicate.getType() == Predicate.Type.IN) {
                 return Optional.of(((InPredicate) predicate).getValues());
             }
-            else if (predicate.getType() == Predicate.Type.NOT_IN) {
+            if (predicate.getType() == Predicate.Type.NOT_IN) {
                 return Optional.of(((NotInPredicate) predicate).getValues());
             }
             return Optional.empty();

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/PinotQueryBuilder.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/PinotQueryBuilder.java
@@ -120,9 +120,7 @@ public final class PinotQueryBuilder
         if (!conjuncts.isEmpty()) {
             return Optional.of(Joiner.on(" AND ").join(conjuncts));
         }
-        else {
-            return Optional.empty();
-        }
+        return Optional.empty();
     }
 
     private static String toPredicate(PinotColumnHandle pinotColumnHandle, Domain domain)
@@ -163,10 +161,10 @@ public final class PinotQueryBuilder
         if (type instanceof RealType) {
             return intBitsToFloat(toIntExact((Long) value));
         }
-        else if (type instanceof VarcharType) {
+        if (type instanceof VarcharType) {
             return ((Slice) value).toStringUtf8();
         }
-        else if (type instanceof VarbinaryType) {
+        if (type instanceof VarbinaryType) {
             return Hex.encodeHexString(((Slice) value).getBytes());
         }
         return value;

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestingPinotCluster.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestingPinotCluster.java
@@ -271,9 +271,7 @@ public class TestingPinotCluster
                     if (statusCode >= 500) {
                         return false;
                     }
-                    else {
-                        throw e;
-                    }
+                    throw e;
                 }
             });
         }

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/TypeUtils.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/TypeUtils.java
@@ -208,13 +208,11 @@ final class TypeUtils
                 long millisUtc = unpackMillisUtc((long) trinoNative);
                 return new Timestamp(millisUtc);
             }
-            else {
-                LongTimestampWithTimeZone value = (LongTimestampWithTimeZone) trinoNative;
-                long epochSeconds = floorDiv(value.getEpochMillis(), MILLISECONDS_PER_SECOND);
-                long nanosOfSecond = floorMod(value.getEpochMillis(), MILLISECONDS_PER_SECOND) * NANOSECONDS_PER_MILLISECOND
-                        + value.getPicosOfMilli() / PICOSECONDS_PER_NANOSECOND;
-                return OffsetDateTime.ofInstant(Instant.ofEpochSecond(epochSeconds, nanosOfSecond), UTC_KEY.getZoneId());
-            }
+            LongTimestampWithTimeZone value = (LongTimestampWithTimeZone) trinoNative;
+            long epochSeconds = floorDiv(value.getEpochMillis(), MILLISECONDS_PER_SECOND);
+            long nanosOfSecond = floorMod(value.getEpochMillis(), MILLISECONDS_PER_SECOND) * NANOSECONDS_PER_MILLISECOND
+                    + value.getPicosOfMilli() / PICOSECONDS_PER_NANOSECOND;
+            return OffsetDateTime.ofInstant(Instant.ofEpochSecond(epochSeconds, nanosOfSecond), UTC_KEY.getZoneId());
         }
 
         if (trinoType instanceof VarcharType || trinoType instanceof CharType) {

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -1813,9 +1813,7 @@ public class TestPostgreSqlTypeMapping
         if (insertWithTrino) {
             return trinoTimestampWithTimeZoneDataType(precision);
         }
-        else {
-            return postgreSqlTimestampWithTimeZoneDataType(precision);
-        }
+        return postgreSqlTimestampWithTimeZoneDataType(precision);
     }
 
     public static DataType<ZonedDateTime> trinoTimestampWithTimeZoneDataType(int precision)
@@ -1848,9 +1846,7 @@ public class TestPostgreSqlTypeMapping
         if (insertWithTrino) {
             return arrayDataType(trinoTimestampWithTimeZoneDataType(precision));
         }
-        else {
-            return arrayDataType(postgreSqlTimestampWithTimeZoneDataType(precision), format("timestamptz(%d)[]", precision));
-        }
+        return arrayDataType(postgreSqlTimestampWithTimeZoneDataType(precision), format("timestamptz(%d)[]", precision));
     }
 
     private Session sessionWithArrayAsArray()

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusRecordCursor.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusRecordCursor.java
@@ -143,9 +143,7 @@ public class PrometheusRecordCursor
             int offsetMinutes = dateTime.atZone(ZoneId.systemDefault()).getOffset().getTotalSeconds() / 60;
             return packDateTimeWithZone(dateTime.toEpochMilli(), offsetMinutes);
         }
-        else {
-            throw new TrinoException(NOT_SUPPORTED, "Unsupported type " + getType(field));
-        }
+        throw new TrinoException(NOT_SUPPORTED, "Unsupported type " + getType(field));
     }
 
     @Override
@@ -264,17 +262,15 @@ public class PrometheusRecordCursor
             Type elementType = ((ArrayType) type).getElementType();
             return getArrayFromBlock(elementType, block.getObject(position, Block.class));
         }
-        else if (type instanceof MapType) {
+        if (type instanceof MapType) {
             return getMapFromBlock(type, block.getObject(position, Block.class));
         }
-        else {
-            if (type.getJavaType() == Slice.class) {
-                Slice slice = (Slice) requireNonNull(TypeUtils.readNativeValue(type, block, position));
-                return (type instanceof VarcharType) ? slice.toStringUtf8() : slice.getBytes();
-            }
-
-            return TypeUtils.readNativeValue(type, block, position);
+        if (type.getJavaType() == Slice.class) {
+            Slice slice = (Slice) requireNonNull(TypeUtils.readNativeValue(type, block, position));
+            return (type instanceof VarcharType) ? slice.toStringUtf8() : slice.getBytes();
         }
+
+        return TypeUtils.readNativeValue(type, block, position);
     }
 
     private static List<Object> getArrayFromBlock(Type elementType, Block block)

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/storage/Row.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/storage/Row.java
@@ -118,27 +118,25 @@ public class Row
         if (block.isNull(position)) {
             return null;
         }
-        else if (type.getJavaType() == boolean.class) {
+        if (type.getJavaType() == boolean.class) {
             return type.getBoolean(block, position);
         }
-        else if (type.getJavaType() == long.class) {
+        if (type.getJavaType() == long.class) {
             return type.getLong(block, position);
         }
-        else if (type.getJavaType() == double.class) {
+        if (type.getJavaType() == double.class) {
             return type.getDouble(block, position);
         }
-        else if (type.getJavaType() == Slice.class) {
+        if (type.getJavaType() == Slice.class) {
             return type.getSlice(block, position);
         }
-        else if (type.getJavaType() == Block.class) {
+        if (type.getJavaType() == Block.class) {
             return type.getObject(block, position);
         }
-        else if (type.getJavaType() == Int128.class) {
+        if (type.getJavaType() == Int128.class) {
             return type.getObject(block, position);
         }
-        else {
-            throw new AssertionError("Unimplemented type: " + type);
-        }
+        throw new AssertionError("Unimplemented type: " + type);
     }
 
     private static Object nativeContainerToOrcValue(Type type, Object nativeValue)

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisRecordCursor.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisRecordCursor.java
@@ -379,19 +379,17 @@ public class RedisRecordCursor
                     log.debug("Set pushdown keys %s with single value", keys.toString());
                     return;
                 }
-                else {
-                    ValueSet valueSet = domain.getValues();
-                    if (valueSet instanceof SortedRangeSet) {
-                        Ranges ranges = ((SortedRangeSet) valueSet).getRanges();
-                        List<Range> rangeList = ranges.getOrderedRanges();
-                        if (rangeList.stream().allMatch(Range::isSingleValue)) {
-                            keys = rangeList.stream()
-                                    .map(range -> ((Slice) range.getSingleValue()).toStringUtf8())
-                                    .filter(str -> keyStringPrefix.isEmpty() || str.contains(keyStringPrefix))
-                                    .collect(toList());
-                            log.debug("Set pushdown keys %s with sorted range values", keys.toString());
-                            return;
-                        }
+                ValueSet valueSet = domain.getValues();
+                if (valueSet instanceof SortedRangeSet) {
+                    Ranges ranges = ((SortedRangeSet) valueSet).getRanges();
+                    List<Range> rangeList = ranges.getOrderedRanges();
+                    if (rangeList.stream().allMatch(Range::isSingleValue)) {
+                        keys = rangeList.stream()
+                                .map(range -> ((Slice) range.getSingleValue()).toStringUtf8())
+                                .filter(str -> keyStringPrefix.isEmpty() || str.contains(keyStringPrefix))
+                                .collect(toList());
+                        log.debug("Set pushdown keys %s with sorted range values", keys.toString());
+                        return;
                     }
                 }
             }

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/AbstractResourceConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/AbstractResourceConfigurationManager.java
@@ -112,15 +112,13 @@ public abstract class AbstractResourceConfigurationManager
         StringBuilder fullyQualifiedGroupName = new StringBuilder();
         for (ResourceGroupNameTemplate groupName : spec.getGroup().getSegments()) {
             fullyQualifiedGroupName.append(groupName);
-            Optional<ResourceGroupSpec> match = groups
+            ResourceGroupSpec match = groups
                     .stream()
                     .filter(groupSpec -> groupSpec.getName().equals(groupName))
-                    .findFirst();
-            if (match.isEmpty()) {
-                throw new IllegalArgumentException(format("Selector refers to nonexistent group: %s", fullyQualifiedGroupName));
-            }
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException(format("Selector refers to nonexistent group: %s", fullyQualifiedGroupName)));
             fullyQualifiedGroupName.append(".");
-            groups = match.get().getSubGroups();
+            groups = match.getSubGroups();
         }
     }
 

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/FlywayMigration.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/FlywayMigration.java
@@ -32,10 +32,10 @@ public class FlywayMigration
         if (configDbUrl.startsWith("jdbc:postgresql")) {
             return "/db/migration/postgresql";
         }
-        else if (configDbUrl.startsWith("jdbc:oracle")) {
+        if (configDbUrl.startsWith("jdbc:oracle")) {
             return "/db/migration/oracle";
         }
-        else if (configDbUrl.startsWith("jdbc:mysql")) {
+        if (configDbUrl.startsWith("jdbc:mysql")) {
             return "/db/migration/mysql";
         }
         // validation is not performed in DbResourceGroupConfig because DB backed

--- a/plugin/trino-thrift-api/src/main/java/io/trino/plugin/thrift/api/TrinoThriftBlock.java
+++ b/plugin/trino-thrift-api/src/main/java/io/trino/plugin/thrift/api/TrinoThriftBlock.java
@@ -300,9 +300,7 @@ public final class TrinoThriftBlock
             if (BigintType.BIGINT.equals(elementType)) {
                 return TrinoThriftBigintArray.fromBlock(block);
             }
-            else {
-                throw new IllegalArgumentException("Unsupported array block type: " + type);
-            }
+            throw new IllegalArgumentException("Unsupported array block type: " + type);
         }
         if (type.getBaseName().equals(JSON)) {
             return TrinoThriftJson.fromBlock(block, type);

--- a/plugin/trino-thrift-api/src/main/java/io/trino/plugin/thrift/api/valuesets/TrinoThriftValueSet.java
+++ b/plugin/trino-thrift-api/src/main/java/io/trino/plugin/thrift/api/valuesets/TrinoThriftValueSet.java
@@ -109,21 +109,19 @@ public final class TrinoThriftValueSet
                     null,
                     null);
         }
-        else if (valueSet.getClass() == EquatableValueSet.class) {
+        if (valueSet.getClass() == EquatableValueSet.class) {
             return new TrinoThriftValueSet(
                     null,
                     fromEquatableValueSet((EquatableValueSet) valueSet),
                     null);
         }
-        else if (valueSet.getClass() == SortedRangeSet.class) {
+        if (valueSet.getClass() == SortedRangeSet.class) {
             return new TrinoThriftValueSet(
                     null,
                     null,
                     fromSortedRangeSet((SortedRangeSet) valueSet));
         }
-        else {
-            throw new IllegalArgumentException("Unknown implementation of a value set: " + valueSet.getClass());
-        }
+        throw new IllegalArgumentException("Unknown implementation of a value set: " + valueSet.getClass());
     }
 
     private static boolean isExactlyOneNonNull(Object a, Object b, Object c)

--- a/plugin/trino-thrift-testing-server/src/main/java/io/trino/plugin/thrift/server/ThriftTpchService.java
+++ b/plugin/trino-thrift-testing-server/src/main/java/io/trino/plugin/thrift/server/ThriftTpchService.java
@@ -310,12 +310,10 @@ public class ThriftTpchService
         if (schemaNameOrNull == null) {
             return SCHEMAS;
         }
-        else if (SCHEMAS.contains(schemaNameOrNull)) {
+        if (SCHEMAS.contains(schemaNameOrNull)) {
             return ImmutableList.of(schemaNameOrNull);
         }
-        else {
-            return ImmutableList.of();
-        }
+        return ImmutableList.of();
     }
 
     private static String getTypeString(TpchColumn<?> column)

--- a/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftIndexPageSource.java
+++ b/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftIndexPageSource.java
@@ -262,13 +262,11 @@ public class ThriftIndexPageSource
             statusFuture = toCompletableFuture(nonCancellationPropagating(splitFuture));
             return false;
         }
-        else {
-            // no more splits
-            splitFuture = null;
-            statusFuture = null;
-            haveSplits = true;
-            return true;
-        }
+        // no more splits
+        splitFuture = null;
+        statusFuture = null;
+        haveSplits = true;
+        return true;
     }
 
     private void updateSignalAndStatusFutures()

--- a/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftMetadata.java
+++ b/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftMetadata.java
@@ -219,13 +219,8 @@ public class ThriftMetadata
 
     private ThriftTableMetadata getRequiredTableMetadata(SchemaTableName schemaTableName)
     {
-        Optional<ThriftTableMetadata> table = tableCache.getUnchecked(schemaTableName);
-        if (table.isEmpty()) {
-            throw new TableNotFoundException(schemaTableName);
-        }
-        else {
-            return table.get();
-        }
+        return tableCache.getUnchecked(schemaTableName)
+                .orElseThrow(() -> new TableNotFoundException(schemaTableName));
     }
 
     // this method makes actual thrift request and should be called only by cache load method

--- a/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftMetadata.java
+++ b/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftMetadata.java
@@ -161,9 +161,7 @@ public class ThriftMetadata
         if (tableMetadata.containsIndexableColumns(indexableColumns)) {
             return Optional.of(new ConnectorResolvedIndex(new ThriftIndexHandle(tableMetadata.getSchemaTableName(), tupleDomain, session), tupleDomain));
         }
-        else {
-            return Optional.empty();
-        }
+        return Optional.empty();
     }
 
     @Override

--- a/plugin/trino-tpcds/src/test/java/io/trino/plugin/tpcds/EstimateAssertion.java
+++ b/plugin/trino-tpcds/src/test/java/io/trino/plugin/tpcds/EstimateAssertion.java
@@ -72,8 +72,6 @@ class EstimateAssertion
         if (object instanceof Number) {
             return ((Number) object).doubleValue();
         }
-        else {
-            throw new UnsupportedOperationException(format("Can't compare with tolerance objects of class %s. Use assertEquals.", object.getClass()));
-        }
+        throw new UnsupportedOperationException(format("Can't compare with tolerance objects of class %s. Use assertEquals.", object.getClass()));
     }
 }

--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchMetadata.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchMetadata.java
@@ -288,21 +288,19 @@ public class TpchMetadata
         if (constraintSummary.isAll()) {
             return emptyMap();
         }
-        else if (constraintSummary.isNone()) {
+        if (constraintSummary.isNone()) {
             Set<TpchColumn<?>> columns = ImmutableSet.copyOf(tpchTable.getColumns());
             return asMap(columns, key -> emptyList());
         }
-        else {
-            Map<ColumnHandle, Domain> domains = constraintSummary.getDomains().orElseThrow();
-            Optional<Domain> orderStatusDomain = Optional.ofNullable(domains.get(toColumnHandle(OrderColumn.ORDER_STATUS)));
-            Optional<Map<TpchColumn<?>, List<Object>>> allowedColumnValues = orderStatusDomain.map(domain -> {
-                List<Object> allowedValues = ORDER_STATUS_VALUES.stream()
-                        .filter(domain::includesNullableValue)
-                        .collect(toList());
-                return avoidTrivialOrderStatusRestriction(allowedValues);
-            });
-            return allowedColumnValues.orElse(emptyMap());
-        }
+        Map<ColumnHandle, Domain> domains = constraintSummary.getDomains().orElseThrow();
+        Optional<Domain> orderStatusDomain = Optional.ofNullable(domains.get(toColumnHandle(OrderColumn.ORDER_STATUS)));
+        Optional<Map<TpchColumn<?>, List<Object>>> allowedColumnValues = orderStatusDomain.map(domain -> {
+            List<Object> allowedValues = ORDER_STATUS_VALUES.stream()
+                    .filter(domain::includesNullableValue)
+                    .collect(toList());
+            return avoidTrivialOrderStatusRestriction(allowedValues);
+        });
+        return allowedColumnValues.orElse(emptyMap());
     }
 
     private static Map<TpchColumn<?>, List<Object>> avoidTrivialOrderStatusRestriction(List<Object> allowedValues)
@@ -310,9 +308,7 @@ public class TpchMetadata
         if (allowedValues.containsAll(ORDER_STATUS_VALUES)) {
             return emptyMap();
         }
-        else {
-            return ImmutableMap.of(OrderColumn.ORDER_STATUS, allowedValues);
-        }
+        return ImmutableMap.of(OrderColumn.ORDER_STATUS, allowedValues);
     }
 
     private TableStatistics toTableStatistics(TableStatisticsData tableStatisticsData, TpchTableHandle tpchTableHandle, Map<String, ColumnHandle> columnHandles)

--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchRecordSet.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchRecordSet.java
@@ -253,15 +253,13 @@ public class TpchRecordSet<E extends TpchEntity>
             if (type.getJavaType() == long.class) {
                 return getLong(column);
             }
-            else if (type.getJavaType() == double.class) {
+            if (type.getJavaType() == double.class) {
                 return getDouble(column);
             }
-            else if (type.getJavaType() == Slice.class) {
+            if (type.getJavaType() == Slice.class) {
                 return getSlice(column);
             }
-            else {
-                throw new TrinoException(NOT_SUPPORTED, format("Unsupported column type %s", type.getDisplayName()));
-            }
+            throw new TrinoException(NOT_SUPPORTED, format("Unsupported column type %s", type.getDisplayName()));
         }
 
         private TpchColumn<E> getTpchColumn(int field)

--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/util/Optionals.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/util/Optionals.java
@@ -32,11 +32,9 @@ public final class Optionals
         if (left.isPresent() && right.isPresent()) {
             return Optional.of(combiner.apply(left.get(), right.get()));
         }
-        else if (left.isPresent()) {
+        if (left.isPresent()) {
             return left;
         }
-        else {
-            return right;
-        }
+        return right;
     }
 }

--- a/plugin/trino-tpch/src/test/java/io/trino/plugin/tpch/EstimateAssertion.java
+++ b/plugin/trino-tpch/src/test/java/io/trino/plugin/tpch/EstimateAssertion.java
@@ -78,8 +78,6 @@ class EstimateAssertion
         if (object instanceof Number) {
             return ((Number) object).doubleValue();
         }
-        else {
-            throw new UnsupportedOperationException(format("Can't compare with tolerance objects of class %s. Use assertEquals.", object.getClass()));
-        }
+        throw new UnsupportedOperationException(format("Can't compare with tolerance objects of class %s. Use assertEquals.", object.getClass()));
     }
 }

--- a/service/trino-verifier/src/main/java/io/trino/verifier/QueryRewriter.java
+++ b/service/trino-verifier/src/main/java/io/trino/verifier/QueryRewriter.java
@@ -110,7 +110,7 @@ public class QueryRewriter
             if (statement instanceof CreateTableAsSelect) {
                 return rewriteCreateTableAsSelect(connection, query, (CreateTableAsSelect) statement);
             }
-            else if (statement instanceof Insert) {
+            if (statement instanceof Insert) {
                 return rewriteInsertQuery(connection, query, (Insert) statement);
             }
         }

--- a/service/trino-verifier/src/main/java/io/trino/verifier/Validator.java
+++ b/service/trino-verifier/src/main/java/io/trino/verifier/Validator.java
@@ -321,7 +321,7 @@ public class Validator
             if (queryResult.getState() == State.TIMEOUT) {
                 return queryResult;
             }
-            else if (queryResult.getState() != State.SUCCESS) {
+            if (queryResult.getState() != State.SUCCESS) {
                 return new QueryResult(State.FAILED_TO_SETUP, queryResult.getException(), queryResult.getWallTime(), queryResult.getCpuTime(), queryResult.getQueryId(), ImmutableList.of(), ImmutableList.of());
             }
         }
@@ -812,10 +812,8 @@ public class Validator
         if (a == 0 || b == 0 || diff < Float.MIN_NORMAL) {
             return diff < (epsilon * Float.MIN_NORMAL);
         }
-        else {
-            // use relative error
-            return diff / Math.min((absA + absB), Float.MAX_VALUE) < epsilon;
-        }
+        // use relative error
+        return diff / Math.min((absA + absB), Float.MAX_VALUE) < epsilon;
     }
 
     @VisibleForTesting
@@ -861,9 +859,7 @@ public class Validator
             if (changed == Changed.ADDED) {
                 return "+ " + row;
             }
-            else {
-                return "- " + row;
-            }
+            return "- " + row;
         }
 
         @Override

--- a/service/trino-verifier/src/main/java/io/trino/verifier/Verifier.java
+++ b/service/trino-verifier/src/main/java/io/trino/verifier/Verifier.java
@@ -220,9 +220,7 @@ public class Verifier
             // If so disable correctness checking
             return false;
         }
-        else {
-            return config.isCheckCorrectnessEnabled();
-        }
+        return config.isCheckCorrectnessEnabled();
     }
 
     private VerifierQueryEvent buildEvent(Validator validator)

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/OptionsPrinter.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/OptionsPrinter.java
@@ -84,7 +84,7 @@ public final class OptionsPrinter
             if ((boolean) value) {
                 return annotation.names()[0].replaceFirst("--no-", "--");
             }
-            else if (annotation.negatable()) {
+            if (annotation.negatable()) {
                 return annotation.names()[0];
             }
 
@@ -103,9 +103,7 @@ public final class OptionsPrinter
             if (((Optional<?>) value).isPresent()) {
                 return formatOption(((Optional<?>) value).get(), annotation);
             }
-            else {
-                return null;
-            }
+            return null;
         }
 
         if (value instanceof Map) {

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/ImmutableLdapObjectDefinitions.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/ImmutableLdapObjectDefinitions.java
@@ -78,10 +78,8 @@ public final class ImmutableLdapObjectDefinitions
         if (childGroupNames.isPresent()) {
             return buildLdapGroupObject(groupName, AMERICA_DISTINGUISHED_NAME, userName, ASIA_DISTINGUISHED_NAME, childGroupNames, Optional.of(AMERICA_DISTINGUISHED_NAME));
         }
-        else {
-            return buildLdapGroupObject(groupName, AMERICA_DISTINGUISHED_NAME, userName, ASIA_DISTINGUISHED_NAME,
-                    Optional.empty(), Optional.empty());
-        }
+        return buildLdapGroupObject(groupName, AMERICA_DISTINGUISHED_NAME, userName, ASIA_DISTINGUISHED_NAME,
+                Optional.empty(), Optional.empty());
     }
 
     public static LdapObjectDefinition buildLdapGroupObject(String groupName, String groupOrganizationName,
@@ -97,15 +95,13 @@ public final class ImmutableLdapObjectDefinitions
                     .setObjectClasses(Arrays.asList("groupOfNames"))
                     .build();
         }
-        else {
-            return LdapObjectDefinition.builder(groupName)
-                    .setDistinguishedName(format("cn=%s,%s", groupName, groupOrganizationName))
-                    .setAttributes(ImmutableMap.of(
-                            "cn", groupName,
-                            "member", format("uid=%s,%s", userName, userOrganizationName)))
-                    .setObjectClasses(Arrays.asList("groupOfNames"))
-                    .build();
-        }
+        return LdapObjectDefinition.builder(groupName)
+                .setDistinguishedName(format("cn=%s,%s", groupName, groupOrganizationName))
+                .setAttributes(ImmutableMap.of(
+                        "cn", groupName,
+                        "member", format("uid=%s,%s", userName, userOrganizationName)))
+                .setObjectClasses(Arrays.asList("groupOfNames"))
+                .build();
     }
 
     public static LdapObjectDefinition buildLdapUserObject(String userName, Optional<List<String>> groupNames, String password)
@@ -114,10 +110,8 @@ public final class ImmutableLdapObjectDefinitions
             return buildLdapUserObject(userName, ASIA_DISTINGUISHED_NAME,
                     groupNames, Optional.of(AMERICA_DISTINGUISHED_NAME), password);
         }
-        else {
-            return buildLdapUserObject(userName, ASIA_DISTINGUISHED_NAME,
-                    Optional.empty(), Optional.empty(), password);
-        }
+        return buildLdapUserObject(userName, ASIA_DISTINGUISHED_NAME,
+                Optional.empty(), Optional.empty(), password);
     }
 
     public static LdapObjectDefinition buildLdapUserObject(String userName, String userOrganizationName,
@@ -134,16 +128,14 @@ public final class ImmutableLdapObjectDefinitions
                     .setModificationAttributes(getAttributes(groupNames.get(), groupOrganizationName.get(), MEMBER_OF))
                     .build();
         }
-        else {
-            return LdapObjectDefinition.builder(userName)
-                    .setDistinguishedName(format("uid=%s,%s", userName, userOrganizationName))
-                    .setAttributes(ImmutableMap.of(
-                            "cn", userName,
-                            "sn", userName,
-                            "userPassword", password))
-                    .setObjectClasses(Arrays.asList("person", "inetOrgPerson"))
-                    .build();
-        }
+        return LdapObjectDefinition.builder(userName)
+                .setDistinguishedName(format("uid=%s,%s", userName, userOrganizationName))
+                .setAttributes(ImmutableMap.of(
+                        "cn", userName,
+                        "sn", userName,
+                        "userPassword", password))
+                .setObjectClasses(Arrays.asList("person", "inetOrgPerson"))
+                .build();
     }
 
     private static ImmutableMap<String, List<String>> getAttributes(List<String> groupNames, String groupOrganizationName, String relation)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAllDatatypesFromHiveConnector.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAllDatatypesFromHiveConnector.java
@@ -410,9 +410,7 @@ public class TestAllDatatypesFromHiveConnector
         if (tableDefinition.getDatabase().isPresent()) {
             return mutableTableInstanceOf(tableDefinition, tableDefinition.getDatabase().get());
         }
-        else {
-            return mutableTableInstanceOf(tableHandleInSchema(tableDefinition));
-        }
+        return mutableTableInstanceOf(tableHandleInSchema(tableDefinition));
     }
 
     private static TableInstance<?> mutableTableInstanceOf(TableDefinition tableDefinition, String database)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercion.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercion.java
@@ -719,9 +719,7 @@ public class TestHiveCoercion
         if (tableDefinition.getDatabase().isPresent()) {
             return mutableTableInstanceOf(tableDefinition, tableDefinition.getDatabase().get());
         }
-        else {
-            return mutableTableInstanceOf(tableHandleInSchema(tableDefinition));
-        }
+        return mutableTableInstanceOf(tableHandleInSchema(tableDefinition));
     }
 
     private static TableInstance<?> mutableTableInstanceOf(TableDefinition tableDefinition, String database)

--- a/testing/trino-testing/src/main/java/io/trino/testing/StructuralTestUtil.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/StructuralTestUtil.java
@@ -132,10 +132,8 @@ public final class StructuralTestUtil
             long longDecimal = decimal.unscaledValue().longValue();
             return arrayBlockOf(type, longDecimal);
         }
-        else {
-            Int128 sliceDecimal = Int128.valueOf(decimal.unscaledValue());
-            return arrayBlockOf(type, sliceDecimal);
-        }
+        Int128 sliceDecimal = Int128.valueOf(decimal.unscaledValue());
+        return arrayBlockOf(type, sliceDecimal);
     }
 
     public static Block decimalMapBlockOf(DecimalType type, BigDecimal decimal)
@@ -144,10 +142,8 @@ public final class StructuralTestUtil
             long longDecimal = decimal.unscaledValue().longValue();
             return mapBlockOf(type, type, longDecimal, longDecimal);
         }
-        else {
-            Int128 sliceDecimal = Int128.valueOf(decimal.unscaledValue());
-            return mapBlockOf(type, type, sliceDecimal, sliceDecimal);
-        }
+        Int128 sliceDecimal = Int128.valueOf(decimal.unscaledValue());
+        return mapBlockOf(type, type, sliceDecimal, sliceDecimal);
     }
 
     public static MapType mapType(Type keyType, Type valueType)

--- a/testing/trino-testing/src/main/java/io/trino/testing/tpch/AppendingRecordSet.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/tpch/AppendingRecordSet.java
@@ -100,9 +100,7 @@ class AppendingRecordSet
             if (field < delegateFieldCount) {
                 return delegate.getType(field);
             }
-            else {
-                return appendedTypes.get(field - delegateFieldCount);
-            }
+            return appendedTypes.get(field - delegateFieldCount);
         }
 
         @Override
@@ -118,9 +116,7 @@ class AppendingRecordSet
             if (field < delegateFieldCount) {
                 return delegate.getBoolean(field);
             }
-            else {
-                return (Boolean) appendedValues.get(field - delegateFieldCount);
-            }
+            return (Boolean) appendedValues.get(field - delegateFieldCount);
         }
 
         @Override
@@ -130,9 +126,7 @@ class AppendingRecordSet
             if (field < delegateFieldCount) {
                 return delegate.getLong(field);
             }
-            else {
-                return (Long) appendedValues.get(field - delegateFieldCount);
-            }
+            return (Long) appendedValues.get(field - delegateFieldCount);
         }
 
         @Override
@@ -142,9 +136,7 @@ class AppendingRecordSet
             if (field < delegateFieldCount) {
                 return delegate.getDouble(field);
             }
-            else {
-                return (Double) appendedValues.get(field - delegateFieldCount);
-            }
+            return (Double) appendedValues.get(field - delegateFieldCount);
         }
 
         @Override
@@ -154,9 +146,7 @@ class AppendingRecordSet
             if (field < delegateFieldCount) {
                 return delegate.getSlice(field);
             }
-            else {
-                return (Slice) appendedValues.get(field - delegateFieldCount);
-            }
+            return (Slice) appendedValues.get(field - delegateFieldCount);
         }
 
         @Override
@@ -172,9 +162,7 @@ class AppendingRecordSet
             if (field < delegateFieldCount) {
                 return delegate.isNull(field);
             }
-            else {
-                return appendedValues.get(field - delegateFieldCount) == null;
-            }
+            return appendedValues.get(field - delegateFieldCount) == null;
         }
 
         @Override


### PR DESCRIPTION
Use of `Optional.orElseThrow` allows to verify the optional is not empty
before assigning to a variable. This subsequently removes need for
`Optional.get()` calls.


--------------
please ignore this section

- [ ] a checkbox
- [ ] another checkbox
