### PR TITLE
Simplify test case

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJoin.java
@@ -101,17 +101,12 @@ public class TestJoin
                     t2 (id, x, y) AS (
                         VALUES
                             (1, 10, 'a'),
-                            (2, 10, 'b')),
-                    t AS (
-                        SELECT
-                            x
-                            , IF(t1.v = 0, 'cc', y) as z
-                        FROM t1 JOIN t2 ON (t1.id = t2.id))
-                SELECT *
-                FROM t
-                WHERE x = 10 AND z = 'b'
+                            (2, 10, 'b'))
+                SELECT x, y
+                FROM t1 JOIN t2 ON (t1.id = t2.id)
+                WHERE IF(t1.v = 0, 'cc', y) = 'b'
                 """))
-                .matches("VALUES (10, CAST('b' AS varchar(2)))");
+                .matches("VALUES (10, 'b')");
     }
 
     @Test


### PR DESCRIPTION
The bug fixed in https://github.com/trinodb/trino/pull/13152 can be reproduced with a simpler query:

    SELECT x, y
    FROM t1 JOIN t2 ON (t1.id = t2.id)
    WHERE IF(t1.v = 0, 'cc', y) = 'b'

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible and no release notes are required.
