### PR TITLE
Add most properties to Identity's hashCode and equals

### DIFF
--- a/core/trino-main/src/test/java/io/trino/server/TestHttpRequestSessionContextFactory.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestHttpRequestSessionContextFactory.java
@@ -86,7 +86,14 @@ public class TestHttpRequestSessionContextFactory
         assertEquals(context.getCatalog().orElse(null), "testCatalog");
         assertEquals(context.getSchema().orElse(null), "testSchema");
         assertEquals(context.getPath().orElse(null), "testPath");
-        assertEquals(context.getIdentity(), Identity.ofUser("testUser"));
+        assertEquals(context.getIdentity(), Identity.forUser("testUser")
+                .withGroups(ImmutableSet.of("testUser"))
+                .withConnectorRoles(ImmutableMap.of(
+                        "foo_connector", new SelectedRole(SelectedRole.Type.ALL, Optional.empty()),
+                        "bar_connector", new SelectedRole(SelectedRole.Type.NONE, Optional.empty()),
+                        "foobar_connector", new SelectedRole(SelectedRole.Type.ROLE, Optional.of("catalog-role"))))
+                .withEnabledRoles(ImmutableSet.of("system-role"))
+                .build());
         assertEquals(context.getClientInfo().orElse(null), "client-info");
         assertEquals(context.getLanguage().orElse(null), "zh-TW");
         assertEquals(context.getTimeZoneId().orElse(null), "Asia/Taipei");
@@ -97,12 +104,7 @@ public class TestHttpRequestSessionContextFactory
                 "some_session_property", "some value with , comma"));
         assertEquals(context.getPreparedStatements(), ImmutableMap.of("query1", "select * from foo", "query2", "select * from bar"));
         assertEquals(context.getSelectedRole(), new SelectedRole(SelectedRole.Type.ROLE, Optional.of("system-role")));
-        assertEquals(context.getIdentity().getCatalogRoles(), ImmutableMap.of(
-                "foo_connector", new SelectedRole(SelectedRole.Type.ALL, Optional.empty()),
-                "bar_connector", new SelectedRole(SelectedRole.Type.NONE, Optional.empty()),
-                "foobar_connector", new SelectedRole(SelectedRole.Type.ROLE, Optional.of("catalog-role"))));
         assertEquals(context.getIdentity().getExtraCredentials(), ImmutableMap.of("test.token.foo", "bar", "test.token.abc", "xyz"));
-        assertEquals(context.getIdentity().getGroups(), ImmutableSet.of("testUser"));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestColumnMask.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestColumnMask.java
@@ -150,7 +150,7 @@ public class TestColumnMask
         runner.createCatalog(MOCK_CATALOG, mock, ImmutableMap.of());
 
         assertions = new QueryAssertions(runner);
-        accessControl = assertions.getQueryRunner().getAccessControl();
+        accessControl = runner.getAccessControl();
     }
 
     @AfterAll

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestColumnMask.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestColumnMask.java
@@ -15,6 +15,7 @@ package io.trino.sql.query;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
 import io.trino.connector.MockConnectorFactory;
 import io.trino.metadata.QualifiedObjectName;
@@ -56,13 +57,16 @@ public class TestColumnMask
     private static final String LOCAL_CATALOG = "local";
     private static final String MOCK_CATALOG = "mock";
     private static final String USER = "user";
+    private static final String USERROLE = "userrole";
     private static final String VIEW_OWNER = "view-owner";
     private static final String RUN_AS_USER = "run-as-user";
 
     private static final Session SESSION = testSessionBuilder()
             .setCatalog(LOCAL_CATALOG)
             .setSchema(TINY_SCHEMA_NAME)
-            .setIdentity(Identity.forUser(USER).build())
+            .setIdentity(Identity.forUser(USER)
+                    .withEnabledRoles(ImmutableSet.of(USERROLE))
+                    .build())
             .build();
 
     private QueryAssertions assertions;
@@ -169,6 +173,8 @@ public class TestColumnMask
                 "custkey",
                 USER,
                 new ViewExpression(USER, Optional.empty(), Optional.empty(), "-custkey"));
+        // ensure that the table referenced in the mask is registered with a proper Identity:
+        accessControl.denyIdentityTable((identity, tableName) -> identity.getEnabledRoles().contains(USERROLE));
         assertThat(assertions.query("SELECT custkey FROM orders WHERE orderkey = 1")).matches("VALUES BIGINT '-370'");
 
         accessControl.reset();
@@ -177,6 +183,8 @@ public class TestColumnMask
                 "custkey",
                 USER,
                 new ViewExpression(USER, Optional.empty(), Optional.empty(), "NULL"));
+        // ensure that the table referenced in the mask is registered with a proper Identity:
+        accessControl.denyIdentityTable((identity, tableName) -> identity.getEnabledRoles().contains(USERROLE));
         assertThat(assertions.query("SELECT custkey FROM orders WHERE orderkey = 1")).matches("VALUES CAST(NULL AS BIGINT)");
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestFilterInaccessibleColumns.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestFilterInaccessibleColumns.java
@@ -62,7 +62,7 @@ public class TestFilterInaccessibleColumns
 
         runner.createCatalog(TEST_CATALOG_NAME, new TpchConnectorFactory(1), ImmutableMap.of());
         assertions = new QueryAssertions(runner);
-        accessControl = assertions.getQueryRunner().getAccessControl();
+        accessControl = runner.getAccessControl();
     }
 
     @AfterClass(alwaysRun = true)

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestRowFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestRowFilter.java
@@ -140,7 +140,7 @@ public class TestRowFilter
         runner.createCatalog(MOCK_CATALOG_MISSING_COLUMNS, mockMissingColumns, ImmutableMap.of());
 
         assertions = new QueryAssertions(runner);
-        accessControl = assertions.getQueryRunner().getAccessControl();
+        accessControl = runner.getAccessControl();
     }
 
     @AfterAll

--- a/core/trino-spi/src/main/java/io/trino/spi/security/Identity.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/Identity.java
@@ -130,13 +130,17 @@ public class Identity
             return false;
         }
         Identity identity = (Identity) o;
-        return Objects.equals(user, identity.user);
+        return Objects.equals(user, identity.user) &&
+               Objects.equals(groups, identity.groups) &&
+               Objects.equals(principal, identity.principal) &&
+               Objects.equals(enabledRoles, identity.enabledRoles) &&
+               Objects.equals(catalogRoles, identity.catalogRoles);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(user);
+        return Objects.hash(user, groups, principal, enabledRoles, catalogRoles);
     }
 
     @Override

--- a/core/trino-spi/src/test/java/io/trino/spi/security/TestIdentity.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/security/TestIdentity.java
@@ -1,0 +1,84 @@
+package io.trino.spi.security;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+public class TestIdentity
+{
+    private static final Identity TEST_IDENTITY = Identity.forUser("user")
+            // part of identity:
+            .withPrincipal(new BasicPrincipal("principal"))
+            .withGroups(ImmutableSet.of("group1", "group2"))
+            .withEnabledRoles(ImmutableSet.of("role1", "role2"))
+            .withConnectorRoles(ImmutableMap.of(
+                    "connector1", new SelectedRole(SelectedRole.Type.ROLE, Optional.of("connector1role")),
+                    "connector2", new SelectedRole(SelectedRole.Type.ROLE, Optional.of("connector2role"))))
+            // not part of identity:
+            .withExtraCredentials(ImmutableMap.of("extra1", "credential1"))
+            .build();
+
+    @Test
+    public void testEquals()
+    {
+        Identity otherIdentity = Identity.from(TEST_IDENTITY)
+                // not part of identity:
+                .withExtraCredentials(ImmutableMap.of("extra2", "credential2"))
+                .build();
+
+        assertThat(otherIdentity)
+                .isEqualTo(TEST_IDENTITY);
+    }
+
+    @Test(dataProvider = "notEqualProvider")
+    public void testNotEquals(Identity otherIdentity)
+    {
+        assertThat(otherIdentity)
+                .isNotEqualTo(TEST_IDENTITY);
+    }
+
+    @DataProvider
+    public static Object[][] notEqualProvider()
+    {
+        return new Object[][]
+                {
+                        {Identity.from(TEST_IDENTITY).withPrincipal(new BasicPrincipal("other principal")).build()},
+                        {Identity.from(TEST_IDENTITY).withGroups(ImmutableSet.of("group2", "group3")).build()},
+                        {Identity.from(TEST_IDENTITY).withEnabledRoles(ImmutableSet.of("role2", "role3")).build()},
+                        {Identity.from(TEST_IDENTITY).withConnectorRoles(ImmutableMap.of(
+                                "connector2", new SelectedRole(SelectedRole.Type.ROLE, Optional.of("connector2role")),
+                                "connector3", new SelectedRole(SelectedRole.Type.ROLE, Optional.of("connector3role"))))
+                                .build()},
+                };
+    }
+
+    @Test
+    public void testHashCode()
+    {
+        Identity otherIdentity = Identity.from(TEST_IDENTITY)
+                // not part of identity:
+                .withExtraCredentials(ImmutableMap.of("extra2", "credential2"))
+                .build();
+
+        assertThat(otherIdentity.hashCode())
+                .isEqualTo(TEST_IDENTITY.hashCode());
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The rationale is that, in addition to the user name, all of these can affect access control decisions for an `Identity`, so they should be considered distinct if any of those attributes differ.

The `StatementAnalyzer`, during the analysis stage, collects all table references along with their corresponding access controls and identities. At the end of the analysis, this is used to do the access checks. They are collected in a `Map`, where the key is the pair of access control and `Identity`, so that we deduplicate the necessary checks. But for this deduplication to work properly, `Identity` instances that result in different accesses should be considered distinct.

In case of views, if we need to add and additional reference, we add it with a changed access control, so the key is properly deduplicated. But a table reference is also added for column masks and row filters. For these we get a `ViewExpression`, which contains only the user name. From that we have to construct a proper `Identity`. Previously it was entirely "synthetic" and included no roles; if the current session has roles enabled, this now makes it distinct. If, then, access to the table is granted for the role, not for the user, then that `Identity` will fail the access checks and the query will fail.

The simple trick to solve this is to return the session's `Identity` if the mask's or filter's user name is equal to the current session's user. A more proper solution would make access controls return a full `Identity` the same way it returns it for views with `SECURITY DEFINER`.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Fixing a possible source of bugs.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
