### PR TITLE
Fix build error and link in PostgreSQL docs

### DIFF
--- a/docs/src/main/sphinx/connector/postgresql.rst
+++ b/docs/src/main/sphinx/connector/postgresql.rst
@@ -41,7 +41,7 @@ as appropriate for your setup:
 The ``connection-url`` defines the connection information and parameters to pass
 to the PostgreSQL JDBC driver. The parameters for the URL are available in the
 `PostgreSQL JDBC driver documentation
-<https://jdbc.postgresql.org/documentation/use/#connecting-to-the-database>`_.
+<https://jdbc.postgresql.org/documentation/use/#connecting-to-the-database>`__.
 Some parameters can have adverse effects on the connector behavior or not work
 with the connector.
 
@@ -69,7 +69,7 @@ property:
   connection-url=jdbc:postgresql://example.net:5432/database?ssl=true
 
 For more information on TLS configuration options, see the `PostgreSQL JDBC
-driver documentation <https://jdbc.postgresql.org/documentation/head/connect.html>`_.
+driver documentation <https://jdbc.postgresql.org/documentation/use/#connecting-to-the-database>`__.
 
 Multiple PostgreSQL databases or servers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Fix the build error in docs. Double underscore makes these anonymous, so they can share the same name. Technically also works as long as the links are the same, but let's just solve the problem twice. 😄 

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
