### PR TITLE
Check catalog & schema access in USE statement

### DIFF
--- a/core/trino-main/src/main/java/io/trino/testing/TestingAccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingAccessControlManager.java
@@ -135,6 +135,7 @@ public class TestingAccessControlManager
     private final Map<RowFilterKey, List<ViewExpression>> rowFilters = new HashMap<>();
     private final Map<ColumnMaskKey, List<ViewExpression>> columnMasks = new HashMap<>();
     private Predicate<String> deniedCatalogs = s -> true;
+    private Predicate<String> deniedSchemas = s -> true;
     private Predicate<SchemaTableName> deniedTables = s -> true;
     private BiPredicate<Identity, String> denyIdentityTable = IDENTITY_TABLE_TRUE;
 
@@ -180,6 +181,7 @@ public class TestingAccessControlManager
     {
         denyPrivileges.clear();
         deniedCatalogs = s -> true;
+        deniedSchemas = s -> true;
         deniedTables = s -> true;
         denyIdentityTable = IDENTITY_TABLE_TRUE;
         rowFilters.clear();
@@ -189,6 +191,11 @@ public class TestingAccessControlManager
     public void denyCatalogs(Predicate<String> deniedCatalogs)
     {
         this.deniedCatalogs = this.deniedCatalogs.and(deniedCatalogs);
+    }
+
+    public void denySchemas(Predicate<String> deniedSchemas)
+    {
+        this.deniedSchemas = this.deniedSchemas.and(deniedSchemas);
     }
 
     public void denyTables(Predicate<SchemaTableName> deniedTables)
@@ -208,6 +215,17 @@ public class TestingAccessControlManager
                 securityContext,
                 catalogs.stream()
                         .filter(this.deniedCatalogs)
+                        .collect(toImmutableSet()));
+    }
+
+    @Override
+    public Set<String> filterSchemas(SecurityContext securityContext, String catalogName, Set<String> schemaNames)
+    {
+        return super.filterSchemas(
+                securityContext,
+                catalogName,
+                schemaNames.stream()
+                        .filter(this.deniedSchemas)
                         .collect(toImmutableSet()));
     }
 


### PR DESCRIPTION
## Description
This PR add checks  if user has an access to catalog and schema in `USE` statement.

## Related issues, pull requests, and links
- Fixes https://github.com/trinodb/trino/issues/14208

## Non-technical explanation
There was a lack of check in `USE` statement if user has an access to catalog or schema.

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Security
* Check access to catalog and schema during execution of USE statement. ({issue}`14208`)
```
