### PR TITLE
Use the view owner's identity even if the current user is the owner

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/testing/TestingSystemSecurityMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/server/testing/TestingSystemSecurityMetadata.java
@@ -27,7 +27,9 @@ import io.trino.spi.security.RoleGrant;
 import io.trino.spi.security.TrinoPrincipal;
 
 import java.util.ArrayDeque;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
@@ -36,18 +38,21 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.spi.security.PrincipalType.ROLE;
 import static io.trino.spi.security.PrincipalType.USER;
+import static java.util.Collections.synchronizedMap;
 import static java.util.Collections.synchronizedSet;
 
-class TestingSystemSecurityMetadata
+public class TestingSystemSecurityMetadata
         implements SystemSecurityMetadata
 {
     private final Set<String> roles = synchronizedSet(new HashSet<>());
     private final Set<RoleGrant> roleGrants = synchronizedSet(new HashSet<>());
+    private final Map<CatalogSchemaTableName, Identity> viewOwners = synchronizedMap(new HashMap<>());
 
     public void reset()
     {
         roles.clear();
         roleGrants.clear();
+        viewOwners.clear();
     }
 
     @Override
@@ -221,13 +226,20 @@ class TestingSystemSecurityMetadata
     @Override
     public Optional<Identity> getViewRunAsIdentity(Session session, CatalogSchemaTableName viewName)
     {
-        return Optional.empty();
+        return Optional.ofNullable(viewOwners.get(viewName))
+                .map(identity -> Identity.from(identity)
+                        .withEnabledRoles(getRoleGrantsRecursively(new TrinoPrincipal(USER, identity.getUser()))
+                                .stream()
+                                .map(RoleGrant::getRoleName)
+                                .collect(toImmutableSet()))
+                        .build());
     }
 
     @Override
     public void setViewOwner(Session session, CatalogSchemaTableName view, TrinoPrincipal principal)
     {
-        throw new UnsupportedOperationException();
+        checkArgument(principal.getType() == USER, "Only a user can be a view owner");
+        viewOwners.put(view, Identity.ofUser(principal.getName()));
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/server/testing/TestingSystemSecurityMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/server/testing/TestingSystemSecurityMetadata.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.security;
+package io.trino.server.testing;
 
 import com.google.common.collect.ImmutableSet;
 import io.trino.Session;

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -3992,11 +3992,17 @@ class StatementAnalyzer
                 // run view as view owner if set; otherwise, run as session user
                 Identity identity;
                 AccessControl viewAccessControl;
-                if (owner.isPresent() && !owner.get().getUser().equals(session.getIdentity().getUser())) {
+                if (owner.isPresent()) {
                     identity = Identity.from(owner.get())
                             .withGroups(groupProvider.getGroups(owner.get().getUser()))
                             .build();
-                    viewAccessControl = new ViewAccessControl(accessControl, session.getIdentity());
+                    if (owner.get().getUser().equals(session.getIdentity().getUser())) {
+                        // don't restrict owner's access
+                        viewAccessControl = accessControl;
+                    }
+                    else {
+                        viewAccessControl = new ViewAccessControl(accessControl, session.getIdentity());
+                    }
                 }
                 else {
                     identity = session.getIdentity();

--- a/core/trino-main/src/test/java/io/trino/server/TestHttpRequestSessionContextFactory.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestHttpRequestSessionContextFactory.java
@@ -29,6 +29,7 @@ import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 
 import java.util.Optional;
+import java.util.Set;
 
 import static io.trino.SystemSessionProperties.HASH_PARTITION_COUNT;
 import static io.trino.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
@@ -86,7 +87,10 @@ public class TestHttpRequestSessionContextFactory
         assertEquals(context.getCatalog().orElse(null), "testCatalog");
         assertEquals(context.getSchema().orElse(null), "testSchema");
         assertEquals(context.getPath().orElse(null), "testPath");
-        assertEquals(context.getIdentity(), Identity.ofUser("testUser"));
+        assertEquals(context.getIdentity(), Identity.forUser("testUser")
+                .withGroups(Set.of("testUser"))
+                .withEnabledRoles(Set.of("system-role"))
+                .build());
         assertEquals(context.getClientInfo().orElse(null), "client-info");
         assertEquals(context.getLanguage().orElse(null), "zh-TW");
         assertEquals(context.getTimeZoneId().orElse(null), "Asia/Taipei");

--- a/core/trino-spi/src/main/java/io/trino/spi/security/Identity.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/Identity.java
@@ -130,13 +130,15 @@ public class Identity
             return false;
         }
         Identity identity = (Identity) o;
-        return Objects.equals(user, identity.user);
+        return Objects.equals(user, identity.user)
+                && enabledRoles.equals(identity.enabledRoles)
+                && groups.equals(identity.groups);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(user);
+        return Objects.hash(user, enabledRoles, groups);
     }
 
     @Override

--- a/testing/trino-tests/src/test/java/io/trino/server/testing/TestSystemSecurityMetadata.java
+++ b/testing/trino-tests/src/test/java/io/trino/server/testing/TestSystemSecurityMetadata.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.security;
+package io.trino.server.testing;
 
 import com.google.common.collect.ImmutableSet;
 import io.trino.Session;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

On the surface it makes sense that if the current session's user is the owner, then it is not necessary to substitute the identity when checking permissions for views. The issue is, though, that the current identity and the substituted one may have a different set of enabled roles. If that happens, then the access permissions may be different (usually lessened) when the view is queried by the owner.

Depends on #14130, because with this change it's now possible to trigger that bug.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?

Fix

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Core engine (access control)

> How would you describe this change to a non-technical end user or system administrator?

When a view owner queries a view with SECURITY DEFINER, the owner's granted roles are used instead of currently enabled roles.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Security
* When a view owner queries a view with SECURITY DEFINER, the owner's granted roles are used instead of currently enabled roles.
```