### PR TITLE
Remove Pinot Column Name Property

### DIFF
--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotColumnHandle.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotColumnHandle.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
 import static io.trino.plugin.pinot.PinotMetadata.PINOT_COLUMN_NAME_PROPERTY;
-import static io.trino.plugin.pinot.query.DynamicTablePqlExtractor.quoteIdentifier;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -70,11 +69,6 @@ public class PinotColumnHandle
         checkState((pushedDownAggregateFunctionName.isPresent() && aggregate) || pushedDownAggregateFunctionName.isEmpty(), "Unexpected arguments: aggregate is false but pushed down aggregation is present");
         this.pushedDownAggregateFunctionName = pushedDownAggregateFunctionName;
         this.pushedDownAggregateFunctionArgument = pushedDownAggregateFunctionArgument;
-    }
-
-    public static PinotColumnHandle fromNonAggregateColumnHandle(PinotColumnHandle columnHandle)
-    {
-        return new PinotColumnHandle(columnHandle.getColumnName(), columnHandle.getDataType(), quoteIdentifier(columnHandle.getColumnName()), false, false, true, Optional.empty(), Optional.empty());
     }
 
     public static PinotColumnHandle fromColumnMetadata(ColumnMetadata columnMetadata)

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotColumnHandle.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotColumnHandle.java
@@ -15,7 +15,6 @@ package io.trino.plugin.pinot;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableMap;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.type.Type;
@@ -25,8 +24,6 @@ import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
-import static io.trino.plugin.pinot.PinotMetadata.PINOT_COLUMN_NAME_PROPERTY;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class PinotColumnHandle
@@ -69,12 +66,6 @@ public class PinotColumnHandle
         checkState((pushedDownAggregateFunctionName.isPresent() && aggregate) || pushedDownAggregateFunctionName.isEmpty(), "Unexpected arguments: aggregate is false but pushed down aggregation is present");
         this.pushedDownAggregateFunctionName = pushedDownAggregateFunctionName;
         this.pushedDownAggregateFunctionArgument = pushedDownAggregateFunctionArgument;
-    }
-
-    public static PinotColumnHandle fromColumnMetadata(ColumnMetadata columnMetadata)
-    {
-        String columnName = (String) requireNonNull(columnMetadata.getProperties().get(PINOT_COLUMN_NAME_PROPERTY), format("Missing required column property '%s'", PINOT_COLUMN_NAME_PROPERTY));
-        return new PinotColumnHandle(columnName, columnMetadata.getType());
     }
 
     @JsonProperty
@@ -145,9 +136,6 @@ public class PinotColumnHandle
         return ColumnMetadata.builder()
                 .setName(columnName)
                 .setType(dataType)
-                .setProperties(ImmutableMap.<String, Object>builder()
-                        .put(PINOT_COLUMN_NAME_PROPERTY, columnName)
-                        .buildOrThrow())
                 .build();
     }
 

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/DynamicTableBuilder.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/DynamicTableBuilder.java
@@ -46,7 +46,6 @@ import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.trino.plugin.pinot.PinotColumnHandle.fromNonAggregateColumnHandle;
 import static io.trino.plugin.pinot.PinotErrorCode.PINOT_EXCEPTION;
 import static io.trino.plugin.pinot.query.PinotExpressionRewriter.rewriteExpression;
 import static io.trino.plugin.pinot.query.PinotPatterns.WILDCARD;
@@ -141,7 +140,8 @@ public final class DynamicTableBuilder
             // Since Pinot doesn't support subqueries yet, we can only have one occurrence of SELECT *
             if (expressionContext.getType() == ExpressionContext.Type.IDENTIFIER && expressionContext.getIdentifier().equals(WILDCARD)) {
                 pinotColumnsBuilder.addAll(columnHandles.values().stream()
-                        .map(handle -> fromNonAggregateColumnHandle((PinotColumnHandle) handle))
+                        .map(PinotColumnHandle.class::cast)
+                        .map(PinotMetadata::toNonAggregateColumnHandle)
                         .collect(toImmutableList()));
             }
             else {

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/BasePinotIntegrationConnectorSmokeTest.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/BasePinotIntegrationConnectorSmokeTest.java
@@ -1000,7 +1000,16 @@ public abstract class BasePinotIntegrationConnectorSmokeTest
     @Override
     public void testShowCreateTable()
     {
-        assertQueryFails("SHOW CREATE TABLE region", "No PropertyMetadata for property: pinotColumnName");
+        assertThat((String) computeScalar("SHOW CREATE TABLE region"))
+                .isEqualTo(
+                        "CREATE TABLE %s.%s.region (\n" +
+                                "   regionkey bigint,\n" +
+                                "   updated_at_seconds bigint,\n" +
+                                "   name varchar,\n" +
+                                "   comment varchar\n" +
+                                ")",
+                        getSession().getCatalog().orElseThrow(),
+                        getSession().getSchema().orElseThrow());
     }
 
     @Override

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotQueryBase.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotQueryBase.java
@@ -45,8 +45,8 @@ public class TestPinotQueryBase
 
     protected List<String> getColumnNames(String table)
     {
-        return pinotMetadata.getColumnsMetadata(table).stream()
-                .map(PinotColumnHandle::fromColumnMetadata)
+        return pinotMetadata.getPinotColumnHandles(table).values().stream()
+                .map(PinotColumnHandle.class::cast)
                 .map(PinotColumnHandle::getColumnName)
                 .collect(toImmutableList());
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Add the column name property to Pinot column properties.
Fixes #14071 

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

The pinot column name property was missing so `SHOW CREATE TABLE` queries would fail.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Pinot
* Fix failure when executing `SHOW CREATE TABLE` statement. ({issue}`14071`)
```
