### PR TITLE
Remove supported statistics from metastore recording

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/recording/RecordingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/recording/RecordingHiveMetastore.java
@@ -78,7 +78,8 @@ public class RecordingHiveMetastore
     @Override
     public Set<ColumnStatisticType> getSupportedColumnStatistics(Type type)
     {
-        return recording.getSupportedColumnStatistics(type.getTypeSignature().toString(), () -> delegate.getSupportedColumnStatistics(type));
+        // No need to record that, since it's a pure local operation.
+        return delegate.getSupportedColumnStatistics(type);
     }
 
     @Override

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/recording/TestRecordingHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/recording/TestRecordingHiveMetastore.java
@@ -49,7 +49,6 @@ import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.security.RoleGrant;
 import io.trino.spi.security.TrinoPrincipal;
-import io.trino.spi.statistics.ColumnStatisticType;
 import io.trino.spi.type.TestingTypeManager;
 import io.trino.spi.type.Type;
 import org.testng.annotations.Test;
@@ -66,10 +65,7 @@ import java.util.concurrent.TimeUnit;
 import static io.trino.plugin.hive.HiveBasicStatistics.createEmptyStatistics;
 import static io.trino.plugin.hive.util.HiveBucketing.BucketingVersion.BUCKETING_V1;
 import static io.trino.spi.security.PrincipalType.USER;
-import static io.trino.spi.statistics.ColumnStatisticType.MAX_VALUE;
-import static io.trino.spi.statistics.ColumnStatisticType.MIN_VALUE;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
-import static io.trino.spi.type.VarcharType.createVarcharType;
 import static org.testng.Assert.assertEquals;
 
 public class TestRecordingHiveMetastore
@@ -181,7 +177,6 @@ public class TestRecordingHiveMetastore
         assertEquals(hiveMetastore.getDatabase("database"), Optional.of(DATABASE));
         assertEquals(hiveMetastore.getAllDatabases(), ImmutableList.of("database"));
         assertEquals(hiveMetastore.getTable("database", "table"), Optional.of(TABLE));
-        assertEquals(hiveMetastore.getSupportedColumnStatistics(createVarcharType(123)), ImmutableSet.of(MIN_VALUE, MAX_VALUE));
         assertEquals(hiveMetastore.getTableStatistics(TABLE), PARTITION_STATISTICS);
         assertEquals(hiveMetastore.getPartitionStatistics(TABLE, ImmutableList.of(PARTITION, OTHER_PARTITION)), ImmutableMap.of(
                 "column=value", PARTITION_STATISTICS,
@@ -236,16 +231,6 @@ public class TestRecordingHiveMetastore
             }
 
             return Optional.empty();
-        }
-
-        @Override
-        public Set<ColumnStatisticType> getSupportedColumnStatistics(Type type)
-        {
-            if (type.equals(createVarcharType(123))) {
-                return ImmutableSet.of(MIN_VALUE, MAX_VALUE);
-            }
-
-            return ImmutableSet.of();
         }
 
         @Override


### PR DESCRIPTION
No need to record that, since it's a pure local operation.

Extracted from https://github.com/trinodb/trino/pull/14233 , since the alternative (https://github.com/trinodb/trino/pull/14222) may not need this, and this is a good change anyway.