### PR TITLE
trino parse time format adapt yyyy-MM-ddTHH:mm:ss 

### DIFF
--- a/core/trino-main/src/main/java/io/trino/type/DateTimes.java
+++ b/core/trino-main/src/main/java/io/trino/type/DateTimes.java
@@ -51,7 +51,7 @@ public final class DateTimes
 {
     public static final Pattern DATETIME_PATTERN = Pattern.compile("" +
             "(?<year>[-+]?\\d{4,})-(?<month>\\d{1,2})-(?<day>\\d{1,2})" +
-            "(?: (?<hour>\\d{1,2}):(?<minute>\\d{1,2})(?::(?<second>\\d{1,2})(?:\\.(?<fraction>\\d+))?)?)?" +
+            "(?:[T ](?<hour>\\d{1,2}):(?<minute>\\d{1,2})(?::(?<second>\\d{1,2})(?:\\.(?<fraction>\\d+))?)?)?" +
             "\\s*(?<timezone>.+)?");
     private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss");
 


### PR DESCRIPTION
DateTimes.class DATETIME_PATTERN and  add '[T ]' to  adapt uuuu-MM-ddTHH:mm:ss time format

## Description
now , I find trino can not correct parse time format like '1962-12-29T16:01:41'.
like this sql : select cast('1962-12-29T16:01:41' as timestamp); 
the correct result is 1962-12-29 16:01:41.000
but trino result 
![image](https://user-images.githubusercontent.com/30335632/190596354-597218e0-11c9-43fb-ad02-560da7c8b0ab.png)

 so I change class DateTimes.class to fix this bug
now we can get correct result 
![image](https://user-images.githubusercontent.com/30335632/190598445-14b2692f-5b25-4b8d-a8f0-557988f43028.png)
