### PR TITLE
Expose PostgreSQL on default port in PostgreSqlQueryRunner.main

### DIFF
--- a/plugin/trino-postgresql/pom.xml
+++ b/plugin/trino-postgresql/pom.xml
@@ -164,6 +164,12 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-testing-containers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-testing-services</artifactId>
             <scope>test</scope>
         </dependency>

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/PostgreSqlQueryRunner.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/PostgreSqlQueryRunner.java
@@ -83,7 +83,7 @@ public final class PostgreSqlQueryRunner
             throws Exception
     {
         DistributedQueryRunner queryRunner = createPostgreSqlQueryRunner(
-                new TestingPostgreSqlServer(),
+                new TestingPostgreSqlServer(true),
                 ImmutableMap.of("http-server.http.port", "8080"),
                 ImmutableMap.of(),
                 TpchTable.getTables());

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestingPostgreSqlServer.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestingPostgreSqlServer.java
@@ -31,6 +31,7 @@ import java.util.stream.Stream;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.jdbc.RemoteDatabaseEvent.Status.CANCELLED;
 import static io.trino.plugin.jdbc.RemoteDatabaseEvent.Status.RUNNING;
+import static io.trino.testing.containers.TestContainers.exposeFixedPorts;
 import static java.lang.String.format;
 import static java.util.function.Predicate.not;
 import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
@@ -51,6 +52,11 @@ public class TestingPostgreSqlServer
 
     public TestingPostgreSqlServer()
     {
+        this(false);
+    }
+
+    public TestingPostgreSqlServer(boolean shouldExposeFixedPorts)
+    {
         // Use the oldest supported PostgreSQL version
         dockerContainer = new PostgreSQLContainer<>("postgres:10.20")
                 .withStartupAttempts(3)
@@ -58,6 +64,9 @@ public class TestingPostgreSqlServer
                 .withUsername(USER)
                 .withPassword(PASSWORD)
                 .withCommand("postgres", "-c", "log_destination=stderr", "-c", "log_statement=all");
+        if (shouldExposeFixedPorts) {
+            exposeFixedPorts(dockerContainer);
+        }
         dockerContainer.start();
 
         execute("CREATE SCHEMA tpch");

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/TestContainers.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/TestContainers.java
@@ -14,14 +14,20 @@
 
 package io.trino.testing.containers;
 
+import com.github.dockerjava.api.model.ExposedPort;
+import com.github.dockerjava.api.model.PortBinding;
+import com.google.common.collect.ImmutableList;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.TestcontainersConfiguration;
 
 import java.io.Closeable;
 
+import static com.github.dockerjava.api.model.Ports.Binding.bindPort;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.System.getenv;
+import static java.util.Objects.requireNonNull;
 import static org.testcontainers.utility.MountableFile.forClasspathResource;
 
 public final class TestContainers
@@ -54,5 +60,21 @@ public final class TestContainers
                 // This ensures that JAR resources are being copied out to tmp locations
                 // and mounted from there.
                 .getResolvedPath();
+    }
+
+    public static void exposeFixedPorts(GenericContainer<?> container)
+    {
+        checkState(System.getenv("CONTINUOUS_INTEGRATION") == null, "" +
+                "Exposing fixed ports should not be used in regular test code. This could break parallel test execution. " +
+                "This method is supposed to be invoked from local development helpers only e.g. QueryRunner.main(), " +
+                "hence it should never run on CI");
+
+        ImmutableList<PortBinding> portBindings = container.getExposedPorts().stream()
+                .map(exposedPort -> new PortBinding(bindPort(exposedPort), new ExposedPort(exposedPort)))
+                .collect(toImmutableList());
+
+        container.withCreateContainerCmdModifier(cmd -> cmd
+                .withHostConfig(requireNonNull(cmd.getHostConfig(), "hostConfig is null")
+                        .withPortBindings(portBindings)));
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Previously ports were randomly bound, which made it harder to work on local environment. Now when running outside of the CI default ports will be used.

For now its initial change for Postgressql only, but it could be extended to others (like Mysql, Sqlserver e.t.c.)

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
