### PR TITLE
Remove deprecated getBucketNodeMap method

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorNodePartitioningProvider.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorNodePartitioningProvider.java
@@ -21,18 +21,9 @@ import java.util.function.ToIntFunction;
 
 public interface ConnectorNodePartitioningProvider
 {
-    /**
-     * @deprecated use {@link #getBucketNodeMapping}
-     */
-    @Deprecated
-    default ConnectorBucketNodeMap getBucketNodeMap(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle)
-    {
-        return null;
-    }
-
     default Optional<ConnectorBucketNodeMap> getBucketNodeMapping(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle)
     {
-        return Optional.ofNullable(getBucketNodeMap(transactionHandle, session, partitioningHandle));
+        return Optional.empty();
     }
 
     default ToIntFunction<ConnectorSplit> getSplitBucketFunction(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle)

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeNodePartitioningProvider.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeNodePartitioningProvider.java
@@ -66,14 +66,6 @@ public final class ClassLoaderSafeNodePartitioningProvider
     }
 
     @Override
-    public ConnectorBucketNodeMap getBucketNodeMap(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle)
-    {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getBucketNodeMap(transactionHandle, session, partitioningHandle);
-        }
-    }
-
-    @Override
     public ToIntFunction<ConnectorSplit> getSplitBucketFunction(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {


### PR DESCRIPTION
## Description

Remove deprecated `ConnectorNodePartitioningProvider.getBucketNodeMap()` method.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# SPI changes
* Remove deprecated `ConnectorNodePartitioningProvider.getBucketNodeMap()` method. ({issue}`14067`)
```
