### PR TITLE
Push whole join condition into connectors

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -31,7 +31,6 @@ import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.ConstraintApplicationResult;
 import io.trino.spi.connector.JoinApplicationResult;
-import io.trino.spi.connector.JoinCondition;
 import io.trino.spi.connector.JoinStatistics;
 import io.trino.spi.connector.JoinType;
 import io.trino.spi.connector.LimitApplicationResult;
@@ -494,7 +493,7 @@ public interface Metadata
             JoinType joinType,
             TableHandle left,
             TableHandle right,
-            List<JoinCondition> joinConditions,
+            ConnectorExpression joinCondition,
             Map<String, ColumnHandle> leftAssignments,
             Map<String, ColumnHandle> rightAssignments,
             JoinStatistics statistics);

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -62,7 +62,6 @@ import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.ConstraintApplicationResult;
 import io.trino.spi.connector.JoinApplicationResult;
-import io.trino.spi.connector.JoinCondition;
 import io.trino.spi.connector.JoinStatistics;
 import io.trino.spi.connector.JoinType;
 import io.trino.spi.connector.LimitApplicationResult;
@@ -1619,7 +1618,7 @@ public final class MetadataManager
             JoinType joinType,
             TableHandle left,
             TableHandle right,
-            List<JoinCondition> joinConditions,
+            ConnectorExpression joinCondition,
             Map<String, ColumnHandle> leftAssignments,
             Map<String, ColumnHandle> rightAssignments,
             JoinStatistics statistics)
@@ -1640,7 +1639,7 @@ public final class MetadataManager
                         joinType,
                         left.getConnectorHandle(),
                         right.getConnectorHandle(),
-                        joinConditions,
+                        joinCondition,
                         leftAssignments,
                         rightAssignments,
                         statistics);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/ConnectorExpressionTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ConnectorExpressionTranslator.java
@@ -125,9 +125,9 @@ public final class ConnectorExpressionTranslator
                 .orElseThrow(() -> new UnsupportedOperationException("Expression is not supported: " + expression.toString()));
     }
 
-    public static Optional<ConnectorExpression> translate(Session session, Expression expression, TypeAnalyzer types, TypeProvider inputTypes, PlannerContext plannerContext)
+    public static Optional<ConnectorExpression> translate(Session session, Expression expression, TypeProvider types, PlannerContext plannerContext, TypeAnalyzer typeAnalyzer)
     {
-        return new SqlToConnectorExpressionTranslator(session, types.getTypes(session, inputTypes, expression), plannerContext)
+        return new SqlToConnectorExpressionTranslator(session, typeAnalyzer.getTypes(session, types, expression), plannerContext)
                 .process(expression);
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -836,7 +836,7 @@ public class PlanOptimizers
                             .addAll(pushIntoTableScanRulesExceptJoins)
                             // PushJoinIntoTableScan must run after ReorderJoins (and DetermineJoinDistributionType)
                             // otherwise too early pushdown could prevent optimal plan from being selected.
-                            .add(new PushJoinIntoTableScan(metadata))
+                            .add(new PushJoinIntoTableScan(plannerContext, typeAnalyzer))
                             // DetermineTableScanNodePartitioning is needed to needs to ensure all table handles have proper partitioning determined
                             // Must run before AddExchanges
                             .add(new DetermineTableScanNodePartitioning(metadata, nodePartitioningManager, taskCountEstimator))

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushJoinIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushJoinIntoTableScan.java
@@ -15,25 +15,24 @@ package io.trino.sql.planner.iterative.rule;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
 import io.trino.cost.PlanNodeStatsEstimate;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
-import io.trino.metadata.Metadata;
 import io.trino.metadata.TableHandle;
 import io.trino.spi.connector.BasicRelationStatistics;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.JoinApplicationResult;
-import io.trino.spi.connector.JoinCondition;
 import io.trino.spi.connector.JoinStatistics;
 import io.trino.spi.connector.JoinType;
-import io.trino.spi.expression.Variable;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
-import io.trino.sql.ExpressionUtils;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.planner.ConnectorExpressionTranslator;
+import io.trino.sql.planner.ConnectorExpressionTranslator.ConnectorExpressionTranslation;
 import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.TypeAnalyzer;
 import io.trino.sql.planner.TypeProvider;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.plan.Assignments;
@@ -43,14 +42,11 @@ import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.ProjectNode;
 import io.trino.sql.planner.plan.TableScanNode;
 import io.trino.sql.tree.BooleanLiteral;
-import io.trino.sql.tree.ComparisonExpression;
 import io.trino.sql.tree.Expression;
-import io.trino.sql.tree.SymbolReference;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -59,7 +55,6 @@ import static io.trino.SystemSessionProperties.isAllowPushdownIntoConnectors;
 import static io.trino.matching.Capture.newCapture;
 import static io.trino.spi.predicate.Domain.onlyNull;
 import static io.trino.sql.ExpressionUtils.and;
-import static io.trino.sql.ExpressionUtils.extractConjuncts;
 import static io.trino.sql.planner.iterative.rule.Rules.deriveTableStatisticsForPushdown;
 import static io.trino.sql.planner.plan.JoinNode.Type.FULL;
 import static io.trino.sql.planner.plan.JoinNode.Type.LEFT;
@@ -81,11 +76,13 @@ public class PushJoinIntoTableScan
                     .with(left().matching(tableScan().capturedAs(LEFT_TABLE_SCAN)))
                     .with(right().matching(tableScan().capturedAs(RIGHT_TABLE_SCAN)));
 
-    private final Metadata metadata;
+    private final PlannerContext plannerContext;
+    private final TypeAnalyzer typeAnalyzer;
 
-    public PushJoinIntoTableScan(Metadata metadata)
+    public PushJoinIntoTableScan(PlannerContext plannerContext, TypeAnalyzer typeAnalyzer)
     {
-        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
+        this.typeAnalyzer = requireNonNull(typeAnalyzer, "typeAnalyzer is null");
     }
 
     @Override
@@ -113,9 +110,14 @@ public class PushJoinIntoTableScan
         verify(!left.isUpdateTarget() && !right.isUpdateTarget(), "Unexpected Join over for-update table scan");
 
         Expression effectiveFilter = getEffectiveFilter(joinNode);
-        FilterSplitResult filterSplitResult = splitFilter(effectiveFilter, left.getOutputSymbols(), right.getOutputSymbols(), context);
+        ConnectorExpressionTranslation translation = ConnectorExpressionTranslator.translateConjuncts(
+                context.getSession(),
+                effectiveFilter,
+                context.getSymbolAllocator().getTypes(),
+                plannerContext,
+                typeAnalyzer);
 
-        if (!filterSplitResult.getRemainingFilter().equals(BooleanLiteral.TRUE_LITERAL)) {
+        if (!translation.remainingExpression().equals(BooleanLiteral.TRUE_LITERAL)) {
             // TODO add extra filter node above join
             return Result.empty();
         }
@@ -144,13 +146,13 @@ public class PushJoinIntoTableScan
          */
         JoinStatistics joinStatistics = getJoinStatistics(joinNode, left, right, context);
 
-        Optional<JoinApplicationResult<TableHandle>> joinApplicationResult = metadata.applyJoin(
+        Optional<JoinApplicationResult<TableHandle>> joinApplicationResult = plannerContext.getMetadata().applyJoin(
                 context.getSession(),
                 getJoinType(joinNode),
                 left.getTable(),
                 right.getTable(),
-                filterSplitResult.getPushableConditions(),
-                // TODO we could pass only subset of assignments here, those which are needed to resolve filterSplitResult.getPushableConditions
+                translation.connectorExpression(),
+                // TODO we could pass only subset of assignments here, those which are needed to resolve translation.getPushableConditions
                 leftAssignments,
                 rightAssignments,
                 joinStatistics);
@@ -252,88 +254,6 @@ public class PushJoinIntoTableScan
             effectiveFilter = and(effectiveFilter, node.getFilter().get());
         }
         return effectiveFilter;
-    }
-
-    private FilterSplitResult splitFilter(Expression filter, List<Symbol> leftSymbolsList, List<Symbol> rightSymbolsList, Context context)
-    {
-        Set<Symbol> leftSymbols = ImmutableSet.copyOf(leftSymbolsList);
-        Set<Symbol> rightSymbols = ImmutableSet.copyOf(rightSymbolsList);
-
-        ImmutableList.Builder<JoinCondition> comparisonConditions = ImmutableList.builder();
-        ImmutableList.Builder<Expression> remainingConjuncts = ImmutableList.builder();
-
-        for (Expression conjunct : extractConjuncts(filter)) {
-            getPushableJoinCondition(conjunct, leftSymbols, rightSymbols, context)
-                    .ifPresentOrElse(comparisonConditions::add, () -> remainingConjuncts.add(conjunct));
-        }
-
-        return new FilterSplitResult(comparisonConditions.build(), ExpressionUtils.and(remainingConjuncts.build()));
-    }
-
-    private Optional<JoinCondition> getPushableJoinCondition(Expression conjunct, Set<Symbol> leftSymbols, Set<Symbol> rightSymbols, Context context)
-    {
-        if (!(conjunct instanceof ComparisonExpression)) {
-            return Optional.empty();
-        }
-        ComparisonExpression comparison = (ComparisonExpression) conjunct;
-
-        if (!(comparison.getLeft() instanceof SymbolReference) || !(comparison.getRight() instanceof SymbolReference)) {
-            return Optional.empty();
-        }
-        Symbol left = Symbol.from(comparison.getLeft());
-        Symbol right = Symbol.from(comparison.getRight());
-        ComparisonExpression.Operator operator = comparison.getOperator();
-
-        if (!leftSymbols.contains(left)) {
-            // lets try with flipped expression
-            Symbol tmp = left;
-            left = right;
-            right = tmp;
-            operator = operator.flip();
-        }
-
-        if (leftSymbols.contains(left) && rightSymbols.contains(right)) {
-            return Optional.of(new JoinCondition(
-                    joinConditionOperator(operator),
-                    new Variable(left.getName(), context.getSymbolAllocator().getTypes().get(left)),
-                    new Variable(right.getName(), context.getSymbolAllocator().getTypes().get(right))));
-        }
-        return Optional.empty();
-    }
-
-    private static class FilterSplitResult
-    {
-        private final List<JoinCondition> pushableConditions;
-        private final Expression remainingFilter;
-
-        public FilterSplitResult(List<JoinCondition> pushableConditions, Expression remainingFilter)
-        {
-            this.pushableConditions = requireNonNull(pushableConditions, "pushableConditions is null");
-            this.remainingFilter = requireNonNull(remainingFilter, "remainingFilter is null");
-        }
-
-        public List<JoinCondition> getPushableConditions()
-        {
-            return pushableConditions;
-        }
-
-        public Expression getRemainingFilter()
-        {
-            return remainingFilter;
-        }
-    }
-
-    private JoinCondition.Operator joinConditionOperator(ComparisonExpression.Operator operator)
-    {
-        return switch (operator) {
-            case EQUAL -> JoinCondition.Operator.EQUAL;
-            case NOT_EQUAL -> JoinCondition.Operator.NOT_EQUAL;
-            case LESS_THAN -> JoinCondition.Operator.LESS_THAN;
-            case LESS_THAN_OR_EQUAL -> JoinCondition.Operator.LESS_THAN_OR_EQUAL;
-            case GREATER_THAN -> JoinCondition.Operator.GREATER_THAN;
-            case GREATER_THAN_OR_EQUAL -> JoinCondition.Operator.GREATER_THAN_OR_EQUAL;
-            case IS_DISTINCT_FROM -> JoinCondition.Operator.IS_DISTINCT_FROM;
-        };
     }
 
     private JoinType getJoinType(JoinNode joinNode)

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -37,7 +37,6 @@ import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.ConstraintApplicationResult;
 import io.trino.spi.connector.JoinApplicationResult;
-import io.trino.spi.connector.JoinCondition;
 import io.trino.spi.connector.JoinStatistics;
 import io.trino.spi.connector.JoinType;
 import io.trino.spi.connector.LimitApplicationResult;
@@ -611,7 +610,7 @@ public abstract class AbstractMockMetadata
             JoinType joinType,
             TableHandle left,
             TableHandle right,
-            List<JoinCondition> joinConditions,
+            ConnectorExpression joinCondition,
             Map<String, ColumnHandle> leftAssignments,
             Map<String, ColumnHandle> rightAssignments,
             JoinStatistics statistics)

--- a/core/trino-main/src/test/java/io/trino/metadata/CountingAccessMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/CountingAccessMetadata.java
@@ -33,7 +33,6 @@ import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.ConstraintApplicationResult;
 import io.trino.spi.connector.JoinApplicationResult;
-import io.trino.spi.connector.JoinCondition;
 import io.trino.spi.connector.JoinStatistics;
 import io.trino.spi.connector.JoinType;
 import io.trino.spi.connector.LimitApplicationResult;
@@ -611,9 +610,9 @@ public class CountingAccessMetadata
     }
 
     @Override
-    public Optional<JoinApplicationResult<TableHandle>> applyJoin(Session session, JoinType joinType, TableHandle left, TableHandle right, List<JoinCondition> joinConditions, Map<String, ColumnHandle> leftAssignments, Map<String, ColumnHandle> rightAssignments, JoinStatistics statistics)
+    public Optional<JoinApplicationResult<TableHandle>> applyJoin(Session session, JoinType joinType, TableHandle left, TableHandle right, ConnectorExpression joinCondition, Map<String, ColumnHandle> leftAssignments, Map<String, ColumnHandle> rightAssignments, JoinStatistics statistics)
     {
-        return delegate.applyJoin(session, joinType, left, right, joinConditions, leftAssignments, rightAssignments, statistics);
+        return delegate.applyJoin(session, joinType, left, right, joinCondition, leftAssignments, rightAssignments, statistics);
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestConnectorExpressionTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestConnectorExpressionTranslator.java
@@ -470,7 +470,7 @@ public class TestConnectorExpressionTranslator
 
     private void assertTranslationToConnectorExpression(Session session, Expression expression, Optional<ConnectorExpression> connectorExpression)
     {
-        Optional<ConnectorExpression> translation = translate(session, expression, TYPE_ANALYZER, TYPE_PROVIDER, PLANNER_CONTEXT);
+        Optional<ConnectorExpression> translation = translate(session, expression, TYPE_PROVIDER, PLANNER_CONTEXT, TYPE_ANALYZER);
         assertEquals(connectorExpression.isPresent(), translation.isPresent());
         translation.ifPresent(value -> assertEquals(value, connectorExpression.get()));
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestPartialTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestPartialTranslator.java
@@ -101,7 +101,7 @@ public class TestPartialTranslator
         Map<NodeRef<Expression>, ConnectorExpression> translation = extractPartialTranslations(expression, TEST_SESSION, TYPE_ANALYZER, TYPE_PROVIDER, PLANNER_CONTEXT);
         assertEquals(subexpressions.size(), translation.size());
         for (Expression subexpression : subexpressions) {
-            assertEquals(translation.get(NodeRef.of(subexpression)), translate(TEST_SESSION, subexpression, TYPE_ANALYZER, TYPE_PROVIDER, PLANNER_CONTEXT).get());
+            assertEquals(translation.get(NodeRef.of(subexpression)), translate(TEST_SESSION, subexpression, TYPE_PROVIDER, PLANNER_CONTEXT, TYPE_ANALYZER).get());
         }
     }
 
@@ -109,6 +109,6 @@ public class TestPartialTranslator
     {
         Map<NodeRef<Expression>, ConnectorExpression> translation = extractPartialTranslations(expression, TEST_SESSION, TYPE_ANALYZER, TYPE_PROVIDER, PLANNER_CONTEXT);
         assertEquals(getOnlyElement(translation.keySet()), NodeRef.of(expression));
-        assertEquals(getOnlyElement(translation.values()), translate(TEST_SESSION, expression, TYPE_ANALYZER, TYPE_PROVIDER, PLANNER_CONTEXT).get());
+        assertEquals(getOnlyElement(translation.values()), translate(TEST_SESSION, expression, TYPE_PROVIDER, PLANNER_CONTEXT, TYPE_ANALYZER).get());
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushProjectionIntoTableScan.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushProjectionIntoTableScan.java
@@ -154,7 +154,7 @@ public class TestPushProjectionIntoTableScan
             TransactionId transactionId = ruleTester.getQueryRunner().getTransactionManager().beginTransaction(false);
             Session session = MOCK_SESSION.beginTransactionId(transactionId, ruleTester.getQueryRunner().getTransactionManager(), ruleTester.getQueryRunner().getAccessControl());
             ImmutableMap<Symbol, String> connectorNames = inputProjections.entrySet().stream()
-                    .collect(toImmutableMap(Map.Entry::getKey, e -> translate(session, e.getValue(), typeAnalyzer, viewOf(types), ruleTester.getPlannerContext()).get().toString()));
+                    .collect(toImmutableMap(Map.Entry::getKey, e -> translate(session, e.getValue(), viewOf(types), ruleTester.getPlannerContext(), typeAnalyzer).get().toString()));
             ImmutableMap<Symbol, String> newNames = ImmutableMap.of(
                     identity, "projected_variable_" + connectorNames.get(identity),
                     dereference, "projected_dereference_" + connectorNames.get(dereference),

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -15,6 +15,7 @@ package io.trino.spi.connector;
 
 import io.airlift.slice.Slice;
 import io.trino.spi.TrinoException;
+import io.trino.spi.expression.Call;
 import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.expression.Constant;
 import io.trino.spi.expression.Variable;
@@ -36,6 +37,7 @@ import io.trino.spi.statistics.TableStatisticsMetadata;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -49,6 +51,7 @@ import java.util.stream.Collectors;
 
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.expression.StandardFunctions.AND_FUNCTION_NAME;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toUnmodifiableList;
@@ -1282,6 +1285,50 @@ public interface ConnectorMetadata
      * It is required that mapping is provided for *all* column handles exposed previously by both left and right join sources.
      * </p>
      */
+    default Optional<JoinApplicationResult<ConnectorTableHandle>> applyJoin(
+            ConnectorSession session,
+            JoinType joinType,
+            ConnectorTableHandle left,
+            ConnectorTableHandle right,
+            ConnectorExpression joinCondition,
+            Map<String, ColumnHandle> leftAssignments,
+            Map<String, ColumnHandle> rightAssignments,
+            JoinStatistics statistics)
+    {
+        List<JoinCondition> conditions;
+        if (joinCondition instanceof Call call && AND_FUNCTION_NAME.equals(call.getFunctionName())) {
+            conditions = new ArrayList<>(call.getArguments().size());
+            for (ConnectorExpression argument : call.getArguments()) {
+                if (Constant.TRUE.equals(argument)) {
+                    continue;
+                }
+                Optional<JoinCondition> condition = JoinCondition.from(argument, leftAssignments.keySet(), rightAssignments.keySet());
+                if (condition.isEmpty()) {
+                    // We would need to add a FilterNode on top of the result
+                    return Optional.empty();
+                }
+                conditions.add(condition.get());
+            }
+        }
+        else {
+            Optional<JoinCondition> condition = JoinCondition.from(joinCondition, leftAssignments.keySet(), rightAssignments.keySet());
+            if (condition.isEmpty()) {
+                return Optional.empty();
+            }
+            conditions = List.of(condition.get());
+        }
+        return applyJoin(
+                session,
+                joinType,
+                left,
+                right,
+                conditions,
+                leftAssignments,
+                rightAssignments,
+                statistics);
+    }
+
+    @Deprecated
     default Optional<JoinApplicationResult<ConnectorTableHandle>> applyJoin(
             ConnectorSession session,
             JoinType joinType,

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/JoinCondition.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/JoinCondition.java
@@ -13,36 +13,113 @@
  */
 package io.trino.spi.connector;
 
+import io.trino.spi.expression.Call;
 import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.expression.StandardFunctions;
+import io.trino.spi.expression.Variable;
 
+import java.util.ArrayDeque;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.Set;
+import java.util.stream.Stream;
 
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toUnmodifiableMap;
 
+@Deprecated
 public final class JoinCondition
 {
+    @Deprecated
     public enum Operator
     {
-        EQUAL("="),
-        NOT_EQUAL("<>"),
-        LESS_THAN("<"),
-        LESS_THAN_OR_EQUAL("<="),
-        GREATER_THAN(">"),
-        GREATER_THAN_OR_EQUAL(">="),
-        IS_DISTINCT_FROM("IS DISTINCT FROM");
+        EQUAL("=", StandardFunctions.EQUAL_OPERATOR_FUNCTION_NAME),
+        NOT_EQUAL("<>", StandardFunctions.NOT_EQUAL_OPERATOR_FUNCTION_NAME),
+        LESS_THAN("<", StandardFunctions.LESS_THAN_OPERATOR_FUNCTION_NAME),
+        LESS_THAN_OR_EQUAL("<=", StandardFunctions.LESS_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME),
+        GREATER_THAN(">", StandardFunctions.GREATER_THAN_OPERATOR_FUNCTION_NAME),
+        GREATER_THAN_OR_EQUAL(">=", StandardFunctions.GREATER_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME),
+        IS_DISTINCT_FROM("IS DISTINCT FROM", StandardFunctions.IS_DISTINCT_FROM_OPERATOR_FUNCTION_NAME),
+        /**/;
+
+        private static final Map<FunctionName, Operator> byFunctionName = Stream.of(values())
+                .collect(toUnmodifiableMap(operator -> operator.callFunctionName, identity()));
 
         private final String value;
+        private final FunctionName callFunctionName;
 
-        Operator(String value)
+        Operator(String value, FunctionName callFunctionName)
         {
             this.value = value;
+            this.callFunctionName = callFunctionName;
         }
 
         public String getValue()
         {
             return value;
         }
+
+        public Operator flip()
+        {
+            return switch (this) {
+                case EQUAL, NOT_EQUAL, IS_DISTINCT_FROM -> this;
+                case LESS_THAN -> GREATER_THAN;
+                case LESS_THAN_OR_EQUAL -> GREATER_THAN_OR_EQUAL;
+                case GREATER_THAN -> LESS_THAN;
+                case GREATER_THAN_OR_EQUAL -> LESS_THAN_OR_EQUAL;
+            };
+        }
+    }
+
+    public static Optional<JoinCondition> from(ConnectorExpression expression, Set<String> leftSymbols, Set<String> rightSymbols)
+    {
+        if (expression instanceof Call call && call.getArguments().size() == 2) {
+            return Optional.ofNullable(Operator.byFunctionName.get(call.getFunctionName()))
+                    .flatMap(operator -> {
+                        rightSymbols.stream().filter(leftSymbols::contains).findAny().ifPresent(symbol -> {
+                            throw new IllegalArgumentException(
+                                    "Left and right symbol sets overlap, are both include %s: %s, %s".formatted(symbol, leftSymbols, rightSymbols));
+                        });
+                        ConnectorExpression left = call.getArguments().get(0);
+                        ConnectorExpression right = call.getArguments().get(1);
+                        Set<String> leftExpressionSymbols = findVariableNames(left);
+                        Set<String> rightExpressionSymbols = findVariableNames(right);
+                        if (leftSymbols.containsAll(leftExpressionSymbols) && rightSymbols.containsAll(rightExpressionSymbols)) {
+                            return Optional.of(new JoinCondition(operator, left, right));
+                        }
+                        if (rightSymbols.containsAll(leftExpressionSymbols) && leftSymbols.containsAll(rightExpressionSymbols)) {
+                            // normalize
+                            return Optional.of(new JoinCondition(operator.flip(), right, left));
+                        }
+                        return Optional.empty();
+                    });
+        }
+        return Optional.empty();
+    }
+
+    private static Set<String> findVariableNames(ConnectorExpression expression)
+    {
+        Set<String> variableNames = new HashSet<>();
+        Set<ConnectorExpression> visited = new HashSet<>();
+        Queue<ConnectorExpression> pending = new ArrayDeque<>(List.of(expression));
+        while (!pending.isEmpty()) {
+            ConnectorExpression next = pending.remove();
+            if (!visited.add(next)) {
+                continue;
+            }
+            pending.addAll(next.getChildren());
+            if (next instanceof Variable variable) {
+                variableNames.add(variable.getName());
+            }
+        }
+        return variableNames;
     }
 
     private final Operator operator;

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -914,6 +914,22 @@ public class ClassLoaderSafeConnectorMetadata
             JoinType joinType,
             ConnectorTableHandle left,
             ConnectorTableHandle right,
+            ConnectorExpression joinCondition,
+            Map<String, ColumnHandle> leftAssignments,
+            Map<String, ColumnHandle> rightAssignments,
+            JoinStatistics statistics)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.applyJoin(session, joinType, left, right, joinCondition, leftAssignments, rightAssignments, statistics);
+        }
+    }
+
+    @Override
+    public Optional<JoinApplicationResult<ConnectorTableHandle>> applyJoin(
+            ConnectorSession session,
+            JoinType joinType,
+            ConnectorTableHandle left,
+            ConnectorTableHandle right,
             List<JoinCondition> joinConditions,
             Map<String, ColumnHandle> leftAssignments,
             Map<String, ColumnHandle> rightAssignments,

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestConstraintExtractor.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestConstraintExtractor.java
@@ -239,10 +239,10 @@ public class TestConstraintExtractor
         return ConnectorExpressionTranslator.translate(
                         TEST_SESSION,
                         expression,
-                        createTestingTypeAnalyzer(PLANNER_CONTEXT),
                         TypeProvider.viewOf(symbolTypes.entrySet().stream()
                                 .collect(toImmutableMap(entry -> new Symbol(entry.getKey()), Map.Entry::getValue))),
-                        PLANNER_CONTEXT)
+                        PLANNER_CONTEXT,
+                        createTestingTypeAnalyzer(PLANNER_CONTEXT))
                 .orElseThrow();
     }
 

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlClient.java
@@ -446,10 +446,10 @@ public class TestPostgreSqlClient
         return ConnectorExpressionTranslator.translate(
                         TEST_SESSION,
                         expression,
-                        createTestingTypeAnalyzer(PLANNER_CONTEXT),
                         TypeProvider.viewOf(symbolTypes.entrySet().stream()
                                 .collect(toImmutableMap(entry -> new Symbol(entry.getKey()), Entry::getValue))),
-                        PLANNER_CONTEXT)
+                        PLANNER_CONTEXT,
+                        createTestingTypeAnalyzer(PLANNER_CONTEXT))
                 .orElseThrow();
     }
 }


### PR DESCRIPTION
Previously join pushdown was limited to simple comparison conditions
between variables. That's because the `applyJoin` was added before we
had real connector expressions. The commit exposes to connectors all
join condition's conjuncts that are translatable to
`ConnectorExpression`.