### PR TITLE
Change optimized parquet writer to match spec for lists

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetSchemaConverter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetSchemaConverter.java
@@ -184,7 +184,7 @@ public class ParquetSchemaConverter
     {
         Type elementType = type.getElementType();
         return Types.list(repetition)
-                .element(convert(elementType, "array", ImmutableList.<String>builder().addAll(parent).add(name).add("list").build(), OPTIONAL))
+                .element(convert(elementType, "element", ImmutableList.<String>builder().addAll(parent).add(name).add("list").build(), OPTIONAL))
                 .named(name);
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/AbstractTestParquetReader.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/AbstractTestParquetReader.java
@@ -1457,6 +1457,7 @@ public abstract class AbstractTestParquetReader
                 new ArrayType(INTEGER),
                 Optional.of(parquetMrNonNullSpecSchema));
 
+        // this style of schema is also written by the trino optimized parquet writer
         MessageType sparkSchema = parseMessageType("message hive_schema {" +
                 "  optional group my_list (LIST){" +
                 "    repeated group list {" +
@@ -1483,6 +1484,15 @@ public abstract class AbstractTestParquetReader
                 "  }" +
                 "} ");
         tester.testRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), values, values, "my_list", new ArrayType(INTEGER), Optional.of(customNamingSchema));
+
+        MessageType optimizedParquetWriterOldListSchema = parseMessageType("message trino_schema {" +
+                "  optional group my_list (LIST){" +
+                "    repeated group list {" +
+                "        optional int32 array;" +
+                "    }" +
+                "  }" +
+                "} ");
+        tester.testRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), values, values, "my_list", new ArrayType(INTEGER), Optional.of(optimizedParquetWriterOldListSchema));
     }
 
     /**

--- a/testing/trino-testing/src/main/java/io/trino/testing/StructuralTestUtil.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/StructuralTestUtil.java
@@ -16,6 +16,7 @@ package io.trino.testing;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Int128;
 import io.trino.spi.type.MapType;
@@ -151,5 +152,11 @@ public final class StructuralTestUtil
         return (MapType) TESTING_TYPE_MANAGER.getParameterizedType(StandardTypes.MAP, ImmutableList.of(
                 TypeSignatureParameter.typeParameter(keyType.getTypeSignature()),
                 TypeSignatureParameter.typeParameter(valueType.getTypeSignature())));
+    }
+
+    public static ArrayType arrayType(Type elementType)
+    {
+        return (ArrayType) TESTING_TYPE_MANAGER.getParameterizedType(StandardTypes.ARRAY, ImmutableList.of(
+                    TypeSignatureParameter.typeParameter(elementType.getTypeSignature())));
     }
 }


### PR DESCRIPTION
This PR changes the optimized parquet writer to match the [current parquet spec for Lists](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#lists). This PR simply changes the inner most field's name to "element".

after this change
```
message trino_schema {
  optional group tags (LIST) {
    repeated group list {
      optional binary element (STRING);
    }
  }
}
```

before
```
message trino_schema {
  optional group tags (LIST) {
    repeated group list {
      optional binary array (STRING);
    }
  }
}

```

This will enable other parquet readers (e.g. BigQuery external table) to infer (https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-parquet#list_logical_type) the schemas written by Trino as `List<String>` instead of a more nested structure.

## Non-technical explanation
Write parquet lists according to spec.

## Release notes

( ) This is not user-visible and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```
# Hive
* Fix incompatibility that prevents BigQuery from reading files produced by Trino’s optimized Parquet writer . ({issue}`14063`)

# DeltaLake
* Fix incompatibility that prevents BigQuery from reading files produced by Trino’s optimized writer . ({issue}`14063`)
```