### PR TITLE
Fix BigQuery predicate pushdown for varchars with backslashes or newlines

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryType.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryType.java
@@ -176,7 +176,7 @@ public enum BigQueryType
     @VisibleForTesting
     public static String dateToStringConverter(Object value)
     {
-        LocalDate date = LocalDate.ofEpochDay(((Long) value).longValue());
+        LocalDate date = LocalDate.ofEpochDay((long) value);
         return "'" + date + "'";
     }
 

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryType.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryType.java
@@ -177,7 +177,7 @@ public enum BigQueryType
     public static String dateToStringConverter(Object value)
     {
         LocalDate date = LocalDate.ofEpochDay(((Long) value).longValue());
-        return quote(date.toString());
+        return "'" + date + "'";
     }
 
     private static String datetimeToStringConverter(Object value)
@@ -223,8 +223,9 @@ public enum BigQueryType
     static String stringToStringConverter(Object value)
     {
         Slice slice = (Slice) value;
-        // TODO (https://github.com/trinodb/trino/issues/7900) Add support for all String and Bytes literals
-        return quote(slice.toStringUtf8().replace("'", "\\'"));
+        return "'%s'".formatted(slice.toStringUtf8()
+                .replace("\\", "\\\\")
+                .replace("'", "\\'"));
     }
 
     static String numericToStringConverter(Object value)
@@ -312,11 +313,6 @@ public enum BigQueryType
             return StandardSQLTypeName.STRUCT;
         }
         throw new TrinoException(NOT_SUPPORTED, "Unsupported column type: " + type.getDisplayName());
-    }
-
-    private static String quote(String value)
-    {
-        return "'" + value + "'";
     }
 
     public Optional<String> convertToString(Type type, Object value)

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryType.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryType.java
@@ -225,6 +225,7 @@ public enum BigQueryType
         Slice slice = (Slice) value;
         return "'%s'".formatted(slice.toStringUtf8()
                 .replace("\\", "\\\\")
+                .replace("\n", "\\n")
                 .replace("'", "\\'"));
     }
 

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -4156,7 +4156,8 @@ public abstract class BaseConnectorTest
                 .add(new DataMappingTestSetup("char(3)", "'ab'", "'zzz'"))
                 .add(new DataMappingTestSetup("varchar(3)", "'de'", "'zzz'"))
                 .add(new DataMappingTestSetup("varchar", "'łąka for the win'", "'ŻŻŻŻŻŻŻŻŻŻ'"))
-                .add(new DataMappingTestSetup("varchar", "'a \\backslash'", "'a a'")) // `a` sorts after `\`
+                .add(new DataMappingTestSetup("varchar", "'a \\backslash'", "'a a'")) // `a` sorts after `\`; \b may be interpreted as an escape sequence
+                .add(new DataMappingTestSetup("varchar", "'end backslash \\'", "'end backslash a'")) // `a` sorts after `\`; final \ before end quote may confuse a parser
                 .add(new DataMappingTestSetup("varchar", "U&'a \\000a newline'", "'a a'")) // `a` sorts after `\n`; newlines can require special handling in a remote system's language
                 .add(new DataMappingTestSetup("varbinary", "X'12ab3f'", "X'ffffffffffffffffffff'"))
                 .build();

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -4157,6 +4157,7 @@ public abstract class BaseConnectorTest
                 .add(new DataMappingTestSetup("varchar(3)", "'de'", "'zzz'"))
                 .add(new DataMappingTestSetup("varchar", "'łąka for the win'", "'ŻŻŻŻŻŻŻŻŻŻ'"))
                 .add(new DataMappingTestSetup("varchar", "'a \\backslash'", "'a a'")) // `a` sorts after `\`
+                .add(new DataMappingTestSetup("varchar", "U&'a \\000a newline'", "'a a'")) // `a` sorts after `\n`; newlines can require special handling in a remote system's language
                 .add(new DataMappingTestSetup("varbinary", "X'12ab3f'", "X'ffffffffffffffffffff'"))
                 .build();
     }

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -4877,8 +4877,9 @@ public abstract class BaseConnectorTest
         @Override
         public String toString()
         {
-            // toString is brief because it's used for test case labels in IDE
-            return trinoTypeName + (unsupportedType ? "!" : "");
+            // Used for test case labels in IDE
+            return trinoTypeName + (unsupportedType ? "!" : "") +
+                    ":" + sampleValueLiteral.replaceAll("[^a-zA-Z0-9_-]", "");
         }
     }
 }


### PR DESCRIPTION
Fixes tests failing on master since https://github.com/trinodb/trino/pull/14125 (past 6 days)

Fixes https://github.com/trinodb/trino/issues/7900 
Follows https://github.com/trinodb/trino/pull/7869 