### PR TITLE
Add DECIMAL to VARCHAR coercion to hive

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
@@ -78,6 +78,7 @@ import static io.trino.plugin.hive.HiveType.HIVE_SHORT;
 import static io.trino.plugin.hive.coercions.DecimalCoercers.createDecimalToDecimalCoercer;
 import static io.trino.plugin.hive.coercions.DecimalCoercers.createDecimalToDoubleCoercer;
 import static io.trino.plugin.hive.coercions.DecimalCoercers.createDecimalToRealCoercer;
+import static io.trino.plugin.hive.coercions.DecimalCoercers.createDecimalToVarcharCoercer;
 import static io.trino.plugin.hive.coercions.DecimalCoercers.createDoubleToDecimalCoercer;
 import static io.trino.plugin.hive.coercions.DecimalCoercers.createRealToDecimalCoercer;
 import static io.trino.plugin.hive.util.HiveBucketing.getHiveBucket;
@@ -336,6 +337,9 @@ public class HivePageSource
         }
         if (fromType instanceof DecimalType && toType == REAL) {
             return Optional.of(createDecimalToRealCoercer((DecimalType) fromType));
+        }
+        if (fromType instanceof DecimalType && toType instanceof VarcharType) {
+            return Optional.of(createDecimalToVarcharCoercer((DecimalType) fromType, (VarcharType) toType));
         }
         if (fromType == DOUBLE && toType instanceof DecimalType) {
             return Optional.of(createDoubleToDecimalCoercer((DecimalType) toType));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/DecimalCoercers.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/DecimalCoercers.java
@@ -14,15 +14,19 @@
 
 package io.trino.plugin.hive.coercions;
 
+import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Decimals;
 import io.trino.spi.type.DoubleType;
 import io.trino.spi.type.Int128;
 import io.trino.spi.type.RealType;
+import io.trino.spi.type.VarcharType;
 
 import java.util.function.Function;
 
+import static io.trino.spi.StandardErrorCode.INVALID_ARGUMENTS;
 import static io.trino.spi.type.DecimalConversions.doubleToLongDecimal;
 import static io.trino.spi.type.DecimalConversions.doubleToShortDecimal;
 import static io.trino.spi.type.DecimalConversions.longDecimalToDouble;
@@ -38,6 +42,8 @@ import static io.trino.spi.type.DecimalConversions.shortToShortCast;
 import static io.trino.spi.type.Decimals.longTenToNth;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.RealType.REAL;
+import static java.lang.Math.min;
+import static java.lang.String.format;
 
 public final class DecimalCoercers
 {
@@ -225,6 +231,60 @@ public final class DecimalCoercers
         {
             toType.writeLong(blockBuilder,
                     longDecimalToReal((Int128) fromType.getObject(block, position), fromType.getScale()));
+        }
+    }
+
+    public static Function<Block, Block> createDecimalToVarcharCoercer(DecimalType fromType, VarcharType toType)
+    {
+        if (fromType.isShort()) {
+            return new ShortDecimalToVarcharCoercer(fromType, toType);
+        }
+        return new LongDecimalToVarcharCoercer(fromType, toType);
+    }
+
+    private static class ShortDecimalToVarcharCoercer
+            extends TypeCoercer<DecimalType, VarcharType>
+    {
+        private final int lengthLimit;
+
+        protected ShortDecimalToVarcharCoercer(DecimalType fromType, VarcharType toType)
+        {
+            super(fromType, toType);
+            this.lengthLimit = toType.getLength().orElse(Integer.MAX_VALUE);
+        }
+
+        @Override
+        protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+        {
+            String stringValue = Decimals.toString(fromType.getLong(block, position), fromType.getScale());
+            // Hive truncates digits (also before the decimal point), which can be perceived as a bug
+            if (stringValue.length() > lengthLimit) {
+                throw new TrinoException(INVALID_ARGUMENTS, format("Decimal value %s representation exceeds varchar(%s) bounds", stringValue, lengthLimit));
+            }
+            toType.writeString(blockBuilder, stringValue.substring(0, min(lengthLimit, stringValue.length())));
+        }
+    }
+
+    private static class LongDecimalToVarcharCoercer
+            extends TypeCoercer<DecimalType, VarcharType>
+    {
+        private final int lengthLimit;
+
+        protected LongDecimalToVarcharCoercer(DecimalType fromType, VarcharType toType)
+        {
+            super(fromType, toType);
+            this.lengthLimit = toType.getLength().orElse(Integer.MAX_VALUE);
+        }
+
+        @Override
+        protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+        {
+            String stringValue = Decimals.toString((Int128) fromType.getObject(block, position), fromType.getScale());
+            // Hive truncates digits (also before the decimal point), which can be perceived as a bug
+            if (stringValue.length() > lengthLimit) {
+                throw new TrinoException(INVALID_ARGUMENTS, format("Decimal value %s representation exceeds varchar(%s) bounds", stringValue, lengthLimit));
+            }
+            toType.writeString(blockBuilder, stringValue.substring(0, min(lengthLimit, stringValue.length())));
         }
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveCoercionPolicy.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveCoercionPolicy.java
@@ -61,7 +61,7 @@ public final class HiveCoercionPolicy
                     toHiveType.equals(HIVE_LONG);
         }
         if (toType instanceof VarcharType) {
-            return fromHiveType.equals(HIVE_BYTE) || fromHiveType.equals(HIVE_SHORT) || fromHiveType.equals(HIVE_INT) || fromHiveType.equals(HIVE_LONG);
+            return fromHiveType.equals(HIVE_BYTE) || fromHiveType.equals(HIVE_SHORT) || fromHiveType.equals(HIVE_INT) || fromHiveType.equals(HIVE_LONG) || fromType instanceof DecimalType;
         }
         if (fromHiveType.equals(HIVE_BYTE)) {
             return toHiveType.equals(HIVE_SHORT) || toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG);


### PR DESCRIPTION
## Description
Add DECIMAL to UNBOUNDED VARCHAR coercion to hive

## Non-technical explanation
This is intended to allow reading data from columns which type changed from decimal to string in hive. 

## Release notes

( ) This is not user-visible and no release notes are required.
( ) Release notes are required, please propose a release note for me.
() Release notes are required, with the following suggested text:

```markdown
# Section
* Allows reading columns which type was changed from decimal to string in hive. ({issue}`issuenumber`)
```
