### PR TITLE
Plan table function invocation with table arguments

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
@@ -47,6 +47,7 @@ import io.trino.sql.planner.plan.AggregationNode;
 import io.trino.sql.planner.plan.AggregationNode.Aggregation;
 import io.trino.sql.planner.plan.AssignUniqueId;
 import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.planner.plan.DeleteNode;
 import io.trino.sql.planner.plan.FilterNode;
 import io.trino.sql.planner.plan.GroupIdNode;
@@ -328,7 +329,7 @@ class QueryPlanner
         WindowNode windowNode = new WindowNode(
                 idAllocator.getNextId(),
                 checkConvergenceStep.getNode(),
-                new WindowNode.Specification(ImmutableList.of(), Optional.empty()),
+                new DataOrganizationSpecification(ImmutableList.of(), Optional.empty()),
                 ImmutableMap.of(countSymbol, countFunction),
                 Optional.empty(),
                 ImmutableSet.of(),
@@ -1829,7 +1830,7 @@ class QueryPlanner
             }
         }
 
-        WindowNode.Specification specification = planWindowSpecification(window.getPartitionBy(), window.getOrderBy(), coercions::get);
+        DataOrganizationSpecification specification = planWindowSpecification(window.getPartitionBy(), window.getOrderBy(), coercions::get);
 
         // Rewrite frame bounds in terms of pre-projected inputs
         WindowNode.Frame frame = new WindowNode.Frame(
@@ -1882,7 +1883,7 @@ class QueryPlanner
             PlanAndMappings coercions,
             Optional<Symbol> frameEndSymbol)
     {
-        WindowNode.Specification specification = planWindowSpecification(window.getPartitionBy(), window.getOrderBy(), coercions::get);
+        DataOrganizationSpecification specification = planWindowSpecification(window.getPartitionBy(), window.getOrderBy(), coercions::get);
 
         // in window frame with pattern recognition, the frame extent is specified as `ROWS BETWEEN CURRENT ROW AND ... `
         WindowFrame frame = window.getFrame().orElseThrow();
@@ -1949,7 +1950,7 @@ class QueryPlanner
                         components.getVariableDefinitions()));
     }
 
-    public static WindowNode.Specification planWindowSpecification(List<Expression> partitionBy, Optional<OrderBy> orderBy, Function<Expression, Symbol> expressionRewrite)
+    public static DataOrganizationSpecification planWindowSpecification(List<Expression> partitionBy, Optional<OrderBy> orderBy, Function<Expression, Symbol> expressionRewrite)
     {
         // Rewrite PARTITION BY
         ImmutableList.Builder<Symbol> partitionBySymbols = ImmutableList.builder();
@@ -1970,7 +1971,7 @@ class QueryPlanner
             orderingScheme = Optional.of(new OrderingScheme(ImmutableList.copyOf(orderings.keySet()), orderings));
         }
 
-        return new WindowNode.Specification(partitionBySymbols.build(), orderingScheme);
+        return new DataOrganizationSpecification(partitionBySymbols.build(), orderingScheme);
     }
 
     private PlanBuilder planWindowMeasures(Node node, PlanBuilder subPlan, List<WindowOperation> windowMeasures)
@@ -2031,7 +2032,7 @@ class QueryPlanner
             ResolvedWindow window,
             Optional<Symbol> frameEndSymbol)
     {
-        WindowNode.Specification specification = planWindowSpecification(window.getPartitionBy(), window.getOrderBy(), subPlan::translate);
+        DataOrganizationSpecification specification = planWindowSpecification(window.getPartitionBy(), window.getOrderBy(), subPlan::translate);
 
         // in window frame with pattern recognition, the frame extent is specified as `ROWS BETWEEN CURRENT ROW AND ... `
         WindowFrame frame = window.getFrame().orElseThrow();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
@@ -1414,7 +1414,7 @@ class QueryPlanner
                 .collect(toImmutableList());
     }
 
-    private static OrderingScheme translateOrderingScheme(List<SortItem> items, Function<Expression, Symbol> coercions)
+    public static OrderingScheme translateOrderingScheme(List<SortItem> items, Function<Expression, Symbol> coercions)
     {
         List<Symbol> coerced = items.stream()
                 .map(SortItem::getSortKey)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
@@ -34,6 +34,7 @@ import io.trino.sql.analyzer.RelationType;
 import io.trino.sql.analyzer.Scope;
 import io.trino.sql.planner.plan.Assignments;
 import io.trino.sql.planner.plan.CorrelatedJoinNode;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.planner.plan.ExceptNode;
 import io.trino.sql.planner.plan.FilterNode;
 import io.trino.sql.planner.plan.IntersectNode;
@@ -49,7 +50,6 @@ import io.trino.sql.planner.plan.TableScanNode;
 import io.trino.sql.planner.plan.UnionNode;
 import io.trino.sql.planner.plan.UnnestNode;
 import io.trino.sql.planner.plan.ValuesNode;
-import io.trino.sql.planner.plan.WindowNode;
 import io.trino.sql.planner.rowpattern.LogicalIndexExtractor;
 import io.trino.sql.planner.rowpattern.LogicalIndexExtractor.ExpressionAndValuePointers;
 import io.trino.sql.planner.rowpattern.RowPatternToIrRewriter;
@@ -416,7 +416,7 @@ class RelationPlanner
         ImmutableList.Builder<Symbol> outputLayout = ImmutableList.builder();
         boolean oneRowOutput = node.getRowsPerMatch().isEmpty() || node.getRowsPerMatch().get().isOneRow();
 
-        WindowNode.Specification specification = planWindowSpecification(node.getPartitionBy(), node.getOrderBy(), planBuilder::translate);
+        DataOrganizationSpecification specification = planWindowSpecification(node.getPartitionBy(), node.getOrderBy(), planBuilder::translate);
         outputLayout.addAll(specification.getPartitionBy());
         if (!oneRowOutput) {
             getSortItemsFromOrderBy(node.getOrderBy()).stream()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DecorrelateUnnest.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DecorrelateUnnest.java
@@ -30,6 +30,7 @@ import io.trino.sql.planner.optimizations.PlanNodeSearcher;
 import io.trino.sql.planner.plan.AssignUniqueId;
 import io.trino.sql.planner.plan.Assignments;
 import io.trino.sql.planner.plan.CorrelatedJoinNode;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.planner.plan.EnforceSingleRowNode;
 import io.trino.sql.planner.plan.FilterNode;
 import io.trino.sql.planner.plan.JoinNode.Type;
@@ -41,7 +42,6 @@ import io.trino.sql.planner.plan.RowNumberNode;
 import io.trino.sql.planner.plan.TopNNode;
 import io.trino.sql.planner.plan.UnnestNode;
 import io.trino.sql.planner.plan.WindowNode;
-import io.trino.sql.planner.plan.WindowNode.Specification;
 import io.trino.sql.tree.Cast;
 import io.trino.sql.tree.ComparisonExpression;
 import io.trino.sql.tree.Expression;
@@ -473,7 +473,7 @@ public class DecorrelateUnnest
             WindowNode windowNode = new WindowNode(
                     idAllocator.getNextId(),
                     source.getPlan(),
-                    new Specification(ImmutableList.of(uniqueSymbol), Optional.of(node.getOrderingScheme())),
+                    new DataOrganizationSpecification(ImmutableList.of(uniqueSymbol), Optional.of(node.getOrderingScheme())),
                     ImmutableMap.of(rowNumberSymbol, rowNumberFunction),
                     Optional.empty(),
                     ImmutableSet.of(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ImplementLimitWithTies.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ImplementLimitWithTies.java
@@ -26,6 +26,7 @@ import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.SymbolAllocator;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.planner.plan.FilterNode;
 import io.trino.sql.planner.plan.LimitNode;
 import io.trino.sql.planner.plan.PlanNode;
@@ -128,7 +129,7 @@ public class ImplementLimitWithTies
         WindowNode windowNode = new WindowNode(
                 idAllocator.getNextId(),
                 source,
-                new WindowNode.Specification(partitionBy, limitNode.getTiesResolvingScheme()),
+                new DataOrganizationSpecification(partitionBy, limitNode.getTiesResolvingScheme()),
                 ImmutableMap.of(rankSymbol, rankFunction),
                 Optional.empty(),
                 ImmutableSet.of(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferencesThroughTopNRanking.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferencesThroughTopNRanking.java
@@ -23,9 +23,9 @@ import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.TypeAnalyzer;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.planner.plan.ProjectNode;
 import io.trino.sql.planner.plan.TopNRankingNode;
-import io.trino.sql.planner.plan.WindowNode;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.SubscriptExpression;
 import io.trino.sql.tree.SymbolReference;
@@ -89,7 +89,7 @@ public class PushDownDereferencesThroughTopNRanking
         Set<SubscriptExpression> dereferences = extractRowSubscripts(projectNode.getAssignments().getExpressions(), false, context.getSession(), typeAnalyzer, context.getSymbolAllocator().getTypes());
 
         // Exclude dereferences on symbols being used in partitionBy and orderBy
-        WindowNode.Specification specification = topNRankingNode.getSpecification();
+        DataOrganizationSpecification specification = topNRankingNode.getSpecification();
         dereferences = dereferences.stream()
                 .filter(expression -> {
                     Symbol symbol = getBase(expression);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferencesThroughWindow.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferencesThroughWindow.java
@@ -23,6 +23,7 @@ import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.TypeAnalyzer;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.planner.plan.ProjectNode;
 import io.trino.sql.planner.plan.WindowNode;
 import io.trino.sql.tree.Expression;
@@ -99,7 +100,7 @@ public class PushDownDereferencesThroughWindow
                 typeAnalyzer,
                 context.getSymbolAllocator().getTypes());
 
-        WindowNode.Specification specification = windowNode.getSpecification();
+        DataOrganizationSpecification specification = windowNode.getSpecification();
         dereferences = dereferences.stream()
                 .filter(expression -> {
                     Symbol symbol = getBase(expression);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SetOperationNodeTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SetOperationNodeTranslator.java
@@ -26,12 +26,12 @@ import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.SymbolAllocator;
 import io.trino.sql.planner.plan.AggregationNode;
 import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.ProjectNode;
 import io.trino.sql.planner.plan.SetOperationNode;
 import io.trino.sql.planner.plan.UnionNode;
 import io.trino.sql.planner.plan.WindowNode;
-import io.trino.sql.planner.plan.WindowNode.Specification;
 import io.trino.sql.tree.Cast;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.NullLiteral;
@@ -210,7 +210,7 @@ public class SetOperationNodeTranslator
         return new WindowNode(
                 idAllocator.getNextId(),
                 sourceNode,
-                new Specification(originalColumns, Optional.empty()),
+                new DataOrganizationSpecification(originalColumns, Optional.empty()),
                 functions.buildOrThrow(),
                 Optional.empty(),
                 ImmutableSet.of(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PlanNodeDecorrelator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PlanNodeDecorrelator.java
@@ -34,6 +34,7 @@ import io.trino.sql.planner.iterative.GroupReference;
 import io.trino.sql.planner.iterative.Lookup;
 import io.trino.sql.planner.plan.AggregationNode;
 import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.planner.plan.EnforceSingleRowNode;
 import io.trino.sql.planner.plan.FilterNode;
 import io.trino.sql.planner.plan.LimitNode;
@@ -44,7 +45,6 @@ import io.trino.sql.planner.plan.ProjectNode;
 import io.trino.sql.planner.plan.RowNumberNode;
 import io.trino.sql.planner.plan.TopNNode;
 import io.trino.sql.planner.plan.TopNRankingNode;
-import io.trino.sql.planner.plan.WindowNode.Specification;
 import io.trino.sql.tree.Cast;
 import io.trino.sql.tree.ComparisonExpression;
 import io.trino.sql.tree.Expression;
@@ -336,7 +336,7 @@ public class PlanNodeDecorrelator
                         TopNRankingNode topNRankingNode = new TopNRankingNode(
                                 node.getId(),
                                 decorrelatedChildNode,
-                                new Specification(
+                                new DataOrganizationSpecification(
                                         ImmutableList.copyOf(childDecorrelationResult.symbolsToPropagate),
                                         Optional.of(orderingScheme)),
                                 ROW_NUMBER,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SymbolMapper.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SymbolMapper.java
@@ -240,7 +240,7 @@ public class SymbolMapper
                 frame.getOriginalEndValue());
     }
 
-    private DataOrganizationSpecification mapAndDistinct(DataOrganizationSpecification specification)
+    public DataOrganizationSpecification mapAndDistinct(DataOrganizationSpecification specification)
     {
         return new DataOrganizationSpecification(
                 mapAndDistinct(specification.getPartitionBy()),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SymbolMapper.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SymbolMapper.java
@@ -22,6 +22,7 @@ import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.SymbolAllocator;
 import io.trino.sql.planner.plan.AggregationNode;
 import io.trino.sql.planner.plan.AggregationNode.Aggregation;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.planner.plan.DistinctLimitNode;
 import io.trino.sql.planner.plan.GroupIdNode;
 import io.trino.sql.planner.plan.LimitNode;
@@ -239,9 +240,9 @@ public class SymbolMapper
                 frame.getOriginalEndValue());
     }
 
-    private WindowNode.Specification mapAndDistinct(WindowNode.Specification specification)
+    private DataOrganizationSpecification mapAndDistinct(DataOrganizationSpecification specification)
     {
-        return new WindowNode.Specification(
+        return new DataOrganizationSpecification(
                 mapAndDistinct(specification.getPartitionBy()),
                 specification.getOrderingScheme().map(this::map));
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/DataOrganizationSpecification.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/DataOrganizationSpecification.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.plan;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import io.trino.sql.planner.OrderingScheme;
+import io.trino.sql.planner.Symbol;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class DataOrganizationSpecification
+{
+    private final List<Symbol> partitionBy;
+    private final Optional<OrderingScheme> orderingScheme;
+
+    @JsonCreator
+    public DataOrganizationSpecification(
+            @JsonProperty("partitionBy") List<Symbol> partitionBy,
+            @JsonProperty("orderingScheme") Optional<OrderingScheme> orderingScheme)
+    {
+        requireNonNull(partitionBy, "partitionBy is null");
+        requireNonNull(orderingScheme, "orderingScheme is null");
+
+        this.partitionBy = ImmutableList.copyOf(partitionBy);
+        this.orderingScheme = requireNonNull(orderingScheme, "orderingScheme is null");
+    }
+
+    @JsonProperty
+    public List<Symbol> getPartitionBy()
+    {
+        return partitionBy;
+    }
+
+    @JsonProperty
+    public Optional<OrderingScheme> getOrderingScheme()
+    {
+        return orderingScheme;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(partitionBy, orderingScheme);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        DataOrganizationSpecification other = (DataOrganizationSpecification) obj;
+
+        return Objects.equals(this.partitionBy, other.partitionBy) &&
+                Objects.equals(this.orderingScheme, other.orderingScheme);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/PatternRecognitionNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/PatternRecognitionNode.java
@@ -23,7 +23,6 @@ import io.trino.spi.type.Type;
 import io.trino.sql.planner.OrderingScheme;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.plan.WindowNode.Frame;
-import io.trino.sql.planner.plan.WindowNode.Specification;
 import io.trino.sql.planner.rowpattern.LogicalIndexExtractor.ExpressionAndValuePointers;
 import io.trino.sql.planner.rowpattern.ir.IrLabel;
 import io.trino.sql.planner.rowpattern.ir.IrRowPattern;
@@ -52,7 +51,7 @@ public class PatternRecognitionNode
         extends PlanNode
 {
     private final PlanNode source;
-    private final Specification specification;
+    private final DataOrganizationSpecification specification;
     private final Optional<Symbol> hashSymbol;
     private final Set<Symbol> prePartitionedInputs;
     private final int preSortedOrderPrefix;
@@ -81,7 +80,7 @@ public class PatternRecognitionNode
     public PatternRecognitionNode(
             @JsonProperty("id") PlanNodeId id,
             @JsonProperty("source") PlanNode source,
-            @JsonProperty("specification") Specification specification,
+            @JsonProperty("specification") DataOrganizationSpecification specification,
             @JsonProperty("hashSymbol") Optional<Symbol> hashSymbol,
             @JsonProperty("prePartitionedInputs") Set<Symbol> prePartitionedInputs,
             @JsonProperty("preSortedOrderPrefix") int preSortedOrderPrefix,
@@ -173,7 +172,7 @@ public class PatternRecognitionNode
     }
 
     @JsonProperty
-    public Specification getSpecification()
+    public DataOrganizationSpecification getSpecification()
     {
         return specification;
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableFunctionNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableFunctionNode.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.metadata.TableFunctionHandle;
 import io.trino.spi.ptf.Argument;
 import io.trino.sql.planner.Symbol;
-import io.trino.sql.planner.plan.WindowNode.Specification;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -122,14 +121,14 @@ public class TableFunctionNode
         private final boolean rowSemantics;
         private final boolean pruneWhenEmpty;
         private final boolean passThroughColumns;
-        private final Specification specification;
+        private final DataOrganizationSpecification specification;
 
         @JsonCreator
         public TableArgumentProperties(
                 @JsonProperty("rowSemantics") boolean rowSemantics,
                 @JsonProperty("pruneWhenEmpty") boolean pruneWhenEmpty,
                 @JsonProperty("passThroughColumns") boolean passThroughColumns,
-                @JsonProperty("specification") Specification specification)
+                @JsonProperty("specification") DataOrganizationSpecification specification)
         {
             this.rowSemantics = rowSemantics;
             this.pruneWhenEmpty = pruneWhenEmpty;
@@ -156,7 +155,7 @@ public class TableFunctionNode
         }
 
         @JsonProperty
-        public Specification getSpecification()
+        public DataOrganizationSpecification getSpecification()
         {
             return specification;
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableFunctionNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableFunctionNode.java
@@ -15,6 +15,8 @@ package io.trino.sql.planner.plan;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.trino.metadata.TableFunctionHandle;
 import io.trino.spi.ptf.Argument;
 import io.trino.sql.planner.Symbol;
@@ -51,10 +53,10 @@ public class TableFunctionNode
     {
         super(id);
         this.name = requireNonNull(name, "name is null");
-        this.arguments = requireNonNull(arguments, "arguments is null");
-        this.properOutputs = requireNonNull(properOutputs, "properOutputs is null");
-        this.sources = requireNonNull(sources, "sources is null");
-        this.tableArgumentProperties = requireNonNull(tableArgumentProperties, "tableArgumentProperties is null");
+        this.arguments = ImmutableMap.copyOf(arguments);
+        this.properOutputs = ImmutableList.copyOf(properOutputs);
+        this.sources = ImmutableList.copyOf(sources);
+        this.tableArgumentProperties = ImmutableList.copyOf(tableArgumentProperties);
         this.handle = requireNonNull(handle, "handle is null");
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/TopNRankingNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/TopNRankingNode.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import io.trino.sql.planner.OrderingScheme;
 import io.trino.sql.planner.Symbol;
-import io.trino.sql.planner.plan.WindowNode.Specification;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -42,7 +41,7 @@ public final class TopNRankingNode
     }
 
     private final PlanNode source;
-    private final Specification specification;
+    private final DataOrganizationSpecification specification;
     private final RankingType rankingType;
     private final Symbol rankingSymbol;
     private final int maxRankingPerPartition;
@@ -53,7 +52,7 @@ public final class TopNRankingNode
     public TopNRankingNode(
             @JsonProperty("id") PlanNodeId id,
             @JsonProperty("source") PlanNode source,
-            @JsonProperty("specification") Specification specification,
+            @JsonProperty("specification") DataOrganizationSpecification specification,
             @JsonProperty("rankingType") RankingType rankingType,
             @JsonProperty("rankingSymbol") Symbol rankingSymbol,
             @JsonProperty("maxRankingPerPartition") int maxRankingPerPartition,
@@ -101,7 +100,7 @@ public final class TopNRankingNode
     }
 
     @JsonProperty
-    public Specification getSpecification()
+    public DataOrganizationSpecification getSpecification()
     {
         return specification;
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/WindowNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/WindowNode.java
@@ -48,7 +48,7 @@ public class WindowNode
 {
     private final PlanNode source;
     private final Set<Symbol> prePartitionedInputs;
-    private final Specification specification;
+    private final DataOrganizationSpecification specification;
     private final int preSortedOrderPrefix;
     private final Map<Symbol, Function> windowFunctions;
     private final Optional<Symbol> hashSymbol;
@@ -57,7 +57,7 @@ public class WindowNode
     public WindowNode(
             @JsonProperty("id") PlanNodeId id,
             @JsonProperty("source") PlanNode source,
-            @JsonProperty("specification") Specification specification,
+            @JsonProperty("specification") DataOrganizationSpecification specification,
             @JsonProperty("windowFunctions") Map<Symbol, Function> windowFunctions,
             @JsonProperty("hashSymbol") Optional<Symbol> hashSymbol,
             @JsonProperty("prePartitionedInputs") Set<Symbol> prePartitionedInputs,
@@ -111,7 +111,7 @@ public class WindowNode
     }
 
     @JsonProperty
-    public Specification getSpecification()
+    public DataOrganizationSpecification getSpecification()
     {
         return specification;
     }
@@ -123,7 +123,7 @@ public class WindowNode
 
     public Optional<OrderingScheme> getOrderingScheme()
     {
-        return specification.orderingScheme;
+        return specification.getOrderingScheme();
     }
 
     @JsonProperty
@@ -167,60 +167,6 @@ public class WindowNode
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
         return new WindowNode(getId(), Iterables.getOnlyElement(newChildren), specification, windowFunctions, hashSymbol, prePartitionedInputs, preSortedOrderPrefix);
-    }
-
-    @Immutable
-    public static class Specification
-    {
-        private final List<Symbol> partitionBy;
-        private final Optional<OrderingScheme> orderingScheme;
-
-        @JsonCreator
-        public Specification(
-                @JsonProperty("partitionBy") List<Symbol> partitionBy,
-                @JsonProperty("orderingScheme") Optional<OrderingScheme> orderingScheme)
-        {
-            requireNonNull(partitionBy, "partitionBy is null");
-            requireNonNull(orderingScheme, "orderingScheme is null");
-
-            this.partitionBy = ImmutableList.copyOf(partitionBy);
-            this.orderingScheme = requireNonNull(orderingScheme, "orderingScheme is null");
-        }
-
-        @JsonProperty
-        public List<Symbol> getPartitionBy()
-        {
-            return partitionBy;
-        }
-
-        @JsonProperty
-        public Optional<OrderingScheme> getOrderingScheme()
-        {
-            return orderingScheme;
-        }
-
-        @Override
-        public int hashCode()
-        {
-            return Objects.hash(partitionBy, orderingScheme);
-        }
-
-        @Override
-        public boolean equals(Object obj)
-        {
-            if (this == obj) {
-                return true;
-            }
-
-            if (obj == null || getClass() != obj.getClass()) {
-                return false;
-            }
-
-            Specification other = (Specification) obj;
-
-            return Objects.equals(this.partitionBy, other.partitionBy) &&
-                    Objects.equals(this.orderingScheme, other.orderingScheme);
-        }
     }
 
     @Immutable

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
@@ -226,7 +226,7 @@ public class PlanPrinter
         this.representation = new PlanRepresentation(planRoot, types, totalCpuTime, totalScheduledTime, totalBlockedTime);
 
         Visitor visitor = new Visitor(types, estimatedStatsAndCosts, stats);
-        planRoot.accept(visitor, null);
+        planRoot.accept(visitor, new Context());
     }
 
     private String toText(boolean verbose, int level)
@@ -591,7 +591,7 @@ public class PlanPrinter
     }
 
     private class Visitor
-            extends PlanVisitor<Void, Void>
+            extends PlanVisitor<Void, Context>
     {
         private final TypeProvider types;
         private final StatsAndCosts estimatedStatsAndCosts;
@@ -605,14 +605,14 @@ public class PlanPrinter
         }
 
         @Override
-        public Void visitExplainAnalyze(ExplainAnalyzeNode node, Void context)
+        public Void visitExplainAnalyze(ExplainAnalyzeNode node, Context context)
         {
-            addNode(node, "ExplainAnalyze");
-            return processChildren(node, context);
+            addNode(node, "ExplainAnalyze", context.tag());
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitJoin(JoinNode node, Void context)
+        public Void visitJoin(JoinNode node, Context context)
         {
             List<Expression> joinExpressions = new ArrayList<>();
             for (JoinNode.EquiJoinClause clause : node.getCriteria()) {
@@ -625,14 +625,14 @@ public class PlanPrinter
             NodeRepresentation nodeOutput;
             if (node.isCrossJoin()) {
                 checkState(joinExpressions.isEmpty());
-                nodeOutput = addNode(node, "CrossJoin");
+                nodeOutput = addNode(node, "CrossJoin", context.tag());
             }
             else {
                 ImmutableMap.Builder<String, String> descriptor = ImmutableMap.<String, String>builder()
                         .put("criteria", Joiner.on(" AND ").join(anonymizeExpressions(joinExpressions)))
                         .put("hash", formatHash(node.getLeftHashSymbol(), node.getRightHashSymbol()));
                 node.getDistributionType().ifPresent(distribution -> descriptor.put("distribution", distribution.name()));
-                nodeOutput = addNode(node, node.getType().getJoinLabel(), descriptor.buildOrThrow(), node.getReorderJoinStatsAndCost());
+                nodeOutput = addNode(node, node.getType().getJoinLabel(), descriptor.buildOrThrow(), node.getReorderJoinStatsAndCost(), context.tag());
             }
 
             node.getDistributionType().ifPresent(distributionType -> nodeOutput.appendDetails("Distribution: %s", distributionType));
@@ -642,61 +642,65 @@ public class PlanPrinter
             if (!node.getDynamicFilters().isEmpty()) {
                 nodeOutput.appendDetails("dynamicFilterAssignments = %s", printDynamicFilterAssignments(node.getDynamicFilters()));
             }
-            node.getLeft().accept(this, context);
-            node.getRight().accept(this, context);
+            node.getLeft().accept(this, new Context());
+            node.getRight().accept(this, new Context());
 
             return null;
         }
 
         @Override
-        public Void visitSpatialJoin(SpatialJoinNode node, Void context)
+        public Void visitSpatialJoin(SpatialJoinNode node, Context context)
         {
             NodeRepresentation nodeOutput = addNode(node,
                     node.getType().getJoinLabel(),
-                    ImmutableMap.of("filter", formatFilter(node.getFilter())));
+                    ImmutableMap.of("filter", formatFilter(node.getFilter())),
+                    context.tag());
 
             nodeOutput.appendDetails("Distribution: %s", node.getDistributionType());
-            node.getLeft().accept(this, context);
-            node.getRight().accept(this, context);
+            node.getLeft().accept(this, new Context());
+            node.getRight().accept(this, new Context());
 
             return null;
         }
 
         @Override
-        public Void visitSemiJoin(SemiJoinNode node, Void context)
+        public Void visitSemiJoin(SemiJoinNode node, Context context)
         {
             NodeRepresentation nodeOutput = addNode(node,
                     "SemiJoin",
                     ImmutableMap.of(
                             "criteria", anonymizer.anonymize(node.getSourceJoinSymbol()) + " = " + anonymizer.anonymize(node.getFilteringSourceJoinSymbol()),
-                            "hash", formatHash(node.getSourceHashSymbol(), node.getFilteringSourceHashSymbol())));
+                            "hash", formatHash(node.getSourceHashSymbol(), node.getFilteringSourceHashSymbol())),
+                    context.tag());
             node.getDistributionType().ifPresent(distributionType -> nodeOutput.appendDetails("Distribution: %s", distributionType));
             node.getDynamicFilterId().ifPresent(dynamicFilterId -> nodeOutput.appendDetails("dynamicFilterId: %s", dynamicFilterId));
-            node.getSource().accept(this, context);
-            node.getFilteringSource().accept(this, context);
+            node.getSource().accept(this, new Context());
+            node.getFilteringSource().accept(this, new Context());
 
             return null;
         }
 
         @Override
-        public Void visitDynamicFilterSource(DynamicFilterSourceNode node, Void context)
+        public Void visitDynamicFilterSource(DynamicFilterSourceNode node, Context context)
         {
             addNode(
                     node,
                     "DynamicFilterSource",
-                    ImmutableMap.of("dynamicFilterAssignments", printDynamicFilterAssignments(node.getDynamicFilters())));
-            node.getSource().accept(this, context);
+                    ImmutableMap.of("dynamicFilterAssignments", printDynamicFilterAssignments(node.getDynamicFilters())),
+                    context.tag());
+            node.getSource().accept(this, new Context());
             return null;
         }
 
         @Override
-        public Void visitIndexSource(IndexSourceNode node, Void context)
+        public Void visitIndexSource(IndexSourceNode node, Context context)
         {
             NodeRepresentation nodeOutput = addNode(node,
                     "IndexSource",
                     ImmutableMap.of(
                             "indexedTable", anonymizer.anonymize(node.getIndexHandle()),
-                            "lookup", formatSymbols(node.getLookupSymbols())));
+                            "lookup", formatSymbols(node.getLookupSymbols())),
+                    context.tag());
 
             for (Map.Entry<Symbol, ColumnHandle> entry : node.getAssignments().entrySet()) {
                 if (node.getOutputSymbols().contains(entry.getKey())) {
@@ -707,7 +711,7 @@ public class PlanPrinter
         }
 
         @Override
-        public Void visitIndexJoin(IndexJoinNode node, Void context)
+        public Void visitIndexJoin(IndexJoinNode node, Context context)
         {
             List<Expression> joinExpressions = new ArrayList<>();
             for (IndexJoinNode.EquiJoinClause clause : node.getCriteria()) {
@@ -720,47 +724,51 @@ public class PlanPrinter
                     format("%sIndexJoin", node.getType().getJoinLabel()),
                     ImmutableMap.of(
                             "criteria", Joiner.on(" AND ").join(anonymizeExpressions(joinExpressions)),
-                            "hash", formatHash(node.getProbeHashSymbol(), node.getIndexHashSymbol())));
-            node.getProbeSource().accept(this, context);
-            node.getIndexSource().accept(this, context);
+                            "hash", formatHash(node.getProbeHashSymbol(), node.getIndexHashSymbol())),
+                    context.tag());
+            node.getProbeSource().accept(this, new Context());
+            node.getIndexSource().accept(this, new Context());
 
             return null;
         }
 
         @Override
-        public Void visitOffset(OffsetNode node, Void context)
+        public Void visitOffset(OffsetNode node, Context context)
         {
             addNode(node,
                     "Offset",
-                    ImmutableMap.of("count", String.valueOf(node.getCount())));
-            return processChildren(node, context);
+                    ImmutableMap.of("count", String.valueOf(node.getCount())),
+                    context.tag());
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitLimit(LimitNode node, Void context)
+        public Void visitLimit(LimitNode node, Context context)
         {
             addNode(node,
                     format("Limit%s", node.isPartial() ? "Partial" : ""),
                     ImmutableMap.of(
                             "count", String.valueOf(node.getCount()),
                             "withTies", formatBoolean(node.isWithTies()),
-                            "inputPreSortedBy", formatSymbols(node.getPreSortedInputs())));
-            return processChildren(node, context);
+                            "inputPreSortedBy", formatSymbols(node.getPreSortedInputs())),
+                    context.tag());
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitDistinctLimit(DistinctLimitNode node, Void context)
+        public Void visitDistinctLimit(DistinctLimitNode node, Context context)
         {
             addNode(node,
                     format("DistinctLimit%s", node.isPartial() ? "Partial" : ""),
                     ImmutableMap.of(
                             "limit", String.valueOf(node.getLimit()),
-                            "hash", formatHash(node.getHashSymbol())));
-            return processChildren(node, context);
+                            "hash", formatHash(node.getHashSymbol())),
+                    context.tag());
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitAggregation(AggregationNode node, Void context)
+        public Void visitAggregation(AggregationNode node, Context context)
         {
             String type = "";
             if (node.getStep() != AggregationNode.Step.SINGLE) {
@@ -777,16 +785,17 @@ public class PlanPrinter
             NodeRepresentation nodeOutput = addNode(
                     node,
                     "Aggregate",
-                    ImmutableMap.of("type", type, "keys", keys, "hash", formatHash(node.getHashSymbol())));
+                    ImmutableMap.of("type", type, "keys", keys, "hash", formatHash(node.getHashSymbol())),
+                    context.tag());
 
             node.getAggregations().forEach((symbol, aggregation) ->
                     nodeOutput.appendDetails("%s := %s", anonymizer.anonymize(symbol), formatAggregation(anonymizer, aggregation)));
 
-            return processChildren(node, context);
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitGroupId(GroupIdNode node, Void context)
+        public Void visitGroupId(GroupIdNode node, Context context)
         {
             // grouping sets are easier to understand in terms of inputs
             List<String> anonymizedInputGroupingSetSymbols = node.getGroupingSets().stream()
@@ -799,30 +808,32 @@ public class PlanPrinter
             NodeRepresentation nodeOutput = addNode(
                     node,
                     "GroupId",
-                    ImmutableMap.of("symbols", formatCollection(anonymizedInputGroupingSetSymbols, Objects::toString)));
+                    ImmutableMap.of("symbols", formatCollection(anonymizedInputGroupingSetSymbols, Objects::toString)),
+                    context.tag());
 
             for (Map.Entry<Symbol, Symbol> mapping : node.getGroupingColumns().entrySet()) {
                 nodeOutput.appendDetails("%s := %s", anonymizer.anonymize(mapping.getKey()), anonymizer.anonymize(mapping.getValue()));
             }
 
-            return processChildren(node, context);
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitMarkDistinct(MarkDistinctNode node, Void context)
+        public Void visitMarkDistinct(MarkDistinctNode node, Context context)
         {
             addNode(node,
                     "MarkDistinct",
                     ImmutableMap.of(
                             "distinct", formatOutputs(types, node.getDistinctSymbols()),
                             "marker", anonymizer.anonymize(node.getMarkerSymbol()),
-                            "hash", formatHash(node.getHashSymbol())));
+                            "hash", formatHash(node.getHashSymbol())),
+                    context.tag());
 
-            return processChildren(node, context);
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitWindow(WindowNode node, Void context)
+        public Void visitWindow(WindowNode node, Context context)
         {
             ImmutableMap.Builder<String, String> descriptor = ImmutableMap.builder();
             if (!node.getPartitionBy().isEmpty()) {
@@ -855,7 +866,8 @@ public class PlanPrinter
             NodeRepresentation nodeOutput = addNode(
                     node,
                     "Window",
-                    descriptor.put("hash", formatHash(node.getHashSymbol())).buildOrThrow());
+                    descriptor.put("hash", formatHash(node.getHashSymbol())).buildOrThrow(),
+                    context.tag());
 
             for (Map.Entry<Symbol, WindowNode.Function> entry : node.getWindowFunctions().entrySet()) {
                 WindowNode.Function function = entry.getValue();
@@ -868,11 +880,11 @@ public class PlanPrinter
                         Joiner.on(", ").join(anonymizeExpressions(function.getArguments())),
                         frameInfo);
             }
-            return processChildren(node, context);
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitPatternRecognition(PatternRecognitionNode node, Void context)
+        public Void visitPatternRecognition(PatternRecognitionNode node, Context context)
         {
             ImmutableMap.Builder<String, String> descriptor = ImmutableMap.builder();
             if (!node.getPartitionBy().isEmpty()) {
@@ -905,7 +917,8 @@ public class PlanPrinter
             NodeRepresentation nodeOutput = addNode(
                     node,
                     "PatterRecognition",
-                    descriptor.put("hash", formatHash(node.getHashSymbol())).buildOrThrow());
+                    descriptor.put("hash", formatHash(node.getHashSymbol())).buildOrThrow(),
+                    context.tag());
 
             if (node.getCommonBaseFrame().isPresent()) {
                 nodeOutput.appendDetails("base frame: " + formatFrame(node.getCommonBaseFrame().get()));
@@ -943,7 +956,7 @@ public class PlanPrinter
                 appendValuePointers(nodeOutput, entry.getValue());
             }
 
-            return processChildren(node, context);
+            return processChildren(node, new Context());
         }
 
         private void appendValuePointers(NodeRepresentation nodeOutput, ExpressionAndValuePointers expressionAndPointers)
@@ -1048,7 +1061,7 @@ public class PlanPrinter
         }
 
         @Override
-        public Void visitTopNRanking(TopNRankingNode node, Void context)
+        public Void visitTopNRanking(TopNRankingNode node, Context context)
         {
             ImmutableMap.Builder<String, String> descriptor = ImmutableMap.builder();
             descriptor.put("partitionBy", formatSymbols(node.getPartitionBy()));
@@ -1060,15 +1073,16 @@ public class PlanPrinter
                     descriptor
                             .put("limit", String.valueOf(node.getMaxRankingPerPartition()))
                             .put("hash", formatHash(node.getHashSymbol()))
-                            .buildOrThrow());
+                            .buildOrThrow(),
+                    context.tag());
 
             nodeOutput.appendDetails("%s := %s", anonymizer.anonymize(node.getRankingSymbol()), node.getRankingType());
 
-            return processChildren(node, context);
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitRowNumber(RowNumberNode node, Void context)
+        public Void visitRowNumber(RowNumberNode node, Context context)
         {
             ImmutableMap.Builder<String, String> descriptor = ImmutableMap.builder();
             if (!node.getPartitionBy().isEmpty()) {
@@ -1082,19 +1096,20 @@ public class PlanPrinter
             NodeRepresentation nodeOutput = addNode(
                     node,
                     "RowNumber",
-                    descriptor.put("hash", formatHash(node.getHashSymbol())).buildOrThrow());
+                    descriptor.put("hash", formatHash(node.getHashSymbol())).buildOrThrow(),
+                    context.tag());
             nodeOutput.appendDetails("%s := %s", anonymizer.anonymize(node.getRowNumberSymbol()), "row_number()");
 
-            return processChildren(node, context);
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitTableScan(TableScanNode node, Void context)
+        public Void visitTableScan(TableScanNode node, Context context)
         {
             TableHandle table = node.getTable();
             TableInfo tableInfo = tableInfoSupplier.apply(node);
             NodeRepresentation nodeOutput;
-            nodeOutput = addNode(node, "TableScan", ImmutableMap.of("table", anonymizer.anonymize(table, tableInfo)));
+            nodeOutput = addNode(node, "TableScan", ImmutableMap.of("table", anonymizer.anonymize(table, tableInfo)), context.tag());
             printTableScanInfo(nodeOutput, node, tableInfo);
             PlanNodeStats nodeStats = stats.map(s -> s.get(node.getId())).orElse(null);
             if (nodeStats != null) {
@@ -1112,9 +1127,9 @@ public class PlanPrinter
         }
 
         @Override
-        public Void visitValues(ValuesNode node, Void context)
+        public Void visitValues(ValuesNode node, Context context)
         {
-            NodeRepresentation nodeOutput = addNode(node, "Values");
+            NodeRepresentation nodeOutput = addNode(node, "Values", context.tag());
             if (node.getRows().isEmpty()) {
                 for (int i = 0; i < node.getRowCount(); i++) {
                     nodeOutput.appendDetails("()");
@@ -1139,13 +1154,13 @@ public class PlanPrinter
         }
 
         @Override
-        public Void visitFilter(FilterNode node, Void context)
+        public Void visitFilter(FilterNode node, Context context)
         {
             return visitScanFilterAndProjectInfo(node, Optional.of(node), Optional.empty(), context);
         }
 
         @Override
-        public Void visitProject(ProjectNode node, Void context)
+        public Void visitProject(ProjectNode node, Context context)
         {
             if (node.getSource() instanceof FilterNode) {
                 return visitScanFilterAndProjectInfo(node, Optional.of((FilterNode) node.getSource()), Optional.of(node), context);
@@ -1158,7 +1173,7 @@ public class PlanPrinter
                 PlanNode node,
                 Optional<FilterNode> filterNode,
                 Optional<ProjectNode> projectNode,
-                Void context)
+                Context context)
         {
             checkState(projectNode.isPresent() || filterNode.isPresent());
 
@@ -1215,7 +1230,8 @@ public class PlanPrinter
                     allNodes,
                     ImmutableList.of(sourceNode),
                     ImmutableList.of(),
-                    Optional.empty());
+                    Optional.empty(),
+                    context.tag());
 
             projectNode.ifPresent(value -> printAssignments(nodeOutput, value.getAssignments()));
 
@@ -1260,7 +1276,7 @@ public class PlanPrinter
                 return null;
             }
 
-            sourceNode.accept(this, context);
+            sourceNode.accept(this, new Context());
             return null;
         }
 
@@ -1310,7 +1326,7 @@ public class PlanPrinter
         }
 
         @Override
-        public Void visitUnnest(UnnestNode node, Void context)
+        public Void visitUnnest(UnnestNode node, Context context)
         {
             String name;
             if (node.getFilter().isPresent()) {
@@ -1338,17 +1354,18 @@ public class PlanPrinter
             }
             descriptor.put("unnest", formatOutputs(types, unnestInputs));
             node.getFilter().ifPresent(filter -> descriptor.put("filter", formatFilter(filter)));
-            addNode(node, name, descriptor.buildOrThrow());
-            return processChildren(node, context);
+            addNode(node, name, descriptor.buildOrThrow(), context.tag());
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitOutput(OutputNode node, Void context)
+        public Void visitOutput(OutputNode node, Context context)
         {
             NodeRepresentation nodeOutput = addNode(
                     node,
                     "Output",
-                    ImmutableMap.of("columnNames", formatCollection(node.getColumnNames(), anonymizer::anonymizeColumn)));
+                    ImmutableMap.of("columnNames", formatCollection(node.getColumnNames(), anonymizer::anonymizeColumn)),
+                    context.tag());
             for (int i = 0; i < node.getColumnNames().size(); i++) {
                 String name = node.getColumnNames().get(i);
                 Symbol symbol = node.getOutputSymbols().get(i);
@@ -1356,32 +1373,34 @@ public class PlanPrinter
                     nodeOutput.appendDetails("%s := %s", anonymizer.anonymizeColumn(name), anonymizer.anonymize(symbol));
                 }
             }
-            return processChildren(node, context);
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitTopN(TopNNode node, Void context)
+        public Void visitTopN(TopNNode node, Context context)
         {
             addNode(node,
                     format("TopN%s", node.getStep() == TopNNode.Step.PARTIAL ? "Partial" : ""),
                     ImmutableMap.of(
                             "count", String.valueOf(node.getCount()),
-                            "orderBy", formatOrderingScheme(node.getOrderingScheme())));
-            return processChildren(node, context);
+                            "orderBy", formatOrderingScheme(node.getOrderingScheme())),
+                    context.tag());
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitSort(SortNode node, Void context)
+        public Void visitSort(SortNode node, Context context)
         {
             addNode(node,
                     format("%sSort", node.isPartial() ? "Partial" : ""),
-                    ImmutableMap.of("orderBy", formatOrderingScheme(node.getOrderingScheme())));
+                    ImmutableMap.of("orderBy", formatOrderingScheme(node.getOrderingScheme())),
+                    context.tag());
 
-            return processChildren(node, context);
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitRemoteSource(RemoteSourceNode node, Void context)
+        public Void visitRemoteSource(RemoteSourceNode node, Context context)
         {
             addNode(node,
                     format("Remote%s", node.getOrderingScheme().isPresent() ? "Merge" : "Source"),
@@ -1389,52 +1408,56 @@ public class PlanPrinter
                     ImmutableList.of(),
                     ImmutableList.of(),
                     node.getSourceFragmentIds(),
-                    Optional.empty());
+                    Optional.empty(),
+                    context.tag());
 
             return null;
         }
 
         @Override
-        public Void visitUnion(UnionNode node, Void context)
+        public Void visitUnion(UnionNode node, Context context)
         {
-            addNode(node, "Union");
+            addNode(node, "Union", context.tag());
 
-            return processChildren(node, context);
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitIntersect(IntersectNode node, Void context)
+        public Void visitIntersect(IntersectNode node, Context context)
         {
             addNode(node,
                     "Intersect",
-                    ImmutableMap.of("isDistinct", formatBoolean(node.isDistinct())));
+                    ImmutableMap.of("isDistinct", formatBoolean(node.isDistinct())),
+                    context.tag());
 
-            return processChildren(node, context);
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitExcept(ExceptNode node, Void context)
+        public Void visitExcept(ExceptNode node, Context context)
         {
             addNode(node,
                     "Except",
-                    ImmutableMap.of("isDistinct", formatBoolean(node.isDistinct())));
+                    ImmutableMap.of("isDistinct", formatBoolean(node.isDistinct())),
+                    context.tag());
 
-            return processChildren(node, context);
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitRefreshMaterializedView(RefreshMaterializedViewNode node, Void context)
+        public Void visitRefreshMaterializedView(RefreshMaterializedViewNode node, Context context)
         {
             addNode(node,
                     "RefreshMaterializedView",
-                    ImmutableMap.of("viewName", anonymizer.anonymize(node.getViewName())));
+                    ImmutableMap.of("viewName", anonymizer.anonymize(node.getViewName())),
+                    context.tag());
             return null;
         }
 
         @Override
-        public Void visitTableWriter(TableWriterNode node, Void context)
+        public Void visitTableWriter(TableWriterNode node, Context context)
         {
-            NodeRepresentation nodeOutput = addNode(node, "TableWriter");
+            NodeRepresentation nodeOutput = addNode(node, "TableWriter", context.tag());
             for (int i = 0; i < node.getColumnNames().size(); i++) {
                 String name = node.getColumnNames().get(i);
                 Symbol symbol = node.getColumns().get(i);
@@ -1446,32 +1469,34 @@ public class PlanPrinter
                 printStatisticAggregations(nodeOutput, node.getStatisticsAggregation().get(), node.getStatisticsAggregationDescriptor().get());
             }
 
-            return processChildren(node, context);
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitStatisticsWriterNode(StatisticsWriterNode node, Void context)
+        public Void visitStatisticsWriterNode(StatisticsWriterNode node, Context context)
         {
             addNode(node,
                     "StatisticsWriter",
-                    ImmutableMap.of("target", anonymizer.anonymize(node.getTarget())));
-            return processChildren(node, context);
+                    ImmutableMap.of("target", anonymizer.anonymize(node.getTarget())),
+                    context.tag());
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitTableFinish(TableFinishNode node, Void context)
+        public Void visitTableFinish(TableFinishNode node, Context context)
         {
             NodeRepresentation nodeOutput = addNode(
                     node,
                     "TableCommit",
-                    ImmutableMap.of("target", anonymizer.anonymize(node.getTarget())));
+                    ImmutableMap.of("target", anonymizer.anonymize(node.getTarget())),
+                    context.tag());
 
             if (node.getStatisticsAggregation().isPresent()) {
                 verify(node.getStatisticsAggregationDescriptor().isPresent(), "statisticsAggregationDescriptor is not present");
                 printStatisticAggregations(nodeOutput, node.getStatisticsAggregation().get(), node.getStatisticsAggregationDescriptor().get());
             }
 
-            return processChildren(node, context);
+            return processChildren(node, new Context());
         }
 
         private void printStatisticAggregations(NodeRepresentation nodeOutput, StatisticAggregations aggregations, StatisticAggregationsDescriptor<Symbol> descriptor)
@@ -1526,24 +1551,26 @@ public class PlanPrinter
         }
 
         @Override
-        public Void visitSample(SampleNode node, Void context)
+        public Void visitSample(SampleNode node, Context context)
         {
             addNode(node,
                     "Sample",
                     ImmutableMap.of(
                             "type", node.getSampleType().name(),
-                            "ratio", String.valueOf(node.getSampleRatio())));
+                            "ratio", String.valueOf(node.getSampleRatio())),
+                    context.tag());
 
-            return processChildren(node, context);
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitExchange(ExchangeNode node, Void context)
+        public Void visitExchange(ExchangeNode node, Context context)
         {
             if (node.getOrderingScheme().isPresent()) {
                 addNode(node,
                         format("%sMerge", UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, node.getScope().toString())),
-                        ImmutableMap.of("orderBy", formatOrderingScheme(node.getOrderingScheme().get())));
+                        ImmutableMap.of("orderBy", formatOrderingScheme(node.getOrderingScheme().get())),
+                        context.tag());
             }
             else if (node.getScope() == Scope.LOCAL) {
                 addNode(node,
@@ -1552,7 +1579,8 @@ public class PlanPrinter
                                 "partitioning", anonymizer.anonymize(node.getPartitioningScheme().getPartitioning().getHandle()),
                                 "isReplicateNullsAndAny", formatBoolean(node.getPartitioningScheme().isReplicateNullsAndAny()),
                                 "hashColumn", formatHash(node.getPartitioningScheme().getHashColumn()),
-                                "arguments", formatCollection(node.getPartitioningScheme().getPartitioning().getArguments(), anonymizer::anonymize)));
+                                "arguments", formatCollection(node.getPartitioningScheme().getPartitioning().getArguments(), anonymizer::anonymize)),
+                        context.tag());
             }
             else {
                 addNode(node,
@@ -1560,146 +1588,155 @@ public class PlanPrinter
                         ImmutableMap.of(
                                 "type", node.getType().name(),
                                 "isReplicateNullsAndAny", formatBoolean(node.getPartitioningScheme().isReplicateNullsAndAny()),
-                                "hashColumn", formatHash(node.getPartitioningScheme().getHashColumn())));
+                                "hashColumn", formatHash(node.getPartitioningScheme().getHashColumn())),
+                        context.tag());
             }
-            return processChildren(node, context);
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitDelete(DeleteNode node, Void context)
+        public Void visitDelete(DeleteNode node, Context context)
         {
             addNode(node,
                     "Delete",
-                    ImmutableMap.of("target", anonymizer.anonymize(node.getTarget())));
+                    ImmutableMap.of("target", anonymizer.anonymize(node.getTarget())),
+                    context.tag());
 
-            return processChildren(node, context);
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitUpdate(UpdateNode node, Void context)
+        public Void visitUpdate(UpdateNode node, Context context)
         {
-            NodeRepresentation nodeOutput = addNode(node, format("Update[%s]", anonymizer.anonymize(node.getTarget())));
+            NodeRepresentation nodeOutput = addNode(node, format("Update[%s]", anonymizer.anonymize(node.getTarget())), context.tag());
             int index = 0;
             for (String columnName : node.getTarget().getUpdatedColumns()) {
                 nodeOutput.appendDetails("%s := %s", anonymizer.anonymizeColumn(columnName), anonymizer.anonymize(node.getColumnValueAndRowIdSymbols().get(index)));
                 index++;
             }
-            return processChildren(node, context);
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitTableExecute(TableExecuteNode node, Void context)
+        public Void visitTableExecute(TableExecuteNode node, Context context)
         {
-            NodeRepresentation nodeOutput = addNode(node, "TableExecute");
+            NodeRepresentation nodeOutput = addNode(node, "TableExecute", context.tag());
             for (int i = 0; i < node.getColumnNames().size(); i++) {
                 String name = node.getColumnNames().get(i);
                 Symbol symbol = node.getColumns().get(i);
                 nodeOutput.appendDetails("%s := %s", anonymizer.anonymizeColumn(name), anonymizer.anonymize(symbol));
             }
 
-            return processChildren(node, context);
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitSimpleTableExecuteNode(SimpleTableExecuteNode node, Void context)
+        public Void visitSimpleTableExecuteNode(SimpleTableExecuteNode node, Context context)
         {
             addNode(node,
                     "SimpleTableExecute",
-                    ImmutableMap.of("table", anonymizer.anonymize(node.getExecuteHandle())));
+                    ImmutableMap.of("table", anonymizer.anonymize(node.getExecuteHandle())),
+                    context.tag());
             return null;
         }
 
         @Override
-        public Void visitMergeWriter(MergeWriterNode node, Void context)
+        public Void visitMergeWriter(MergeWriterNode node, Context context)
         {
             addNode(node,
                     "MergeWriter",
-                    ImmutableMap.of("table", anonymizer.anonymize(node.getTarget())));
-            return processChildren(node, context);
+                    ImmutableMap.of("table", anonymizer.anonymize(node.getTarget())),
+                    context.tag());
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitMergeProcessor(MergeProcessorNode node, Void context)
+        public Void visitMergeProcessor(MergeProcessorNode node, Context context)
         {
-            NodeRepresentation nodeOutput = addNode(node, "MergeProcessor");
+            NodeRepresentation nodeOutput = addNode(node, "MergeProcessor", context.tag());
             nodeOutput.appendDetails("target: %s", anonymizer.anonymize(node.getTarget()));
             nodeOutput.appendDetails("merge row column: %s", anonymizer.anonymize(node.getMergeRowSymbol()));
             nodeOutput.appendDetails("row id column: %s", anonymizer.anonymize(node.getRowIdSymbol()));
             nodeOutput.appendDetails("redistribution columns: %s", anonymize(node.getRedistributionColumnSymbols()));
             nodeOutput.appendDetails("data columns: %s", anonymize(node.getDataColumnSymbols()));
 
-            return processChildren(node, context);
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitTableDelete(TableDeleteNode node, Void context)
+        public Void visitTableDelete(TableDeleteNode node, Context context)
         {
             addNode(node,
                     "TableDelete",
-                    ImmutableMap.of("target", anonymizer.anonymize(node.getTarget())));
+                    ImmutableMap.of("target", anonymizer.anonymize(node.getTarget())),
+                    context.tag());
 
-            return processChildren(node, context);
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitEnforceSingleRow(EnforceSingleRowNode node, Void context)
+        public Void visitEnforceSingleRow(EnforceSingleRowNode node, Context context)
         {
-            addNode(node, "EnforceSingleRow");
+            addNode(node, "EnforceSingleRow", context.tag());
 
-            return processChildren(node, context);
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitAssignUniqueId(AssignUniqueId node, Void context)
+        public Void visitAssignUniqueId(AssignUniqueId node, Context context)
         {
-            addNode(node, "AssignUniqueId");
+            addNode(node, "AssignUniqueId", context.tag());
 
-            return processChildren(node, context);
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitGroupReference(GroupReference node, Void context)
+        public Void visitGroupReference(GroupReference node, Context context)
         {
             addNode(node,
                     "GroupReference",
                     ImmutableMap.of("groupId", String.valueOf(node.getGroupId())),
                     ImmutableList.of(),
-                    Optional.empty());
+                    Optional.empty(),
+                    context.tag());
 
             return null;
         }
 
         @Override
-        public Void visitApply(ApplyNode node, Void context)
+        public Void visitApply(ApplyNode node, Context context)
         {
             NodeRepresentation nodeOutput = addNode(
                     node,
                     "Apply",
-                    ImmutableMap.of("correlation", formatSymbols(node.getCorrelation())));
+                    ImmutableMap.of("correlation", formatSymbols(node.getCorrelation())),
+                    context.tag());
             printAssignments(nodeOutput, node.getSubqueryAssignments());
 
-            return processChildren(node, context);
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitCorrelatedJoin(CorrelatedJoinNode node, Void context)
+        public Void visitCorrelatedJoin(CorrelatedJoinNode node, Context context)
         {
             addNode(node,
                     "CorrelatedJoin",
                     ImmutableMap.of(
                             "correlation", formatSymbols(node.getCorrelation()),
-                            "filter", formatFilter(node.getFilter())));
+                            "filter", formatFilter(node.getFilter())),
+                    context.tag());
 
-            return processChildren(node, context);
+            return processChildren(node, new Context());
         }
 
         @Override
-        public Void visitTableFunction(TableFunctionNode node, Void context)
+        public Void visitTableFunction(TableFunctionNode node, Context context)
         {
             NodeRepresentation nodeOutput = addNode(
                     node,
                     "TableFunction",
-                    ImmutableMap.of("name", node.getName()));
+                    ImmutableMap.of("name", node.getName()),
+                    context.tag());
 
             checkArgument(
                     node.getSources().isEmpty() && node.getTableArgumentProperties().isEmpty(),
@@ -1722,12 +1759,12 @@ public class PlanPrinter
         }
 
         @Override
-        protected Void visitPlan(PlanNode node, Void context)
+        protected Void visitPlan(PlanNode node, Context context)
         {
             throw new UnsupportedOperationException("not yet implemented: " + node.getClass().getName());
         }
 
-        private Void processChildren(PlanNode node, Void context)
+        private Void processChildren(PlanNode node, Context context)
         {
             for (PlanNode child : node.getSources()) {
                 child.accept(this, context);
@@ -1875,24 +1912,24 @@ public class PlanPrinter
                     .collect(joining(", ", "[", "]"));
         }
 
-        public NodeRepresentation addNode(PlanNode node, String name)
+        public NodeRepresentation addNode(PlanNode node, String name, Optional<String> tag)
         {
-            return addNode(node, name, ImmutableMap.of());
+            return addNode(node, name, ImmutableMap.of(), tag);
         }
 
-        public NodeRepresentation addNode(PlanNode node, String name, Map<String, String> descriptor)
+        public NodeRepresentation addNode(PlanNode node, String name, Map<String, String> descriptor, Optional<String> tag)
         {
-            return addNode(node, name, descriptor, node.getSources(), Optional.empty());
+            return addNode(node, name, descriptor, node.getSources(), Optional.empty(), tag);
         }
 
-        public NodeRepresentation addNode(PlanNode node, String name, Map<String, String> descriptor, Optional<PlanNodeStatsAndCostSummary> reorderJoinStatsAndCost)
+        public NodeRepresentation addNode(PlanNode node, String name, Map<String, String> descriptor, Optional<PlanNodeStatsAndCostSummary> reorderJoinStatsAndCost, Optional<String> tag)
         {
-            return addNode(node, name, descriptor, node.getSources(), reorderJoinStatsAndCost);
+            return addNode(node, name, descriptor, node.getSources(), reorderJoinStatsAndCost, tag);
         }
 
-        public NodeRepresentation addNode(PlanNode node, String name, Map<String, String> descriptor, List<PlanNode> children, Optional<PlanNodeStatsAndCostSummary> reorderJoinStatsAndCost)
+        public NodeRepresentation addNode(PlanNode node, String name, Map<String, String> descriptor, List<PlanNode> children, Optional<PlanNodeStatsAndCostSummary> reorderJoinStatsAndCost, Optional<String> tag)
         {
-            return addNode(node, name, descriptor, ImmutableList.of(node.getId()), children, ImmutableList.of(), reorderJoinStatsAndCost);
+            return addNode(node, name, descriptor, ImmutableList.of(node.getId()), children, ImmutableList.of(), reorderJoinStatsAndCost, tag);
         }
 
         public NodeRepresentation addNode(
@@ -1902,7 +1939,8 @@ public class PlanPrinter
                 List<PlanNodeId> allNodes,
                 List<PlanNode> children,
                 List<PlanFragmentId> remoteSources,
-                Optional<PlanNodeStatsAndCostSummary> reorderJoinStatsAndCost)
+                Optional<PlanNodeStatsAndCostSummary> reorderJoinStatsAndCost,
+                Optional<String> tag)
         {
             List<PlanNodeId> childrenIds = children.stream().map(PlanNode::getId).collect(toImmutableList());
             List<PlanNodeStatsEstimate> estimatedStats = allNodes.stream()
@@ -1911,6 +1949,9 @@ public class PlanPrinter
             List<PlanCostEstimate> estimatedCosts = allNodes.stream()
                     .map(nodeId -> estimatedStatsAndCosts.getCosts().getOrDefault(nodeId, PlanCostEstimate.unknown()))
                     .collect(toList());
+            name = tag
+                    .map(tagName -> format("[%s] ", tagName))
+                    .orElse("") + name;
 
             NodeRepresentation nodeOutput = new NodeRepresentation(
                     rootNode.getId(),
@@ -1993,5 +2034,23 @@ public class PlanPrinter
                         rewritten.getArguments());
             }
         }, expression);
+    }
+
+    private record Context(Optional<String> tag)
+    {
+        public Context()
+        {
+            this(Optional.empty());
+        }
+
+        public Context(String tag)
+        {
+            this(Optional.of(tag));
+        }
+
+        private Context
+        {
+            requireNonNull(tag, "tag is null");
+        }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
@@ -42,6 +42,8 @@ import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.NullableValue;
 import io.trino.spi.predicate.Range;
 import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.ptf.Argument;
+import io.trino.spi.ptf.DescriptorArgument;
 import io.trino.spi.ptf.ScalarArgument;
 import io.trino.spi.statistics.ColumnStatisticMetadata;
 import io.trino.spi.statistics.TableStatisticType;
@@ -104,6 +106,7 @@ import io.trino.sql.planner.plan.TableDeleteNode;
 import io.trino.sql.planner.plan.TableExecuteNode;
 import io.trino.sql.planner.plan.TableFinishNode;
 import io.trino.sql.planner.plan.TableFunctionNode;
+import io.trino.sql.planner.plan.TableFunctionNode.TableArgumentProperties;
 import io.trino.sql.planner.plan.TableScanNode;
 import io.trino.sql.planner.plan.TableWriterNode;
 import io.trino.sql.planner.plan.TopNNode;
@@ -154,6 +157,7 @@ import static io.airlift.units.Duration.succinctNanos;
 import static io.trino.execution.StageInfo.getAllStages;
 import static io.trino.metadata.ResolvedFunction.extractFunctionName;
 import static io.trino.server.DynamicFilterService.DynamicFilterDomainStats;
+import static io.trino.spi.ptf.DescriptorArgument.NULL_DESCRIPTOR;
 import static io.trino.sql.DynamicFilters.extractDynamicFilters;
 import static io.trino.sql.ExpressionUtils.combineConjunctsWithDuplicates;
 import static io.trino.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
@@ -1738,24 +1742,77 @@ public class PlanPrinter
                     ImmutableMap.of("name", node.getName()),
                     context.tag());
 
-            checkArgument(
-                    node.getSources().isEmpty() && node.getTableArgumentProperties().isEmpty(),
-                    "Table or descriptor arguments are not yet supported in PlanPrinter");
+            if (!node.getArguments().isEmpty()) {
+                nodeOutput.appendDetails("Arguments:");
 
-            node.getArguments().entrySet().stream()
-                    .forEach(entry -> nodeOutput.appendDetails(entry.getKey() + " => " + formatArgument((ScalarArgument) entry.getValue())));
+                Map<String, TableArgumentProperties> tableArguments = node.getTableArgumentProperties().stream()
+                        .collect(toImmutableMap(TableArgumentProperties::getArgumentName, identity()));
+
+                node.getArguments().entrySet().stream()
+                        .forEach(entry -> nodeOutput.appendDetails(formatArgument(entry.getKey(), entry.getValue(), tableArguments)));
+
+                if (!node.getCopartitioningLists().isEmpty()) {
+                    nodeOutput.appendDetails(node.getCopartitioningLists().stream()
+                            .map(list -> list.stream().collect(Collectors.joining(", ", "(", ")")))
+                            .collect(joining(", ", "Co-partition: [", "]")));
+                }
+            }
+
+            for (int i = 0; i < node.getSources().size(); i++) {
+                node.getSources().get(i).accept(this, new Context(node.getTableArgumentProperties().get(i).getArgumentName()));
+            }
 
             return null;
         }
 
-        private String formatArgument(ScalarArgument argument)
+        private String formatArgument(String argumentName, Argument argument, Map<String, TableArgumentProperties> tableArguments)
         {
-            return format(
-                    "ScalarArgument{type=%s, value=%s}",
-                    argument.getType(),
-                    anonymizer.anonymize(
-                            argument.getType(),
-                            valuePrinter.castToVarchar(argument.getType(), argument.getValue())));
+            if (argument instanceof ScalarArgument scalarArgument) {
+                return format(
+                        "%s => ScalarArgument{type=%s, value=%s}",
+                        argumentName,
+                        scalarArgument.getType().getDisplayName(),
+                        anonymizer.anonymize(
+                                scalarArgument.getType(),
+                                valuePrinter.castToVarchar(scalarArgument.getType(), scalarArgument.getValue())));
+            }
+            if (argument instanceof DescriptorArgument descriptorArgument) {
+                String descriptor;
+                if (descriptorArgument.equals(NULL_DESCRIPTOR)) {
+                    descriptor = "NULL";
+                }
+                else {
+                    descriptor = descriptorArgument.getDescriptor().orElseThrow().getFields().stream()
+                            .map(field -> anonymizer.anonymizeColumn(field.getName()) + field.getType().map(type -> " " + type.getDisplayName()).orElse(""))
+                            .collect(joining(", ", "(", ")"));
+                }
+                return format("%s => DescriptorArgument{%s}", argumentName, descriptor);
+            }
+            else {
+                TableArgumentProperties argumentProperties = tableArguments.get(argumentName);
+                StringBuilder properties = new StringBuilder();
+                if (argumentProperties.isRowSemantics()) {
+                    properties.append("row semantics");
+                }
+                argumentProperties.getSpecification().ifPresent(specification -> {
+                    properties
+                            .append("partition by: [")
+                            .append(Joiner.on(", ").join(anonymize(specification.getPartitionBy())))
+                            .append("]");
+                    specification.getOrderingScheme().ifPresent(orderingScheme -> {
+                        properties
+                                .append(", order by: ")
+                                .append(formatOrderingScheme(orderingScheme));
+                    });
+                });
+                if (argumentProperties.isPruneWhenEmpty()) {
+                    properties.append(", prune when empty");
+                }
+                if (argumentProperties.isPassThroughColumns()) {
+                    properties.append(", pass through columns");
+                }
+                return format("%s => TableArgument{%s}", argumentName, properties);
+            }
         }
 
         @Override

--- a/core/trino-main/src/test/java/io/trino/connector/TestingTableFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/connector/TestingTableFunctions.java
@@ -329,6 +329,45 @@ public class TestingTableFunctions
         }
     }
 
+    public static class DifferentArgumentTypesFunction
+            extends AbstractConnectorTableFunction
+    {
+        public DifferentArgumentTypesFunction()
+        {
+            super(
+                    SCHEMA_NAME,
+                    "different_arguments_function",
+                    ImmutableList.of(
+                            TableArgumentSpecification.builder()
+                                    .name("INPUT_1")
+                                    .passThroughColumns()
+                                    .build(),
+                            DescriptorArgumentSpecification.builder()
+                                    .name("LAYOUT")
+                                    .build(),
+                            TableArgumentSpecification.builder()
+                                    .name("INPUT_2")
+                                    .rowSemantics()
+                                    .passThroughColumns()
+                                    .build(),
+                            ScalarArgumentSpecification.builder()
+                                    .name("ID")
+                                    .type(BIGINT)
+                                    .build(),
+                            TableArgumentSpecification.builder()
+                                    .name("INPUT_3")
+                                    .pruneWhenEmpty()
+                                    .build()),
+                    GENERIC_TABLE);
+        }
+
+        @Override
+        public TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments)
+        {
+            return ANALYSIS;
+        }
+    }
+
     public static class TestingTableFunctionHandle
             implements ConnectorTableFunctionHandle
     {

--- a/core/trino-main/src/test/java/io/trino/connector/TestingTableFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/connector/TestingTableFunctions.java
@@ -45,10 +45,15 @@ import static io.trino.spi.type.VarcharType.VARCHAR;
 public class TestingTableFunctions
 {
     private static final String SCHEMA_NAME = "system";
-    private static final ConnectorTableFunctionHandle HANDLE = new ConnectorTableFunctionHandle() {};
+    private static final String TABLE_NAME = "table";
+    private static final String COLUMN_NAME = "column";
+    private static final ConnectorTableFunctionHandle HANDLE = new TestingTableFunctionHandle();
     private static final TableFunctionAnalysis ANALYSIS = TableFunctionAnalysis.builder()
             .handle(HANDLE)
-            .returnedType(new Descriptor(ImmutableList.of(new Descriptor.Field("column", Optional.of(BOOLEAN)))))
+            .returnedType(new Descriptor(ImmutableList.of(new Descriptor.Field(COLUMN_NAME, Optional.of(BOOLEAN)))))
+            .build();
+    private static final TableFunctionAnalysis NO_DESCRIPTOR_ANALYSIS = TableFunctionAnalysis.builder()
+            .handle(HANDLE)
             .build();
 
     /**
@@ -252,9 +257,7 @@ public class TestingTableFunctions
         @Override
         public TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments)
         {
-            return TableFunctionAnalysis.builder()
-                    .handle(HANDLE)
-                    .build();
+            return NO_DESCRIPTOR_ANALYSIS;
         }
     }
 
@@ -275,9 +278,7 @@ public class TestingTableFunctions
         @Override
         public TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments)
         {
-            return TableFunctionAnalysis.builder()
-                    .handle(HANDLE)
-                    .build();
+            return NO_DESCRIPTOR_ANALYSIS;
         }
     }
 
@@ -300,9 +301,7 @@ public class TestingTableFunctions
         @Override
         public TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments)
         {
-            return TableFunctionAnalysis.builder()
-                    .handle(HANDLE)
-                    .build();
+            return NO_DESCRIPTOR_ANALYSIS;
         }
     }
 
@@ -326,9 +325,26 @@ public class TestingTableFunctions
         @Override
         public TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments)
         {
-            return TableFunctionAnalysis.builder()
-                    .handle(HANDLE)
-                    .build();
+            return NO_DESCRIPTOR_ANALYSIS;
+        }
+    }
+
+    public static class TestingTableFunctionHandle
+            implements ConnectorTableFunctionHandle
+    {
+        private final MockConnectorTableHandle tableHandle;
+
+        public TestingTableFunctionHandle()
+        {
+            this.tableHandle = new MockConnectorTableHandle(
+                    new SchemaTableName(SCHEMA_NAME, TABLE_NAME),
+                    TupleDomain.all(),
+                    Optional.of(ImmutableList.of(new MockConnectorColumnHandle(COLUMN_NAME, BOOLEAN))));
+        }
+
+        public MockConnectorTableHandle getTableHandle()
+        {
+            return tableHandle;
         }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestCanonicalize.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestCanonicalize.java
@@ -22,7 +22,7 @@ import io.trino.sql.planner.assertions.ExpectedValueProvider;
 import io.trino.sql.planner.iterative.IterativeOptimizer;
 import io.trino.sql.planner.iterative.rule.RemoveRedundantIdentityProjections;
 import io.trino.sql.planner.optimizations.UnaliasSymbolReferences;
-import io.trino.sql.planner.plan.WindowNode;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.tree.GenericLiteral;
 import io.trino.sql.tree.LongLiteral;
 import org.testng.annotations.Test;
@@ -55,7 +55,7 @@ public class TestCanonicalize
     @Test
     public void testDuplicatesInWindowOrderBy()
     {
-        ExpectedValueProvider<WindowNode.Specification> specification = specification(
+        ExpectedValueProvider<DataOrganizationSpecification> specification = specification(
                 ImmutableList.of(),
                 ImmutableList.of("A"),
                 ImmutableMap.of("A", SortOrder.ASC_NULLS_LAST));

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestEffectivePredicateExtractor.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestEffectivePredicateExtractor.java
@@ -44,6 +44,7 @@ import io.trino.sql.analyzer.TypeSignatureProvider;
 import io.trino.sql.planner.plan.AggregationNode;
 import io.trino.sql.planner.plan.AggregationNode.Aggregation;
 import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.planner.plan.FilterNode;
 import io.trino.sql.planner.plan.JoinNode;
 import io.trino.sql.planner.plan.LimitNode;
@@ -445,7 +446,7 @@ public class TestEffectivePredicateExtractor
                                 equals(AE, BE),
                                 equals(BE, CE),
                                 lessThan(CE, bigintLiteral(10)))),
-                new WindowNode.Specification(
+                new DataOrganizationSpecification(
                         ImmutableList.of(A),
                         Optional.of(new OrderingScheme(
                                 ImmutableList.of(A),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestTableFunctionInvocation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestTableFunctionInvocation.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.trino.connector.MockConnectorFactory;
+import io.trino.connector.MockConnectorPlugin;
+import io.trino.connector.TestingTableFunctions.DescriptorArgumentFunction;
+import io.trino.connector.TestingTableFunctions.DifferentArgumentTypesFunction;
+import io.trino.connector.TestingTableFunctions.TestingTableFunctionHandle;
+import io.trino.connector.TestingTableFunctions.TwoScalarArgumentsFunction;
+import io.trino.spi.connector.TableFunctionApplicationResult;
+import io.trino.spi.ptf.Descriptor;
+import io.trino.spi.ptf.Descriptor.Field;
+import io.trino.sql.planner.assertions.BasePlanTest;
+import io.trino.sql.tree.LongLiteral;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.trino.spi.connector.SortOrder.ASC_NULLS_LAST;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.sql.planner.LogicalPlanner.Stage.CREATED;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.specification;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.tableFunction;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.sql.planner.assertions.TableFunctionMatcher.DescriptorArgumentValue.descriptorArgument;
+import static io.trino.sql.planner.assertions.TableFunctionMatcher.DescriptorArgumentValue.nullDescriptor;
+import static io.trino.sql.planner.assertions.TableFunctionMatcher.TableArgumentValue.Builder.tableArgument;
+
+public class TestTableFunctionInvocation
+        extends BasePlanTest
+{
+    private static final String TESTING_CATALOG = "mock";
+
+    @BeforeClass
+    public final void setup()
+    {
+        getQueryRunner().installPlugin(new MockConnectorPlugin(MockConnectorFactory.builder()
+                .withTableFunctions(ImmutableSet.of(
+                        new DifferentArgumentTypesFunction(),
+                        new TwoScalarArgumentsFunction(),
+                        new DescriptorArgumentFunction()))
+                .withApplyTableFunction((session, handle) -> {
+                    if (handle instanceof TestingTableFunctionHandle) {
+                        TestingTableFunctionHandle functionHandle = (TestingTableFunctionHandle) handle;
+                        return Optional.of(new TableFunctionApplicationResult<>(functionHandle.getTableHandle(), functionHandle.getTableHandle().getColumns().orElseThrow()));
+                    }
+                    throw new IllegalStateException("Unsupported table function handle: " + handle.getClass().getSimpleName());
+                })
+                .build()));
+        getQueryRunner().createCatalog(TESTING_CATALOG, "mock", ImmutableMap.of());
+    }
+
+    @Test
+    public void testTableFunctionInitialPlan()
+    {
+        assertPlan(
+                """
+                        SELECT * FROM TABLE(mock.system.different_arguments_function(
+                           INPUT_1 => TABLE(SELECT 'a') t1(c1) PARTITION BY c1 ORDER BY c1,
+                           INPUT_3 => TABLE(SELECT 'b') t3(c3) PARTITION BY c3,
+                           INPUT_2 => TABLE(VALUES 1) t2(c2),
+                           ID => BIGINT '2001',
+                           LAYOUT => DESCRIPTOR (x boolean, y bigint)
+                           COPARTITION (t1, t3))) t
+                        """,
+                CREATED,
+                anyTree(tableFunction(builder -> builder
+                                .name("different_arguments_function")
+                                .addTableArgument(
+                                        "INPUT_1",
+                                        tableArgument(0)
+                                                .specification(specification(ImmutableList.of("c1"), ImmutableList.of("c1"), ImmutableMap.of("c1", ASC_NULLS_LAST)))
+                                                .passThroughColumns())
+                                .addTableArgument(
+                                        "INPUT_3",
+                                        tableArgument(2)
+                                                .specification(specification(ImmutableList.of("c3"), ImmutableList.of(), ImmutableMap.of()))
+                                                .pruneWhenEmpty())
+                                .addTableArgument(
+                                        "INPUT_2",
+                                        tableArgument(1)
+                                                .rowSemantics()
+                                                .passThroughColumns())
+                                .addScalarArgument("ID", 2001L)
+                                .addDescriptorArgument(
+                                        "LAYOUT",
+                                        descriptorArgument(new Descriptor(ImmutableList.of(
+                                                new Field("X", Optional.of(BOOLEAN)),
+                                                new Field("Y", Optional.of(BIGINT))))))
+                                .addCopartitioning(ImmutableList.of("INPUT_1", "INPUT_3"))
+                                .properOutputs(ImmutableList.of("OUTPUT")),
+                        anyTree(project(ImmutableMap.of("c1", expression("'a'")), values(1))),
+                        anyTree(values(ImmutableList.of("c2"), ImmutableList.of(ImmutableList.of(new LongLiteral("1"))))),
+                        anyTree(project(ImmutableMap.of("c3", expression("'b'")), values(1))))));
+    }
+
+    @Test
+    public void testNullScalarArgument()
+    {
+        // the argument NUMBER has null default value
+        assertPlan(
+                " SELECT * FROM TABLE(mock.system.two_arguments_function(TEXT => null))",
+                CREATED,
+                anyTree(tableFunction(builder -> builder
+                        .name("two_arguments_function")
+                        .addScalarArgument("TEXT", null)
+                        .addScalarArgument("NUMBER", null)
+                        .properOutputs(ImmutableList.of("OUTPUT")))));
+    }
+
+    @Test
+    public void testNullDescriptorArgument()
+    {
+        assertPlan(
+                " SELECT * FROM TABLE(mock.system.descriptor_argument_function(SCHEMA => CAST(null AS DESCRIPTOR)))",
+                CREATED,
+                anyTree(tableFunction(builder -> builder
+                        .name("descriptor_argument_function")
+                        .addDescriptorArgument("SCHEMA", nullDescriptor())
+                        .properOutputs(ImmutableList.of("OUTPUT")))));
+
+        // the argument SCHEMA has null default value
+        assertPlan(
+                " SELECT * FROM TABLE(mock.system.descriptor_argument_function())",
+                CREATED,
+                anyTree(tableFunction(builder -> builder
+                        .name("descriptor_argument_function")
+                        .addDescriptorArgument("SCHEMA", nullDescriptor())
+                        .properOutputs(ImmutableList.of("OUTPUT")))));
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestTypeValidator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestTypeValidator.java
@@ -26,6 +26,7 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.VarcharType;
 import io.trino.sql.planner.plan.AggregationNode.Aggregation;
 import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.sql.planner.plan.ProjectNode;
@@ -158,7 +159,7 @@ public class TestTypeValidator
 
         WindowNode.Function function = new WindowNode.Function(resolvedFunction, ImmutableList.of(columnC.toSymbolReference()), frame, false);
 
-        WindowNode.Specification specification = new WindowNode.Specification(ImmutableList.of(), Optional.empty());
+        DataOrganizationSpecification specification = new DataOrganizationSpecification(ImmutableList.of(), Optional.empty());
 
         PlanNode node = new WindowNode(
                 newId(),
@@ -287,7 +288,7 @@ public class TestTypeValidator
 
         WindowNode.Function function = new WindowNode.Function(resolvedFunction, ImmutableList.of(columnA.toSymbolReference()), frame, false);
 
-        WindowNode.Specification specification = new WindowNode.Specification(ImmutableList.of(), Optional.empty());
+        DataOrganizationSpecification specification = new DataOrganizationSpecification(ImmutableList.of(), Optional.empty());
 
         PlanNode node = new WindowNode(
                 newId(),
@@ -322,7 +323,7 @@ public class TestTypeValidator
 
         WindowNode.Function function = new WindowNode.Function(resolvedFunction, ImmutableList.of(columnC.toSymbolReference()), frame, false);
 
-        WindowNode.Specification specification = new WindowNode.Specification(ImmutableList.of(), Optional.empty());
+        DataOrganizationSpecification specification = new DataOrganizationSpecification(ImmutableList.of(), Optional.empty());
 
         PlanNode node = new WindowNode(
                 newId(),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PatternRecognitionMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PatternRecognitionMatcher.java
@@ -19,6 +19,7 @@ import io.trino.Session;
 import io.trino.cost.StatsProvider;
 import io.trino.metadata.Metadata;
 import io.trino.spi.type.Type;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.planner.plan.PatternRecognitionNode;
 import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.WindowNode;
@@ -53,7 +54,7 @@ import static java.util.Objects.requireNonNull;
 public class PatternRecognitionMatcher
         implements Matcher
 {
-    private final Optional<ExpectedValueProvider<WindowNode.Specification>> specification;
+    private final Optional<ExpectedValueProvider<DataOrganizationSpecification>> specification;
     private final Optional<ExpectedValueProvider<WindowNode.Frame>> frame;
     private final RowsPerMatch rowsPerMatch;
     private final Optional<IrLabel> skipToLabel;
@@ -64,7 +65,7 @@ public class PatternRecognitionMatcher
     private final Map<IrLabel, ExpressionAndValuePointers> variableDefinitions;
 
     private PatternRecognitionMatcher(
-            Optional<ExpectedValueProvider<WindowNode.Specification>> specification,
+            Optional<ExpectedValueProvider<DataOrganizationSpecification>> specification,
             Optional<ExpectedValueProvider<WindowNode.Frame>> frame,
             RowsPerMatch rowsPerMatch,
             Optional<IrLabel> skipToLabel,
@@ -179,7 +180,7 @@ public class PatternRecognitionMatcher
     public static class Builder
     {
         private final PlanMatchPattern source;
-        private Optional<ExpectedValueProvider<WindowNode.Specification>> specification = Optional.empty();
+        private Optional<ExpectedValueProvider<DataOrganizationSpecification>> specification = Optional.empty();
         private final List<AliasMatcher> windowFunctionMatchers = new LinkedList<>();
         private final Map<String, Map.Entry<String, Type>> measures = new HashMap<>();
         private Optional<ExpectedValueProvider<WindowNode.Frame>> frame = Optional.empty();
@@ -198,7 +199,7 @@ public class PatternRecognitionMatcher
         }
 
         @CanIgnoreReturnValue
-        public Builder specification(ExpectedValueProvider<WindowNode.Specification> specification)
+        public Builder specification(ExpectedValueProvider<DataOrganizationSpecification> specification)
         {
             this.specification = Optional.of(specification);
             return this;

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
@@ -35,6 +35,7 @@ import io.trino.sql.planner.plan.AggregationNode.Step;
 import io.trino.sql.planner.plan.ApplyNode;
 import io.trino.sql.planner.plan.AssignUniqueId;
 import io.trino.sql.planner.plan.CorrelatedJoinNode;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.planner.plan.DistinctLimitNode;
 import io.trino.sql.planner.plan.EnforceSingleRowNode;
 import io.trino.sql.planner.plan.ExceptNode;
@@ -1073,7 +1074,7 @@ public final class PlanMatchPattern
                 .collect(toImmutableList());
     }
 
-    public static ExpectedValueProvider<WindowNode.Specification> specification(
+    public static ExpectedValueProvider<DataOrganizationSpecification> specification(
             List<String> partitionBy,
             List<String> orderBy,
             Map<String, SortOrder> orderings)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
@@ -835,6 +835,13 @@ public final class PlanMatchPattern
         return node(TableExecuteNode.class, source).with(new TableExecuteMatcher(columns, columnNames));
     }
 
+    public static PlanMatchPattern tableFunction(Consumer<TableFunctionMatcher.Builder> handler, PlanMatchPattern... sources)
+    {
+        TableFunctionMatcher.Builder builder = new TableFunctionMatcher.Builder(sources);
+        handler.accept(builder);
+        return builder.build();
+    }
+
     public PlanMatchPattern(List<PlanMatchPattern> sourcePatterns)
     {
         requireNonNull(sourcePatterns, "sourcePatterns are null");

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/SpecificationProvider.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/SpecificationProvider.java
@@ -17,7 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.spi.connector.SortOrder;
 import io.trino.sql.planner.OrderingScheme;
-import io.trino.sql.planner.plan.WindowNode;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 
 import java.util.List;
 import java.util.Map;
@@ -29,7 +29,7 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Objects.requireNonNull;
 
 public class SpecificationProvider
-        implements ExpectedValueProvider<WindowNode.Specification>
+        implements ExpectedValueProvider<DataOrganizationSpecification>
 {
     private final List<SymbolAlias> partitionBy;
     private final List<SymbolAlias> orderBy;
@@ -46,7 +46,7 @@ public class SpecificationProvider
     }
 
     @Override
-    public WindowNode.Specification getExpectedValue(SymbolAliases aliases)
+    public DataOrganizationSpecification getExpectedValue(SymbolAliases aliases)
     {
         Optional<OrderingScheme> orderingScheme = Optional.empty();
         if (!orderBy.isEmpty()) {
@@ -61,7 +61,7 @@ public class SpecificationProvider
                             .collect(toImmutableMap(entry -> entry.getKey().toSymbol(aliases), Map.Entry::getValue))));
         }
 
-        return new WindowNode.Specification(
+        return new DataOrganizationSpecification(
                 partitionBy
                         .stream()
                         .map(alias -> alias.toSymbol(aliases))

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/TableFunctionMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/TableFunctionMatcher.java
@@ -1,0 +1,310 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.assertions;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.trino.Session;
+import io.trino.cost.StatsProvider;
+import io.trino.metadata.Metadata;
+import io.trino.spi.ptf.Argument;
+import io.trino.spi.ptf.Descriptor;
+import io.trino.spi.ptf.DescriptorArgument;
+import io.trino.spi.ptf.ScalarArgument;
+import io.trino.spi.ptf.TableArgument;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.TableFunctionNode;
+import io.trino.sql.planner.plan.TableFunctionNode.TableArgumentProperties;
+import io.trino.sql.tree.SymbolReference;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.sql.planner.assertions.MatchResult.NO_MATCH;
+import static io.trino.sql.planner.assertions.MatchResult.match;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
+import static java.util.Objects.requireNonNull;
+
+public class TableFunctionMatcher
+        implements Matcher
+{
+    private final String name;
+    private final Map<String, ArgumentValue> arguments;
+    private final List<String> properOutputs;
+    private final List<List<String>> copartitioningLists;
+
+    private TableFunctionMatcher(
+            String name,
+            Map<String, ArgumentValue> arguments,
+            List<String> properOutputs,
+            List<List<String>> copartitioningLists)
+    {
+        this.name = requireNonNull(name, "name is null");
+        this.arguments = ImmutableMap.copyOf(requireNonNull(arguments, "arguments is null"));
+        this.properOutputs = ImmutableList.copyOf(requireNonNull(properOutputs, "properOutputs is null"));
+        requireNonNull(copartitioningLists, "copartitioningLists is null");
+        this.copartitioningLists = copartitioningLists.stream()
+                .map(ImmutableList::copyOf)
+                .collect(toImmutableList());
+    }
+
+    @Override
+    public boolean shapeMatches(PlanNode node)
+    {
+        return node instanceof TableFunctionNode;
+    }
+
+    @Override
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
+
+        TableFunctionNode tableFunctionNode = (TableFunctionNode) node;
+
+        if (!name.equals(tableFunctionNode.getName())) {
+            return NO_MATCH;
+        }
+
+        if (arguments.size() != tableFunctionNode.getArguments().size()) {
+            return NO_MATCH;
+        }
+        for (Map.Entry<String, ArgumentValue> entry : arguments.entrySet()) {
+            String name = entry.getKey();
+            Argument actual = tableFunctionNode.getArguments().get(name);
+            if (actual == null) {
+                return NO_MATCH;
+            }
+            ArgumentValue expected = entry.getValue();
+            if (expected instanceof DescriptorArgumentValue expectedDescriptor) {
+                if (!(actual instanceof DescriptorArgument actualDescriptor) || !expectedDescriptor.descriptor().equals(actualDescriptor.getDescriptor())) {
+                    return NO_MATCH;
+                }
+            }
+            else if (expected instanceof ScalarArgumentValue expectedScalar) {
+                if (!(actual instanceof ScalarArgument actualScalar) || !Objects.equals(expectedScalar.value(), actualScalar.getValue())) {
+                    return NO_MATCH;
+                }
+            }
+            else {
+                if (!(actual instanceof TableArgument)) {
+                    return NO_MATCH;
+                }
+                TableArgumentValue expectedTableArgument = (TableArgumentValue) expected;
+                TableArgumentProperties argumentProperties = tableFunctionNode.getTableArgumentProperties().get(expectedTableArgument.sourceIndex());
+                if (!name.equals(argumentProperties.getArgumentName())) {
+                    return NO_MATCH;
+                }
+                if (expectedTableArgument.rowSemantics() != argumentProperties.isRowSemantics() ||
+                        expectedTableArgument.pruneWhenEmpty() != argumentProperties.isPruneWhenEmpty() ||
+                        expectedTableArgument.passThroughColumns() != argumentProperties.isPassThroughColumns()) {
+                    return NO_MATCH;
+                }
+                boolean specificationMatches = expectedTableArgument.specification()
+                        .map(specification -> specification.getExpectedValue(symbolAliases))
+                        .equals(argumentProperties.getSpecification());
+                if (!specificationMatches) {
+                    return NO_MATCH;
+                }
+            }
+        }
+
+        if (properOutputs.size() != tableFunctionNode.getProperOutputs().size()) {
+            return NO_MATCH;
+        }
+
+        if (!ImmutableSet.copyOf(copartitioningLists).equals(ImmutableSet.copyOf(tableFunctionNode.getCopartitioningLists()))) {
+            return NO_MATCH;
+        }
+
+        ImmutableMap.Builder<String, SymbolReference> properOutputsMapping = ImmutableMap.builder();
+        for (int i = 0; i < properOutputs.size(); i++) {
+            properOutputsMapping.put(properOutputs.get(i), tableFunctionNode.getProperOutputs().get(i).toSymbolReference());
+        }
+
+        return match(SymbolAliases.builder()
+                .putAll(symbolAliases)
+                .putAll(properOutputsMapping.buildOrThrow())
+                .build());
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .omitNullValues()
+                .add("name", name)
+                .add("arguments", arguments)
+                .add("properOutputs", properOutputs)
+                .add("copartitioningLists", copartitioningLists)
+                .toString();
+    }
+
+    public static class Builder
+    {
+        private final PlanMatchPattern[] sources;
+        private String name;
+        private final ImmutableMap.Builder<String, ArgumentValue> arguments = ImmutableMap.builder();
+        private List<String> properOutputs = ImmutableList.of();
+        private final ImmutableList.Builder<List<String>> copartitioningLists = ImmutableList.builder();
+
+        Builder(PlanMatchPattern... sources)
+        {
+            this.sources = Arrays.copyOf(sources, sources.length);
+        }
+
+        public Builder name(String name)
+        {
+            this.name = name;
+            return this;
+        }
+
+        public Builder addDescriptorArgument(String name, DescriptorArgumentValue descriptor)
+        {
+            this.arguments.put(name, descriptor);
+            return this;
+        }
+
+        public Builder addScalarArgument(String name, Object value)
+        {
+            this.arguments.put(name, new ScalarArgumentValue(value));
+            return this;
+        }
+
+        public Builder addTableArgument(String name, TableArgumentValue.Builder tableArgument)
+        {
+            this.arguments.put(name, tableArgument.build());
+            return this;
+        }
+
+        public Builder properOutputs(List<String> properOutputs)
+        {
+            this.properOutputs = properOutputs;
+            return this;
+        }
+
+        public Builder addCopartitioning(List<String> copartitioning)
+        {
+            this.copartitioningLists.add(copartitioning);
+            return this;
+        }
+
+        public PlanMatchPattern build()
+        {
+            return node(TableFunctionNode.class, sources)
+                    .with(new TableFunctionMatcher(name, arguments.buildOrThrow(), properOutputs, copartitioningLists.build()));
+        }
+    }
+
+    public sealed interface ArgumentValue
+            permits DescriptorArgumentValue, ScalarArgumentValue, TableArgumentValue
+    {}
+
+    public record DescriptorArgumentValue(Optional<Descriptor> descriptor)
+            implements ArgumentValue
+    {
+        public DescriptorArgumentValue(Optional<Descriptor> descriptor)
+        {
+            this.descriptor = requireNonNull(descriptor, "descriptor is null");
+        }
+
+        public static DescriptorArgumentValue descriptorArgument(Descriptor descriptor)
+        {
+            return new DescriptorArgumentValue(Optional.of(requireNonNull(descriptor, "descriptor is null")));
+        }
+
+        public static DescriptorArgumentValue nullDescriptor()
+        {
+            return new DescriptorArgumentValue(Optional.empty());
+        }
+    }
+
+    public record ScalarArgumentValue(Object value)
+            implements ArgumentValue
+    {}
+
+    public record TableArgumentValue(
+            int sourceIndex,
+            boolean rowSemantics,
+            boolean pruneWhenEmpty,
+            boolean passThroughColumns,
+            Optional<ExpectedValueProvider<DataOrganizationSpecification>> specification)
+            implements ArgumentValue
+    {
+        public TableArgumentValue(int sourceIndex, boolean rowSemantics, boolean pruneWhenEmpty, boolean passThroughColumns, Optional<ExpectedValueProvider<DataOrganizationSpecification>> specification)
+        {
+            this.sourceIndex = sourceIndex;
+            this.rowSemantics = rowSemantics;
+            this.pruneWhenEmpty = pruneWhenEmpty;
+            this.passThroughColumns = passThroughColumns;
+            this.specification = requireNonNull(specification, "specification is null");
+        }
+
+        public static class Builder
+        {
+            private final int sourceIndex;
+            private boolean rowSemantics;
+            private boolean pruneWhenEmpty;
+            private boolean passThroughColumns;
+            private Optional<ExpectedValueProvider<DataOrganizationSpecification>> specification = Optional.empty();
+
+            private Builder(int sourceIndex)
+            {
+                this.sourceIndex = sourceIndex;
+            }
+
+            public static Builder tableArgument(int sourceIndex)
+            {
+                return new Builder(sourceIndex);
+            }
+
+            public Builder rowSemantics()
+            {
+                this.rowSemantics = true;
+                this.pruneWhenEmpty = true;
+                return this;
+            }
+
+            public Builder pruneWhenEmpty()
+            {
+                this.pruneWhenEmpty = true;
+                return this;
+            }
+
+            public Builder passThroughColumns()
+            {
+                this.passThroughColumns = true;
+                return this;
+            }
+
+            public Builder specification(ExpectedValueProvider<DataOrganizationSpecification> specification)
+            {
+                this.specification = Optional.of(specification);
+                return this;
+            }
+
+            private TableArgumentValue build()
+            {
+                return new TableArgumentValue(sourceIndex, rowSemantics, pruneWhenEmpty, passThroughColumns, specification);
+            }
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/TopNRankingMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/TopNRankingMatcher.java
@@ -18,10 +18,10 @@ import io.trino.cost.StatsProvider;
 import io.trino.metadata.Metadata;
 import io.trino.spi.connector.SortOrder;
 import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.TopNRankingNode;
 import io.trino.sql.planner.plan.TopNRankingNode.RankingType;
-import io.trino.sql.planner.plan.WindowNode;
 
 import java.util.List;
 import java.util.Map;
@@ -37,7 +37,7 @@ import static java.util.Objects.requireNonNull;
 public class TopNRankingMatcher
         implements Matcher
 {
-    private final Optional<ExpectedValueProvider<WindowNode.Specification>> specification;
+    private final Optional<ExpectedValueProvider<DataOrganizationSpecification>> specification;
     private final Optional<SymbolAlias> rankingSymbol;
     private final Optional<RankingType> rankingType;
     private final Optional<Integer> maxRankingPerPartition;
@@ -45,7 +45,7 @@ public class TopNRankingMatcher
     private final Optional<Optional<SymbolAlias>> hashSymbol;
 
     private TopNRankingMatcher(
-            Optional<ExpectedValueProvider<WindowNode.Specification>> specification,
+            Optional<ExpectedValueProvider<DataOrganizationSpecification>> specification,
             Optional<SymbolAlias> rankingSymbol,
             Optional<RankingType> rankingType,
             Optional<Integer> maxRankingPerPartition,
@@ -74,7 +74,7 @@ public class TopNRankingMatcher
         TopNRankingNode topNRankingNode = (TopNRankingNode) node;
 
         if (specification.isPresent()) {
-            WindowNode.Specification expected = specification.get().getExpectedValue(symbolAliases);
+            DataOrganizationSpecification expected = specification.get().getExpectedValue(symbolAliases);
             if (!expected.equals(topNRankingNode.getSpecification())) {
                 return NO_MATCH;
             }
@@ -131,7 +131,7 @@ public class TopNRankingMatcher
     public static class Builder
     {
         private final PlanMatchPattern source;
-        private Optional<ExpectedValueProvider<WindowNode.Specification>> specification = Optional.empty();
+        private Optional<ExpectedValueProvider<DataOrganizationSpecification>> specification = Optional.empty();
         private Optional<SymbolAlias> rankingSymbol = Optional.empty();
         private Optional<RankingType> rankingType = Optional.empty();
         private Optional<Integer> maxRankingPerPartition = Optional.empty();

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/WindowMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/WindowMatcher.java
@@ -18,6 +18,7 @@ import io.trino.cost.StatsProvider;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.ResolvedFunction;
 import io.trino.spi.connector.SortOrder;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.WindowNode;
 import io.trino.sql.tree.FunctionCall;
@@ -43,13 +44,13 @@ public final class WindowMatcher
         implements Matcher
 {
     private final Optional<Set<SymbolAlias>> prePartitionedInputs;
-    private final Optional<ExpectedValueProvider<WindowNode.Specification>> specification;
+    private final Optional<ExpectedValueProvider<DataOrganizationSpecification>> specification;
     private final Optional<Integer> preSortedOrderPrefix;
     private final Optional<Optional<SymbolAlias>> hashSymbol;
 
     private WindowMatcher(
             Optional<Set<SymbolAlias>> prePartitionedInputs,
-            Optional<ExpectedValueProvider<WindowNode.Specification>> specification,
+            Optional<ExpectedValueProvider<DataOrganizationSpecification>> specification,
             Optional<Integer> preSortedOrderPrefix,
             Optional<Optional<SymbolAlias>> hashSymbol)
     {
@@ -133,7 +134,7 @@ public final class WindowMatcher
     {
         private final PlanMatchPattern source;
         private Optional<Set<SymbolAlias>> prePartitionedInputs = Optional.empty();
-        private Optional<ExpectedValueProvider<WindowNode.Specification>> specification = Optional.empty();
+        private Optional<ExpectedValueProvider<DataOrganizationSpecification>> specification = Optional.empty();
         private Optional<Integer> preSortedOrderPrefix = Optional.empty();
         private final List<AliasMatcher> windowFunctionMatchers = new LinkedList<>();
         private Optional<Optional<SymbolAlias>> hashSymbol = Optional.empty();
@@ -161,7 +162,7 @@ public final class WindowMatcher
             return specification(PlanMatchPattern.specification(partitionBy, orderBy, orderings));
         }
 
-        public Builder specification(ExpectedValueProvider<WindowNode.Specification> specification)
+        public Builder specification(ExpectedValueProvider<DataOrganizationSpecification> specification)
         {
             requireNonNull(specification, "specification is null");
             this.specification = Optional.of(specification);

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestMergeAdjacentWindows.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestMergeAdjacentWindows.java
@@ -22,6 +22,7 @@ import io.trino.sql.planner.assertions.PlanMatchPattern;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
 import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.planner.plan.WindowNode;
 import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.SymbolReference;
@@ -51,7 +52,7 @@ public class TestMergeAdjacentWindows
     private static final ResolvedFunction LAG = FUNCTION_RESOLUTION.resolveFunction(QualifiedName.of("lag"), fromTypes(DOUBLE));
 
     private static final String columnAAlias = "ALIAS_A";
-    private static final ExpectedValueProvider<WindowNode.Specification> specificationA =
+    private static final ExpectedValueProvider<DataOrganizationSpecification> specificationA =
             specification(ImmutableList.of(columnAAlias), ImmutableList.of(), ImmutableMap.of());
 
     @Test
@@ -203,9 +204,9 @@ public class TestMergeAdjacentWindows
                                                         values(columnAAlias, unusedAlias))))));
     }
 
-    private static WindowNode.Specification newWindowNodeSpecification(PlanBuilder planBuilder, String symbolName)
+    private static DataOrganizationSpecification newWindowNodeSpecification(PlanBuilder planBuilder, String symbolName)
     {
-        return new WindowNode.Specification(ImmutableList.of(planBuilder.symbol(symbolName, BIGINT)), Optional.empty());
+        return new DataOrganizationSpecification(ImmutableList.of(planBuilder.symbol(symbolName, BIGINT)), Optional.empty());
     }
 
     private static WindowNode.Function newWindowNodeFunction(ResolvedFunction resolvedFunction, String... symbols)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneTopNRankingColumns.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneTopNRankingColumns.java
@@ -21,7 +21,7 @@ import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.assertions.TopNRankingSymbolMatcher;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.plan.Assignments;
-import io.trino.sql.planner.plan.WindowNode.Specification;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
@@ -46,7 +46,7 @@ public class TestPruneTopNRankingColumns
                     return p.project(
                             Assignments.identity(b, ranking),
                             p.topNRanking(
-                                    new Specification(
+                                    new DataOrganizationSpecification(
                                             ImmutableList.of(a),
                                             Optional.of(new OrderingScheme(ImmutableList.of(b), ImmutableMap.of(b, SortOrder.ASC_NULLS_FIRST)))),
                                     ROW_NUMBER,
@@ -68,7 +68,7 @@ public class TestPruneTopNRankingColumns
                     return p.project(
                             Assignments.identity(ranking),
                             p.topNRanking(
-                                    new Specification(
+                                    new DataOrganizationSpecification(
                                             ImmutableList.of(),
                                             Optional.of(new OrderingScheme(ImmutableList.of(a), ImmutableMap.of(a, SortOrder.ASC_NULLS_FIRST)))),
                                     ROW_NUMBER,
@@ -91,7 +91,7 @@ public class TestPruneTopNRankingColumns
                     return p.project(
                             Assignments.identity(a, ranking),
                             p.topNRanking(
-                                    new Specification(
+                                    new DataOrganizationSpecification(
                                             ImmutableList.of(),
                                             Optional.of(new OrderingScheme(ImmutableList.of(a), ImmutableMap.of(a, SortOrder.ASC_NULLS_FIRST)))),
                                     ROW_NUMBER,
@@ -114,7 +114,7 @@ public class TestPruneTopNRankingColumns
                     return p.project(
                             Assignments.identity(a, ranking),
                             p.topNRanking(
-                                    new Specification(
+                                    new DataOrganizationSpecification(
                                             ImmutableList.of(),
                                             Optional.of(new OrderingScheme(ImmutableList.of(a), ImmutableMap.of(a, SortOrder.ASC_NULLS_FIRST)))),
                                     ROW_NUMBER,
@@ -151,7 +151,7 @@ public class TestPruneTopNRankingColumns
                     return p.project(
                             Assignments.identity(a, b, ranking),
                             p.topNRanking(
-                                    new Specification(
+                                    new DataOrganizationSpecification(
                                             ImmutableList.of(),
                                             Optional.of(new OrderingScheme(ImmutableList.of(a), ImmutableMap.of(a, SortOrder.ASC_NULLS_FIRST)))),
                                     ROW_NUMBER,
@@ -173,7 +173,7 @@ public class TestPruneTopNRankingColumns
                     return p.project(
                             Assignments.identity(a),
                             p.topNRanking(
-                                    new Specification(
+                                    new DataOrganizationSpecification(
                                             ImmutableList.of(),
                                             Optional.of(new OrderingScheme(ImmutableList.of(a), ImmutableMap.of(a, SortOrder.ASC_NULLS_FIRST)))),
                                     ROW_NUMBER,

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneWindowColumns.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneWindowColumns.java
@@ -28,6 +28,7 @@ import io.trino.sql.planner.assertions.PlanMatchPattern;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
 import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.WindowNode;
 import io.trino.sql.tree.QualifiedName;
@@ -207,7 +208,7 @@ public class TestPruneWindowColumns
                                 .filter(projectionFilter)
                                 .collect(toImmutableList())),
                 p.window(
-                        new WindowNode.Specification(
+                        new DataOrganizationSpecification(
                                 ImmutableList.of(partitionKey),
                                 Optional.of(new OrderingScheme(
                                         ImmutableList.of(orderKey),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushDownDereferencesRules.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushDownDereferencesRules.java
@@ -28,6 +28,7 @@ import io.trino.sql.planner.assertions.ExpressionMatcher;
 import io.trino.sql.planner.assertions.PlanMatchPattern;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.planner.plan.UnnestNode;
 import io.trino.sql.planner.plan.WindowNode;
 import io.trino.sql.tree.FrameBound;
@@ -518,7 +519,7 @@ public class TestPushDownDereferencesRules
                                         .put(p.symbol("msg3_x"), expression("msg3[1]"))
                                         .build(),
                                 p.topNRanking(
-                                        new WindowNode.Specification(
+                                        new DataOrganizationSpecification(
                                                 ImmutableList.of(p.symbol("msg1", ROW_TYPE)),
                                                 Optional.of(new OrderingScheme(
                                                         ImmutableList.of(p.symbol("msg2", ROW_TYPE)),
@@ -589,7 +590,7 @@ public class TestPushDownDereferencesRules
                                         .put(p.symbol("msg5_x"), expression("msg5[1]"))
                                         .build(),
                                 p.window(
-                                        new WindowNode.Specification(
+                                        new DataOrganizationSpecification(
                                                 ImmutableList.of(p.symbol("msg1", ROW_TYPE)),
                                                 Optional.of(new OrderingScheme(
                                                         ImmutableList.of(p.symbol("msg2", ROW_TYPE)),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushPredicateThroughProjectIntoWindow.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushPredicateThroughProjectIntoWindow.java
@@ -22,9 +22,9 @@ import io.trino.sql.planner.assertions.TopNRankingSymbolMatcher;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
 import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.planner.plan.TopNRankingNode.RankingType;
 import io.trino.sql.planner.plan.WindowNode.Function;
-import io.trino.sql.planner.plan.WindowNode.Specification;
 import io.trino.sql.tree.QualifiedName;
 import org.testng.annotations.Test;
 
@@ -63,7 +63,7 @@ public class TestPushPredicateThroughProjectIntoWindow
                             p.project(
                                     Assignments.identity(a),
                                     p.window(
-                                            new Specification(
+                                            new DataOrganizationSpecification(
                                                     ImmutableList.of(),
                                                     Optional.of(new OrderingScheme(ImmutableList.of(a), ImmutableMap.of(a, ASC_NULLS_FIRST)))),
                                             ImmutableMap.of(ranking, rankingFunction),
@@ -90,7 +90,7 @@ public class TestPushPredicateThroughProjectIntoWindow
                             p.project(
                                     Assignments.identity(a, ranking),
                                     p.window(
-                                            new Specification(
+                                            new DataOrganizationSpecification(
                                                     ImmutableList.of(),
                                                     Optional.of(new OrderingScheme(ImmutableList.of(a), ImmutableMap.of(a, ASC_NULLS_FIRST)))),
                                             ImmutableMap.of(ranking, rankingFunction),
@@ -117,7 +117,7 @@ public class TestPushPredicateThroughProjectIntoWindow
                             p.project(
                                     Assignments.identity(a, ranking),
                                     p.window(
-                                            new Specification(
+                                            new DataOrganizationSpecification(
                                                     ImmutableList.of(),
                                                     Optional.of(new OrderingScheme(ImmutableList.of(a), ImmutableMap.of(a, ASC_NULLS_FIRST)))),
                                             ImmutableMap.of(ranking, rankingFunction),
@@ -144,7 +144,7 @@ public class TestPushPredicateThroughProjectIntoWindow
                             p.project(
                                     Assignments.identity(ranking),
                                     p.window(
-                                            new Specification(
+                                            new DataOrganizationSpecification(
                                                     ImmutableList.of(),
                                                     Optional.of(new OrderingScheme(ImmutableList.of(a), ImmutableMap.of(a, ASC_NULLS_FIRST)))),
                                             ImmutableMap.of(ranking, rankingFunction),
@@ -185,7 +185,7 @@ public class TestPushPredicateThroughProjectIntoWindow
                             p.project(
                                     Assignments.identity(ranking),
                                     p.window(
-                                            new Specification(
+                                            new DataOrganizationSpecification(
                                                     ImmutableList.of(),
                                                     Optional.of(new OrderingScheme(ImmutableList.of(a), ImmutableMap.of(a, ASC_NULLS_FIRST)))),
                                             ImmutableMap.of(ranking, rankingFunction),
@@ -224,7 +224,7 @@ public class TestPushPredicateThroughProjectIntoWindow
                             p.project(
                                     Assignments.identity(ranking, a),
                                     p.window(
-                                            new Specification(
+                                            new DataOrganizationSpecification(
                                                     ImmutableList.of(),
                                                     Optional.of(new OrderingScheme(ImmutableList.of(a), ImmutableMap.of(a, ASC_NULLS_FIRST)))),
                                             ImmutableMap.of(ranking, rankingFunction),
@@ -255,7 +255,7 @@ public class TestPushPredicateThroughProjectIntoWindow
                             p.project(
                                     Assignments.identity(ranking),
                                     p.window(
-                                            new Specification(
+                                            new DataOrganizationSpecification(
                                                     ImmutableList.of(),
                                                     Optional.of(new OrderingScheme(ImmutableList.of(a), ImmutableMap.of(a, ASC_NULLS_FIRST)))),
                                             ImmutableMap.of(ranking, rankingFunction),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushdownFilterIntoWindow.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushdownFilterIntoWindow.java
@@ -21,6 +21,7 @@ import io.trino.sql.planner.OrderingScheme;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.assertions.TopNRankingSymbolMatcher;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.planner.plan.WindowNode;
 import io.trino.sql.tree.QualifiedName;
 import org.testng.annotations.Test;
@@ -56,7 +57,7 @@ public class TestPushdownFilterIntoWindow
                             ImmutableList.of(a),
                             ImmutableMap.of(a, SortOrder.ASC_NULLS_FIRST));
                     return p.filter(expression("rank_1 < cast(100 as bigint)"), p.window(
-                            new WindowNode.Specification(ImmutableList.of(a), Optional.of(orderingScheme)),
+                            new DataOrganizationSpecification(ImmutableList.of(a), Optional.of(orderingScheme)),
                             ImmutableMap.of(rankSymbol, newWindowNodeFunction(ranking, a)),
                             p.values(p.symbol("a"))));
                 })
@@ -84,7 +85,7 @@ public class TestPushdownFilterIntoWindow
                             ImmutableList.of(a),
                             ImmutableMap.of(a, SortOrder.ASC_NULLS_FIRST));
                     return p.filter(expression("cast(3 as bigint) < row_number_1 and row_number_1 < cast(100 as bigint)"), p.window(
-                            new WindowNode.Specification(ImmutableList.of(a), Optional.of(orderingScheme)),
+                            new DataOrganizationSpecification(ImmutableList.of(a), Optional.of(orderingScheme)),
                             ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(ranking, a)),
                             p.values(p.symbol("a"))));
                 })
@@ -107,7 +108,7 @@ public class TestPushdownFilterIntoWindow
                             ImmutableList.of(a),
                             ImmutableMap.of(a, SortOrder.ASC_NULLS_FIRST));
                     return p.filter(expression("row_number_1 < cast(100 as bigint) and a = BIGINT '1'"), p.window(
-                            new WindowNode.Specification(ImmutableList.of(a), Optional.of(orderingScheme)),
+                            new DataOrganizationSpecification(ImmutableList.of(a), Optional.of(orderingScheme)),
                             ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(ranking, a)),
                             p.values(p.symbol("a"))));
                 })
@@ -143,7 +144,7 @@ public class TestPushdownFilterIntoWindow
                     return p.filter(
                             expression("cast(3 as bigint) < row_number_1"),
                             p.window(
-                                    new WindowNode.Specification(ImmutableList.of(a), Optional.of(orderingScheme)),
+                                    new DataOrganizationSpecification(ImmutableList.of(a), Optional.of(orderingScheme)),
                                     ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(ranking, a)),
                                     p.values(a)));
                 })

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushdownLimitIntoWindow.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushdownLimitIntoWindow.java
@@ -20,6 +20,7 @@ import io.trino.spi.connector.SortOrder;
 import io.trino.sql.planner.OrderingScheme;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.planner.plan.WindowNode;
 import io.trino.sql.tree.QualifiedName;
 import org.testng.annotations.Test;
@@ -55,7 +56,7 @@ public class TestPushdownLimitIntoWindow
                     return p.limit(
                             3,
                             p.window(
-                                    new WindowNode.Specification(ImmutableList.of(a), Optional.of(orderingScheme)),
+                                    new DataOrganizationSpecification(ImmutableList.of(a), Optional.of(orderingScheme)),
                                     ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(ranking, a)),
                                     p.values(a)));
                 })
@@ -82,7 +83,7 @@ public class TestPushdownLimitIntoWindow
                             ImmutableList.of(a),
                             ImmutableMap.of(a, SortOrder.ASC_NULLS_FIRST));
                     return p.limit(3, p.window(
-                            new WindowNode.Specification(ImmutableList.of(), Optional.of(orderingScheme)),
+                            new DataOrganizationSpecification(ImmutableList.of(), Optional.of(orderingScheme)),
                             ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(ranking, a)),
                             p.values(a)));
                 })
@@ -114,7 +115,7 @@ public class TestPushdownLimitIntoWindow
                             false,
                             ImmutableList.of(a),
                             p.window(
-                                    new WindowNode.Specification(ImmutableList.of(), Optional.of(orderingScheme)),
+                                    new DataOrganizationSpecification(ImmutableList.of(), Optional.of(orderingScheme)),
                                     ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(ranking, a)),
                                     p.values(a)));
                 })
@@ -141,7 +142,7 @@ public class TestPushdownLimitIntoWindow
                     return p.limit(
                             0,
                             p.window(
-                                    new WindowNode.Specification(ImmutableList.of(a), Optional.of(orderingScheme)),
+                                    new DataOrganizationSpecification(ImmutableList.of(a), Optional.of(orderingScheme)),
                                     ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(ranking, a)),
                                     p.values(a)));
                 })
@@ -165,7 +166,7 @@ public class TestPushdownLimitIntoWindow
                     return p.limit(
                             3,
                             p.window(
-                                    new WindowNode.Specification(ImmutableList.of(a), Optional.empty()),
+                                    new DataOrganizationSpecification(ImmutableList.of(a), Optional.empty()),
                                     ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(ranking, a)),
                                     p.values(a)));
                 })
@@ -185,7 +186,7 @@ public class TestPushdownLimitIntoWindow
                     return p.limit(
                             3,
                             p.window(
-                                    new WindowNode.Specification(ImmutableList.of(a), Optional.empty()),
+                                    new DataOrganizationSpecification(ImmutableList.of(a), Optional.empty()),
                                     ImmutableMap.of(
                                             rowNumberSymbol,
                                             newWindowNodeFunction(rowNumberFunction, a),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestReplaceWindowWithRowNumber.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestReplaceWindowWithRowNumber.java
@@ -20,6 +20,7 @@ import io.trino.spi.connector.SortOrder;
 import io.trino.sql.planner.OrderingScheme;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.planner.plan.WindowNode;
 import io.trino.sql.tree.QualifiedName;
 import org.testng.annotations.Test;
@@ -43,7 +44,7 @@ public class TestReplaceWindowWithRowNumber
                     Symbol a = p.symbol("a");
                     Symbol rowNumberSymbol = p.symbol("row_number_1");
                     return p.window(
-                            new WindowNode.Specification(ImmutableList.of(a), Optional.empty()),
+                            new DataOrganizationSpecification(ImmutableList.of(a), Optional.empty()),
                             ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(rowNumberFunction)),
                             p.values(a));
                 })
@@ -58,7 +59,7 @@ public class TestReplaceWindowWithRowNumber
                     Symbol a = p.symbol("a");
                     Symbol rowNumberSymbol = p.symbol("row_number_1");
                     return p.window(
-                            new WindowNode.Specification(ImmutableList.of(), Optional.empty()),
+                            new DataOrganizationSpecification(ImmutableList.of(), Optional.empty()),
                             ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(rowNumberFunction)),
                             p.values(a));
                 })
@@ -78,7 +79,7 @@ public class TestReplaceWindowWithRowNumber
                     Symbol a = p.symbol("a");
                     Symbol rank1 = p.symbol("rank_1");
                     return p.window(
-                            new WindowNode.Specification(ImmutableList.of(a), Optional.empty()),
+                            new DataOrganizationSpecification(ImmutableList.of(a), Optional.empty()),
                             ImmutableMap.of(rank1, newWindowNodeFunction(rank)),
                             p.values(a));
                 })
@@ -91,7 +92,7 @@ public class TestReplaceWindowWithRowNumber
                     Symbol rowNumber1 = p.symbol("row_number_1");
                     Symbol rank1 = p.symbol("rank_1");
                     return p.window(
-                            new WindowNode.Specification(ImmutableList.of(a), Optional.empty()),
+                            new DataOrganizationSpecification(ImmutableList.of(a), Optional.empty()),
                             ImmutableMap.of(rowNumber1, newWindowNodeFunction(rowNumber), rank1, newWindowNodeFunction(rank)),
                             p.values(a));
                 })
@@ -103,7 +104,7 @@ public class TestReplaceWindowWithRowNumber
                     OrderingScheme orderingScheme = new OrderingScheme(ImmutableList.of(a), ImmutableMap.of(a, SortOrder.ASC_NULLS_FIRST));
                     Symbol rowNumber1 = p.symbol("row_number_1");
                     return p.window(
-                            new WindowNode.Specification(ImmutableList.of(a), Optional.of(orderingScheme)),
+                            new DataOrganizationSpecification(ImmutableList.of(a), Optional.of(orderingScheme)),
                             ImmutableMap.of(rowNumber1, newWindowNodeFunction(rowNumber)),
                             p.values(a));
                 })

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSwapAdjacentWindowsBySpecifications.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSwapAdjacentWindowsBySpecifications.java
@@ -19,6 +19,7 @@ import io.trino.metadata.ResolvedFunction;
 import io.trino.metadata.TestingFunctionResolution;
 import io.trino.sql.planner.assertions.ExpectedValueProvider;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.planner.plan.WindowNode;
 import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.SymbolReference;
@@ -57,7 +58,7 @@ public class TestSwapAdjacentWindowsBySpecifications
     public void doesNotFireOnPlanWithSingleWindowNode()
     {
         tester().assertThat(new GatherAndMergeWindows.SwapAdjacentWindowsBySpecifications(0))
-                .on(p -> p.window(new WindowNode.Specification(
+                .on(p -> p.window(new DataOrganizationSpecification(
                                 ImmutableList.of(p.symbol("a")),
                                 Optional.empty()),
                         ImmutableMap.of(p.symbol("avg_1"),
@@ -72,17 +73,17 @@ public class TestSwapAdjacentWindowsBySpecifications
         String columnAAlias = "ALIAS_A";
         String columnBAlias = "ALIAS_B";
 
-        ExpectedValueProvider<WindowNode.Specification> specificationA = specification(ImmutableList.of(columnAAlias), ImmutableList.of(), ImmutableMap.of());
-        ExpectedValueProvider<WindowNode.Specification> specificationAB = specification(ImmutableList.of(columnAAlias, columnBAlias), ImmutableList.of(), ImmutableMap.of());
+        ExpectedValueProvider<DataOrganizationSpecification> specificationA = specification(ImmutableList.of(columnAAlias), ImmutableList.of(), ImmutableMap.of());
+        ExpectedValueProvider<DataOrganizationSpecification> specificationAB = specification(ImmutableList.of(columnAAlias, columnBAlias), ImmutableList.of(), ImmutableMap.of());
 
         tester().assertThat(new GatherAndMergeWindows.SwapAdjacentWindowsBySpecifications(0))
                 .on(p ->
-                        p.window(new WindowNode.Specification(
+                        p.window(new DataOrganizationSpecification(
                                         ImmutableList.of(p.symbol("a")),
                                         Optional.empty()),
                                 ImmutableMap.of(p.symbol("avg_1", DOUBLE),
                                         new WindowNode.Function(resolvedFunction, ImmutableList.of(new SymbolReference("a")), DEFAULT_FRAME, false)),
-                                p.window(new WindowNode.Specification(
+                                p.window(new DataOrganizationSpecification(
                                                 ImmutableList.of(p.symbol("a"), p.symbol("b")),
                                                 Optional.empty()),
                                         ImmutableMap.of(p.symbol("avg_2", DOUBLE),
@@ -103,12 +104,12 @@ public class TestSwapAdjacentWindowsBySpecifications
     {
         tester().assertThat(new GatherAndMergeWindows.SwapAdjacentWindowsBySpecifications(0))
                 .on(p ->
-                        p.window(new WindowNode.Specification(
+                        p.window(new DataOrganizationSpecification(
                                         ImmutableList.of(p.symbol("a")),
                                         Optional.empty()),
                                 ImmutableMap.of(p.symbol("avg_1"),
                                         new WindowNode.Function(resolvedFunction, ImmutableList.of(new SymbolReference("avg_2")), DEFAULT_FRAME, false)),
-                                p.window(new WindowNode.Specification(
+                                p.window(new DataOrganizationSpecification(
                                                 ImmutableList.of(p.symbol("a"), p.symbol("b")),
                                                 Optional.empty()),
                                         ImmutableMap.of(p.symbol("avg_2"),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PatternRecognitionBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PatternRecognitionBuilder.java
@@ -20,6 +20,7 @@ import io.trino.spi.type.Type;
 import io.trino.sql.planner.OrderingScheme;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.planner.plan.PatternRecognitionNode;
 import io.trino.sql.planner.plan.PatternRecognitionNode.Measure;
 import io.trino.sql.planner.plan.PlanNode;
@@ -156,7 +157,7 @@ public class PatternRecognitionBuilder
         return new PatternRecognitionNode(
                 idAllocator.getNextId(),
                 source,
-                new WindowNode.Specification(partitionBy, orderBy),
+                new DataOrganizationSpecification(partitionBy, orderBy),
                 Optional.empty(),
                 ImmutableSet.of(),
                 0,

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -54,6 +54,7 @@ import io.trino.sql.planner.plan.ApplyNode;
 import io.trino.sql.planner.plan.AssignUniqueId;
 import io.trino.sql.planner.plan.Assignments;
 import io.trino.sql.planner.plan.CorrelatedJoinNode;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.planner.plan.DeleteNode;
 import io.trino.sql.planner.plan.DistinctLimitNode;
 import io.trino.sql.planner.plan.DynamicFilterId;
@@ -103,7 +104,6 @@ import io.trino.sql.planner.plan.UnnestNode;
 import io.trino.sql.planner.plan.UpdateNode;
 import io.trino.sql.planner.plan.ValuesNode;
 import io.trino.sql.planner.plan.WindowNode;
-import io.trino.sql.planner.plan.WindowNode.Specification;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.FunctionCall;
 import io.trino.sql.tree.NullLiteral;
@@ -1344,7 +1344,7 @@ public class PlanBuilder
                 filter);
     }
 
-    public WindowNode window(Specification specification, Map<Symbol, WindowNode.Function> functions, PlanNode source)
+    public WindowNode window(DataOrganizationSpecification specification, Map<Symbol, WindowNode.Function> functions, PlanNode source)
     {
         return new WindowNode(
                 idAllocator.getNextId(),
@@ -1356,7 +1356,7 @@ public class PlanBuilder
                 0);
     }
 
-    public WindowNode window(Specification specification, Map<Symbol, WindowNode.Function> functions, Symbol hashSymbol, PlanNode source)
+    public WindowNode window(DataOrganizationSpecification specification, Map<Symbol, WindowNode.Function> functions, Symbol hashSymbol, PlanNode source)
     {
         return new WindowNode(
                 idAllocator.getNextId(),
@@ -1385,7 +1385,7 @@ public class PlanBuilder
                 hashSymbol);
     }
 
-    public TopNRankingNode topNRanking(Specification specification, RankingType rankingType, int maxRankingPerPartition, Symbol rankingSymbol, Optional<Symbol> hashSymbol, PlanNode source)
+    public TopNRankingNode topNRanking(DataOrganizationSpecification specification, RankingType rankingType, int maxRankingPerPartition, Symbol rankingSymbol, Optional<Symbol> hashSymbol, PlanNode source)
     {
         return new TopNRankingNode(
                 idAllocator.getNextId(),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestEliminateSorts.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestEliminateSorts.java
@@ -26,7 +26,7 @@ import io.trino.sql.planner.assertions.PlanMatchPattern;
 import io.trino.sql.planner.iterative.IterativeOptimizer;
 import io.trino.sql.planner.iterative.rule.DetermineTableScanNodePartitioning;
 import io.trino.sql.planner.iterative.rule.RemoveRedundantIdentityProjections;
-import io.trino.sql.planner.plan.WindowNode;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 
@@ -47,7 +47,7 @@ public class TestEliminateSorts
 {
     private static final String QUANTITY_ALIAS = "QUANTITY";
 
-    private static final ExpectedValueProvider<WindowNode.Specification> windowSpec = specification(
+    private static final ExpectedValueProvider<DataOrganizationSpecification> windowSpec = specification(
             ImmutableList.of(),
             ImmutableList.of(QUANTITY_ALIAS),
             ImmutableMap.of(QUANTITY_ALIAS, SortOrder.ASC_NULLS_LAST));

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestMergeWindows.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestMergeWindows.java
@@ -25,6 +25,7 @@ import io.trino.sql.planner.iterative.IterativeOptimizer;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.iterative.rule.GatherAndMergeWindows;
 import io.trino.sql.planner.iterative.rule.RemoveRedundantIdentityProjections;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.planner.plan.WindowNode;
 import io.trino.sql.tree.FrameBound;
 import io.trino.sql.tree.WindowFrame;
@@ -95,8 +96,8 @@ public class TestMergeWindows
 
     private static final Optional<WindowFrame> UNSPECIFIED_FRAME = Optional.empty();
 
-    private final ExpectedValueProvider<WindowNode.Specification> specificationA;
-    private final ExpectedValueProvider<WindowNode.Specification> specificationB;
+    private final ExpectedValueProvider<DataOrganizationSpecification> specificationA;
+    private final ExpectedValueProvider<DataOrganizationSpecification> specificationB;
 
     public TestMergeWindows()
     {
@@ -305,12 +306,12 @@ public class TestMergeWindows
     @Test
     public void testIdenticalWindowSpecificationsDefaultFrame()
     {
-        ExpectedValueProvider<WindowNode.Specification> specificationC = specification(
+        ExpectedValueProvider<DataOrganizationSpecification> specificationC = specification(
                 ImmutableList.of(SUPPKEY_ALIAS),
                 ImmutableList.of(ORDERKEY_ALIAS),
                 ImmutableMap.of(ORDERKEY_ALIAS, SortOrder.ASC_NULLS_LAST));
 
-        ExpectedValueProvider<WindowNode.Specification> specificationD = specification(
+        ExpectedValueProvider<DataOrganizationSpecification> specificationD = specification(
                 ImmutableList.of(ORDERKEY_ALIAS),
                 ImmutableList.of(SHIPDATE_ALIAS),
                 ImmutableMap.of(SHIPDATE_ALIAS, SortOrder.ASC_NULLS_LAST));
@@ -348,7 +349,7 @@ public class TestMergeWindows
                 ImmutableList.of(),
                 ImmutableList.of()));
 
-        ExpectedValueProvider<WindowNode.Specification> specificationC = specification(
+        ExpectedValueProvider<DataOrganizationSpecification> specificationC = specification(
                 ImmutableList.of(SUPPKEY_ALIAS),
                 ImmutableList.of(ORDERKEY_ALIAS),
                 ImmutableMap.of(ORDERKEY_ALIAS, SortOrder.ASC_NULLS_LAST));
@@ -394,7 +395,7 @@ public class TestMergeWindows
                 ImmutableList.of(),
                 ImmutableList.of()));
 
-        ExpectedValueProvider<WindowNode.Specification> specificationD = specification(
+        ExpectedValueProvider<DataOrganizationSpecification> specificationD = specification(
                 ImmutableList.of(SUPPKEY_ALIAS),
                 ImmutableList.of(ORDERKEY_ALIAS),
                 ImmutableMap.of(ORDERKEY_ALIAS, SortOrder.ASC_NULLS_LAST));
@@ -436,12 +437,12 @@ public class TestMergeWindows
                 ")" +
                 "SELECT * FROM foo, bar WHERE foo.a = bar.b";
 
-        ExpectedValueProvider<WindowNode.Specification> leftSpecification = specification(
+        ExpectedValueProvider<DataOrganizationSpecification> leftSpecification = specification(
                 ImmutableList.of(ORDERKEY_ALIAS),
                 ImmutableList.of(SHIPDATE_ALIAS, QUANTITY_ALIAS),
                 ImmutableMap.of(SHIPDATE_ALIAS, SortOrder.ASC_NULLS_LAST, QUANTITY_ALIAS, SortOrder.DESC_NULLS_LAST));
 
-        ExpectedValueProvider<WindowNode.Specification> rightSpecification = specification(
+        ExpectedValueProvider<DataOrganizationSpecification> rightSpecification = specification(
                 ImmutableList.of(rOrderkeyAlias),
                 ImmutableList.of(rShipdateAlias, rQuantityAlias),
                 ImmutableMap.of(rShipdateAlias, SortOrder.ASC_NULLS_LAST, rQuantityAlias, SortOrder.DESC_NULLS_LAST));
@@ -492,7 +493,7 @@ public class TestMergeWindows
                 "SUM(quantity) over (PARTITION BY quantity ORDER BY orderkey ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) sum_quantity_C " +
                 "FROM lineitem";
 
-        ExpectedValueProvider<WindowNode.Specification> specificationC = specification(
+        ExpectedValueProvider<DataOrganizationSpecification> specificationC = specification(
                 ImmutableList.of(QUANTITY_ALIAS),
                 ImmutableList.of(ORDERKEY_ALIAS),
                 ImmutableMap.of(ORDERKEY_ALIAS, SortOrder.ASC_NULLS_LAST));
@@ -517,7 +518,7 @@ public class TestMergeWindows
                 "SUM(quantity) OVER (PARTITION BY suppkey ORDER BY quantity ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) sum_quantity_C " +
                 "FROM lineitem";
 
-        ExpectedValueProvider<WindowNode.Specification> specificationC = specification(
+        ExpectedValueProvider<DataOrganizationSpecification> specificationC = specification(
                 ImmutableList.of(SUPPKEY_ALIAS),
                 ImmutableList.of(QUANTITY_ALIAS),
                 ImmutableMap.of(QUANTITY_ALIAS, SortOrder.ASC_NULLS_LAST));
@@ -543,7 +544,7 @@ public class TestMergeWindows
                 "SUM(discount) over (PARTITION BY suppkey ORDER BY orderkey ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) sum_discount_A " +
                 "FROM lineitem";
 
-        ExpectedValueProvider<WindowNode.Specification> specificationC = specification(
+        ExpectedValueProvider<DataOrganizationSpecification> specificationC = specification(
                 ImmutableList.of(SUPPKEY_ALIAS),
                 ImmutableList.of(ORDERKEY_ALIAS),
                 ImmutableMap.of(ORDERKEY_ALIAS, SortOrder.DESC_NULLS_LAST));
@@ -570,7 +571,7 @@ public class TestMergeWindows
                 "SUM(discount) OVER (PARTITION BY suppkey ORDER BY orderkey ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) sum_discount_A " +
                 "FROM lineitem";
 
-        ExpectedValueProvider<WindowNode.Specification> specificationC = specification(
+        ExpectedValueProvider<DataOrganizationSpecification> specificationC = specification(
                 ImmutableList.of(SUPPKEY_ALIAS),
                 ImmutableList.of(ORDERKEY_ALIAS),
                 ImmutableMap.of(ORDERKEY_ALIAS, SortOrder.ASC_NULLS_FIRST));

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestReorderWindows.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestReorderWindows.java
@@ -25,7 +25,7 @@ import io.trino.sql.planner.iterative.IterativeOptimizer;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.iterative.rule.GatherAndMergeWindows;
 import io.trino.sql.planner.iterative.rule.RemoveRedundantIdentityProjections;
-import io.trino.sql.planner.plan.WindowNode;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.tree.WindowFrame;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
@@ -61,13 +61,13 @@ public class TestReorderWindows
 
     private static final Optional<WindowFrame> commonFrame;
 
-    private static final ExpectedValueProvider<WindowNode.Specification> windowA;
-    private static final ExpectedValueProvider<WindowNode.Specification> windowAp;
-    private static final ExpectedValueProvider<WindowNode.Specification> windowApp;
-    private static final ExpectedValueProvider<WindowNode.Specification> windowB;
-    private static final ExpectedValueProvider<WindowNode.Specification> windowC;
-    private static final ExpectedValueProvider<WindowNode.Specification> windowD;
-    private static final ExpectedValueProvider<WindowNode.Specification> windowE;
+    private static final ExpectedValueProvider<DataOrganizationSpecification> windowA;
+    private static final ExpectedValueProvider<DataOrganizationSpecification> windowAp;
+    private static final ExpectedValueProvider<DataOrganizationSpecification> windowApp;
+    private static final ExpectedValueProvider<DataOrganizationSpecification> windowB;
+    private static final ExpectedValueProvider<DataOrganizationSpecification> windowC;
+    private static final ExpectedValueProvider<DataOrganizationSpecification> windowD;
+    private static final ExpectedValueProvider<DataOrganizationSpecification> windowE;
 
     static {
         ImmutableMap.Builder<String, String> columns = ImmutableMap.builder();

--- a/core/trino-main/src/test/java/io/trino/sql/planner/plan/TestPatternRecognitionNodeSerialization.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/plan/TestPatternRecognitionNodeSerialization.java
@@ -28,7 +28,6 @@ import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.plan.PatternRecognitionNode.Measure;
 import io.trino.sql.planner.plan.WindowNode.Frame;
 import io.trino.sql.planner.plan.WindowNode.Function;
-import io.trino.sql.planner.plan.WindowNode.Specification;
 import io.trino.sql.planner.rowpattern.AggregatedSetDescriptor;
 import io.trino.sql.planner.rowpattern.AggregationValuePointer;
 import io.trino.sql.planner.rowpattern.LogicalIndexExtractor.ExpressionAndValuePointers;
@@ -197,7 +196,7 @@ public class TestPatternRecognitionNodeSerialization
         PatternRecognitionNode node = new PatternRecognitionNode(
                 new PlanNodeId("0"),
                 new ValuesNode(new PlanNodeId("1"), 1),
-                new Specification(ImmutableList.of(), Optional.empty()),
+                new DataOrganizationSpecification(ImmutableList.of(), Optional.empty()),
                 Optional.empty(),
                 ImmutableSet.of(),
                 0,

--- a/core/trino-main/src/test/java/io/trino/sql/planner/plan/TestWindowNode.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/plan/TestWindowNode.java
@@ -109,7 +109,7 @@ public class TestWindowNode
                 Optional.empty());
 
         PlanNodeId id = newId();
-        WindowNode.Specification specification = new WindowNode.Specification(
+        DataOrganizationSpecification specification = new DataOrganizationSpecification(
                 ImmutableList.of(columnA),
                 Optional.of(new OrderingScheme(
                         ImmutableList.of(columnB),

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -325,7 +325,11 @@ public final class SqlFormatter
         protected Void visitTableArgument(TableFunctionTableArgument node, Integer indent)
         {
             Relation relation = node.getTable();
-            Relation unaliased = relation instanceof AliasedRelation ? ((AliasedRelation) relation).getRelation() : relation;
+            Node unaliased = relation instanceof AliasedRelation ? ((AliasedRelation) relation).getRelation() : relation;
+            if (unaliased instanceof TableSubquery) {
+                // unpack the relation from TableSubquery to avoid adding another pair of parentheses
+                unaliased = ((TableSubquery) unaliased).getQuery();
+            }
             builder.append("TABLE(");
             process(unaliased, indent);
             builder.append(")");


### PR DESCRIPTION
This PR adds the RelationPlanner part for table function invocation with table and descriptor arguments. 
These types of arguments are not yet supported -- they cause the query to fail during the initial planning phase.

No docs or release notes required.

based on https://github.com/trinodb/trino/pull/14115

Example output from the `PlanPrinter`:
query:
```
SELECT * FROM TABLE(mock.system.different_arguments_function(
     INPUT_1 => TABLE(SELECT 'a') t1(c1) PARTITION BY c1 ORDER BY c1,
     INPUT_3 => TABLE(SELECT 'b') t3(c3) PARTITION BY c3,
     INPUT_2 => TABLE(VALUES 1) t2(c2),
     ID => BIGINT '2001',
     LAYOUT => DESCRIPTOR (x boolean, y bigint)
     COPARTITION (t1, t3))) t
```
fragment of the plan:
```
         └─ Project[]
            │   Layout: [some_column:boolean, expr:varchar(1), field:integer, expr_0:varchar(1)]
            │   Estimates: 
            └─ TableFunction[name = different_arguments_function]
               │   Layout: [some_column:boolean, expr:varchar(1), field:integer, expr_0:varchar(1)]
               │   Estimates: 
               │   Arguments:
               │   INPUT_1 => TableArgument{partition by: [expr], order by: [expr ASC NULLS LAST], pass through columns}
               │   INPUT_3 => TableArgument{partition by: [expr_0], prune when empty}
               │   INPUT_2 => TableArgument{row semantics, prune when empty, pass through columns}
               │   ID => ScalarArgument{type=bigint, value=2001}
               │   LAYOUT => DescriptorArgument{(X boolean, Y bigint)}
               │   Co-partition: [(INPUT_1, INPUT_3)]
               ├─ [INPUT_1] Project[]
               │  │   Layout: [expr:varchar(1)]
               │  │   Estimates: 
               │  └─ Project[]
```