### PR TITLE
Add support for reading `DateTime(timezone)` from ClickHouse

### DIFF
--- a/docs/src/main/sphinx/connector/clickhouse.rst
+++ b/docs/src/main/sphinx/connector/clickhouse.rst
@@ -238,8 +238,8 @@ to the following table:
   * - ``Date``
     - ``DATE``
     -
-  * - ``DateTime``
-    - ``TIMESTAMP(0)``
+  * - ``DateTime[(timezone)]``
+    - ``TIMESTAMP(0) [WITH TIME ZONE]``
     -
   * - ``IPv4``
     - ``IPADDRESS``

--- a/docs/src/main/sphinx/connector/clickhouse.rst
+++ b/docs/src/main/sphinx/connector/clickhouse.rst
@@ -239,7 +239,7 @@ to the following table:
     - ``DATE``
     -
   * - ``DateTime``
-    - ``TIMESTAMP``
+    - ``TIMESTAMP(0)``
     -
   * - ``IPv4``
     - ``IPADDRESS``


### PR DESCRIPTION
## Description
Previously Trino only supported reading `DateTime` from ClickHouse (no
timezone specified) and for `DateTime(timezone)` users had to configure
the parameter `unsupported-type-handling` or
`jdbc-types-mapped-to-varchar` to support reading of this type.

This commit supports reading `DateTime(timezone)` from ClickHouse and
maps it to Trino's `TIMESTAMP(0) WITH TIME ZONE`.

NOTE: writing data from Trino to ClickHouse `DateTime(timezone)` is not
supported.

Fixes #13541
Related https://github.com/trinodb/trino/pull/11148#pullrequestreview-952788802

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# ClickHouse
* Add support for reading `DateTime(timezone)`. ({issue}`issuenumber`)
```
