### PR TITLE
Fix losing expose ports for connectors on local environments

### DIFF
--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/TestContainers.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/TestContainers.java
@@ -16,7 +16,6 @@ package io.trino.testing.containers;
 
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.PortBinding;
-import com.google.common.collect.ImmutableList;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.TestcontainersConfiguration;
 
@@ -69,12 +68,10 @@ public final class TestContainers
                 "This method is supposed to be invoked from local development helpers only e.g. QueryRunner.main(), " +
                 "hence it should never run on CI");
 
-        ImmutableList<PortBinding> portBindings = container.getExposedPorts().stream()
-                .map(exposedPort -> new PortBinding(bindPort(exposedPort), new ExposedPort(exposedPort)))
-                .collect(toImmutableList());
-
         container.withCreateContainerCmdModifier(cmd -> cmd
                 .withHostConfig(requireNonNull(cmd.getHostConfig(), "hostConfig is null")
-                        .withPortBindings(portBindings)));
+                        .withPortBindings(container.getExposedPorts().stream()
+                                .map(exposedPort -> new PortBinding(bindPort(exposedPort), new ExposedPort(exposedPort)))
+                                .collect(toImmutableList()))));
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This PR contains fix which prevents lose exposed ports, for functionality introduced in this PR:
https://github.com/trinodb/trino/pull/14037


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
