### PR TITLE
Fix broken PostgreSQL JDBC driver docs link

### DIFF
--- a/docs/src/main/sphinx/connector/postgresql.rst
+++ b/docs/src/main/sphinx/connector/postgresql.rst
@@ -41,9 +41,9 @@ as appropriate for your setup:
 The ``connection-url`` defines the connection information and parameters to pass
 to the PostgreSQL JDBC driver. The parameters for the URL are available in the
 `PostgreSQL JDBC driver documentation
-<https://jdbc.postgresql.org/documentation/head/connect.html>`_. Some parameters
-can have adverse effects on the connector behavior or not work with the
-connector.
+<https://jdbc.postgresql.org/documentation/use/#connecting-to-the-database>`_.
+Some parameters can have adverse effects on the connector behavior or not work
+with the connector.
 
 The ``connection-user`` and ``connection-password`` are typically required and
 determine the user credentials for the connection, often a service user. You can


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The current link to PostgreSQL JDBC driver documentation (https://jdbc.postgresql.org/documentation/head/connect.html) is broken. https://jdbc.postgresql.org/documentation/use/#connecting-to-the-database appears to be a suitable replacement.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Fix a broken link in documentation

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
