### PR TITLE
Handle overflow in IntegerNumberToVarcharCoercer

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/IntegerNumberToVarcharCoercer.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/IntegerNumberToVarcharCoercer.java
@@ -14,12 +14,17 @@
 
 package io.trino.plugin.hive.coercions;
 
+import io.airlift.slice.Slice;
+import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 
+import static io.airlift.slice.SliceUtf8.countCodePoints;
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.spi.StandardErrorCode.INVALID_ARGUMENTS;
+import static java.lang.String.format;
 
 public class IntegerNumberToVarcharCoercer<F extends Type>
         extends TypeCoercer<F, VarcharType>
@@ -32,6 +37,11 @@ public class IntegerNumberToVarcharCoercer<F extends Type>
     @Override
     protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
     {
-        toType.writeSlice(blockBuilder, utf8Slice(String.valueOf(fromType.getLong(block, position))));
+        long value = fromType.getLong(block, position);
+        Slice converted = utf8Slice(String.valueOf(value));
+        if (!toType.isUnbounded() && countCodePoints(converted) > toType.getBoundedLength()) {
+            throw new TrinoException(INVALID_ARGUMENTS, format("Varchar representation of %s exceed %s bounds", value, toType));
+        }
+        toType.writeSlice(blockBuilder, converted);
     }
 }


### PR DESCRIPTION
Before the change, `IntegerNumberToVarcharCoercer` could produce a `Slice` value that's not valid value for destination `VarcharType`.


Fixes #5015 