### PR TITLE
[trino-parquet] Using ImmutableList for descriptor map key

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
@@ -52,7 +52,7 @@ public final class ParquetTypeUtils
 
     public static List<PrimitiveColumnIO> getColumns(MessageType fileSchema, MessageType requestedSchema)
     {
-        return (new ColumnIOFactory()).getColumnIO(requestedSchema, fileSchema, true).getLeaves();
+        return ImmutableList.copyOf((new ColumnIOFactory()).getColumnIO(requestedSchema, fileSchema, true).getLeaves());
     }
 
     public static MessageColumnIO getColumnIO(MessageType fileSchema, MessageType requestedSchema)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

It is a bad practice to use mutable list(ArrayList as specified in ColumnIOFactory's ColumnIOCreatorVisitor's leaves) as a map key. Since one can modify the key's content. 

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

[trino-parquet] Using ImmutableList for descriptor map key

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
