### PR TITLE
Finish query when client has consumed results

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResource.java
@@ -135,6 +135,15 @@ public class ExecutingStatementResource
                     catch (Throwable e) {
                         log.warn(e, "Error removing old queries");
                     }
+
+                    try {
+                        for (Query query : queries.values()) {
+                            query.markResultsConsumedIfReady();
+                        }
+                    }
+                    catch (Throwable e) {
+                        log.warn(e, "Error marking results consumed");
+                    }
                 },
                 200,
                 200,

--- a/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
@@ -343,6 +343,13 @@ class Query
         return Futures.transform(futureStateChange, ignored -> getNextResult(token, uriInfo, targetResultSize), resultsProcessorExecutor);
     }
 
+    public synchronized void markResultsConsumedIfReady()
+    {
+        if (!resultsConsumed && exchangeDataSource.isFinished()) {
+            queryManager.resultsConsumed(queryId);
+        }
+    }
+
     private synchronized ListenableFuture<Void> getFutureStateChange()
     {
         // if the exchange client is open, wait for data
@@ -424,7 +431,7 @@ class Query
             updateCount = updatedRowsCount.orElse(null);
         }
 
-        if (queryInfo.getOutputStage().isEmpty() || (exchangeDataSource.isFinished() && resultRows.isEmpty())) {
+        if (queryInfo.getOutputStage().isEmpty() || exchangeDataSource.isFinished()) {
             queryManager.resultsConsumed(queryId);
             resultsConsumed = true;
             // update query since the query might have been transitioned to the FINISHED state


### PR DESCRIPTION
This works around broken clients that don't fetch the final link.

## Release notes

(x) This is not user-visible and no release notes are required.
