### PR TITLE
Remove trailing slash when building metadata location in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractIcebergTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractIcebergTableOperations.java
@@ -51,6 +51,7 @@ import static org.apache.iceberg.TableMetadataParser.getFileExtension;
 import static org.apache.iceberg.TableProperties.METADATA_COMPRESSION;
 import static org.apache.iceberg.TableProperties.METADATA_COMPRESSION_DEFAULT;
 import static org.apache.iceberg.TableProperties.WRITE_METADATA_LOCATION;
+import static org.apache.iceberg.util.LocationUtil.stripTrailingSlash;
 
 @NotThreadSafe
 public abstract class AbstractIcebergTableOperations
@@ -173,14 +174,14 @@ public abstract class AbstractIcebergTableOperations
         if (metadata != null) {
             String writeLocation = metadata.properties().get(WRITE_METADATA_LOCATION);
             if (writeLocation != null) {
-                return format("%s/%s", writeLocation, filename);
+                return format("%s/%s", stripTrailingSlash(writeLocation), filename);
             }
             location = metadata.location();
         }
         else {
             location = this.location.orElseThrow(() -> new IllegalStateException("Location not set"));
         }
-        return format("%s/%s/%s", location, METADATA_FOLDER_NAME, filename);
+        return format("%s/%s/%s", stripTrailingSlash(location), METADATA_FOLDER_NAME, filename);
     }
 
     @Override
@@ -244,9 +245,9 @@ public abstract class AbstractIcebergTableOperations
     {
         String location = metadata.properties().get(WRITE_METADATA_LOCATION);
         if (location != null) {
-            return format("%s/%s", location, filename);
+            return format("%s/%s", stripTrailingSlash(location), filename);
         }
-        return format("%s/%s/%s", metadata.location(), METADATA_FOLDER_NAME, filename);
+        return format("%s/%s/%s", stripTrailingSlash(metadata.location()), METADATA_FOLDER_NAME, filename);
     }
 
     protected static int parseVersion(String metadataLocation)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMinioConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMinioConnectorSmokeTest.java
@@ -19,6 +19,7 @@ import io.trino.testing.QueryRunner;
 import org.apache.iceberg.FileFormat;
 import org.testng.annotations.Test;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -26,6 +27,7 @@ import static io.trino.plugin.hive.containers.HiveMinioDataLake.MINIO_ACCESS_KEY
 import static io.trino.plugin.hive.containers.HiveMinioDataLake.MINIO_SECRET_KEY;
 import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class BaseIcebergMinioConnectorSmokeTest
         extends BaseIcebergConnectorSmokeTest
@@ -84,5 +86,25 @@ public abstract class BaseIcebergMinioConnectorSmokeTest
         assertQueryFails(
                 format("ALTER SCHEMA %s RENAME TO %s", schemaName, schemaName + randomTableSuffix()),
                 "Hive metastore does not support renaming schemas");
+    }
+
+    @Test
+    public void testS3LocationWithTrailingSlash()
+    {
+        // Verify data and metadata files' uri don't contain fragments
+        String schemaName = getSession().getSchema().orElseThrow();
+        String tableName = "test_s3_location_with_trailing_slash_" + randomTableSuffix();
+        String location = "s3://%s/%s/%s/".formatted(bucketName, schemaName, tableName);
+        assertThat(location).doesNotContain("#");
+
+        assertUpdate("CREATE TABLE " + tableName + " WITH (location='" + location + "') AS SELECT 1 col", 1);
+
+        List<String> dataFiles = hiveMinioDataLake.getMinioClient().listObjects(bucketName, "/%s/%s/data".formatted(schemaName, tableName));
+        assertThat(dataFiles).isNotEmpty().filteredOn(filePath -> filePath.contains("#")).isEmpty();
+
+        List<String> metadataFiles = hiveMinioDataLake.getMinioClient().listObjects(bucketName, "/%s/%s/metadata".formatted(schemaName, tableName));
+        assertThat(metadataFiles).isNotEmpty().filteredOn(filePath -> filePath.contains("#")).isEmpty();
+
+        assertUpdate("DROP TABLE " + tableName);
     }
 }


### PR DESCRIPTION
## Description

`stripTrailingSlash` is already used in `IcebergUtil#getLocationProvider` > `locationsFor` for data path. We may want additional handling for double slash in the middle of path, but removing trailing slash anyway as data path. 
Fixes #13759

## Documentation

(x) No documentation is needed.

## Release notes

(x) Release notes entries required with the following suggested text:

```markdown
# Iceberg
* Fix creating metadata and manifest files with url encoded name when the metadata location has trailing slashes on S3. ({issue}`13759`)
```
