### PR TITLE
adapt json principal

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Authenticator.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Authenticator.java
@@ -72,7 +72,14 @@ public class OAuth2Authenticator
         if (claims.isEmpty()) {
             return Optional.empty();
         }
-        String principal = (String) claims.get().get(principalField);
+        Object principalObj = claims.get().get(principalField);
+        String principal = null;
+        if (principalObj instanceof String) {
+            principal = (String) principalObj;
+        }else{
+            ObjectMapper mapper = new ObjectMapper();
+            principal = mapper.writeValueAsString(principalObj);
+        }
         Identity.Builder builder = Identity.forUser(userMapping.mapUser(principal));
         builder.withPrincipal(new BasicPrincipal(principal));
         groupsField.flatMap(field -> Optional.ofNullable((List<String>) claims.get().get(field)))

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Authenticator.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Authenticator.java
@@ -13,6 +13,8 @@
  */
 package io.trino.server.security.oauth2;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSet;
 import io.trino.server.security.AbstractBearerAuthenticator;
 import io.trino.server.security.AuthenticationException;
@@ -62,7 +64,7 @@ public class OAuth2Authenticator
 
     @Override
     protected Optional<Identity> createIdentity(String token)
-            throws UserMappingException
+            throws UserMappingException, JsonProcessingException
     {
         TokenPair tokenPair = tokenPairSerializer.deserialize(token);
         if (tokenPair.getExpiration().before(Date.from(Instant.now()))) {

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Authenticator.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Authenticator.java
@@ -64,7 +64,7 @@ public class OAuth2Authenticator
 
     @Override
     protected Optional<Identity> createIdentity(String token)
-            throws UserMappingException, JsonProcessingException
+            throws UserMappingException
     {
         TokenPair tokenPair = tokenPairSerializer.deserialize(token);
         if (tokenPair.getExpiration().before(Date.from(Instant.now()))) {
@@ -78,9 +78,14 @@ public class OAuth2Authenticator
         String principal = null;
         if (principalObj instanceof String) {
             principal = (String) principalObj;
-        }else{
+        } else {
             ObjectMapper mapper = new ObjectMapper();
-            principal = mapper.writeValueAsString(principalObj);
+            try {
+                principal = mapper.writeValueAsString(principalObj);
+            }
+            catch (JsonProcessingException e) {
+                return Optional.empty();
+            }
         }
         Identity.Builder builder = Identity.forUser(userMapping.mapUser(principal));
         builder.withPrincipal(new BasicPrincipal(principal));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
We are using keycloak as the OAuth2 server, and in some scenarios, we pass a JSON as the principal, then the following error happens(we are using Trino 367):
`
Caused by: java.lang.ClassCastException: Cannot cast java.util.LinkedHashMap to java.lang.String
        at java.base/java.lang.Class.cast(Class.java:3605)
        at java.base/java.util.Optional.map(Optional.java:265)
        at io.trino.server.security.oauth2.OAuth2Authenticator.extractPrincipalFromToken(OAuth2Authenticator.java:54)
        at io.trino.server.security.AbstractBearerAuthenticator.authenticate(AbstractBearerAuthenticator.java:50)
        ... 58 more
`
To solve this issue, I think the non-string type should also be handled.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

This is not user-visible and no release notes are required.

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
