### PR TITLE
Improve decoding of short decimals in parquet reader

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
@@ -247,7 +247,6 @@ public final class ParquetTypeUtils
         return !required && (definitionLevel == maxDefinitionLevel - 1);
     }
 
-    // copied from trino-hive DecimalUtils
     public static long getShortDecimalValue(byte[] bytes)
     {
         return getShortDecimalValue(bytes, 0, bytes.length);
@@ -256,16 +255,32 @@ public final class ParquetTypeUtils
     public static long getShortDecimalValue(byte[] bytes, int startOffset, int length)
     {
         long value = 0;
-        if (bytes[startOffset] < 0) {
-            for (int i = 0; i < 8 - length; ++i) {
-                value |= 0xFFL << (8 * (7 - i));
-            }
+        switch (length) {
+            case 8:
+                value |= bytes[startOffset + 7] & 0xFFL;
+                // fall through
+            case 7:
+                value |= (bytes[startOffset + 6] & 0xFFL) << 8;
+                // fall through
+            case 6:
+                value |= (bytes[startOffset + 5] & 0xFFL) << 16;
+                // fall through
+            case 5:
+                value |= (bytes[startOffset + 4] & 0xFFL) << 24;
+                // fall through
+            case 4:
+                value |= (bytes[startOffset + 3] & 0xFFL) << 32;
+                // fall through
+            case 3:
+                value |= (bytes[startOffset + 2] & 0xFFL) << 40;
+                // fall through
+            case 2:
+                value |= (bytes[startOffset + 1] & 0xFFL) << 48;
+                // fall through
+            case 1:
+                value |= (bytes[startOffset] & 0xFFL) << 56;
         }
-
-        for (int i = 0; i < length; i++) {
-            value |= (bytes[startOffset + length - i - 1] & 0xFFL) << (8 * i);
-        }
-
+        value = value >> ((8 - length) * 8);
         return value;
     }
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
@@ -445,7 +445,7 @@ public class ParquetReader
             List<Slice> slices = allocateBlock(fieldId);
             columnReader.setPageReader(createPageReader(slices, metadata, columnDescriptor, offsetIndex), currentGroupRowRanges);
         }
-        ColumnChunk columnChunk = columnReader.readPrimitive(field);
+        ColumnChunk columnChunk = columnReader.readPrimitive();
 
         // update max size per primitive column chunk
         long bytesPerCell = columnChunk.getBlock().getSizeInBytes() / batchSize;

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PrimitiveColumnReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PrimitiveColumnReader.java
@@ -18,7 +18,6 @@ import io.trino.parquet.DataPage;
 import io.trino.parquet.DataPageV1;
 import io.trino.parquet.DataPageV2;
 import io.trino.parquet.DictionaryPage;
-import io.trino.parquet.Field;
 import io.trino.parquet.ParquetEncoding;
 import io.trino.parquet.ParquetTypeUtils;
 import io.trino.parquet.PrimitiveField;
@@ -214,7 +213,7 @@ public abstract class PrimitiveColumnReader
         nextBatchSize = batchSize;
     }
 
-    public ColumnChunk readPrimitive(Field field)
+    public ColumnChunk readPrimitive()
     {
         // Pre-allocate these arrays to the necessary size. This saves a substantial amount of
         // CPU time by avoiding container resizing.

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkShortDecimalColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkShortDecimalColumnReader.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.parquet.DataPage;
+import io.trino.parquet.DataPageV1;
+import io.trino.parquet.PrimitiveField;
+import io.trino.spi.type.DecimalType;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.column.values.plain.FixedLenByteArrayPlainValuesWriter;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.options.WarmupMode;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.OptionalLong;
+
+import static io.trino.jmh.Benchmarks.benchmark;
+import static io.trino.parquet.ParquetEncoding.PLAIN;
+import static io.trino.parquet.ParquetEncoding.RLE;
+import static io.trino.parquet.reader.TestData.longToBytes;
+import static io.trino.parquet.reader.TestData.unscaledRandomShortDecimalSupplier;
+import static java.lang.Math.toIntExact;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.parquet.hadoop.metadata.CompressionCodecName.UNCOMPRESSED;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
+import static org.joda.time.DateTimeZone.UTC;
+
+@State(Scope.Thread)
+@OutputTimeUnit(SECONDS)
+@Measurement(iterations = 15, time = 500, timeUnit = MILLISECONDS)
+@Warmup(iterations = 5, time = 500, timeUnit = MILLISECONDS)
+@Fork(2)
+public class BenchmarkShortDecimalColumnReader
+{
+    // Parquet pages are usually about 1MB
+    private static final int MIN_PAGE_SIZE = 1_000_000;
+    private static final int OUTPUT_BUFFER_SIZE = MIN_PAGE_SIZE * 2; // Needs to be more than MIN_PAGE_SIZE
+    private static final int MAX_VALUES = 5_000_000;
+
+    private static final int DATA_GENERATION_BATCH_SIZE = 16384;
+    private static final int READ_BATCH_SIZE = 4096;
+
+    private final List<DataPage> dataPages = new ArrayList<>();
+
+    @Param({
+            "1", "2", "3", "4", "5", "6", "7", "8",
+    })
+    private int byteArrayLength;
+    private PrimitiveField field;
+
+    public BenchmarkShortDecimalColumnReader() {}
+
+    public BenchmarkShortDecimalColumnReader(int byteArrayLength)
+    {
+        this.byteArrayLength = byteArrayLength;
+    }
+
+    @Setup
+    public void setup()
+            throws IOException
+    {
+        int precision = maxPrecision(byteArrayLength);
+        PrimitiveType parquetType = Types.optional(FIXED_LEN_BYTE_ARRAY)
+                .length(byteArrayLength)
+                .as(LogicalTypeAnnotation.decimalType(0, precision))
+                .named("name");
+        this.field = new PrimitiveField(
+                DecimalType.createDecimalType(precision),
+                true,
+                new ColumnDescriptor(new String[] {}, parquetType, 0, 0),
+                0);
+
+        ValuesWriter writer = createValuesWriter(OUTPUT_BUFFER_SIZE);
+        int positions = 0;
+        int batchIndex = 0;
+        long[] batch = generateDataBatch(DATA_GENERATION_BATCH_SIZE, precision);
+        while (writer.getBufferedSize() < MIN_PAGE_SIZE && positions < MAX_VALUES) {
+            if (batchIndex == DATA_GENERATION_BATCH_SIZE) {
+                dataPages.add(createDataPage(writer, batchIndex));
+                batch = generateDataBatch(DATA_GENERATION_BATCH_SIZE, precision);
+                batchIndex = 0;
+            }
+            writeValue(writer, batch, batchIndex++);
+            positions++;
+        }
+
+        if (batchIndex > 0) {
+            dataPages.add(createDataPage(writer, batchIndex));
+        }
+    }
+
+    @Benchmark
+    public int read()
+            throws IOException
+    {
+        PrimitiveColumnReader columnReader = PrimitiveColumnReader.createReader(field, UTC);
+        columnReader.setPageReader(new PageReader(UNCOMPRESSED, new LinkedList<>(dataPages), null, MAX_VALUES), null);
+        int rowsRead = 0;
+        while (rowsRead < MAX_VALUES) {
+            int remaining = MAX_VALUES - rowsRead;
+            columnReader.prepareNextRead(Math.min(READ_BATCH_SIZE, remaining));
+            rowsRead += columnReader.readPrimitive().getBlock().getPositionCount();
+        }
+        return rowsRead;
+    }
+
+    private DataPage createDataPage(ValuesWriter writer, int valuesCount)
+    {
+        Slice data;
+        try {
+            data = Slices.wrappedBuffer(writer.getBytes().toByteArray());
+            writer.reset();
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return new DataPageV1(
+                data,
+                valuesCount,
+                byteArrayLength * valuesCount,
+                OptionalLong.empty(),
+                RLE,
+                RLE,
+                PLAIN);
+    }
+
+    private ValuesWriter createValuesWriter(int bufferSize)
+    {
+        return new FixedLenByteArrayPlainValuesWriter(byteArrayLength, bufferSize, bufferSize, HeapByteBufferAllocator.getInstance());
+    }
+
+    private void writeValue(ValuesWriter writer, long[] batch, int index)
+    {
+        Binary binary = Binary.fromConstantByteArray(longToBytes(batch[index], byteArrayLength));
+        writer.writeBytes(binary);
+    }
+
+    private long[] generateDataBatch(int size, int precision)
+    {
+        return unscaledRandomShortDecimalSupplier(byteArrayLength * Byte.SIZE, precision).apply(size);
+    }
+
+    private static int maxPrecision(int numBytes)
+    {
+        return toIntExact(
+                // convert double to long
+                Math.round(
+                        // number of base-10 digits
+                        Math.floor(Math.log10(
+                                Math.pow(2, 8 * numBytes - 1) - 1))));  // max value stored in numBytes
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        benchmark(BenchmarkShortDecimalColumnReader.class, WarmupMode.BULK)
+                .withOptions(optionsBuilder -> optionsBuilder.jvmArgsAppend("-Xmx4g", "-Xms4g"))
+                .run();
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnReader.java
@@ -113,7 +113,7 @@ public class TestColumnReader
                 }
             }
             else {
-                Block block = reader.readPrimitive(columnReaderProvider.getField()).getBlock();
+                Block block = reader.readPrimitive().getBlock();
                 assertThat(block.getPositionCount()).isEqualTo(batchSize);
                 for (int i = 0; i < block.getPositionCount(); i++) {
                     long selectedRowNumber = rowRangesIterator.next();

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestData.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestData.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import io.trino.spi.type.Decimals;
+
+import java.util.Random;
+import java.util.function.IntFunction;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public final class TestData
+{
+    private TestData() {}
+
+    public static IntFunction<long[]> unscaledRandomShortDecimalSupplier(int bitWidth, int precision)
+    {
+        long min = (-1 * Decimals.longTenToNth(precision)) + 1;
+        long max = Decimals.longTenToNth(precision) - 1;
+        return size -> {
+            Random random = new Random(1);
+            long[] result = new long[size];
+            for (int i = 0; i < size; i++) {
+                result[i] = Math.max(
+                        Math.min(randomLong(random, bitWidth), max),
+                        min);
+            }
+            return result;
+        };
+    }
+
+    public static byte[] longToBytes(long value, int length)
+    {
+        byte[] result = new byte[length];
+        for (int i = length - 1; i >= 0; i--) {
+            result[i] = (byte) (value & 0xFF);
+            value >>= Byte.SIZE;
+        }
+        return result;
+    }
+
+    private static long randomLong(Random r, int bitWidth)
+    {
+        checkArgument(bitWidth <= 64 && bitWidth > 0, "bit width must be in range 1 - 64 inclusive");
+        if (bitWidth == 64) {
+            return r.nextLong();
+        }
+        return propagateSignBit(r.nextLong(), 64 - bitWidth);
+    }
+
+    /**
+     * Propagate the sign bit in values that are shorter than 8 bytes.
+     * <p>
+     * When the value of less than 8 bytes in put into a long variable, the padding bytes on the
+     * left side of the number should be all zeros for a positive number or all ones for negatives.
+     * This method does this padding using signed bit shift operator without branches.
+     *
+     * @param value Value to trim
+     * @param bitsToPad Number of bits to pad
+     * @return Value with correct padding
+     */
+    private static long propagateSignBit(long value, int bitsToPad)
+    {
+        return value << bitsToPad >> bitsToPad;
+    }
+}


### PR DESCRIPTION
## Description

Improves performance by using simpler dedicated decoding logic for each possible byte array length

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Improves performance of reading short decimal columns from parquet files

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Delta, Iceberg
* Improve performance of reading short decimal columns from parquet files. ({issue}`14260`)
```
