### PR TITLE
Deliver RemoteSplit exactly once

### DIFF
--- a/core/trino-main/src/main/java/io/trino/exchange/LazyExchangeDataSource.java
+++ b/core/trino-main/src/main/java/io/trino/exchange/LazyExchangeDataSource.java
@@ -116,6 +116,7 @@ public class LazyExchangeDataSource
                 return;
             }
             ExchangeDataSource dataSource = delegate.get();
+            boolean inputAdded = false;
             if (dataSource == null) {
                 if (input instanceof DirectExchangeInput) {
                     DirectExchangeClient client = directExchangeClientSupplier.get(queryId, exchangeId, systemMemoryContext, taskFailureListener, retryPolicy);
@@ -126,7 +127,8 @@ public class LazyExchangeDataSource
                     ExchangeManager exchangeManager = exchangeManagerRegistry.getExchangeManager();
                     List<ExchangeSourceHandle> sourceHandles = spoolingExchangeInput.getExchangeSourceHandles();
                     ExchangeSource exchangeSource = exchangeManager.createSource(sourceHandles);
-                    dataSource = new SpoolingExchangeDataSource(exchangeSource, sourceHandles, systemMemoryContext);
+                    dataSource = new SpoolingExchangeDataSource(exchangeSource, systemMemoryContext);
+                    inputAdded = true;
                 }
                 else {
                     throw new IllegalArgumentException("Unexpected input: " + input);
@@ -134,7 +136,9 @@ public class LazyExchangeDataSource
                 delegate.set(dataSource);
                 initialized = true;
             }
-            dataSource.addInput(input);
+            if (!inputAdded) {
+                dataSource.addInput(input);
+            }
         }
 
         if (initialized) {

--- a/core/trino-main/src/main/java/io/trino/exchange/SpoolingExchangeDataSource.java
+++ b/core/trino-main/src/main/java/io/trino/exchange/SpoolingExchangeDataSource.java
@@ -13,18 +13,13 @@
  */
 package io.trino.exchange;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
 import io.trino.memory.context.LocalMemoryContext;
 import io.trino.operator.OperatorInfo;
 import io.trino.spi.exchange.ExchangeSource;
-import io.trino.spi.exchange.ExchangeSourceHandle;
 
-import java.util.List;
-
-import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.airlift.concurrent.MoreFutures.toListenableFuture;
 import static java.util.Objects.requireNonNull;
@@ -39,18 +34,13 @@ public class SpoolingExchangeDataSource
     // It doesn't have to be declared as volatile as the nullification of this variable doesn't have to be immediately visible to other threads.
     // However since close can be called at any moment this variable has to be accessed in a safe way (avoiding "check-then-use").
     private ExchangeSource exchangeSource;
-    private final List<ExchangeSourceHandle> exchangeSourceHandles;
     private final LocalMemoryContext systemMemoryContext;
     private volatile boolean closed;
 
-    public SpoolingExchangeDataSource(
-            ExchangeSource exchangeSource,
-            List<ExchangeSourceHandle> exchangeSourceHandles,
-            LocalMemoryContext systemMemoryContext)
+    public SpoolingExchangeDataSource(ExchangeSource exchangeSource, LocalMemoryContext systemMemoryContext)
     {
         // this assignment is expected to be followed by an assignment of a final field to ensure safe publication
         this.exchangeSource = requireNonNull(exchangeSource, "exchangeSource is null");
-        this.exchangeSourceHandles = ImmutableList.copyOf(requireNonNull(exchangeSourceHandles, "exchangeSourceHandles is null"));
         this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");
     }
 
@@ -96,16 +86,7 @@ public class SpoolingExchangeDataSource
     @Override
     public void addInput(ExchangeInput input)
     {
-        SpoolingExchangeInput exchangeInput = (SpoolingExchangeInput) input;
-        // Only a single input is expected when the spooling exchange is used.
-        // The engine adds the same input to every instance of the ExchangeOperator.
-        // Since the ExchangeDataSource is shared between ExchangeOperator instances
-        // the same input may be delivered multiple times.
-        checkState(
-                exchangeInput.getExchangeSourceHandles().equals(exchangeSourceHandles),
-                "exchange input is expected to contain an identical exchangeSourceHandles list: %s != %s",
-                exchangeInput.getExchangeSourceHandles(),
-                exchangeSourceHandles);
+        throw new UnsupportedOperationException("only a single input is expected");
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/execution/DataDefinitionExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DataDefinitionExecution.java
@@ -165,7 +165,7 @@ public class DataDefinitionExecution<T extends Statement>
     }
 
     @Override
-    public void addOutputInfoListener(Consumer<QueryOutputInfo> listener)
+    public void setOutputInfoListener(Consumer<QueryOutputInfo> listener)
     {
         // DDL does not have an output
     }

--- a/core/trino-main/src/main/java/io/trino/execution/QueryExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryExecution.java
@@ -41,7 +41,7 @@ public interface QueryExecution
 
     void addStateChangeListener(StateChangeListener<QueryState> stateChangeListener);
 
-    void addOutputInfoListener(Consumer<QueryOutputInfo> listener);
+    void setOutputInfoListener(Consumer<QueryOutputInfo> listener);
 
     void outputTaskFailed(TaskId taskId, Throwable failure);
 

--- a/core/trino-main/src/main/java/io/trino/execution/QueryExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryExecution.java
@@ -28,6 +28,7 @@ import io.trino.spi.type.Type;
 import io.trino.sql.planner.Plan;
 
 import java.util.List;
+import java.util.Queue;
 import java.util.function.Consumer;
 
 import static java.util.Objects.requireNonNull;
@@ -86,23 +87,23 @@ public interface QueryExecution
     }
 
     /**
-     * Output schema and buffer URIs for query.  The info will always contain column names and types.  Buffer locations will always
-     * contain the full location set, but may be empty.  Users of this data should keep a private copy of the seen buffers to
-     * handle out of order events from the listener.  Once noMoreBufferLocations is set the locations will never change, and
-     * it is guaranteed that all previously sent locations are contained in the buffer locations.
+     * The info will always contain column names and types.
+     * The {@code inputsQueue} is shared between {@link QueryOutputInfo} instances.
+     * It is guaranteed that no new entries will be added to {@code inputsQueue} after {@link QueryOutputInfo}
+     * with {@link #isNoMoreInputs()} {@code == true} is created.
      */
     class QueryOutputInfo
     {
         private final List<String> columnNames;
         private final List<Type> columnTypes;
-        private final List<ExchangeInput> inputs;
+        private final Queue<ExchangeInput> inputsQueue;
         private final boolean noMoreInputs;
 
-        public QueryOutputInfo(List<String> columnNames, List<Type> columnTypes, List<ExchangeInput> inputs, boolean noMoreInputs)
+        public QueryOutputInfo(List<String> columnNames, List<Type> columnTypes, Queue<ExchangeInput> inputsQueue, boolean noMoreInputs)
         {
             this.columnNames = ImmutableList.copyOf(requireNonNull(columnNames, "columnNames is null"));
             this.columnTypes = ImmutableList.copyOf(requireNonNull(columnTypes, "columnTypes is null"));
-            this.inputs = ImmutableList.copyOf(requireNonNull(inputs, "inputs is null"));
+            this.inputsQueue = requireNonNull(inputsQueue, "inputsQueue is null");
             this.noMoreInputs = noMoreInputs;
         }
 
@@ -116,9 +117,15 @@ public interface QueryExecution
             return columnTypes;
         }
 
-        public List<ExchangeInput> getInputs()
+        public void drainInputs(Consumer<ExchangeInput> consumer)
         {
-            return inputs;
+            while (true) {
+                ExchangeInput input = inputsQueue.poll();
+                if (input == null) {
+                    break;
+                }
+                consumer.accept(input);
+            }
         }
 
         public boolean isNoMoreInputs()

--- a/core/trino-main/src/main/java/io/trino/execution/QueryManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryManager.java
@@ -33,7 +33,7 @@ public interface QueryManager
      *
      * @throws NoSuchElementException if query does not exist
      */
-    void addOutputInfoListener(QueryId queryId, Consumer<QueryExecution.QueryOutputInfo> listener)
+    void setOutputInfoListener(QueryId queryId, Consumer<QueryExecution.QueryOutputInfo> listener)
             throws NoSuchElementException;
 
     /**

--- a/core/trino-main/src/main/java/io/trino/execution/SqlQueryExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlQueryExecution.java
@@ -598,9 +598,9 @@ public class SqlQueryExecution
     }
 
     @Override
-    public void addOutputInfoListener(Consumer<QueryOutputInfo> listener)
+    public void setOutputInfoListener(Consumer<QueryOutputInfo> listener)
     {
-        stateMachine.addOutputInfoListener(listener);
+        stateMachine.setOutputInfoListener(listener);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/execution/SqlQueryManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlQueryManager.java
@@ -148,11 +148,11 @@ public class SqlQueryManager
     }
 
     @Override
-    public void addOutputInfoListener(QueryId queryId, Consumer<QueryOutputInfo> listener)
+    public void setOutputInfoListener(QueryId queryId, Consumer<QueryOutputInfo> listener)
     {
         requireNonNull(listener, "listener is null");
 
-        queryTracker.getQuery(queryId).addOutputInfoListener(listener);
+        queryTracker.getQuery(queryId).setOutputInfoListener(listener);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/DirectExchangeClient.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DirectExchangeClient.java
@@ -45,6 +45,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Sets.newConcurrentHashSet;
 import static java.util.Objects.requireNonNull;
@@ -155,10 +156,7 @@ public class DirectExchangeClient
             return;
         }
 
-        // ignore duplicate locations
-        if (allClients.containsKey(location)) {
-            return;
-        }
+        checkArgument(!allClients.containsKey(location), "location already exist: %s", location);
 
         checkState(!noMoreLocations, "No more locations already set");
         buffer.addTask(taskId);

--- a/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
@@ -582,7 +582,7 @@ class Query
             types = outputInfo.getColumnTypes();
         }
 
-        outputInfo.getInputs().forEach(exchangeDataSource::addInput);
+        outputInfo.drainInputs(exchangeDataSource::addInput);
         if (outputInfo.isNoMoreInputs()) {
             exchangeDataSource.noMoreInputs();
         }

--- a/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
@@ -187,7 +187,7 @@ class Query
 
         Query result = new Query(session, slug, queryManager, queryInfoUrl, exchangeDataSource, dataProcessorExecutor, timeoutExecutor, blockEncodingSerde);
 
-        result.queryManager.addOutputInfoListener(result.getQueryId(), result::setQueryOutputInfo);
+        result.queryManager.setOutputInfoListener(result.getQueryId(), result::setQueryOutputInfo);
 
         result.queryManager.addStateChangeListener(result.getQueryId(), state -> {
             // Wait for the query info to become available and close the exchange client if there is no output stage for the query results to be pulled from.

--- a/core/trino-main/src/test/java/io/trino/operator/TestExchangeOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestExchangeOperator.java
@@ -272,6 +272,7 @@ public class TestExchangeOperator
 
         SourceOperator operator = operatorFactory.createOperator(driverContext);
         assertEquals(getOnlyElement(operator.getOperatorContext().getNestedOperatorStats()).getUserMemoryReservation().toBytes(), 0);
+        operatorFactory.noMoreOperators();
         return operator;
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeSourceHandle.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeSourceHandle.java
@@ -16,7 +16,7 @@ package io.trino.spi.exchange;
 import io.trino.spi.Experimental;
 
 /*
- * Implementation is expected to be Jackson serializable and include equals, hashCode and toString methods
+ * Implementation is expected to be Jackson serializable
  */
 @Experimental(eta = "2023-01-01")
 public interface ExchangeSourceHandle
@@ -26,13 +26,4 @@ public interface ExchangeSourceHandle
     long getDataSizeInBytes();
 
     long getRetainedSizeInBytes();
-
-    @Override
-    boolean equals(Object obj);
-
-    @Override
-    int hashCode();
-
-    @Override
-    String toString();
 }

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeSourceHandle.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeSourceHandle.java
@@ -20,9 +20,7 @@ import io.airlift.slice.SizeOf;
 import io.trino.spi.exchange.ExchangeSourceHandle;
 import org.openjdk.jol.info.ClassLayout;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -83,28 +81,6 @@ public class FileSystemExchangeSourceHandle
     public Optional<byte[]> getSecretKey()
     {
         return secretKey;
-    }
-
-    @Override
-    public boolean equals(Object o)
-    {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        FileSystemExchangeSourceHandle that = (FileSystemExchangeSourceHandle) o;
-        if (secretKey.isPresent() && that.secretKey.isPresent()) {
-            return partitionId == that.getPartitionId() && Arrays.equals(secretKey.get(), that.secretKey.get());
-        }
-        return partitionId == that.getPartitionId() && secretKey.isEmpty() && that.secretKey.isEmpty();
-    }
-
-    @Override
-    public int hashCode()
-    {
-        return Objects.hash(partitionId, files, secretKey);
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

Currently a single `RemoteSplit` is delivered multiple times (once per ExchangeOperator instance). The deduplication is done at the `DirectExchangeClient` level. While it is easy to de-duplicate based on the URI, it is not as straightforward when it comes to spooling exhange. Currently there is a guarantee of an excacly one RemoteSplit per exchange when SpoolingExchange is used, however this is about to be changed (see https://github.com/trinodb/trino/pull/13968), thus this change is required.

> Is this change a fix, improvement, new feature, refactoring, or other?

Refactor

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core engine

> How would you describe this change to a non-technical end user or system administrator?

N/A

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

https://github.com/trinodb/trino/pull/13968

## Documentation

(X) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(X) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
