### PR TITLE
Improve logic for reading dictionaries during row group pruning

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/DictionaryDescriptor.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/DictionaryDescriptor.java
@@ -21,17 +21,24 @@ import java.util.Optional;
 public class DictionaryDescriptor
 {
     private final ColumnDescriptor columnDescriptor;
+    private final boolean nullAllowed;
     private final Optional<DictionaryPage> dictionaryPage;
 
-    public DictionaryDescriptor(ColumnDescriptor columnDescriptor, Optional<DictionaryPage> dictionaryPage)
+    public DictionaryDescriptor(ColumnDescriptor columnDescriptor, boolean nullAllowed, Optional<DictionaryPage> dictionaryPage)
     {
         this.columnDescriptor = columnDescriptor;
+        this.nullAllowed = nullAllowed;
         this.dictionaryPage = dictionaryPage;
     }
 
     public ColumnDescriptor getColumnDescriptor()
     {
         return columnDescriptor;
+    }
+
+    public boolean isNullAllowed()
+    {
+        return nullAllowed;
     }
 
     public Optional<DictionaryPage> getDictionaryPage()

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/Predicate.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/Predicate.java
@@ -21,20 +21,28 @@ import org.apache.parquet.filter2.predicate.FilterPredicate;
 import org.apache.parquet.internal.filter2.columnindex.ColumnIndexStore;
 import org.joda.time.DateTimeZone;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 public interface Predicate
 {
     /**
-     * Should the Parquet Reader process a file section with the specified statistics.
+     * Should the Parquet Reader process a file section with the specified statistics,
+     * and if it should, then return the columns are candidates for further inspection of more
+     * granular statistics from column index and dictionary.
      *
      * @param numberOfRows the number of rows in the segment; this can be used with
      * Statistics to determine if a column is only null
      * @param statistics column statistics
      * @param id Parquet file name
+     *
+     * @return Optional.empty() if statistics were sufficient to eliminate the file section.
+     * Otherwise, a list of columns for which page-level indices and dictionary could be consulted
+     * to potentially eliminate the file section. An optional with empty list is returned if there is
+     * going to be no benefit in looking at column index or dictionary for any column.
      */
-    boolean matches(long numberOfRows, Map<ColumnDescriptor, Statistics<?>> statistics, ParquetDataSourceId id)
+    Optional<List<ColumnDescriptor>> getIndexLookupCandidates(long numberOfRows, Map<ColumnDescriptor, Statistics<?>> statistics, ParquetDataSourceId id)
             throws ParquetCorruptionException;
 
     /**

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
@@ -486,7 +486,10 @@ public class TupleDomainParquetPredicate
         int dictionarySize = dictionaryPage.get().getDictionarySize();
 
         if (dictionarySize == 0) {
-            return Domain.onlyNull(type);
+            if (dictionaryDescriptor.isNullAllowed()) {
+                return Domain.onlyNull(type);
+            }
+            return Domain.none(type);
         }
 
         DictionaryValueConverter converter = new DictionaryValueConverter(dictionary);
@@ -497,7 +500,7 @@ public class TupleDomainParquetPredicate
         }
 
         // TODO: when min == max (i.e., singleton ranges, the construction of Domains can be done more efficiently
-        return getDomain(columnDescriptor, type, values, values, true, timeZone);
+        return getDomain(columnDescriptor, type, values, values, dictionaryDescriptor.isNullAllowed(), timeZone);
     }
 
     private static ParquetCorruptionException corruptionException(String column, ParquetDataSourceId id, Statistics<?> statistics, Exception cause)

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
@@ -268,7 +268,7 @@ public class TupleDomainParquetPredicate
         }
 
         if (type.equals(BIGINT) || type.equals(INTEGER) || type.equals(DATE) || type.equals(SMALLINT) || type.equals(TINYINT)) {
-            List<Range> ranges = new ArrayList<>();
+            List<Range> ranges = new ArrayList<>(minimums.size());
             for (int i = 0; i < minimums.size(); i++) {
                 long min = asLong(minimums.get(i));
                 long max = asLong(maximums.get(i));
@@ -284,7 +284,7 @@ public class TupleDomainParquetPredicate
 
         if (type instanceof DecimalType) {
             DecimalType decimalType = (DecimalType) type;
-            List<Range> ranges = new ArrayList<>();
+            List<Range> ranges = new ArrayList<>(minimums.size());
             if (decimalType.isShort()) {
                 for (int i = 0; i < minimums.size(); i++) {
                     Object min = minimums.get(i);
@@ -313,7 +313,7 @@ public class TupleDomainParquetPredicate
         }
 
         if (type.equals(REAL)) {
-            List<Range> ranges = new ArrayList<>();
+            List<Range> ranges = new ArrayList<>(minimums.size());
             for (int i = 0; i < minimums.size(); i++) {
                 Float min = (Float) minimums.get(i);
                 Float max = (Float) maximums.get(i);
@@ -328,7 +328,7 @@ public class TupleDomainParquetPredicate
         }
 
         if (type.equals(DOUBLE)) {
-            List<Range> ranges = new ArrayList<>();
+            List<Range> ranges = new ArrayList<>(minimums.size());
             for (int i = 0; i < minimums.size(); i++) {
                 Double min = (Double) minimums.get(i);
                 Double max = (Double) maximums.get(i);
@@ -343,7 +343,7 @@ public class TupleDomainParquetPredicate
         }
 
         if (type instanceof VarcharType) {
-            List<Range> ranges = new ArrayList<>();
+            List<Range> ranges = new ArrayList<>(minimums.size());
             for (int i = 0; i < minimums.size(); i++) {
                 Slice min = Slices.wrappedBuffer(((Binary) minimums.get(i)).toByteBuffer());
                 Slice max = Slices.wrappedBuffer(((Binary) maximums.get(i)).toByteBuffer());
@@ -355,7 +355,7 @@ public class TupleDomainParquetPredicate
         if (type instanceof TimestampType) {
             if (column.getPrimitiveType().getPrimitiveTypeName().equals(INT96)) {
                 TrinoTimestampEncoder<?> timestampEncoder = createTimestampEncoder((TimestampType) type, timeZone);
-                List<Object> values = new ArrayList<>();
+                List<Object> values = new ArrayList<>(minimums.size());
                 for (int i = 0; i < minimums.size(); i++) {
                     Object min = minimums.get(i);
                     Object max = maximums.get(i);
@@ -386,7 +386,7 @@ public class TupleDomainParquetPredicate
                 }
                 TrinoTimestampEncoder<?> timestampEncoder = createTimestampEncoder((TimestampType) type, DateTimeZone.UTC);
 
-                List<Range> ranges = new ArrayList<>();
+                List<Range> ranges = new ArrayList<>(minimums.size());
                 for (int i = 0; i < minimums.size(); i++) {
                     long min = (long) minimums.get(i);
                     long max = (long) maximums.get(i);
@@ -445,8 +445,8 @@ public class TupleDomainParquetPredicate
             int pageCount = minValues.size();
             ColumnIndexValueConverter converter = new ColumnIndexValueConverter();
             Function<ByteBuffer, Object> converterFunction = converter.getConverter(descriptor.getPrimitiveType());
-            List<Object> min = new ArrayList<>();
-            List<Object> max = new ArrayList<>();
+            List<Object> min = new ArrayList<>(pageCount);
+            List<Object> max = new ArrayList<>(pageCount);
             for (int i = 0; i < pageCount; i++) {
                 if (nullPages.get(i)) {
                     continue;
@@ -501,7 +501,7 @@ public class TupleDomainParquetPredicate
 
         DictionaryValueConverter converter = new DictionaryValueConverter(dictionary);
         Function<Integer, Object> convertFunction = converter.getConverter(columnDescriptor.getPrimitiveType());
-        List<Object> values = new ArrayList<>();
+        List<Object> values = new ArrayList<>(dictionarySize);
         for (int i = 0; i < dictionarySize; i++) {
             values.add(convertFunction.apply(i));
         }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/predicate/BenchmarkTupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/predicate/BenchmarkTupleDomainParquetPredicate.java
@@ -93,6 +93,7 @@ public class BenchmarkTupleDomainParquetPredicate
 
             return new DictionaryDescriptor(
                     new ColumnDescriptor(new String[] {"path"}, Types.optional(INT64).named("Test column"), 0, 0),
+                    true,
                     Optional.of(
                             new DictionaryPage(
                                     slice,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
@@ -241,7 +241,7 @@ public class ParquetPageSourceFactory
                 long firstDataPage = block.getColumns().get(0).getFirstDataPageOffset();
                 Optional<ColumnIndexStore> columnIndex = getColumnIndexStore(dataSource, block, descriptorsByPath, parquetTupleDomain, options);
                 if (start <= firstDataPage && firstDataPage < start + length
-                        && predicateMatches(parquetPredicate, block, dataSource, descriptorsByPath, parquetTupleDomain, columnIndex)) {
+                        && predicateMatches(parquetPredicate, block, dataSource, descriptorsByPath, parquetTupleDomain, columnIndex, timeZone)) {
                     blocks.add(block);
                     blockStarts.add(nextStart);
                     columnIndexes.add(columnIndex);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -981,7 +981,7 @@ public class IcebergPageSourceProvider
             for (BlockMetaData block : parquetMetadata.getBlocks()) {
                 long firstDataPage = block.getColumns().get(0).getFirstDataPageOffset();
                 if (start <= firstDataPage && firstDataPage < start + length &&
-                        predicateMatches(parquetPredicate, block, dataSource, descriptorsByPath, parquetTupleDomain)) {
+                        predicateMatches(parquetPredicate, block, dataSource, descriptorsByPath, parquetTupleDomain, Optional.empty(), UTC)) {
                     blocks.add(block);
                     blockStarts.add(nextStart);
                     if (startRowPosition.isEmpty()) {


### PR DESCRIPTION
## Description

Improve logic for reading dictionaries during row group pruning in parquet reader

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Improves parquet reader performance in the presence of predicates.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Delta, Iceberg
* Improve performance of reading parquet files for queries with predicates. ({issue}`14247`)
```
