### PR TITLE
Reset allowed-no-matching-node-period timeout on new nodes in cluster

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/BinPackingNodeAllocatorService.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/BinPackingNodeAllocatorService.java
@@ -247,6 +247,7 @@ public class BinPackingNodeAllocatorService
                     iterator.remove();
                     break;
                 case NOT_ENOUGH_RESOURCES_NOW:
+                    pendingAcquire.resetNoMatchingNodeFound();
                     break; // nothing to be done
                 default:
                     throw new IllegalArgumentException("unknown status: " + result.getStatus());
@@ -338,6 +339,11 @@ public class BinPackingNodeAllocatorService
                 noMatchingNodeStopwatch.start();
             }
             return noMatchingNodeStopwatch.elapsed();
+        }
+
+        public void resetNoMatchingNodeFound()
+        {
+            noMatchingNodeStopwatch.reset();
         }
     }
 


### PR DESCRIPTION
We allow for situation when there are no nodes in the cluster which match task requirement for timeout governed by
node-scheduler.allowed-no-matching-node-period config variable. Previously if new node appeared in the cluster, but could not be used because it did not have enough free resources at given moment timeout counter was not reset.
This commit changes the behaviour. If new node appears and then disappears again, the no-nodes timeout will be recounted again from zero.

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Improve handling of `node-scheduler.allowed-no-matching-node-period` timeout. ({issue}`14256`)
```
