### PR TITLE
Unbind MetastoreTypeConfig in Hive tests

### DIFF
--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/s3select/S3SelectTestHelper.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/s3select/S3SelectTestHelper.java
@@ -48,7 +48,6 @@ import io.trino.plugin.hive.aws.athena.PartitionProjectionService;
 import io.trino.plugin.hive.fs.FileSystemDirectoryLister;
 import io.trino.plugin.hive.metastore.HiveMetastoreConfig;
 import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
-import io.trino.plugin.hive.metastore.MetastoreTypeConfig;
 import io.trino.plugin.hive.metastore.thrift.BridgingHiveMetastore;
 import io.trino.plugin.hive.s3.HiveS3Config;
 import io.trino.plugin.hive.s3.TrinoS3ConfigurationInitializer;
@@ -152,7 +151,7 @@ public class S3SelectTestHelper
                 SqlStandardAccessControlMetadata::new,
                 new FileSystemDirectoryLister(),
                 new PartitionProjectionService(this.hiveConfig, ImmutableMap.of(), new TestingTypeManager()),
-                new MetastoreTypeConfig());
+                true);
         transactionManager = new HiveTransactionManager(metadataFactory);
 
         splitManager = new HiveSplitManager(

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/AllowHiveTableRename.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/AllowHiveTableRename.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+public @interface AllowHiveTableRename {}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -371,7 +371,7 @@ public class HiveMetadata
     private final AccessControlMetadata accessControlMetadata;
     private final DirectoryLister directoryLister;
     private final PartitionProjectionService partitionProjectionService;
-    private final String metastoreType;
+    private final boolean allowTableRename;
 
     public HiveMetadata(
             CatalogName catalogName,
@@ -396,7 +396,7 @@ public class HiveMetadata
             AccessControlMetadata accessControlMetadata,
             DirectoryLister directoryLister,
             PartitionProjectionService partitionProjectionService,
-            String metastoreType)
+            boolean allowTableRename)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.metastore = requireNonNull(metastore, "metastore is null");
@@ -420,7 +420,7 @@ public class HiveMetadata
         this.accessControlMetadata = requireNonNull(accessControlMetadata, "accessControlMetadata is null");
         this.directoryLister = requireNonNull(directoryLister, "directoryLister is null");
         this.partitionProjectionService = requireNonNull(partitionProjectionService, "partitionProjectionService is null");
-        this.metastoreType = requireNonNull(metastoreType, "metastoreType is null");
+        this.allowTableRename = allowTableRename;
     }
 
     @Override
@@ -1266,8 +1266,8 @@ public class HiveMetadata
     @Override
     public void renameTable(ConnectorSession session, ConnectorTableHandle tableHandle, SchemaTableName newTableName)
     {
-        if (metastoreType.equalsIgnoreCase("glue")) {
-            throw new TrinoException(NOT_SUPPORTED, "Table rename is not yet supported by Glue service");
+        if (!allowTableRename) {
+            throw new TrinoException(NOT_SUPPORTED, "Table rename is not supported with current metastore configuration");
         }
         HiveTableHandle handle = (HiveTableHandle) tableHandle;
         metastore.renameTable(handle.getSchemaName(), handle.getTableName(), newTableName.getSchemaName(), newTableName.getTableName());

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadataFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadataFactory.java
@@ -23,7 +23,6 @@ import io.trino.plugin.hive.fs.DirectoryLister;
 import io.trino.plugin.hive.fs.TransactionScopeCachingDirectoryLister;
 import io.trino.plugin.hive.metastore.HiveMetastoreConfig;
 import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
-import io.trino.plugin.hive.metastore.MetastoreTypeConfig;
 import io.trino.plugin.hive.metastore.SemiTransactionalHiveMetastore;
 import io.trino.plugin.hive.security.AccessControlMetadataFactory;
 import io.trino.plugin.hive.statistics.MetastoreHiveStatisticsProvider;
@@ -76,7 +75,7 @@ public class HiveMetadataFactory
     private final DirectoryLister directoryLister;
     private final long perTransactionFileStatusCacheMaximumSize;
     private final PartitionProjectionService partitionProjectionService;
-    private final String metastoreType;
+    private final boolean allowTableRename;
 
     @Inject
     public HiveMetadataFactory(
@@ -99,7 +98,7 @@ public class HiveMetadataFactory
             AccessControlMetadataFactory accessControlMetadataFactory,
             DirectoryLister directoryLister,
             PartitionProjectionService partitionProjectionService,
-            MetastoreTypeConfig metastoreTypeConfig)
+            @AllowHiveTableRename boolean allowTableRename)
     {
         this(
                 catalogName,
@@ -133,7 +132,7 @@ public class HiveMetadataFactory
                 directoryLister,
                 hiveConfig.getPerTransactionFileStatusCacheMaximumSize(),
                 partitionProjectionService,
-                metastoreTypeConfig);
+                allowTableRename);
     }
 
     public HiveMetadataFactory(
@@ -168,7 +167,7 @@ public class HiveMetadataFactory
             DirectoryLister directoryLister,
             long perTransactionFileStatusCacheMaximumSize,
             PartitionProjectionService partitionProjectionService,
-            MetastoreTypeConfig metastoreTypeConfig)
+            boolean allowTableRename)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.skipDeletionForAlter = skipDeletionForAlter;
@@ -208,8 +207,7 @@ public class HiveMetadataFactory
         this.directoryLister = requireNonNull(directoryLister, "directoryLister is null");
         this.perTransactionFileStatusCacheMaximumSize = perTransactionFileStatusCacheMaximumSize;
         this.partitionProjectionService = requireNonNull(partitionProjectionService, "partitionProjectionService is null");
-        requireNonNull(metastoreTypeConfig, "metastoreTypeConfig is null");
-        this.metastoreType = requireNonNull(metastoreTypeConfig.getMetastoreType(), "metastoreType is null");
+        this.allowTableRename = allowTableRename;
     }
 
     @Override
@@ -256,6 +254,6 @@ public class HiveMetadataFactory
                 accessControlMetadataFactory.create(metastore),
                 directoryLister,
                 partitionProjectionService,
-                metastoreType);
+                allowTableRename);
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastoreModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastoreModule.java
@@ -14,10 +14,12 @@
 package io.trino.plugin.hive.metastore;
 
 import com.google.inject.Binder;
+import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.plugin.hive.AllowHiveTableRename;
 import io.trino.plugin.hive.HideDeltaLakeTables;
 import io.trino.plugin.hive.metastore.file.FileMetastoreModule;
 import io.trino.plugin.hive.metastore.glue.GlueMetastoreModule;
@@ -42,9 +44,7 @@ public class HiveMetastoreModule
     {
         if (metastore.isPresent()) {
             binder.bind(HiveMetastoreFactory.class).annotatedWith(RawHiveMetastoreFactory.class).toInstance(HiveMetastoreFactory.ofInstance(metastore.get()));
-            MetastoreTypeConfig metastoreTypeConfig = new MetastoreTypeConfig();
-            metastoreTypeConfig.setMetastoreType("provided");
-            binder.bind(MetastoreTypeConfig.class).toInstance(metastoreTypeConfig);
+            binder.bind(Key.get(boolean.class, AllowHiveTableRename.class)).toInstance(true);
         }
         else {
             bindMetastoreModule("thrift", new ThriftMetastoreModule());

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/alluxio/AlluxioMetastoreModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/alluxio/AlluxioMetastoreModule.java
@@ -21,9 +21,11 @@ import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.master.MasterClientContext;
 import com.google.inject.Binder;
+import com.google.inject.Key;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.plugin.hive.AllowHiveTableRename;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
 import io.trino.plugin.hive.metastore.RawHiveMetastoreFactory;
@@ -42,6 +44,7 @@ public class AlluxioMetastoreModule
         configBinder(binder).bindConfig(AlluxioHiveMetastoreConfig.class);
 
         binder.bind(HiveMetastoreFactory.class).annotatedWith(RawHiveMetastoreFactory.class).to(AlluxioHiveMetastoreFactory.class).in(Scopes.SINGLETON);
+        binder.bind(Key.get(boolean.class, AllowHiveTableRename.class)).toInstance(false);
     }
 
     @Provides

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileMetastoreModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileMetastoreModule.java
@@ -14,8 +14,10 @@
 package io.trino.plugin.hive.metastore.file;
 
 import com.google.inject.Binder;
+import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
+import io.trino.plugin.hive.AllowHiveTableRename;
 import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
 import io.trino.plugin.hive.metastore.RawHiveMetastoreFactory;
 
@@ -29,5 +31,6 @@ public class FileMetastoreModule
     {
         configBinder(binder).bindConfig(FileHiveMetastoreConfig.class);
         binder.bind(HiveMetastoreFactory.class).annotatedWith(RawHiveMetastoreFactory.class).to(FileHiveMetastoreFactory.class).in(Scopes.SINGLETON);
+        binder.bind(Key.get(boolean.class, AllowHiveTableRename.class)).toInstance(true);
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueMetastoreModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueMetastoreModule.java
@@ -26,6 +26,7 @@ import com.google.inject.TypeLiteral;
 import io.airlift.concurrent.BoundedExecutor;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.trino.plugin.base.CatalogName;
+import io.trino.plugin.hive.AllowHiveTableRename;
 import io.trino.plugin.hive.HiveConfig;
 import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
 import io.trino.plugin.hive.metastore.RawHiveMetastoreFactory;
@@ -64,6 +65,8 @@ public class GlueMetastoreModule
         // export under the old name, for backwards compatibility
         binder.bind(GlueHiveMetastoreFactory.class).in(Scopes.SINGLETON);
         newExporter(binder).export(GlueHiveMetastoreFactory.class).as(generator -> generator.generatedNameOf(GlueHiveMetastore.class));
+
+        binder.bind(Key.get(boolean.class, AllowHiveTableRename.class)).toInstance(false);
 
         install(conditionalModule(
                 HiveConfig.class,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreModule.java
@@ -14,9 +14,11 @@
 package io.trino.plugin.hive.metastore.thrift;
 
 import com.google.inject.Binder;
+import com.google.inject.Key;
 import com.google.inject.Scopes;
 import com.google.inject.multibindings.OptionalBinder;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.plugin.hive.AllowHiveTableRename;
 import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
 import io.trino.plugin.hive.metastore.RawHiveMetastoreFactory;
 
@@ -43,6 +45,8 @@ public class ThriftMetastoreModule
                 .annotatedWith(RawHiveMetastoreFactory.class)
                 .to(BridgingHiveMetastoreFactory.class)
                 .in(Scopes.SINGLETON);
+
+        binder.bind(Key.get(boolean.class, AllowHiveTableRename.class)).toInstance(true);
 
         install(new ThriftMetastoreAuthenticationModule());
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -41,7 +41,6 @@ import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
 import io.trino.plugin.hive.metastore.HivePrincipal;
 import io.trino.plugin.hive.metastore.HivePrivilegeInfo;
 import io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege;
-import io.trino.plugin.hive.metastore.MetastoreTypeConfig;
 import io.trino.plugin.hive.metastore.Partition;
 import io.trino.plugin.hive.metastore.PartitionWithStatistics;
 import io.trino.plugin.hive.metastore.PrincipalPrivileges;
@@ -874,7 +873,7 @@ public abstract class AbstractTestHive
                 countingDirectoryLister,
                 1000,
                 new PartitionProjectionService(hiveConfig, ImmutableMap.of(), new TestingTypeManager()),
-                new MetastoreTypeConfig());
+                true);
         transactionManager = new HiveTransactionManager(metadataFactory);
         splitManager = new HiveSplitManager(
                 transactionManager,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
@@ -40,7 +40,6 @@ import io.trino.plugin.hive.metastore.ForwardingHiveMetastore;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.HiveMetastoreConfig;
 import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
-import io.trino.plugin.hive.metastore.MetastoreTypeConfig;
 import io.trino.plugin.hive.metastore.PrincipalPrivileges;
 import io.trino.plugin.hive.metastore.StorageFormat;
 import io.trino.plugin.hive.metastore.Table;
@@ -216,7 +215,7 @@ public abstract class AbstractTestHiveFileSystem
                 SqlStandardAccessControlMetadata::new,
                 new FileSystemDirectoryLister(),
                 new PartitionProjectionService(config, ImmutableMap.of(), new TestingTypeManager()),
-                new MetastoreTypeConfig());
+                true);
         transactionManager = new HiveTransactionManager(metadataFactory);
         splitManager = new HiveSplitManager(
                 transactionManager,


### PR DESCRIPTION
This removes `MetastoreTypeConfig` binding added in
https://github.com/findepi/trino/commit/722973898cefb43a5fdbc54a39571c678606a3c6 (https://github.com/trinodb/trino/pull/13707) and replaces it with an
annotated boolean, decoupling the `HiveMetadata` logic from metastore
implementations.