### PR TITLE
Make EXPLAIN print local cost + Do not print Estimates line when estimates are absent

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/NodeRepresentation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/NodeRepresentation.java
@@ -16,6 +16,7 @@ package io.trino.sql.planner.planprinter;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import io.trino.cost.LocalCostEstimate;
 import io.trino.cost.PlanCostEstimate;
 import io.trino.cost.PlanNodeStatsAndCostSummary;
 import io.trino.cost.PlanNodeStatsEstimate;
@@ -151,14 +152,14 @@ public class NodeRepresentation
     public List<PlanNodeStatsAndCostSummary> getEstimates(TypeProvider typeProvider)
     {
         if (getEstimatedStats().stream().allMatch(PlanNodeStatsEstimate::isOutputRowCountUnknown) &&
-                getEstimatedCost().stream().allMatch(c -> c.equals(PlanCostEstimate.unknown()))) {
+                getEstimatedCost().stream().allMatch(c -> c.getRootNodeLocalCostEstimate().equals(LocalCostEstimate.unknown()))) {
             return ImmutableList.of();
         }
 
         ImmutableList.Builder<PlanNodeStatsAndCostSummary> estimates = ImmutableList.builder();
         for (int i = 0; i < getEstimatedStats().size(); i++) {
             PlanNodeStatsEstimate stats = getEstimatedStats().get(i);
-            PlanCostEstimate cost = getEstimatedCost().get(i);
+            LocalCostEstimate cost = getEstimatedCost().get(i).getRootNodeLocalCostEstimate();
 
             List<Symbol> outputSymbols = getOutputs().stream()
                     .map(NodeRepresentation.TypedSymbol::getSymbol)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/TextRenderer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/TextRenderer.java
@@ -83,9 +83,9 @@ public class TextRenderer
             output.append(indentMultilineString(reorderJoinStatsAndCost, indent.detailIndent()));
         }
 
-        String estimates = printEstimates(plan, node);
+        List<PlanNodeStatsAndCostSummary> estimates = node.getEstimates(plan.getTypes());
         if (!estimates.isEmpty()) {
-            output.append(indentMultilineString(estimates, indent.detailIndent()));
+            output.append(indentMultilineString(printEstimates(estimates), indent.detailIndent()));
         }
 
         String stats = printStats(plan, node);
@@ -265,9 +265,9 @@ public class TextRenderer
         return "";
     }
 
-    private String printEstimates(PlanRepresentation plan, NodeRepresentation node)
+    private String printEstimates(List<PlanNodeStatsAndCostSummary> estimates)
     {
-        return node.getEstimates(plan.getTypes()).stream()
+        return estimates.stream()
                 .map(this::formatPlanNodeStatsAndCostSummary)
                 .collect(joining("/", "Estimates: ", "\n"));
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
@@ -84,14 +84,14 @@ public class TestJsonRepresentation
                         ImmutableMap.of("columnNames", "[quantity]"),
                         ImmutableList.of(typedSymbol("quantity", "double")),
                         ImmutableList.of(),
-                        ImmutableList.of(new PlanNodeStatsAndCostSummary(10, 90, 541665, 0, 0)),
+                        ImmutableList.of(new PlanNodeStatsAndCostSummary(10, 90, 0, 0, 0)),
                         ImmutableList.of(new JsonRenderedNode(
                                 "98",
                                 "Limit",
                                 ImmutableMap.of("count", "10", "withTies", "", "inputPreSortedBy", "[]"),
                                 ImmutableList.of(typedSymbol("quantity", "double")),
                                 ImmutableList.of(),
-                                ImmutableList.of(new PlanNodeStatsAndCostSummary(10, 90, 541665, 0, 0)),
+                                ImmutableList.of(new PlanNodeStatsAndCostSummary(10, 90, 90, 0, 0)),
                                 ImmutableList.of(new JsonRenderedNode(
                                         "147",
                                         "LocalExchange",
@@ -102,7 +102,7 @@ public class TestJsonRepresentation
                                                 "arguments", "[]"),
                                         ImmutableList.of(typedSymbol("quantity", "double")),
                                         ImmutableList.of(),
-                                        ImmutableList.of(new PlanNodeStatsAndCostSummary(60175, 541575, 541575, 0, 0)),
+                                        ImmutableList.of(new PlanNodeStatsAndCostSummary(60175, 541575, 0, 0, 0)),
                                         ImmutableList.of(new JsonRenderedNode(
                                                 "0",
                                                 "TableScan",
@@ -111,7 +111,7 @@ public class TestJsonRepresentation
                                                 ImmutableList.of("quantity := tpch:quantity"),
                                                 ImmutableList.of(new PlanNodeStatsAndCostSummary(60175, 541575, 541575, 0, 0)),
                                                 ImmutableList.of()))))))));
-        MaterializedResult expectedPlan = resultBuilder(queryRunner.getDefaultSession(), createVarcharType(2072))
+        MaterializedResult expectedPlan = resultBuilder(queryRunner.getDefaultSession(), createVarcharType(2058))
                 .row(DISTRIBUTED_PLAN_JSON_CODEC.toJson(distributedPlan))
                 .build();
         assertThat(actualPlan).isEqualTo(expectedPlan);
@@ -127,14 +127,14 @@ public class TestJsonRepresentation
                 ImmutableMap.of("columnNames", "[quantity]"),
                 ImmutableList.of(typedSymbol("quantity", "double")),
                 ImmutableList.of(),
-                ImmutableList.of(new PlanNodeStatsAndCostSummary(10, 90, 541665, 0, 0)),
+                ImmutableList.of(new PlanNodeStatsAndCostSummary(10, 90, 0, 0, 0)),
                 ImmutableList.of(new JsonRenderedNode(
                         "98",
                         "Limit",
                         ImmutableMap.of("count", "10", "withTies", "", "inputPreSortedBy", "[]"),
                         ImmutableList.of(typedSymbol("quantity", "double")),
                         ImmutableList.of(),
-                        ImmutableList.of(new PlanNodeStatsAndCostSummary(10, 90, 541665, 0, 0)),
+                        ImmutableList.of(new PlanNodeStatsAndCostSummary(10, 90, 90, 0, 0)),
                         ImmutableList.of(new JsonRenderedNode(
                                 "147",
                                 "LocalExchange",
@@ -145,7 +145,7 @@ public class TestJsonRepresentation
                                         "arguments", "[]"),
                                 ImmutableList.of(typedSymbol("quantity", "double")),
                                 ImmutableList.of(),
-                                ImmutableList.of(new PlanNodeStatsAndCostSummary(60175, 541575, 541575, 0, 0)),
+                                ImmutableList.of(new PlanNodeStatsAndCostSummary(60175, 541575, 0, 0, 0)),
                                 ImmutableList.of(new JsonRenderedNode(
                                         "0",
                                         "TableScan",
@@ -154,7 +154,7 @@ public class TestJsonRepresentation
                                         ImmutableList.of("quantity := tpch:quantity"),
                                         ImmutableList.of(new PlanNodeStatsAndCostSummary(60175, 541575, 541575, 0, 0)),
                                         ImmutableList.of())))))));
-        MaterializedResult expectedPlan = resultBuilder(queryRunner.getDefaultSession(), createVarcharType(1898))
+        MaterializedResult expectedPlan = resultBuilder(queryRunner.getDefaultSession(), createVarcharType(1884))
                 .row(JSON_RENDERED_NODE_CODEC.toJson(expectedJsonNode))
                 .build();
         assertThat(actualPlan).isEqualTo(expectedPlan);

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestLocalQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestLocalQueries.java
@@ -48,6 +48,7 @@ public class TestLocalQueries
                 .build();
 
         LocalQueryRunner localQueryRunner = LocalQueryRunner.builder(defaultSession)
+                .withNodeCountForStats(1)
                 .build();
 
         // add the tpch catalog


### PR DESCRIPTION
    Show local cost in EXPLAIN.

    https://github.com/trinodb/trino/commit/e438e1ef8becdf84c320b07615b1f99e915e2b19
    changed cost calculations to be cumulative.
    However, EXPLAIN still used PlanCostEstimate for
    showing plan node cost.
    This commit makes EXPLAIN use local cost.

+

    Do not print Estimates line when estimates are absent