### PR TITLE
Lower number of max error retries for exchange spooling

### DIFF
--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
@@ -410,7 +410,7 @@ the property may be configured for:
    * - ``exchange.s3.max-error-retries``
      - Maximum number of times the exchange manager's S3 client should retry
        a request.
-     - ``10``
+     - ``3``
      - Any S3-compatible storage
    * - ``exchange.s3.upload.part-size``
      - Part size for S3 multi-part upload.
@@ -438,7 +438,7 @@ the property may be configured for:
    * - ``exchange.azure.max-error-retries``
      - Maximum number of times the exchange manager's Azure client should
        retry a request.
-     - ``10``
+     - ``4``
      - Azure Blob Storage
 
 It is recommended to set the ``exchange.compression-enabled`` property to

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/azure/ExchangeAzureConfig.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/azure/ExchangeAzureConfig.java
@@ -31,7 +31,7 @@ public class ExchangeAzureConfig
 {
     private Optional<String> azureStorageConnectionString = Optional.empty();
     private DataSize azureStorageBlockSize = DataSize.of(4, MEGABYTE);
-    private int maxErrorRetries = 10;
+    private int maxErrorRetries = 4;
 
     public Optional<String> getAzureStorageConnectionString()
     {

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/s3/ExchangeS3Config.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/s3/ExchangeS3Config.java
@@ -41,7 +41,7 @@ public class ExchangeS3Config
     private Optional<String> s3ExternalId = Optional.empty();
     private Optional<Region> s3Region = Optional.empty();
     private Optional<String> s3Endpoint = Optional.empty();
-    private int s3MaxErrorRetries = 10;
+    private int s3MaxErrorRetries = 3;
     // Default to S3 multi-part upload minimum size to avoid excessive memory consumption from buffering
     private DataSize s3UploadPartSize = DataSize.of(5, MEGABYTE);
     private StorageClass storageClass = StorageClass.STANDARD;

--- a/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/azure/TestExchangeAzureConfig.java
+++ b/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/azure/TestExchangeAzureConfig.java
@@ -32,7 +32,7 @@ public class TestExchangeAzureConfig
         assertRecordedDefaults(recordDefaults(ExchangeAzureConfig.class)
                 .setAzureStorageConnectionString(null)
                 .setAzureStorageBlockSize(DataSize.of(4, MEGABYTE))
-                .setMaxErrorRetries(10));
+                .setMaxErrorRetries(4));
     }
 
     @Test

--- a/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/s3/TestExchangeS3Config.java
+++ b/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/s3/TestExchangeS3Config.java
@@ -40,7 +40,7 @@ public class TestExchangeS3Config
                 .setS3ExternalId(null)
                 .setS3Region(null)
                 .setS3Endpoint(null)
-                .setS3MaxErrorRetries(10)
+                .setS3MaxErrorRetries(3)
                 .setS3UploadPartSize(DataSize.of(5, MEGABYTE))
                 .setStorageClass(StorageClass.STANDARD)
                 .setRetryMode(RetryMode.ADAPTIVE)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This lowers the default `max-error-retries` for exchange-spooling. Reason is, FTE already defaults to a maxRetries = 4, meaning it will try 5 times before it fails. `max-error-retries` is another layer of retry on the exchange storage, currently it's 10. This means if exchange storage is not configured correctly, Trino will retry 50 times before failing the query.

This PR lowers `max-error-retries` to the default values provided by the SDK --- 3 (for AWS/GCP) and 4 (for Azure).


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation
This will fail the query faster if exchange spooling is not configured correctly.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
