### PR TITLE
Bump airlift units to 1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -873,7 +873,7 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>units</artifactId>
-                <version>1.6</version>
+                <version>1.7</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Version 1.7 includes an improvement to `DataSize` JSON deserialization that skips using a `Pattern` matcher on input strings.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Update airlift units to 1.7, which includes a performance improvement for JSON deserialization of `DataSize` values.


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation
No non-technical explanation should be necessary.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
