### PR TITLE
Fix PTF support in TestingAccessControlManager

### DIFF
--- a/core/trino-main/src/main/java/io/trino/testing/TestingAccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingAccessControlManager.java
@@ -616,7 +616,7 @@ public class TestingAccessControlManager
             denyGrantExecuteFunctionPrivilege(functionName.toString(), context.getIdentity(), grantee);
         }
         if (denyPrivileges.isEmpty()) {
-            super.checkCanGrantExecuteFunctionPrivilege(context, functionName.toString(), grantee, grantOption);
+            super.checkCanGrantExecuteFunctionPrivilege(context, functionKind, functionName, grantee, grantOption);
         }
     }
 
@@ -681,6 +681,17 @@ public class TestingAccessControlManager
         }
         if (denyPrivileges.isEmpty()) {
             super.checkCanExecuteFunction(context, functionName);
+        }
+    }
+
+    @Override
+    public void checkCanExecuteFunction(SecurityContext context, FunctionKind functionKind, QualifiedObjectName functionName)
+    {
+        if (shouldDenyPrivilege(context.getIdentity().getUser(), functionName.toString(), EXECUTE_FUNCTION)) {
+            denyExecuteFunction(functionName.toString());
+        }
+        if (denyPrivileges.isEmpty()) {
+            super.checkCanExecuteFunction(context, functionKind, functionName);
         }
     }
 


### PR DESCRIPTION
## Description
Invoked PTF from a `SECURITY DEFINER` view using `LocalQueryRunner` cause to call incorrect overloaded method `checkCanGrantExecuteFunctionPrivilege`.
This cause perform a wrong check from `SystemAccessControl`, this check invoked:
```
checkCanGrantExecuteFunctionPrivilege(SystemSecurityContext context, String functionName, TrinoPrincipal grantee, boolean grantOption)
```
instead of:
```
checkCanGrantExecuteFunctionPrivilege(SystemSecurityContext context, FunctionKind functionKind, CatalogSchemaRoutineName functionName, TrinoPrincipal grantee, boolean grantOption)
```

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
