### PR TITLE
Truncate month names in release note headers

### DIFF
--- a/docs/src/main/sphinx/release/release-383.md
+++ b/docs/src/main/sphinx/release/release-383.md
@@ -1,4 +1,4 @@
-# Release 383 (1 June 2022)
+# Release 383 (1 Jun 2022)
 
 ```{warning}
 This release has a regression that may cause queries to fail.

--- a/docs/src/main/sphinx/release/release-384.md
+++ b/docs/src/main/sphinx/release/release-384.md
@@ -1,4 +1,4 @@
-# Release 384 (3 June 2022)
+# Release 384 (3 Jun 2022)
 
 ## General
 

--- a/docs/src/main/sphinx/release/release-385.md
+++ b/docs/src/main/sphinx/release/release-385.md
@@ -1,4 +1,4 @@
-# Release 385 (8 June 2022)
+# Release 385 (8 Jun 2022)
 
 ## General
 

--- a/docs/src/main/sphinx/release/release-386.md
+++ b/docs/src/main/sphinx/release/release-386.md
@@ -1,4 +1,4 @@
-# Release 386 (15 June 2022)
+# Release 386 (15 Jun 2022)
 
 ## General
 

--- a/docs/src/main/sphinx/release/release-387.md
+++ b/docs/src/main/sphinx/release/release-387.md
@@ -1,4 +1,4 @@
-# Release 387 (22 June 2022)
+# Release 387 (22 Jun 2022)
 
 ## General
 

--- a/docs/src/main/sphinx/release/release-388.md
+++ b/docs/src/main/sphinx/release/release-388.md
@@ -1,4 +1,4 @@
-# Release 388 (29 June 2022)
+# Release 388 (29 Jun 2022)
 
 ## General
 

--- a/docs/src/main/sphinx/release/release-389.md
+++ b/docs/src/main/sphinx/release/release-389.md
@@ -1,5 +1,4 @@
-
-# Release 389 (7 July 2022)
+# Release 389 (7 Jul 2022)
 
 ## General
 

--- a/docs/src/main/sphinx/release/release-390.md
+++ b/docs/src/main/sphinx/release/release-390.md
@@ -1,4 +1,4 @@
-# Release 390 (13 July 2022)
+# Release 390 (13 Jul 2022)
 
 ## General
 

--- a/docs/src/main/sphinx/release/release-391.md
+++ b/docs/src/main/sphinx/release/release-391.md
@@ -1,4 +1,4 @@
-# Release 391 (22 July 2022)
+# Release 391 (22 Jul 2022)
 
 ## General
 

--- a/docs/src/main/sphinx/release/release-392.md
+++ b/docs/src/main/sphinx/release/release-392.md
@@ -1,4 +1,4 @@
-# Release 392 (3 August 2022)
+# Release 392 (3 Aug 2022)
 
 ## General
 

--- a/docs/src/main/sphinx/release/release-393.md
+++ b/docs/src/main/sphinx/release/release-393.md
@@ -1,4 +1,4 @@
-# Release 393 (17 August 2022)
+# Release 393 (17 Aug 2022)
 
 ## General
 

--- a/docs/src/main/sphinx/release/release-394.md
+++ b/docs/src/main/sphinx/release/release-394.md
@@ -1,4 +1,4 @@
-# Release 394 (29 August 2022)
+# Release 394 (29 Aug 2022)
 
 ## General
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

I've just now realized that all of our months in headers for past release notes have been 3 characters, but since I've taken over writing them, I've been spelling out the whole month. This has been fine up until this month, but 'September' needs to be abbreviated to 'Sep' to avoid the sidebar wrapping onto a second line, and we should probably fix all the past notes for consistency's sake.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Updating release notes.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

- [x] This is not user-visible and no release notes are required.
- [ ] Release notes are required, please propose a release note for me.
- [ ] Release notes are required, with the following suggested text:

...kinda feels like maybe that release note selection isn't the best... might add "This is a docs change and no release notes are required."