### PR TITLE
Use ZSTD compression by default for PARQUET in Hive connector

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveCompressionCodecs.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveCompressionCodecs.java
@@ -48,35 +48,23 @@ public final class HiveCompressionCodecs
 
     private static HiveCompressionCodec selectCompressionCodec(HiveCompressionOption compressionOption)
     {
-        switch (compressionOption) {
-            case NONE:
-                return HiveCompressionCodec.NONE;
-            case SNAPPY:
-                return HiveCompressionCodec.SNAPPY;
-            case LZ4:
-                return HiveCompressionCodec.LZ4;
-            case ZSTD:
-                return HiveCompressionCodec.ZSTD;
-            case GZIP:
-                return HiveCompressionCodec.GZIP;
-        }
-        throw new IllegalArgumentException("Unknown compressionOption " + compressionOption);
+        return switch (compressionOption) {
+            case NONE -> HiveCompressionCodec.NONE;
+            case SNAPPY -> HiveCompressionCodec.SNAPPY;
+            case LZ4 -> HiveCompressionCodec.LZ4;
+            case ZSTD -> HiveCompressionCodec.ZSTD;
+            case GZIP -> HiveCompressionCodec.GZIP;
+        };
     }
 
     private static HiveCompressionCodec selectCompressionCodecForUnknownStorageFormat(HiveCompressionOption compressionOption)
     {
-        switch (compressionOption) {
-            case NONE:
-                return HiveCompressionCodec.NONE;
-            case SNAPPY:
-                return HiveCompressionCodec.SNAPPY;
-            case LZ4:
-                return HiveCompressionCodec.LZ4;
-            case ZSTD:
-                return HiveCompressionCodec.ZSTD;
-            case GZIP:
-                return HiveCompressionCodec.GZIP;
-        }
-        throw new IllegalArgumentException("Unknown compressionOption " + compressionOption);
+        return switch (compressionOption) {
+            case NONE -> HiveCompressionCodec.NONE;
+            case SNAPPY -> HiveCompressionCodec.SNAPPY;
+            case LZ4 -> HiveCompressionCodec.LZ4;
+            case ZSTD -> HiveCompressionCodec.ZSTD;
+            case GZIP -> HiveCompressionCodec.GZIP;
+        };
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveCompressionCodecs.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveCompressionCodecs.java
@@ -42,6 +42,7 @@ public final class HiveCompressionCodecs
             case LZ4 -> HiveCompressionCodec.LZ4;
             case ZSTD -> HiveCompressionCodec.ZSTD;
             case GZIP -> HiveCompressionCodec.GZIP;
+            case DEFAULT -> HiveCompressionCodec.GZIP;
         };
 
         // perform codec vs format validation
@@ -60,6 +61,7 @@ public final class HiveCompressionCodecs
             case LZ4 -> HiveCompressionCodec.LZ4;
             case ZSTD -> HiveCompressionCodec.ZSTD;
             case GZIP -> HiveCompressionCodec.GZIP;
+            case DEFAULT -> HiveCompressionCodec.GZIP;
         };
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveCompressionCodecs.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveCompressionCodecs.java
@@ -36,7 +36,13 @@ public final class HiveCompressionCodecs
 
     public static HiveCompressionCodec selectCompressionCodec(HiveCompressionOption compressionOption, HiveStorageFormat storageFormat)
     {
-        HiveCompressionCodec selectedCodec = selectCompressionCodec(compressionOption);
+        HiveCompressionCodec selectedCodec = switch (compressionOption) {
+            case NONE -> HiveCompressionCodec.NONE;
+            case SNAPPY -> HiveCompressionCodec.SNAPPY;
+            case LZ4 -> HiveCompressionCodec.LZ4;
+            case ZSTD -> HiveCompressionCodec.ZSTD;
+            case GZIP -> HiveCompressionCodec.GZIP;
+        };
 
         // perform codec vs format validation
         if (storageFormat == HiveStorageFormat.AVRO && selectedCodec.getAvroCompressionCodec().isEmpty()) {
@@ -44,17 +50,6 @@ public final class HiveCompressionCodecs
         }
 
         return selectedCodec;
-    }
-
-    private static HiveCompressionCodec selectCompressionCodec(HiveCompressionOption compressionOption)
-    {
-        return switch (compressionOption) {
-            case NONE -> HiveCompressionCodec.NONE;
-            case SNAPPY -> HiveCompressionCodec.SNAPPY;
-            case LZ4 -> HiveCompressionCodec.LZ4;
-            case ZSTD -> HiveCompressionCodec.ZSTD;
-            case GZIP -> HiveCompressionCodec.GZIP;
-        };
     }
 
     private static HiveCompressionCodec selectCompressionCodecForUnknownStorageFormat(HiveCompressionOption compressionOption)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveCompressionCodecs.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveCompressionCodecs.java
@@ -42,7 +42,10 @@ public final class HiveCompressionCodecs
             case LZ4 -> HiveCompressionCodec.LZ4;
             case ZSTD -> HiveCompressionCodec.ZSTD;
             case GZIP -> HiveCompressionCodec.GZIP;
-            case DEFAULT -> HiveCompressionCodec.GZIP;
+            case DEFAULT -> switch (storageFormat) {
+                case PARQUET -> HiveCompressionCodec.ZSTD;
+                default -> HiveCompressionCodec.GZIP;
+            };
         };
 
         // perform codec vs format validation

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveCompressionOption.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveCompressionOption.java
@@ -20,5 +20,6 @@ public enum HiveCompressionOption
     LZ4,
     ZSTD,
     GZIP,
+    DEFAULT,
     /**/;
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
@@ -93,7 +93,7 @@ public class HiveConfig
     private long perTransactionMetastoreCacheMaximumSize = 1000;
 
     private HiveStorageFormat hiveStorageFormat = HiveStorageFormat.ORC;
-    private HiveCompressionOption hiveCompressionCodec = HiveCompressionOption.GZIP;
+    private HiveCompressionOption hiveCompressionCodec = HiveCompressionOption.DEFAULT;
     private boolean respectTableFormat = true;
     private boolean immutablePartitions;
     private Optional<InsertExistingPartitionsBehavior> insertExistingPartitionsBehavior = Optional.empty();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
