### PR TITLE
Upgrade minimum supported version to 21.8 in ClickHouse 

### DIFF
--- a/docs/src/main/sphinx/connector/clickhouse.rst
+++ b/docs/src/main/sphinx/connector/clickhouse.rst
@@ -16,7 +16,7 @@ Requirements
 
 To connect to a ClickHouse server, you need:
 
-* ClickHouse (version 21.3 or higher) or Altinity (version 20.8 or higher).
+* ClickHouse (version 21.8 or higher) or Altinity (version 20.8 or higher).
 * Network access from the Trino coordinator and workers to the ClickHouse
   server. Port 8123 is the default port.
 

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseConnectorTest.java
@@ -634,13 +634,13 @@ public abstract class BaseClickHouseConnectorTest
     @Override
     protected String errorMessageForCreateTableAsSelectNegativeDate(String date)
     {
-        return "Date must be between 1970-01-01 and 2106-02-07 in ClickHouse: " + date;
+        return "Date must be between 1970-01-01 and 2149-06-06 in ClickHouse: " + date;
     }
 
     @Override
     protected String errorMessageForInsertNegativeDate(String date)
     {
-        return "Date must be between 1970-01-01 and 2106-02-07 in ClickHouse: " + date;
+        return "Date must be between 1970-01-01 and 2149-06-06 in ClickHouse: " + date;
     }
 
     @Test
@@ -656,7 +656,7 @@ public abstract class BaseClickHouseConnectorTest
 
     protected String errorMessageForDateYearOfEraPredicate(String date)
     {
-        return "Date must be between 1970-01-01 and 2106-02-07 in ClickHouse: " + date;
+        return "Date must be between 1970-01-01 and 2149-06-06 in ClickHouse: " + date;
     }
 
     @Override
@@ -843,6 +843,13 @@ public abstract class BaseClickHouseConnectorTest
         assertThatThrownBy(() -> assertUpdate("ALTER TABLE " + sourceTableName + " RENAME TO " + invalidTargetTableName))
                 .hasMessageMatching("(?s).*(Cannot rename|File name too long).*");
         assertFalse(getQueryRunner().tableExists(getSession(), invalidTargetTableName));
+    }
+
+    @Override
+    protected OptionalInt maxTableNameLength()
+    {
+        // The numeric value depends on file system
+        return OptionalInt.of(255 - ".sql.detached".length());
     }
 
     @Override

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseTypeMapping.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseTypeMapping.java
@@ -648,7 +648,7 @@ public abstract class BaseClickHouseTypeMapping
     {
         return new Object[][] {
                 {"1970-01-01"}, // min value in ClickHouse
-                {"2106-02-07"}, // max value in ClickHouse
+                {"2149-06-06"}, // max value in ClickHouse
         };
     }
 
@@ -675,7 +675,7 @@ public abstract class BaseClickHouseTypeMapping
     {
         return new Object[][] {
                 {"1969-12-31"}, // min - 1 day
-                {"2106-02-08"}, // max + 1 day
+                {"2149-06-07"}, // max + 1 day
         };
     }
 
@@ -715,7 +715,7 @@ public abstract class BaseClickHouseTypeMapping
     protected SqlDataTypeTest unsupportedTimestampBecomeUnexpectedValueTest(String inputType)
     {
         return SqlDataTypeTest.create()
-                .addRoundTrip(inputType, "'1969-12-31 23:59:59'", createTimestampType(0), "TIMESTAMP '1970-01-01 23:59:59'"); // unsupported timestamp become 1970-01-01 23:59:59
+                .addRoundTrip(inputType, "'1969-12-31 23:59:59'", createTimestampType(0), "TIMESTAMP '1970-01-01 00:00:00'");
     }
 
     @Test(dataProvider = "clickHouseDateTimeMinMaxValuesDataProvider")
@@ -747,7 +747,7 @@ public abstract class BaseClickHouseTypeMapping
     {
         return new Object[][] {
                 {"1970-01-01 00:00:00"}, // min value in ClickHouse
-                {"2106-02-06 06:28:15"}, // max value in ClickHouse
+                {"2106-02-07 06:28:15"}, // max value in ClickHouse
         };
     }
 
@@ -774,7 +774,7 @@ public abstract class BaseClickHouseTypeMapping
     {
         return new Object[][] {
                 {"1969-12-31 23:59:59"}, // min - 1 second
-                {"2106-02-06 06:28:16"}, // max + 1 second
+                {"2106-02-07 06:28:16"}, // max + 1 second
         };
     }
 

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
@@ -16,8 +16,6 @@ package io.trino.plugin.clickhouse;
 import com.google.common.collect.ImmutableMap;
 import io.trino.testing.QueryRunner;
 
-import java.util.OptionalInt;
-
 import static io.trino.plugin.clickhouse.ClickHouseQueryRunner.createClickHouseQueryRunner;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -46,49 +44,10 @@ public class TestClickHouseConnectorTest
     }
 
     @Override
-    public void testCreateTableWithTableComment()
-    {
-        // Table comment is unsupported in old ClickHouse version
-        assertThatThrownBy(super::testCreateTableWithTableComment)
-                .hasMessageMatching("(?s).* Syntax error: .* COMMENT 'test comment'.*");
-    }
-
-    @Override
-    public void testCreateTableAsSelectWithTableComment()
-    {
-        // Table comment is unsupported in old ClickHouse version
-        assertThatThrownBy(super::testCreateTableAsSelectWithTableComment)
-                .hasMessageMatching("(?s).* Syntax error: .* COMMENT 'test comment'.*");
-    }
-
-    @Override
-    public void testCreateTableWithTableCommentSpecialCharacter(String comment)
-    {
-        // Table comment is unsupported in old ClickHouse version
-        assertThatThrownBy(() -> super.testCreateTableWithTableCommentSpecialCharacter(comment))
-                .hasMessageMatching("(?s).* Syntax error: .* COMMENT .*");
-    }
-
-    @Override
-    public void testCreateTableAsSelectWithTableCommentSpecialCharacter(String comment)
-    {
-        // Table comment is unsupported in old ClickHouse version
-        assertThatThrownBy(() -> super.testCreateTableAsSelectWithTableCommentSpecialCharacter(comment))
-                .hasMessageMatching("(?s).* Syntax error: .* COMMENT .*");
-    }
-
-    @Override
     public void testCommentTableSpecialCharacter(String comment)
     {
         // Table comment is unsupported in old ClickHouse version
         assertThatThrownBy(() -> super.testCommentTableSpecialCharacter(comment))
                 .hasMessageMatching("(?s).* Syntax error: .* COMMENT .*");
-    }
-
-    @Override
-    protected OptionalInt maxTableNameLength()
-    {
-        // The numeric value depends on file system
-        return OptionalInt.of(255 - ".sql.tmp".length());
     }
 }

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseLatestConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseLatestConnectorTest.java
@@ -16,8 +16,6 @@ package io.trino.plugin.clickhouse;
 import com.google.common.collect.ImmutableMap;
 import io.trino.testing.QueryRunner;
 
-import java.util.OptionalInt;
-
 import static io.trino.plugin.clickhouse.ClickHouseQueryRunner.createClickHouseQueryRunner;
 import static io.trino.plugin.clickhouse.TestingClickHouseServer.CLICKHOUSE_LATEST_IMAGE;
 
@@ -36,33 +34,5 @@ public class TestClickHouseLatestConnectorTest
                         .put("clickhouse.map-string-as-varchar", "true")
                         .buildOrThrow(),
                 REQUIRED_TPCH_TABLES);
-    }
-
-    @Override
-    protected OptionalInt maxTableNameLength()
-    {
-        // The numeric value depends on file system
-        return OptionalInt.of(255 - ".sql.detached".length());
-    }
-
-    @Override
-    protected String errorMessageForCreateTableAsSelectNegativeDate(String date)
-    {
-        // Override because the DateTime range was expanded in version 21.4 and later
-        return "Date must be between 1970-01-01 and 2149-06-06 in ClickHouse: " + date;
-    }
-
-    @Override
-    protected String errorMessageForInsertNegativeDate(String date)
-    {
-        // Override because the DateTime range was expanded in version 21.4 and later
-        return "Date must be between 1970-01-01 and 2149-06-06 in ClickHouse: " + date;
-    }
-
-    @Override
-    protected String errorMessageForDateYearOfEraPredicate(String date)
-    {
-        // Override because the DateTime range was expanded in version 21.4 and later
-        return "Date must be between 1970-01-01 and 2149-06-06 in ClickHouse: " + date;
     }
 }

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseLatestTypeMapping.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseLatestTypeMapping.java
@@ -13,8 +13,6 @@
  */
 package io.trino.plugin.clickhouse;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.datatype.SqlDataTypeTest;
 import org.testng.annotations.DataProvider;
@@ -31,12 +29,7 @@ public class TestClickHouseLatestTypeMapping
             throws Exception
     {
         clickhouseServer = closeAfterClass(new TestingClickHouseServer(CLICKHOUSE_LATEST_IMAGE));
-        return createClickHouseQueryRunner(clickhouseServer, ImmutableMap.of(),
-                ImmutableMap.<String, String>builder()
-                        .put("metadata.cache-ttl", "10m")
-                        .put("metadata.cache-missing", "true")
-                        .buildOrThrow(),
-                ImmutableList.of());
+        return createClickHouseQueryRunner(clickhouseServer);
     }
 
     @DataProvider

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseLatestTypeMapping.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseLatestTypeMapping.java
@@ -14,12 +14,9 @@
 package io.trino.plugin.clickhouse;
 
 import io.trino.testing.QueryRunner;
-import io.trino.testing.datatype.SqlDataTypeTest;
-import org.testng.annotations.DataProvider;
 
 import static io.trino.plugin.clickhouse.ClickHouseQueryRunner.createClickHouseQueryRunner;
 import static io.trino.plugin.clickhouse.TestingClickHouseServer.CLICKHOUSE_LATEST_IMAGE;
-import static io.trino.spi.type.TimestampType.createTimestampType;
 
 public class TestClickHouseLatestTypeMapping
         extends BaseClickHouseTypeMapping
@@ -30,59 +27,5 @@ public class TestClickHouseLatestTypeMapping
     {
         clickhouseServer = closeAfterClass(new TestingClickHouseServer(CLICKHOUSE_LATEST_IMAGE));
         return createClickHouseQueryRunner(clickhouseServer);
-    }
-
-    @DataProvider
-    @Override
-    public Object[][] clickHouseDateMinMaxValuesDataProvider()
-    {
-        // Override because the Date range was expanded in version 21.4 and later
-        return new Object[][] {
-                {"1970-01-01"}, // min value in ClickHouse
-                {"2149-06-06"}, // max value in ClickHouse
-        };
-    }
-
-    @DataProvider
-    @Override
-    public Object[][] unsupportedClickHouseDateValuesDataProvider()
-    {
-        // Override because the Date range was expanded in version 21.4 and later
-        return new Object[][] {
-                {"1969-12-31"}, // min - 1 day
-                {"2149-06-07"}, // max + 1 day
-        };
-    }
-
-    @Override
-    protected SqlDataTypeTest unsupportedTimestampBecomeUnexpectedValueTest(String inputType)
-    {
-        // Override because insert DateTime '1969-12-31 23:59:59' directly in ClickHouse will
-        // become '1970-01-01 00:00:00' in version 21.4 and later, however in versions prior
-        // to 21.4 the value will become '1970-01-01 23:59:59'.
-        return SqlDataTypeTest.create()
-                .addRoundTrip(inputType, "'1969-12-31 23:59:59'", createTimestampType(0), "TIMESTAMP '1970-01-01 00:00:00'");
-    }
-
-    @DataProvider
-    @Override
-    public Object[][] clickHouseDateTimeMinMaxValuesDataProvider()
-    {
-        // Override because the DateTime range was expanded in version 21.4 and later
-        return new Object[][] {
-                {"1970-01-01 00:00:00"}, // min value in ClickHouse
-                {"2106-02-07 06:28:15"}, // max value in ClickHouse
-        };
-    }
-
-    @DataProvider
-    @Override
-    public Object[][] unsupportedTimestampDataProvider()
-    {
-        // Override because the DateTime range was expanded in version 21.4 and later
-        return new Object[][] {
-                {"1969-12-31 23:59:59"}, // min - 1 second
-                {"2106-02-07 06:28:16"}, // max + 1 second
-        };
     }
 }

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseTypeMapping.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseTypeMapping.java
@@ -13,8 +13,6 @@
  */
 package io.trino.plugin.clickhouse;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.trino.testing.QueryRunner;
 
 import static io.trino.plugin.clickhouse.ClickHouseQueryRunner.createClickHouseQueryRunner;
@@ -27,11 +25,6 @@ public class TestClickHouseTypeMapping
             throws Exception
     {
         clickhouseServer = closeAfterClass(new TestingClickHouseServer());
-        return createClickHouseQueryRunner(clickhouseServer, ImmutableMap.of(),
-                ImmutableMap.<String, String>builder()
-                        .put("metadata.cache-ttl", "10m")
-                        .put("metadata.cache-missing", "true")
-                        .buildOrThrow(),
-                ImmutableList.of());
+        return createClickHouseQueryRunner(clickhouseServer);
     }
 }

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestingClickHouseServer.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestingClickHouseServer.java
@@ -31,7 +31,7 @@ public class TestingClickHouseServer
 {
     private static final DockerImageName CLICKHOUSE_IMAGE = DockerImageName.parse("yandex/clickhouse-server");
     public static final DockerImageName CLICKHOUSE_LATEST_IMAGE = CLICKHOUSE_IMAGE.withTag("21.11.10.1");
-    public static final DockerImageName CLICKHOUSE_DEFAULT_IMAGE = CLICKHOUSE_IMAGE.withTag("21.3.2.5"); // EOL is 30 Mar 2022
+    public static final DockerImageName CLICKHOUSE_DEFAULT_IMAGE = CLICKHOUSE_IMAGE.withTag("21.8.14.5"); // EOL is 31 Aug 2022
 
     private static final String CLICKHOUSE_LATEST_DRIVER_CLASS_NAME = "com.clickhouse.jdbc.ClickHouseDriver";
     // TODO: This Driver will not be available when clickhouse-jdbc is upgraded to 0.4.0 or above


### PR DESCRIPTION
## Description

Upgrade minimum supported version to 21.8 in ClickHouse 
Fixes #14112

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# ClickHouse
* Upgrade minimum supported version to 21.8. ({issue}`14112`)
```
