### PR TITLE
In CI use runner's JDK17 by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # checkout all commits, as the build result depends on `git describe` equivalent
+      # Unset the default Java in case actions/setup-java silently fails
+      - name: Unset default Java
+        run: echo "JAVA_HOME=" >> $GITHUB_ENV
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
@@ -94,6 +97,9 @@ jobs:
           fetch-depth: 0 # checkout all commits to be able to determine merge base for GIB
       - name: Fetch base ref to find merge-base for GIB
         run: .github/bin/git-fetch-base-ref.sh
+      # Unset the default Java in case actions/setup-java silently fails
+      - name: Unset default Java
+        run: echo "JAVA_HOME=" >> $GITHUB_ENV
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
@@ -133,6 +139,9 @@ jobs:
           fetch-depth: 0 # checkout tags so version in Manifest is set properly
       - name: Fetch base ref to find merge-base for GIB
         run: .github/bin/git-fetch-base-ref.sh
+      # Unset the default Java in case actions/setup-java silently fails
+      - name: Unset default Java
+        run: echo "JAVA_HOME=" >> $GITHUB_ENV
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
@@ -195,6 +204,9 @@ jobs:
           fetch-depth: 0 # checkout all commits to be able to determine merge base for GIB
       - name: Fetch base ref to find merge-base for GIB
         run: .github/bin/git-fetch-base-ref.sh
+      # Unset the default Java in case actions/setup-java silently fails
+      - name: Unset default Java
+        run: echo "JAVA_HOME=" >> $GITHUB_ENV
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
@@ -319,6 +331,9 @@ jobs:
           fetch-depth: 0 # checkout all commits to be able to determine merge base for GIB
       - name: Fetch base ref to find merge-base for GIB
         run: .github/bin/git-fetch-base-ref.sh
+      # Unset the default Java in case actions/setup-java silently fails
+      - name: Unset default Java
+        run: echo "JAVA_HOME=" >> $GITHUB_ENV
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
@@ -396,6 +411,9 @@ jobs:
           fetch-depth: 0 # checkout all commits to be able to determine merge base for GIB
       - name: Fetch base ref to find merge-base for GIB
         run: .github/bin/git-fetch-base-ref.sh
+      # Unset the default Java in case actions/setup-java silently fails
+      - name: Unset default Java
+        run: echo "JAVA_HOME=" >> $GITHUB_ENV
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,6 +49,9 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
+      # Unset the default Java in case actions/setup-java silently fails
+      - name: Unset default Java
+        run: echo "JAVA_HOME=" >> $GITHUB_ENV
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
@@ -79,6 +82,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # checkout all commits, as the build result depends on `git describe` equivalent
+      # Unset the default Java in case actions/setup-java silently fails
+      - name: Unset default Java
+        run: echo "JAVA_HOME=" >> $GITHUB_ENV
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Fixes #14141. This makes me wonder if we should be downloading the JDK at all. We could replace `actions/setup-java` with `actions/cache` (since we do use it implicitly for the local Maven repository).

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
