### PR TITLE
Increase spiller-max-used-space-threshold for tests

### DIFF
--- a/testing/trino-tests/src/test/java/io/trino/tests/TestQuerySpillLimits.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestQuerySpillLimits.java
@@ -78,7 +78,8 @@ public class TestQuerySpillLimits
                 .withFeaturesConfig(
                         new FeaturesConfig()
                                 .setSpillerSpillPaths(spillPath.getAbsolutePath())
-                                .setSpillEnabled(true))
+                                .setSpillEnabled(true)
+                                .setSpillMaxUsedSpaceThreshold(1.0))
                 .withNodeSpillConfig(nodeSpillConfig)
                 .withAlwaysRevokeMemory()
                 .build();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
The tests testMaxSpillPerNodeLimit and testQueryMaxSpillPerNodeLimit will fail when the disk usage of the temporary directory is greater than 0.9 (default value). This makes the tests flaky because the tests will fail when the disk of the host has usage > 0.9.

Setting the config spiller-max-used-space-threshold to 1.0 should fix the issue. It also follows the config in another test suite TestDistributedSpilledQueries. https://github.com/trinodb/trino/blob/master/testing/trino-tests/src/test/java/io/trino/tests/TestDistributedSpilledQueries.java#L53



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

