### PR TITLE
Don't use explicit Guice binding for config class

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastoreModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastoreModule.java
@@ -26,6 +26,7 @@ import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreModule;
 import java.util.Optional;
 
 import static io.airlift.configuration.ConditionalModule.conditionalModule;
+import static io.airlift.configuration.ConfigBinder.configBinder;
 
 public class HiveMetastoreModule
         extends AbstractConfigurationAwareModule
@@ -42,9 +43,8 @@ public class HiveMetastoreModule
     {
         if (metastore.isPresent()) {
             binder.bind(HiveMetastoreFactory.class).annotatedWith(RawHiveMetastoreFactory.class).toInstance(HiveMetastoreFactory.ofInstance(metastore.get()));
-            MetastoreTypeConfig metastoreTypeConfig = new MetastoreTypeConfig();
-            metastoreTypeConfig.setMetastoreType("provided");
-            binder.bind(MetastoreTypeConfig.class).toInstance(metastoreTypeConfig);
+            configBinder(binder).bindConfigDefaults(MetastoreTypeConfig.class, config -> config.setMetastoreType("provided"));
+            configBinder(binder).bindConfig(MetastoreTypeConfig.class);
         }
         else {
             bindMetastoreModule("thrift", new ThriftMetastoreModule());

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
@@ -65,6 +65,7 @@ import static java.nio.file.Files.createDirectories;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 public final class HiveQueryRunner
@@ -138,6 +139,9 @@ public final class HiveQueryRunner
 
         public SELF setHiveProperties(Map<String, String> hiveProperties)
         {
+            assertThat(hiveProperties)
+                    .withFailMessage("Setting hive.metastore is not allowed in HiveQueryRunner")
+                    .doesNotContainKey("hive.metastore");
             this.hiveProperties = ImmutableMap.<String, String>builder()
                     .putAll(requireNonNull(hiveProperties, "hiveProperties is null"));
             return self();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The binding is necessary because `HiveMetadataFactory` has an `@Inject`ed parameter `MetastoreTypeConfig` now. This means that it needs to be bound now in all code paths, even when the metastore is provided externally (which only happens when using `HiveQueryRunner`). But explicit binding is bad, because it is incompatible with bindings managed by io.airlift:configuration, specifically with `buildConfigObject` and anything that calls it.

This commit changes the binding to use a regular `configBinder()`; in order to prevent unexpected configuration "leaking" from the environment, the `HiveQueryRunner` now explicitly forbids setting the `hive.metastore` property.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Fixes incorrect internal use of configuration management interfaces.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
