### PR TITLE
Improve handling of interrupts in TrinoResultSet

### DIFF
--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoResultSet.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoResultSet.java
@@ -183,7 +183,7 @@ public class TrinoResultSet
                     }
                 }
                 catch (InterruptedException e) {
-                    interrupt(e);
+                    handleInterrupt(e);
                 }
                 finally {
                     semaphore.release();
@@ -199,7 +199,7 @@ public class TrinoResultSet
             cleanup();
         }
 
-        public void interrupt(InterruptedException e)
+        private void handleInterrupt(InterruptedException e)
         {
             cleanup();
             Thread.currentThread().interrupt();
@@ -234,7 +234,7 @@ public class TrinoResultSet
                 semaphore.acquire();
             }
             catch (InterruptedException e) {
-                interrupt(e);
+                handleInterrupt(e);
             }
             if (rowQueue.isEmpty()) {
                 // If we got here and the queue is empty the thread fetching from the underlying iterator is done.
@@ -243,7 +243,7 @@ public class TrinoResultSet
                     future.get();
                 }
                 catch (InterruptedException e) {
-                    interrupt(e);
+                    handleInterrupt(e);
                 }
                 catch (ExecutionException e) {
                     throwIfUnchecked(e.getCause());

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriver.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriver.java
@@ -906,7 +906,7 @@ public class TestTrinoDriver
         assertTrue(queryFinished.await(10, SECONDS));
         assertThat(queryFailure.get())
                 .isInstanceOf(SQLException.class)
-                .hasMessage("ResultSet thread was interrupted");
+                .hasMessage("Interrupted");
         assertEquals(getQueryState(queryId.get()), FAILED);
     }
 


### PR DESCRIPTION
Differentiate between interrupts happening in the calling thread and
interrupts of the background thread.

- use different message
- the interrupts happening in the calling thread should result in full
  cancellation of the background thread. Previously they would close
  client, but wouldn't set `cancelled` flag.