### PR TITLE
Avoid cleaning up metadata files in case of AWS Glue failure

### DIFF
--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -418,6 +418,7 @@
                                 <exclude>**/TestSharedGlueMetastore.java</exclude>
                                 <exclude>**/TestIcebergGlueCatalogAccessOperations.java</exclude>
                                 <exclude>**/TestIcebergGlueCatalogMaterializedViewTest.java</exclude>
+                                <exclude>**/TestIcebergGlueTableOperationsInsertFailure.java</exclude>
                                 <exclude>**/TestIcebergGcsConnectorSmokeTest.java</exclude>
                             </excludes>
                         </configuration>
@@ -440,6 +441,7 @@
                                 <include>**/TestSharedGlueMetastore.java</include>
                                 <include>**/TestIcebergGlueCatalogAccessOperations.java</include>
                                 <include>**/TestIcebergGlueCatalogMaterializedViewTest.java</include>
+                                <include>**/TestIcebergGlueTableOperationsInsertFailure.java</include>
                                 <include>**/TestIcebergGcsConnectorSmokeTest.java</include>
                             </includes>
                         </configuration>

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/AWSGlueAsyncAdapterProvider.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/AWSGlueAsyncAdapterProvider.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.glue;
+
+import com.amazonaws.services.glue.AWSGlueAsync;
+
+public interface AWSGlueAsyncAdapterProvider
+{
+    AWSGlueAsync createAWSGlueAsyncAdapter(AWSGlueAsync delegate);
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueTableOperationsInsertFailure.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueTableOperationsInsertFailure.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.glue;
+
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.services.glue.AWSGlueAsync;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.log.Logger;
+import io.trino.Session;
+import io.trino.plugin.hive.metastore.Database;
+import io.trino.plugin.hive.metastore.glue.DefaultGlueColumnStatisticsProviderFactory;
+import io.trino.plugin.hive.metastore.glue.GlueHiveMetastore;
+import io.trino.plugin.hive.metastore.glue.GlueHiveMetastoreConfig;
+import io.trino.plugin.iceberg.TestingIcebergConnectorFactory;
+import io.trino.spi.security.PrincipalType;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.LocalQueryRunner;
+import org.apache.iceberg.exceptions.CommitStateUnknownException;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import static com.google.common.reflect.Reflection.newProxy;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static com.google.inject.util.Modules.EMPTY_MODULE;
+import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/*
+ * The test currently uses AWS Default Credential Provider Chain,
+ * See https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
+ * on ways to set your AWS credentials which will be needed to run this test.
+ */
+public class TestIcebergGlueTableOperationsInsertFailure
+        extends AbstractTestQueryFramework
+{
+    private static final Logger LOG = Logger.get(TestIcebergGlueTableOperationsInsertFailure.class);
+
+    private static final String ICEBERG_CATALOG = "iceberg";
+
+    private final String schemaName = "test_iceberg_glue_" + randomTableSuffix();
+
+    private GlueHiveMetastore glueHiveMetastore;
+
+    @Override
+    protected LocalQueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setCatalog(ICEBERG_CATALOG)
+                .setSchema(schemaName)
+                .build();
+        LocalQueryRunner queryRunner = LocalQueryRunner.create(session);
+
+        AWSGlueAsyncAdapterProvider awsGlueAsyncAdapterProvider = delegate -> newProxy(AWSGlueAsync.class, (proxy, method, methodArgs) -> {
+            Object result;
+            try {
+                result = method.invoke(delegate, methodArgs);
+            }
+            catch (InvocationTargetException e) {
+                throw e.getCause();
+            }
+            if (method.getName().equals("updateTable")) {
+                throw new RuntimeException("Test-simulated Glue timeout exception");
+            }
+            return result;
+        });
+
+        queryRunner.createCatalog(
+                ICEBERG_CATALOG,
+                new TestingIcebergConnectorFactory(Optional.of(new TestingIcebergGlueCatalogModule(awsGlueAsyncAdapterProvider)), Optional.empty(), EMPTY_MODULE),
+                ImmutableMap.of());
+
+        Path dataDirectory = Files.createTempDirectory("iceberg_data");
+        dataDirectory.toFile().deleteOnExit();
+
+        glueHiveMetastore = new GlueHiveMetastore(
+                HDFS_ENVIRONMENT,
+                new GlueHiveMetastoreConfig(),
+                DefaultAWSCredentialsProviderChain.getInstance(),
+                directExecutor(),
+                new DefaultGlueColumnStatisticsProviderFactory(directExecutor(), directExecutor()),
+                Optional.empty(),
+                table -> true);
+
+        Database database = Database.builder()
+                .setDatabaseName(schemaName)
+                .setOwnerName(Optional.of("public"))
+                .setOwnerType(Optional.of(PrincipalType.ROLE))
+                .setLocation(Optional.of(dataDirectory.toString()))
+                .build();
+        glueHiveMetastore.createDatabase(database);
+
+        return queryRunner;
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void cleanup()
+    {
+        try {
+            if (glueHiveMetastore != null) {
+                // Data is on the local disk and will be deleted by the deleteOnExit hook
+                glueHiveMetastore.dropDatabase(schemaName, false);
+            }
+        }
+        catch (Exception e) {
+            LOG.error(e, "Failed to clean up Glue database: %s", schemaName);
+        }
+    }
+
+    @Test
+    public void testInsertFailureDoesNotCorruptTheTableMetadata()
+    {
+        String tableName = "test_insert_failure" + randomTableSuffix();
+
+        getQueryRunner().execute(format("CREATE TABLE %s (a_varchar) AS VALUES ('Trino')", tableName));
+        assertThatThrownBy(() -> getQueryRunner().execute("INSERT INTO " + tableName + " VALUES 'rocks'"))
+                .isInstanceOf(CommitStateUnknownException.class)
+                .hasMessageContaining("Test-simulated Glue timeout exception");
+        assertQuery("SELECT * FROM " + tableName, "VALUES 'Trino', 'rocks'");
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestingGlueIcebergTableOperationsProvider.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestingGlueIcebergTableOperationsProvider.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.glue;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.glue.AWSGlueAsync;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.plugin.hive.metastore.glue.GlueHiveMetastoreConfig;
+import io.trino.plugin.hive.metastore.glue.GlueMetastoreStats;
+import io.trino.plugin.iceberg.catalog.IcebergTableOperations;
+import io.trino.plugin.iceberg.catalog.IcebergTableOperationsProvider;
+import io.trino.plugin.iceberg.catalog.TrinoCatalog;
+import io.trino.spi.connector.ConnectorSession;
+
+import javax.inject.Inject;
+
+import java.util.Optional;
+
+import static io.trino.plugin.hive.metastore.glue.GlueHiveMetastore.createAsyncGlueClient;
+import static java.util.Objects.requireNonNull;
+
+public class TestingGlueIcebergTableOperationsProvider
+        implements IcebergTableOperationsProvider
+{
+    private final TrinoFileSystemFactory fileSystemFactory;
+    private final AWSGlueAsync glueClient;
+    private final GlueMetastoreStats stats;
+
+    @Inject
+    public TestingGlueIcebergTableOperationsProvider(
+            TrinoFileSystemFactory fileSystemFactory,
+            GlueMetastoreStats stats,
+            GlueHiveMetastoreConfig glueConfig,
+            AWSCredentialsProvider credentialsProvider,
+            AWSGlueAsyncAdapterProvider awsGlueAsyncAdapterProvider)
+    {
+        this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
+        this.stats = requireNonNull(stats, "stats is null");
+        requireNonNull(glueConfig, "glueConfig is null");
+        requireNonNull(credentialsProvider, "credentialsProvider is null");
+        requireNonNull(awsGlueAsyncAdapterProvider, "awsGlueAsyncAdapterProvider is null");
+        this.glueClient = awsGlueAsyncAdapterProvider.createAWSGlueAsyncAdapter(
+                createAsyncGlueClient(glueConfig, credentialsProvider, Optional.empty(), stats.newRequestMetricsCollector()));
+    }
+
+    @Override
+    public IcebergTableOperations createTableOperations(
+            TrinoCatalog catalog,
+            ConnectorSession session,
+            String database,
+            String table,
+            Optional<String> owner,
+            Optional<String> location)
+    {
+        return new GlueIcebergTableOperations(
+                glueClient,
+                stats,
+                fileSystemFactory.create(session).toFileIo(),
+                session,
+                database,
+                table,
+                owner,
+                location);
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestingIcebergGlueCatalogModule.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestingIcebergGlueCatalogModule.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.glue;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.google.inject.Binder;
+import com.google.inject.Scopes;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.plugin.hive.metastore.glue.GlueCredentialsProvider;
+import io.trino.plugin.hive.metastore.glue.GlueHiveMetastoreConfig;
+import io.trino.plugin.hive.metastore.glue.GlueMetastoreStats;
+import io.trino.plugin.iceberg.catalog.IcebergTableOperationsProvider;
+import io.trino.plugin.iceberg.catalog.TrinoCatalogFactory;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static java.util.Objects.requireNonNull;
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
+
+public class TestingIcebergGlueCatalogModule
+        extends AbstractConfigurationAwareModule
+{
+    private final AWSGlueAsyncAdapterProvider awsGlueAsyncAdapterProvider;
+
+    public TestingIcebergGlueCatalogModule(AWSGlueAsyncAdapterProvider awsGlueAsyncAdapterProvider)
+    {
+        this.awsGlueAsyncAdapterProvider = requireNonNull(awsGlueAsyncAdapterProvider, "awsGlueAsyncAdapterProvider is null");
+    }
+
+    @Override
+    protected void setup(Binder binder)
+    {
+        configBinder(binder).bindConfig(GlueHiveMetastoreConfig.class);
+        binder.bind(GlueMetastoreStats.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(GlueMetastoreStats.class).withGeneratedName();
+        binder.bind(AWSCredentialsProvider.class).toProvider(GlueCredentialsProvider.class).in(Scopes.SINGLETON);
+        binder.bind(IcebergTableOperationsProvider.class).to(TestingGlueIcebergTableOperationsProvider.class).in(Scopes.SINGLETON);
+        binder.bind(TrinoCatalogFactory.class).to(TrinoGlueCatalogFactory.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(TrinoCatalogFactory.class).withGeneratedName();
+        binder.bind(AWSGlueAsyncAdapterProvider.class).toInstance(awsGlueAsyncAdapterProvider);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This is a follow-up of https://github.com/trinodb/trino/pull/14118

In case of dealing with an `RuntimeException` while commiting an Iceberg transaction, the Iceberg framework will clean up the metadata file corresponding to the transaction. In case of a metastore client timeout operation the Iceberg library can therefore delete metadata files which eventually get referenced from the configuration of the table persisted on the metastore for the table which leaves the table in a corrupt state.

Throw `CommitStateUnknownException` when dealing
with AWS Glue exceptions to ensure that the
table is not left in a corrupt state after the erroneous completion of the DML operation.



<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Avoid deleting metadata files in case of a Glue operation failure because these files may eventually get referenced from the AWS Glue metastore configuration of the Iceberg table.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Avoid cleaning up metadata files in case of AWS Glue failure
```
