### PR TITLE
add test coverage for basic format of iso8601

### DIFF
--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestDateTimeFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestDateTimeFunctions.java
@@ -107,6 +107,7 @@ public class TestDateTimeFunctions
     protected static final DateTime TIMESTAMP = new DateTime(2001, 8, 22, 3, 4, 5, 321, UTC_TIME_ZONE); // This is TIMESTAMP w/o TZ
     protected static final DateTime TIMESTAMP_WITH_NUMERICAL_ZONE = new DateTime(2001, 8, 22, 3, 4, 5, 321, DATE_TIME_ZONE_NUMERICAL);
     protected static final String TIMESTAMP_LITERAL = "TIMESTAMP '2001-08-22 03:04:05.321'";
+    protected static final String TIMESTAMP_ISO8601_BASIC_STRING = "20010822T030405.321-1100";
     protected static final String TIMESTAMP_ISO8601_STRING = "2001-08-22T03:04:05.321-11:00";
     protected static final String TIMESTAMP_ISO8601_STRING_NO_TIME_ZONE = "2001-08-22T03:04:05.321";
     protected static final DateTime WEIRD_TIMESTAMP = new DateTime(2001, 8, 22, 3, 4, 5, 321, WEIRD_DATE_TIME_ZONE);
@@ -309,6 +310,7 @@ public class TestDateTimeFunctions
     @Test
     public void testFromISO8601()
     {
+        assertFunction("from_iso8601_timestamp('" + TIMESTAMP_ISO8601_BASIC_STRING + "')", TIMESTAMP_WITH_TIME_ZONE, toTimestampWithTimeZone(TIMESTAMP_WITH_NUMERICAL_ZONE));
         assertFunction("from_iso8601_timestamp('" + TIMESTAMP_ISO8601_STRING + "')", TIMESTAMP_WITH_TIME_ZONE, toTimestampWithTimeZone(TIMESTAMP_WITH_NUMERICAL_ZONE));
         assertFunction("from_iso8601_timestamp('" + WEIRD_TIMESTAMP_ISO8601_STRING + "')", TIMESTAMP_WITH_TIME_ZONE, toTimestampWithTimeZone(WEIRD_TIMESTAMP));
         assertFunction("from_iso8601_date('" + DATE_ISO8601_STRING + "')", DateType.DATE, toDate(DATE));


### PR DESCRIPTION
the format covered by the tests is only the *extended format*.

the *basic format* doesn't use separators between date and time components.

The testcase added in basic format should result in the same value that the
existing one in *extended format*

- check: ISO 8601:2004 section 2.3.3 basic format

