### PR TITLE
Do not allow RLE or Dictionary to be nested in an RLE or Dictionary

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/BigintGroupByHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/BigintGroupByHash.java
@@ -656,7 +656,7 @@ public class BigintGroupByHash
 
             return new GroupByIdBlock(
                     nextGroupId,
-                    new RunLengthEncodedBlock(
+                    RunLengthEncodedBlock.create(
                             BIGINT.createFixedSizeBlockBuilder(1).writeLong(groupId).build(),
                             block.getPositionCount()));
         }

--- a/core/trino-main/src/main/java/io/trino/operator/ChangeOnlyUpdatedColumnsMergeProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ChangeOnlyUpdatedColumnsMergeProcessor.java
@@ -79,7 +79,7 @@ public class ChangeOnlyUpdatedColumnsMergeProcessor
         Block operationChannelBlock = mergeRow.getField(mergeRow.getFieldCount() - 2);
         builder.add(operationChannelBlock);
         builder.add(inputPage.getBlock(rowIdChannel));
-        builder.add(new RunLengthEncodedBlock(INSERT_FROM_UPDATE_BLOCK, positionCount));
+        builder.add(RunLengthEncodedBlock.create(INSERT_FROM_UPDATE_BLOCK, positionCount));
 
         Page result = new Page(builder.toArray(Block[]::new));
 

--- a/core/trino-main/src/main/java/io/trino/operator/GroupIdOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupIdOperator.java
@@ -178,14 +178,14 @@ public class GroupIdOperator
 
         for (int i = 0; i < groupingSetInputs[currentGroupingSet].length; i++) {
             if (groupingSetInputs[currentGroupingSet][i] == -1) {
-                outputBlocks[i] = new RunLengthEncodedBlock(nullBlocks[i], currentPage.getPositionCount());
+                outputBlocks[i] = RunLengthEncodedBlock.create(nullBlocks[i], currentPage.getPositionCount());
             }
             else {
                 outputBlocks[i] = currentPage.getBlock(groupingSetInputs[currentGroupingSet][i]);
             }
         }
 
-        outputBlocks[outputBlocks.length - 1] = new RunLengthEncodedBlock(groupIdBlocks[currentGroupingSet], currentPage.getPositionCount());
+        outputBlocks[outputBlocks.length - 1] = RunLengthEncodedBlock.create(groupIdBlocks[currentGroupingSet], currentPage.getPositionCount());
         currentGroupingSet = (currentGroupingSet + 1) % groupingSetInputs.length;
         Page outputPage = new Page(currentPage.getPositionCount(), outputBlocks);
 

--- a/core/trino-main/src/main/java/io/trino/operator/MarkDistinctHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/MarkDistinctHash.java
@@ -67,12 +67,12 @@ public class MarkDistinctHash
             // must have > 1 positions to benefit from using a RunLengthEncoded block
             if (nextDistinctId == ids.getGroupCount()) {
                 // no new distinct positions
-                return new RunLengthEncodedBlock(BooleanType.createBlockForSingleNonNullValue(false), positions);
+                return RunLengthEncodedBlock.create(BooleanType.createBlockForSingleNonNullValue(false), positions);
             }
             if (nextDistinctId + positions == ids.getGroupCount()) {
                 // all positions are distinct
                 nextDistinctId = ids.getGroupCount();
-                return new RunLengthEncodedBlock(BooleanType.createBlockForSingleNonNullValue(true), positions);
+                return RunLengthEncodedBlock.create(BooleanType.createBlockForSingleNonNullValue(true), positions);
             }
         }
         byte[] distinctMask = new byte[positions];

--- a/core/trino-main/src/main/java/io/trino/operator/MultiChannelGroupByHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/MultiChannelGroupByHash.java
@@ -972,7 +972,7 @@ public class MultiChannelGroupByHash
 
             return new GroupByIdBlock(
                     nextGroupId,
-                    new RunLengthEncodedBlock(
+                    RunLengthEncodedBlock.create(
                             BIGINT.createFixedSizeBlockBuilder(1).writeLong(groupId).build(),
                             page.getPositionCount()));
         }

--- a/core/trino-main/src/main/java/io/trino/operator/join/NestedLoopJoinOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/NestedLoopJoinOperator.java
@@ -392,7 +392,7 @@ public class NestedLoopJoinOperator
             // For the page with less rows, create RLE blocks and add them to the blocks array
             for (int i = 0; i < smallPageOutputBlocks.length; i++) {
                 Block block = smallPageOutputBlocks[i].getSingleValueBlock(rowIndex);
-                resultBlockBuffer[indexForRleBlocks + i] = new RunLengthEncodedBlock(block, largePagePositionCount);
+                resultBlockBuffer[indexForRleBlocks + i] = RunLengthEncodedBlock.create(block, largePagePositionCount);
             }
             // Page constructor will create a copy of the block buffer (and must for correctness)
             return new Page(largePagePositionCount, resultBlockBuffer);

--- a/core/trino-main/src/main/java/io/trino/operator/output/BytePositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/BytePositionsAppender.java
@@ -123,7 +123,7 @@ public class BytePositionsAppender
             result = new ByteArrayBlock(positionCount, hasNullValue ? Optional.of(valueIsNull) : Optional.empty(), values);
         }
         else {
-            result = new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+            result = RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, positionCount);
         }
         reset();
         return result;

--- a/core/trino-main/src/main/java/io/trino/operator/output/BytePositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/BytePositionsAppender.java
@@ -94,9 +94,8 @@ public class BytePositionsAppender
     }
 
     @Override
-    public void appendRle(RunLengthEncodedBlock block)
+    public void appendRle(Block block, int rlePositionCount)
     {
-        int rlePositionCount = block.getPositionCount();
         if (rlePositionCount == 0) {
             return;
         }

--- a/core/trino-main/src/main/java/io/trino/operator/output/Int128PositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/Int128PositionsAppender.java
@@ -136,7 +136,7 @@ public class Int128PositionsAppender
             result = new Int128ArrayBlock(positionCount, hasNullValue ? Optional.of(valueIsNull) : Optional.empty(), values);
         }
         else {
-            result = new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+            result = RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, positionCount);
         }
         reset();
         return result;

--- a/core/trino-main/src/main/java/io/trino/operator/output/Int128PositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/Int128PositionsAppender.java
@@ -101,9 +101,8 @@ public class Int128PositionsAppender
     }
 
     @Override
-    public void appendRle(RunLengthEncodedBlock block)
+    public void appendRle(Block block, int rlePositionCount)
     {
-        int rlePositionCount = block.getPositionCount();
         if (rlePositionCount == 0) {
             return;
         }

--- a/core/trino-main/src/main/java/io/trino/operator/output/Int96PositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/Int96PositionsAppender.java
@@ -98,9 +98,8 @@ public class Int96PositionsAppender
     }
 
     @Override
-    public void appendRle(RunLengthEncodedBlock block)
+    public void appendRle(Block block, int rlePositionCount)
     {
-        int rlePositionCount = block.getPositionCount();
         if (rlePositionCount == 0) {
             return;
         }

--- a/core/trino-main/src/main/java/io/trino/operator/output/Int96PositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/Int96PositionsAppender.java
@@ -131,7 +131,7 @@ public class Int96PositionsAppender
             result = new Int96ArrayBlock(positionCount, hasNullValue ? Optional.of(valueIsNull) : Optional.empty(), high, low);
         }
         else {
-            result = new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+            result = RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, positionCount);
         }
         reset();
         return result;

--- a/core/trino-main/src/main/java/io/trino/operator/output/IntPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/IntPositionsAppender.java
@@ -94,9 +94,8 @@ public class IntPositionsAppender
     }
 
     @Override
-    public void appendRle(RunLengthEncodedBlock block)
+    public void appendRle(Block block, int rlePositionCount)
     {
-        int rlePositionCount = block.getPositionCount();
         if (rlePositionCount == 0) {
             return;
         }

--- a/core/trino-main/src/main/java/io/trino/operator/output/IntPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/IntPositionsAppender.java
@@ -123,7 +123,7 @@ public class IntPositionsAppender
             result = new IntArrayBlock(positionCount, hasNullValue ? Optional.of(valueIsNull) : Optional.empty(), values);
         }
         else {
-            result = new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+            result = RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, positionCount);
         }
         reset();
         return result;

--- a/core/trino-main/src/main/java/io/trino/operator/output/LongPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/LongPositionsAppender.java
@@ -94,9 +94,8 @@ public class LongPositionsAppender
     }
 
     @Override
-    public void appendRle(RunLengthEncodedBlock block)
+    public void appendRle(Block block, int rlePositionCount)
     {
-        int rlePositionCount = block.getPositionCount();
         if (rlePositionCount == 0) {
             return;
         }

--- a/core/trino-main/src/main/java/io/trino/operator/output/LongPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/LongPositionsAppender.java
@@ -123,7 +123,7 @@ public class LongPositionsAppender
             result = new LongArrayBlock(positionCount, hasNullValue ? Optional.of(valueIsNull) : Optional.empty(), values);
         }
         else {
-            result = new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+            result = RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, positionCount);
         }
         reset();
         return result;

--- a/core/trino-main/src/main/java/io/trino/operator/output/PagePartitioner.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/PagePartitioner.java
@@ -459,7 +459,7 @@ public class PagePartitioner
         for (int i = 0; i < blocks.length; i++) {
             int channel = partitionChannels[i];
             if (channel < 0) {
-                blocks[i] = new RunLengthEncodedBlock(partitionConstantBlocks[i], page.getPositionCount());
+                blocks[i] = RunLengthEncodedBlock.create(partitionConstantBlocks[i], page.getPositionCount());
             }
             else {
                 blocks[i] = page.getBlock(channel);

--- a/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppender.java
@@ -14,7 +14,6 @@
 package io.trino.operator.output;
 
 import io.trino.spi.block.Block;
-import io.trino.spi.block.RunLengthEncodedBlock;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 
 public interface PositionsAppender
@@ -22,12 +21,11 @@ public interface PositionsAppender
     void append(IntArrayList positions, Block source);
 
     /**
-     * Appends value from the {@code rleBlock} to this appender {@link RunLengthEncodedBlock#getPositionCount()} times.
+     * Appends the specified value positionCount times.
      * The result is the same as with using {@link PositionsAppender#append(IntArrayList, Block)} with
-     * positions list [0...{@link RunLengthEncodedBlock#getPositionCount()} -1]
-     * but with possible performance optimizations for {@link RunLengthEncodedBlock}.
+     * positions list [0...positionCount -1] but with possible performance optimizations.
      */
-    void appendRle(RunLengthEncodedBlock rleBlock);
+    void appendRle(Block value, int rlePositionCount);
 
     /**
      * Creates the block from the appender data.

--- a/core/trino-main/src/main/java/io/trino/operator/output/RleAwarePositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/RleAwarePositionsAppender.java
@@ -60,31 +60,32 @@ public class RleAwarePositionsAppender
     }
 
     @Override
-    public void appendRle(RunLengthEncodedBlock source)
+    public void appendRle(Block value, int positionCount)
     {
-        if (source.getPositionCount() == 0) {
+        if (positionCount == 0) {
             return;
         }
+        checkArgument(value.getPositionCount() == 1, "Expected value to contain a single position but has %d positions".formatted(value.getPositionCount()));
 
         if (rlePositionCount == 0) {
             // initial empty state, switch to RLE state
-            rleValue = source.getValue();
-            rlePositionCount = source.getPositionCount();
+            rleValue = value;
+            rlePositionCount = positionCount;
         }
         else if (rleValue != null) {
             // we are in the RLE state
-            if (equalOperator.equalNullSafe(rleValue, 0, source.getValue(), 0)) {
+            if (equalOperator.equalNullSafe(rleValue, 0, value, 0)) {
                 // the values match. we can just add positions.
-                this.rlePositionCount += source.getPositionCount();
+                this.rlePositionCount += positionCount;
                 return;
             }
             // RLE values do not match. switch to flat state
             switchToFlat();
-            delegate.appendRle(source);
+            delegate.appendRle(value, positionCount);
         }
         else {
             // flat state
-            delegate.appendRle(source);
+            delegate.appendRle(value, positionCount);
         }
     }
 
@@ -127,7 +128,7 @@ public class RleAwarePositionsAppender
     {
         if (rleValue != null) {
             // we are in the RLE state, flatten all RLE blocks
-            delegate.appendRle(new RunLengthEncodedBlock(rleValue, rlePositionCount));
+            delegate.appendRle(rleValue, rlePositionCount);
             rleValue = null;
         }
         rlePositionCount = NO_RLE;

--- a/core/trino-main/src/main/java/io/trino/operator/output/RleAwarePositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/RleAwarePositionsAppender.java
@@ -94,7 +94,7 @@ public class RleAwarePositionsAppender
     {
         Block result;
         if (rleValue != null) {
-            result = new RunLengthEncodedBlock(rleValue, rlePositionCount);
+            result = RunLengthEncodedBlock.create(rleValue, rlePositionCount);
         }
         else {
             result = delegate.build();

--- a/core/trino-main/src/main/java/io/trino/operator/output/RowPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/RowPositionsAppender.java
@@ -96,11 +96,10 @@ public class RowPositionsAppender
     }
 
     @Override
-    public void appendRle(RunLengthEncodedBlock rleBlock)
+    public void appendRle(Block value, int rlePositionCount)
     {
-        int rlePositionCount = rleBlock.getPositionCount();
         ensureCapacity(rlePositionCount);
-        AbstractRowBlock sourceRowBlock = (AbstractRowBlock) rleBlock.getValue();
+        AbstractRowBlock sourceRowBlock = (AbstractRowBlock) value;
         if (sourceRowBlock.isNull(0)) {
             // append rlePositionCount nulls
             Arrays.fill(rowIsNull, positionCount, positionCount + rlePositionCount, true);
@@ -111,7 +110,7 @@ public class RowPositionsAppender
             List<Block> fieldBlocks = sourceRowBlock.getChildren();
             int fieldPosition = sourceRowBlock.getFieldBlockOffset(0);
             for (int i = 0; i < fieldAppenders.length; i++) {
-                fieldAppenders[i].appendRle(new RunLengthEncodedBlock(fieldBlocks.get(i).getSingleValueBlock(fieldPosition), rlePositionCount));
+                fieldAppenders[i].appendRle(fieldBlocks.get(i).getSingleValueBlock(fieldPosition), rlePositionCount);
             }
             hasNonNullRow = true;
         }

--- a/core/trino-main/src/main/java/io/trino/operator/output/RowPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/RowPositionsAppender.java
@@ -131,7 +131,7 @@ public class RowPositionsAppender
         }
         else {
             Block nullRowBlock = fromFieldBlocks(1, Optional.of(new boolean[] {true}), fieldBlocks);
-            result = new RunLengthEncodedBlock(nullRowBlock, positionCount);
+            result = RunLengthEncodedBlock.create(nullRowBlock, positionCount);
         }
 
         reset();

--- a/core/trino-main/src/main/java/io/trino/operator/output/ShortPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/ShortPositionsAppender.java
@@ -94,9 +94,8 @@ public class ShortPositionsAppender
     }
 
     @Override
-    public void appendRle(RunLengthEncodedBlock block)
+    public void appendRle(Block block, int rlePositionCount)
     {
-        int rlePositionCount = block.getPositionCount();
         if (rlePositionCount == 0) {
             return;
         }

--- a/core/trino-main/src/main/java/io/trino/operator/output/ShortPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/ShortPositionsAppender.java
@@ -123,7 +123,7 @@ public class ShortPositionsAppender
             result = new ShortArrayBlock(positionCount, hasNullValue ? Optional.of(valueIsNull) : Optional.empty(), values);
         }
         else {
-            result = new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+            result = RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, positionCount);
         }
         reset();
         return result;

--- a/core/trino-main/src/main/java/io/trino/operator/output/SlicePositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/SlicePositionsAppender.java
@@ -121,9 +121,8 @@ public class SlicePositionsAppender
     }
 
     @Override
-    public void appendRle(RunLengthEncodedBlock block)
+    public void appendRle(Block block, int rlePositionCount)
     {
-        int rlePositionCount = block.getPositionCount();
         if (rlePositionCount == 0) {
             return;
         }

--- a/core/trino-main/src/main/java/io/trino/operator/output/SlicePositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/SlicePositionsAppender.java
@@ -153,7 +153,7 @@ public class SlicePositionsAppender
                     hasNullValue ? Optional.of(valueIsNull) : Optional.empty());
         }
         else {
-            result = new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+            result = RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, positionCount);
         }
         reset();
         return result;

--- a/core/trino-main/src/main/java/io/trino/operator/output/TypedPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/TypedPositionsAppender.java
@@ -15,7 +15,6 @@ package io.trino.operator.output;
 
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
-import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.type.Type;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import org.openjdk.jol.info.ClassLayout;
@@ -53,9 +52,9 @@ class TypedPositionsAppender
     }
 
     @Override
-    public void appendRle(RunLengthEncodedBlock block)
+    public void appendRle(Block block, int rlePositionCount)
     {
-        for (int i = 0; i < block.getPositionCount(); i++) {
+        for (int i = 0; i < rlePositionCount; i++) {
             type.appendTo(block, 0, blockBuilder);
         }
     }

--- a/core/trino-main/src/main/java/io/trino/operator/output/UnnestingPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/UnnestingPositionsAppender.java
@@ -86,22 +86,7 @@ public class UnnestingPositionsAppender
 
     private void appendDictionary(IntArrayList positions, DictionaryBlock source)
     {
-        Block dictionary = source.getDictionary();
-
-        while (dictionary instanceof RunLengthEncodedBlock || dictionary instanceof DictionaryBlock) {
-            if (dictionary instanceof RunLengthEncodedBlock) {
-                // if at some level dictionary contains only a single value then it can be flattened to rle
-                appendRle(new RunLengthEncodedBlock(((RunLengthEncodedBlock) dictionary).getValue(), positions.size()));
-                return;
-            }
-
-            // dictionary is a nested dictionary. we need to remap the ids
-            DictionaryBlock nestedDictionary = (DictionaryBlock) dictionary;
-            positions = mapPositions(positions, source);
-            dictionary = nestedDictionary.getDictionary();
-            source = nestedDictionary;
-        }
-        delegate.append(mapPositions(positions, source), dictionary);
+        delegate.append(mapPositions(positions, source), source.getDictionary());
     }
 
     private RunLengthEncodedBlock flatten(RunLengthEncodedBlock source, int positionCount)

--- a/core/trino-main/src/main/java/io/trino/operator/project/ConstantPageProjection.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/ConstantPageProjection.java
@@ -63,6 +63,6 @@ public class ConstantPageProjection
     @Override
     public Work<Block> project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
     {
-        return new CompletedWork<>(new RunLengthEncodedBlock(value, selectedPositions.size()));
+        return new CompletedWork<>(RunLengthEncodedBlock.create(value, selectedPositions.size()));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/project/DictionaryAwarePageProjection.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/DictionaryAwarePageProjection.java
@@ -169,7 +169,7 @@ public class DictionaryAwarePageProjection
                     DictionaryBlock dictionaryBlock = (DictionaryBlock) block;
                     // if dictionary was processed, produce a dictionary block; otherwise do normal processing
                     int[] outputIds = filterDictionaryIds(dictionaryBlock, selectedPositions);
-                    result = new DictionaryBlock(selectedPositions.size(), dictionaryOutput.get(), outputIds, false, sourceIdFunction.apply(dictionaryBlock));
+                    result = new DictionaryBlock(selectedPositions.size(), dictionaryOutput.get(), outputIds, sourceIdFunction.apply(dictionaryBlock));
                     return true;
                 }
 

--- a/core/trino-main/src/main/java/io/trino/operator/project/DictionaryAwarePageProjection.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/DictionaryAwarePageProjection.java
@@ -32,6 +32,7 @@ import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
+import static io.trino.spi.block.DictionaryBlock.createProjectedDictionaryBlock;
 import static java.util.Objects.requireNonNull;
 
 public class DictionaryAwarePageProjection
@@ -169,7 +170,7 @@ public class DictionaryAwarePageProjection
                     DictionaryBlock dictionaryBlock = (DictionaryBlock) block;
                     // if dictionary was processed, produce a dictionary block; otherwise do normal processing
                     int[] outputIds = filterDictionaryIds(dictionaryBlock, selectedPositions);
-                    result = new DictionaryBlock(selectedPositions.size(), dictionaryOutput.get(), outputIds, sourceIdFunction.apply(dictionaryBlock));
+                    result = createProjectedDictionaryBlock(selectedPositions.size(), dictionaryOutput.get(), outputIds, sourceIdFunction.apply(dictionaryBlock));
                     return true;
                 }
 

--- a/core/trino-main/src/main/java/io/trino/operator/project/DictionaryAwarePageProjection.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/DictionaryAwarePageProjection.java
@@ -162,7 +162,7 @@ public class DictionaryAwarePageProjection
                 if (block instanceof RunLengthEncodedBlock) {
                     // single value block is always considered effective, but the processing could have thrown
                     // in that case we fallback and process again so the correct error message sent
-                    result = new RunLengthEncodedBlock(dictionaryOutput.get(), selectedPositions.size());
+                    result = RunLengthEncodedBlock.create(dictionaryOutput.get(), selectedPositions.size());
                     return true;
                 }
 

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayCombinationsFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayCombinationsFunction.java
@@ -81,7 +81,7 @@ public final class ArrayCombinationsFunction
         int[] offsets = new int[combinationCount + 1];
         setAll(offsets, i -> i * combinationLength);
 
-        return ArrayBlock.fromElementBlock(combinationCount, Optional.empty(), offsets, new DictionaryBlock(ids.length, array, ids));
+        return ArrayBlock.fromElementBlock(combinationCount, Optional.empty(), offsets, DictionaryBlock.create(ids.length, array, ids));
     }
 
     @VisibleForTesting

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayCombinationsFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayCombinationsFunction.java
@@ -81,7 +81,7 @@ public final class ArrayCombinationsFunction
         int[] offsets = new int[combinationCount + 1];
         setAll(offsets, i -> i * combinationLength);
 
-        return ArrayBlock.fromElementBlock(combinationCount, Optional.empty(), offsets, new DictionaryBlock(array, ids));
+        return ArrayBlock.fromElementBlock(combinationCount, Optional.empty(), offsets, new DictionaryBlock(ids.length, array, ids));
     }
 
     @VisibleForTesting

--- a/core/trino-main/src/main/java/io/trino/operator/unnest/ReplicatedBlockBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/unnest/ReplicatedBlockBuilder.java
@@ -42,6 +42,6 @@ public class ReplicatedBlockBuilder
             fromPosition = toPosition;
         }
 
-        return new DictionaryBlock(outputRowCount, source, ids);
+        return DictionaryBlock.create(outputRowCount, source, ids);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/unnest/UnnestBlockBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/unnest/UnnestBlockBuilder.java
@@ -114,7 +114,7 @@ public class UnnestBlockBuilder
             }
         }
 
-        return new DictionaryBlock(outputPositionCount, source, ids);
+        return DictionaryBlock.create(outputPositionCount, source, ids);
     }
 
     /**

--- a/core/trino-main/src/main/java/io/trino/operator/window/pattern/ProjectingPagesWindowIndex.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/pattern/ProjectingPagesWindowIndex.java
@@ -244,7 +244,7 @@ public class ProjectingPagesWindowIndex
         // projection always creates a single row block, and will not align with the blocks from the pages index,
         // so we use an RLE block of the same length as the raw block
         int rawBlockPositionCount = pagesIndex.getRawBlock(0, position(position)).getPositionCount();
-        return new RunLengthEncodedBlock(compute, rawBlockPositionCount);
+        return RunLengthEncodedBlock.create(compute, rawBlockPositionCount);
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/block/BlockAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/block/BlockAssertions.java
@@ -134,8 +134,8 @@ public final class BlockAssertions
 
     public static RunLengthEncodedBlock createRandomRleBlock(Block block, int positionCount)
     {
-        checkArgument(block.getPositionCount() > 0, format("block positions %d is less than or equal to 0", block.getPositionCount()));
-        return new RunLengthEncodedBlock(block.getSingleValueBlock(random().nextInt(block.getPositionCount())), positionCount);
+        checkArgument(block.getPositionCount() >= 2, format("block positions %d is less 2", block.getPositionCount()));
+        return (RunLengthEncodedBlock) RunLengthEncodedBlock.create(block.getSingleValueBlock(random().nextInt(block.getPositionCount())), positionCount);
     }
 
     public static Block createRandomBlockForType(Type type, int positionCount, float nullRate)
@@ -893,18 +893,18 @@ public final class BlockAssertions
         return builder.build();
     }
 
-    public static RunLengthEncodedBlock createRLEBlock(double value, int positionCount)
+    public static Block createRepeatedValuesBlock(double value, int positionCount)
     {
         BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(null, 1);
         DOUBLE.writeDouble(blockBuilder, value);
-        return new RunLengthEncodedBlock(blockBuilder.build(), positionCount);
+        return RunLengthEncodedBlock.create(blockBuilder.build(), positionCount);
     }
 
-    public static RunLengthEncodedBlock createRLEBlock(long value, int positionCount)
+    public static Block createRepeatedValuesBlock(long value, int positionCount)
     {
         BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, 1);
         BIGINT.writeLong(blockBuilder, value);
-        return new RunLengthEncodedBlock(blockBuilder.build(), positionCount);
+        return RunLengthEncodedBlock.create(blockBuilder.build(), positionCount);
     }
 
     private static <T> Block createBlock(Type type, ValueWriter<T> valueWriter, Iterable<T> values)

--- a/core/trino-main/src/test/java/io/trino/block/BlockAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/block/BlockAssertions.java
@@ -121,7 +121,7 @@ public final class BlockAssertions
         }
     }
 
-    public static DictionaryBlock createRandomDictionaryBlock(Block dictionary, int positionCount)
+    public static Block createRandomDictionaryBlock(Block dictionary, int positionCount)
     {
         checkArgument(dictionary.getPositionCount() > 0, "dictionary position count %s is less than or equal to 0", dictionary.getPositionCount());
 
@@ -129,7 +129,7 @@ public final class BlockAssertions
         int[] ids = IntStream.range(0, positionCount)
                 .map(i -> random.nextInt(dictionary.getPositionCount()))
                 .toArray();
-        return new DictionaryBlock(positionCount, dictionary, ids);
+        return DictionaryBlock.create(positionCount, dictionary, ids);
     }
 
     public static RunLengthEncodedBlock createRandomRleBlock(Block block, int positionCount)
@@ -445,7 +445,7 @@ public final class BlockAssertions
         for (int i = 0; i < length; i++) {
             ids[i] = i % dictionarySize;
         }
-        return new DictionaryBlock(ids.length, builder.build(), ids);
+        return DictionaryBlock.create(ids.length, builder.build(), ids);
     }
 
     public static Block createStringArraysBlock(Iterable<? extends Iterable<String>> values)
@@ -716,7 +716,7 @@ public final class BlockAssertions
         for (int i = 0; i < length; i++) {
             ids[i] = i % dictionarySize;
         }
-        return new DictionaryBlock(ids.length, builder.build(), ids);
+        return DictionaryBlock.create(ids.length, builder.build(), ids);
     }
 
     public static Block createLongRepeatBlock(int value, int length)

--- a/core/trino-main/src/test/java/io/trino/block/BlockAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/block/BlockAssertions.java
@@ -52,7 +52,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.block.ArrayBlock.fromElementBlock;
-import static io.trino.spi.block.DictionaryId.randomDictionaryId;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateType.DATE;
@@ -130,7 +129,7 @@ public final class BlockAssertions
         int[] ids = IntStream.range(0, positionCount)
                 .map(i -> random.nextInt(dictionary.getPositionCount()))
                 .toArray();
-        return new DictionaryBlock(0, positionCount, dictionary, ids, false, randomDictionaryId());
+        return new DictionaryBlock(positionCount, dictionary, ids);
     }
 
     public static RunLengthEncodedBlock createRandomRleBlock(Block block, int positionCount)
@@ -446,7 +445,7 @@ public final class BlockAssertions
         for (int i = 0; i < length; i++) {
             ids[i] = i % dictionarySize;
         }
-        return new DictionaryBlock(builder.build(), ids);
+        return new DictionaryBlock(ids.length, builder.build(), ids);
     }
 
     public static Block createStringArraysBlock(Iterable<? extends Iterable<String>> values)
@@ -717,7 +716,7 @@ public final class BlockAssertions
         for (int i = 0; i < length; i++) {
             ids[i] = i % dictionarySize;
         }
-        return new DictionaryBlock(builder.build(), ids);
+        return new DictionaryBlock(ids.length, builder.build(), ids);
     }
 
     public static Block createLongRepeatBlock(int value, int length)

--- a/core/trino-main/src/test/java/io/trino/block/ColumnarTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/block/ColumnarTestUtils.java
@@ -157,6 +157,6 @@ public final class ColumnarTestUtils
 
     public static RunLengthEncodedBlock createTestRleBlock(Block block, int position)
     {
-        return new RunLengthEncodedBlock(block.getRegion(position, 1), 10);
+        return (RunLengthEncodedBlock) RunLengthEncodedBlock.create(block.getRegion(position, 1), 10);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/block/ColumnarTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/block/ColumnarTestUtils.java
@@ -118,10 +118,10 @@ public final class ColumnarTestUtils
         return BLOCK_ENCODING_SERDE.readBlock(sliceOutput.slice().getInput());
     }
 
-    public static DictionaryBlock createTestDictionaryBlock(Block block)
+    public static Block createTestDictionaryBlock(Block block)
     {
         int[] dictionaryIndexes = createTestDictionaryIndexes(block.getPositionCount());
-        return new DictionaryBlock(dictionaryIndexes.length, block, dictionaryIndexes);
+        return DictionaryBlock.create(dictionaryIndexes.length, block, dictionaryIndexes);
     }
 
     public static <T> T[] createTestDictionaryExpectedValues(T[] expectedValues)

--- a/core/trino-main/src/test/java/io/trino/block/TestColumnarArray.java
+++ b/core/trino-main/src/test/java/io/trino/block/TestColumnarArray.java
@@ -18,7 +18,6 @@ import io.airlift.slice.Slices;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.ColumnarArray;
-import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.type.ArrayType;
 import org.testng.annotations.Test;
@@ -86,7 +85,7 @@ public class TestColumnarArray
 
     private static <T> void assertDictionaryBlock(Block block, T[] expectedValues)
     {
-        DictionaryBlock dictionaryBlock = createTestDictionaryBlock(block);
+        Block dictionaryBlock = createTestDictionaryBlock(block);
         T[] expectedDictionaryValues = createTestDictionaryExpectedValues(expectedValues);
 
         assertBlock(dictionaryBlock, expectedDictionaryValues);

--- a/core/trino-main/src/test/java/io/trino/block/TestColumnarMap.java
+++ b/core/trino-main/src/test/java/io/trino/block/TestColumnarMap.java
@@ -18,7 +18,6 @@ import io.airlift.slice.Slices;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.ColumnarMap;
-import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.block.MapBlockBuilder;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.type.MapType;
@@ -94,7 +93,7 @@ public class TestColumnarMap
 
     private static void assertDictionaryBlock(Block block, Slice[][][] expectedValues)
     {
-        DictionaryBlock dictionaryBlock = createTestDictionaryBlock(block);
+        Block dictionaryBlock = createTestDictionaryBlock(block);
         Slice[][][] expectedDictionaryValues = createTestDictionaryExpectedValues(expectedValues);
 
         assertBlock(dictionaryBlock, expectedDictionaryValues);

--- a/core/trino-main/src/test/java/io/trino/block/TestColumnarRow.java
+++ b/core/trino-main/src/test/java/io/trino/block/TestColumnarRow.java
@@ -19,7 +19,6 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.BlockBuilderStatus;
 import io.trino.spi.block.ColumnarRow;
-import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.block.RowBlockBuilder;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import org.testng.annotations.Test;
@@ -89,7 +88,7 @@ public class TestColumnarRow
 
     private static <T> void assertDictionaryBlock(Block block, T[] expectedValues)
     {
-        DictionaryBlock dictionaryBlock = createTestDictionaryBlock(block);
+        Block dictionaryBlock = createTestDictionaryBlock(block);
         T[] expectedDictionaryValues = createTestDictionaryExpectedValues(expectedValues);
 
         assertBlock(dictionaryBlock, expectedDictionaryValues);

--- a/core/trino-main/src/test/java/io/trino/block/TestRunLengthEncodedBlock.java
+++ b/core/trino-main/src/test/java/io/trino/block/TestRunLengthEncodedBlock.java
@@ -42,7 +42,7 @@ public class TestRunLengthEncodedBlock
     private void assertRleBlock(int positionCount)
     {
         Slice expectedValue = createExpectedValue(0);
-        Block block = new RunLengthEncodedBlock(createSingleValueBlock(expectedValue), positionCount);
+        Block block = RunLengthEncodedBlock.create(createSingleValueBlock(expectedValue), positionCount);
         Slice[] expectedValues = new Slice[positionCount];
         for (int position = 0; position < positionCount; position++) {
             expectedValues[position] = expectedValue;
@@ -66,7 +66,7 @@ public class TestRunLengthEncodedBlock
     public void testPositionsSizeInBytes()
     {
         Block valueBlock = createSingleValueBlock(createExpectedValue(10));
-        Block rleBlock = new RunLengthEncodedBlock(valueBlock, 10);
+        Block rleBlock = RunLengthEncodedBlock.create(valueBlock, 10);
         // Size in bytes is not fixed per position
         assertTrue(rleBlock.fixedSizeInBytesPerPosition().isEmpty());
         // Accepts specific position selection
@@ -119,7 +119,7 @@ public class TestRunLengthEncodedBlock
     {
         int positionCount = 10;
         Slice expectedValue = createExpectedValue(5);
-        Block block = new RunLengthEncodedBlock(createSingleValueBlock(expectedValue), positionCount);
+        Block block = RunLengthEncodedBlock.create(createSingleValueBlock(expectedValue), positionCount);
         for (int postition = 0; postition < positionCount; postition++) {
             assertEquals(block.getEstimatedDataSizeForStats(postition), expectedValue.length());
         }

--- a/core/trino-main/src/test/java/io/trino/execution/TestPageSplitterUtil.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestPageSplitterUtil.java
@@ -83,7 +83,7 @@ public class TestPageSplitterUtil
         Slice expectedValue = wrappedBuffer("test".getBytes(UTF_8));
         BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, 1, expectedValue.length());
         blockBuilder.writeBytes(expectedValue, 0, expectedValue.length()).closeEntry();
-        Block rleBlock = new RunLengthEncodedBlock(blockBuilder.build(), positionCount);
+        Block rleBlock = RunLengthEncodedBlock.create(blockBuilder.build(), positionCount);
         Page initialPage = new Page(rleBlock);
         List<Page> pages = splitPage(initialPage, maxPageSizeInBytes);
 

--- a/core/trino-main/src/test/java/io/trino/execution/buffer/TestPagesSerde.java
+++ b/core/trino-main/src/test/java/io/trino/execution/buffer/TestPagesSerde.java
@@ -68,7 +68,7 @@ public class TestPagesSerde
         // empty page
         Page page = new Page(builder.build());
         int pageSize = serializedSize(ImmutableList.of(BIGINT), page);
-        assertEquals(pageSize, 52); // page overhead ideally 35 but since a 0 sized block will be a RLEBlock we have an overhead of 17
+        assertEquals(pageSize, 40);
 
         // page with one value
         BIGINT.writeLong(builder, 123);
@@ -92,7 +92,7 @@ public class TestPagesSerde
         // empty page
         Page page = new Page(builder.build());
         int pageSize = serializedSize(ImmutableList.of(VARCHAR), page);
-        assertEquals(pageSize, 60); // page overhead ideally 44 but since a 0 sized block will be a RLEBlock we have an overhead of 16
+        assertEquals(pageSize, 44);
 
         // page with one value
         VARCHAR.writeString(builder, "alice");

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupByHash.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupByHash.java
@@ -264,7 +264,7 @@ public class BenchmarkGroupByHash
                         int[] positions = IntStream.range(0, page.getPositionCount()).toArray();
                         Block[] blocks = new Block[page.getChannelCount()];
                         for (int channel = 0; channel < page.getChannelCount(); ++channel) {
-                            blocks[channel] = new DictionaryBlock(page.getBlock(channel), positions);
+                            blocks[channel] = new DictionaryBlock(positions.length, page.getBlock(channel), positions);
                         }
                         pages.add(new Page(blocks));
                     }

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupByHash.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupByHash.java
@@ -255,7 +255,7 @@ public class BenchmarkGroupByHash
                         // rle page
                         Block[] blocks = new Block[page.getChannelCount()];
                         for (int channel = 0; channel < blocks.length; ++channel) {
-                            blocks[channel] = new RunLengthEncodedBlock(page.getBlock(channel).getSingleValueBlock(0), page.getPositionCount());
+                            blocks[channel] = RunLengthEncodedBlock.create(page.getBlock(channel).getSingleValueBlock(0), page.getPositionCount());
                         }
                         pages.add(new Page(blocks));
                     }

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupByHash.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupByHash.java
@@ -264,7 +264,7 @@ public class BenchmarkGroupByHash
                         int[] positions = IntStream.range(0, page.getPositionCount()).toArray();
                         Block[] blocks = new Block[page.getChannelCount()];
                         for (int channel = 0; channel < page.getChannelCount(); ++channel) {
-                            blocks[channel] = new DictionaryBlock(positions.length, page.getBlock(channel), positions);
+                            blocks[channel] = DictionaryBlock.create(positions.length, page.getBlock(channel), positions);
                         }
                         pages.add(new Page(blocks));
                     }

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupByHashOnSimulatedData.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupByHashOnSimulatedData.java
@@ -556,7 +556,7 @@ public class BenchmarkGroupByHashOnSimulatedData
                     }
                 }
 
-                blocks[i] = new DictionaryBlock(dictionary, indexes);
+                blocks[i] = new DictionaryBlock(indexes.length, dictionary, indexes);
             }
         }
 

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupByHashOnSimulatedData.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupByHashOnSimulatedData.java
@@ -556,7 +556,7 @@ public class BenchmarkGroupByHashOnSimulatedData
                     }
                 }
 
-                blocks[i] = new DictionaryBlock(indexes.length, dictionary, indexes);
+                blocks[i] = DictionaryBlock.create(indexes.length, dictionary, indexes);
             }
         }
 

--- a/core/trino-main/src/test/java/io/trino/operator/TestAggregationOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestAggregationOperator.java
@@ -132,7 +132,7 @@ public class TestAggregationOperator
                 Optional.of(new boolean[] {true, true, true, true}), /* all positions are null */
                 new byte[] {1, 1, 1, 1}); /* non-zero value is true, all masks are true */
 
-        Block trueNullRleMask = new RunLengthEncodedBlock(trueMaskAllNull.getSingleValueBlock(0), 4);
+        Block trueNullRleMask = RunLengthEncodedBlock.create(trueMaskAllNull.getSingleValueBlock(0), 4);
 
         List<Page> nullTrueMaskInput = ImmutableList.of(
                 new Page(4, createLongsBlock(1, 2, 3, 4), trueMaskAllNull),

--- a/core/trino-main/src/test/java/io/trino/operator/TestGroupByHash.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestGroupByHash.java
@@ -22,7 +22,6 @@ import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.DictionaryBlock;
-import io.trino.spi.block.DictionaryId;
 import io.trino.spi.block.LongArrayBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.block.VariableWidthBlock;
@@ -49,7 +48,6 @@ import static io.trino.block.BlockAssertions.createLongsBlock;
 import static io.trino.block.BlockAssertions.createStringSequenceBlock;
 import static io.trino.operator.GroupByHash.createGroupByHash;
 import static io.trino.operator.UpdateMemory.NOOP;
-import static io.trino.spi.block.DictionaryId.randomDictionaryId;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.VarcharType.VARCHAR;
@@ -175,8 +173,8 @@ public class TestGroupByHash
         Block hashBlock = TypeTestUtils.getHashBlock(ImmutableList.of(BIGINT), block);
         int[] ids = new int[] {0, 0, 1, 1};
         Page page = new Page(
-                new DictionaryBlock(block, ids),
-                new DictionaryBlock(hashBlock, ids));
+                new DictionaryBlock(ids.length, block, ids),
+                new DictionaryBlock(ids.length, hashBlock, ids));
 
         groupByHash.addPage(page).process();
 
@@ -475,9 +473,8 @@ public class TestGroupByHash
         int dictionaryLength = 1_000;
         int length = 2_000_000;
         int[] ids = IntStream.range(0, dictionaryLength).toArray();
-        DictionaryId dictionaryId = randomDictionaryId();
-        Block valuesBlock = new DictionaryBlock(dictionaryLength, createLongSequenceBlock(0, length), ids, dictionaryId);
-        Block hashBlock = new DictionaryBlock(dictionaryLength, getHashBlock(ImmutableList.of(BIGINT), valuesBlock), ids, dictionaryId);
+        Block valuesBlock = new DictionaryBlock(dictionaryLength, createLongSequenceBlock(0, length), ids);
+        Block hashBlock = new DictionaryBlock(dictionaryLength, getHashBlock(ImmutableList.of(BIGINT), valuesBlock), ids);
         Page page = new Page(valuesBlock, hashBlock);
         AtomicInteger currentQuota = new AtomicInteger(0);
         AtomicInteger allowedQuota = new AtomicInteger(3);
@@ -637,8 +634,8 @@ public class TestGroupByHash
         for (int i = 0; i < 16; i++) {
             ids[i] = 1;
         }
-        Block block1 = new DictionaryBlock(dictionary, ids);
-        Block block2 = new DictionaryBlock(dictionary, ids);
+        Block block1 = new DictionaryBlock(ids.length, dictionary, ids);
+        Block block2 = new DictionaryBlock(ids.length, dictionary, ids);
 
         Page page = new Page(block1, block2);
 

--- a/core/trino-main/src/test/java/io/trino/operator/TestGroupByHash.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestGroupByHash.java
@@ -144,8 +144,8 @@ public class TestGroupByHash
         Block block = BlockAssertions.createLongsBlock(0L);
         Block hashBlock = TypeTestUtils.getHashBlock(ImmutableList.of(BIGINT), block);
         Page page = new Page(
-                new RunLengthEncodedBlock(block, 2),
-                new RunLengthEncodedBlock(hashBlock, 2));
+                RunLengthEncodedBlock.create(block, 2),
+                RunLengthEncodedBlock.create(hashBlock, 2));
 
         groupByHash.addPage(page).process();
 
@@ -658,10 +658,10 @@ public class TestGroupByHash
     {
         Block bigintBlock = BlockAssertions.createLongsBlock(1, 2, 3, 4, 5, 6, 7, 8);
         Block bigintDictionaryBlock = BlockAssertions.createLongDictionaryBlock(0, 8);
-        Block bigintRleBlock = BlockAssertions.createRLEBlock(42, 8);
+        Block bigintRleBlock = BlockAssertions.createRepeatedValuesBlock(42, 8);
         Block varcharBlock = BlockAssertions.createStringsBlock("1", "2", "3", "4", "5", "6", "7", "8");
         Block varcharDictionaryBlock = BlockAssertions.createStringDictionaryBlock(1, 8);
-        Block varcharRleBlock = new RunLengthEncodedBlock(new VariableWidthBlock(1, Slices.EMPTY_SLICE, new int[] {0, 1}, Optional.empty()), 8);
+        Block varcharRleBlock = RunLengthEncodedBlock.create(new VariableWidthBlock(1, Slices.EMPTY_SLICE, new int[] {0, 1}, Optional.empty()), 8);
         Block bigintBigDictionaryBlock = BlockAssertions.createLongDictionaryBlock(1, 8, 1000);
         Block bigintSingletonDictionaryBlock = BlockAssertions.createLongDictionaryBlock(1, 500000, 1);
         Block bigintHugeDictionaryBlock = BlockAssertions.createLongDictionaryBlock(1, 500000, 66000); // Above Short.MAX_VALUE

--- a/core/trino-main/src/test/java/io/trino/operator/TestGroupByHash.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestGroupByHash.java
@@ -173,8 +173,8 @@ public class TestGroupByHash
         Block hashBlock = TypeTestUtils.getHashBlock(ImmutableList.of(BIGINT), block);
         int[] ids = new int[] {0, 0, 1, 1};
         Page page = new Page(
-                new DictionaryBlock(ids.length, block, ids),
-                new DictionaryBlock(ids.length, hashBlock, ids));
+                DictionaryBlock.create(ids.length, block, ids),
+                DictionaryBlock.create(ids.length, hashBlock, ids));
 
         groupByHash.addPage(page).process();
 
@@ -473,8 +473,8 @@ public class TestGroupByHash
         int dictionaryLength = 1_000;
         int length = 2_000_000;
         int[] ids = IntStream.range(0, dictionaryLength).toArray();
-        Block valuesBlock = new DictionaryBlock(dictionaryLength, createLongSequenceBlock(0, length), ids);
-        Block hashBlock = new DictionaryBlock(dictionaryLength, getHashBlock(ImmutableList.of(BIGINT), valuesBlock), ids);
+        Block valuesBlock = DictionaryBlock.create(dictionaryLength, createLongSequenceBlock(0, length), ids);
+        Block hashBlock = DictionaryBlock.create(dictionaryLength, getHashBlock(ImmutableList.of(BIGINT), valuesBlock), ids);
         Page page = new Page(valuesBlock, hashBlock);
         AtomicInteger currentQuota = new AtomicInteger(0);
         AtomicInteger allowedQuota = new AtomicInteger(3);
@@ -634,8 +634,8 @@ public class TestGroupByHash
         for (int i = 0; i < 16; i++) {
             ids[i] = 1;
         }
-        Block block1 = new DictionaryBlock(ids.length, dictionary, ids);
-        Block block2 = new DictionaryBlock(ids.length, dictionary, ids);
+        Block block1 = DictionaryBlock.create(ids.length, dictionary, ids);
+        Block block2 = DictionaryBlock.create(ids.length, dictionary, ids);
 
         Page page = new Page(block1, block2);
 

--- a/core/trino-main/src/test/java/io/trino/operator/TestHashAggregationOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestHashAggregationOperator.java
@@ -69,7 +69,7 @@ import static io.airlift.units.DataSize.succinctBytes;
 import static io.trino.RowPagesBuilder.rowPagesBuilder;
 import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.block.BlockAssertions.createLongsBlock;
-import static io.trino.block.BlockAssertions.createRLEBlock;
+import static io.trino.block.BlockAssertions.createRepeatedValuesBlock;
 import static io.trino.operator.GroupByHashYieldAssertion.GroupByHashYieldResult;
 import static io.trino.operator.GroupByHashYieldAssertion.createPagesWithDistinctHashKeys;
 import static io.trino.operator.GroupByHashYieldAssertion.finishOperatorWithYieldingGroupByHash;
@@ -744,11 +744,11 @@ public class TestHashAggregationOperator
         // First operator will trigger adaptive partial aggregation after the first page
         List<Page> operator1Input = rowPagesBuilder(false, hashChannels, BIGINT)
                 .addBlocksPage(createLongsBlock(0, 1, 2, 3, 4, 5, 6, 7, 8, 8)) // first page will be hashed but the values are almost unique, so it will trigger adaptation
-                .addBlocksPage(createRLEBlock(1, 10)) // second page would be hashed to existing value 1. but if adaptive PA kicks in, the raw values will be passed on
+                .addBlocksPage(createRepeatedValuesBlock(1, 10)) // second page would be hashed to existing value 1. but if adaptive PA kicks in, the raw values will be passed on
                 .build();
         List<Page> operator1Expected = rowPagesBuilder(BIGINT, BIGINT)
                 .addBlocksPage(createLongsBlock(0, 1, 2, 3, 4, 5, 6, 7, 8), createLongsBlock(0, 1, 2, 3, 4, 5, 6, 7, 8)) // the last position was aggregated
-                .addBlocksPage(createRLEBlock(1, 10), createRLEBlock(1, 10)) // we are expecting second page with raw values
+                .addBlocksPage(createRepeatedValuesBlock(1, 10), createRepeatedValuesBlock(1, 10)) // we are expecting second page with raw values
                 .build();
         assertOperatorEquals(operatorFactory, operator1Input, operator1Expected);
 
@@ -756,12 +756,12 @@ public class TestHashAggregationOperator
         assertTrue(partialAggregationController.isPartialAggregationDisabled());
         // second operator using the same factory, reuses PartialAggregationControl, so it will only produce raw pages (partial aggregation is disabled at this point)
         List<Page> operator2Input = rowPagesBuilder(false, hashChannels, BIGINT)
-                .addBlocksPage(createRLEBlock(1, 10))
-                .addBlocksPage(createRLEBlock(2, 10))
+                .addBlocksPage(createRepeatedValuesBlock(1, 10))
+                .addBlocksPage(createRepeatedValuesBlock(2, 10))
                 .build();
         List<Page> operator2Expected = rowPagesBuilder(BIGINT, BIGINT)
-                .addBlocksPage(createRLEBlock(1, 10), createRLEBlock(1, 10))
-                .addBlocksPage(createRLEBlock(2, 10), createRLEBlock(2, 10))
+                .addBlocksPage(createRepeatedValuesBlock(1, 10), createRepeatedValuesBlock(1, 10))
+                .addBlocksPage(createRepeatedValuesBlock(2, 10), createRepeatedValuesBlock(2, 10))
                 .build();
 
         assertOperatorEquals(operatorFactory, operator2Input, operator2Expected);
@@ -792,7 +792,7 @@ public class TestHashAggregationOperator
 
         List<Page> operator1Input = rowPagesBuilder(false, hashChannels, BIGINT)
                 .addSequencePage(10, 0) // first page are unique values, so it would trigger adaptation, but it won't because flush is not called
-                .addBlocksPage(createRLEBlock(1, 2)) // second page will be hashed to existing value 1
+                .addBlocksPage(createRepeatedValuesBlock(1, 2)) // second page will be hashed to existing value 1
                 .build();
         // the total unique ows ratio for the first operator will be 10/12 so > 0.8 (adaptive partial aggregation uniqueRowsRatioThreshold)
         List<Page> operator1Expected = rowPagesBuilder(BIGINT, BIGINT)
@@ -805,12 +805,12 @@ public class TestHashAggregationOperator
 
         // second operator using the same factory, reuses PartialAggregationControl, so it will only produce raw pages (partial aggregation is disabled at this point)
         List<Page> operator2Input = rowPagesBuilder(false, hashChannels, BIGINT)
-                .addBlocksPage(createRLEBlock(1, 10))
-                .addBlocksPage(createRLEBlock(2, 10))
+                .addBlocksPage(createRepeatedValuesBlock(1, 10))
+                .addBlocksPage(createRepeatedValuesBlock(2, 10))
                 .build();
         List<Page> operator2Expected = rowPagesBuilder(BIGINT, BIGINT)
-                .addBlocksPage(createRLEBlock(1, 10), createRLEBlock(1, 10))
-                .addBlocksPage(createRLEBlock(2, 10), createRLEBlock(2, 10))
+                .addBlocksPage(createRepeatedValuesBlock(1, 10), createRepeatedValuesBlock(1, 10))
+                .addBlocksPage(createRepeatedValuesBlock(2, 10), createRepeatedValuesBlock(2, 10))
                 .build();
 
         assertOperatorEquals(operatorFactory, operator2Input, operator2Expected);

--- a/core/trino-main/src/test/java/io/trino/operator/TestPageUtils.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestPageUtils.java
@@ -50,8 +50,8 @@ public class TestPageUtils
     public void testNestedBlocks()
     {
         Block elements = lazyWrapper(createIntsBlock(1, 2, 3));
-        DictionaryBlock dictBlock = new DictionaryBlock(1, elements, new int[] {0});
-        Page page = new Page(1, dictBlock);
+        Block dictBlock = DictionaryBlock.create(2, elements, new int[] {0, 0});
+        Page page = new Page(2, dictBlock);
 
         AtomicLong sizeInBytes = new AtomicLong();
         recordMaterializedBytes(page, sizeInBytes::getAndAdd);

--- a/core/trino-main/src/test/java/io/trino/operator/TestPageUtils.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestPageUtils.java
@@ -50,7 +50,7 @@ public class TestPageUtils
     public void testNestedBlocks()
     {
         Block elements = lazyWrapper(createIntsBlock(1, 2, 3));
-        DictionaryBlock dictBlock = new DictionaryBlock(elements, new int[] {0});
+        DictionaryBlock dictBlock = new DictionaryBlock(1, elements, new int[] {0});
         Page page = new Page(1, dictBlock);
 
         AtomicLong sizeInBytes = new AtomicLong();

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/AggregationTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/AggregationTestUtils.java
@@ -175,7 +175,7 @@ public final class AggregationTestUtils
         Page[] maskedPages = new Page[pages.length];
         for (int i = 0; i < pages.length; i++) {
             Page page = pages[i];
-            maskedPages[i] = page.appendColumn(new RunLengthEncodedBlock(BooleanType.createBlockForSingleNonNullValue(maskValue), page.getPositionCount()));
+            maskedPages[i] = page.appendColumn(RunLengthEncodedBlock.create(BooleanType.createBlockForSingleNonNullValue(maskValue), page.getPositionCount()));
         }
         return maskedPages;
     }
@@ -416,7 +416,7 @@ public final class AggregationTestUtils
             Page page = pages[i];
             Block[] newBlocks = new Block[page.getChannelCount() + offset];
             for (int channel = 0; channel < offset; channel++) {
-                newBlocks[channel] = createNullRLEBlock(page.getPositionCount());
+                newBlocks[channel] = createAllNullBlock(page.getPositionCount());
             }
             for (int channel = 0; channel < page.getChannelCount(); channel++) {
                 newBlocks[channel + offset] = page.getBlock(channel);
@@ -426,9 +426,9 @@ public final class AggregationTestUtils
         return newPages;
     }
 
-    private static RunLengthEncodedBlock createNullRLEBlock(int positionCount)
+    private static Block createAllNullBlock(int positionCount)
     {
-        return (RunLengthEncodedBlock) RunLengthEncodedBlock.create(BOOLEAN, null, positionCount);
+        return RunLengthEncodedBlock.create(BOOLEAN, null, positionCount);
     }
 
     public static Object getGroupValue(Type finalType, GroupedAggregator groupedAggregator, int groupId)

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestApproximatePercentileAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestApproximatePercentileAggregation.java
@@ -15,6 +15,7 @@ package io.trino.operator.aggregation;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.metadata.TestingFunctionResolution;
+import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.type.ArrayType;
@@ -72,7 +73,7 @@ public class TestApproximatePercentileAggregation
                 LONG_APPROXIMATE_PERCENTILE,
                 null,
                 createLongsBlock(null, null),
-                createRLEBlock(0.5, 2));
+                createRleBlock(0.5, 2));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -80,7 +81,7 @@ public class TestApproximatePercentileAggregation
                 LONG_APPROXIMATE_PERCENTILE,
                 1L,
                 createLongsBlock(null, 1L),
-                createRLEBlock(0.5, 2));
+                createRleBlock(0.5, 2));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -88,7 +89,7 @@ public class TestApproximatePercentileAggregation
                 LONG_APPROXIMATE_PERCENTILE,
                 2L,
                 createLongsBlock(null, 1L, 2L, 3L),
-                createRLEBlock(0.5, 4));
+                createRleBlock(0.5, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -96,7 +97,7 @@ public class TestApproximatePercentileAggregation
                 LONG_APPROXIMATE_PERCENTILE,
                 2L,
                 createLongsBlock(1L, 2L, 3L),
-                createRLEBlock(0.5, 3));
+                createRleBlock(0.5, 3));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -104,7 +105,7 @@ public class TestApproximatePercentileAggregation
                 LONG_APPROXIMATE_PERCENTILE,
                 3L,
                 createLongsBlock(1L, null, 2L, 2L, null, 2L, 2L, null, 2L, 2L, null, 3L, 3L, null, 3L, null, 3L, 4L, 5L, 6L, 7L),
-                createRLEBlock(0.5, 21));
+                createRleBlock(0.5, 21));
 
         // array of approx_percentile
         assertAggregation(
@@ -113,7 +114,7 @@ public class TestApproximatePercentileAggregation
                 LONG_APPROXIMATE_PERCENTILE_ARRAY,
                 null,
                 createLongsBlock(null, null),
-                createRLEBlock(ImmutableList.of(0.5), 2));
+                createRleBlock(ImmutableList.of(0.5), 2));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -121,7 +122,7 @@ public class TestApproximatePercentileAggregation
                 LONG_APPROXIMATE_PERCENTILE_ARRAY,
                 null,
                 createLongsBlock(null, null),
-                createRLEBlock(ImmutableList.of(0.5, 0.99), 2));
+                createRleBlock(ImmutableList.of(0.5, 0.99), 2));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -129,7 +130,7 @@ public class TestApproximatePercentileAggregation
                 LONG_APPROXIMATE_PERCENTILE_ARRAY,
                 ImmutableList.of(1L, 1L),
                 createLongsBlock(null, 1L),
-                createRLEBlock(ImmutableList.of(0.5, 0.5), 2));
+                createRleBlock(ImmutableList.of(0.5, 0.5), 2));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -137,7 +138,7 @@ public class TestApproximatePercentileAggregation
                 LONG_APPROXIMATE_PERCENTILE_ARRAY,
                 ImmutableList.of(1L, 2L, 3L),
                 createLongsBlock(null, 1L, 2L, 3L),
-                createRLEBlock(ImmutableList.of(0.2, 0.5, 0.8), 4));
+                createRleBlock(ImmutableList.of(0.2, 0.5, 0.8), 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -145,7 +146,7 @@ public class TestApproximatePercentileAggregation
                 LONG_APPROXIMATE_PERCENTILE_ARRAY,
                 ImmutableList.of(2L, 3L),
                 createLongsBlock(1L, 2L, 3L),
-                createRLEBlock(ImmutableList.of(0.5, 0.99), 3));
+                createRleBlock(ImmutableList.of(0.5, 0.99), 3));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -153,7 +154,7 @@ public class TestApproximatePercentileAggregation
                 LONG_APPROXIMATE_PERCENTILE_ARRAY,
                 ImmutableList.of(1L, 3L),
                 createLongsBlock(1L, null, 2L, 2L, null, 2L, 2L, null, 2L, 2L, null, 3L, 3L, null, 3L, null, 3L, 4L, 5L, 6L, 7L),
-                createRLEBlock(ImmutableList.of(0.01, 0.5), 21));
+                createRleBlock(ImmutableList.of(0.01, 0.5), 21));
 
         // unsorted percentiles
         assertAggregation(
@@ -162,7 +163,7 @@ public class TestApproximatePercentileAggregation
                 LONG_APPROXIMATE_PERCENTILE_ARRAY,
                 ImmutableList.of(3L, 1L, 2L),
                 createLongsBlock(null, 1L, 2L, 3L),
-                createRLEBlock(ImmutableList.of(0.8, 0.2, 0.5), 4));
+                createRleBlock(ImmutableList.of(0.8, 0.2, 0.5), 4));
 
         // weighted approx_percentile
         assertAggregation(
@@ -172,7 +173,7 @@ public class TestApproximatePercentileAggregation
                 null,
                 createLongsBlock(null, null),
                 createLongsBlock(1L, 1L),
-                createRLEBlock(0.5, 2));
+                createRleBlock(0.5, 2));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -181,7 +182,7 @@ public class TestApproximatePercentileAggregation
                 1L,
                 createLongsBlock(null, 1L),
                 createDoublesBlock(1.0, 1.0),
-                createRLEBlock(0.5, 2));
+                createRleBlock(0.5, 2));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -190,7 +191,7 @@ public class TestApproximatePercentileAggregation
                 2L,
                 createLongsBlock(null, 1L, 2L, 3L),
                 createDoublesBlock(1.0, 1.0, 1.0, 1.0),
-                createRLEBlock(0.5, 4));
+                createRleBlock(0.5, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -199,7 +200,7 @@ public class TestApproximatePercentileAggregation
                 2L,
                 createLongsBlock(1L, 2L, 3L),
                 createDoublesBlock(1.0, 1.0, 1.0),
-                createRLEBlock(0.5, 3));
+                createRleBlock(0.5, 3));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -208,7 +209,7 @@ public class TestApproximatePercentileAggregation
                 2L,
                 createLongsBlock(1L, 2L, 3L),
                 createDoublesBlock(23.4, 23.4, 23.4),
-                createRLEBlock(0.5, 3));
+                createRleBlock(0.5, 3));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -217,7 +218,7 @@ public class TestApproximatePercentileAggregation
                 3L,
                 createLongsBlock(1L, null, 2L, null, 2L, null, 2L, null, 3L, null, 3L, null, 3L, 4L, 5L, 6L, 7L),
                 createDoublesBlock(1.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0),
-                createRLEBlock(0.5, 17));
+                createRleBlock(0.5, 17));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -226,7 +227,7 @@ public class TestApproximatePercentileAggregation
                 3L,
                 createLongsBlock(1L, null, 2L, null, 2L, null, 2L, null, 3L, null, 3L, null, 3L, 4L, 5L, 6L, 7L),
                 createDoublesBlock(1.1, 1.1, 2.2, 1.1, 2.2, 1.1, 2.2, 1.1, 2.2, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1),
-                createRLEBlock(0.5, 17));
+                createRleBlock(0.5, 17));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -235,8 +236,8 @@ public class TestApproximatePercentileAggregation
                 9900L,
                 createLongSequenceBlock(0, 10000),
                 createDoubleRepeatBlock(1.0, 10000),
-                createRLEBlock(0.99, 10000),
-                createRLEBlock(0.001, 10000));
+                createRleBlock(0.99, 10000),
+                createRleBlock(0.001, 10000));
 
         // weighted + array of approx_percentile
         assertAggregation(
@@ -246,7 +247,7 @@ public class TestApproximatePercentileAggregation
                 ImmutableList.of(2L, 3L),
                 createLongsBlock(1L, 2L, 3L),
                 createDoublesBlock(4.0, 2.0, 1.0),
-                createRLEBlock(ImmutableList.of(0.5, 0.8), 3));
+                createRleBlock(ImmutableList.of(0.5, 0.8), 3));
     }
 
     @Test
@@ -259,7 +260,7 @@ public class TestApproximatePercentileAggregation
                 FLOAT_APPROXIMATE_PERCENTILE,
                 null,
                 createBlockOfReals(null, null),
-                createRLEBlock(0.5, 2));
+                createRleBlock(0.5, 2));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -267,7 +268,7 @@ public class TestApproximatePercentileAggregation
                 FLOAT_APPROXIMATE_PERCENTILE,
                 1.0f,
                 createBlockOfReals(null, 1.0f),
-                createRLEBlock(0.5, 2));
+                createRleBlock(0.5, 2));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -275,7 +276,7 @@ public class TestApproximatePercentileAggregation
                 FLOAT_APPROXIMATE_PERCENTILE,
                 2.0f,
                 createBlockOfReals(null, 1.0f, 2.0f, 3.0f),
-                createRLEBlock(0.5, 4));
+                createRleBlock(0.5, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -283,7 +284,7 @@ public class TestApproximatePercentileAggregation
                 FLOAT_APPROXIMATE_PERCENTILE,
                 1.0f,
                 createBlockOfReals(-1.0f, 1.0f),
-                createRLEBlock(0.5, 2));
+                createRleBlock(0.5, 2));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -291,7 +292,7 @@ public class TestApproximatePercentileAggregation
                 FLOAT_APPROXIMATE_PERCENTILE,
                 -1.0f,
                 createBlockOfReals(-2.0f, 3.0f, -1.0f),
-                createRLEBlock(0.5, 3));
+                createRleBlock(0.5, 3));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -299,7 +300,7 @@ public class TestApproximatePercentileAggregation
                 FLOAT_APPROXIMATE_PERCENTILE,
                 2.0f,
                 createBlockOfReals(1.0f, 2.0f, 3.0f),
-                createRLEBlock(0.5, 3));
+                createRleBlock(0.5, 3));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -307,7 +308,7 @@ public class TestApproximatePercentileAggregation
                 FLOAT_APPROXIMATE_PERCENTILE,
                 3.0f,
                 createBlockOfReals(1.0f, null, 2.0f, 2.0f, null, 2.0f, 2.0f, null, 2.0f, 2.0f, null, 3.0f, 3.0f, null, 3.0f, null, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f),
-                createRLEBlock(0.5, 21));
+                createRleBlock(0.5, 21));
 
         // array of approx_percentile
         assertAggregation(
@@ -316,7 +317,7 @@ public class TestApproximatePercentileAggregation
                 FLOAT_APPROXIMATE_PERCENTILE_ARRAY,
                 null,
                 createBlockOfReals(null, null),
-                createRLEBlock(ImmutableList.of(0.5), 2));
+                createRleBlock(ImmutableList.of(0.5), 2));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -324,7 +325,7 @@ public class TestApproximatePercentileAggregation
                 FLOAT_APPROXIMATE_PERCENTILE_ARRAY,
                 null,
                 createBlockOfReals(null, null),
-                createRLEBlock(ImmutableList.of(0.5, 0.5), 2));
+                createRleBlock(ImmutableList.of(0.5, 0.5), 2));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -332,7 +333,7 @@ public class TestApproximatePercentileAggregation
                 FLOAT_APPROXIMATE_PERCENTILE_ARRAY,
                 ImmutableList.of(1.0f, 1.0f),
                 createBlockOfReals(null, 1.0f),
-                createRLEBlock(ImmutableList.of(0.5, 0.5), 2));
+                createRleBlock(ImmutableList.of(0.5, 0.5), 2));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -340,7 +341,7 @@ public class TestApproximatePercentileAggregation
                 FLOAT_APPROXIMATE_PERCENTILE_ARRAY,
                 ImmutableList.of(1.0f, 2.0f, 3.0f),
                 createBlockOfReals(null, 1.0f, 2.0f, 3.0f),
-                createRLEBlock(ImmutableList.of(0.2, 0.5, 0.8), 4));
+                createRleBlock(ImmutableList.of(0.2, 0.5, 0.8), 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -348,7 +349,7 @@ public class TestApproximatePercentileAggregation
                 FLOAT_APPROXIMATE_PERCENTILE_ARRAY,
                 ImmutableList.of(2.0f, 3.0f),
                 createBlockOfReals(1.0f, 2.0f, 3.0f),
-                createRLEBlock(ImmutableList.of(0.5, 0.99), 3));
+                createRleBlock(ImmutableList.of(0.5, 0.99), 3));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -356,7 +357,7 @@ public class TestApproximatePercentileAggregation
                 FLOAT_APPROXIMATE_PERCENTILE_ARRAY,
                 ImmutableList.of(1.0f, 3.0f),
                 createBlockOfReals(1.0f, null, 2.0f, 2.0f, null, 2.0f, 2.0f, null, 2.0f, 2.0f, null, 3.0f, 3.0f, null, 3.0f, null, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f),
-                createRLEBlock(ImmutableList.of(0.01, 0.5), 21));
+                createRleBlock(ImmutableList.of(0.01, 0.5), 21));
 
         // unsorted percentiles
         assertAggregation(
@@ -365,7 +366,7 @@ public class TestApproximatePercentileAggregation
                 FLOAT_APPROXIMATE_PERCENTILE_ARRAY,
                 ImmutableList.of(3.0f, 1.0f, 2.0f),
                 createBlockOfReals(null, 1.0f, 2.0f, 3.0f),
-                createRLEBlock(ImmutableList.of(0.8, 0.2, 0.5), 4));
+                createRleBlock(ImmutableList.of(0.8, 0.2, 0.5), 4));
 
         // weighted approx_percentile
         assertAggregation(
@@ -375,7 +376,7 @@ public class TestApproximatePercentileAggregation
                 null,
                 createBlockOfReals(null, null),
                 createLongsBlock(1L, 1L),
-                createRLEBlock(0.5, 2));
+                createRleBlock(0.5, 2));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -384,7 +385,7 @@ public class TestApproximatePercentileAggregation
                 1.0f,
                 createBlockOfReals(null, 1.0f),
                 createDoublesBlock(1.0, 1.0),
-                createRLEBlock(0.5, 2));
+                createRleBlock(0.5, 2));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -393,7 +394,7 @@ public class TestApproximatePercentileAggregation
                 2.0f,
                 createBlockOfReals(null, 1.0f, 2.0f, 3.0f),
                 createDoublesBlock(1.0, 1.0, 1.0, 1.0),
-                createRLEBlock(0.5, 4));
+                createRleBlock(0.5, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -402,7 +403,7 @@ public class TestApproximatePercentileAggregation
                 2.0f,
                 createBlockOfReals(1.0f, 2.0f, 3.0f),
                 createDoublesBlock(1.0, 1.0, 1.0),
-                createRLEBlock(0.5, 3));
+                createRleBlock(0.5, 3));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -411,7 +412,7 @@ public class TestApproximatePercentileAggregation
                 2.75f,
                 createBlockOfReals(1.0f, null, 2.0f, null, 2.0f, null, 2.0f, null, 3.0f, null, 3.0f, null, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f),
                 createDoublesBlock(1.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0),
-                createRLEBlock(0.5, 17));
+                createRleBlock(0.5, 17));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -420,7 +421,7 @@ public class TestApproximatePercentileAggregation
                 2.75f,
                 createBlockOfReals(1.0f, null, 2.0f, null, 2.0f, null, 2.0f, null, 3.0f, null, 3.0f, null, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f),
                 createDoublesBlock(1.1, 1.1, 2.2, 1.1, 2.2, 1.1, 2.2, 1.1, 2.2, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1),
-                createRLEBlock(0.5, 17));
+                createRleBlock(0.5, 17));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -429,8 +430,8 @@ public class TestApproximatePercentileAggregation
                 9900.0f,
                 createSequenceBlockOfReal(0, 10000),
                 createDoubleRepeatBlock(1, 10000),
-                createRLEBlock(0.99, 10000),
-                createRLEBlock(0.001, 10000));
+                createRleBlock(0.99, 10000),
+                createRleBlock(0.001, 10000));
 
         // weighted + array of approx_percentile
         assertAggregation(
@@ -440,7 +441,7 @@ public class TestApproximatePercentileAggregation
                 ImmutableList.of(1.5f, 2.6f),
                 createBlockOfReals(1.0f, 2.0f, 3.0f),
                 createDoublesBlock(4.0, 2.0, 1.0),
-                createRLEBlock(ImmutableList.of(0.5, 0.8), 3));
+                createRleBlock(ImmutableList.of(0.5, 0.8), 3));
     }
 
     @Test
@@ -453,7 +454,7 @@ public class TestApproximatePercentileAggregation
                 DOUBLE_APPROXIMATE_PERCENTILE,
                 null,
                 createDoublesBlock(null, null),
-                createRLEBlock(0.5, 2));
+                createRleBlock(0.5, 2));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -461,7 +462,7 @@ public class TestApproximatePercentileAggregation
                 DOUBLE_APPROXIMATE_PERCENTILE,
                 1.0,
                 createDoublesBlock(null, 1.0),
-                createRLEBlock(0.5, 2));
+                createRleBlock(0.5, 2));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -469,7 +470,7 @@ public class TestApproximatePercentileAggregation
                 DOUBLE_APPROXIMATE_PERCENTILE,
                 2.0,
                 createDoublesBlock(null, 1.0, 2.0, 3.0),
-                createRLEBlock(0.5, 4));
+                createRleBlock(0.5, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -477,7 +478,7 @@ public class TestApproximatePercentileAggregation
                 DOUBLE_APPROXIMATE_PERCENTILE,
                 2.0,
                 createDoublesBlock(1.0, 2.0, 3.0),
-                createRLEBlock(0.5, 3));
+                createRleBlock(0.5, 3));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -485,7 +486,7 @@ public class TestApproximatePercentileAggregation
                 DOUBLE_APPROXIMATE_PERCENTILE,
                 3.0,
                 createDoublesBlock(1.0, null, 2.0, 2.0, null, 2.0, 2.0, null, 2.0, 2.0, null, 3.0, 3.0, null, 3.0, null, 3.0, 4.0, 5.0, 6.0, 7.0),
-                createRLEBlock(0.5, 21));
+                createRleBlock(0.5, 21));
 
         // array of approx_percentile
         assertAggregation(
@@ -494,7 +495,7 @@ public class TestApproximatePercentileAggregation
                 DOUBLE_APPROXIMATE_PERCENTILE_ARRAY,
                 null,
                 createDoublesBlock(null, null),
-                createRLEBlock(ImmutableList.of(0.5), 2));
+                createRleBlock(ImmutableList.of(0.5), 2));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -502,7 +503,7 @@ public class TestApproximatePercentileAggregation
                 DOUBLE_APPROXIMATE_PERCENTILE_ARRAY,
                 null,
                 createDoublesBlock(null, null),
-                createRLEBlock(ImmutableList.of(0.5, 0.5), 2));
+                createRleBlock(ImmutableList.of(0.5, 0.5), 2));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -510,7 +511,7 @@ public class TestApproximatePercentileAggregation
                 DOUBLE_APPROXIMATE_PERCENTILE_ARRAY,
                 ImmutableList.of(1.0, 1.0),
                 createDoublesBlock(null, 1.0),
-                createRLEBlock(ImmutableList.of(0.5, 0.5), 2));
+                createRleBlock(ImmutableList.of(0.5, 0.5), 2));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -518,7 +519,7 @@ public class TestApproximatePercentileAggregation
                 DOUBLE_APPROXIMATE_PERCENTILE_ARRAY,
                 ImmutableList.of(1.0, 2.0, 3.0),
                 createDoublesBlock(null, 1.0, 2.0, 3.0),
-                createRLEBlock(ImmutableList.of(0.2, 0.5, 0.8), 4));
+                createRleBlock(ImmutableList.of(0.2, 0.5, 0.8), 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -526,7 +527,7 @@ public class TestApproximatePercentileAggregation
                 DOUBLE_APPROXIMATE_PERCENTILE_ARRAY,
                 ImmutableList.of(2.0, 3.0),
                 createDoublesBlock(1.0, 2.0, 3.0),
-                createRLEBlock(ImmutableList.of(0.5, 0.99), 3));
+                createRleBlock(ImmutableList.of(0.5, 0.99), 3));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -534,7 +535,7 @@ public class TestApproximatePercentileAggregation
                 DOUBLE_APPROXIMATE_PERCENTILE_ARRAY,
                 ImmutableList.of(1.0, 3.0),
                 createDoublesBlock(1.0, null, 2.0, 2.0, null, 2.0, 2.0, null, 2.0, 2.0, null, 3.0, 3.0, null, 3.0, null, 3.0, 4.0, 5.0, 6.0, 7.0),
-                createRLEBlock(ImmutableList.of(0.01, 0.5), 21));
+                createRleBlock(ImmutableList.of(0.01, 0.5), 21));
 
         // unsorted percentiles
         assertAggregation(
@@ -543,7 +544,7 @@ public class TestApproximatePercentileAggregation
                 DOUBLE_APPROXIMATE_PERCENTILE_ARRAY,
                 ImmutableList.of(3.0, 1.0, 2.0),
                 createDoublesBlock(null, 1.0, 2.0, 3.0),
-                createRLEBlock(ImmutableList.of(0.8, 0.2, 0.5), 4));
+                createRleBlock(ImmutableList.of(0.8, 0.2, 0.5), 4));
 
         // weighted approx_percentile
         assertAggregation(
@@ -553,7 +554,7 @@ public class TestApproximatePercentileAggregation
                 null,
                 createDoublesBlock(null, null),
                 createLongsBlock(1L, 1L),
-                createRLEBlock(0.5, 2));
+                createRleBlock(0.5, 2));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -562,7 +563,7 @@ public class TestApproximatePercentileAggregation
                 1.0,
                 createDoublesBlock(null, 1.0),
                 createDoublesBlock(1.0, 1.0),
-                createRLEBlock(0.5, 2));
+                createRleBlock(0.5, 2));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -571,7 +572,7 @@ public class TestApproximatePercentileAggregation
                 2.0,
                 createDoublesBlock(null, 1.0, 2.0, 3.0),
                 createDoublesBlock(1.0, 1.0, 1.0, 1.0),
-                createRLEBlock(0.5, 4));
+                createRleBlock(0.5, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -580,7 +581,7 @@ public class TestApproximatePercentileAggregation
                 2.0,
                 createDoublesBlock(1.0, 2.0, 3.0),
                 createDoublesBlock(1.0, 1.0, 1.0),
-                createRLEBlock(0.5, 3));
+                createRleBlock(0.5, 3));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -589,7 +590,7 @@ public class TestApproximatePercentileAggregation
                 2.75,
                 createDoublesBlock(1.0, null, 2.0, null, 2.0, null, 2.0, null, 3.0, null, 3.0, null, 3.0, 4.0, 5.0, 6.0, 7.0),
                 createDoublesBlock(1.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0),
-                createRLEBlock(0.5, 17));
+                createRleBlock(0.5, 17));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -598,7 +599,7 @@ public class TestApproximatePercentileAggregation
                 2.75,
                 createDoublesBlock(1.0, null, 2.0, null, 2.0, null, 2.0, null, 3.0, null, 3.0, null, 3.0, 4.0, 5.0, 6.0, 7.0),
                 createDoublesBlock(1.1, 1.1, 2.2, 1.1, 2.2, 1.1, 2.2, 1.1, 2.2, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1),
-                createRLEBlock(0.5, 17));
+                createRleBlock(0.5, 17));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -607,8 +608,8 @@ public class TestApproximatePercentileAggregation
                 9900.0,
                 createDoubleSequenceBlock(0, 10000),
                 createDoubleRepeatBlock(1.0, 10000),
-                createRLEBlock(0.99, 10000),
-                createRLEBlock(0.001, 10000));
+                createRleBlock(0.99, 10000),
+                createRleBlock(0.001, 10000));
 
         // weighted + array of approx_percentile
         assertAggregation(
@@ -618,17 +619,17 @@ public class TestApproximatePercentileAggregation
                 ImmutableList.of(1.5, 2.6000000000000005),
                 createDoublesBlock(1.0, 2.0, 3.0),
                 createDoublesBlock(4.0, 2.0, 1.0),
-                createRLEBlock(ImmutableList.of(0.5, 0.8), 3));
+                createRleBlock(ImmutableList.of(0.5, 0.8), 3));
     }
 
-    private static RunLengthEncodedBlock createRLEBlock(double percentile, int positionCount)
+    private static Block createRleBlock(double percentile, int positionCount)
     {
         BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(null, 1);
         DOUBLE.writeDouble(blockBuilder, percentile);
-        return new RunLengthEncodedBlock(blockBuilder.build(), positionCount);
+        return RunLengthEncodedBlock.create(blockBuilder.build(), positionCount);
     }
 
-    private static RunLengthEncodedBlock createRLEBlock(Iterable<Double> percentiles, int positionCount)
+    private static Block createRleBlock(Iterable<Double> percentiles, int positionCount)
     {
         BlockBuilder rleBlockBuilder = new ArrayType(DOUBLE).createBlockBuilder(null, 1);
         BlockBuilder arrayBlockBuilder = rleBlockBuilder.beginBlockEntry();
@@ -639,6 +640,6 @@ public class TestApproximatePercentileAggregation
 
         rleBlockBuilder.closeEntry();
 
-        return new RunLengthEncodedBlock(rleBlockBuilder.build(), positionCount);
+        return RunLengthEncodedBlock.create(rleBlockBuilder.build(), positionCount);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestQuantileDigestAggregationFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestQuantileDigestAggregationFunction.java
@@ -16,6 +16,7 @@ package io.trino.operator.aggregation;
 import com.google.common.base.Joiner;
 import com.google.common.primitives.Floats;
 import io.airlift.stats.QuantileDigest;
+import io.trino.block.BlockAssertions;
 import io.trino.metadata.TestingFunctionResolution;
 import io.trino.operator.scalar.AbstractTestFunctions;
 import io.trino.spi.Page;
@@ -39,7 +40,7 @@ import static io.trino.block.BlockAssertions.createDoubleSequenceBlock;
 import static io.trino.block.BlockAssertions.createDoublesBlock;
 import static io.trino.block.BlockAssertions.createLongSequenceBlock;
 import static io.trino.block.BlockAssertions.createLongsBlock;
-import static io.trino.block.BlockAssertions.createRLEBlock;
+import static io.trino.block.BlockAssertions.createRepeatedValuesBlock;
 import static io.trino.block.BlockAssertions.createSequenceBlockOfReal;
 import static io.trino.operator.aggregation.AggregationTestUtils.assertAggregation;
 import static io.trino.operator.aggregation.FloatingPointBitsConverterUtil.doubleToSortableLong;
@@ -67,31 +68,31 @@ public class TestQuantileDigestAggregationFunction
     {
         testAggregationDouble(
                 createDoublesBlock(1.0, null, 2.0, null, 3.0, null, 4.0, null, 5.0, null),
-                createRLEBlock(1, 10),
+                createRepeatedValuesBlock(1, 10),
                 0.01, 1.0, 2.0, 3.0, 4.0, 5.0);
         testAggregationDouble(
                 createDoublesBlock(null, null, null, null, null),
-                createRLEBlock(1, 5),
+                createRepeatedValuesBlock(1, 5),
                 NaN);
         testAggregationDouble(
                 createDoublesBlock(-1.0, -2.0, -3.0, -4.0, -5.0, -6.0, -7.0, -8.0, -9.0, -10.0),
-                createRLEBlock(1, 10),
+                createRepeatedValuesBlock(1, 10),
                 0.01, -1.0, -2.0, -3.0, -4.0, -5.0, -6.0, -7.0, -8.0, -9.0, -10.0);
         testAggregationDouble(
                 createDoublesBlock(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0),
-                createRLEBlock(1, 10),
+                createRepeatedValuesBlock(1, 10),
                 0.01, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0);
         testAggregationDouble(
                 createDoublesBlock(),
-                createRLEBlock(1, 0),
+                createRepeatedValuesBlock(1, 0),
                 NaN);
         testAggregationDouble(
                 createDoublesBlock(1.0),
-                createRLEBlock(1, 1),
+                createRepeatedValuesBlock(1, 1),
                 0.01, 1.0);
         testAggregationDouble(
                 createDoubleSequenceBlock(-1000, 1000),
-                createRLEBlock(1, 2000),
+                createRepeatedValuesBlock(1, 2000),
                 0.01,
                 LongStream.range(-1000, 1000).asDoubleStream().toArray());
     }
@@ -101,31 +102,31 @@ public class TestQuantileDigestAggregationFunction
     {
         testAggregationReal(
                 createBlockOfReals(1.0F, null, 2.0F, null, 3.0F, null, 4.0F, null, 5.0F, null),
-                createRLEBlock(1, 10),
+                createRepeatedValuesBlock(1, 10),
                 0.01, 1.0F, 2.0F, 3.0F, 4.0F, 5.0F);
         testAggregationReal(
                 createBlockOfReals(null, null, null, null, null),
-                createRLEBlock(1, 5),
+                createRepeatedValuesBlock(1, 5),
                 NaN);
         testAggregationReal(
                 createBlockOfReals(-1.0F, -2.0F, -3.0F, -4.0F, -5.0F, -6.0F, -7.0F, -8.0F, -9.0F, -10.0F),
-                createRLEBlock(1, 10),
+                createRepeatedValuesBlock(1, 10),
                 0.01, -1.0F, -2.0F, -3.0F, -4.0F, -5.0F, -6.0F, -7.0F, -8.0F, -9.0F, -10.0F);
         testAggregationReal(
                 createBlockOfReals(1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F, 7.0F, 8.0F, 9.0F, 10.0F),
-                createRLEBlock(1, 10),
+                createRepeatedValuesBlock(1, 10),
                 0.01, 1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F, 7.0F, 8.0F, 9.0F, 10.0F);
         testAggregationReal(
                 createBlockOfReals(),
-                createRLEBlock(1, 0),
+                createRepeatedValuesBlock(1, 0),
                 NaN);
         testAggregationReal(
                 createBlockOfReals(1.0F),
-                createRLEBlock(1, 1),
+                createRepeatedValuesBlock(1, 1),
                 0.01, 1.0F);
         testAggregationReal(
                 createSequenceBlockOfReal(-1000, 1000),
-                createRLEBlock(1, 2000),
+                createRepeatedValuesBlock(1, 2000),
                 0.01,
                 Floats.toArray(LongStream.range(-1000, 1000).mapToObj(Float::new).collect(toImmutableList())));
     }
@@ -135,31 +136,31 @@ public class TestQuantileDigestAggregationFunction
     {
         testAggregationBigint(
                 createLongsBlock(1L, null, 2L, null, 3L, null, 4L, null, 5L, null),
-                createRLEBlock(1, 10),
+                createRepeatedValuesBlock(1, 10),
                 0.01, 1, 2, 3, 4, 5);
         testAggregationBigint(
                 createLongsBlock(null, null, null, null, null),
-                createRLEBlock(1, 5),
+                createRepeatedValuesBlock(1, 5),
                 NaN);
         testAggregationBigint(
                 createLongsBlock(-1, -2, -3, -4, -5, -6, -7, -8, -9, -10),
-                createRLEBlock(1, 10),
+                createRepeatedValuesBlock(1, 10),
                 0.01, -1, -2, -3, -4, -5, -6, -7, -8, -9, -10);
         testAggregationBigint(
                 createLongsBlock(1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
-                createRLEBlock(1, 10),
+                createRepeatedValuesBlock(1, 10),
                 0.01, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         testAggregationBigint(
                 createLongsBlock(new int[] {}),
-                createRLEBlock(1, 0),
+                createRepeatedValuesBlock(1, 0),
                 NaN);
         testAggregationBigint(
                 createLongsBlock(1),
-                createRLEBlock(1, 1),
+                createRepeatedValuesBlock(1, 1),
                 0.01, 1);
         testAggregationBigint(
                 createLongSequenceBlock(-1000, 1000),
-                createRLEBlock(1, 2000),
+                createRepeatedValuesBlock(1, 2000),
                 0.01,
                 LongStream.range(-1000, 1000).toArray());
     }
@@ -182,7 +183,7 @@ public class TestQuantileDigestAggregationFunction
         // Test with weights and accuracy
         testAggregationBigints(
                 fromTypes(BIGINT, BIGINT, DOUBLE),
-                new Page(inputBlock, weightsBlock, createRLEBlock(maxError, inputBlock.getPositionCount())),
+                new Page(inputBlock, weightsBlock, BlockAssertions.createRepeatedValuesBlock(maxError, inputBlock.getPositionCount())),
                 maxError,
                 inputs);
     }
@@ -204,7 +205,7 @@ public class TestQuantileDigestAggregationFunction
         // Test with weights and accuracy
         testAggregationReal(
                 fromTypes(REAL, BIGINT, DOUBLE),
-                new Page(longsBlock, weightsBlock, createRLEBlock(maxError, longsBlock.getPositionCount())),
+                new Page(longsBlock, weightsBlock, BlockAssertions.createRepeatedValuesBlock(maxError, longsBlock.getPositionCount())),
                 maxError,
                 inputs);
     }
@@ -226,7 +227,7 @@ public class TestQuantileDigestAggregationFunction
         // Test with weights and accuracy
         testAggregationDoubles(
                 fromTypes(DOUBLE, BIGINT, DOUBLE),
-                new Page(longsBlock, weightsBlock, createRLEBlock(maxError, longsBlock.getPositionCount())),
+                new Page(longsBlock, weightsBlock, BlockAssertions.createRepeatedValuesBlock(maxError, longsBlock.getPositionCount())),
                 maxError,
                 inputs);
     }

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestTDigestAggregationFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestTDigestAggregationFunction.java
@@ -15,6 +15,7 @@ package io.trino.operator.aggregation;
 
 import com.google.common.collect.ImmutableList;
 import io.airlift.stats.TDigest;
+import io.trino.block.BlockAssertions;
 import io.trino.metadata.TestingFunctionResolution;
 import io.trino.operator.scalar.AbstractTestFunctions;
 import io.trino.spi.Page;
@@ -31,7 +32,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static io.trino.block.BlockAssertions.createDoubleSequenceBlock;
 import static io.trino.block.BlockAssertions.createDoublesBlock;
-import static io.trino.block.BlockAssertions.createRLEBlock;
 import static io.trino.operator.aggregation.AggregationTestUtils.assertAggregation;
 import static io.trino.operator.scalar.TDigestFunctions.DEFAULT_WEIGHT;
 import static io.trino.spi.type.DoubleType.DOUBLE;
@@ -71,7 +71,7 @@ public class TestTDigestAggregationFunction
                 1.0, 2.0, 3.0, 4.0, 5.0);
         testAggregation(
                 createDoublesBlock(null, null, null, null, null),
-                createRLEBlock(1.0, 5),
+                BlockAssertions.createRepeatedValuesBlock(1.0, 5),
                 ImmutableList.of());
         testAggregation(
                 createDoublesBlock(-1.0, -2.0, -3.0, -4.0, -5.0, -6.0, -7.0, -8.0, -9.0, -10.0),
@@ -85,11 +85,11 @@ public class TestTDigestAggregationFunction
                 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0);
         testAggregation(
                 createDoublesBlock(),
-                createRLEBlock(1.0, 0),
+                BlockAssertions.createRepeatedValuesBlock(1.0, 0),
                 ImmutableList.of());
         testAggregation(
                 createDoublesBlock(1.0),
-                createRLEBlock(1.1, 1),
+                BlockAssertions.createRepeatedValuesBlock(1.1, 1),
                 ImmutableList.of(1.1),
                 1.0);
 

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/minmaxbyn/TestMinMaxByNAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/minmaxbyn/TestMinMaxByNAggregation.java
@@ -30,7 +30,7 @@ import static io.trino.block.BlockAssertions.createArrayBigintBlock;
 import static io.trino.block.BlockAssertions.createBlockOfReals;
 import static io.trino.block.BlockAssertions.createDoublesBlock;
 import static io.trino.block.BlockAssertions.createLongsBlock;
-import static io.trino.block.BlockAssertions.createRLEBlock;
+import static io.trino.block.BlockAssertions.createRepeatedValuesBlock;
 import static io.trino.block.BlockAssertions.createStringsBlock;
 import static io.trino.operator.aggregation.AggregationTestUtils.assertAggregation;
 import static io.trino.operator.aggregation.AggregationTestUtils.groupedAggregation;
@@ -56,7 +56,7 @@ public class TestMinMaxByNAggregation
                 Arrays.asList((Double) null),
                 createDoublesBlock(1.0, null),
                 createDoublesBlock(3.0, 5.0),
-                createRLEBlock(1L, 2));
+                createRepeatedValuesBlock(1L, 2));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -65,7 +65,7 @@ public class TestMinMaxByNAggregation
                 null,
                 createDoublesBlock(null, null),
                 createDoublesBlock(null, null),
-                createRLEBlock(1L, 2));
+                createRepeatedValuesBlock(1L, 2));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -74,7 +74,7 @@ public class TestMinMaxByNAggregation
                 Arrays.asList(1.0),
                 createDoublesBlock(null, 1.0, null, null),
                 createDoublesBlock(null, 0.0, null, null),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -83,7 +83,7 @@ public class TestMinMaxByNAggregation
                 Arrays.asList(1.0),
                 createDoublesBlock(1.0),
                 createDoublesBlock(0.0),
-                createRLEBlock(2L, 1));
+                createRepeatedValuesBlock(2L, 1));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -92,7 +92,7 @@ public class TestMinMaxByNAggregation
                 null,
                 createDoublesBlock(),
                 createDoublesBlock(),
-                createRLEBlock(2L, 0));
+                createRepeatedValuesBlock(2L, 0));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -101,7 +101,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of(2.5),
                 createDoublesBlock(2.5, 2.0, 5.0, 3.0),
                 createDoublesBlock(4.0, 1.5, 2.0, 3.0),
-                createRLEBlock(1L, 4));
+                createRepeatedValuesBlock(1L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -110,7 +110,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of(2.5, 3.0),
                 createDoublesBlock(2.5, 2.0, 5.0, 3.0),
                 createDoublesBlock(4.0, 1.5, 2.0, 3.0),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
     }
 
     @Test
@@ -124,7 +124,7 @@ public class TestMinMaxByNAggregation
                 Arrays.asList((Double) null),
                 createDoublesBlock(1.0, null),
                 createDoublesBlock(5.0, 3.0),
-                createRLEBlock(1L, 2));
+                createRepeatedValuesBlock(1L, 2));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -133,7 +133,7 @@ public class TestMinMaxByNAggregation
                 null,
                 createDoublesBlock(null, null),
                 createDoublesBlock(null, null),
-                createRLEBlock(1L, 2));
+                createRepeatedValuesBlock(1L, 2));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -142,7 +142,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of(2.0),
                 createDoublesBlock(2.5, 2.0, 5.0, 3.0),
                 createDoublesBlock(4.0, 1.5, 2.0, 3.0),
-                createRLEBlock(1L, 4));
+                createRepeatedValuesBlock(1L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -151,7 +151,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of(2.0, 5.0),
                 createDoublesBlock(2.5, 2.0, 5.0, 3.0),
                 createDoublesBlock(4.0, 1.5, 2.0, 3.0),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
     }
 
     @Test
@@ -165,7 +165,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("z", "a"),
                 createStringsBlock("z", "a", "x", "b"),
                 createDoublesBlock(1.0, 2.0, 2.0, 3.0),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -174,7 +174,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("a", "zz"),
                 createStringsBlock("zz", "hi", "bb", "a"),
                 createDoublesBlock(0.0, 1.0, 2.0, -1.0),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -183,7 +183,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("a", "zz"),
                 createStringsBlock("zz", "hi", null, "a"),
                 createDoublesBlock(0.0, 1.0, null, -1.0),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -192,7 +192,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("b", "c"),
                 createStringsBlock("a", "b", "c", "d"),
                 createDoublesBlock(Double.NaN, 2.0, 3.0, 4.0),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -201,7 +201,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("a", "c"),
                 createStringsBlock("a", "b", "c", "d"),
                 createDoublesBlock(1.0, Double.NaN, 3.0, 4.0),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -210,7 +210,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("a", "b"),
                 createStringsBlock("a", "b", "c", "d"),
                 createDoublesBlock(1.0, 2.0, Double.NaN, 4.0),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -219,7 +219,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("a", "b"),
                 createStringsBlock("a", "b", "c", "d"),
                 createDoublesBlock(1.0, 2.0, 3.0, Double.NaN),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -228,7 +228,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("a", "b"),
                 createStringsBlock("a", "b"),
                 createDoublesBlock(1.0, Double.NaN),
-                createRLEBlock(2L, 2));
+                createRepeatedValuesBlock(2L, 2));
     }
 
     @Test
@@ -242,7 +242,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("a", "z"),
                 createStringsBlock("z", "a", null),
                 createDoublesBlock(1.0, 2.0, null),
-                createRLEBlock(2L, 3));
+                createRepeatedValuesBlock(2L, 3));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -251,7 +251,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("bb", "hi"),
                 createStringsBlock("zz", "hi", "bb", "a"),
                 createDoublesBlock(0.0, 1.0, 2.0, -1.0),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -260,7 +260,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("hi", "zz"),
                 createStringsBlock("zz", "hi", null, "a"),
                 createDoublesBlock(0.0, 1.0, null, -1.0),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -269,7 +269,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("d", "c"),
                 createStringsBlock("a", "b", "c", "d"),
                 createDoublesBlock(Double.NaN, 2.0, 3.0, 4.0),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -278,7 +278,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("d", "c"),
                 createStringsBlock("a", "b", "c", "d"),
                 createDoublesBlock(1.0, Double.NaN, 3.0, 4.0),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -287,7 +287,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("d", "b"),
                 createStringsBlock("a", "b", "c", "d"),
                 createDoublesBlock(1.0, 2.0, Double.NaN, 4.0),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -296,7 +296,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("c", "b"),
                 createStringsBlock("a", "b", "c", "d"),
                 createDoublesBlock(1.0, 2.0, 3.0, Double.NaN),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -305,7 +305,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("a", "b"),
                 createStringsBlock("a", "b"),
                 createDoublesBlock(1.0, Double.NaN),
-                createRLEBlock(2L, 2));
+                createRepeatedValuesBlock(2L, 2));
     }
 
     @Test
@@ -319,7 +319,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("z", "a"),
                 createStringsBlock("z", "a", "x", "b"),
                 createBlockOfReals(1.0f, 2.0f, 2.0f, 3.0f),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -328,7 +328,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("a", "zz"),
                 createStringsBlock("zz", "hi", "bb", "a"),
                 createBlockOfReals(0.0f, 1.0f, 2.0f, -1.0f),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -337,7 +337,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("a", "zz"),
                 createStringsBlock("zz", "hi", null, "a"),
                 createBlockOfReals(0.0f, 1.0f, null, -1.0f),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -346,7 +346,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("b", "c"),
                 createStringsBlock("a", "b", "c", "d"),
                 createBlockOfReals(Float.NaN, 2.0f, 3.0f, 4.0f),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -355,7 +355,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("a", "c"),
                 createStringsBlock("a", "b", "c", "d"),
                 createBlockOfReals(1.0f, Float.NaN, 3.0f, 4.0f),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -364,7 +364,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("a", "b"),
                 createStringsBlock("a", "b", "c", "d"),
                 createBlockOfReals(1.0f, 2.0f, Float.NaN, 4.0f),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -373,7 +373,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("a", "b"),
                 createStringsBlock("a", "b", "c", "d"),
                 createBlockOfReals(1.0f, 2.0f, 3.0f, Float.NaN),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -382,7 +382,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("a", "b"),
                 createStringsBlock("a", "b"),
                 createBlockOfReals(1.0f, Float.NaN),
-                createRLEBlock(2L, 2));
+                createRepeatedValuesBlock(2L, 2));
     }
 
     @Test
@@ -396,7 +396,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("a", "z"),
                 createStringsBlock("z", "a", null),
                 createBlockOfReals(1.0f, 2.0f, null),
-                createRLEBlock(2L, 3));
+                createRepeatedValuesBlock(2L, 3));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -405,7 +405,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("bb", "hi"),
                 createStringsBlock("zz", "hi", "bb", "a"),
                 createBlockOfReals(0.0f, 1.0f, 2.0f, -1.0f),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -414,7 +414,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("hi", "zz"),
                 createStringsBlock("zz", "hi", null, "a"),
                 createBlockOfReals(0.0f, 1.0f, null, -1.0f),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -423,7 +423,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("d", "c"),
                 createStringsBlock("a", "b", "c", "d"),
                 createBlockOfReals(Float.NaN, 2.0f, 3.0f, 4.0f),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -432,7 +432,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("d", "c"),
                 createStringsBlock("a", "b", "c", "d"),
                 createBlockOfReals(1.0f, Float.NaN, 3.0f, 4.0f),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -441,7 +441,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("d", "b"),
                 createStringsBlock("a", "b", "c", "d"),
                 createBlockOfReals(1.0f, 2.0f, Float.NaN, 4.0f),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -450,7 +450,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("c", "b"),
                 createStringsBlock("a", "b", "c", "d"),
                 createBlockOfReals(1.0f, 2.0f, 3.0f, Float.NaN),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -459,7 +459,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("a", "b"),
                 createStringsBlock("a", "b"),
                 createBlockOfReals(1.0f, Float.NaN),
-                createRLEBlock(2L, 2));
+                createRepeatedValuesBlock(2L, 2));
     }
 
     @Test
@@ -473,7 +473,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of(2.0, 3.0),
                 createDoublesBlock(1.0, 2.0, 2.0, 3.0),
                 createStringsBlock("z", "a", "x", "b"),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -482,7 +482,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of(-1.0, 2.0),
                 createDoublesBlock(0.0, 1.0, 2.0, -1.0),
                 createStringsBlock("zz", "hi", "bb", "a"),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -491,7 +491,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of(-1.0, 1.0),
                 createDoublesBlock(0.0, 1.0, null, -1.0),
                 createStringsBlock("zz", "hi", null, "a"),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
     }
 
     @Test
@@ -505,7 +505,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of(1.0, 2.0),
                 createDoublesBlock(1.0, 2.0, null),
                 createStringsBlock("z", "a", null),
-                createRLEBlock(2L, 3));
+                createRepeatedValuesBlock(2L, 3));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -514,7 +514,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of(0.0, 1.0),
                 createDoublesBlock(0.0, 1.0, 2.0, -1.0),
                 createStringsBlock("zz", "hi", "bb", "a"),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
 
         assertAggregation(
                 FUNCTION_RESOLUTION,
@@ -523,7 +523,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of(0.0, 1.0),
                 createDoublesBlock(0.0, 1.0, null, -1.0),
                 createStringsBlock("zz", "hi", null, "a"),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
     }
 
     @Test
@@ -537,7 +537,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of(ImmutableList.of(2L, 3L), ImmutableList.of(4L, 5L)),
                 createArrayBigintBlock(ImmutableList.of(ImmutableList.of(1L, 2L), ImmutableList.of(2L, 3L), ImmutableList.of(3L, 4L), ImmutableList.of(4L, 5L))),
                 createStringsBlock("z", "a", "x", "b"),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
     }
 
     @Test
@@ -551,7 +551,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of(ImmutableList.of(1L, 2L), ImmutableList.of(3L, 4L)),
                 createArrayBigintBlock(ImmutableList.of(ImmutableList.of(1L, 2L), ImmutableList.of(2L, 3L), ImmutableList.of(3L, 4L), ImmutableList.of(4L, 5L))),
                 createStringsBlock("z", "a", "x", "b"),
-                createRLEBlock(2L, 4));
+                createRepeatedValuesBlock(2L, 4));
     }
 
     @Test
@@ -565,7 +565,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("b", "x", "z"),
                 createStringsBlock("z", "a", "x", "b"),
                 createArrayBigintBlock(ImmutableList.of(ImmutableList.of(1L, 2L), ImmutableList.of(2L, 3L), ImmutableList.of(0L, 3L), ImmutableList.of(0L, 2L))),
-                createRLEBlock(3L, 4));
+                createRepeatedValuesBlock(3L, 4));
     }
 
     @Test
@@ -579,7 +579,7 @@ public class TestMinMaxByNAggregation
                 ImmutableList.of("a", "z", "x"),
                 createStringsBlock("z", "a", "x", "b"),
                 createArrayBigintBlock(ImmutableList.of(ImmutableList.of(1L, 2L), ImmutableList.of(2L, 3L), ImmutableList.of(0L, 3L), ImmutableList.of(0L, 2L))),
-                createRLEBlock(3L, 4));
+                createRepeatedValuesBlock(3L, 4));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/operator/output/BenchmarkPartitionedOutputOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/BenchmarkPartitionedOutputOperator.java
@@ -86,9 +86,9 @@ import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.block.BlockAssertions.chooseNullPositions;
 import static io.trino.block.BlockAssertions.createLongDictionaryBlock;
 import static io.trino.block.BlockAssertions.createLongsBlock;
-import static io.trino.block.BlockAssertions.createRLEBlock;
 import static io.trino.block.BlockAssertions.createRandomBlockForType;
 import static io.trino.block.BlockAssertions.createRandomLongsBlock;
+import static io.trino.block.BlockAssertions.createRepeatedValuesBlock;
 import static io.trino.execution.buffer.OutputBuffers.BufferType.PARTITIONED;
 import static io.trino.execution.buffer.OutputBuffers.createInitialEmptyOutputBuffers;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
@@ -264,14 +264,14 @@ public class BenchmarkPartitionedOutputOperator
                         positionCount,
                         types.size(),
                         () -> createRandomBlockForType(BigintType.BIGINT, positionCount, nullRate),
-                        createRLEBlock(42, positionCount));
+                        createRepeatedValuesBlock(42, positionCount));
             }),
             BIGINT_PARTITION_CHANNEL_RLE_NULL(BigintType.BIGINT, 20, (types, positionCount, nullRate) -> {
                 return page(
                         positionCount,
                         types.size(),
                         () -> createRandomBlockForType(BigintType.BIGINT, positionCount, nullRate),
-                        new RunLengthEncodedBlock(createLongsBlock((Long) null), positionCount));
+                        RunLengthEncodedBlock.create(createLongsBlock((Long) null), positionCount));
             }),
             LONG_DECIMAL(createDecimalType(MAX_SHORT_PRECISION + 1), 5000),
             DICTIONARY_LONG_DECIMAL(createDecimalType(MAX_SHORT_PRECISION + 1), 5000, PageTestUtils::createRandomDictionaryPage),
@@ -313,7 +313,7 @@ public class BenchmarkPartitionedOutputOperator
                                             positionCount,
                                             Optional.ofNullable(isNull),
                                             new Block[] {
-                                                    new RunLengthEncodedBlock(createLongsBlock(-65128734213L), notNullPositionsCount),
+                                                    RunLengthEncodedBlock.create(createLongsBlock(-65128734213L), notNullPositionsCount),
                                                     createRandomLongsBlock(notNullPositionsCount, nullRate)});
                                 })
                                 .collect(toImmutableList()));

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPagePartitioner.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPagePartitioner.java
@@ -317,7 +317,7 @@ public class TestPagePartitioner
     public void testOutputForOneValueDictionaryBlock(PartitioningMode partitioningMode)
     {
         PagePartitioner pagePartitioner = pagePartitioner(BIGINT).build();
-        Page page = new Page(new DictionaryBlock(createLongsBlock(0), new int[] {0, 0, 0, 0}));
+        Page page = new Page(new DictionaryBlock(4, createLongsBlock(0), new int[] {0, 0, 0, 0}));
 
         processPages(pagePartitioner, partitioningMode, page);
 
@@ -331,7 +331,7 @@ public class TestPagePartitioner
     public void testOutputForViewDictionaryBlock(PartitioningMode partitioningMode)
     {
         PagePartitioner pagePartitioner = pagePartitioner(BIGINT).build();
-        Page page = new Page(new DictionaryBlock(createLongSequenceBlock(4, 8), new int[] {1, 0, 3, 2}));
+        Page page = new Page(new DictionaryBlock(4, createLongSequenceBlock(4, 8), new int[] {1, 0, 3, 2}));
 
         processPages(pagePartitioner, partitioningMode, page);
 

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPagePartitioner.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPagePartitioner.java
@@ -71,8 +71,8 @@ import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.block.BlockAssertions.createLongDictionaryBlock;
 import static io.trino.block.BlockAssertions.createLongSequenceBlock;
 import static io.trino.block.BlockAssertions.createLongsBlock;
-import static io.trino.block.BlockAssertions.createRLEBlock;
 import static io.trino.block.BlockAssertions.createRandomBlockForType;
+import static io.trino.block.BlockAssertions.createRepeatedValuesBlock;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.CharType.createCharType;
@@ -260,7 +260,7 @@ public class TestPagePartitioner
     public void testPartitionPositionsWithRleNotNull(PartitioningMode partitioningMode)
     {
         PagePartitioner pagePartitioner = pagePartitioner(BIGINT, BIGINT).build();
-        Page page = new Page(createRLEBlock(0, POSITIONS_PER_PAGE), createLongSequenceBlock(0, POSITIONS_PER_PAGE));
+        Page page = new Page(createRepeatedValuesBlock(0, POSITIONS_PER_PAGE), createLongSequenceBlock(0, POSITIONS_PER_PAGE));
 
         processPages(pagePartitioner, partitioningMode, page);
 
@@ -275,7 +275,7 @@ public class TestPagePartitioner
     public void testPartitionPositionsWithRleNotNullWithReplication(PartitioningMode partitioningMode)
     {
         PagePartitioner pagePartitioner = pagePartitioner(BIGINT, BIGINT).replicate().build();
-        Page page = new Page(createRLEBlock(0, POSITIONS_PER_PAGE), createLongSequenceBlock(0, POSITIONS_PER_PAGE));
+        Page page = new Page(createRepeatedValuesBlock(0, POSITIONS_PER_PAGE), createLongSequenceBlock(0, POSITIONS_PER_PAGE));
 
         processPages(pagePartitioner, partitioningMode, page);
 
@@ -289,7 +289,7 @@ public class TestPagePartitioner
     public void testPartitionPositionsWithRleNullWithNullChannel(PartitioningMode partitioningMode)
     {
         PagePartitioner pagePartitioner = pagePartitioner(BIGINT, BIGINT).withNullChannel(0).build();
-        Page page = new Page(new RunLengthEncodedBlock(createLongsBlock((Long) null), POSITIONS_PER_PAGE), createLongSequenceBlock(0, POSITIONS_PER_PAGE));
+        Page page = new Page(RunLengthEncodedBlock.create(createLongsBlock((Long) null), POSITIONS_PER_PAGE), createLongSequenceBlock(0, POSITIONS_PER_PAGE));
 
         processPages(pagePartitioner, partitioningMode, page);
 

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPagePartitioner.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPagePartitioner.java
@@ -317,7 +317,7 @@ public class TestPagePartitioner
     public void testOutputForOneValueDictionaryBlock(PartitioningMode partitioningMode)
     {
         PagePartitioner pagePartitioner = pagePartitioner(BIGINT).build();
-        Page page = new Page(new DictionaryBlock(4, createLongsBlock(0), new int[] {0, 0, 0, 0}));
+        Page page = new Page(DictionaryBlock.create(4, createLongsBlock(0), new int[] {0, 0, 0, 0}));
 
         processPages(pagePartitioner, partitioningMode, page);
 
@@ -331,7 +331,7 @@ public class TestPagePartitioner
     public void testOutputForViewDictionaryBlock(PartitioningMode partitioningMode)
     {
         PagePartitioner pagePartitioner = pagePartitioner(BIGINT).build();
-        Page page = new Page(new DictionaryBlock(4, createLongSequenceBlock(4, 8), new int[] {1, 0, 3, 2}));
+        Page page = new Page(DictionaryBlock.create(4, createLongSequenceBlock(4, 8), new int[] {1, 0, 3, 2}));
 
         processPages(pagePartitioner, partitioningMode, page);
 

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppender.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppender.java
@@ -300,17 +300,17 @@ public class TestPositionsAppender
         return new IntArrayList(positions);
     }
 
-    private DictionaryBlock dictionaryBlock(Block dictionary, int positionCount)
+    private Block dictionaryBlock(Block dictionary, int positionCount)
     {
         return createRandomDictionaryBlock(dictionary, positionCount);
     }
 
-    private DictionaryBlock dictionaryBlock(Block dictionary, int[] ids)
+    private Block dictionaryBlock(Block dictionary, int[] ids)
     {
-        return new DictionaryBlock(ids.length, dictionary, ids);
+        return DictionaryBlock.create(ids.length, dictionary, ids);
     }
 
-    private DictionaryBlock dictionaryBlock(TestType type, int positionCount, int dictionarySize, float nullRate)
+    private Block dictionaryBlock(TestType type, int positionCount, int dictionarySize, float nullRate)
     {
         Block dictionary = createRandomBlockForType(type, dictionarySize, nullRate);
         return createRandomDictionaryBlock(dictionary, positionCount);

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppender.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppender.java
@@ -244,11 +244,11 @@ public class TestPositionsAppender
         PositionsAppender positionsAppender = POSITIONS_APPENDER_FACTORY.create(VARCHAR, 10, DEFAULT_MAX_PAGE_SIZE_IN_BYTES);
 
         // first append some not empty value to avoid RleAwarePositionsAppender for the empty value
-        positionsAppender.appendRle(new RunLengthEncodedBlock(singleValueBlock("some value"), 1));
+        positionsAppender.appendRle(singleValueBlock("some value"), 1);
         // append empty value multiple times to trigger jit compilation
         Block emptyStringBlock = singleValueBlock("");
         for (int i = 0; i < 1000; i++) {
-            positionsAppender.appendRle(new RunLengthEncodedBlock(emptyStringBlock, 2000));
+            positionsAppender.appendRle(emptyStringBlock, 2000);
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppender.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppender.java
@@ -218,17 +218,13 @@ public class TestPositionsAppender
         assertBlockEquals(type.getType(), positionsAppender.build(), block);
 
         // append not null rle
-        Block rleBlock = rleBlock(type, 1);
-        positionsAppender.append(allPositions(1), rleBlock);
+        Block rleBlock = rleBlock(type, 10);
+        positionsAppender.append(allPositions(10), rleBlock);
         assertBlockEquals(type.getType(), positionsAppender.build(), rleBlock);
 
-        // append empty rle
-        positionsAppender.append(positions(), rleBlock(type, 0));
-        assertEquals(positionsAppender.build().getPositionCount(), 0);
-
         // append null rle
-        Block nullRleBlock = nullRleBlock(type, 1);
-        positionsAppender.append(allPositions(1), nullRleBlock);
+        Block nullRleBlock = nullRleBlock(type, 10);
+        positionsAppender.append(allPositions(10), nullRleBlock);
         assertBlockEquals(type.getType(), positionsAppender.build(), nullRleBlock);
 
         // just build to confirm appender was reset
@@ -318,19 +314,22 @@ public class TestPositionsAppender
 
     private RunLengthEncodedBlock rleBlock(Block value, int positionCount)
     {
-        return new RunLengthEncodedBlock(value, positionCount);
+        checkArgument(positionCount >= 2);
+        return (RunLengthEncodedBlock) RunLengthEncodedBlock.create(value, positionCount);
     }
 
     private RunLengthEncodedBlock rleBlock(TestType type, int positionCount)
     {
+        checkArgument(positionCount >= 2);
         Block rleValue = createRandomBlockForType(type, 1, 0);
-        return new RunLengthEncodedBlock(rleValue, positionCount);
+        return (RunLengthEncodedBlock) RunLengthEncodedBlock.create(rleValue, positionCount);
     }
 
     private RunLengthEncodedBlock nullRleBlock(TestType type, int positionCount)
     {
+        checkArgument(positionCount >= 2);
         Block rleValue = nullBlock(type, 1);
-        return new RunLengthEncodedBlock(rleValue, positionCount);
+        return (RunLengthEncodedBlock) RunLengthEncodedBlock.create(rleValue, positionCount);
     }
 
     private Block partiallyNullBlock(TestType type, int positionCount)
@@ -508,7 +507,7 @@ public class TestPositionsAppender
         {
             if (block instanceof RunLengthEncodedBlock) {
                 checkArgument(block.getPositionCount() == 0 || block.isNull(0));
-                return new RunLengthEncodedBlock(new TestVariableWidthBlock(0, 1, EMPTY_SLICE, new int[] {0, 0}, new boolean[] {true}), block.getPositionCount());
+                return RunLengthEncodedBlock.create(new TestVariableWidthBlock(0, 1, EMPTY_SLICE, new int[] {0, 0}, new boolean[] {true}), block.getPositionCount());
             }
 
             int[] offsets = new int[block.getPositionCount() + 1];

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppender.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppender.java
@@ -71,7 +71,6 @@ import static io.trino.block.BlockAssertions.createSlicesBlock;
 import static io.trino.block.BlockAssertions.createSmallintsBlock;
 import static io.trino.block.BlockAssertions.createStringsBlock;
 import static io.trino.block.BlockAssertions.createTinyintsBlock;
-import static io.trino.spi.block.DictionaryId.randomDictionaryId;
 import static io.trino.spi.block.PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.CharType.createCharType;
@@ -308,7 +307,7 @@ public class TestPositionsAppender
 
     private DictionaryBlock dictionaryBlock(Block dictionary, int[] ids)
     {
-        return new DictionaryBlock(0, ids.length, dictionary, ids, false, randomDictionaryId());
+        return new DictionaryBlock(ids.length, dictionary, ids);
     }
 
     private DictionaryBlock dictionaryBlock(TestType type, int positionCount, int dictionarySize, float nullRate)

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestSlicePositionsAppender.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestSlicePositionsAppender.java
@@ -43,7 +43,7 @@ public class TestSlicePositionsAppender
 
         Block actualBlock = positionsAppender.build();
 
-        assertBlockEquals(VARCHAR, actualBlock, new RunLengthEncodedBlock(value, 10));
+        assertBlockEquals(VARCHAR, actualBlock, RunLengthEncodedBlock.create(value, 10));
     }
 
     // test append with VariableWidthBlock using Slice not backed by byte array

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestSlicePositionsAppender.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestSlicePositionsAppender.java
@@ -38,12 +38,12 @@ public class TestSlicePositionsAppender
     {
         // test SlicePositionAppender.appendRle with empty value (Slice with length 0)
         PositionsAppender positionsAppender = new SlicePositionsAppender(1, 100);
-        RunLengthEncodedBlock rleBlock = new RunLengthEncodedBlock(createStringsBlock(""), 10);
-        positionsAppender.appendRle(rleBlock);
+        Block value = createStringsBlock("");
+        positionsAppender.appendRle(value, 10);
 
         Block actualBlock = positionsAppender.build();
 
-        assertBlockEquals(VARCHAR, actualBlock, rleBlock);
+        assertBlockEquals(VARCHAR, actualBlock, new RunLengthEncodedBlock(value, 10));
     }
 
     // test append with VariableWidthBlock using Slice not backed by byte array

--- a/core/trino-main/src/test/java/io/trino/operator/project/BenchmarkDictionaryBlock.java
+++ b/core/trino-main/src/test/java/io/trino/operator/project/BenchmarkDictionaryBlock.java
@@ -130,10 +130,10 @@ public class BenchmarkDictionaryBlock
                 default:
                     throw new IllegalArgumentException("Unrecognized value type: " + valueType);
             }
-            dictionaryBlock = new DictionaryBlock(positionsIds.length, mapBlock, positionsIds);
+            dictionaryBlock = (DictionaryBlock) DictionaryBlock.create(positionsIds.length, mapBlock, positionsIds);
             int[] allPositions = IntStream.range(0, POSITIONS).toArray();
-            allPositionsDictionaryBlock = new DictionaryBlock(allPositions.length, mapBlock, allPositions);
-            allPositionsCompactDictionaryBlock = new DictionaryBlock(POSITIONS, mapBlock, allPositions);
+            allPositionsDictionaryBlock = (DictionaryBlock) DictionaryBlock.create(allPositions.length, mapBlock, allPositions);
+            allPositionsCompactDictionaryBlock = (DictionaryBlock) DictionaryBlock.create(POSITIONS, mapBlock, allPositions);
         }
 
         private static Block createVarcharMapBlock(int positionCount)
@@ -156,7 +156,7 @@ public class BenchmarkDictionaryBlock
             for (int i = 0; i < ids.length; i++) {
                 ids[i] = i;
             }
-            return new DictionaryBlock(ids.length, dictionary, ids);
+            return DictionaryBlock.create(ids.length, dictionary, ids);
         }
 
         private static Block createIntMapBlock(int positionCount)
@@ -179,7 +179,7 @@ public class BenchmarkDictionaryBlock
             for (int i = 0; i < ids.length; i++) {
                 ids[i] = i;
             }
-            return new DictionaryBlock(ids.length, dictionary, ids);
+            return DictionaryBlock.create(ids.length, dictionary, ids);
         }
 
         private static Block createIntBlock(int positionCount)

--- a/core/trino-main/src/test/java/io/trino/operator/project/BenchmarkDictionaryBlock.java
+++ b/core/trino-main/src/test/java/io/trino/operator/project/BenchmarkDictionaryBlock.java
@@ -130,10 +130,10 @@ public class BenchmarkDictionaryBlock
                 default:
                     throw new IllegalArgumentException("Unrecognized value type: " + valueType);
             }
-            dictionaryBlock = new DictionaryBlock(mapBlock, positionsIds);
+            dictionaryBlock = new DictionaryBlock(positionsIds.length, mapBlock, positionsIds);
             int[] allPositions = IntStream.range(0, POSITIONS).toArray();
-            allPositionsDictionaryBlock = new DictionaryBlock(mapBlock, allPositions);
-            allPositionsCompactDictionaryBlock = new DictionaryBlock(POSITIONS, mapBlock, allPositions, true);
+            allPositionsDictionaryBlock = new DictionaryBlock(allPositions.length, mapBlock, allPositions);
+            allPositionsCompactDictionaryBlock = new DictionaryBlock(POSITIONS, mapBlock, allPositions);
         }
 
         private static Block createVarcharMapBlock(int positionCount)
@@ -156,7 +156,7 @@ public class BenchmarkDictionaryBlock
             for (int i = 0; i < ids.length; i++) {
                 ids[i] = i;
             }
-            return new DictionaryBlock(dictionary, ids);
+            return new DictionaryBlock(ids.length, dictionary, ids);
         }
 
         private static Block createIntMapBlock(int positionCount)
@@ -179,7 +179,7 @@ public class BenchmarkDictionaryBlock
             for (int i = 0; i < ids.length; i++) {
                 ids[i] = i;
             }
-            return new DictionaryBlock(dictionary, ids);
+            return new DictionaryBlock(ids.length, dictionary, ids);
         }
 
         private static Block createIntBlock(int positionCount)

--- a/core/trino-main/src/test/java/io/trino/operator/project/TestDictionaryAwarePageFilter.java
+++ b/core/trino-main/src/test/java/io/trino/operator/project/TestDictionaryAwarePageFilter.java
@@ -88,7 +88,7 @@ public class TestDictionaryAwarePageFilter
         testFilter(createDictionaryBlock(20, 0), LongArrayBlock.class);
 
         // match all
-        testFilter(new DictionaryBlock(100, createLongSequenceBlock(4, 5), new int[100]), LongArrayBlock.class);
+        testFilter(DictionaryBlock.create(100, createLongSequenceBlock(4, 5), new int[100]), LongArrayBlock.class);
     }
 
     @Test
@@ -109,7 +109,7 @@ public class TestDictionaryAwarePageFilter
         testFilter(createDictionaryBlockWithUnusedEntries(20, 0), DictionaryBlock.class);
 
         // match all
-        testFilter(new DictionaryBlock(100, createLongsBlock(4, 5, -1), new int[100]), DictionaryBlock.class);
+        testFilter(DictionaryBlock.create(100, createLongsBlock(4, 5, -1), new int[100]), DictionaryBlock.class);
     }
 
     @Test
@@ -118,8 +118,8 @@ public class TestDictionaryAwarePageFilter
         TestDictionaryFilter nestedFilter = new TestDictionaryFilter(true);
         DictionaryAwarePageFilter filter = new DictionaryAwarePageFilter(nestedFilter);
 
-        DictionaryBlock ineffectiveBlock = createDictionaryBlock(100, 20);
-        DictionaryBlock effectiveBlock = createDictionaryBlock(10, 100);
+        Block ineffectiveBlock = createDictionaryBlock(100, 20);
+        Block effectiveBlock = createDictionaryBlock(10, 100);
 
         // function will always processes the first dictionary
         nestedFilter.setExpectedType(LongArrayBlock.class);
@@ -138,28 +138,28 @@ public class TestDictionaryAwarePageFilter
         testFilter(filter, effectiveBlock, true);
     }
 
-    private static DictionaryBlock createDictionaryBlock(int dictionarySize, int blockSize)
+    private static Block createDictionaryBlock(int dictionarySize, int blockSize)
     {
         Block dictionary = createLongSequenceBlock(0, dictionarySize);
         int[] ids = new int[blockSize];
         Arrays.setAll(ids, index -> index % dictionarySize);
-        return new DictionaryBlock(ids.length, dictionary, ids);
+        return DictionaryBlock.create(ids.length, dictionary, ids);
     }
 
-    private static DictionaryBlock createDictionaryBlockWithFailure(int dictionarySize, int blockSize)
+    private static Block createDictionaryBlockWithFailure(int dictionarySize, int blockSize)
     {
         Block dictionary = createLongSequenceBlock(-10, dictionarySize - 10);
         int[] ids = new int[blockSize];
         Arrays.setAll(ids, index -> index % dictionarySize);
-        return new DictionaryBlock(ids.length, dictionary, ids);
+        return DictionaryBlock.create(ids.length, dictionary, ids);
     }
 
-    private static DictionaryBlock createDictionaryBlockWithUnusedEntries(int dictionarySize, int blockSize)
+    private static Block createDictionaryBlockWithUnusedEntries(int dictionarySize, int blockSize)
     {
         Block dictionary = createLongSequenceBlock(-10, dictionarySize);
         int[] ids = new int[blockSize];
         Arrays.setAll(ids, index -> (index % dictionarySize) + 10);
-        return new DictionaryBlock(ids.length, dictionary, ids);
+        return DictionaryBlock.create(ids.length, dictionary, ids);
     }
 
     private static void testFilter(Block block, Class<? extends Block> expectedType)

--- a/core/trino-main/src/test/java/io/trino/operator/project/TestDictionaryAwarePageFilter.java
+++ b/core/trino-main/src/test/java/io/trino/operator/project/TestDictionaryAwarePageFilter.java
@@ -62,9 +62,9 @@ public class TestDictionaryAwarePageFilter
     private static void testRleBlock(boolean filterRange)
     {
         DictionaryAwarePageFilter filter = createDictionaryAwarePageFilter(filterRange, LongArrayBlock.class);
-        RunLengthEncodedBlock match = new RunLengthEncodedBlock(createLongSequenceBlock(4, 5), 100);
+        RunLengthEncodedBlock match = (RunLengthEncodedBlock) RunLengthEncodedBlock.create(createLongSequenceBlock(4, 5), 100);
         testFilter(filter, match, filterRange);
-        RunLengthEncodedBlock noMatch = new RunLengthEncodedBlock(createLongSequenceBlock(0, 1), 100);
+        RunLengthEncodedBlock noMatch = (RunLengthEncodedBlock) RunLengthEncodedBlock.create(createLongSequenceBlock(0, 1), 100);
         testFilter(filter, noMatch, filterRange);
     }
 
@@ -72,7 +72,7 @@ public class TestDictionaryAwarePageFilter
     public void testRleBlockWithFailure()
     {
         DictionaryAwarePageFilter filter = createDictionaryAwarePageFilter(true, LongArrayBlock.class);
-        RunLengthEncodedBlock fail = new RunLengthEncodedBlock(createLongSequenceBlock(-10, -9), 100);
+        RunLengthEncodedBlock fail = (RunLengthEncodedBlock) RunLengthEncodedBlock.create(createLongSequenceBlock(-10, -9), 100);
         assertThatThrownBy(() -> testFilter(filter, fail, true))
                 .isInstanceOf(NegativeValueException.class)
                 .hasMessage("value is negative: -10");

--- a/core/trino-main/src/test/java/io/trino/operator/project/TestDictionaryAwarePageFilter.java
+++ b/core/trino-main/src/test/java/io/trino/operator/project/TestDictionaryAwarePageFilter.java
@@ -88,7 +88,7 @@ public class TestDictionaryAwarePageFilter
         testFilter(createDictionaryBlock(20, 0), LongArrayBlock.class);
 
         // match all
-        testFilter(new DictionaryBlock(createLongSequenceBlock(4, 5), new int[100]), LongArrayBlock.class);
+        testFilter(new DictionaryBlock(100, createLongSequenceBlock(4, 5), new int[100]), LongArrayBlock.class);
     }
 
     @Test
@@ -109,7 +109,7 @@ public class TestDictionaryAwarePageFilter
         testFilter(createDictionaryBlockWithUnusedEntries(20, 0), DictionaryBlock.class);
 
         // match all
-        testFilter(new DictionaryBlock(createLongsBlock(4, 5, -1), new int[100]), DictionaryBlock.class);
+        testFilter(new DictionaryBlock(100, createLongsBlock(4, 5, -1), new int[100]), DictionaryBlock.class);
     }
 
     @Test
@@ -143,7 +143,7 @@ public class TestDictionaryAwarePageFilter
         Block dictionary = createLongSequenceBlock(0, dictionarySize);
         int[] ids = new int[blockSize];
         Arrays.setAll(ids, index -> index % dictionarySize);
-        return new DictionaryBlock(dictionary, ids);
+        return new DictionaryBlock(ids.length, dictionary, ids);
     }
 
     private static DictionaryBlock createDictionaryBlockWithFailure(int dictionarySize, int blockSize)
@@ -151,7 +151,7 @@ public class TestDictionaryAwarePageFilter
         Block dictionary = createLongSequenceBlock(-10, dictionarySize - 10);
         int[] ids = new int[blockSize];
         Arrays.setAll(ids, index -> index % dictionarySize);
-        return new DictionaryBlock(dictionary, ids);
+        return new DictionaryBlock(ids.length, dictionary, ids);
     }
 
     private static DictionaryBlock createDictionaryBlockWithUnusedEntries(int dictionarySize, int blockSize)
@@ -159,7 +159,7 @@ public class TestDictionaryAwarePageFilter
         Block dictionary = createLongSequenceBlock(-10, dictionarySize);
         int[] ids = new int[blockSize];
         Arrays.setAll(ids, index -> (index % dictionarySize) + 10);
-        return new DictionaryBlock(dictionary, ids);
+        return new DictionaryBlock(ids.length, dictionary, ids);
     }
 
     private static void testFilter(Block block, Class<? extends Block> expectedType)

--- a/core/trino-main/src/test/java/io/trino/operator/project/TestDictionaryAwarePageProjection.java
+++ b/core/trino-main/src/test/java/io/trino/operator/project/TestDictionaryAwarePageProjection.java
@@ -107,7 +107,7 @@ public class TestDictionaryAwarePageProjection
     @Test(dataProvider = "forceYield")
     public void testDictionaryBlock(boolean forceYield, boolean produceLazyBlock)
     {
-        DictionaryBlock block = createDictionaryBlock(10, 100);
+        Block block = createDictionaryBlock(10, 100);
 
         testProject(block, DictionaryBlock.class, forceYield, produceLazyBlock);
     }
@@ -115,7 +115,7 @@ public class TestDictionaryAwarePageProjection
     @Test(dataProvider = "forceYield")
     public void testDictionaryBlockWithFailure(boolean forceYield, boolean produceLazyBlock)
     {
-        DictionaryBlock block = createDictionaryBlockWithFailure(10, 100);
+        Block block = createDictionaryBlockWithFailure(10, 100);
 
         testProjectFails(block, DictionaryBlock.class, forceYield, produceLazyBlock);
     }
@@ -123,7 +123,7 @@ public class TestDictionaryAwarePageProjection
     @Test(dataProvider = "forceYield")
     public void testDictionaryBlockProcessingWithUnusedFailure(boolean forceYield, boolean produceLazyBlock)
     {
-        DictionaryBlock block = createDictionaryBlockWithUnusedEntries(10, 100);
+        Block block = createDictionaryBlockWithUnusedEntries(10, 100);
 
         // failures in the dictionary processing will cause a fallback to normal columnar processing
         testProject(block, LongArrayBlock.class, forceYield, produceLazyBlock);
@@ -135,7 +135,7 @@ public class TestDictionaryAwarePageProjection
         DictionaryAwarePageProjection projection = createProjection(false);
 
         // the same input block will bypass yield with multiple projections
-        DictionaryBlock block = createDictionaryBlock(10, 100);
+        Block block = createDictionaryBlock(10, 100);
         testProjectRange(block, DictionaryBlock.class, projection, true, false);
         testProjectFastReturnIgnoreYield(block, projection, false);
         testProjectFastReturnIgnoreYield(block, projection, false);
@@ -148,7 +148,7 @@ public class TestDictionaryAwarePageProjection
         DictionaryAwarePageProjection projection = createProjection(produceLazyBlock);
 
         // function will always processes the first dictionary
-        DictionaryBlock ineffectiveBlock = createDictionaryBlock(100, 20);
+        Block ineffectiveBlock = createDictionaryBlock(100, 20);
         testProjectRange(ineffectiveBlock, DictionaryBlock.class, projection, forceYield, produceLazyBlock);
         testProjectFastReturnIgnoreYield(ineffectiveBlock, projection, produceLazyBlock);
         // dictionary processing can reuse the last dictionary
@@ -156,7 +156,7 @@ public class TestDictionaryAwarePageProjection
         testProjectList(ineffectiveBlock, DictionaryBlock.class, projection, false, produceLazyBlock);
 
         // last dictionary not effective, so dictionary processing is disabled
-        DictionaryBlock effectiveBlock = createDictionaryBlock(10, 100);
+        Block effectiveBlock = createDictionaryBlock(10, 100);
         testProjectRange(effectiveBlock, LongArrayBlock.class, projection, forceYield, produceLazyBlock);
         testProjectList(effectiveBlock, LongArrayBlock.class, projection, forceYield, produceLazyBlock);
 
@@ -180,17 +180,17 @@ public class TestDictionaryAwarePageProjection
                 block -> randomDictionaryId(),
                 false);
         Block dictionary = createLongsBlock(0, 1);
-        DictionaryBlock firstDictionaryBlock = new DictionaryBlock(4, dictionary, new int[] {0, 1, 2, 3});
-        DictionaryBlock secondDictionaryBlock = new DictionaryBlock(4, dictionary, new int[] {3, 2, 1, 0});
+        Block firstDictionaryBlock = DictionaryBlock.create(4, dictionary, new int[] {0, 1, 2, 3});
+        Block secondDictionaryBlock = DictionaryBlock.create(4, dictionary, new int[] {3, 2, 1, 0});
 
         DriverYieldSignal yieldSignal = new DriverYieldSignal();
-        Work<Block> firstWork = projection.project(null, yieldSignal, new Page(firstDictionaryBlock), SelectedPositions.positionsList(new int[] {0}, 0, 1));
+        Work<Block> firstWork = projection.project(null, yieldSignal, new Page(firstDictionaryBlock), SelectedPositions.positionsList(new int[] {0, 1}, 0, 2));
 
         assertTrue(firstWork.process());
         Block firstOutputBlock = firstWork.getResult();
         assertInstanceOf(firstOutputBlock, DictionaryBlock.class);
 
-        Work<Block> secondWork = projection.project(null, yieldSignal, new Page(secondDictionaryBlock), SelectedPositions.positionsList(new int[] {0}, 0, 1));
+        Work<Block> secondWork = projection.project(null, yieldSignal, new Page(secondDictionaryBlock), SelectedPositions.positionsList(new int[] {0, 1}, 0, 2));
 
         assertTrue(secondWork.process());
         Block secondOutputBlock = secondWork.getResult();
@@ -203,28 +203,28 @@ public class TestDictionaryAwarePageProjection
         assertSame(firstDictionary, dictionary);
     }
 
-    private static DictionaryBlock createDictionaryBlock(int dictionarySize, int blockSize)
+    private static Block createDictionaryBlock(int dictionarySize, int blockSize)
     {
         Block dictionary = createLongSequenceBlock(0, dictionarySize);
         int[] ids = new int[blockSize];
         Arrays.setAll(ids, index -> index % dictionarySize);
-        return new DictionaryBlock(ids.length, dictionary, ids);
+        return DictionaryBlock.create(ids.length, dictionary, ids);
     }
 
-    private static DictionaryBlock createDictionaryBlockWithFailure(int dictionarySize, int blockSize)
+    private static Block createDictionaryBlockWithFailure(int dictionarySize, int blockSize)
     {
         Block dictionary = createLongSequenceBlock(-10, dictionarySize - 10);
         int[] ids = new int[blockSize];
         Arrays.setAll(ids, index -> index % dictionarySize);
-        return new DictionaryBlock(ids.length, dictionary, ids);
+        return DictionaryBlock.create(ids.length, dictionary, ids);
     }
 
-    private static DictionaryBlock createDictionaryBlockWithUnusedEntries(int dictionarySize, int blockSize)
+    private static Block createDictionaryBlockWithUnusedEntries(int dictionarySize, int blockSize)
     {
         Block dictionary = createLongSequenceBlock(-10, dictionarySize);
         int[] ids = new int[blockSize];
         Arrays.setAll(ids, index -> (index % dictionarySize) + 10);
-        return new DictionaryBlock(ids.length, dictionary, ids);
+        return DictionaryBlock.create(ids.length, dictionary, ids);
     }
 
     private static Block projectWithYield(Work<Block> work, DriverYieldSignal yieldSignal)

--- a/core/trino-main/src/test/java/io/trino/operator/project/TestDictionaryAwarePageProjection.java
+++ b/core/trino-main/src/test/java/io/trino/operator/project/TestDictionaryAwarePageProjection.java
@@ -90,7 +90,7 @@ public class TestDictionaryAwarePageProjection
     public void testRleBlock(boolean forceYield, boolean produceLazyBlock)
     {
         Block value = createLongSequenceBlock(42, 43);
-        RunLengthEncodedBlock block = new RunLengthEncodedBlock(value, 100);
+        RunLengthEncodedBlock block = (RunLengthEncodedBlock) RunLengthEncodedBlock.create(value, 100);
 
         testProject(block, RunLengthEncodedBlock.class, forceYield, produceLazyBlock);
     }
@@ -99,7 +99,7 @@ public class TestDictionaryAwarePageProjection
     public void testRleBlockWithFailure(boolean forceYield, boolean produceLazyBlock)
     {
         Block value = createLongSequenceBlock(-43, -42);
-        RunLengthEncodedBlock block = new RunLengthEncodedBlock(value, 100);
+        RunLengthEncodedBlock block = (RunLengthEncodedBlock) RunLengthEncodedBlock.create(value, 100);
 
         testProjectFails(block, RunLengthEncodedBlock.class, forceYield, produceLazyBlock);
     }

--- a/core/trino-main/src/test/java/io/trino/operator/project/TestDictionaryAwarePageProjection.java
+++ b/core/trino-main/src/test/java/io/trino/operator/project/TestDictionaryAwarePageProjection.java
@@ -180,8 +180,8 @@ public class TestDictionaryAwarePageProjection
                 block -> randomDictionaryId(),
                 false);
         Block dictionary = createLongsBlock(0, 1);
-        DictionaryBlock firstDictionaryBlock = new DictionaryBlock(dictionary, new int[] {0, 1, 2, 3});
-        DictionaryBlock secondDictionaryBlock = new DictionaryBlock(dictionary, new int[] {3, 2, 1, 0});
+        DictionaryBlock firstDictionaryBlock = new DictionaryBlock(4, dictionary, new int[] {0, 1, 2, 3});
+        DictionaryBlock secondDictionaryBlock = new DictionaryBlock(4, dictionary, new int[] {3, 2, 1, 0});
 
         DriverYieldSignal yieldSignal = new DriverYieldSignal();
         Work<Block> firstWork = projection.project(null, yieldSignal, new Page(firstDictionaryBlock), SelectedPositions.positionsList(new int[] {0}, 0, 1));
@@ -208,7 +208,7 @@ public class TestDictionaryAwarePageProjection
         Block dictionary = createLongSequenceBlock(0, dictionarySize);
         int[] ids = new int[blockSize];
         Arrays.setAll(ids, index -> index % dictionarySize);
-        return new DictionaryBlock(dictionary, ids);
+        return new DictionaryBlock(ids.length, dictionary, ids);
     }
 
     private static DictionaryBlock createDictionaryBlockWithFailure(int dictionarySize, int blockSize)
@@ -216,7 +216,7 @@ public class TestDictionaryAwarePageProjection
         Block dictionary = createLongSequenceBlock(-10, dictionarySize - 10);
         int[] ids = new int[blockSize];
         Arrays.setAll(ids, index -> index % dictionarySize);
-        return new DictionaryBlock(dictionary, ids);
+        return new DictionaryBlock(ids.length, dictionary, ids);
     }
 
     private static DictionaryBlock createDictionaryBlockWithUnusedEntries(int dictionarySize, int blockSize)
@@ -224,7 +224,7 @@ public class TestDictionaryAwarePageProjection
         Block dictionary = createLongSequenceBlock(-10, dictionarySize);
         int[] ids = new int[blockSize];
         Arrays.setAll(ids, index -> (index % dictionarySize) + 10);
-        return new DictionaryBlock(dictionary, ids);
+        return new DictionaryBlock(ids.length, dictionary, ids);
     }
 
     private static Block projectWithYield(Work<Block> work, DriverYieldSignal yieldSignal)

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArraySubscript.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArraySubscript.java
@@ -198,7 +198,7 @@ public class BenchmarkArraySubscript
             for (int i = 0; i < keyIds.length; i++) {
                 keyIds[i] = ThreadLocalRandom.current().nextInt(0, dictionarySize);
             }
-            return new DictionaryBlock(dictionaryBlock, keyIds);
+            return new DictionaryBlock(keyIds.length, dictionaryBlock, keyIds);
         }
 
         private static String randomString(int length)

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArraySubscript.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArraySubscript.java
@@ -198,7 +198,7 @@ public class BenchmarkArraySubscript
             for (int i = 0; i < keyIds.length; i++) {
                 keyIds[i] = ThreadLocalRandom.current().nextInt(0, dictionarySize);
             }
-            return new DictionaryBlock(keyIds.length, dictionaryBlock, keyIds);
+            return DictionaryBlock.create(keyIds.length, dictionaryBlock, keyIds);
         }
 
         private static String randomString(int length)

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkMapConcat.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkMapConcat.java
@@ -169,7 +169,7 @@ public class BenchmarkMapConcat
             for (int i = 0; i < keyIds.length; i++) {
                 keyIds[i] = i % keys.size();
             }
-            return new DictionaryBlock(keyDictionaryBlock, keyIds);
+            return new DictionaryBlock(keyIds.length, keyDictionaryBlock, keyIds);
         }
 
         private static Block createValueBlock(int positionCount, int mapSize)

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkMapConcat.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkMapConcat.java
@@ -169,7 +169,7 @@ public class BenchmarkMapConcat
             for (int i = 0; i < keyIds.length; i++) {
                 keyIds[i] = i % keys.size();
             }
-            return new DictionaryBlock(keyIds.length, keyDictionaryBlock, keyIds);
+            return DictionaryBlock.create(keyIds.length, keyDictionaryBlock, keyIds);
         }
 
         private static Block createValueBlock(int positionCount, int mapSize)

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkMapSubscript.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkMapSubscript.java
@@ -180,7 +180,7 @@ public class BenchmarkMapSubscript
             for (int i = 0; i < keyIds.length; i++) {
                 keyIds[i] = i % keys.size();
             }
-            return new DictionaryBlock(keyIds.length, keyDictionaryBlock, keyIds);
+            return DictionaryBlock.create(keyIds.length, keyDictionaryBlock, keyIds);
         }
 
         private static Block createFixWidthValueBlock(int positionCount, int mapSize)
@@ -219,7 +219,7 @@ public class BenchmarkMapSubscript
             for (int i = 0; i < keyIds.length; i++) {
                 keyIds[i] = ThreadLocalRandom.current().nextInt(0, dictionarySize);
             }
-            return new DictionaryBlock(keyIds.length, dictionaryBlock, keyIds);
+            return DictionaryBlock.create(keyIds.length, dictionaryBlock, keyIds);
         }
 
         private static String randomString(int length)

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkMapSubscript.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkMapSubscript.java
@@ -180,7 +180,7 @@ public class BenchmarkMapSubscript
             for (int i = 0; i < keyIds.length; i++) {
                 keyIds[i] = i % keys.size();
             }
-            return new DictionaryBlock(keyDictionaryBlock, keyIds);
+            return new DictionaryBlock(keyIds.length, keyDictionaryBlock, keyIds);
         }
 
         private static Block createFixWidthValueBlock(int positionCount, int mapSize)
@@ -219,7 +219,7 @@ public class BenchmarkMapSubscript
             for (int i = 0; i < keyIds.length; i++) {
                 keyIds[i] = ThreadLocalRandom.current().nextInt(0, dictionarySize);
             }
-            return new DictionaryBlock(dictionaryBlock, keyIds);
+            return new DictionaryBlock(keyIds.length, dictionaryBlock, keyIds);
         }
 
         private static String randomString(int length)

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestPageProcessorCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestPageProcessorCompiler.java
@@ -37,7 +37,7 @@ import java.util.Optional;
 
 import static com.google.common.collect.Iterators.getOnlyElement;
 import static io.trino.block.BlockAssertions.createLongDictionaryBlock;
-import static io.trino.block.BlockAssertions.createRLEBlock;
+import static io.trino.block.BlockAssertions.createRepeatedValuesBlock;
 import static io.trino.block.BlockAssertions.createSlicesBlock;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.operator.project.PageProcessor.MAX_BATCH_SIZE;
@@ -147,7 +147,7 @@ public class TestPageProcessorCompiler
 
         PageProcessor processor = compiler.compilePageProcessor(Optional.of(filter), ImmutableList.of(field(0, BIGINT)), MAX_BATCH_SIZE).get();
 
-        Page page = new Page(createRLEBlock(5L, 100));
+        Page page = new Page(createRepeatedValuesBlock(5L, 100));
         Page outputPage = getOnlyElement(
                 processor.process(
                         null,

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestPageProcessorCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestPageProcessorCompiler.java
@@ -216,7 +216,7 @@ public class TestPageProcessorCompiler
         for (int i = 0; i < positionCount; i++) {
             ids[i] = i % dictionarySize;
         }
-        return new DictionaryBlock(createSlicesBlock(expectedValues), ids);
+        return new DictionaryBlock(ids.length, createSlicesBlock(expectedValues), ids);
     }
 
     private static Slice[] createExpectedValues(int positionCount)

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestPageProcessorCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestPageProcessorCompiler.java
@@ -22,6 +22,7 @@ import io.trino.metadata.TestingFunctionResolution;
 import io.trino.operator.DriverYieldSignal;
 import io.trino.operator.project.PageProcessor;
 import io.trino.spi.Page;
+import io.trino.spi.block.Block;
 import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.type.ArrayType;
@@ -208,7 +209,7 @@ public class TestPageProcessorCompiler
         assertFalse(outputPage.getBlock(0) instanceof DictionaryBlock);
     }
 
-    private static DictionaryBlock createDictionaryBlock(Slice[] expectedValues, int positionCount)
+    private static Block createDictionaryBlock(Slice[] expectedValues, int positionCount)
     {
         int dictionarySize = expectedValues.length;
         int[] ids = new int[positionCount];
@@ -216,7 +217,7 @@ public class TestPageProcessorCompiler
         for (int i = 0; i < positionCount; i++) {
             ids[i] = i % dictionarySize;
         }
-        return new DictionaryBlock(ids.length, createSlicesBlock(expectedValues), ids);
+        return DictionaryBlock.create(ids.length, createSlicesBlock(expectedValues), ids);
     }
 
     private static Slice[] createExpectedValues(int positionCount)

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -179,20 +179,8 @@
                                         <match>@java.lang.Deprecated(*) ^*;</match>
                                     </old>
                                 </item>
-                                <!-- Backwards incompatible changes since the previous release (394) -->
+                                <!-- Backwards incompatible changes since the previous release (395) -->
                                 <!-- Any exclusions below can be deleted after each release -->
-                                <item>
-                                    <code>java.method.removed</code>
-                                    <old>method java.util.Set&lt;io.trino.spi.security.RoleGrant&gt; io.trino.spi.connector.ConnectorMetadata::listAllRoleGrants(io.trino.spi.connector.ConnectorSession, java.util.Optional&lt;java.util.Set&lt;java.lang.String&gt;&gt;, java.util.Optional&lt;java.util.Set&lt;java.lang.String&gt;&gt;, java.util.OptionalLong)</old>
-                                </item>
-                                <item>
-                                    <code>java.method.addedToInterface</code>
-                                    <new>method io.trino.spi.block.BlockBuilder io.trino.spi.block.BlockBuilder::newBlockBuilderLike(int, io.trino.spi.block.BlockBuilderStatus)</new>
-                                </item>
-                                <item>
-                                    <code>java.field.removed</code>
-                                    <old>field io.trino.spi.expression.StandardFunctions.LIKE_PATTERN_FUNCTION_NAME</old>
-                                </item>
                                 <item>
                                     <code>java.method.returnTypeChanged</code>
                                     <new>method io.trino.spi.block.Block io.trino.spi.block.ArrayBlockBuilder::build()</new>

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -224,6 +224,18 @@
                                     <code>java.method.removed</code>
                                     <old>method void io.trino.spi.block.DictionaryBlock::&lt;init&gt;(int, io.trino.spi.block.Block, int[], io.trino.spi.block.DictionaryId)</old>
                                 </item>
+                                <item>
+                                    <code>java.method.returnTypeChanged</code>
+                                    <old>method io.trino.spi.block.RunLengthEncodedBlock io.trino.spi.block.RunLengthBlockEncoding::readBlock(io.trino.spi.block.BlockEncodingSerde, io.airlift.slice.SliceInput)</old>
+                                    <new>method io.trino.spi.block.Block io.trino.spi.block.RunLengthBlockEncoding::readBlock(io.trino.spi.block.BlockEncodingSerde, io.airlift.slice.SliceInput)</new>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityReduced</code>
+                                    <old>method void io.trino.spi.block.RunLengthEncodedBlock::&lt;init&gt;(io.trino.spi.block.Block, int)</old>
+                                    <new>method void io.trino.spi.block.RunLengthEncodedBlock::&lt;init&gt;(io.trino.spi.block.Block, int)</new>
+                                    <oldVisibility>public</oldVisibility>
+                                    <newVisibility>private</newVisibility>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -185,6 +185,33 @@
                                     <code>java.method.returnTypeChanged</code>
                                     <new>method io.trino.spi.block.Block io.trino.spi.block.ArrayBlockBuilder::build()</new>
                                 </item>
+                                <item>
+                                    <code>java.method.visibilityReduced</code>
+                                    <old>method void io.trino.spi.block.DictionaryBlock::&lt;init&gt;(int, int, io.trino.spi.block.Block, int[], boolean, boolean, io.trino.spi.block.DictionaryId)</old>
+                                    <new>method void io.trino.spi.block.DictionaryBlock::&lt;init&gt;(int, int, io.trino.spi.block.Block, int[], boolean, boolean, io.trino.spi.block.DictionaryId)</new>
+                                    <oldVisibility>public</oldVisibility>
+                                    <newVisibility>private</newVisibility>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.visibilityReduced</code>
+                                    <old>method void io.trino.spi.block.DictionaryBlock::&lt;init&gt;(io.trino.spi.block.Block, int[])</old>
+                                    <new>method void io.trino.spi.block.DictionaryBlock::&lt;init&gt;(int, int, io.trino.spi.block.Block, int[])</new>
+                                    <oldVisibility>public</oldVisibility>
+                                    <newVisibility>package</newVisibility>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method void io.trino.spi.block.DictionaryBlock::&lt;init&gt;(int, io.trino.spi.block.Block, int[], boolean)</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method void io.trino.spi.block.DictionaryBlock::&lt;init&gt;(int, io.trino.spi.block.Block, int[], boolean, io.trino.spi.block.DictionaryId)</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method void io.trino.spi.block.DictionaryBlock::&lt;init&gt;(int, int, io.trino.spi.block.Block, int[], boolean, io.trino.spi.block.DictionaryId)</old>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -202,6 +202,10 @@
                                 </item>
                                 <item>
                                     <code>java.method.removed</code>
+                                    <old>method void io.trino.spi.block.DictionaryBlock::&lt;init&gt;(int, io.trino.spi.block.Block, int[])</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
                                     <old>method void io.trino.spi.block.DictionaryBlock::&lt;init&gt;(int, io.trino.spi.block.Block, int[], boolean)</old>
                                 </item>
                                 <item>
@@ -211,6 +215,14 @@
                                 <item>
                                     <code>java.method.removed</code>
                                     <old>method void io.trino.spi.block.DictionaryBlock::&lt;init&gt;(int, int, io.trino.spi.block.Block, int[], boolean, io.trino.spi.block.DictionaryId)</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method void io.trino.spi.block.DictionaryBlock::&lt;init&gt;(int, io.trino.spi.block.Block, int[], boolean, io.trino.spi.block.DictionaryId)</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method void io.trino.spi.block.DictionaryBlock::&lt;init&gt;(int, io.trino.spi.block.Block, int[], io.trino.spi.block.DictionaryId)</old>
                                 </item>
                             </differences>
                         </revapi.differences>

--- a/core/trino-spi/src/main/java/io/trino/spi/Page.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/Page.java
@@ -25,8 +25,6 @@ import java.util.List;
 import java.util.Map;
 
 import static io.airlift.slice.SizeOf.sizeOf;
-import static io.trino.spi.block.DictionaryId.randomDictionaryId;
-import static java.lang.Math.min;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -187,7 +185,7 @@ public final class Page
 
         Map<DictionaryId, DictionaryBlockIndexes> dictionaryBlocks = getRelatedDictionaryBlocks();
         for (DictionaryBlockIndexes blockIndexes : dictionaryBlocks.values()) {
-            List<DictionaryBlock> compactBlocks = compactRelatedBlocks(blockIndexes.getBlocks());
+            List<DictionaryBlock> compactBlocks = DictionaryBlock.compactRelatedBlocks(blockIndexes.getBlocks());
             List<Integer> indexes = blockIndexes.getIndexes();
             for (int i = 0; i < compactBlocks.size(); i++) {
                 blocks[indexes.get(i)] = compactBlocks.get(i);
@@ -210,68 +208,6 @@ public final class Page
             }
         }
         return relatedDictionaryBlocks;
-    }
-
-    private static List<DictionaryBlock> compactRelatedBlocks(List<DictionaryBlock> blocks)
-    {
-        DictionaryBlock firstDictionaryBlock = blocks.get(0);
-        Block dictionary = firstDictionaryBlock.getDictionary();
-
-        int positionCount = firstDictionaryBlock.getPositionCount();
-        int dictionarySize = dictionary.getPositionCount();
-
-        // determine which dictionary entries are referenced and build a reindex for them
-        int[] dictionaryPositionsToCopy = new int[min(dictionarySize, positionCount)];
-        int[] remapIndex = new int[dictionarySize];
-        Arrays.fill(remapIndex, -1);
-
-        int numberOfIndexes = 0;
-        for (int i = 0; i < positionCount; i++) {
-            int position = firstDictionaryBlock.getId(i);
-            if (remapIndex[position] == -1) {
-                dictionaryPositionsToCopy[numberOfIndexes] = position;
-                remapIndex[position] = numberOfIndexes;
-                numberOfIndexes++;
-            }
-        }
-
-        // entire dictionary is referenced
-        if (numberOfIndexes == dictionarySize) {
-            return blocks;
-        }
-
-        // compact the dictionaries
-        int[] newIds = getNewIds(positionCount, firstDictionaryBlock, remapIndex);
-        List<DictionaryBlock> outputDictionaryBlocks = new ArrayList<>(blocks.size());
-        DictionaryId newDictionaryId = randomDictionaryId();
-        for (DictionaryBlock dictionaryBlock : blocks) {
-            if (!firstDictionaryBlock.getDictionarySourceId().equals(dictionaryBlock.getDictionarySourceId())) {
-                throw new IllegalArgumentException("dictionarySourceIds must be the same");
-            }
-
-            try {
-                Block compactDictionary = dictionaryBlock.getDictionary().copyPositions(dictionaryPositionsToCopy, 0, numberOfIndexes);
-                outputDictionaryBlocks.add(new DictionaryBlock(positionCount, compactDictionary, newIds, !(compactDictionary instanceof DictionaryBlock), newDictionaryId));
-            }
-            catch (UnsupportedOperationException e) {
-                // ignore if copy positions is not supported for the dictionary
-                outputDictionaryBlocks.add(dictionaryBlock);
-            }
-        }
-        return outputDictionaryBlocks;
-    }
-
-    private static int[] getNewIds(int positionCount, DictionaryBlock dictionaryBlock, int[] remapIndex)
-    {
-        int[] newIds = new int[positionCount];
-        for (int i = 0; i < positionCount; i++) {
-            int newId = remapIndex[dictionaryBlock.getId(i)];
-            if (newId == -1) {
-                throw new IllegalStateException("reference to a non-existent key");
-            }
-            newIds[i] = newId;
-        }
-        return newIds;
     }
 
     /**

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlockBuilder.java
@@ -283,9 +283,9 @@ public class ArrayBlockBuilder
         return super.copyRegion(position, length);
     }
 
-    private RunLengthEncodedBlock nullRle(int positionCount)
+    private Block nullRle(int positionCount)
     {
         ArrayBlock nullValueBlock = createArrayBlockInternal(0, 1, new boolean[] {true}, new int[] {0, 0}, values.newBlockBuilderLike(null).build());
-        return new RunLengthEncodedBlock(nullValueBlock, positionCount);
+        return RunLengthEncodedBlock.create(nullValueBlock, positionCount);
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Block.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Block.java
@@ -21,7 +21,6 @@ import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
-import static io.trino.spi.block.DictionaryId.randomDictionaryId;
 
 public interface Block
 {
@@ -244,7 +243,7 @@ public interface Block
     {
         checkArrayRange(positions, offset, length);
 
-        return new DictionaryBlock(offset, length, this, positions, false, randomDictionaryId());
+        return new DictionaryBlock(offset, length, this, positions);
     }
 
     /**

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlockBuilder.java
@@ -102,7 +102,7 @@ public class ByteArrayBlockBuilder
     public Block build()
     {
         if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+            return RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, positionCount);
         }
         return new ByteArrayBlock(0, positionCount, hasNullValue ? valueIsNull : null, values);
     }
@@ -227,7 +227,7 @@ public class ByteArrayBlockBuilder
         checkArrayRange(positions, offset, length);
 
         if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+            return RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, length);
         }
         boolean[] newValueIsNull = null;
         if (hasNullValue) {
@@ -251,7 +251,7 @@ public class ByteArrayBlockBuilder
         checkValidRegion(getPositionCount(), positionOffset, length);
 
         if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+            return RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, length);
         }
         return new ByteArrayBlock(positionOffset, length, hasNullValue ? valueIsNull : null, values);
     }
@@ -262,7 +262,7 @@ public class ByteArrayBlockBuilder
         checkValidRegion(getPositionCount(), positionOffset, length);
 
         if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+            return RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, length);
         }
         boolean[] newValueIsNull = null;
         if (hasNullValue) {

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ColumnarArray.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ColumnarArray.java
@@ -84,7 +84,7 @@ public class ColumnarArray
                 dictionaryBlock,
                 0,
                 offsets,
-                new DictionaryBlock(dictionaryIds.length, columnarArray.getElementsBlock(), dictionaryIds));
+                DictionaryBlock.create(dictionaryIds.length, columnarArray.getElementsBlock(), dictionaryIds));
     }
 
     private static ColumnarArray toColumnarArray(RunLengthEncodedBlock rleBlock)
@@ -112,7 +112,7 @@ public class ColumnarArray
                 rleBlock,
                 0,
                 offsets,
-                new DictionaryBlock(dictionaryIds.length, columnarArray.getElementsBlock(), dictionaryIds));
+                DictionaryBlock.create(dictionaryIds.length, columnarArray.getElementsBlock(), dictionaryIds));
     }
 
     private ColumnarArray(Block nullCheckBlock, int offsetsOffset, int[] offsets, Block elementsBlock)

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ColumnarMap.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ColumnarMap.java
@@ -84,8 +84,8 @@ public class ColumnarMap
                 dictionaryBlock,
                 0,
                 offsets,
-                new DictionaryBlock(dictionaryIds.length, columnarMap.getKeysBlock(), dictionaryIds),
-                new DictionaryBlock(dictionaryIds.length, columnarMap.getValuesBlock(), dictionaryIds));
+                DictionaryBlock.create(dictionaryIds.length, columnarMap.getKeysBlock(), dictionaryIds),
+                DictionaryBlock.create(dictionaryIds.length, columnarMap.getValuesBlock(), dictionaryIds));
     }
 
     private static ColumnarMap toColumnarMap(RunLengthEncodedBlock rleBlock)
@@ -113,8 +113,8 @@ public class ColumnarMap
                 rleBlock,
                 0,
                 offsets,
-                new DictionaryBlock(dictionaryIds.length, columnarMap.getKeysBlock(), dictionaryIds),
-                new DictionaryBlock(dictionaryIds.length, columnarMap.getValuesBlock(), dictionaryIds));
+                DictionaryBlock.create(dictionaryIds.length, columnarMap.getKeysBlock(), dictionaryIds),
+                DictionaryBlock.create(dictionaryIds.length, columnarMap.getValuesBlock(), dictionaryIds));
     }
 
     private ColumnarMap(Block nullCheckBlock, int offsetsOffset, int[] offsets, Block keysBlock, Block valuesBlock)

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ColumnarRow.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ColumnarRow.java
@@ -85,7 +85,7 @@ public final class ColumnarRow
         ColumnarRow columnarRow = toColumnarRow(dictionaryBlock.getDictionary());
         Block[] fields = new Block[columnarRow.getFieldCount()];
         for (int i = 0; i < columnarRow.getFieldCount(); i++) {
-            fields[i] = new DictionaryBlock(nonNullPositionCount, columnarRow.getField(i), dictionaryIds);
+            fields[i] = DictionaryBlock.create(nonNullPositionCount, columnarRow.getField(i), dictionaryIds);
         }
 
         int positionCount = dictionaryBlock.getPositionCount();

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ColumnarRow.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ColumnarRow.java
@@ -127,7 +127,7 @@ public final class ColumnarRow
                 fields[i] = nullSuppressedField;
             }
             else {
-                fields[i] = new RunLengthEncodedBlock(nullSuppressedField, rleBlock.getPositionCount());
+                fields[i] = RunLengthEncodedBlock.create(nullSuppressedField, rleBlock.getPositionCount());
             }
         }
         return new ColumnarRow(rleBlock.getPositionCount(), rleBlock, fields);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ColumnarRow.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ColumnarRow.java
@@ -106,9 +106,7 @@ public final class ColumnarRow
                     dictionaryBlock.getRawIdsOffset(),
                     dictionaryBlock.getPositionCount(),
                     columnarRow.getField(i),
-                    dictionaryBlock.getRawIds(),
-                    false,
-                    DictionaryId.randomDictionaryId());
+                    dictionaryBlock.getRawIds());
         }
         return new ColumnarRow(dictionaryBlock.getPositionCount(), null, fields);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
@@ -76,7 +76,7 @@ public class DictionaryBlock
 
         // if dictionary is an RLE then this can just be a new RLE
         if (dictionary instanceof RunLengthEncodedBlock rle) {
-            return new RunLengthEncodedBlock(rle.getValue(), positionCount);
+            return RunLengthEncodedBlock.create(rle.getValue(), positionCount);
         }
 
         // unwrap dictionary in dictionary

--- a/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlockEncoding.java
@@ -78,7 +78,7 @@ public class DictionaryBlockEncoding
         // We always compact the dictionary before we send it. However, dictionaryBlock comes from sliceInput, which may over-retain memory.
         // As a result, setting dictionaryIsCompacted to true is not appropriate here.
         // TODO: fix DictionaryBlock so that dictionaryIsCompacted can be set to true when the underlying block over-retains memory.
-        return new DictionaryBlock(positionCount, dictionaryBlock, ids, false, new DictionaryId(mostSignificantBits, leastSignificantBits, sequenceId));
+        return new DictionaryBlock(positionCount, dictionaryBlock, ids, new DictionaryId(mostSignificantBits, leastSignificantBits, sequenceId));
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlockEncoding.java
@@ -19,6 +19,8 @@ import io.airlift.slice.Slices;
 
 import java.util.Optional;
 
+import static io.trino.spi.block.DictionaryBlock.createProjectedDictionaryBlock;
+
 public class DictionaryBlockEncoding
         implements BlockEncoding
 {
@@ -78,7 +80,7 @@ public class DictionaryBlockEncoding
         // We always compact the dictionary before we send it. However, dictionaryBlock comes from sliceInput, which may over-retain memory.
         // As a result, setting dictionaryIsCompacted to true is not appropriate here.
         // TODO: fix DictionaryBlock so that dictionaryIsCompacted can be set to true when the underlying block over-retains memory.
-        return new DictionaryBlock(positionCount, dictionaryBlock, ids, new DictionaryId(mostSignificantBits, leastSignificantBits, sequenceId));
+        return createProjectedDictionaryBlock(positionCount, dictionaryBlock, ids, new DictionaryId(mostSignificantBits, leastSignificantBits, sequenceId));
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlockBuilder.java
@@ -116,7 +116,7 @@ public class Int128ArrayBlockBuilder
     public Block build()
     {
         if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+            return RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, positionCount);
         }
         return new Int128ArrayBlock(0, positionCount, hasNullValue ? valueIsNull : null, values);
     }
@@ -246,7 +246,7 @@ public class Int128ArrayBlockBuilder
         checkArrayRange(positions, offset, length);
 
         if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+            return RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, length);
         }
         boolean[] newValueIsNull = null;
         if (hasNullValue) {
@@ -271,7 +271,7 @@ public class Int128ArrayBlockBuilder
         checkValidRegion(getPositionCount(), positionOffset, length);
 
         if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+            return RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, length);
         }
         return new Int128ArrayBlock(positionOffset, length, hasNullValue ? valueIsNull : null, values);
     }
@@ -282,7 +282,7 @@ public class Int128ArrayBlockBuilder
         checkValidRegion(getPositionCount(), positionOffset, length);
 
         if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+            return RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, length);
         }
         boolean[] newValueIsNull = null;
         if (hasNullValue) {

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Int96ArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Int96ArrayBlockBuilder.java
@@ -138,7 +138,7 @@ public class Int96ArrayBlockBuilder
     public Block build()
     {
         if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+            return RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, positionCount);
         }
         return new Int96ArrayBlock(0, positionCount, hasNullValue ? valueIsNull : null, high, low);
     }
@@ -278,7 +278,7 @@ public class Int96ArrayBlockBuilder
         checkArrayRange(positions, offset, length);
 
         if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+            return RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, length);
         }
         boolean[] newValueIsNull = null;
         if (hasNullValue) {
@@ -304,7 +304,7 @@ public class Int96ArrayBlockBuilder
         checkValidRegion(getPositionCount(), positionOffset, length);
 
         if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+            return RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, length);
         }
         return new Int96ArrayBlock(positionOffset, length, hasNullValue ? valueIsNull : null, high, low);
     }
@@ -315,7 +315,7 @@ public class Int96ArrayBlockBuilder
         checkValidRegion(getPositionCount(), positionOffset, length);
 
         if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+            return RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, length);
         }
         boolean[] newValueIsNull = null;
         if (hasNullValue) {

--- a/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlockBuilder.java
@@ -102,7 +102,7 @@ public class IntArrayBlockBuilder
     public Block build()
     {
         if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+            return RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, positionCount);
         }
         return new IntArrayBlock(0, positionCount, hasNullValue ? valueIsNull : null, values);
     }
@@ -227,7 +227,7 @@ public class IntArrayBlockBuilder
         checkArrayRange(positions, offset, length);
 
         if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+            return RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, length);
         }
         boolean[] newValueIsNull = null;
         if (hasNullValue) {
@@ -251,7 +251,7 @@ public class IntArrayBlockBuilder
         checkValidRegion(getPositionCount(), positionOffset, length);
 
         if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+            return RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, length);
         }
         return new IntArrayBlock(positionOffset, length, hasNullValue ? valueIsNull : null, values);
     }
@@ -262,7 +262,7 @@ public class IntArrayBlockBuilder
         checkValidRegion(getPositionCount(), positionOffset, length);
 
         if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+            return RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, length);
         }
         boolean[] newValueIsNull = null;
         if (hasNullValue) {

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlockBuilder.java
@@ -103,7 +103,7 @@ public class LongArrayBlockBuilder
     public Block build()
     {
         if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+            return RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, positionCount);
         }
         return new LongArrayBlock(0, positionCount, hasNullValue ? valueIsNull : null, values);
     }
@@ -274,7 +274,7 @@ public class LongArrayBlockBuilder
         checkArrayRange(positions, offset, length);
 
         if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+            return RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, length);
         }
         boolean[] newValueIsNull = null;
         if (hasNullValue) {
@@ -298,7 +298,7 @@ public class LongArrayBlockBuilder
         checkValidRegion(getPositionCount(), positionOffset, length);
 
         if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+            return RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, length);
         }
         return new LongArrayBlock(positionOffset, length, hasNullValue ? valueIsNull : null, values);
     }
@@ -309,7 +309,7 @@ public class LongArrayBlockBuilder
         checkValidRegion(getPositionCount(), positionOffset, length);
 
         if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+            return RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, length);
         }
         boolean[] newValueIsNull = null;
         if (hasNullValue) {

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlockBuilder.java
@@ -284,7 +284,7 @@ public class RowBlockBuilder
         return super.copyRegion(position, length);
     }
 
-    private RunLengthEncodedBlock nullRle(int length)
+    private Block nullRle(int length)
     {
         Block[] fieldBlocks = new Block[numFields];
         for (int i = 0; i < numFields; i++) {
@@ -292,6 +292,6 @@ public class RowBlockBuilder
         }
 
         RowBlock nullRowBlock = createRowBlockInternal(0, 1, new boolean[] {true}, new int[] {0, 0}, fieldBlocks);
-        return new RunLengthEncodedBlock(nullRowBlock, length);
+        return RunLengthEncodedBlock.create(nullRowBlock, length);
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthBlockEncoding.java
@@ -40,7 +40,7 @@ public class RunLengthBlockEncoding
     }
 
     @Override
-    public RunLengthEncodedBlock readBlock(BlockEncodingSerde blockEncodingSerde, SliceInput sliceInput)
+    public Block readBlock(BlockEncodingSerde blockEncodingSerde, SliceInput sliceInput)
     {
         // read the run length
         int positionCount = sliceInput.readInt();
@@ -48,6 +48,6 @@ public class RunLengthBlockEncoding
         // read the value
         Block value = blockEncodingSerde.readBlock(sliceInput);
 
-        return new RunLengthEncodedBlock(value, positionCount);
+        return RunLengthEncodedBlock.create(value, positionCount);
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
@@ -307,7 +307,7 @@ public class RunLengthEncodedBlock
         Block dictionary = value.copyWithAppendedNull();
         int[] ids = new int[positionCount + 1];
         ids[positionCount] = 1;
-        return new DictionaryBlock(dictionary, ids);
+        return new DictionaryBlock(ids.length, dictionary, ids);
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
@@ -307,7 +307,7 @@ public class RunLengthEncodedBlock
         Block dictionary = value.copyWithAppendedNull();
         int[] ids = new int[positionCount + 1];
         ids[positionCount] = 1;
-        return new DictionaryBlock(ids.length, dictionary, ids);
+        return DictionaryBlock.create(ids.length, dictionary, ids);
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
@@ -43,20 +43,36 @@ public class RunLengthEncodedBlock
         if (block instanceof RunLengthEncodedBlock) {
             block = ((RunLengthEncodedBlock) block).getValue();
         }
-        return new RunLengthEncodedBlock(block, positionCount);
+        return create(block, positionCount);
     }
 
-    private final Block value;
-    private final int positionCount;
-
-    public RunLengthEncodedBlock(Block value, int positionCount)
+    public static Block create(Block value, int positionCount)
     {
         requireNonNull(value, "value is null");
         if (value.getPositionCount() != 1) {
             throw new IllegalArgumentException(format("Expected value to contain a single position but has %s positions", value.getPositionCount()));
         }
+
+        if (positionCount == 0) {
+            return value.copyRegion(0, 0);
+        }
+        if (positionCount == 1) {
+            return value;
+        }
+        return new RunLengthEncodedBlock(value, positionCount);
+    }
+
+    private final Block value;
+    private final int positionCount;
+
+    private RunLengthEncodedBlock(Block value, int positionCount)
+    {
+        requireNonNull(value, "value is null");
         if (positionCount < 0) {
             throw new IllegalArgumentException("positionCount is negative");
+        }
+        if (positionCount < 2) {
+            throw new IllegalArgumentException("positionCount must be at least 2");
         }
 
         // do not nest an RLE or Dictionary in an RLE
@@ -91,6 +107,9 @@ public class RunLengthEncodedBlock
         return value;
     }
 
+    /**
+     * Positions count will always be at least 2
+     */
     @Override
     public int getPositionCount()
     {
@@ -147,7 +166,7 @@ public class RunLengthEncodedBlock
         for (int i = offset; i < offset + length; i++) {
             checkValidPosition(positions[i], positionCount);
         }
-        return new RunLengthEncodedBlock(value, length);
+        return create(value, length);
     }
 
     @Override
@@ -157,14 +176,14 @@ public class RunLengthEncodedBlock
         for (int i = offset; i < offset + length; i++) {
             checkValidPosition(positions[i], positionCount);
         }
-        return new RunLengthEncodedBlock(value.copyRegion(0, 1), length);
+        return create(value.copyRegion(0, 1), length);
     }
 
     @Override
     public Block getRegion(int positionOffset, int length)
     {
         checkValidRegion(positionCount, positionOffset, length);
-        return new RunLengthEncodedBlock(value, length);
+        return create(value, length);
     }
 
     @Override
@@ -183,7 +202,7 @@ public class RunLengthEncodedBlock
     public Block copyRegion(int positionOffset, int length)
     {
         checkValidRegion(positionCount, positionOffset, length);
-        return new RunLengthEncodedBlock(value.copyRegion(0, 1), length);
+        return create(value.copyRegion(0, 1), length);
     }
 
     @Override
@@ -301,7 +320,7 @@ public class RunLengthEncodedBlock
     public Block copyWithAppendedNull()
     {
         if (value.isNull(0)) {
-            return new RunLengthEncodedBlock(value, positionCount + 1);
+            return create(value, positionCount + 1);
         }
 
         Block dictionary = value.copyWithAppendedNull();
@@ -334,6 +353,6 @@ public class RunLengthEncodedBlock
         if (loadedValueBlock == value) {
             return this;
         }
-        return new RunLengthEncodedBlock(loadedValueBlock, positionCount);
+        return create(loadedValueBlock, positionCount);
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
@@ -55,16 +55,26 @@ public class RunLengthEncodedBlock
         if (value.getPositionCount() != 1) {
             throw new IllegalArgumentException(format("Expected value to contain a single position but has %s positions", value.getPositionCount()));
         }
+        if (positionCount < 0) {
+            throw new IllegalArgumentException("positionCount is negative");
+        }
 
-        if (value instanceof RunLengthEncodedBlock) {
-            this.value = ((RunLengthEncodedBlock) value).getValue();
+        // do not nest an RLE or Dictionary in an RLE
+        if (value instanceof RunLengthEncodedBlock block) {
+            this.value = block.getValue();
+        }
+        else if (value instanceof DictionaryBlock block) {
+            Block dictionary = block.getDictionary();
+            int id = block.getId(0);
+            if (dictionary.getPositionCount() == 1 && id == 0) {
+                this.value = dictionary;
+            }
+            else {
+                this.value = dictionary.getRegion(id, 1);
+            }
         }
         else {
             this.value = value;
-        }
-
-        if (positionCount < 0) {
-            throw new IllegalArgumentException("positionCount is negative");
         }
 
         this.positionCount = positionCount;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlockBuilder.java
@@ -102,7 +102,7 @@ public class ShortArrayBlockBuilder
     public Block build()
     {
         if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+            return RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, positionCount);
         }
         return new ShortArrayBlock(0, positionCount, hasNullValue ? valueIsNull : null, values);
     }
@@ -227,7 +227,7 @@ public class ShortArrayBlockBuilder
         checkArrayRange(positions, offset, length);
 
         if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+            return RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, length);
         }
         boolean[] newValueIsNull = null;
         if (hasNullValue) {
@@ -251,7 +251,7 @@ public class ShortArrayBlockBuilder
         checkValidRegion(getPositionCount(), positionOffset, length);
 
         if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+            return RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, length);
         }
         return new ShortArrayBlock(positionOffset, length, hasNullValue ? valueIsNull : null, values);
     }
@@ -262,7 +262,7 @@ public class ShortArrayBlockBuilder
         checkValidRegion(getPositionCount(), positionOffset, length);
 
         if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+            return RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, length);
         }
         boolean[] newValueIsNull = null;
         if (hasNullValue) {

--- a/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlockBuilder.java
@@ -164,7 +164,7 @@ public class VariableWidthBlockBuilder
         checkArrayRange(positions, offset, length);
 
         if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+            return RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, length);
         }
 
         int finalLength = 0;
@@ -329,7 +329,7 @@ public class VariableWidthBlockBuilder
         checkValidRegion(positionCount, positionOffset, length);
 
         if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+            return RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, length);
         }
 
         return new VariableWidthBlock(positionOffset, length, sliceOutput.slice(), offsets, hasNullValue ? valueIsNull : null);
@@ -341,7 +341,7 @@ public class VariableWidthBlockBuilder
         int positionCount = getPositionCount();
         checkValidRegion(positionCount, positionOffset, length);
         if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+            return RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, length);
         }
 
         int[] newOffsets = compactOffsets(offsets, positionOffset, length);
@@ -361,7 +361,7 @@ public class VariableWidthBlockBuilder
             throw new IllegalStateException("Current entry must be closed before the block can be built");
         }
         if (!hasNonNullValue) {
-            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positions);
+            return RunLengthEncodedBlock.create(NULL_VALUE_BLOCK, positions);
         }
         return new VariableWidthBlock(0, positions, sliceOutput.slice(), offsets, hasNullValue ? valueIsNull : null);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
@@ -223,10 +223,7 @@ public final class SortedRangeSet
         return new SortedRangeSet(
                 type,
                 inclusive,
-                new DictionaryBlock(
-                        dictionaryIndex,
-                        block,
-                        dictionary));
+                DictionaryBlock.create(dictionaryIndex, block, dictionary));
     }
 
     /**

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
@@ -256,7 +256,7 @@ public final class SortedRangeSet
         return new SortedRangeSet(
                 type,
                 new boolean[] {true, true},
-                new RunLengthEncodedBlock(block, 2));
+                RunLengthEncodedBlock.create(block, 2));
     }
 
     static SortedRangeSet copyOf(Type type, Collection<Range> ranges)

--- a/core/trino-spi/src/test/java/io/trino/spi/TestPage.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/TestPage.java
@@ -25,12 +25,12 @@ import org.testng.annotations.Test;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verifyNotNull;
 import static io.airlift.slice.SizeOf.sizeOf;
+import static io.trino.spi.block.DictionaryBlock.createProjectedDictionaryBlock;
 import static io.trino.spi.block.DictionaryId.randomDictionaryId;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -85,20 +85,20 @@ public class TestPage
         // first dictionary contains "varbinary" values
         Slice[] dictionaryValues1 = createExpectedValues(50);
         Block dictionary1 = createSlicesBlock(dictionaryValues1);
-        DictionaryBlock commonSourceIdBlock1 = new DictionaryBlock(positionCount, dictionary1, commonDictionaryIds, commonSourceId);
+        Block commonSourceIdBlock1 = createProjectedDictionaryBlock(positionCount, dictionary1, commonDictionaryIds, commonSourceId);
 
         // second dictionary block is "length(firstColumn)"
         BlockBuilder dictionary2 = BIGINT.createBlockBuilder(null, dictionary1.getPositionCount());
         for (Slice expectedValue : dictionaryValues1) {
             BIGINT.writeLong(dictionary2, expectedValue.length());
         }
-        DictionaryBlock commonSourceIdBlock2 = new DictionaryBlock(positionCount, dictionary2.build(), commonDictionaryIds, commonSourceId);
+        Block commonSourceIdBlock2 = createProjectedDictionaryBlock(positionCount, dictionary2.build(), commonDictionaryIds, commonSourceId);
 
         // Create block with a different source id, dictionary size, used
         int otherDictionaryUsedPositions = 30;
         int[] otherDictionaryIds = getDictionaryIds(positionCount, otherDictionaryUsedPositions);
         Block dictionary3 = createSlicesBlock(createExpectedValues(70));
-        DictionaryBlock randomSourceIdBlock = new DictionaryBlock(otherDictionaryIds.length, dictionary3, otherDictionaryIds);
+        Block randomSourceIdBlock = DictionaryBlock.create(otherDictionaryIds.length, dictionary3, otherDictionaryIds);
 
         Page page = new Page(commonSourceIdBlock1, randomSourceIdBlock, commonSourceIdBlock2);
         page.compact();
@@ -114,20 +114,6 @@ public class TestPage
         // Blocks that had the same source id before compacting page should have the same source id after compacting page
         assertNotEquals(((DictionaryBlock) page.getBlock(0)).getDictionarySourceId(), ((DictionaryBlock) page.getBlock(1)).getDictionarySourceId());
         assertEquals(((DictionaryBlock) page.getBlock(0)).getDictionarySourceId(), ((DictionaryBlock) page.getBlock(2)).getDictionarySourceId());
-    }
-
-    @Test
-    public void testCompactNestedDictionary()
-    {
-        Slice[] expectedValues = createExpectedValues(10);
-        Block valuesBlock = createSlicesBlock(expectedValues);
-        DictionaryBlock nestedDictionary = new DictionaryBlock(6, valuesBlock, new int[] {0, 1, 2, 2, 4, 5});
-        DictionaryBlock dictionary = new DictionaryBlock(4, nestedDictionary, new int[] {2, 3, 2, 0});
-
-        Page page = new Page(dictionary);
-        page.compact();
-        // Page#compact does not unnest nested dictionaries
-        assertFalse(((DictionaryBlock) page.getBlock(0)).isCompact());
     }
 
     @Test

--- a/core/trino-spi/src/test/java/io/trino/spi/TestPage.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/TestPage.java
@@ -98,7 +98,7 @@ public class TestPage
         int otherDictionaryUsedPositions = 30;
         int[] otherDictionaryIds = getDictionaryIds(positionCount, otherDictionaryUsedPositions);
         Block dictionary3 = createSlicesBlock(createExpectedValues(70));
-        DictionaryBlock randomSourceIdBlock = new DictionaryBlock(dictionary3, otherDictionaryIds);
+        DictionaryBlock randomSourceIdBlock = new DictionaryBlock(otherDictionaryIds.length, dictionary3, otherDictionaryIds);
 
         Page page = new Page(commonSourceIdBlock1, randomSourceIdBlock, commonSourceIdBlock2);
         page.compact();
@@ -121,8 +121,8 @@ public class TestPage
     {
         Slice[] expectedValues = createExpectedValues(10);
         Block valuesBlock = createSlicesBlock(expectedValues);
-        DictionaryBlock nestedDictionary = new DictionaryBlock(valuesBlock, new int[] {0, 1, 2, 2, 4, 5});
-        DictionaryBlock dictionary = new DictionaryBlock(nestedDictionary, new int[] {2, 3, 2, 0});
+        DictionaryBlock nestedDictionary = new DictionaryBlock(6, valuesBlock, new int[] {0, 1, 2, 2, 4, 5});
+        DictionaryBlock dictionary = new DictionaryBlock(4, nestedDictionary, new int[] {2, 3, 2, 0});
 
         Page page = new Page(dictionary);
         page.compact();

--- a/core/trino-spi/src/test/java/io/trino/spi/block/TestArrayBlockBuilder.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/TestArrayBlockBuilder.java
@@ -78,18 +78,18 @@ public class TestArrayBlockBuilder
     public void testBuilderProducesNullRleForNullRows()
     {
         // empty block
-        assertIsNullRle(blockBuilder().build(), 0);
+        assertIsAllNulls(blockBuilder().build(), 0);
 
         // single null
-        assertIsNullRle(blockBuilder().appendNull().build(), 1);
+        assertIsAllNulls(blockBuilder().appendNull().build(), 1);
 
         // multiple nulls
-        assertIsNullRle(blockBuilder().appendNull().appendNull().build(), 2);
+        assertIsAllNulls(blockBuilder().appendNull().appendNull().build(), 2);
 
         BlockBuilder blockBuilder = blockBuilder().appendNull().appendNull();
-        assertIsNullRle(blockBuilder.copyPositions(new int[] {0}, 0, 1), 1);
-        assertIsNullRle(blockBuilder.getRegion(0, 1), 1);
-        assertIsNullRle(blockBuilder.copyRegion(0, 1), 1);
+        assertIsAllNulls(blockBuilder.copyPositions(new int[] {0}, 0, 1), 1);
+        assertIsAllNulls(blockBuilder.getRegion(0, 1), 1);
+        assertIsAllNulls(blockBuilder.copyRegion(0, 1), 1);
     }
 
     private static BlockBuilder blockBuilder()
@@ -97,10 +97,16 @@ public class TestArrayBlockBuilder
         return new ArrayBlockBuilder(BIGINT, null, 10);
     }
 
-    private void assertIsNullRle(Block block, int expectedPositionCount)
+    private static void assertIsAllNulls(Block block, int expectedPositionCount)
     {
         assertEquals(block.getPositionCount(), expectedPositionCount);
-        assertEquals(block.getClass(), RunLengthEncodedBlock.class);
+        if (expectedPositionCount <= 1) {
+            assertEquals(block.getClass(), ArrayBlock.class);
+        }
+        else {
+            assertEquals(block.getClass(), RunLengthEncodedBlock.class);
+            assertEquals(((RunLengthEncodedBlock) block).getValue().getClass(), ArrayBlock.class);
+        }
         if (expectedPositionCount > 0) {
             assertTrue(block.isNull(0));
         }

--- a/core/trino-spi/src/test/java/io/trino/spi/block/TestBlockRetainedSizeBreakdown.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/TestBlockRetainedSizeBreakdown.java
@@ -65,7 +65,7 @@ public class TestBlockRetainedSizeBreakdown
         for (int i = 0; i < keyIds.length; i++) {
             keyIds[i] = i;
         }
-        checkRetainedSize(new DictionaryBlock(EXPECTED_ENTRIES, keyDictionaryBlock, keyIds), false);
+        checkRetainedSize(DictionaryBlock.create(EXPECTED_ENTRIES, keyDictionaryBlock, keyIds), false);
     }
 
     @Test

--- a/core/trino-spi/src/test/java/io/trino/spi/block/TestBlockRetainedSizeBreakdown.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/TestBlockRetainedSizeBreakdown.java
@@ -89,7 +89,7 @@ public class TestBlockRetainedSizeBreakdown
     {
         BlockBuilder blockBuilder = new LongArrayBlockBuilder(null, 1);
         writeEntries(1, blockBuilder, BIGINT);
-        checkRetainedSize(new RunLengthEncodedBlock(blockBuilder.build(), 1), false);
+        checkRetainedSize(RunLengthEncodedBlock.create(blockBuilder.build(), 1), false);
     }
 
     @Test

--- a/core/trino-spi/src/test/java/io/trino/spi/block/TestDictionaryBlockEncoding.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/TestDictionaryBlockEncoding.java
@@ -37,7 +37,7 @@ public class TestDictionaryBlockEncoding
             ids[i] = i % 4;
         }
 
-        DictionaryBlock dictionaryBlock = new DictionaryBlock(dictionary, ids);
+        DictionaryBlock dictionaryBlock = new DictionaryBlock(ids.length, dictionary, ids);
 
         Block actualBlock = roundTripBlock(dictionaryBlock);
         assertTrue(actualBlock instanceof DictionaryBlock);
@@ -53,7 +53,7 @@ public class TestDictionaryBlockEncoding
     public void testNonSequentialDictionaryUnnest()
     {
         int[] ids = new int[] {3, 2, 1, 0};
-        DictionaryBlock dictionaryBlock = new DictionaryBlock(dictionary, ids);
+        DictionaryBlock dictionaryBlock = new DictionaryBlock(ids.length, dictionary, ids);
 
         Block actualBlock = roundTripBlock(dictionaryBlock);
         assertTrue(actualBlock instanceof DictionaryBlock);
@@ -64,7 +64,7 @@ public class TestDictionaryBlockEncoding
     public void testNonSequentialDictionaryUnnestWithGaps()
     {
         int[] ids = new int[] {3, 2, 0};
-        DictionaryBlock dictionaryBlock = new DictionaryBlock(dictionary, ids);
+        DictionaryBlock dictionaryBlock = new DictionaryBlock(ids.length, dictionary, ids);
 
         Block actualBlock = roundTripBlock(dictionaryBlock);
         assertTrue(actualBlock instanceof VariableWidthBlock);
@@ -75,7 +75,7 @@ public class TestDictionaryBlockEncoding
     public void testSequentialDictionaryUnnest()
     {
         int[] ids = new int[] {0, 1, 2, 3};
-        DictionaryBlock dictionaryBlock = new DictionaryBlock(dictionary, ids);
+        DictionaryBlock dictionaryBlock = new DictionaryBlock(ids.length, dictionary, ids);
 
         Block actualBlock = roundTripBlock(dictionaryBlock);
         assertTrue(actualBlock instanceof VariableWidthBlock);
@@ -86,8 +86,8 @@ public class TestDictionaryBlockEncoding
     public void testNestedSequentialDictionaryUnnest()
     {
         int[] ids = new int[] {0, 1, 2, 3};
-        DictionaryBlock nestedDictionaryBlock = new DictionaryBlock(dictionary, ids);
-        DictionaryBlock dictionary = new DictionaryBlock(nestedDictionaryBlock, ids);
+        DictionaryBlock nestedDictionaryBlock = new DictionaryBlock(ids.length, dictionary, ids);
+        DictionaryBlock dictionary = new DictionaryBlock(ids.length, nestedDictionaryBlock, ids);
 
         Block actualBlock = roundTripBlock(dictionary);
         assertTrue(actualBlock instanceof VariableWidthBlock);

--- a/core/trino-spi/src/test/java/io/trino/spi/block/TestDictionaryBlockEncoding.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/TestDictionaryBlockEncoding.java
@@ -37,7 +37,7 @@ public class TestDictionaryBlockEncoding
             ids[i] = i % 4;
         }
 
-        DictionaryBlock dictionaryBlock = new DictionaryBlock(ids.length, dictionary, ids);
+        DictionaryBlock dictionaryBlock = (DictionaryBlock) DictionaryBlock.create(ids.length, dictionary, ids);
 
         Block actualBlock = roundTripBlock(dictionaryBlock);
         assertTrue(actualBlock instanceof DictionaryBlock);
@@ -53,7 +53,7 @@ public class TestDictionaryBlockEncoding
     public void testNonSequentialDictionaryUnnest()
     {
         int[] ids = new int[] {3, 2, 1, 0};
-        DictionaryBlock dictionaryBlock = new DictionaryBlock(ids.length, dictionary, ids);
+        DictionaryBlock dictionaryBlock = (DictionaryBlock) DictionaryBlock.create(ids.length, dictionary, ids);
 
         Block actualBlock = roundTripBlock(dictionaryBlock);
         assertTrue(actualBlock instanceof DictionaryBlock);
@@ -64,7 +64,7 @@ public class TestDictionaryBlockEncoding
     public void testNonSequentialDictionaryUnnestWithGaps()
     {
         int[] ids = new int[] {3, 2, 0};
-        DictionaryBlock dictionaryBlock = new DictionaryBlock(ids.length, dictionary, ids);
+        DictionaryBlock dictionaryBlock = (DictionaryBlock) DictionaryBlock.create(ids.length, dictionary, ids);
 
         Block actualBlock = roundTripBlock(dictionaryBlock);
         assertTrue(actualBlock instanceof VariableWidthBlock);
@@ -75,23 +75,11 @@ public class TestDictionaryBlockEncoding
     public void testSequentialDictionaryUnnest()
     {
         int[] ids = new int[] {0, 1, 2, 3};
-        DictionaryBlock dictionaryBlock = new DictionaryBlock(ids.length, dictionary, ids);
+        DictionaryBlock dictionaryBlock = (DictionaryBlock) DictionaryBlock.create(ids.length, dictionary, ids);
 
         Block actualBlock = roundTripBlock(dictionaryBlock);
         assertTrue(actualBlock instanceof VariableWidthBlock);
         assertBlockEquals(VARCHAR, actualBlock, dictionary.getPositions(ids, 0, 4));
-    }
-
-    @Test
-    public void testNestedSequentialDictionaryUnnest()
-    {
-        int[] ids = new int[] {0, 1, 2, 3};
-        DictionaryBlock nestedDictionaryBlock = new DictionaryBlock(ids.length, dictionary, ids);
-        DictionaryBlock dictionary = new DictionaryBlock(ids.length, nestedDictionaryBlock, ids);
-
-        Block actualBlock = roundTripBlock(dictionary);
-        assertTrue(actualBlock instanceof VariableWidthBlock);
-        assertBlockEquals(VARCHAR, actualBlock, this.dictionary.getPositions(ids, 0, 4));
     }
 
     private Block roundTripBlock(Block block)
@@ -101,7 +89,7 @@ public class TestDictionaryBlockEncoding
         return blockEncodingSerde.readBlock(sliceOutput.slice().getInput());
     }
 
-    private Block buildTestDictionary()
+    private static Block buildTestDictionary()
     {
         // build dictionary
         BlockBuilder dictionaryBuilder = VARCHAR.createBlockBuilder(null, 4);

--- a/core/trino-spi/src/test/java/io/trino/spi/block/TestLazyBlock.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/TestLazyBlock.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -68,14 +69,18 @@ public class TestLazyBlock
         List<Block> actualNotifications = new ArrayList<>();
         Block arrayBlock = new IntArrayBlock(1, Optional.empty(), new int[] {0});
         LazyBlock lazyArrayBlock = new LazyBlock(1, () -> arrayBlock);
-        DictionaryBlock dictionaryBlock = new DictionaryBlock(1, lazyArrayBlock, new int[] {0});
-        LazyBlock lazyBlock = new LazyBlock(1, () -> dictionaryBlock);
+        Block dictionaryBlock = DictionaryBlock.create(2, lazyArrayBlock, new int[] {0, 0});
+        LazyBlock lazyBlock = new LazyBlock(2, () -> dictionaryBlock);
         LazyBlock.listenForLoads(lazyBlock, actualNotifications::add);
 
         Block loadedBlock = lazyBlock.getBlock();
+        assertThat(loadedBlock).isInstanceOf(DictionaryBlock.class);
+        assertThat(((DictionaryBlock) loadedBlock).getDictionary()).isInstanceOf(LazyBlock.class);
         assertEquals(actualNotifications, ImmutableList.of(loadedBlock));
 
-        lazyBlock.getLoadedBlock();
+        Block fullyLoadedBlock = lazyBlock.getLoadedBlock();
+        assertThat(fullyLoadedBlock).isInstanceOf(DictionaryBlock.class);
+        assertThat(((DictionaryBlock) fullyLoadedBlock).getDictionary()).isInstanceOf(IntArrayBlock.class);
         assertEquals(actualNotifications, ImmutableList.of(loadedBlock, arrayBlock));
         assertTrue(lazyBlock.isLoaded());
         assertTrue(dictionaryBlock.isLoaded());

--- a/core/trino-spi/src/test/java/io/trino/spi/block/TestLazyBlock.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/TestLazyBlock.java
@@ -68,7 +68,7 @@ public class TestLazyBlock
         List<Block> actualNotifications = new ArrayList<>();
         Block arrayBlock = new IntArrayBlock(1, Optional.empty(), new int[] {0});
         LazyBlock lazyArrayBlock = new LazyBlock(1, () -> arrayBlock);
-        DictionaryBlock dictionaryBlock = new DictionaryBlock(lazyArrayBlock, new int[] {0});
+        DictionaryBlock dictionaryBlock = new DictionaryBlock(1, lazyArrayBlock, new int[] {0});
         LazyBlock lazyBlock = new LazyBlock(1, () -> dictionaryBlock);
         LazyBlock.listenForLoads(lazyBlock, actualNotifications::add);
 

--- a/core/trino-spi/src/test/java/io/trino/spi/block/TestVariableWidthBlockBuilder.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/TestVariableWidthBlockBuilder.java
@@ -74,18 +74,18 @@ public class TestVariableWidthBlockBuilder
     public void testBuilderProducesNullRleForNullRows()
     {
         // empty block
-        assertIsNullRle(blockBuilder().build(), 0);
+        assertIsAllNulls(blockBuilder().build(), 0);
 
         // single null
-        assertIsNullRle(blockBuilder().appendNull().build(), 1);
+        assertIsAllNulls(blockBuilder().appendNull().build(), 1);
 
         // multiple nulls
-        assertIsNullRle(blockBuilder().appendNull().appendNull().build(), 2);
+        assertIsAllNulls(blockBuilder().appendNull().appendNull().build(), 2);
 
         BlockBuilder blockBuilder = blockBuilder().appendNull().appendNull();
-        assertIsNullRle(blockBuilder.copyPositions(new int[] {0}, 0, 1), 1);
-        assertIsNullRle(blockBuilder.getRegion(0, 1), 1);
-        assertIsNullRle(blockBuilder.copyRegion(0, 1), 1);
+        assertIsAllNulls(blockBuilder.copyPositions(new int[] {0}, 0, 1), 1);
+        assertIsAllNulls(blockBuilder.getRegion(0, 1), 1);
+        assertIsAllNulls(blockBuilder.copyRegion(0, 1), 1);
     }
 
     private static BlockBuilder blockBuilder()
@@ -93,10 +93,16 @@ public class TestVariableWidthBlockBuilder
         return new VariableWidthBlockBuilder(null, 10, 0);
     }
 
-    private void assertIsNullRle(Block block, int expectedPositionCount)
+    private static void assertIsAllNulls(Block block, int expectedPositionCount)
     {
         assertEquals(block.getPositionCount(), expectedPositionCount);
-        assertEquals(block.getClass(), RunLengthEncodedBlock.class);
+        if (expectedPositionCount <= 1) {
+            assertEquals(block.getClass(), VariableWidthBlock.class);
+        }
+        else {
+            assertEquals(block.getClass(), RunLengthEncodedBlock.class);
+            assertEquals(((RunLengthEncodedBlock) block).getValue().getClass(), VariableWidthBlock.class);
+        }
         if (expectedPositionCount > 0) {
             assertTrue(block.isNull(0));
         }

--- a/lib/trino-orc/src/main/java/io/trino/orc/reader/SliceDictionaryColumnReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/reader/SliceDictionaryColumnReader.java
@@ -174,7 +174,7 @@ public class SliceDictionaryColumnReader
         verifyNotNull(dataStream);
         int[] values = new int[nextBatchSize];
         dataStream.next(values, nextBatchSize);
-        return new DictionaryBlock(nextBatchSize, dictionaryBlock, values);
+        return DictionaryBlock.create(nextBatchSize, dictionaryBlock, values);
     }
 
     private Block readNullBlock(boolean[] isNull, int nonNullCount)
@@ -205,7 +205,7 @@ public class SliceDictionaryColumnReader
             result[nonNullPositionList[i]] = nonNullValueTemp[i];
         }
 
-        return new DictionaryBlock(nextBatchSize, dictionaryBlock, result);
+        return DictionaryBlock.create(nextBatchSize, dictionaryBlock, result);
     }
 
     private void setDictionaryBlockData(byte[] dictionaryData, int[] dictionaryOffsets, int positionCount)

--- a/lib/trino-orc/src/main/java/io/trino/orc/reader/SliceDictionaryColumnReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/reader/SliceDictionaryColumnReader.java
@@ -163,9 +163,9 @@ public class SliceDictionaryColumnReader
         return block;
     }
 
-    private RunLengthEncodedBlock readAllNullsBlock()
+    private Block readAllNullsBlock()
     {
-        return new RunLengthEncodedBlock(new VariableWidthBlock(1, EMPTY_SLICE, new int[2], Optional.of(new boolean[] {true})), nextBatchSize);
+        return RunLengthEncodedBlock.create(new VariableWidthBlock(1, EMPTY_SLICE, new int[2], Optional.of(new boolean[] {true})), nextBatchSize);
     }
 
     private Block readNonNullBlock()

--- a/lib/trino-orc/src/main/java/io/trino/orc/reader/SliceDirectColumnReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/reader/SliceDirectColumnReader.java
@@ -230,9 +230,9 @@ public class SliceDirectColumnReader
         return new VariableWidthBlock(currentBatchSize, slice, offsetVector, Optional.ofNullable(isNullVector));
     }
 
-    private RunLengthEncodedBlock readAllNullsBlock()
+    private Block readAllNullsBlock()
     {
-        return new RunLengthEncodedBlock(new VariableWidthBlock(1, EMPTY_SLICE, new int[2], Optional.of(new boolean[] {true})), nextBatchSize);
+        return RunLengthEncodedBlock.create(new VariableWidthBlock(1, EMPTY_SLICE, new int[2], Optional.of(new boolean[] {true})), nextBatchSize);
     }
 
     private void openRowGroup()

--- a/lib/trino-orc/src/main/java/io/trino/orc/reader/UnionColumnReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/reader/UnionColumnReader.java
@@ -259,7 +259,7 @@ public class UnionColumnReader
                 blocks[i + 1] = new LazyBlock(positionCount, new UnpackLazyBlockLoader(rawBlock, fieldType, valueIsNonNull[i]));
             }
             else {
-                blocks[i + 1] = new RunLengthEncodedBlock(
+                blocks[i + 1] = RunLengthEncodedBlock.create(
                         fieldType.createBlockBuilder(null, 1).appendNull().build(),
                         positionCount);
             }

--- a/lib/trino-orc/src/main/java/io/trino/orc/reader/UuidColumnReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/reader/UuidColumnReader.java
@@ -255,9 +255,9 @@ public class UuidColumnReader
         return values;
     }
 
-    private RunLengthEncodedBlock createAllNullsBlock()
+    private Block createAllNullsBlock()
     {
-        return new RunLengthEncodedBlock(new Int128ArrayBlock(1, Optional.of(new boolean[] {true}), new long[2]), nextBatchSize);
+        return RunLengthEncodedBlock.create(new Int128ArrayBlock(1, Optional.of(new boolean[] {true}), new long[2]), nextBatchSize);
     }
 
     private void openRowGroup()

--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/SliceDictionaryColumnWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/SliceDictionaryColumnWriter.java
@@ -216,7 +216,7 @@ public class SliceDictionaryColumnWriter
         for (int i = 0; valueCount > 0 && i < segments.length; i++) {
             int[] segment = segments[i];
             int positionCount = Math.min(valueCount, segment.length);
-            Block block = new DictionaryBlock(positionCount, dictionary, segment);
+            Block block = DictionaryBlock.create(positionCount, dictionary, segment);
 
             while (block != null) {
                 int chunkPositionCount = block.getPositionCount();

--- a/lib/trino-rcfile/src/main/java/io/trino/rcfile/RcFileReader.java
+++ b/lib/trino-rcfile/src/main/java/io/trino/rcfile/RcFileReader.java
@@ -428,7 +428,7 @@ public class RcFileReader
         if (columnIndex >= columns.length) {
             Type type = readColumns.get(columnIndex);
             Block nullBlock = type.createBlockBuilder(null, 1, 0).appendNull().build();
-            return new RunLengthEncodedBlock(nullBlock, currentChunkRowCount);
+            return RunLengthEncodedBlock.create(nullBlock, currentChunkRowCount);
         }
 
         return columns[columnIndex].readBlock(rowGroupPosition, currentChunkRowCount);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSource.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSource.java
@@ -165,7 +165,7 @@ public class DeltaLakePageSource
             Block[] blocks = new Block[prefilledBlocks.length];
             for (int i = 0; i < prefilledBlocks.length; i++) {
                 if (prefilledBlocks[i] != null) {
-                    blocks[i] = new RunLengthEncodedBlock(prefilledBlocks[i], batchSize);
+                    blocks[i] = RunLengthEncodedBlock.create(prefilledBlocks[i], batchSize);
                 }
                 else if (i == rowIdIndex) {
                     blocks[i] = createRowIdBlock(dataPage.getBlock(delegateIndexes[i]));
@@ -187,9 +187,9 @@ public class DeltaLakePageSource
     {
         int positions = rowIndexBlock.getPositionCount();
         Block[] fields = {
-                new RunLengthEncodedBlock(pathBlock, positions),
+                RunLengthEncodedBlock.create(pathBlock, positions),
                 rowIndexBlock,
-                new RunLengthEncodedBlock(partitionsBlock, positions),
+                RunLengthEncodedBlock.create(partitionsBlock, positions),
         };
         return RowBlock.fromFieldBlocks(positions, Optional.empty(), fields);
     }

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialPartitioningInternalAggregation.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialPartitioningInternalAggregation.java
@@ -73,7 +73,7 @@ public class TestSpatialPartitioningInternalAggregation
         List<OGCGeometry> geometries = makeGeometries();
         Block geometryBlock = makeGeometryBlock(geometries);
 
-        Block partitionCountBlock = BlockAssertions.createRLEBlock(partitionCount, geometries.size());
+        Block partitionCountBlock = BlockAssertions.createRepeatedValuesBlock(partitionCount, geometries.size());
 
         Rectangle expectedExtent = new Rectangle(-10, -10, Math.nextUp(10.0), Math.nextUp(10.0));
         String expectedValue = getSpatialPartitioning(expectedExtent, geometries, partitionCount);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/AbstractHiveAcidWriters.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/AbstractHiveAcidWriters.java
@@ -152,12 +152,12 @@ public abstract class AbstractHiveAcidWriters
         int positionCount = rowIdsRowBlock.getPositionCount();
         // We've verified that the rowIds block has no null rows, so it's okay to get the field blocks
         Block[] blockArray = {
-                new RunLengthEncodedBlock(DELETE_OPERATION_BLOCK, positionCount),
+                RunLengthEncodedBlock.create(DELETE_OPERATION_BLOCK, positionCount),
                 columnarRow.getField(ORIGINAL_TRANSACTION_CHANNEL),
                 columnarRow.getField(BUCKET_CHANNEL),
                 columnarRow.getField(ROW_ID_CHANNEL),
                 RunLengthEncodedBlock.create(BIGINT, writeId, positionCount),
-                new RunLengthEncodedBlock(rowTypeNullsBlock, positionCount),
+                RunLengthEncodedBlock.create(rowTypeNullsBlock, positionCount),
         };
         return new Page(blockArray);
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
@@ -482,7 +482,7 @@ public class HivePageSource
                     fields[i] = rowBlock.getField(i);
                 }
                 else {
-                    fields[i] = new DictionaryBlock(nullBlocks[i], ids);
+                    fields[i] = new DictionaryBlock(ids.length, nullBlocks[i], ids);
                 }
             }
             boolean[] valueIsNull = null;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
@@ -482,7 +482,7 @@ public class HivePageSource
                     fields[i] = rowBlock.getField(i);
                 }
                 else {
-                    fields[i] = new DictionaryBlock(ids.length, nullBlocks[i], ids);
+                    fields[i] = DictionaryBlock.create(ids.length, nullBlocks[i], ids);
                 }
             }
             boolean[] valueIsNull = null;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveUpdatablePageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveUpdatablePageSource.java
@@ -131,12 +131,12 @@ public class HiveUpdatablePageSource
 
         Block originalTransactionChannel = columnarRow.getField(ORIGINAL_TRANSACTION_CHANNEL);
         Block[] blockArray = {
-                new RunLengthEncodedBlock(DELETE_OPERATION_BLOCK, positionCount),
+                RunLengthEncodedBlock.create(DELETE_OPERATION_BLOCK, positionCount),
                 originalTransactionChannel,
                 columnarRow.getField(BUCKET_CHANNEL),
                 columnarRow.getField(ROW_ID_CHANNEL),
                 RunLengthEncodedBlock.create(BIGINT, writeId, positionCount),
-                new RunLengthEncodedBlock(hiveRowTypeNullsBlock, positionCount),
+                RunLengthEncodedBlock.create(hiveRowTypeNullsBlock, positionCount),
         };
         Page deletePage = new Page(blockArray);
 
@@ -165,7 +165,7 @@ public class HiveUpdatablePageSource
 
         Block currentTransactionBlock = RunLengthEncodedBlock.create(BIGINT, writeId, positionCount);
         Block[] blockArray = {
-                new RunLengthEncodedBlock(INSERT_OPERATION_BLOCK, positionCount),
+                RunLengthEncodedBlock.create(INSERT_OPERATION_BLOCK, positionCount),
                 currentTransactionBlock,
                 acidBlock.getField(BUCKET_CHANNEL),
                 createRowIdBlock(positionCount),

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/MergeFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/MergeFileWriter.java
@@ -110,9 +110,9 @@ public class MergeFileWriter
         Block mergedColumnsBlock = RowBlock.fromFieldBlocks(positionCount, Optional.empty(), dataColumns.toArray(new Block[]{}));
         Block currentTransactionBlock = RunLengthEncodedBlock.create(BIGINT, writeId, positionCount);
         Block[] blockArray = {
-                new RunLengthEncodedBlock(INSERT_OPERATION_BLOCK, positionCount),
+                RunLengthEncodedBlock.create(INSERT_OPERATION_BLOCK, positionCount),
                 currentTransactionBlock,
-                new RunLengthEncodedBlock(bucketValueBlock, positionCount),
+                RunLengthEncodedBlock.create(bucketValueBlock, positionCount),
                 createRowIdBlock(positionCount, insertRowCount),
                 currentTransactionBlock,
                 mergedColumnsBlock

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RcFileFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RcFileFileWriter.java
@@ -114,7 +114,7 @@ public class RcFileFileWriter
         for (int i = 0; i < fileInputColumnIndexes.length; i++) {
             int inputColumnIndex = fileInputColumnIndexes[i];
             if (inputColumnIndex < 0) {
-                blocks[i] = new RunLengthEncodedBlock(nullBlocks.get(i), dataPage.getPositionCount());
+                blocks[i] = RunLengthEncodedBlock.create(nullBlocks.get(i), dataPage.getPositionCount());
             }
             else {
                 blocks[i] = dataPage.getBlock(inputColumnIndex);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcDeletedRows.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcDeletedRows.java
@@ -183,7 +183,7 @@ public class OrcDeletedRows
             if (positionCount == block.getPositionCount()) {
                 return block;
             }
-            return new DictionaryBlock(positionCount, block, validPositions);
+            return DictionaryBlock.create(positionCount, block, validPositions);
         }
 
         private void loadValidPositions()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcFileWriter.java
@@ -157,7 +157,7 @@ public class OrcFileWriter
             int inputColumnIndex = fileInputColumnIndexes[i];
             if (inputColumnIndex < 0) {
                 hasNullBlocks = true;
-                blocks[i] = new RunLengthEncodedBlock(nullBlocks.get(i), positionCount);
+                blocks[i] = RunLengthEncodedBlock.create(nullBlocks.get(i), positionCount);
             }
             else {
                 blocks[i] = dataPage.getBlock(inputColumnIndex);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSource.java
@@ -331,7 +331,7 @@ public class OrcPageSource
         @Override
         public Block block(Page sourcePage, MaskDeletedRowsFunction maskDeletedRowsFunction, long filePosition, OptionalLong startRowId)
         {
-            return new RunLengthEncodedBlock(nullBlock, maskDeletedRowsFunction.getPositionCount());
+            return RunLengthEncodedBlock.create(nullBlock, maskDeletedRowsFunction.getPositionCount());
         }
 
         @Override
@@ -467,8 +467,8 @@ public class OrcPageSource
             int positionCount = sourcePage.getPositionCount();
             ImmutableList.Builder<Block> originalFilesBlockBuilder = ImmutableList.builder();
             originalFilesBlockBuilder.add(
-                    new RunLengthEncodedBlock(ORIGINAL_FILE_TRANSACTION_ID_BLOCK, positionCount),
-                    new RunLengthEncodedBlock(bucketBlock, positionCount),
+                    RunLengthEncodedBlock.create(ORIGINAL_FILE_TRANSACTION_ID_BLOCK, positionCount),
+                    RunLengthEncodedBlock.create(bucketBlock, positionCount),
                     createRowNumberBlock(startingRowId, filePosition, positionCount));
             for (int channel = 0; channel < sourcePage.getChannelCount(); channel++) {
                 originalFilesBlockBuilder.add(sourcePage.getBlock(channel));
@@ -524,8 +524,8 @@ public class OrcPageSource
                     positionCount,
                     Optional.empty(),
                     new Block[] {
-                            new RunLengthEncodedBlock(ORIGINAL_FILE_TRANSACTION_ID_BLOCK, positionCount),
-                            new RunLengthEncodedBlock(bucketBlock, positionCount),
+                            RunLengthEncodedBlock.create(ORIGINAL_FILE_TRANSACTION_ID_BLOCK, positionCount),
+                            RunLengthEncodedBlock.create(bucketBlock, positionCount),
                             createRowNumberBlock(startingRowId, filePosition, positionCount)
                     }));
         }
@@ -551,8 +551,8 @@ public class OrcPageSource
                     positionCount,
                     Optional.empty(),
                     new Block[] {
-                            new RunLengthEncodedBlock(ORIGINAL_FILE_TRANSACTION_ID_BLOCK, positionCount),
-                            new RunLengthEncodedBlock(bucketBlock, positionCount),
+                            RunLengthEncodedBlock.create(ORIGINAL_FILE_TRANSACTION_ID_BLOCK, positionCount),
+                            RunLengthEncodedBlock.create(bucketBlock, positionCount),
                             createRowNumberBlock(startingRowId, filePosition, positionCount)
                     }));
             return rowBlock;
@@ -574,7 +574,7 @@ public class OrcPageSource
         @Override
         public Block block(Page sourcePage, MaskDeletedRowsFunction maskDeletedRowsFunction, long filePosition, OptionalLong startRowId)
         {
-            return new RunLengthEncodedBlock(singleValueBlock, sourcePage.getPositionCount());
+            return RunLengthEncodedBlock.create(singleValueBlock, sourcePage.getPositionCount());
         }
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriter.java
@@ -121,7 +121,7 @@ public class ParquetFileWriter
         for (int i = 0; i < fileInputColumnIndexes.length; i++) {
             int inputColumnIndex = fileInputColumnIndexes[i];
             if (inputColumnIndex < 0) {
-                blocks[i] = new RunLengthEncodedBlock(nullBlocks.get(i), dataPage.getPositionCount());
+                blocks[i] = RunLengthEncodedBlock.create(nullBlocks.get(i), dataPage.getPositionCount());
             }
             else {
                 blocks[i] = dataPage.getBlock(inputColumnIndex);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/rcfile/RcFilePageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/rcfile/RcFilePageSource.java
@@ -129,7 +129,7 @@ public class RcFilePageSource
             Block[] blocks = new Block[hiveColumnIndexes.length];
             for (int fieldId = 0; fieldId < blocks.length; fieldId++) {
                 if (constantBlocks[fieldId] != null) {
-                    blocks[fieldId] = new RunLengthEncodedBlock(constantBlocks[fieldId], currentPageSize);
+                    blocks[fieldId] = RunLengthEncodedBlock.create(constantBlocks[fieldId], currentPageSize);
                 }
                 else {
                     blocks[fieldId] = createBlock(currentPageSize, fieldId);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcDeletedRows.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcDeletedRows.java
@@ -190,7 +190,7 @@ public class TestOrcDeletedRows
         return new Page(
                 size,
                 originalTransaction.build(),
-                new RunLengthEncodedBlock(bucketBlock, size),
-                new RunLengthEncodedBlock(rowIdBlock, size));
+                RunLengthEncodedBlock.create(bucketBlock, size),
+                RunLengthEncodedBlock.create(rowIdBlock, size));
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ConstantPopulatingPageSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ConstantPopulatingPageSource.java
@@ -80,7 +80,7 @@ public class ConstantPopulatingPageSource
         for (int targetChannel = 0; targetChannel < size; targetChannel++) {
             Block constantValue = constantColumns[targetChannel];
             if (constantValue != null) {
-                blocks[targetChannel] = new RunLengthEncodedBlock(constantValue, delegatePage.getPositionCount());
+                blocks[targetChannel] = RunLengthEncodedBlock.create(constantValue, delegatePage.getPositionCount());
             }
             else {
                 blocks[targetChannel] = delegatePage.getBlock(targetChannelToSourceChannel[targetChannel]);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTransforms.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTransforms.java
@@ -689,7 +689,7 @@ public final class PartitionTransforms
                 type,
                 true,
                 true,
-                block -> new RunLengthEncodedBlock(nullBlock, block.getPositionCount()),
+                block -> RunLengthEncodedBlock.create(nullBlock, block.getPositionCount()),
                 (block, position) -> null);
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/IcebergPositionDeletePageSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/IcebergPositionDeletePageSink.java
@@ -111,7 +111,7 @@ public class IcebergPositionDeletePageSink
         checkArgument(page.getChannelCount() == 1, "IcebergPositionDeletePageSink expected a Page with only one channel, but got " + page.getChannelCount());
 
         Block[] blocks = new Block[2];
-        blocks[0] = new RunLengthEncodedBlock(nativeValueToBlock(VARCHAR, utf8Slice(dataFilePath)), page.getPositionCount());
+        blocks[0] = RunLengthEncodedBlock.create(nativeValueToBlock(VARCHAR, utf8Slice(dataFilePath)), page.getPositionCount());
         blocks[1] = page.getBlock(0);
         writer.appendRows(new Page(blocks));
 

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/storage/RaptorPageSource.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/storage/RaptorPageSource.java
@@ -233,7 +233,7 @@ public class RaptorPageSource
         @Override
         public Block block(Page sourcePage, long filePosition)
         {
-            return new RunLengthEncodedBlock(shardUuidBlock, sourcePage.getPositionCount());
+            return RunLengthEncodedBlock.create(shardUuidBlock, sourcePage.getPositionCount());
         }
 
         @Override
@@ -288,8 +288,8 @@ public class RaptorPageSource
         @Override
         public Block block(Page sourcePage, long filePosition)
         {
-            Block bucketNumberBlock = new RunLengthEncodedBlock(bucketNumberValue, sourcePage.getPositionCount());
-            Block shardUuidBlock = new RunLengthEncodedBlock(shardUuidValue, sourcePage.getPositionCount());
+            Block bucketNumberBlock = RunLengthEncodedBlock.create(bucketNumberValue, sourcePage.getPositionCount());
+            Block shardUuidBlock = RunLengthEncodedBlock.create(shardUuidValue, sourcePage.getPositionCount());
             Block rowIdBlock = RowIdColumn.INSTANCE.block(sourcePage, filePosition);
             return RowBlock.fromFieldBlocks(
                     sourcePage.getPositionCount(),
@@ -315,7 +315,7 @@ public class RaptorPageSource
         @Override
         public Block block(Page sourcePage, long filePosition)
         {
-            return new RunLengthEncodedBlock(nullBlock, sourcePage.getPositionCount());
+            return RunLengthEncodedBlock.create(nullBlock, sourcePage.getPositionCount());
         }
 
         @Override
@@ -342,7 +342,7 @@ public class RaptorPageSource
         @Override
         public Block block(Page sourcePage, long filePosition)
         {
-            return new RunLengthEncodedBlock(bucketNumberBlock, sourcePage.getPositionCount());
+            return RunLengthEncodedBlock.create(bucketNumberBlock, sourcePage.getPositionCount());
         }
 
         @Override


### PR DESCRIPTION
## Description
Simplify RLE and Dictionary blocks by not allowing the nested block to be an RLE or Dictionary block.
When an RLE or Dictionary block is zero or one positions, return `getRegion` over the nested block instead.

## Release notes

( ) This is not user-visible and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# SPI
* Replace DictionaryBlock constructors with factory method. ({issue}`14092`)
* Replace RunLengthEncodedBlock constructors with factory method. ({issue}`14092`)
```
