### PR TITLE
Allow to configure prefix for internal Kafka fields

### DIFF
--- a/docs/src/main/sphinx/connector/kafka.rst
+++ b/docs/src/main/sphinx/connector/kafka.rst
@@ -86,6 +86,7 @@ Property name                                              Description
 ``kafka.nodes``                                            List of nodes in the Kafka cluster.
 ``kafka.buffer-size``                                      Kafka read buffer size.
 ``kafka.hide-internal-columns``                            Controls whether internal columns are part of the table schema or not.
+``kafka.internal-column-prefix``                           Prefix for internal columns, defaults to ``_``
 ``kafka.messages-per-split``                               Number of messages that are processed by each Trino split; defaults to ``100000``.
 ``kafka.timestamp-upper-bound-force-push-down-enabled``    Controls if upper bound timestamp pushdown is enabled for topics using ``CreateTime`` mode.
 ``kafka.security-protocol``                                Security protocol for connection to Kafka cluster; defaults to ``PLAINTEXT``.
@@ -227,6 +228,12 @@ This property is optional; default is ``https``.
 
 Internal columns
 ----------------
+
+The internal column prefix is configurable by ``kafka.internal-column-prefix``
+configuration property and defaults to ``_``. A different prefix affects the
+internal column names in the following sections. For example, a value of
+``internal_`` changes the partition ID column name from ``_partition_id``
+to ``internal_partition_id``.
 
 For each defined table, the connector maintains the following columns:
 

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConfig.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConfig.java
@@ -26,6 +26,7 @@ import io.trino.plugin.kafka.schema.file.FileTableDescriptionSupplier;
 import io.trino.spi.HostAddress;
 
 import javax.validation.constraints.Min;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
@@ -50,6 +51,7 @@ public class KafkaConfig
     private boolean timestampUpperBoundPushDownEnabled;
     private String tableDescriptionSupplier = FileTableDescriptionSupplier.NAME;
     private List<File> resourceConfigFiles = ImmutableList.of();
+    private String internalFieldPrefix = "_";
 
     @Size(min = 1)
     public Set<HostAddress> getNodes()
@@ -172,6 +174,20 @@ public class KafkaConfig
         this.resourceConfigFiles = files.stream()
                 .map(File::new)
                 .collect(toImmutableList());
+        return this;
+    }
+
+    @NotEmpty
+    public String getInternalFieldPrefix()
+    {
+        return internalFieldPrefix;
+    }
+
+    @Config("kafka.internal-column-prefix")
+    @ConfigDescription("Prefix for internal columns")
+    public KafkaConfig setInternalFieldPrefix(String internalFieldPrefix)
+    {
+        this.internalFieldPrefix = internalFieldPrefix;
         return this;
     }
 }

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaFilterManager.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaFilterManager.java
@@ -45,6 +45,7 @@ import java.util.function.Function;
 
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.plugin.kafka.KafkaErrorCode.KAFKA_SPLIT_ERROR;
@@ -91,30 +92,20 @@ public class KafkaFilterManager
 
         if (!constraint.isAll()) {
             Set<Long> partitionIds = partitionInfos.stream().map(partitionInfo -> (long) partitionInfo.partition()).collect(toImmutableSet());
-            Optional<Range> offsetRanged = Optional.empty();
-            Optional<Range> offsetTimestampRanged = Optional.empty();
-            Set<Long> partitionIdsFiltered = partitionIds;
-            Optional<Map<ColumnHandle, Domain>> domains = constraint.getDomains();
 
-            for (Map.Entry<ColumnHandle, Domain> entry : domains.get().entrySet()) {
-                KafkaColumnHandle columnHandle = (KafkaColumnHandle) entry.getKey();
-                if (!columnHandle.isInternal()) {
-                    continue;
-                }
-                switch (columnHandle.getName()) {
-                    case PARTITION_OFFSET_FIELD:
-                        offsetRanged = filterRangeByDomain(entry.getValue());
-                        break;
-                    case PARTITION_ID_FIELD:
-                        partitionIdsFiltered = filterValuesByDomain(entry.getValue(), partitionIds);
-                        break;
-                    case OFFSET_TIMESTAMP_FIELD:
-                        offsetTimestampRanged = filterRangeByDomain(entry.getValue());
-                        break;
-                    default:
-                        break;
-                }
-            }
+            Map<String, Domain> domains = constraint.getDomains().orElseThrow()
+                    .entrySet().stream()
+                    .collect(toImmutableMap(
+                            entry -> ((KafkaColumnHandle) entry.getKey()).getName(),
+                            Map.Entry::getValue));
+
+            Optional<Range> offsetRanged = getDomain(PARTITION_OFFSET_FIELD, domains)
+                    .flatMap(KafkaFilterManager::filterRangeByDomain);
+            Set<Long> partitionIdsFiltered = getDomain(PARTITION_ID_FIELD, domains)
+                    .map(domain -> filterValuesByDomain(domain, partitionIds))
+                    .orElse(partitionIds);
+            Optional<Range> offsetTimestampRanged = getDomain(OFFSET_TIMESTAMP_FIELD, domains)
+                    .flatMap(KafkaFilterManager::filterRangeByDomain);
 
             // push down offset
             if (offsetRanged.isPresent()) {
@@ -128,29 +119,32 @@ public class KafkaFilterManager
             // push down timestamp if possible
             if (offsetTimestampRanged.isPresent()) {
                 try (KafkaConsumer<byte[], byte[]> kafkaConsumer = consumerFactory.create(session)) {
-                    Optional<Range> finalOffsetTimestampRanged = offsetTimestampRanged;
                     // filter negative value to avoid java.lang.IllegalArgumentException when using KafkaConsumer offsetsForTimes
                     if (offsetTimestampRanged.get().getBegin() > INVALID_KAFKA_RANGE_INDEX) {
                         partitionBeginOffsets = overridePartitionBeginOffsets(partitionBeginOffsets,
-                                partition -> findOffsetsForTimestampGreaterOrEqual(kafkaConsumer, partition, finalOffsetTimestampRanged.get().getBegin()));
+                                partition -> findOffsetsForTimestampGreaterOrEqual(kafkaConsumer, partition, offsetTimestampRanged.get().getBegin()));
                     }
                     if (isTimestampUpperBoundPushdownEnabled(session, kafkaTableHandle.getTopicName())) {
                         if (offsetTimestampRanged.get().getEnd() > INVALID_KAFKA_RANGE_INDEX) {
                             partitionEndOffsets = overridePartitionEndOffsets(partitionEndOffsets,
-                                    partition -> findOffsetsForTimestampGreaterOrEqual(kafkaConsumer, partition, finalOffsetTimestampRanged.get().getEnd()));
+                                    partition -> findOffsetsForTimestampGreaterOrEqual(kafkaConsumer, partition, offsetTimestampRanged.get().getEnd()));
                         }
                     }
                 }
             }
 
             // push down partitions
-            final Set<Long> finalPartitionIdsFiltered = partitionIdsFiltered;
             List<PartitionInfo> partitionFilteredInfos = partitionInfos.stream()
-                    .filter(partitionInfo -> finalPartitionIdsFiltered.contains((long) partitionInfo.partition()))
+                    .filter(partitionInfo -> partitionIdsFiltered.contains((long) partitionInfo.partition()))
                     .collect(toImmutableList());
             return new KafkaFilteringResult(partitionFilteredInfos, partitionBeginOffsets, partitionEndOffsets);
         }
         return new KafkaFilteringResult(partitionInfos, partitionBeginOffsets, partitionEndOffsets);
+    }
+
+    private Optional<Domain> getDomain(String columnName, Map<String, Domain> columnNameToDomain)
+    {
+        return Optional.ofNullable(columnNameToDomain.get(columnName));
     }
 
     private boolean isTimestampUpperBoundPushdownEnabled(ConnectorSession session, String topic)

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaInternalFieldManager.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaInternalFieldManager.java
@@ -107,7 +107,7 @@ public class KafkaInternalFieldManager
             return type;
         }
 
-        KafkaColumnHandle getColumnHandle(int index, boolean hidden)
+        KafkaColumnHandle getColumnHandle(boolean hidden)
         {
             return new KafkaColumnHandle(
                     getColumnName(),

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaInternalFieldManager.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaInternalFieldManager.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.kafka;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.type.BigintType;
@@ -21,9 +20,23 @@ import io.trino.spi.type.BooleanType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.trino.plugin.kafka.KafkaInternalFieldManager.InternalFieldId.HEADERS_FIELD;
+import static io.trino.plugin.kafka.KafkaInternalFieldManager.InternalFieldId.KEY_CORRUPT_FIELD;
+import static io.trino.plugin.kafka.KafkaInternalFieldManager.InternalFieldId.KEY_LENGTH_FIELD;
+import static io.trino.plugin.kafka.KafkaInternalFieldManager.InternalFieldId.MESSAGE_CORRUPT_FIELD;
+import static io.trino.plugin.kafka.KafkaInternalFieldManager.InternalFieldId.MESSAGE_FIELD;
+import static io.trino.plugin.kafka.KafkaInternalFieldManager.InternalFieldId.MESSAGE_LENGTH_FIELD;
+import static io.trino.plugin.kafka.KafkaInternalFieldManager.InternalFieldId.OFFSET_TIMESTAMP_FIELD;
+import static io.trino.plugin.kafka.KafkaInternalFieldManager.InternalFieldId.PARTITION_ID_FIELD;
+import static io.trino.plugin.kafka.KafkaInternalFieldManager.InternalFieldId.PARTITION_OFFSET_FIELD;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.trino.spi.type.TypeSignature.arrayType;
 import static io.trino.spi.type.TypeSignature.mapType;
@@ -31,70 +44,81 @@ import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
 
 public class KafkaInternalFieldManager
 {
-    /**
-     * <tt>_partition_id</tt> - Kafka partition id.
-     */
-    public static final String PARTITION_ID_FIELD = "_partition_id";
+    public enum InternalFieldId
+    {
+        /**
+         * Kafka partition id.
+         */
+        PARTITION_ID_FIELD,
 
-    /**
-     * <tt>_partition_offset</tt> - The current offset of the message in the partition.
-     */
-    public static final String PARTITION_OFFSET_FIELD = "_partition_offset";
+        /**
+         * The current offset of the message in the partition.
+         */
+        PARTITION_OFFSET_FIELD,
 
-    /**
-     * <tt>_message_corrupt</tt> - True if the row converter could not read the a message. May be null if the row converter does not set a value (e.g. the dummy row converter does not).
-     */
-    public static final String MESSAGE_CORRUPT_FIELD = "_message_corrupt";
+        /**
+         * Field is true if the row converter could not read a message. May be null if the row converter does not set a value (e.g. the dummy row converter does not).
+         */
+        MESSAGE_CORRUPT_FIELD,
 
-    /**
-     * <tt>_message</tt> - Represents the full topic as a text column. Format is UTF-8 which may be wrong for some topics. TODO: make charset configurable.
-     */
-    public static final String MESSAGE_FIELD = "_message";
+        /**
+         * Represents the full topic as a text column. Format is UTF-8 which may be wrong for some topics. TODO: make charset configurable.
+         */
+        MESSAGE_FIELD,
 
-    /**
-     * <tt>_message_length</tt> - length in bytes of the message.
-     */
-    public static final String MESSAGE_LENGTH_FIELD = "_message_length";
+        /**
+         * length in bytes of the message.
+         */
+        MESSAGE_LENGTH_FIELD,
 
-    /**
-     * <tt>_headers</tt> - The header fields of the Kafka message. Key is a UTF-8 String and values an array of byte[].
-     */
-    public static final String HEADERS_FIELD = "_headers";
+        /**
+         * The header fields of the Kafka message. Key is a UTF-8 String and values an array of byte[].
+         */
+        HEADERS_FIELD,
 
-    /**
-     * <tt>_key_corrupt</tt> - True if the row converter could not read the a key. May be null if the row converter does not set a value (e.g. the dummy row converter does not).
-     */
-    public static final String KEY_CORRUPT_FIELD = "_key_corrupt";
+        /**
+         * Field is true if the row converter could not read a key. May be null if the row converter does not set a value (e.g. the dummy row converter does not).
+         */
+        KEY_CORRUPT_FIELD,
 
-    /**
-     * <tt>_key</tt> - Represents the key as a text column. Format is UTF-8 which may be wrong for topics. TODO: make charset configurable.
-     */
-    public static final String KEY_FIELD = "_key";
+        /**
+         * Represents the key as a text column. Format is UTF-8 which may be wrong for topics. TODO: make charset configurable.
+         */
+        KEY_FIELD,
 
-    /**
-     * <tt>_key_length</tt> - length in bytes of the key.
-     */
-    public static final String KEY_LENGTH_FIELD = "_key_length";
+        /**
+         * length in bytes of the key.
+         */
+        KEY_LENGTH_FIELD,
 
-    /**
-     * <tt>_timestamp</tt> - message timestamp
-     */
-    public static final String OFFSET_TIMESTAMP_FIELD = "_timestamp";
+        /**
+         * message timestamp
+         */
+        OFFSET_TIMESTAMP_FIELD,
+    }
 
     public static class InternalField
     {
+        private final InternalFieldId internalFieldId;
         private final String columnName;
         private final String comment;
         private final Type type;
 
-        InternalField(String columnName, String comment, Type type)
+        InternalField(InternalFieldId internalFieldId, String columnName, String comment, Type type)
         {
+            this.internalFieldId = requireNonNull(internalFieldId, "internalFieldId is null");
             this.columnName = requireNonNull(columnName, "columnName is null");
             this.comment = requireNonNull(comment, "comment is null");
             this.type = requireNonNull(type, "type is null");
+        }
+
+        public InternalFieldId getInternalFieldId()
+        {
+            return internalFieldId;
         }
 
         public String getColumnName()
@@ -131,62 +155,87 @@ public class KafkaInternalFieldManager
         }
     }
 
-    private final Map<String, InternalField> internalFields;
+    private final Map<String, InternalField> fieldsByNames;
+    private final Map<InternalFieldId, InternalField> fieldsByIds;
 
     @Inject
-    public KafkaInternalFieldManager(TypeManager typeManager)
+    public KafkaInternalFieldManager(TypeManager typeManager, KafkaConfig kafkaConfig)
     {
         Type varcharMapType = typeManager.getType(mapType(VARCHAR.getTypeSignature(), arrayType(VARBINARY.getTypeSignature())));
-
-        internalFields = ImmutableMap.<String, InternalField>builder()
-                .put(PARTITION_ID_FIELD, new InternalField(
-                        PARTITION_ID_FIELD,
-                        "Partition Id",
-                        BigintType.BIGINT))
-                .put(PARTITION_OFFSET_FIELD, new InternalField(
-                        PARTITION_OFFSET_FIELD,
-                        "Offset for the message within the partition",
-                        BigintType.BIGINT))
-                .put(MESSAGE_CORRUPT_FIELD, new InternalField(
-                        MESSAGE_CORRUPT_FIELD,
-                        "Message data is corrupt",
-                        BooleanType.BOOLEAN))
-                .put(MESSAGE_FIELD, new InternalField(
-                        MESSAGE_FIELD,
-                        "Message text",
-                        createUnboundedVarcharType()))
-                .put(HEADERS_FIELD, new InternalField(
-                        HEADERS_FIELD,
-                        "Headers of the message as map",
-                        varcharMapType))
-                .put(MESSAGE_LENGTH_FIELD, new InternalField(
-                        MESSAGE_LENGTH_FIELD,
-                        "Total number of message bytes",
-                        BigintType.BIGINT))
-                .put(KEY_CORRUPT_FIELD, new InternalField(
-                        KEY_CORRUPT_FIELD,
-                        "Key data is corrupt",
-                        BooleanType.BOOLEAN))
-                .put(KEY_FIELD, new InternalField(
-                        KEY_FIELD,
-                        "Key text",
-                        createUnboundedVarcharType()))
-                .put(KEY_LENGTH_FIELD, new InternalField(
-                        KEY_LENGTH_FIELD,
-                        "Total number of key bytes",
-                        BigintType.BIGINT))
-                .put(OFFSET_TIMESTAMP_FIELD, new InternalField(
-                        OFFSET_TIMESTAMP_FIELD,
-                        "Message timestamp",
-                        TIMESTAMP_MILLIS))
-                .buildOrThrow();
+        String prefix = kafkaConfig.getInternalFieldPrefix();
+        List<InternalField> fields = Stream.of(
+                        new InternalField(
+                                PARTITION_ID_FIELD,
+                                prefix + "partition_id",
+                                "Partition Id",
+                                BigintType.BIGINT),
+                        new InternalField(
+                                PARTITION_OFFSET_FIELD,
+                                prefix + "partition_offset",
+                                "Offset for the message within the partition",
+                                BigintType.BIGINT),
+                        new InternalField(
+                                MESSAGE_CORRUPT_FIELD,
+                                prefix + "message_corrupt",
+                                "Message data is corrupt",
+                                BooleanType.BOOLEAN),
+                        new InternalField(
+                                MESSAGE_FIELD,
+                                prefix + "message",
+                                "Message text",
+                                createUnboundedVarcharType()),
+                        new InternalField(
+                                HEADERS_FIELD,
+                                prefix + "headers",
+                                "Headers of the message as map",
+                                varcharMapType),
+                        new InternalField(
+                                MESSAGE_LENGTH_FIELD,
+                                prefix + "message_length",
+                                "Total number of message bytes",
+                                BigintType.BIGINT),
+                        new InternalField(
+                                KEY_CORRUPT_FIELD,
+                                prefix + "key_corrupt",
+                                "Key data is corrupt",
+                                BooleanType.BOOLEAN),
+                        new InternalField(
+                                InternalFieldId.KEY_FIELD,
+                                prefix + "key",
+                                "Key text",
+                                createUnboundedVarcharType()),
+                        new InternalField(
+                                KEY_LENGTH_FIELD,
+                                prefix + "key_length",
+                                "Total number of key bytes",
+                                BigintType.BIGINT),
+                        new InternalField(
+                                OFFSET_TIMESTAMP_FIELD,
+                                prefix + "timestamp",
+                                "Message timestamp",
+                                TIMESTAMP_MILLIS))
+                .collect(toImmutableList());
+        fieldsByNames = fields.stream()
+                .collect(toImmutableMap(InternalField::getColumnName, identity()));
+        fieldsByIds = fields.stream()
+                .collect(toImmutableMap(InternalField::getInternalFieldId, identity()));
     }
 
     /**
      * @return Map of {@link InternalField} for each internal field.
      */
-    public Map<String, InternalField> getInternalFields()
+    public Collection<InternalField> getInternalFields()
     {
-        return internalFields;
+        return fieldsByNames.values();
+    }
+
+    public InternalField getFieldByName(String name)
+    {
+        return fieldsByNames.get(name);
+    }
+
+    public InternalField getFieldById(InternalFieldId id)
+    {
+        return fieldsByIds.get(id);
     }
 }

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaMetadata.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaMetadata.java
@@ -43,7 +43,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -134,13 +133,11 @@ public class KafkaMetadata
 
         ImmutableMap.Builder<String, ColumnHandle> columnHandles = ImmutableMap.builder();
 
-        AtomicInteger index = new AtomicInteger(0);
-
         kafkaTopicDescription.getKey().ifPresent(key -> {
             List<KafkaTopicFieldDescription> fields = key.getFields();
             if (fields != null) {
                 for (KafkaTopicFieldDescription kafkaTopicFieldDescription : fields) {
-                    columnHandles.put(kafkaTopicFieldDescription.getName(), kafkaTopicFieldDescription.getColumnHandle(true, index.getAndIncrement()));
+                    columnHandles.put(kafkaTopicFieldDescription.getName(), kafkaTopicFieldDescription.getColumnHandle(true));
                 }
             }
         });
@@ -149,13 +146,13 @@ public class KafkaMetadata
             List<KafkaTopicFieldDescription> fields = message.getFields();
             if (fields != null) {
                 for (KafkaTopicFieldDescription kafkaTopicFieldDescription : fields) {
-                    columnHandles.put(kafkaTopicFieldDescription.getName(), kafkaTopicFieldDescription.getColumnHandle(false, index.getAndIncrement()));
+                    columnHandles.put(kafkaTopicFieldDescription.getName(), kafkaTopicFieldDescription.getColumnHandle(false));
                 }
             }
         });
 
         for (KafkaInternalFieldManager.InternalField kafkaInternalField : kafkaInternalFieldManager.getInternalFields().values()) {
-            columnHandles.put(kafkaInternalField.getColumnName(), kafkaInternalField.getColumnHandle(index.getAndIncrement(), hideInternalColumns));
+            columnHandles.put(kafkaInternalField.getColumnName(), kafkaInternalField.getColumnHandle(hideInternalColumns));
         }
 
         return columnHandles.buildOrThrow();

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaMetadata.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaMetadata.java
@@ -151,7 +151,7 @@ public class KafkaMetadata
         List<KafkaColumnHandle> topicColumnHandles = concat(keyColumnHandles, messageColumnHandles)
                 .collect(toImmutableList());
 
-        List<KafkaColumnHandle> internalColumnHandles = kafkaInternalFieldManager.getInternalFields().values().stream()
+        List<KafkaColumnHandle> internalColumnHandles = kafkaInternalFieldManager.getInternalFields().stream()
                 .map(kafkaInternalField -> kafkaInternalField.getColumnHandle(hideInternalColumns))
                 .collect(toImmutableList());
 
@@ -159,6 +159,7 @@ public class KafkaMetadata
         conflictingColumns.retainAll(internalColumnHandles.stream().map(KafkaColumnHandle::getName).collect(toSet()));
         if (!conflictingColumns.isEmpty()) {
             throw new TrinoException(DUPLICATE_COLUMN_NAME, "Internal Kafka column names conflict with column names from the table. "
+                    + "Consider changing kafka.internal-column-prefix configuration property. "
                     + "topic=" + schemaTableName
                     + ", Conflicting names=" + conflictingColumns);
         }
@@ -223,7 +224,7 @@ public class KafkaMetadata
             }
         });
 
-        for (KafkaInternalFieldManager.InternalField fieldDescription : kafkaInternalFieldManager.getInternalFields().values()) {
+        for (KafkaInternalFieldManager.InternalField fieldDescription : kafkaInternalFieldManager.getInternalFields()) {
             builder.add(fieldDescription.getColumnMetadata(hideInternalColumns));
         }
 

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaRecordSetProvider.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaRecordSetProvider.java
@@ -39,12 +39,14 @@ public class KafkaRecordSetProvider
 {
     private final DispatchingRowDecoderFactory decoderFactory;
     private final KafkaConsumerFactory consumerFactory;
+    private final KafkaInternalFieldManager kafkaInternalFieldManager;
 
     @Inject
-    public KafkaRecordSetProvider(DispatchingRowDecoderFactory decoderFactory, KafkaConsumerFactory consumerFactory)
+    public KafkaRecordSetProvider(DispatchingRowDecoderFactory decoderFactory, KafkaConsumerFactory consumerFactory, KafkaInternalFieldManager kafkaInternalFieldManager)
     {
         this.decoderFactory = requireNonNull(decoderFactory, "decoderFactory is null");
         this.consumerFactory = requireNonNull(consumerFactory, "consumerFactory is null");
+        this.kafkaInternalFieldManager = requireNonNull(kafkaInternalFieldManager, "kafkaInternalFieldManager is null");
     }
 
     @Override
@@ -72,7 +74,7 @@ public class KafkaRecordSetProvider
                         .filter(col -> !col.isKeyCodec())
                         .collect(toImmutableSet()));
 
-        return new KafkaRecordSet(kafkaSplit, consumerFactory, session, kafkaColumns, keyDecoder, messageDecoder);
+        return new KafkaRecordSet(kafkaSplit, consumerFactory, session, kafkaColumns, keyDecoder, messageDecoder, kafkaInternalFieldManager);
     }
 
     private static Map<String, String> getDecoderParameters(Optional<String> dataSchema)

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaTopicFieldDescription.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaTopicFieldDescription.java
@@ -101,7 +101,7 @@ public final class KafkaTopicFieldDescription
         return hidden;
     }
 
-    KafkaColumnHandle getColumnHandle(boolean keyCodec, int index)
+    KafkaColumnHandle getColumnHandle(boolean keyCodec)
     {
         return new KafkaColumnHandle(
                 getName(),

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestInternalFieldConflict.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestInternalFieldConflict.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.kafka.TestingKafka;
+import org.testng.annotations.Test;
+
+import static io.trino.plugin.kafka.util.TestUtils.createDescription;
+import static io.trino.plugin.kafka.util.TestUtils.createOneFieldDescription;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static io.trino.testing.sql.TestTable.randomTableSuffix;
+
+@Test(singleThreaded = true)
+public class TestInternalFieldConflict
+        extends AbstractTestQueryFramework
+{
+    private SchemaTableName topicWithDefaultPrefixes;
+    private SchemaTableName topicWithCustomPrefixes;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        TestingKafka testingKafka = closeAfterClass(TestingKafka.create());
+        topicWithDefaultPrefixes = new SchemaTableName("default", "test_" + randomTableSuffix());
+        topicWithCustomPrefixes = new SchemaTableName("default", "test_" + randomTableSuffix());
+        return KafkaQueryRunner.builder(testingKafka)
+                .setExtraTopicDescription(ImmutableMap.of(
+                        topicWithDefaultPrefixes, createDescription(
+                                topicWithDefaultPrefixes,
+                                createOneFieldDescription("_key", createVarcharType(15)),
+                                ImmutableList.of(createOneFieldDescription("custkey", BIGINT), createOneFieldDescription("acctbal", DOUBLE))),
+                        topicWithCustomPrefixes, createDescription(
+                                topicWithCustomPrefixes,
+                                createOneFieldDescription("unpredictable_prefix_key", createVarcharType(15)),
+                                ImmutableList.of(createOneFieldDescription("custkey", BIGINT), createOneFieldDescription("acctbal", DOUBLE)))))
+                .setExtraKafkaProperties(ImmutableMap.<String, String>builder()
+                        .put("kafka.internal-column-prefix", "unpredictable_prefix_")
+                        .buildOrThrow())
+                .build();
+    }
+
+    @Test
+    public void testInternalFieldPrefix()
+    {
+        assertQuery("SELECT count(*) FROM " + topicWithDefaultPrefixes, "VALUES 0");
+        assertQueryFails("SELECT count(*) FROM " + topicWithCustomPrefixes, ""
+                + "Internal Kafka column names conflict with column names from the table. "
+                + "Consider changing kafka.internal-column-prefix configuration property. "
+                + "topic=" + topicWithCustomPrefixes
+                + ", Conflicting names=\\[unpredictable_prefix_key]");
+    }
+}

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaConfig.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaConfig.java
@@ -41,7 +41,8 @@ public class TestKafkaConfig
                 .setHideInternalColumns(true)
                 .setMessagesPerSplit(100_000)
                 .setTimestampUpperBoundPushDownEnabled(false)
-                .setResourceConfigFiles(List.of()));
+                .setResourceConfigFiles(List.of())
+                .setInternalFieldPrefix("_"));
     }
 
     @Test
@@ -60,6 +61,7 @@ public class TestKafkaConfig
                 .put("kafka.messages-per-split", "1")
                 .put("kafka.timestamp-upper-bound-force-push-down-enabled", "true")
                 .put("kafka.config.resources", resource1.toString() + "," + resource2.toString())
+                .put("kafka.internal-column-prefix", "the_most_unexpected_prefix_")
                 .buildOrThrow();
 
         KafkaConfig expected = new KafkaConfig()
@@ -70,7 +72,8 @@ public class TestKafkaConfig
                 .setHideInternalColumns(false)
                 .setMessagesPerSplit(1)
                 .setTimestampUpperBoundPushDownEnabled(true)
-                .setResourceConfigFiles(ImmutableList.of(resource1.toString(), resource2.toString()));
+                .setResourceConfigFiles(ImmutableList.of(resource1.toString(), resource2.toString()))
+                .setInternalFieldPrefix("the_most_unexpected_prefix_");
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaConnectorTest.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaConnectorTest.java
@@ -45,6 +45,9 @@ import static io.trino.plugin.kafka.encoder.json.format.DateTimeFormat.ISO8601;
 import static io.trino.plugin.kafka.encoder.json.format.DateTimeFormat.MILLISECONDS_SINCE_EPOCH;
 import static io.trino.plugin.kafka.encoder.json.format.DateTimeFormat.RFC2822;
 import static io.trino.plugin.kafka.encoder.json.format.DateTimeFormat.SECONDS_SINCE_EPOCH;
+import static io.trino.plugin.kafka.util.TestUtils.createDescription;
+import static io.trino.plugin.kafka.util.TestUtils.createFieldGroup;
+import static io.trino.plugin.kafka.util.TestUtils.createOneFieldDescription;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateType.DATE;
@@ -463,47 +466,6 @@ public class TestKafkaConnectorTest
     public void testInsertRowConcurrently()
     {
         throw new SkipException("TODO Prepare a topic in Kafka and enable this test");
-    }
-
-    private static KafkaTopicDescription createDescription(SchemaTableName schemaTableName, KafkaTopicFieldDescription key, List<KafkaTopicFieldDescription> fields)
-    {
-        return new KafkaTopicDescription(
-                schemaTableName.getTableName(),
-                Optional.of(schemaTableName.getSchemaName()),
-                schemaTableName.getTableName(),
-                Optional.of(new KafkaTopicFieldGroup("json", Optional.empty(), Optional.empty(), ImmutableList.of(key))),
-                Optional.of(new KafkaTopicFieldGroup("json", Optional.empty(), Optional.empty(), fields)));
-    }
-
-    private static KafkaTopicDescription createDescription(String name, String schema, String topic, Optional<KafkaTopicFieldGroup> message)
-    {
-        return new KafkaTopicDescription(name, Optional.of(schema), topic, Optional.empty(), message);
-    }
-
-    private static Optional<KafkaTopicFieldGroup> createFieldGroup(String dataFormat, List<KafkaTopicFieldDescription> fields)
-    {
-        return Optional.of(new KafkaTopicFieldGroup(dataFormat, Optional.empty(), Optional.empty(), fields));
-    }
-
-    private static KafkaTopicFieldDescription createOneFieldDescription(String name, Type type)
-    {
-        return new KafkaTopicFieldDescription(name, type, name, null, null, null, false);
-    }
-
-    private static KafkaTopicFieldDescription createOneFieldDescription(String name, Type type, String dataFormat)
-    {
-        return new KafkaTopicFieldDescription(name, type, name, null, dataFormat, null, false);
-    }
-
-    private static KafkaTopicFieldDescription createOneFieldDescription(String name, Type type, String dataFormat, Optional<String> formatHint)
-    {
-        return formatHint.map(s -> new KafkaTopicFieldDescription(name, type, name, null, dataFormat, s, false))
-                .orElseGet(() -> new KafkaTopicFieldDescription(name, type, name, null, dataFormat, null, false));
-    }
-
-    private static KafkaTopicFieldDescription createOneFieldDescription(String name, Type type, String mapping, String dataFormat)
-    {
-        return new KafkaTopicFieldDescription(name, type, mapping, null, dataFormat, null, false);
     }
 
     @Test

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaInternalFieldManager.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaInternalFieldManager.java
@@ -19,7 +19,7 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
-import static io.trino.plugin.kafka.KafkaInternalFieldManager.PARTITION_ID_FIELD;
+import static io.trino.plugin.kafka.KafkaInternalFieldManager.InternalFieldId.PARTITION_ID_FIELD;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestKafkaInternalFieldManager
@@ -30,12 +30,13 @@ public class TestKafkaInternalFieldManager
         KafkaInternalFieldManager.InternalField internalField =
                 new KafkaInternalFieldManager.InternalField(
                         PARTITION_ID_FIELD,
+                        "internal_field_name",
                         "Partition Id",
                         BigintType.BIGINT);
 
         KafkaColumnHandle kafkaColumnHandle =
                 new KafkaColumnHandle(
-                        PARTITION_ID_FIELD,
+                        "internal_field_name",
                         BigintType.BIGINT,
                         null,
                         null,
@@ -46,13 +47,14 @@ public class TestKafkaInternalFieldManager
 
         ColumnMetadata columnMetadata =
                 ColumnMetadata.builder()
-                        .setName(PARTITION_ID_FIELD)
+                        .setName("internal_field_name")
                         .setType(BigintType.BIGINT)
                         .setComment(Optional.of("Partition Id"))
                         .setHidden(false)
                         .build();
 
-        assertThat(internalField.getColumnName()).isEqualTo(PARTITION_ID_FIELD);
+        assertThat(internalField.getInternalFieldId()).isEqualTo(PARTITION_ID_FIELD);
+        assertThat(internalField.getColumnName()).isEqualTo("internal_field_name");
         assertThat(internalField.getColumnHandle(false)).isEqualTo(kafkaColumnHandle);
         assertThat(internalField.getColumnMetadata(false)).isEqualTo(columnMetadata);
     }

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaInternalFieldManager.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaInternalFieldManager.java
@@ -53,7 +53,7 @@ public class TestKafkaInternalFieldManager
                         .build();
 
         assertThat(internalField.getColumnName()).isEqualTo(PARTITION_ID_FIELD);
-        assertThat(internalField.getColumnHandle(0, false)).isEqualTo(kafkaColumnHandle);
+        assertThat(internalField.getColumnHandle(false)).isEqualTo(kafkaColumnHandle);
         assertThat(internalField.getColumnMetadata(false)).isEqualTo(columnMetadata);
     }
 }

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/util/TestUtils.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/util/TestUtils.java
@@ -13,13 +13,18 @@
  */
 package io.trino.plugin.kafka.util;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteStreams;
 import io.airlift.json.JsonCodec;
 import io.trino.plugin.kafka.KafkaTopicDescription;
+import io.trino.plugin.kafka.KafkaTopicFieldDescription;
+import io.trino.plugin.kafka.KafkaTopicFieldGroup;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.type.Type;
 
 import java.io.IOException;
 import java.util.AbstractMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -44,5 +49,46 @@ public final class TestUtils
         return new AbstractMap.SimpleImmutableEntry<>(
                 schemaTableName,
                 new KafkaTopicDescription(schemaTableName.getTableName(), Optional.of(schemaTableName.getSchemaName()), topicName, Optional.empty(), Optional.empty()));
+    }
+
+    public static KafkaTopicDescription createDescription(SchemaTableName schemaTableName, KafkaTopicFieldDescription key, List<KafkaTopicFieldDescription> fields)
+    {
+        return new KafkaTopicDescription(
+                schemaTableName.getTableName(),
+                Optional.of(schemaTableName.getSchemaName()),
+                schemaTableName.getTableName(),
+                Optional.of(new KafkaTopicFieldGroup("json", Optional.empty(), Optional.empty(), ImmutableList.of(key))),
+                Optional.of(new KafkaTopicFieldGroup("json", Optional.empty(), Optional.empty(), fields)));
+    }
+
+    public static KafkaTopicDescription createDescription(String name, String schema, String topic, Optional<KafkaTopicFieldGroup> message)
+    {
+        return new KafkaTopicDescription(name, Optional.of(schema), topic, Optional.empty(), message);
+    }
+
+    public static Optional<KafkaTopicFieldGroup> createFieldGroup(String dataFormat, List<KafkaTopicFieldDescription> fields)
+    {
+        return Optional.of(new KafkaTopicFieldGroup(dataFormat, Optional.empty(), Optional.empty(), fields));
+    }
+
+    public static KafkaTopicFieldDescription createOneFieldDescription(String name, Type type)
+    {
+        return new KafkaTopicFieldDescription(name, type, name, null, null, null, false);
+    }
+
+    public static KafkaTopicFieldDescription createOneFieldDescription(String name, Type type, String dataFormat)
+    {
+        return new KafkaTopicFieldDescription(name, type, name, null, dataFormat, null, false);
+    }
+
+    public static KafkaTopicFieldDescription createOneFieldDescription(String name, Type type, String dataFormat, Optional<String> formatHint)
+    {
+        return formatHint.map(s -> new KafkaTopicFieldDescription(name, type, name, null, dataFormat, s, false))
+                .orElseGet(() -> new KafkaTopicFieldDescription(name, type, name, null, dataFormat, null, false));
+    }
+
+    public static KafkaTopicFieldDescription createOneFieldDescription(String name, Type type, String mapping, String dataFormat)
+    {
+        return new KafkaTopicFieldDescription(name, type, mapping, null, dataFormat, null, false);
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
When we process Kafka topics, for internal usage we add some bunch of additional columns with some useful data and we fill them with data which is coming from Kafka (RecordSet), for example:
`case PARTITION_OFFSET_FIELD -> longValueProvider(message.offset());`
By default in current implementation this columns have some hardcoded names like:
`_partition_id` `_message_corrupt` e.t.c
So it could be a situation, that Kafka topic itself have some fields with similar name, and in this case during processing we could have a conflict (like two columns have the same name, for example `_key`)
So reason of this PR is to provide ability to tune internal column names with custom prefix like `XX_my_prefix_XX_key`, so this conflict could be more rare then with simple current default prefix `_key`
This PR will not resolve problem, but just postpone it until times when users will have more difficult column name, which will conflict with our internal column.
This change is backward compatible so for people who don't have colliding field names they don't need to change their existing queries to work with newer version.
The drawback is that this can't anticipate a collision ahead of time. It does however allow adminstrators to use a unique prefix unlikely to ever exist - e.g. `__kafka_message_metadata_`.

Thank you, @vlad-lyutenko and @hashhar for the description :)

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(*) Release notes are required, with the following suggested text:
Workaround for encountering "multiple entries with same key" while querying Kafka

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
