### PR TITLE
Improve concurrency control in TestSystemConnector

### DIFF
--- a/testing/trino-tests/src/test/java/io/trino/connector/system/runtime/TestSystemConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/connector/system/runtime/TestSystemConnector.java
@@ -48,6 +48,7 @@ import static io.airlift.concurrent.Threads.threadsNamed;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.testing.assertions.Assert.assertEventually;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -234,12 +235,12 @@ public class TestSystemConnector
                 format("SELECT state FROM system.runtime.queries WHERE query LIKE '%%%s%%' AND query NOT LIKE '%%system.runtime.queries%%'", testQueryId),
                 "VALUES 'FINISHED'",
                 new Duration(10, SECONDS));
-        assertTrue(queryFuture.isDone());
+        // Client should receive query result immediately afterwards
+        assertEventually(new Duration(5, SECONDS), () -> assertTrue(queryFuture.isDone()));
     }
 
     @Test(timeOut = 60_000)
     public void testQueryKillingDuringAnalysis()
-            throws InterruptedException
     {
         SettableFuture<List<ColumnMetadata>> metadataFuture = SettableFuture.create();
         getColumns = schemaTableName -> {
@@ -260,7 +261,12 @@ public class TestSystemConnector
             getQueryRunner().execute(format("EXPLAIN SELECT 1 AS %s FROM test_table", testQueryId));
         });
 
-        Thread.sleep(100);
+        // Wait for query to start
+        assertQueryEventually(
+                getSession(),
+                format("SELECT count(*) FROM system.runtime.queries WHERE query LIKE '%%%s%%' AND query NOT LIKE '%%system.runtime.queries%%'", testQueryId),
+                "VALUES 1",
+                new Duration(5, SECONDS));
 
         Optional<Object> queryId = computeActual(format("SELECT query_id FROM system.runtime.queries WHERE query LIKE '%%%s%%' AND query NOT LIKE '%%system.runtime.queries%%'", testQueryId))
                 .getOnlyColumn()
@@ -270,10 +276,10 @@ public class TestSystemConnector
         assertTrue(queryId.isPresent());
 
         getQueryRunner().execute(format("CALL system.runtime.kill_query('%s', 'because')", queryId.get()));
-
-        Thread.sleep(100);
-        assertTrue(queryFuture.isDone());
-        assertTrue(metadataFuture.isCancelled());
+        // Cancellation should happen within kill_query, but it still needs to be propagated to the thread performing analysis.
+        assertEventually(new Duration(5, SECONDS), () -> assertTrue(metadataFuture.isCancelled()));
+        // Client should receive query result (failure) immediately afterwards
+        assertEventually(new Duration(5, SECONDS), () -> assertTrue(queryFuture.isDone()));
     }
 
     @Test


### PR DESCRIPTION
Fix a race in `testQueryDuringAnalysisIsCaptured`. The test waits until query is FINISHED, but the thread calling `getQueryRunner().execute` may not have finished yet, so the Future is not done.

Also, improve concurrency in `testQueryKillingDuringAnalysis`. Sleeps are not necessary to wait until query is started.

Hopefully fixes https://github.com/trinodb/trino/issues/14170