### PR TITLE
Support text type predicate pushdown with collation in MySQL

### DIFF
--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/CollationAwareQueryBuilder.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/CollationAwareQueryBuilder.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mysql;
+
+import com.google.common.base.Joiner;
+import io.trino.plugin.jdbc.DefaultQueryBuilder;
+import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcTypeHandle;
+import io.trino.plugin.jdbc.QueryParameter;
+import io.trino.plugin.jdbc.WriteFunction;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import static java.lang.String.format;
+import static java.util.Collections.nCopies;
+
+public class CollationAwareQueryBuilder
+        extends DefaultQueryBuilder
+{
+    private final boolean enableStringPushdownWithCollate;
+
+    @Inject
+    public CollationAwareQueryBuilder(MySqlConfig mySqlConfig)
+    {
+        this.enableStringPushdownWithCollate = mySqlConfig.isEnableStringPushdownWithCollate();
+    }
+
+    @Override
+    protected String toPredicate(JdbcClient client, ConnectorSession session, JdbcColumnHandle column, JdbcTypeHandle jdbcType, Type type, WriteFunction writeFunction, String operator, Object value, Consumer<QueryParameter> accumulator)
+    {
+        if (isCollatable(column) && enableStringPushdownWithCollate) {
+            accumulator.accept(new QueryParameter(jdbcType, type, Optional.of(value)));
+            return format("%s %s %s COLLATE \"utf8mb4_0900_bin\"", client.quoted(column.getColumnName()), operator, writeFunction.getBindExpression());
+        }
+        return super.toPredicate(client, session, column, jdbcType, type, writeFunction, operator, value, accumulator);
+    }
+
+    @Override
+    protected String toInPredicate(JdbcClient client, ConnectorSession session, JdbcColumnHandle column, JdbcTypeHandle jdbcType, Type type, WriteFunction writeFunction, List<Object> values, Consumer<QueryParameter> accumulator)
+    {
+        if (isCollatable(column) && enableStringPushdownWithCollate) {
+            for (Object value : values) {
+                accumulator.accept(new QueryParameter(jdbcType, type, Optional.of(value)));
+            }
+            String inValues = Joiner.on(",").join(nCopies(values.size(), format("%s %s", writeFunction.getBindExpression(), "COLLATE \"utf8mb4_0900_bin\"")));
+            return client.quoted(column.getColumnName()) + " IN (" + inValues + ")";
+        }
+        return super.toInPredicate(client, session, column, jdbcType, type, writeFunction, values, accumulator);
+    }
+
+    private static boolean isCollatable(JdbcColumnHandle column)
+    {
+        return column.getColumnType() instanceof CharType || column.getColumnType() instanceof VarcharType;
+    }
+}

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
@@ -197,11 +197,13 @@ public class MySqlClient
     private final boolean statisticsEnabled;
     private final ConnectorExpressionRewriter<String> connectorExpressionRewriter;
     private final AggregateFunctionRewriter<JdbcExpression, String> aggregateFunctionRewriter;
+    private final boolean enableStringPushdownWithCollate;
 
     @Inject
     public MySqlClient(
             BaseJdbcConfig config,
             JdbcStatisticsConfig statisticsConfig,
+            MySqlConfig mySqlConfig,
             ConnectionFactory connectionFactory,
             QueryBuilder queryBuilder,
             TypeManager typeManager,
@@ -231,6 +233,7 @@ public class MySqlClient
                         .add(new ImplementVarianceSamp())
                         .add(new ImplementVariancePop())
                         .build());
+        this.enableStringPushdownWithCollate = mySqlConfig.isEnableStringPushdownWithCollate();
     }
 
     @Override
@@ -426,14 +429,14 @@ public class MySqlClient
                 return Optional.of(decimalColumnMapping(createDecimalType(precision, max(decimalDigits, 0))));
 
             case Types.CHAR:
-                return Optional.of(defaultCharColumnMapping(typeHandle.getRequiredColumnSize(), false));
+                return Optional.of(defaultCharColumnMapping(typeHandle.getRequiredColumnSize(), enableStringPushdownWithCollate));
 
             // TODO not all these type constants are necessarily used by the JDBC driver
             case Types.VARCHAR:
             case Types.NVARCHAR:
             case Types.LONGVARCHAR:
             case Types.LONGNVARCHAR:
-                return Optional.of(defaultVarcharColumnMapping(typeHandle.getRequiredColumnSize(), false));
+                return Optional.of(defaultVarcharColumnMapping(typeHandle.getRequiredColumnSize(), enableStringPushdownWithCollate));
 
             case Types.BINARY:
             case Types.VARBINARY:

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlConfig.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlConfig.java
@@ -31,6 +31,7 @@ public class MySqlConfig
     // implementation, which throw SQL exception when a table disappears during listing.
     // Using `useInformationSchema=false` may provide more diagnostic information (see https://github.com/trinodb/trino/issues/1597)
     private boolean driverUseInformationSchema = true;
+    private boolean enableStringPushdownWithCollate;
 
     public boolean isAutoReconnect()
     {
@@ -79,6 +80,20 @@ public class MySqlConfig
     public MySqlConfig setDriverUseInformationSchema(boolean driverUseInformationSchema)
     {
         this.driverUseInformationSchema = driverUseInformationSchema;
+        return this;
+    }
+
+    public boolean isEnableStringPushdownWithCollate()
+    {
+        return enableStringPushdownWithCollate;
+    }
+
+    // before enabling this config, make sure mysql server version is 8.0.17+ as we use collation
+    // utf8mb4_0900_bin which is only supported after that version
+    @Config("mysql.experimental.enable-string-pushdown-with-collate")
+    public MySqlConfig setEnableStringPushdownWithCollate(boolean enableStringPushdownWithCollate)
+    {
+        this.enableStringPushdownWithCollate = enableStringPushdownWithCollate;
         return this;
     }
 }

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlClient.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlClient.java
@@ -61,6 +61,7 @@ public class TestMySqlClient
     private static final JdbcClient JDBC_CLIENT = new MySqlClient(
             new BaseJdbcConfig(),
             new JdbcStatisticsConfig(),
+            new MySqlConfig(),
             session -> {
                 throw new UnsupportedOperationException();
             },

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlClientModule.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlClientModule.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mysql;
+
+import org.testng.annotations.Test;
+
+import java.util.Properties;
+
+import static io.trino.plugin.mysql.MySqlClientModule.validateConnectionUrl;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestMySqlClientModule
+{
+    @Test
+    public void testValidateConnectionUrl()
+    {
+        Properties properties = new Properties();
+        properties.setProperty("characterEncoding", "utf8");
+        properties.setProperty("character_set_server", "utf8mb4");
+        assertThatThrownBy(() -> validateConnectionUrl("jdbc:mysql://localhost:3306?characterEncoding=big5", properties))
+                .hasMessage("characterEncoding not allowed to be set in connectionUrl");
+        assertThatThrownBy(() -> validateConnectionUrl("jdbc:mysql://localhost:3306?character_set_server=utf8mb4", properties))
+                .hasMessage("character_set_server not allowed to be set in connectionUrl");
+        assertThatThrownBy(() -> validateConnectionUrl("jdbc:mysql://localhost:3306?characterEncoding=big5&character_set_server=utf8mb4", properties))
+                .hasMessage("characterEncoding, character_set_server not allowed to be set in connectionUrl");
+        assertThatCode(() -> validateConnectionUrl("jdbc:mysql://localhost:3306", properties))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> validateConnectionUrl("jdbc:mysql://localhost:3306?foo=bar", properties))
+                .doesNotThrowAnyException();
+    }
+}

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlCollateAwareConnectorTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlCollateAwareConnectorTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mysql;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.TestingConnectorBehavior;
+
+import static io.trino.plugin.mysql.MySqlQueryRunner.createMySqlQueryRunner;
+
+public class TestMySqlCollateAwareConnectorTest
+        extends TestMySqlConnectorTest
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        mySqlServer = closeAfterClass(new TestingMySqlServer(false));
+        return createMySqlQueryRunner(
+                mySqlServer,
+                ImmutableMap.of(),
+                ImmutableMap.of("mysql.experimental.enable-string-pushdown-with-collate", "true"),
+                REQUIRED_TPCH_TABLES);
+    }
+
+    @Override
+    protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
+    {
+        return switch (connectorBehavior) {
+            case SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_EQUALITY, SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_INEQUALITY -> true;
+            case SUPPORTS_TOPN_PUSHDOWN_WITH_VARCHAR,
+                    SUPPORTS_JOIN_PUSHDOWN_WITH_VARCHAR_EQUALITY,
+                    SUPPORTS_JOIN_PUSHDOWN_WITH_VARCHAR_INEQUALITY,
+                    SUPPORTS_AGGREGATION_PUSHDOWN_WITH_VARCHAR -> false;
+            default -> super.hasBehavior(connectorBehavior);
+        };
+    }
+}

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlConfig.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlConfig.java
@@ -33,7 +33,8 @@ public class TestMySqlConfig
                 .setAutoReconnect(true)
                 .setMaxReconnects(3)
                 .setConnectionTimeout(new Duration(10, TimeUnit.SECONDS))
-                .setDriverUseInformationSchema(true));
+                .setDriverUseInformationSchema(true)
+                .setEnableStringPushdownWithCollate(false));
     }
 
     @Test
@@ -44,13 +45,15 @@ public class TestMySqlConfig
                 .put("mysql.max-reconnects", "4")
                 .put("mysql.connection-timeout", "4s")
                 .put("mysql.jdbc.use-information-schema", "false")
+                .put("mysql.experimental.enable-string-pushdown-with-collate", "true")
                 .buildOrThrow();
 
         MySqlConfig expected = new MySqlConfig()
                 .setAutoReconnect(false)
                 .setMaxReconnects(4)
                 .setConnectionTimeout(new Duration(4, TimeUnit.SECONDS))
-                .setDriverUseInformationSchema(false);
+                .setDriverUseInformationSchema(false)
+                .setEnableStringPushdownWithCollate(true);
 
         assertFullMapping(properties, expected);
     }

--- a/testing/trino-testing/src/main/java/io/trino/testing/TestingConnectorBehavior.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/TestingConnectorBehavior.java
@@ -41,6 +41,7 @@ public enum TestingConnectorBehavior
     SUPPORTS_AGGREGATION_PUSHDOWN_CORRELATION(false),
     SUPPORTS_AGGREGATION_PUSHDOWN_REGRESSION(false),
     SUPPORTS_AGGREGATION_PUSHDOWN_COUNT_DISTINCT(false),
+    SUPPORTS_AGGREGATION_PUSHDOWN_WITH_VARCHAR(fallback -> fallback.test(SUPPORTS_AGGREGATION_PUSHDOWN) && fallback.test(SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_INEQUALITY)),
 
     SUPPORTS_JOIN_PUSHDOWN(
             // Currently no connector supports Join pushdown by default. JDBC connectors may support Join pushdown and BaseJdbcConnectorTest


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
related to https://github.com/trinodb/trino/issues/7496, support text type predicate pushdown in MySQL connector, this pr mainly did predicate pushdown, and didn't involved with top-n/aggregate/join text type pushdown.

This pr use `utf8mb4_0900_bin` which is supported in **mysql 8.0.17+**, and according to https://github.com/trinodb/trino/issues/7496#issuecomment-1231331703, `utf8mb4_0900_bin` is the one which is under utf8mb4 charset and doesn’t ignore trailing spaces. To enable this collation, we need to specify `character_set_server` in jdbc properties through MySqlConfig.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
