### PR TITLE
Add guards to prevent possible NPE in test cleanup

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractDistributedEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractDistributedEngineOnlyQueries.java
@@ -54,7 +54,10 @@ public abstract class AbstractDistributedEngineOnlyQueries
     @AfterClass(alwaysRun = true)
     public void shutdown()
     {
-        executorService.shutdownNow();
+        if (executorService != null) {
+            executorService.shutdownNow();
+            executorService = null;
+        }
     }
 
     /**


### PR DESCRIPTION
It was possible for executorService to not be initialized if setup() was not called due to failure in initialization driven by superclass.

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
