### PR TITLE
Filter out values from system.metadata tables using access control

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/system/AbstractPropertiesSystemTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/AbstractPropertiesSystemTable.java
@@ -13,8 +13,12 @@
  */
 package io.trino.connector.system;
 
+import io.trino.FullConnectorSession;
+import io.trino.Session;
 import io.trino.connector.CatalogHandle;
 import io.trino.metadata.CatalogInfo;
+import io.trino.metadata.Metadata;
+import io.trino.security.AccessControl;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTransactionHandle;
@@ -24,8 +28,6 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.session.PropertyMetadata;
-import io.trino.transaction.TransactionId;
-import io.trino.transaction.TransactionManager;
 
 import java.util.Collection;
 import java.util.Comparator;
@@ -34,6 +36,7 @@ import java.util.function.Function;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.metadata.MetadataListing.listCatalogs;
 import static io.trino.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
 import static io.trino.spi.connector.SystemTable.Distribution.SINGLE_COORDINATOR;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
@@ -43,10 +46,11 @@ abstract class AbstractPropertiesSystemTable
         implements SystemTable
 {
     private final ConnectorTableMetadata tableMetadata;
-    private final TransactionManager transactionManager;
+    private final Metadata metadata;
+    private final AccessControl accessControl;
     private final Function<CatalogHandle, Collection<PropertyMetadata<?>>> catalogProperties;
 
-    protected AbstractPropertiesSystemTable(String tableName, TransactionManager transactionManager, Function<CatalogHandle, Collection<PropertyMetadata<?>>> catalogProperties)
+    protected AbstractPropertiesSystemTable(String tableName, Metadata metadata, AccessControl accessControl, Function<CatalogHandle, Collection<PropertyMetadata<?>>> catalogProperties)
     {
         this.tableMetadata = tableMetadataBuilder(new SchemaTableName("metadata", tableName))
                 .column("catalog_name", createUnboundedVarcharType())
@@ -55,7 +59,8 @@ abstract class AbstractPropertiesSystemTable
                 .column("type", createUnboundedVarcharType())
                 .column("description", createUnboundedVarcharType())
                 .build();
-        this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.catalogProperties = requireNonNull(catalogProperties, "catalogProperties is null");
     }
 
@@ -72,13 +77,12 @@ abstract class AbstractPropertiesSystemTable
     }
 
     @Override
-    public final RecordCursor cursor(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
+    public final RecordCursor cursor(ConnectorTransactionHandle transactionHandle, ConnectorSession connectorSession, TupleDomain<Integer> constraint)
     {
-        TransactionId transactionId = ((GlobalSystemTransactionHandle) transactionHandle).getTransactionId();
-
+        Session session = ((FullConnectorSession) connectorSession).getSession();
         InMemoryRecordSet.Builder table = InMemoryRecordSet.builder(tableMetadata);
 
-        List<CatalogInfo> catalogInfos = transactionManager.getCatalogs(transactionId).stream()
+        List<CatalogInfo> catalogInfos = listCatalogs(session, metadata, accessControl).stream()
                 .sorted(Comparator.comparing(CatalogInfo::getCatalogName))
                 .collect(toImmutableList());
 

--- a/core/trino-main/src/main/java/io/trino/connector/system/AnalyzePropertiesSystemTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/AnalyzePropertiesSystemTable.java
@@ -14,7 +14,8 @@
 package io.trino.connector.system;
 
 import io.trino.metadata.AnalyzePropertyManager;
-import io.trino.transaction.TransactionManager;
+import io.trino.metadata.Metadata;
+import io.trino.security.AccessControl;
 
 import javax.inject.Inject;
 
@@ -22,8 +23,8 @@ public class AnalyzePropertiesSystemTable
         extends AbstractPropertiesSystemTable
 {
     @Inject
-    public AnalyzePropertiesSystemTable(TransactionManager transactionManager, AnalyzePropertyManager analyzePropertyManager)
+    public AnalyzePropertiesSystemTable(Metadata metadata, AccessControl accessControl, AnalyzePropertyManager analyzePropertyManager)
     {
-        super("analyze_properties", transactionManager, analyzePropertyManager::getAllProperties);
+        super("analyze_properties", metadata, accessControl, analyzePropertyManager::getAllProperties);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/connector/system/ColumnPropertiesSystemTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/ColumnPropertiesSystemTable.java
@@ -14,7 +14,8 @@
 package io.trino.connector.system;
 
 import io.trino.metadata.ColumnPropertyManager;
-import io.trino.transaction.TransactionManager;
+import io.trino.metadata.Metadata;
+import io.trino.security.AccessControl;
 
 import javax.inject.Inject;
 
@@ -22,8 +23,8 @@ public class ColumnPropertiesSystemTable
         extends AbstractPropertiesSystemTable
 {
     @Inject
-    public ColumnPropertiesSystemTable(TransactionManager transactionManager, ColumnPropertyManager columnPropertyManager)
+    public ColumnPropertiesSystemTable(Metadata metadata, AccessControl accessControl, ColumnPropertyManager columnPropertyManager)
     {
-        super("column_properties", transactionManager, columnPropertyManager::getAllProperties);
+        super("column_properties", metadata, accessControl, columnPropertyManager::getAllProperties);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/connector/system/MaterializedViewPropertiesSystemTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/MaterializedViewPropertiesSystemTable.java
@@ -14,7 +14,8 @@
 package io.trino.connector.system;
 
 import io.trino.metadata.MaterializedViewPropertyManager;
-import io.trino.transaction.TransactionManager;
+import io.trino.metadata.Metadata;
+import io.trino.security.AccessControl;
 
 import javax.inject.Inject;
 
@@ -22,8 +23,8 @@ public class MaterializedViewPropertiesSystemTable
         extends AbstractPropertiesSystemTable
 {
     @Inject
-    public MaterializedViewPropertiesSystemTable(TransactionManager transactionManager, MaterializedViewPropertyManager materializedViewPropertyManager)
+    public MaterializedViewPropertiesSystemTable(Metadata metadata, AccessControl accessControl, MaterializedViewPropertyManager materializedViewPropertyManager)
     {
-        super("materialized_view_properties", transactionManager, materializedViewPropertyManager::getAllProperties);
+        super("materialized_view_properties", metadata, accessControl, materializedViewPropertyManager::getAllProperties);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/connector/system/SchemaPropertiesSystemTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/SchemaPropertiesSystemTable.java
@@ -13,8 +13,9 @@
  */
 package io.trino.connector.system;
 
+import io.trino.metadata.Metadata;
 import io.trino.metadata.SchemaPropertyManager;
-import io.trino.transaction.TransactionManager;
+import io.trino.security.AccessControl;
 
 import javax.inject.Inject;
 
@@ -22,8 +23,8 @@ public class SchemaPropertiesSystemTable
         extends AbstractPropertiesSystemTable
 {
     @Inject
-    public SchemaPropertiesSystemTable(TransactionManager transactionManager, SchemaPropertyManager schemaPropertyManager)
+    public SchemaPropertiesSystemTable(Metadata metadata, AccessControl accessControl, SchemaPropertyManager schemaPropertyManager)
     {
-        super("schema_properties", transactionManager, schemaPropertyManager::getAllProperties);
+        super("schema_properties", metadata, accessControl, schemaPropertyManager::getAllProperties);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/connector/system/TablePropertiesSystemTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/TablePropertiesSystemTable.java
@@ -13,8 +13,9 @@
  */
 package io.trino.connector.system;
 
+import io.trino.metadata.Metadata;
 import io.trino.metadata.TablePropertyManager;
-import io.trino.transaction.TransactionManager;
+import io.trino.security.AccessControl;
 
 import javax.inject.Inject;
 
@@ -22,8 +23,8 @@ public class TablePropertiesSystemTable
         extends AbstractPropertiesSystemTable
 {
     @Inject
-    public TablePropertiesSystemTable(TransactionManager transactionManager, TablePropertyManager tablePropertyManager)
+    public TablePropertiesSystemTable(Metadata metadata, AccessControl accessControl, TablePropertyManager tablePropertyManager)
     {
-        super("table_properties", transactionManager, tablePropertyManager::getAllProperties);
+        super("table_properties", metadata, accessControl, tablePropertyManager::getAllProperties);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -454,11 +454,11 @@ public class LocalQueryRunner
                 new CatalogSystemTable(metadata, accessControl),
                 new TableCommentSystemTable(metadata, accessControl),
                 new MaterializedViewSystemTable(metadata, accessControl),
-                new SchemaPropertiesSystemTable(transactionManager, schemaPropertyManager),
-                new TablePropertiesSystemTable(transactionManager, tablePropertyManager),
-                new MaterializedViewPropertiesSystemTable(transactionManager, materializedViewPropertyManager),
-                new ColumnPropertiesSystemTable(transactionManager, columnPropertyManager),
-                new AnalyzePropertiesSystemTable(transactionManager, analyzePropertyManager),
+                new SchemaPropertiesSystemTable(metadata, accessControl, schemaPropertyManager),
+                new TablePropertiesSystemTable(metadata, accessControl, tablePropertyManager),
+                new MaterializedViewPropertiesSystemTable(metadata, accessControl, materializedViewPropertyManager),
+                new ColumnPropertiesSystemTable(metadata, accessControl, columnPropertyManager),
+                new AnalyzePropertiesSystemTable(metadata, accessControl, analyzePropertyManager),
                 new TransactionsSystemTable(typeManager, transactionManager)),
                 ImmutableSet.of());
 

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
@@ -154,8 +154,10 @@ public class MockConnector
     private final Set<ConnectorTableFunction> tableFunctions;
     private final boolean supportsReportingWrittenBytes;
     private final boolean allowMissingColumnsOnInsert;
+    private final Supplier<List<PropertyMetadata<?>>> analyzeProperties;
     private final Supplier<List<PropertyMetadata<?>>> schemaProperties;
     private final Supplier<List<PropertyMetadata<?>>> tableProperties;
+    private final Supplier<List<PropertyMetadata<?>>> columnProperties;
     private final List<PropertyMetadata<?>> sessionProperties;
 
     MockConnector(
@@ -191,8 +193,10 @@ public class MockConnector
             Set<TableProcedureMetadata> tableProcedures,
             Set<ConnectorTableFunction> tableFunctions,
             boolean allowMissingColumnsOnInsert,
+            Supplier<List<PropertyMetadata<?>>> analyzeProperties,
             Supplier<List<PropertyMetadata<?>>> schemaProperties,
             Supplier<List<PropertyMetadata<?>>> tableProperties,
+            Supplier<List<PropertyMetadata<?>>> columnProperties,
             boolean supportsReportingWrittenBytes)
     {
         this.sessionProperties = ImmutableList.copyOf(requireNonNull(sessionProperties, "sessionProperties is null"));
@@ -228,8 +232,10 @@ public class MockConnector
         this.tableFunctions = requireNonNull(tableFunctions, "tableFunctions is null");
         this.supportsReportingWrittenBytes = supportsReportingWrittenBytes;
         this.allowMissingColumnsOnInsert = allowMissingColumnsOnInsert;
+        this.analyzeProperties = requireNonNull(analyzeProperties, "analyzeProperties is null");
         this.schemaProperties = requireNonNull(schemaProperties, "schemaProperties is null");
         this.tableProperties = requireNonNull(tableProperties, "tableProperties is null");
+        this.columnProperties = requireNonNull(columnProperties, "columnProperties is null");
     }
 
     @Override
@@ -323,6 +329,12 @@ public class MockConnector
     }
 
     @Override
+    public List<PropertyMetadata<?>> getAnalyzeProperties()
+    {
+        return analyzeProperties.get();
+    }
+
+    @Override
     public List<PropertyMetadata<?>> getTableProperties()
     {
         return tableProperties.get();
@@ -332,6 +344,12 @@ public class MockConnector
     public List<PropertyMetadata<?>> getMaterializedViewProperties()
     {
         return getMaterializedViewProperties.get();
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getColumnProperties()
+    {
+        return columnProperties.get();
     }
 
     private class MockConnectorMetadata

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
@@ -108,8 +108,10 @@ public class MockConnectorFactory
     private final Set<TableProcedureMetadata> tableProcedures;
     private final Set<ConnectorTableFunction> tableFunctions;
     private final boolean allowMissingColumnsOnInsert;
+    private final Supplier<List<PropertyMetadata<?>>> analyzeProperties;
     private final Supplier<List<PropertyMetadata<?>>> schemaProperties;
     private final Supplier<List<PropertyMetadata<?>>> tableProperties;
+    private final Supplier<List<PropertyMetadata<?>>> columnProperties;
     private final Optional<ConnectorNodePartitioningProvider> partitioningProvider;
 
     // access control
@@ -147,8 +149,10 @@ public class MockConnectorFactory
             Set<Procedure> procedures,
             Set<TableProcedureMetadata> tableProcedures,
             Set<ConnectorTableFunction> tableFunctions,
+            Supplier<List<PropertyMetadata<?>>> analyzeProperties,
             Supplier<List<PropertyMetadata<?>>> schemaProperties,
             Supplier<List<PropertyMetadata<?>>> tableProperties,
+            Supplier<List<PropertyMetadata<?>>> columnProperties,
             Optional<ConnectorNodePartitioningProvider> partitioningProvider,
             ListRoleGrants roleGrants,
             boolean supportsReportingWrittenBytes,
@@ -179,8 +183,10 @@ public class MockConnectorFactory
         this.getNewTableLayout = requireNonNull(getNewTableLayout, "getNewTableLayout is null");
         this.getTableProperties = requireNonNull(getTableProperties, "getTableProperties is null");
         this.eventListeners = requireNonNull(eventListeners, "eventListeners is null");
+        this.analyzeProperties = requireNonNull(analyzeProperties, "analyzeProperties is null");
         this.schemaProperties = requireNonNull(schemaProperties, "schemaProperties is null");
         this.tableProperties = requireNonNull(tableProperties, "tableProperties is null");
+        this.columnProperties = requireNonNull(columnProperties, "columnProperties is null");
         this.partitioningProvider = requireNonNull(partitioningProvider, "partitioningProvider is null");
         this.roleGrants = requireNonNull(roleGrants, "roleGrants is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
@@ -235,8 +241,10 @@ public class MockConnectorFactory
                 tableProcedures,
                 tableFunctions,
                 allowMissingColumnsOnInsert,
+                analyzeProperties,
                 schemaProperties,
                 tableProperties,
+                columnProperties,
                 supportsReportingWrittenBytes);
     }
 
@@ -355,8 +363,10 @@ public class MockConnectorFactory
         private Set<Procedure> procedures = ImmutableSet.of();
         private Set<TableProcedureMetadata> tableProcedures = ImmutableSet.of();
         private Set<ConnectorTableFunction> tableFunctions = ImmutableSet.of();
+        private Supplier<List<PropertyMetadata<?>>> analyzeProperties = ImmutableList::of;
         private Supplier<List<PropertyMetadata<?>>> schemaProperties = ImmutableList::of;
         private Supplier<List<PropertyMetadata<?>>> tableProperties = ImmutableList::of;
+        private Supplier<List<PropertyMetadata<?>>> columnProperties = ImmutableList::of;
         private Optional<ConnectorNodePartitioningProvider> partitioningProvider = Optional.empty();
 
         // access control
@@ -563,6 +573,12 @@ public class MockConnectorFactory
             return this;
         }
 
+        public Builder withAnalyzeProperties(Supplier<List<PropertyMetadata<?>>> analyzeProperties)
+        {
+            this.analyzeProperties = requireNonNull(analyzeProperties, "analyzeProperties is null");
+            return this;
+        }
+
         public Builder withSchemaProperties(Supplier<List<PropertyMetadata<?>>> schemaProperties)
         {
             this.schemaProperties = requireNonNull(schemaProperties, "schemaProperties is null");
@@ -572,6 +588,12 @@ public class MockConnectorFactory
         public Builder withTableProperties(Supplier<List<PropertyMetadata<?>>> tableProperties)
         {
             this.tableProperties = requireNonNull(tableProperties, "tableProperties is null");
+            return this;
+        }
+
+        public Builder withColumnProperties(Supplier<List<PropertyMetadata<?>>> columnProperties)
+        {
+            this.columnProperties = requireNonNull(columnProperties, "columnProperties is null");
             return this;
         }
 
@@ -664,8 +686,10 @@ public class MockConnectorFactory
                     procedures,
                     tableProcedures,
                     tableFunctions,
+                    analyzeProperties,
                     schemaProperties,
                     tableProperties,
+                    columnProperties,
                     partitioningProvider,
                     roleGrants,
                     supportsReportingWrittenBytes,


### PR DESCRIPTION
## Description
This PR filter out values using configured access control from tables:
- `analyze_properties`
- `column_properties`
- `materialized_view_properties`
- `schema_properties`
- `table_properties`

## Related issues, pull requests, and links
- Fixes https://github.com/trinodb/trino/issues/14000

## Non-technical explanation
Do not leak configured catalogs names when user does not have an access to them

## Release notes

( ) This is not user-visible and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Security
* Filter out values from system.metadata tables using access control ({issue}`14000`)
```
