### PR TITLE
Allow for extension of `delta.security` access controls

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeAccessControlMetadataFactory.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeAccessControlMetadataFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.plugin.hive.security.AccessControlMetadata;
+
+public interface DeltaLakeAccessControlMetadataFactory
+{
+    DeltaLakeAccessControlMetadataFactory SYSTEM = metastore -> new AccessControlMetadata() {
+        @Override
+        public boolean isUsingSystemSecurity()
+        {
+            return true;
+        }
+    };
+    DeltaLakeAccessControlMetadataFactory DEFAULT = metastore -> new AccessControlMetadata() {};
+
+    AccessControlMetadata create(HiveMetastore metastore);
+}

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -55,9 +55,11 @@ import io.trino.plugin.hive.SchemaAlreadyExistsException;
 import io.trino.plugin.hive.TableAlreadyExistsException;
 import io.trino.plugin.hive.metastore.Column;
 import io.trino.plugin.hive.metastore.Database;
+import io.trino.plugin.hive.metastore.HivePrincipal;
 import io.trino.plugin.hive.metastore.PrincipalPrivileges;
 import io.trino.plugin.hive.metastore.StorageFormat;
 import io.trino.plugin.hive.metastore.Table;
+import io.trino.plugin.hive.security.AccessControlMetadata;
 import io.trino.spi.NodeManager;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
@@ -95,6 +97,9 @@ import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.expression.Variable;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.security.GrantInfo;
+import io.trino.spi.security.Privilege;
+import io.trino.spi.security.RoleGrant;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.statistics.ColumnStatisticMetadata;
 import io.trino.spi.statistics.ColumnStatisticType;
@@ -272,6 +277,7 @@ public class DeltaLakeMetadata
     private final TrinoFileSystemFactory fileSystemFactory;
     private final HdfsEnvironment hdfsEnvironment;
     private final TypeManager typeManager;
+    private final AccessControlMetadata accessControlMetadata;
     private final CheckpointWriterManager checkpointWriterManager;
     private final long defaultCheckpointInterval;
     private final int domainCompactionThreshold;
@@ -294,6 +300,7 @@ public class DeltaLakeMetadata
             TrinoFileSystemFactory fileSystemFactory,
             HdfsEnvironment hdfsEnvironment,
             TypeManager typeManager,
+            AccessControlMetadata accessControlMetadata,
             int domainCompactionThreshold,
             boolean unsafeWritesEnabled,
             JsonCodec<DataFileInfo> dataFileInfoCodec,
@@ -313,6 +320,7 @@ public class DeltaLakeMetadata
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.accessControlMetadata = requireNonNull(accessControlMetadata, "accessControlMetadata is null");
         this.domainCompactionThreshold = domainCompactionThreshold;
         this.unsafeWritesEnabled = unsafeWritesEnabled;
         this.dataFileInfoCodec = requireNonNull(dataFileInfoCodec, "dataFileInfoCodec is null");
@@ -2009,6 +2017,83 @@ public class DeltaLakeMetadata
         checkState(!schema.equals("information_schema") && !schema.equals("sys"), "Schema is not accessible: %s", schemaName);
         Optional<Database> db = metastore.getDatabase(schema);
         return db.map(DeltaLakeSchemaProperties::fromDatabase).orElseThrow(() -> new SchemaNotFoundException(schema));
+    }
+
+    @Override
+    public void createRole(ConnectorSession session, String role, Optional<TrinoPrincipal> grantor)
+    {
+        accessControlMetadata.createRole(session, role, grantor.map(HivePrincipal::from));
+    }
+
+    @Override
+    public void dropRole(ConnectorSession session, String role)
+    {
+        accessControlMetadata.dropRole(session, role);
+    }
+
+    @Override
+    public Set<String> listRoles(ConnectorSession session)
+    {
+        return accessControlMetadata.listRoles(session);
+    }
+
+    @Override
+    public Set<RoleGrant> listRoleGrants(ConnectorSession session, TrinoPrincipal principal)
+    {
+        return ImmutableSet.copyOf(accessControlMetadata.listRoleGrants(session, HivePrincipal.from(principal)));
+    }
+
+    @Override
+    public void grantRoles(ConnectorSession session, Set<String> roles, Set<TrinoPrincipal> grantees, boolean withAdminOption, Optional<TrinoPrincipal> grantor)
+    {
+        accessControlMetadata.grantRoles(session, roles, HivePrincipal.from(grantees), withAdminOption, grantor.map(HivePrincipal::from));
+    }
+
+    @Override
+    public void revokeRoles(ConnectorSession session, Set<String> roles, Set<TrinoPrincipal> grantees, boolean adminOptionFor, Optional<TrinoPrincipal> grantor)
+    {
+        accessControlMetadata.revokeRoles(session, roles, HivePrincipal.from(grantees), adminOptionFor, grantor.map(HivePrincipal::from));
+    }
+
+    @Override
+    public Set<RoleGrant> listApplicableRoles(ConnectorSession session, TrinoPrincipal principal)
+    {
+        return accessControlMetadata.listApplicableRoles(session, HivePrincipal.from(principal));
+    }
+
+    @Override
+    public Set<String> listEnabledRoles(ConnectorSession session)
+    {
+        return accessControlMetadata.listEnabledRoles(session);
+    }
+
+    @Override
+    public void grantTablePrivileges(ConnectorSession session, SchemaTableName schemaTableName, Set<Privilege> privileges, TrinoPrincipal grantee, boolean grantOption)
+    {
+        accessControlMetadata.grantTablePrivileges(session, schemaTableName, privileges, HivePrincipal.from(grantee), grantOption);
+    }
+
+    @Override
+    public void revokeTablePrivileges(ConnectorSession session, SchemaTableName schemaTableName, Set<Privilege> privileges, TrinoPrincipal grantee, boolean grantOption)
+    {
+        accessControlMetadata.revokeTablePrivileges(session, schemaTableName, privileges, HivePrincipal.from(grantee), grantOption);
+    }
+
+    @Override
+    public List<GrantInfo> listTablePrivileges(ConnectorSession session, SchemaTablePrefix schemaTablePrefix)
+    {
+        return accessControlMetadata.listTablePrivileges(session, listTables(session, schemaTablePrefix));
+    }
+
+    private List<SchemaTableName> listTables(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        if (prefix.getTable().isEmpty()) {
+            return listTables(session, prefix.getSchema());
+        }
+        SchemaTableName tableName = prefix.toSchemaTableName();
+        return metastore.getTable(tableName.getSchemaName(), tableName.getTableName())
+                .map(table -> ImmutableList.of(tableName))
+                .orElse(ImmutableList.of());
     }
 
     private void setRollback(Runnable action)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadataFactory.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadataFactory.java
@@ -41,6 +41,7 @@ public class DeltaLakeMetadataFactory
     private final HdfsEnvironment hdfsEnvironment;
     private final TransactionLogAccess transactionLogAccess;
     private final TypeManager typeManager;
+    private final DeltaLakeAccessControlMetadataFactory accessControlMetadataFactory;
     private final JsonCodec<DataFileInfo> dataFileInfoCodec;
     private final JsonCodec<DeltaLakeUpdateResult> updateResultJsonCodec;
     private final JsonCodec<DeltaLakeMergeResult> mergeResultJsonCodec;
@@ -65,6 +66,7 @@ public class DeltaLakeMetadataFactory
             HdfsEnvironment hdfsEnvironment,
             TransactionLogAccess transactionLogAccess,
             TypeManager typeManager,
+            DeltaLakeAccessControlMetadataFactory accessControlMetadataFactory,
             DeltaLakeConfig deltaLakeConfig,
             JsonCodec<DataFileInfo> dataFileInfoCodec,
             JsonCodec<DeltaLakeUpdateResult> updateResultJsonCodec,
@@ -81,6 +83,7 @@ public class DeltaLakeMetadataFactory
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.transactionLogAccess = requireNonNull(transactionLogAccess, "transactionLogAccess is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.accessControlMetadataFactory = requireNonNull(accessControlMetadataFactory, "accessControlMetadataFactory is null");
         this.dataFileInfoCodec = requireNonNull(dataFileInfoCodec, "dataFileInfoCodec is null");
         this.updateResultJsonCodec = requireNonNull(updateResultJsonCodec, "updateResultJsonCodec is null");
         this.mergeResultJsonCodec = requireNonNull(mergeResultJsonCodec, "mergeResultJsonCodec is null");
@@ -115,6 +118,7 @@ public class DeltaLakeMetadataFactory
                 fileSystemFactory,
                 hdfsEnvironment,
                 typeManager,
+                accessControlMetadataFactory.create(cachingHiveMetastore),
                 domainCompactionThreshold,
                 unsafeWritesEnabled,
                 dataFileInfoCodec,

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeModule.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeModule.java
@@ -78,6 +78,7 @@ import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.json.JsonCodecBinder.jsonCodecBinder;
+import static io.trino.plugin.deltalake.DeltaLakeAccessControlMetadataFactory.SYSTEM;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
@@ -96,7 +97,7 @@ public class DeltaLakeModule
         configBinder(binder).bindConfigDefaults(ParquetWriterConfig.class, config -> config.setParquetOptimizedWriterEnabled(true));
 
         install(new ConnectorAccessControlModule());
-        configBinder(binder).bindConfig(DeltaLakeSecurityConfig.class);
+        newOptionalBinder(binder, DeltaLakeAccessControlMetadataFactory.class).setDefault().toInstance(SYSTEM);
 
         Multibinder<SystemTableProvider> systemTableProviders = newSetBinder(binder, SystemTableProvider.class);
         systemTableProviders.addBinding().to(PropertiesSystemTableProvider.class).in(Scopes.SINGLETON);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSecurityConfig.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSecurityConfig.java
@@ -18,29 +18,21 @@ import io.airlift.configuration.ConfigDescription;
 
 import javax.validation.constraints.NotNull;
 
-import static io.trino.plugin.deltalake.DeltaLakeSecurityConfig.DeltaLakeSecurity.ALLOW_ALL;
+import static io.trino.plugin.deltalake.DeltaLakeSecurityModule.ALLOW_ALL;
 
 public class DeltaLakeSecurityConfig
 {
-    public enum DeltaLakeSecurity
-    {
-        ALLOW_ALL,
-        READ_ONLY,
-        SYSTEM,
-        FILE,
-    }
-
-    private DeltaLakeSecurity securitySystem = ALLOW_ALL;
+    private String securitySystem = ALLOW_ALL;
 
     @NotNull
-    public DeltaLakeSecurity getSecuritySystem()
+    public String getSecuritySystem()
     {
         return securitySystem;
     }
 
     @Config("delta.security")
     @ConfigDescription("Authorization checks for Delta Lake connector")
-    public DeltaLakeSecurityConfig setSecuritySystem(DeltaLakeSecurity securitySystem)
+    public DeltaLakeSecurityConfig setSecuritySystem(String securitySystem)
     {
         this.securitySystem = securitySystem;
         return this;

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSecurityModule.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSecurityModule.java
@@ -16,35 +16,53 @@ package io.trino.plugin.deltalake;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
-import io.trino.plugin.base.security.ConnectorAccessControlModule;
 import io.trino.plugin.base.security.FileBasedAccessControlModule;
 import io.trino.plugin.base.security.ReadOnlySecurityModule;
-import io.trino.plugin.deltalake.DeltaLakeSecurityConfig.DeltaLakeSecurity;
 import io.trino.plugin.hive.security.AllowAllSecurityModule;
 
+import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConditionalModule.conditionalModule;
-import static io.trino.plugin.deltalake.DeltaLakeSecurityConfig.DeltaLakeSecurity.ALLOW_ALL;
-import static io.trino.plugin.deltalake.DeltaLakeSecurityConfig.DeltaLakeSecurity.FILE;
-import static io.trino.plugin.deltalake.DeltaLakeSecurityConfig.DeltaLakeSecurity.READ_ONLY;
+import static io.airlift.configuration.ConfigurationAwareModule.combine;
+import static io.trino.plugin.deltalake.DeltaLakeAccessControlMetadataFactory.DEFAULT;
 
 public class DeltaLakeSecurityModule
         extends AbstractConfigurationAwareModule
 {
+    public static final String FILE = "file";
+    public static final String READ_ONLY = "read_only";
+    public static final String ALLOW_ALL = "allow_all";
+
     @Override
     protected void setup(Binder binder)
     {
-        install(new ConnectorAccessControlModule());
-        bindSecurityModule(ALLOW_ALL, new AllowAllSecurityModule());
-        bindSecurityModule(READ_ONLY, new ReadOnlySecurityModule());
-        bindSecurityModule(FILE, new FileBasedAccessControlModule());
+        bindSecurityModule(ALLOW_ALL, combine(
+                new AllowAllSecurityModule(),
+                new StaticAccessControlMetadataModule()));
+        bindSecurityModule(READ_ONLY, combine(
+                new ReadOnlySecurityModule(),
+                new StaticAccessControlMetadataModule()));
+        bindSecurityModule(FILE, combine(
+                new FileBasedAccessControlModule(),
+                new StaticAccessControlMetadataModule()));
         // SYSTEM: do not bind an ConnectorAccessControl so the engine will use system security with system roles
     }
 
-    private void bindSecurityModule(DeltaLakeSecurity deltaLakeSecurity, Module module)
+    protected void bindSecurityModule(String name, Module module)
     {
         install(conditionalModule(
                 DeltaLakeSecurityConfig.class,
-                security -> deltaLakeSecurity == security.getSecuritySystem(),
+                // imitate Airlift's enum matching
+                security -> name.equalsIgnoreCase(security.getSecuritySystem().replace("-", "_")),
                 module));
+    }
+
+    private static class StaticAccessControlMetadataModule
+            implements Module
+    {
+        @Override
+        public void configure(Binder binder)
+        {
+            newOptionalBinder(binder, DeltaLakeAccessControlMetadataFactory.class).setBinding().toInstance(DEFAULT);
+        }
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSecurityConfig.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSecurityConfig.java
@@ -21,8 +21,8 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
-import static io.trino.plugin.deltalake.DeltaLakeSecurityConfig.DeltaLakeSecurity.ALLOW_ALL;
-import static io.trino.plugin.deltalake.DeltaLakeSecurityConfig.DeltaLakeSecurity.READ_ONLY;
+import static io.trino.plugin.deltalake.DeltaLakeSecurityModule.ALLOW_ALL;
+import static io.trino.plugin.deltalake.DeltaLakeSecurityModule.READ_ONLY;
 
 public class TestDeltaLakeSecurityConfig
 {
@@ -37,7 +37,7 @@ public class TestDeltaLakeSecurityConfig
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
-                .put("delta.security", "read-only")
+                .put("delta.security", "read_only")
                 .buildOrThrow();
 
         DeltaLakeSecurityConfig expected = new DeltaLakeSecurityConfig()


### PR DESCRIPTION
## Description

Allow `delta.security` access control to be extended by:

- making `delta.security` configurations string-based instead of a enum-based (new)
- providing an interface to implement AccessControlMetadata (removed in #11779)

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
