### PR TITLE
Lower Kafka ConsumerConfig log level

### DIFF
--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConsumerFactory.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConsumerFactory.java
@@ -15,14 +15,18 @@
 package io.trino.plugin.kafka;
 
 import io.trino.spi.connector.ConnectorSession;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 
 import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public interface KafkaConsumerFactory
 {
     default KafkaConsumer<byte[], byte[]> create(ConnectorSession session)
     {
+        Logger.getLogger(ConsumerConfig.class.getName()).setLevel(Level.WARNING);
         return new KafkaConsumer<>(configure(session));
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

`KafkaConsumer` logs `ConsumerConfig` via [`AbstractConfig`](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java#L121) on object creation and pollutes Trino logging.

This change lowers `ConsumerConfig` log level.

`AbstractConfig` has a constructor with `boolean doLog` but it's not exposed through `ConsumerConfig`. And there doesn't seem to be an easy way to configure `j.u.Logger` within a module. Airlift log-manager's has a [`Logging.setLevel`](https://github.com/airlift/airlift/blob/master/log-manager/src/main/java/io/airlift/log/Logging.java#L183) that might do the job but it's used tests only. Any idea why? 

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Make Kafka connector logging less verbose.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
