### PR TITLE
Use monotonic clock in Glue metrics

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -963,7 +963,7 @@ public class GlueHiveMetastore
                 List<Future<BatchCreatePartitionResult>> futures = new ArrayList<>();
 
                 for (List<PartitionWithStatistics> partitionBatch : Lists.partition(partitions, BATCH_CREATE_PARTITION_MAX_PAGE_SIZE)) {
-                    List<PartitionInput> partitionInputs = mappedCopy(partitionBatch, partition -> GlueInputConverter.convertPartition(partition));
+                    List<PartitionInput> partitionInputs = mappedCopy(partitionBatch, GlueInputConverter::convertPartition);
                     futures.add(glueClient.batchCreatePartitionAsync(
                             new BatchCreatePartitionRequest()
                                     .withDatabaseName(databaseName)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueMetastoreApiStats.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueMetastoreApiStats.java
@@ -20,6 +20,8 @@ import org.weakref.jmx.Nested;
 
 import javax.annotation.concurrent.ThreadSafe;
 
+import java.util.concurrent.Callable;
+
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 @ThreadSafe
@@ -63,7 +65,9 @@ public class GlueMetastoreApiStats
     }
 
     public interface ThrowingCallable<V, E extends Exception>
+            extends Callable<V>
     {
+        @Override
         V call()
                 throws E;
     }


### PR DESCRIPTION
## Description
Change usage of `System.currentTimeMillis()` to Guava's `Stopwatch` in Glue API stats collection, since `System.currentTimeMillis()` is not guaranteed to be monotonic and therefore not ideal for measuring elapsed time. Metrics are still recorded in milliseconds.

## Non-technical explanation
No non-technical explanation is necessary.


## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
