### PR TITLE
Export metrics to api: schedulingTime and runningTime

### DIFF
--- a/core/trino-main/src/main/java/io/trino/dispatcher/FailedDispatchQuery.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/FailedDispatchQuery.java
@@ -262,6 +262,8 @@ public class FailedDispatchQuery
                 new Duration(0, MILLISECONDS),
                 new Duration(0, MILLISECONDS),
                 new Duration(0, MILLISECONDS),
+                new Duration(0, MILLISECONDS),
+                new Duration(0, MILLISECONDS),
                 0,
                 0,
                 0,

--- a/core/trino-main/src/main/java/io/trino/execution/QueryStats.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryStats.java
@@ -52,6 +52,8 @@ public class QueryStats
     private final Duration executionTime;
     private final Duration analysisTime;
     private final Duration planningTime;
+    private final Duration schedulingTime;
+    private final Duration runningTime;
     private final Duration finishingTime;
 
     private final int totalTasks;
@@ -142,6 +144,8 @@ public class QueryStats
             @JsonProperty("executionTime") Duration executionTime,
             @JsonProperty("analysisTime") Duration analysisTime,
             @JsonProperty("planningTime") Duration planningTime,
+            @JsonProperty("schedulingTime") Duration schedulingTime,
+            @JsonProperty("runningTime") Duration runningTime,
             @JsonProperty("finishingTime") Duration finishingTime,
 
             @JsonProperty("totalTasks") int totalTasks,
@@ -230,6 +234,8 @@ public class QueryStats
         this.executionTime = requireNonNull(executionTime, "executionTime is null");
         this.analysisTime = requireNonNull(analysisTime, "analysisTime is null");
         this.planningTime = requireNonNull(planningTime, "planningTime is null");
+        this.schedulingTime = requireNonNull(schedulingTime, "schedulingTime is null");
+        this.runningTime = requireNonNull(runningTime, "runningTime is null");
         this.finishingTime = requireNonNull(finishingTime, "finishingTime is null");
 
         checkArgument(totalTasks >= 0, "totalTasks is negative");
@@ -390,6 +396,18 @@ public class QueryStats
     public Duration getPlanningTime()
     {
         return planningTime;
+    }
+
+    @JsonProperty
+    public Duration getSchedulingTime()
+    {
+        return schedulingTime;
+    }
+
+    @JsonProperty
+    public Duration getRunningTime()
+    {
+        return runningTime;
     }
 
     @JsonProperty

--- a/core/trino-main/src/test/java/io/trino/execution/MockManagedQueryExecution.java
+++ b/core/trino-main/src/test/java/io/trino/execution/MockManagedQueryExecution.java
@@ -173,6 +173,8 @@ public class MockManagedQueryExecution
                         new Duration(41, NANOSECONDS),
                         new Duration(7, NANOSECONDS),
                         new Duration(8, NANOSECONDS),
+                        new Duration(8, NANOSECONDS),
+                        new Duration(8, NANOSECONDS),
 
                         new Duration(100, NANOSECONDS),
                         new Duration(200, NANOSECONDS),

--- a/core/trino-main/src/test/java/io/trino/execution/TestQueryStats.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestQueryStats.java
@@ -175,6 +175,8 @@ public class TestQueryStats
 
             new Duration(100, NANOSECONDS),
             new Duration(200, NANOSECONDS),
+            new Duration(200, NANOSECONDS),
+            new Duration(200, NANOSECONDS),
 
             9,
             10,

--- a/core/trino-main/src/test/java/io/trino/server/TestBasicQueryInfo.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestBasicQueryInfo.java
@@ -68,6 +68,8 @@ public class TestBasicQueryInfo
                                 new Duration(9, MINUTES),
                                 new Duration(99, SECONDS),
                                 new Duration(12, MINUTES),
+                                new Duration(99, SECONDS),
+                                new Duration(12, MINUTES),
                                 13,
                                 14,
                                 15,

--- a/core/trino-main/src/test/java/io/trino/server/TestQueryStateInfo.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestQueryStateInfo.java
@@ -118,6 +118,8 @@ public class TestQueryStateInfo
                         new Duration(10, MINUTES),
                         new Duration(11, MINUTES),
                         new Duration(12, MINUTES),
+                        new Duration(12, MINUTES),
+                        new Duration(12, MINUTES),
                         13,
                         14,
                         15,


### PR DESCRIPTION

## Description
schedulingTime and runningTime are helping for performance troubleshooting. Export them to /ui/api/query/queryId json.

