### PR TITLE
Extends flush_metadata_cache procedure

### DIFF
--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -1079,6 +1079,11 @@ The following procedures are available:
 
   Flush all Hive metadata caches.
 
+* ``system.flush_metadata_cache(schema_name => ..., table_name => ...)``
+
+  Flush Hive metadata caches entries connected with selected table.
+  Procedure requires named parameters to be passed
+
 * ``system.flush_metadata_cache(schema_name => ..., table_name => ..., partition_column => ARRAY[...], partition_value => ARRAY[...])``
 
   Flush Hive metadata cache entries connected with selected partition.

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/procedure/FlushHiveMetastoreCacheProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/procedure/FlushHiveMetastoreCacheProcedure.java
@@ -48,6 +48,7 @@ public class FlushHiveMetastoreCacheProcedure
     private static final String PROCEDURE_USAGE_EXAMPLES = format(
             "Valid usages:%n" +
                     " - '%1$s()'%n" +
+                    " - %1$s(%2$s => ..., %3$s => ...)" +
                     " - %1$s(%2$s => ..., %3$s => ..., %4$s => ARRAY['...'], %5$s => ARRAY['...'])",
             PROCEDURE_NAME,
             // Use lowercase parameter names per convention. In the usage example the names are not delimited.
@@ -113,8 +114,13 @@ public class FlushHiveMetastoreCacheProcedure
         if (schemaName.isEmpty() && tableName.isEmpty() && partitionColumns.isEmpty()) {
             cachingHiveMetastore.flushCache();
         }
-        else if (schemaName.isPresent() && tableName.isPresent() && !partitionColumns.isEmpty()) {
-            cachingHiveMetastore.flushPartitionCache(schemaName.get(), tableName.get(), partitionColumns, partitionValues);
+        else if (schemaName.isPresent() && tableName.isPresent()) {
+            if (!partitionColumns.isEmpty()) {
+                cachingHiveMetastore.flushPartitionCache(schemaName.get(), tableName.get(), partitionColumns, partitionValues);
+            }
+            else {
+                cachingHiveMetastore.invalidateTable(schemaName.get(), tableName.get());
+            }
         }
         else {
             throw new TrinoException(

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveOnDataLake.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveOnDataLake.java
@@ -243,6 +243,16 @@ public abstract class BaseTestHiveOnDataLake
         // Should return 0 rows as we left cache untouched
         assertQueryReturnsEmptyResult(queryUsingPartitionCacheForValue2);
 
+        // Refresh cache for schema_name => 'dummy_schema', table_name => 'dummy_table'
+        getQueryRunner().execute(format(
+                "CALL system.flush_metadata_cache(schema_name => '%s', table_name => '%s')",
+                HIVE_TEST_SCHEMA,
+                tableName));
+
+        // Should return expected rows for all partitions
+        assertQuery(queryUsingPartitionCacheForValue1, expectedQueryResultForValue1);
+        assertQuery(queryUsingPartitionCacheForValue2, expectedQueryResultForValue2);
+
         computeActual(format("DROP TABLE %s", fullyQualifiedTestTableName));
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastoreWithQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastoreWithQueryRunner.java
@@ -143,14 +143,15 @@ public class TestCachingHiveMetastoreWithQueryRunner
     @Test
     public void testIllegalFlushHiveMetastoreCacheProcedureCalls()
     {
-        String illegalParameterMessage = "Illegal parameter set passed. Valid usages:\n - 'flush_metadata_cache()'\n - flush_metadata_cache(schema_name => ..., table_name => ..., partition_column => ARRAY['...'], partition_value => ARRAY['...'])";
+        String illegalParameterMessage = "Illegal parameter set passed. Valid usages:\n" +
+                " - 'flush_metadata_cache()'\n" +
+                " - flush_metadata_cache(schema_name => ..., table_name => ...)" +
+                " - flush_metadata_cache(schema_name => ..., table_name => ..., partition_column => ARRAY['...'], partition_value => ARRAY['...'])";
 
         assertThatThrownBy(() -> getQueryRunner().execute("CALL system.flush_metadata_cache('dummy_schema')"))
                 .hasMessageContaining("Only named arguments are allowed for this procedure");
 
         assertThatThrownBy(() -> getQueryRunner().execute("CALL system.flush_metadata_cache(schema_name => 'dummy_schema')"))
-                .hasMessage(illegalParameterMessage);
-        assertThatThrownBy(() -> getQueryRunner().execute("CALL system.flush_metadata_cache(schema_name => 'dummy_schema', table_name => 'dummy_table')"))
                 .hasMessage(illegalParameterMessage);
 
         assertThatThrownBy(() -> getQueryRunner().execute("CALL system.flush_metadata_cache(schema_name => 'dummy_schema', table_name => 'dummy_table', partition_column => ARRAY['dummy_partition'])"))


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Make `flush_metadata_cache` with schema and table arguments clear table-related caches

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Make `flush_metadata_cache` with schema and table arguments clear table-related caches

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Extend procedure `flush_metadata_cache` with the ability to flush table related caches
```
