### PR TITLE
Fix hive.hive-views.run-as-invoker handling with legacy view translation

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/LegacyHiveViewReader.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/LegacyHiveViewReader.java
@@ -49,7 +49,7 @@ public class LegacyHiveViewReader
                         .map(column -> new ConnectorViewDefinition.ViewColumn(column.getName(), TypeId.of(column.getType().getTypeSignature().toString())))
                         .collect(toImmutableList()),
                 Optional.ofNullable(table.getParameters().get(TABLE_COMMENT)),
-                table.getOwner(),
+                Optional.empty(), // will be filled in later by HiveMetadata
                 hiveViewsRunAsInvoker);
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
@@ -227,7 +227,7 @@ public final class ViewReaderUtil
                         Optional.of(table.getDatabaseName()),
                         columns,
                         Optional.ofNullable(table.getParameters().get(TABLE_COMMENT)),
-                        Optional.empty(),
+                        Optional.empty(), // will be filled in later by HiveMetadata
                         hiveViewsRunAsInvoker);
             }
             catch (RuntimeException e) {

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Hadoop.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Hadoop.java
@@ -40,6 +40,7 @@ public final class Hadoop
     public static final String CONTAINER_PRESTO_HIVE_PROPERTIES = CONTAINER_PRESTO_ETC + "/catalog/hive.properties";
     public static final String CONTAINER_PRESTO_HIVE_WITH_EXTERNAL_WRITES_PROPERTIES = CONTAINER_PRESTO_ETC + "/catalog/hive_with_external_writes.properties";
     public static final String CONTAINER_PRESTO_HIVE_TIMESTAMP_NANOS = CONTAINER_PRESTO_ETC + "/catalog/hive_timestamp_nanos.properties";
+    public static final String CONTAINER_PRESTO_HIVE_RUN_VIEW_AS_INVOKER = CONTAINER_PRESTO_ETC + "/catalog/hive_with_run_view_as_invoker.properties";
     public static final String CONTAINER_PRESTO_ICEBERG_PROPERTIES = CONTAINER_PRESTO_ETC + "/catalog/iceberg.properties";
 
     private final DockerFiles dockerFiles;
@@ -68,6 +69,7 @@ public final class Hadoop
         builder.addConnector("hive", forHostPath(dockerFiles.getDockerFilesHostPath("common/hadoop/hive.properties")), CONTAINER_PRESTO_HIVE_PROPERTIES);
         builder.addConnector("hive", forHostPath(dockerFiles.getDockerFilesHostPath("common/hadoop/hive_with_external_writes.properties")), CONTAINER_PRESTO_HIVE_WITH_EXTERNAL_WRITES_PROPERTIES);
         builder.addConnector("hive", forHostPath(dockerFiles.getDockerFilesHostPath("common/hadoop/hive_timestamp_nanos.properties")), CONTAINER_PRESTO_HIVE_TIMESTAMP_NANOS);
+        builder.addConnector("hive", forHostPath(dockerFiles.getDockerFilesHostPath("common/hadoop/hive_with_run_view_as_invoker.properties")), CONTAINER_PRESTO_HIVE_RUN_VIEW_AS_INVOKER);
         builder.addConnector("iceberg", forHostPath(dockerFiles.getDockerFilesHostPath("common/hadoop/iceberg.properties")), CONTAINER_PRESTO_ICEBERG_PROPERTIES);
     }
 

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinode.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinode.java
@@ -26,9 +26,11 @@ import javax.inject.Inject;
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.WORKER;
 import static io.trino.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_HIVE_PROPERTIES;
+import static io.trino.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_HIVE_RUN_VIEW_AS_INVOKER;
 import static io.trino.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_HIVE_TIMESTAMP_NANOS;
 import static io.trino.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_HIVE_WITH_EXTERNAL_WRITES_PROPERTIES;
 import static io.trino.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_ICEBERG_PROPERTIES;
+import static io.trino.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_ETC;
 import static io.trino.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_JVM_CONFIG;
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.utility.MountableFile.forHostPath;
@@ -37,6 +39,8 @@ import static org.testcontainers.utility.MountableFile.forHostPath;
 public final class EnvMultinode
         extends EnvironmentProvider
 {
+    public static final String CONTAINER_PRESTO_HIVE_ACCESS_CONTROL = CONTAINER_PRESTO_ETC + "/catalog/hive.properties";
+
     private final DockerFiles dockerFiles;
     private final DockerFiles.ResourceProvider configDir;
 
@@ -59,6 +63,7 @@ public final class EnvMultinode
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("common/hadoop/hive.properties")), CONTAINER_PRESTO_HIVE_PROPERTIES)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("common/hadoop/hive_with_external_writes.properties")), CONTAINER_PRESTO_HIVE_WITH_EXTERNAL_WRITES_PROPERTIES)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("common/hadoop/hive_timestamp_nanos.properties")), CONTAINER_PRESTO_HIVE_TIMESTAMP_NANOS)
+                .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("common/hadoop/hive_with_run_view_as_invoker.properties")), CONTAINER_PRESTO_HIVE_RUN_VIEW_AS_INVOKER)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("common/hadoop/iceberg.properties")), CONTAINER_PRESTO_ICEBERG_PROPERTIES));
     }
 }

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop/hive_with_run_view_as_invoker.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop/hive_with_run_view_as_invoker.properties
@@ -1,0 +1,8 @@
+connector.name=hive
+hive.metastore.uri=thrift://hadoop-master:9083
+hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
+hive.metastore-cache-ttl=0s
+hive.fs.cache.max-size=10
+hive.hive-views.enabled=true
+hive.hive-views.run-as-invoker=true
+hive.security=sql-standard


### PR DESCRIPTION
This is https://github.com/trinodb/trino/pull/12403 + product tests that should cover https://github.com/trinodb/trino/pull/12221 as well

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Fix a bug when querying hive views with `hive.hive-views.run-as-invoker` set to true

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

I am not sure release notes are required since this feature was not working in the first place

( ) This is not user-visible and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
