### PR TITLE
Make PartitionedOutputOperator.finish() idempotent

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppenderPageBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppenderPageBuilder.java
@@ -98,10 +98,6 @@ public class PositionsAppenderPageBuilder
 
     public Page build()
     {
-        if (channelAppenders.length == 0) {
-            return new Page(declaredPositions);
-        }
-
         Block[] blocks = new Block[channelAppenders.length];
         for (int i = 0; i < blocks.length; i++) {
             blocks[i] = channelAppenders[i].build();


### PR DESCRIPTION
The PartitionedOutputOperator.finish() was not idempotent in the case when only position counter was tracked in
PositionsAppenderPageBuilder. This could result in wrong query results.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible and no release notes are required.
(x) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# General
* Fix bug which could manifest in wrong results for queries where all data scanned from tables 
  was processed in the leaf stage and was not passed for downstream. ({issue}`issuenumber`)
```
