### PR TITLE
Remove unnecessary method

### DIFF
--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestColorFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestColorFunctions.java
@@ -13,7 +13,6 @@
  */
 package io.trino.operator.scalar;
 
-import io.airlift.slice.Slice;
 import org.testng.annotations.Test;
 
 import static io.airlift.slice.Slices.utf8Slice;
@@ -36,24 +35,24 @@ public class TestColorFunctions
     @Test
     public void testParseRgb()
     {
-        assertEquals(parseRgb(toSlice("#000")), 0x00_00_00);
-        assertEquals(parseRgb(toSlice("#FFF")), 0xFF_FF_FF);
-        assertEquals(parseRgb(toSlice("#F00")), 0xFF_00_00);
-        assertEquals(parseRgb(toSlice("#0F0")), 0x00_FF_00);
-        assertEquals(parseRgb(toSlice("#00F")), 0x00_00_FF);
-        assertEquals(parseRgb(toSlice("#700")), 0x77_00_00);
-        assertEquals(parseRgb(toSlice("#070")), 0x00_77_00);
-        assertEquals(parseRgb(toSlice("#007")), 0x00_00_77);
+        assertEquals(parseRgb(utf8Slice("#000")), 0x00_00_00);
+        assertEquals(parseRgb(utf8Slice("#FFF")), 0xFF_FF_FF);
+        assertEquals(parseRgb(utf8Slice("#F00")), 0xFF_00_00);
+        assertEquals(parseRgb(utf8Slice("#0F0")), 0x00_FF_00);
+        assertEquals(parseRgb(utf8Slice("#00F")), 0x00_00_FF);
+        assertEquals(parseRgb(utf8Slice("#700")), 0x77_00_00);
+        assertEquals(parseRgb(utf8Slice("#070")), 0x00_77_00);
+        assertEquals(parseRgb(utf8Slice("#007")), 0x00_00_77);
 
-        assertEquals(parseRgb(toSlice("#cde")), 0xCC_DD_EE);
+        assertEquals(parseRgb(utf8Slice("#cde")), 0xCC_DD_EE);
     }
 
     @Test
     public void testGetComponent()
     {
-        assertEquals(getRed(parseRgb(toSlice("#789"))), 0x77);
-        assertEquals(getGreen(parseRgb(toSlice("#789"))), 0x88);
-        assertEquals(getBlue(parseRgb(toSlice("#789"))), 0x99);
+        assertEquals(getRed(parseRgb(utf8Slice("#789"))), 0x77);
+        assertEquals(getGreen(parseRgb(utf8Slice("#789"))), 0x88);
+        assertEquals(getBlue(parseRgb(utf8Slice("#789"))), 0x99);
     }
 
     @Test
@@ -67,91 +66,91 @@ public class TestColorFunctions
     @Test
     public void testColor()
     {
-        assertEquals(color(toSlice("black")), -1);
-        assertEquals(color(toSlice("red")), -2);
-        assertEquals(color(toSlice("green")), -3);
-        assertEquals(color(toSlice("yellow")), -4);
-        assertEquals(color(toSlice("blue")), -5);
-        assertEquals(color(toSlice("magenta")), -6);
-        assertEquals(color(toSlice("cyan")), -7);
-        assertEquals(color(toSlice("white")), -8);
+        assertEquals(color(utf8Slice("black")), -1);
+        assertEquals(color(utf8Slice("red")), -2);
+        assertEquals(color(utf8Slice("green")), -3);
+        assertEquals(color(utf8Slice("yellow")), -4);
+        assertEquals(color(utf8Slice("blue")), -5);
+        assertEquals(color(utf8Slice("magenta")), -6);
+        assertEquals(color(utf8Slice("cyan")), -7);
+        assertEquals(color(utf8Slice("white")), -8);
 
-        assertEquals(color(toSlice("#f00")), 0xFF_00_00);
-        assertEquals(color(toSlice("#0f0")), 0x00_FF_00);
-        assertEquals(color(toSlice("#00f")), 0x00_00_FF);
+        assertEquals(color(utf8Slice("#f00")), 0xFF_00_00);
+        assertEquals(color(utf8Slice("#0f0")), 0x00_FF_00);
+        assertEquals(color(utf8Slice("#00f")), 0x00_00_FF);
     }
 
     @Test
     public void testBar()
     {
-        assertEquals(bar(0.6, 5, color(toSlice("#f0f")), color(toSlice("#00f"))),
-                toSlice("\u001B[38;5;201m\u2588\u001B[38;5;165m\u2588\u001B[38;5;129m\u2588\u001B[0m  "));
+        assertEquals(bar(0.6, 5, color(utf8Slice("#f0f")), color(utf8Slice("#00f"))),
+                utf8Slice("\u001B[38;5;201m\u2588\u001B[38;5;165m\u2588\u001B[38;5;129m\u2588\u001B[0m  "));
 
-        assertEquals(bar(1, 10, color(toSlice("#f00")), color(toSlice("#0f0"))),
-                toSlice("\u001B[38;5;196m\u2588\u001B[38;5;202m\u2588\u001B[38;5;208m\u2588\u001B[38;5;214m\u2588\u001B[38;5;226m\u2588\u001B[38;5;226m\u2588\u001B[38;5;154m\u2588\u001B[38;5;118m\u2588\u001B[38;5;82m\u2588\u001B[38;5;46m\u2588\u001B[0m"));
+        assertEquals(bar(1, 10, color(utf8Slice("#f00")), color(utf8Slice("#0f0"))),
+                utf8Slice("\u001B[38;5;196m\u2588\u001B[38;5;202m\u2588\u001B[38;5;208m\u2588\u001B[38;5;214m\u2588\u001B[38;5;226m\u2588\u001B[38;5;226m\u2588\u001B[38;5;154m\u2588\u001B[38;5;118m\u2588\u001B[38;5;82m\u2588\u001B[38;5;46m\u2588\u001B[0m"));
 
-        assertEquals(bar(0.6, 5, color(toSlice("#f0f")), color(toSlice("#00f"))),
-                toSlice("\u001B[38;5;201m\u2588\u001B[38;5;165m\u2588\u001B[38;5;129m\u2588\u001B[0m  "));
+        assertEquals(bar(0.6, 5, color(utf8Slice("#f0f")), color(utf8Slice("#00f"))),
+                utf8Slice("\u001B[38;5;201m\u2588\u001B[38;5;165m\u2588\u001B[38;5;129m\u2588\u001B[0m  "));
     }
 
     @Test
     public void testRenderBoolean()
     {
-        assertEquals(render(true), toSlice("\u001b[38;5;2m✓\u001b[0m"));
-        assertEquals(render(false), toSlice("\u001b[38;5;1m✗\u001b[0m"));
+        assertEquals(render(true), utf8Slice("\u001b[38;5;2m✓\u001b[0m"));
+        assertEquals(render(false), utf8Slice("\u001b[38;5;1m✗\u001b[0m"));
     }
 
     @Test
     public void testRenderString()
     {
-        assertEquals(render(toSlice("hello"), color(toSlice("red"))), toSlice("\u001b[38;5;1mhello\u001b[0m"));
+        assertEquals(render(utf8Slice("hello"), color(utf8Slice("red"))), utf8Slice("\u001b[38;5;1mhello\u001b[0m"));
 
-        assertEquals(render(toSlice("hello"), color(toSlice("#f00"))), toSlice("\u001b[38;5;196mhello\u001b[0m"));
-        assertEquals(render(toSlice("hello"), color(toSlice("#0f0"))), toSlice("\u001b[38;5;46mhello\u001b[0m"));
-        assertEquals(render(toSlice("hello"), color(toSlice("#00f"))), toSlice("\u001b[38;5;21mhello\u001b[0m"));
+        assertEquals(render(utf8Slice("hello"), color(utf8Slice("#f00"))), utf8Slice("\u001b[38;5;196mhello\u001b[0m"));
+        assertEquals(render(utf8Slice("hello"), color(utf8Slice("#0f0"))), utf8Slice("\u001b[38;5;46mhello\u001b[0m"));
+        assertEquals(render(utf8Slice("hello"), color(utf8Slice("#00f"))), utf8Slice("\u001b[38;5;21mhello\u001b[0m"));
     }
 
     @Test
     public void testRenderLong()
     {
-        assertEquals(render(1234, color(toSlice("red"))), toSlice("\u001b[38;5;1m1234\u001b[0m"));
+        assertEquals(render(1234, color(utf8Slice("red"))), utf8Slice("\u001b[38;5;1m1234\u001b[0m"));
 
-        assertEquals(render(1234, color(toSlice("#f00"))), toSlice("\u001b[38;5;196m1234\u001b[0m"));
-        assertEquals(render(1234, color(toSlice("#0f0"))), toSlice("\u001b[38;5;46m1234\u001b[0m"));
-        assertEquals(render(1234, color(toSlice("#00f"))), toSlice("\u001b[38;5;21m1234\u001b[0m"));
+        assertEquals(render(1234, color(utf8Slice("#f00"))), utf8Slice("\u001b[38;5;196m1234\u001b[0m"));
+        assertEquals(render(1234, color(utf8Slice("#0f0"))), utf8Slice("\u001b[38;5;46m1234\u001b[0m"));
+        assertEquals(render(1234, color(utf8Slice("#00f"))), utf8Slice("\u001b[38;5;21m1234\u001b[0m"));
     }
 
     @Test
     public void testRenderDouble()
     {
-        assertEquals(render(1234.5678, color(toSlice("red"))), toSlice("\u001b[38;5;1m1234.5678\u001b[0m"));
-        assertEquals(render(1234.5678f, color(toSlice("red"))), toSlice(format("\u001b[38;5;1m%s\u001b[0m", (double) 1234.5678f)));
+        assertEquals(render(1234.5678, color(utf8Slice("red"))), utf8Slice("\u001b[38;5;1m1234.5678\u001b[0m"));
+        assertEquals(render(1234.5678f, color(utf8Slice("red"))), utf8Slice(format("\u001b[38;5;1m%s\u001b[0m", (double) 1234.5678f)));
 
-        assertEquals(render(1234.5678, color(toSlice("#f00"))), toSlice("\u001b[38;5;196m1234.5678\u001b[0m"));
-        assertEquals(render(1234.5678, color(toSlice("#0f0"))), toSlice("\u001b[38;5;46m1234.5678\u001b[0m"));
-        assertEquals(render(1234.5678, color(toSlice("#00f"))), toSlice("\u001b[38;5;21m1234.5678\u001b[0m"));
+        assertEquals(render(1234.5678, color(utf8Slice("#f00"))), utf8Slice("\u001b[38;5;196m1234.5678\u001b[0m"));
+        assertEquals(render(1234.5678, color(utf8Slice("#0f0"))), utf8Slice("\u001b[38;5;46m1234.5678\u001b[0m"));
+        assertEquals(render(1234.5678, color(utf8Slice("#00f"))), utf8Slice("\u001b[38;5;21m1234.5678\u001b[0m"));
     }
 
     @Test
     public void testInterpolate()
     {
-        assertEquals(color(0, 0, 255, color(toSlice("#000")), color(toSlice("#fff"))), 0x00_00_00);
-        assertEquals(color(0.0f, 0.0f, 255.0f, color(toSlice("#000")), color(toSlice("#fff"))), 0x00_00_00);
-        assertEquals(color(128, 0, 255, color(toSlice("#000")), color(toSlice("#fff"))), 0x80_80_80);
-        assertEquals(color(255, 0, 255, color(toSlice("#000")), color(toSlice("#fff"))), 0xFF_FF_FF);
+        assertEquals(color(0, 0, 255, color(utf8Slice("#000")), color(utf8Slice("#fff"))), 0x00_00_00);
+        assertEquals(color(0.0f, 0.0f, 255.0f, color(utf8Slice("#000")), color(utf8Slice("#fff"))), 0x00_00_00);
+        assertEquals(color(128, 0, 255, color(utf8Slice("#000")), color(utf8Slice("#fff"))), 0x80_80_80);
+        assertEquals(color(255, 0, 255, color(utf8Slice("#000")), color(utf8Slice("#fff"))), 0xFF_FF_FF);
 
         assertEquals(color(-1, 42, 52, rgb(0xFF, 0, 0), rgb(0xFF, 0xFF, 0)), 0xFF_00_00);
         assertEquals(color(47, 42, 52, rgb(0xFF, 0, 0), rgb(0xFF, 0xFF, 0)), 0xFF_80_00);
         assertEquals(color(142, 42, 52, rgb(0xFF, 0, 0), rgb(0xFF, 0xFF, 0)), 0xFF_FF_00);
 
-        assertEquals(color(-42, color(toSlice("#000")), color(toSlice("#fff"))), 0x00_00_00);
-        assertEquals(color(0.0, color(toSlice("#000")), color(toSlice("#fff"))), 0x00_00_00);
-        assertEquals(color(0.5, color(toSlice("#000")), color(toSlice("#fff"))), 0x80_80_80);
-        assertEquals(color(1.0, color(toSlice("#000")), color(toSlice("#fff"))), 0xFF_FF_FF);
-        assertEquals(color(42, color(toSlice("#000")), color(toSlice("#fff"))), 0xFF_FF_FF);
-        assertEquals(color(1.0f, color(toSlice("#000")), color(toSlice("#fff"))), 0xFF_FF_FF);
-        assertEquals(color(-0.0f, color(toSlice("#000")), color(toSlice("#fff"))), 0x00_00_00);
-        assertEquals(color(0.0f, color(toSlice("#000")), color(toSlice("#fff"))), 0x00_00_00);
+        assertEquals(color(-42, color(utf8Slice("#000")), color(utf8Slice("#fff"))), 0x00_00_00);
+        assertEquals(color(0.0, color(utf8Slice("#000")), color(utf8Slice("#fff"))), 0x00_00_00);
+        assertEquals(color(0.5, color(utf8Slice("#000")), color(utf8Slice("#fff"))), 0x80_80_80);
+        assertEquals(color(1.0, color(utf8Slice("#000")), color(utf8Slice("#fff"))), 0xFF_FF_FF);
+        assertEquals(color(42, color(utf8Slice("#000")), color(utf8Slice("#fff"))), 0xFF_FF_FF);
+        assertEquals(color(1.0f, color(utf8Slice("#000")), color(utf8Slice("#fff"))), 0xFF_FF_FF);
+        assertEquals(color(-0.0f, color(utf8Slice("#000")), color(utf8Slice("#fff"))), 0x00_00_00);
+        assertEquals(color(0.0f, color(utf8Slice("#000")), color(utf8Slice("#fff"))), 0x00_00_00);
     }
 
     @Test
@@ -159,10 +158,5 @@ public class TestColorFunctions
     {
         assertOperator(INDETERMINATE, "color(null)", BOOLEAN, true);
         assertOperator(INDETERMINATE, "color('black')", BOOLEAN, false);
-    }
-
-    private static Slice toSlice(String string)
-    {
-        return utf8Slice(string);
     }
 }


### PR DESCRIPTION
The method was a left-over from before the utf8Slice() convenience method existed.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible and no release notes are required.
