### PR TITLE
Improve Iceberg deletes when an entire file can be removed

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/CommitTaskData.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/CommitTaskData.java
@@ -32,6 +32,8 @@ public class CommitTaskData
     private final Optional<String> partitionDataJson;
     private final FileContent content;
     private final Optional<String> referencedDataFile;
+    private final Optional<Long> fileRecordCount;
+    private final Optional<Long> deletedRowCount;
 
     @JsonCreator
     public CommitTaskData(
@@ -42,7 +44,9 @@ public class CommitTaskData
             @JsonProperty("partitionSpecJson") String partitionSpecJson,
             @JsonProperty("partitionDataJson") Optional<String> partitionDataJson,
             @JsonProperty("content") FileContent content,
-            @JsonProperty("referencedDataFile") Optional<String> referencedDataFile)
+            @JsonProperty("referencedDataFile") Optional<String> referencedDataFile,
+            @JsonProperty("fileRecordCount") Optional<Long> fileRecordCount,
+            @JsonProperty("deletedRowCount") Optional<Long> deletedRowCount)
     {
         this.path = requireNonNull(path, "path is null");
         this.fileFormat = requireNonNull(fileFormat, "fileFormat is null");
@@ -52,6 +56,11 @@ public class CommitTaskData
         this.partitionDataJson = requireNonNull(partitionDataJson, "partitionDataJson is null");
         this.content = requireNonNull(content, "content is null");
         this.referencedDataFile = requireNonNull(referencedDataFile, "referencedDataFile is null");
+        this.fileRecordCount = requireNonNull(fileRecordCount, "fileRecordCount is null");
+        fileRecordCount.ifPresent(rowCount -> checkArgument(rowCount >= 0, "fileRecordCount cannot be negative"));
+        this.deletedRowCount = requireNonNull(deletedRowCount, "deletedRowCount is null");
+        deletedRowCount.ifPresent(rowCount -> checkArgument(rowCount >= 0, "deletedRowCount cannot be negative"));
+        checkArgument(fileRecordCount.isPresent() == deletedRowCount.isPresent(), "fileRecordCount and deletedRowCount must be specified together");
         checkArgument(fileSizeInBytes >= 0, "fileSizeInBytes is negative");
     }
 
@@ -101,5 +110,17 @@ public class CommitTaskData
     public Optional<String> getReferencedDataFile()
     {
         return referencedDataFile;
+    }
+
+    @JsonProperty
+    public Optional<Long> getFileRecordCount()
+    {
+        return fileRecordCount;
+    }
+
+    @JsonProperty
+    public Optional<Long> getDeletedRowCount()
+    {
+        return deletedRowCount;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergColumnHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergColumnHandle.java
@@ -40,6 +40,7 @@ public class IcebergColumnHandle
     public static final int TRINO_MERGE_ROW_ID = Integer.MIN_VALUE + 1;
     public static final String TRINO_ROW_ID_NAME = "$row_id";
 
+    public static final int TRINO_MERGE_FILE_RECORD_COUNT = Integer.MIN_VALUE + 2;
     public static final int TRINO_MERGE_PARTITION_SPEC_ID = Integer.MIN_VALUE + 3;
     public static final int TRINO_MERGE_PARTITION_DATA = Integer.MIN_VALUE + 4;
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
@@ -312,6 +312,8 @@ public class IcebergPageSink
                 PartitionSpecParser.toJson(partitionSpec),
                 writeContext.getPartitionData().map(PartitionData::toJson),
                 DATA,
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
 
         commitTasks.add(wrappedBuffer(jsonCodec.toJsonBytes(task)));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplit.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplit.java
@@ -39,6 +39,7 @@ public class IcebergSplit
     private final long start;
     private final long length;
     private final long fileSize;
+    private final long fileRecordCount;
     private final IcebergFileFormat fileFormat;
     private final List<HostAddress> addresses;
     private final String partitionSpecJson;
@@ -52,6 +53,7 @@ public class IcebergSplit
             @JsonProperty("start") long start,
             @JsonProperty("length") long length,
             @JsonProperty("fileSize") long fileSize,
+            @JsonProperty("fileRecordCount") long fileRecordCount,
             @JsonProperty("fileFormat") IcebergFileFormat fileFormat,
             @JsonProperty("addresses") List<HostAddress> addresses,
             @JsonProperty("partitionSpecJson") String partitionSpecJson,
@@ -63,6 +65,7 @@ public class IcebergSplit
         this.start = start;
         this.length = length;
         this.fileSize = fileSize;
+        this.fileRecordCount = fileRecordCount;
         this.fileFormat = requireNonNull(fileFormat, "fileFormat is null");
         this.addresses = ImmutableList.copyOf(requireNonNull(addresses, "addresses is null"));
         this.partitionSpecJson = requireNonNull(partitionSpecJson, "partitionSpecJson is null");
@@ -106,6 +109,12 @@ public class IcebergSplit
     public long getFileSize()
     {
         return fileSize;
+    }
+
+    @JsonProperty
+    public long getFileRecordCount()
+    {
+        return fileRecordCount;
     }
 
     @JsonProperty
@@ -167,9 +176,12 @@ public class IcebergSplit
         ToStringHelper helper = toStringHelper(this)
                 .addValue(path)
                 .add("start", start)
-                .add("length", length);
+                .add("length", length)
+                .add("records", fileRecordCount);
         if (!deletes.isEmpty()) {
             helper.add("deleteFiles", deletes.size());
+            helper.add("deleteRecords", deletes.stream()
+                    .mapToLong(DeleteFile::recordCount).sum());
         }
         return helper.toString();
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
@@ -427,6 +427,7 @@ public class IcebergSplitSource
                 task.start(),
                 task.length(),
                 task.file().fileSizeInBytes(),
+                task.file().recordCount(),
                 IcebergFileFormat.fromIceberg(task.file().format()),
                 ImmutableList.of(),
                 PartitionSpecParser.toJson(task.spec()),

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/DeleteFile.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/DeleteFile.java
@@ -41,6 +41,7 @@ public final class DeleteFile
     private final FileContent content;
     private final String path;
     private final FileFormat format;
+    private final long recordCount;
     private final long fileSizeInBytes;
     private final List<Integer> equalityFieldIds;
     private final Map<Integer, byte[]> lowerBounds;
@@ -57,6 +58,7 @@ public final class DeleteFile
                 deleteFile.content(),
                 deleteFile.path().toString(),
                 deleteFile.format(),
+                deleteFile.recordCount(),
                 deleteFile.fileSizeInBytes(),
                 Optional.ofNullable(deleteFile.equalityFieldIds()).orElseGet(ImmutableList::of),
                 lowerBounds,
@@ -68,6 +70,7 @@ public final class DeleteFile
             FileContent content,
             String path,
             FileFormat format,
+            long recordCount,
             long fileSizeInBytes,
             List<Integer> equalityFieldIds,
             Map<Integer, byte[]> lowerBounds,
@@ -76,6 +79,7 @@ public final class DeleteFile
         this.content = requireNonNull(content, "content is null");
         this.path = requireNonNull(path, "path is null");
         this.format = requireNonNull(format, "format is null");
+        this.recordCount = recordCount;
         this.fileSizeInBytes = fileSizeInBytes;
         this.equalityFieldIds = ImmutableList.copyOf(requireNonNull(equalityFieldIds, "equalityFieldIds is null"));
         this.lowerBounds = ImmutableMap.copyOf(requireNonNull(lowerBounds, "lowerBounds is null"));
@@ -98,6 +102,12 @@ public final class DeleteFile
     public FileFormat format()
     {
         return format;
+    }
+
+    @JsonProperty
+    public long recordCount()
+    {
+        return recordCount;
     }
 
     @JsonProperty
@@ -138,6 +148,7 @@ public final class DeleteFile
     {
         return toStringHelper(this)
                 .addValue(path)
+                .add("records", recordCount)
                 .toString();
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/IcebergPositionDeletePageSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/IcebergPositionDeletePageSink.java
@@ -57,9 +57,11 @@ public class IcebergPositionDeletePageSink
     private final JsonCodec<CommitTaskData> jsonCodec;
     private final IcebergFileWriter writer;
     private final IcebergFileFormat fileFormat;
+    private final long fileRecordCount;
 
     private long validationCpuNanos;
     private boolean writtenData;
+    private long deletedRowCount;
 
     public IcebergPositionDeletePageSink(
             String dataFilePath,
@@ -71,13 +73,15 @@ public class IcebergPositionDeletePageSink
             JsonCodec<CommitTaskData> jsonCodec,
             ConnectorSession session,
             IcebergFileFormat fileFormat,
-            Map<String, String> storageProperties)
+            Map<String, String> storageProperties,
+            long fileRecordCount)
     {
         this.dataFilePath = requireNonNull(dataFilePath, "dataFilePath is null");
         this.jsonCodec = requireNonNull(jsonCodec, "jsonCodec is null");
         this.partitionSpec = requireNonNull(partitionSpec, "partitionSpec is null");
         this.partition = requireNonNull(partition, "partition is null");
         this.fileFormat = requireNonNull(fileFormat, "fileFormat is null");
+        this.fileRecordCount = fileRecordCount;
         // prepend query id to a file name so we can determine which files were written by which query. This is needed for opportunistic cleanup of extra files
         // which may be present for successfully completing query in presence of failure recovery mechanisms.
         String fileName = fileFormat.toIceberg().addExtension(session.getQueryId() + "-" + randomUUID());
@@ -116,6 +120,7 @@ public class IcebergPositionDeletePageSink
         writer.appendRows(new Page(blocks));
 
         writtenData = true;
+        deletedRowCount += page.getPositionCount();
         return NOT_BLOCKED;
     }
 
@@ -133,7 +138,9 @@ public class IcebergPositionDeletePageSink
                     PartitionSpecParser.toJson(partitionSpec),
                     partition.map(PartitionData::toJson),
                     FileContent.POSITION_DELETES,
-                    Optional.of(dataFilePath));
+                    Optional.of(dataFilePath),
+                    Optional.of(fileRecordCount),
+                    Optional.of(deletedRowCount));
             Long recordCount = task.getMetrics().recordCount();
             if (recordCount != null && recordCount > 0) {
                 commitTasks.add(wrappedBuffer(jsonCodec.toJsonBytes(task)));

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -1555,7 +1555,6 @@ public abstract class BaseIcebergConnectorTest
 
         // The old partition scheme is no longer used so pushdown using the hour transform is allowed
         assertUpdate("DELETE FROM " + tableName + " WHERE year(d) = 1969", 3);
-        assertUpdate("ALTER TABLE " + tableName + " EXECUTE optimize");
         assertUpdate("INSERT INTO " + tableName + " VALUES " + initialValues, 3);
         assertThat(query(selectQuery))
                 .containsAll("VALUES 1, 8, 9, 10")

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergAnalyze.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergAnalyze.java
@@ -145,8 +145,8 @@ public class TestIcebergAnalyze
                           ('nationkey', null, 25, 0, null, '0', '24'),
                           ('regionkey', null, 5, 0, null, '0', '4'),
                           ('name', null, 25, 0, null, null, null),
-                          ('info', null, null, null, null, null, null),
-                          (null, null, null, null, 50, null, null)""");
+                          ('info', null, null, 0, null, null, null),
+                          (null, null, null, null, 25, null, null)""");
 
         assertUpdate("ANALYZE " + tableName);
         assertQuery(
@@ -156,8 +156,8 @@ public class TestIcebergAnalyze
                           ('nationkey', null, 25, 0, null, '0', '24'),
                           ('regionkey', null, 5, 0, null, '0', '4'),
                           ('name', null, 25, 0, null, null, null),
-                          ('info', null, 25, null, null, null, null),
-                          (null, null, null, null, 50, null, null)""");
+                          ('info', null, 25, 0, null, null, null),
+                          (null, null, null, null, 25, null, null)""");
 
         assertUpdate("DROP TABLE " + tableName);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
@@ -157,6 +157,7 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                 0,
                 outputFile.length(),
                 outputFile.length(),
+                0, // This is incorrect, but the value is only used for delete operations
                 ORC,
                 ImmutableList.of(),
                 PartitionSpecParser.toJson(PartitionSpec.unpartitioned()),

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
@@ -383,7 +383,7 @@ public class TestIcebergV2
         assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(2);
         assertUpdate("DELETE FROM " + tableName + " WHERE regionkey <= 2", "SELECT count(*) FROM nation WHERE regionkey <= 2");
         assertQuery("SELECT * FROM " + tableName, "SELECT * FROM nation WHERE regionkey > 2");
-        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(2);
+        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(1);
     }
 
     @Test
@@ -397,7 +397,7 @@ public class TestIcebergV2
         assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(4);
         assertUpdate("DELETE FROM " + tableName + " WHERE b % 2 = 0", 6);
         assertQuery("SELECT * FROM " + tableName, "VALUES (1, 1), (1, 3), (1, 5), (2, 1), (2, 3), (2, 5)");
-        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(4);
+        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(2);
     }
 
     @Test
@@ -411,7 +411,7 @@ public class TestIcebergV2
         assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(2);
         assertUpdate("DELETE FROM " + tableName + " WHERE regionkey % 2 = 1", "SELECT count(*) FROM nation WHERE regionkey % 2 = 1");
         assertQuery("SELECT * FROM " + tableName, "SELECT * FROM nation WHERE regionkey % 2 = 0");
-        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(2);
+        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(1);
     }
 
     @Test
@@ -431,7 +431,7 @@ public class TestIcebergV2
         long parentSnapshotId = (long) computeScalar("SELECT parent_id FROM \"" + tableName + "$snapshots\" ORDER BY committed_at DESC FETCH FIRST 1 ROW WITH TIES");
         assertEquals(initialSnapshotId, parentSnapshotId);
         assertThat(query("SELECT * FROM " + tableName)).returnsEmptyResult();
-        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(1);
+        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(0);
     }
 
     @Test


### PR DESCRIPTION
## Description

This reverts commit d4355493e6becf33511fe75fcb2e1f5044478660.

There were some minor conflicts due to the change to TrinoFileSystem

Replace the feature where if a whole file is deleted by a single operation, remove it from the Iceberg manifest rather than writing position deletes.

## Non-technical explanation

Improve performance of large delete operations.

## Related PRs

Original changes: https://github.com/trinodb/trino/pull/12197
Revert: https://github.com/trinodb/trino/pull/13485
Iceberg core issue: https://github.com/apache/iceberg/issues/5442
Iceberg dep. version bump: https://github.com/trinodb/trino/pull/14074

## Release notes

( ) This is not user-visible and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
