### PR TITLE
Hide Elasticsearch prefix-based pass-through query behind feature toggle

### DIFF
--- a/docs/src/main/sphinx/connector/elasticsearch.rst
+++ b/docs/src/main/sphinx/connector/elasticsearch.rst
@@ -83,6 +83,9 @@ Configuration properties
       - Disables using the address published by Elasticsearch to connect for
         queries.
       -
+    * - ``elasticsearch.legacy-pass-through-query.enabled``
+      - Enables legacy pass-through query
+      - false
 
 TLS security
 ------------
@@ -378,6 +381,13 @@ Elasticsearch Trino         Supports
 
 Pass-through queries
 --------------------
+
+.. note::
+
+    This feature is deprecated and disabled by default. It's recommended to use
+    ``raw_query`` :doc:`table function</functions/table>` instead.
+    To enable legacy pass-through query please use
+    ``elasticsearch.legacy-pass-through-query-enabled`` configuration property.
 
 The Elasticsearch connector allows you to embed any valid Elasticsearch query,
 that uses the `Elasticsearch Query DSL

--- a/plugin/trino-elasticsearch/pom.xml
+++ b/plugin/trino-elasticsearch/pom.xml
@@ -16,6 +16,7 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <dep.elasticsearch.version>6.8.23</dep.elasticsearch.version>
+        <air.test.parallel>instances</air.test.parallel>
     </properties>
 
     <dependencies>

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchConfig.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchConfig.java
@@ -79,6 +79,8 @@ public class ElasticsearchConfig
 
     private Security security;
 
+    private boolean legacyPassThroughQueryEnabled;
+
     @NotNull
     public List<String> getHosts()
     {
@@ -356,6 +358,19 @@ public class ElasticsearchConfig
     public ElasticsearchConfig setSecurity(Security security)
     {
         this.security = security;
+        return this;
+    }
+
+    public boolean isLegacyPassThroughQueryEnabled()
+    {
+        return legacyPassThroughQueryEnabled;
+    }
+
+    @Config("elasticsearch.legacy-pass-through-query.enabled")
+    @ConfigDescription("Enable legacy Elasticsearch pass-through query")
+    public ElasticsearchConfig setLegacyPassThroughQueryEnabled(boolean legacyPassThroughQuery)
+    {
+        this.legacyPassThroughQueryEnabled = legacyPassThroughQuery;
         return this;
     }
 }

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
@@ -59,12 +59,14 @@ public abstract class BaseElasticsearchConnectorTest
         extends BaseConnectorTest
 {
     private final String image;
+    private final String catalogName;
     private ElasticsearchServer elasticsearch;
     protected RestHighLevelClient client;
 
-    BaseElasticsearchConnectorTest(String image)
+    BaseElasticsearchConnectorTest(String image, String catalogName)
     {
         this.image = image;
+        this.catalogName = catalogName;
     }
 
     @Override
@@ -81,7 +83,8 @@ public abstract class BaseElasticsearchConnectorTest
                 TpchTable.getTables(),
                 ImmutableMap.of(),
                 ImmutableMap.of("elasticsearch.legacy-pass-through-query.enabled", "true"),
-                3);
+                3,
+                catalogName);
     }
 
     @Override
@@ -152,8 +155,8 @@ public abstract class BaseElasticsearchConnectorTest
     {
         assertQuerySucceeds("SELECT * FROM orders");
         // Check that JMX stats show no sign of backpressure
-        assertQueryReturnsEmptyResult("SELECT 1 FROM jmx.current.\"trino.plugin.elasticsearch.client:*\" WHERE \"backpressurestats.alltime.count\" > 0");
-        assertQueryReturnsEmptyResult("SELECT 1 FROM jmx.current.\"trino.plugin.elasticsearch.client:*\" WHERE \"backpressurestats.alltime.max\" > 0");
+        assertQueryReturnsEmptyResult(format("SELECT 1 FROM jmx.current.\"trino.plugin.elasticsearch.client:*name=%s*\" WHERE \"backpressurestats.alltime.count\" > 0", catalogName));
+        assertQueryReturnsEmptyResult(format("SELECT 1 FROM jmx.current.\"trino.plugin.elasticsearch.client:*name=%s*\" WHERE \"backpressurestats.alltime.max\" > 0", catalogName));
     }
 
     @Test
@@ -214,7 +217,7 @@ public abstract class BaseElasticsearchConnectorTest
     public void testShowCreateTable()
     {
         assertThat(computeActual("SHOW CREATE TABLE orders").getOnlyValue())
-                .isEqualTo("CREATE TABLE elasticsearch.tpch.orders (\n" +
+                .isEqualTo(format("CREATE TABLE %s.tpch.orders (\n", catalogName) +
                         "   clerk varchar,\n" +
                         "   comment varchar,\n" +
                         "   custkey bigint,\n" +
@@ -1818,7 +1821,7 @@ public abstract class BaseElasticsearchConnectorTest
                 "FROM data", BaseEncoding.base32().encode(query.getBytes(UTF_8)))))
                 .matches(format("WITH data(r) AS (" +
                         "   SELECT CAST(json_parse(result) AS ROW(aggregations ROW(max_orderkey ROW(value BIGINT), sum_orderkey ROW(value BIGINT)))) " +
-                        "   FROM TABLE(elasticsearch.system.raw_query(" +
+                        format("   FROM TABLE(%s.system.raw_query(", catalogName) +
                         "                        schema => 'tpch', " +
                         "                        index => 'orders', " +
                         "                        query => '%s'))) " +
@@ -1887,7 +1890,7 @@ public abstract class BaseElasticsearchConnectorTest
     {
         // select single record
         assertQuery("SELECT json_query(result, 'lax $[0][0].hits.hits._source') " +
-                        "FROM TABLE(elasticsearch.system.raw_query(" +
+                        format("FROM TABLE(%s.system.raw_query(", catalogName) +
                         "schema => 'tpch', " +
                         "index => 'nation', " +
                         "query => '{\"query\": {\"match\": {\"name\": \"ALGERIA\"}}}')) t(result)",
@@ -1897,7 +1900,7 @@ public abstract class BaseElasticsearchConnectorTest
         Session session = Session.builder(getSession())
                 .addPreparedStatement(
                         "my_query",
-                        "SELECT json_query(result, 'lax $[0][0].hits.hits._source') FROM TABLE(elasticsearch.system.raw_query(schema => ?, index => ?, query => ?))")
+                        format("SELECT json_query(result, 'lax $[0][0].hits.hits._source') FROM TABLE(%s.system.raw_query(schema => ?, index => ?, query => ?))", catalogName))
                 .build();
         assertQuery(
                 session,
@@ -1906,7 +1909,7 @@ public abstract class BaseElasticsearchConnectorTest
 
         // select multiple records by range. Use array wrapper to wrap multiple results
         assertQuery("SELECT array_sort(CAST(json_parse(json_query(result, 'lax $[0][0].hits.hits._source.name' WITH ARRAY WRAPPER)) AS array(varchar))) " +
-                        "FROM TABLE(elasticsearch.system.raw_query(" +
+                        format("FROM TABLE(%s.system.raw_query(", catalogName) +
                         "schema => 'tpch', " +
                         "index => 'nation', " +
                         "query => '{\"query\": {\"range\": {\"nationkey\": {\"gte\": 0,\"lte\": 3}}}}')) t(result)",
@@ -1914,7 +1917,7 @@ public abstract class BaseElasticsearchConnectorTest
 
         // no matches
         assertQuery("SELECT json_query(result, 'lax $[0][0].hits.hits') " +
-                        "FROM TABLE(elasticsearch.system.raw_query(" +
+                        format("FROM TABLE(%s.system.raw_query(", catalogName) +
                         "schema => 'tpch', " +
                         "index => 'nation', " +
                         "query => '{\"query\": {\"match\": {\"name\": \"UTOPIA\"}}}')) t(result)",
@@ -1922,7 +1925,7 @@ public abstract class BaseElasticsearchConnectorTest
 
         // syntax error
         assertThatThrownBy(() -> query("SELECT * " +
-                "FROM TABLE(elasticsearch.system.raw_query(" +
+                format("FROM TABLE(%s.system.raw_query(", catalogName) +
                 "schema => 'tpch', " +
                 "index => 'nation', " +
                 "query => 'wrong syntax')) t(result)"))
@@ -1933,7 +1936,7 @@ public abstract class BaseElasticsearchConnectorTest
     {
         assertQueryReturnsEmptyResult(format("SELECT * FROM information_schema.columns WHERE table_name = '%s'", name));
         assertFalse(computeActual("SHOW TABLES").getOnlyColumnAsSet().contains(name));
-        assertQueryFails("SELECT * FROM " + name, ".*Table 'elasticsearch.tpch." + name + "' does not exist");
+        assertQueryFails("SELECT * FROM " + name, ".*Table '" + catalogName + ".tpch." + name + "' does not exist");
     }
 
     protected abstract String indexEndpoint(String index, String docId);

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
@@ -76,7 +76,12 @@ public abstract class BaseElasticsearchConnectorTest
         HostAndPort address = elasticsearch.getAddress();
         client = new RestHighLevelClient(RestClient.builder(new HttpHost(address.getHost(), address.getPort())));
 
-        return createElasticsearchQueryRunner(elasticsearch.getAddress(), TpchTable.getTables(), ImmutableMap.of(), ImmutableMap.of(), 3);
+        return createElasticsearchQueryRunner(
+                elasticsearch.getAddress(),
+                TpchTable.getTables(),
+                ImmutableMap.of(),
+                ImmutableMap.of("elasticsearch.legacy-pass-through-query.enabled", "true"),
+                3);
     }
 
     @Override

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestDisabledLegacyPassThroughQuery.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestDisabledLegacyPassThroughQuery.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.elasticsearch;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.BaseEncoding;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.tpch.TpchTable;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static io.trino.plugin.elasticsearch.ElasticsearchQueryRunner.createElasticsearchQueryRunner;
+import static io.trino.plugin.elasticsearch.ElasticsearchServer.ELASTICSEARCH_7_IMAGE;
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class TestDisabledLegacyPassThroughQuery
+        extends AbstractTestQueryFramework
+{
+    private ElasticsearchServer elasticsearch;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        elasticsearch = new ElasticsearchServer(ELASTICSEARCH_7_IMAGE, ImmutableMap.of());
+
+        return createElasticsearchQueryRunner(
+                elasticsearch.getAddress(),
+                TpchTable.getTables(),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                1);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public final void destroy()
+            throws IOException
+    {
+        elasticsearch.stop();
+    }
+
+    @Test
+    public void testDisabledPassthroughQuery()
+    {
+        @Language("JSON")
+        String query = "{\n" +
+                "    \"size\": 0,\n" +
+                "    \"aggs\" : {\n" +
+                "        \"max_orderkey\" : { \"max\" : { \"field\" : \"orderkey\" } },\n" +
+                "        \"sum_orderkey\" : { \"sum\" : { \"field\" : \"orderkey\" } }\n" +
+                "    }\n" +
+                "}";
+
+        assertQueryFails(
+                format("WITH data(r) AS (" +
+                        "   SELECT CAST(json_parse(result) AS ROW(aggregations ROW(max_orderkey ROW(value BIGINT), sum_orderkey ROW(value BIGINT)))) " +
+                        "   FROM \"orders$query:%s\") " +
+                        "SELECT r.aggregations.max_orderkey.value, r.aggregations.sum_orderkey.value " +
+                        "FROM data", BaseEncoding.base32().encode(query.getBytes(UTF_8))),
+                "Pass-through query not supported\\. Please turn it on explicitly using elasticsearch\\.legacy-pass-through-query\\.enabled feature toggle");
+    }
+}

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestDisabledLegacyPassThroughQuery.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestDisabledLegacyPassThroughQuery.java
@@ -45,7 +45,8 @@ public class TestDisabledLegacyPassThroughQuery
                 TpchTable.getTables(),
                 ImmutableMap.of(),
                 ImmutableMap.of(),
-                1);
+                1,
+                "elasticsearch-legacy-pass-through-query");
     }
 
     @AfterClass(alwaysRun = true)

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearch6ConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearch6ConnectorTest.java
@@ -28,7 +28,7 @@ public class TestElasticsearch6ConnectorTest
 {
     public TestElasticsearch6ConnectorTest()
     {
-        super("docker.elastic.co/elasticsearch/elasticsearch-oss:6.6.0");
+        super("docker.elastic.co/elasticsearch/elasticsearch-oss:6.6.0", "elasticsearch6");
     }
 
     @Test

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearch7ConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearch7ConnectorTest.java
@@ -21,7 +21,7 @@ public class TestElasticsearch7ConnectorTest
 {
     public TestElasticsearch7ConnectorTest()
     {
-        super(ELASTICSEARCH_7_IMAGE);
+        super(ELASTICSEARCH_7_IMAGE, "elasticsearch7");
     }
 
     @Override

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearchConfig.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearchConfig.java
@@ -57,7 +57,8 @@ public class TestElasticsearchConfig
                 .setTruststorePassword(null)
                 .setVerifyHostnames(true)
                 .setIgnorePublishAddress(false)
-                .setSecurity(null));
+                .setSecurity(null)
+                .setLegacyPassThroughQueryEnabled(false));
     }
 
     @Test
@@ -89,6 +90,7 @@ public class TestElasticsearchConfig
                 .put("elasticsearch.tls.verify-hostnames", "false")
                 .put("elasticsearch.ignore-publish-address", "true")
                 .put("elasticsearch.security", "AWS")
+                .put("elasticsearch.legacy-pass-through-query.enabled", "true")
                 .buildOrThrow();
 
         ElasticsearchConfig expected = new ElasticsearchConfig()
@@ -112,7 +114,8 @@ public class TestElasticsearchConfig
                 .setTruststorePassword("truststore-password")
                 .setVerifyHostnames(false)
                 .setIgnorePublishAddress(true)
-                .setSecurity(AWS);
+                .setSecurity(AWS)
+                .setLegacyPassThroughQueryEnabled(true);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearchOpenSearchConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearchOpenSearchConnectorTest.java
@@ -21,7 +21,7 @@ public class TestElasticsearchOpenSearchConnectorTest
     public TestElasticsearchOpenSearchConnectorTest()
     {
         // 1.0.0 and 1.0.1 causes NotSslRecordException during the initialization
-        super("opensearchproject/opensearch:1.1.0");
+        super("opensearchproject/opensearch:1.1.0", "opensearch");
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Hides Elasticsearch prefix-based pass-through query behind a feature toggle as discussed here #13390

The prefix-based pass-through query is deprecated. the `raw_query` table function should be used instead. To emphasize the fact that prefix-based pass-through query is deprecated before removing it at all, we decided to hide it behind the feature toggle.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible and no release notes are required.
(x) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
