### PR TITLE
Add support of creating iceberg table with existing data

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableProperties.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.iceberg.IcebergConfig.FORMAT_VERSION_SUPPORT_MAX;
 import static io.trino.plugin.iceberg.IcebergConfig.FORMAT_VERSION_SUPPORT_MIN;
+import static io.trino.plugin.iceberg.IcebergMetadata.EXISTING_LATEST_METADATA_LOCATION;
 import static io.trino.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
 import static io.trino.spi.session.PropertyMetadata.doubleProperty;
 import static io.trino.spi.session.PropertyMetadata.enumProperty;
@@ -116,6 +117,11 @@ public class IcebergTableProperties
     {
         List<String> partitioning = (List<String>) tableProperties.get(PARTITIONING_PROPERTY);
         return partitioning == null ? ImmutableList.of() : ImmutableList.copyOf(partitioning);
+    }
+
+    public static Optional<String> getExistingLatestMetadataLocation(Map<String, Object> tableProperties)
+    {
+        return Optional.ofNullable((String) tableProperties.get(EXISTING_LATEST_METADATA_LOCATION));
     }
 
     public static Optional<String> getTableLocation(Map<String, Object> tableProperties)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -87,6 +87,7 @@ import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.plugin.hive.HiveMetadata.TABLE_COMMENT;
 import static io.trino.plugin.iceberg.ColumnIdentity.createColumnIdentity;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_PARTITION_VALUE;
+import static io.trino.plugin.iceberg.IcebergMetadata.EXISTING_LATEST_METADATA_LOCATION;
 import static io.trino.plugin.iceberg.IcebergMetadata.ORC_BLOOM_FILTER_COLUMNS_KEY;
 import static io.trino.plugin.iceberg.IcebergMetadata.ORC_BLOOM_FILTER_FPP_KEY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.FILE_FORMAT_PROPERTY;
@@ -95,6 +96,7 @@ import static io.trino.plugin.iceberg.IcebergTableProperties.LOCATION_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.ORC_BLOOM_FILTER_COLUMNS;
 import static io.trino.plugin.iceberg.IcebergTableProperties.ORC_BLOOM_FILTER_FPP;
 import static io.trino.plugin.iceberg.IcebergTableProperties.PARTITIONING_PROPERTY;
+import static io.trino.plugin.iceberg.IcebergTableProperties.getExistingLatestMetadataLocation;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getOrcBloomFilterColumns;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getOrcBloomFilterFpp;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getPartitioning;
@@ -572,6 +574,11 @@ public final class IcebergUtil
         IcebergFileFormat fileFormat = IcebergTableProperties.getFileFormat(tableMetadata.getProperties());
         propertiesBuilder.put(DEFAULT_FILE_FORMAT, fileFormat.toIceberg().toString());
         propertiesBuilder.put(FORMAT_VERSION, Integer.toString(IcebergTableProperties.getFormatVersion(tableMetadata.getProperties())));
+
+        Optional<String> existingLatestMetadataLocation = getExistingLatestMetadataLocation(tableMetadata.getProperties());
+        if (existingLatestMetadataLocation.isPresent()) {
+            propertiesBuilder.put(EXISTING_LATEST_METADATA_LOCATION, existingLatestMetadataLocation.get());
+        }
 
         // iceberg ORC format bloom filter properties used by create table
         List<String> columns = getOrcBloomFilterColumns(tableMetadata.getProperties());

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/AbstractMetastoreTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/AbstractMetastoreTableOperations.java
@@ -35,6 +35,7 @@ import static io.trino.plugin.hive.ViewReaderUtil.isHiveOrPrestoView;
 import static io.trino.plugin.hive.ViewReaderUtil.isPrestoView;
 import static io.trino.plugin.hive.metastore.PrincipalPrivileges.NO_PRIVILEGES;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
+import static io.trino.plugin.iceberg.IcebergMetadata.EXISTING_LATEST_METADATA_LOCATION;
 import static io.trino.plugin.iceberg.IcebergUtil.isIcebergTable;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -88,7 +89,10 @@ public abstract class AbstractMetastoreTableOperations
     @Override
     protected final void commitNewTable(TableMetadata metadata)
     {
-        String newMetadataLocation = writeNewMetadata(metadata, version + 1);
+        String newMetadataLocation = metadata.properties().get(EXISTING_LATEST_METADATA_LOCATION);
+        if (newMetadataLocation == null) {
+            newMetadataLocation = writeNewMetadata(metadata, version + 1);
+        }
 
         Table.Builder builder = Table.builder()
                 .setDatabaseName(database)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -1239,7 +1239,7 @@ public abstract class BaseIcebergConnectorTest
     }
 
     @Test
-    public void testCreateTableSucceedsOnEmptyDirectory()
+    public void testCreateTableFailureOnEmptyDirectory()
     {
         File tempDir = getDistributedQueryRunner().getCoordinator().getBaseDataDir().toFile();
         String tmpName = "test_rename_table_tmp_" + randomTableSuffix();
@@ -1247,7 +1247,7 @@ public abstract class BaseIcebergConnectorTest
         File directory = newPath.toFile();
         verify(directory.mkdirs(), "Could not make directory on filesystem");
         try {
-            assertUpdate("CREATE TABLE " + tmpName + " WITH (location='" + directory + "') AS SELECT 1 as a", 1);
+            assertQueryFails("CREATE TABLE " + tmpName + " WITH (location='" + directory + "') AS SELECT 1 as a", "No metadata file exists at location.*");
         }
         finally {
             assertUpdate("DROP TABLE IF EXISTS " + tmpName);
@@ -1290,11 +1290,9 @@ public abstract class BaseIcebergConnectorTest
                 format("   format = '%s',\n   format_version = 2,\n   location = '%s'\n)", format, getTableLocation("test_create_table_like_copy2")));
         dropTable("test_create_table_like_copy2");
 
-        assertQueryFails("CREATE TABLE test_create_table_like_copy3 (LIKE test_create_table_like_original INCLUDING PROPERTIES)",
-                "Cannot create a table on a non-empty location.*");
+        assertQuerySucceeds("CREATE TABLE test_create_table_like_copy3 (LIKE test_create_table_like_original INCLUDING PROPERTIES)");
 
-        assertQueryFails(format("CREATE TABLE test_create_table_like_copy4 (LIKE test_create_table_like_original INCLUDING PROPERTIES) WITH (format = '%s')", otherFormat),
-                "Cannot create a table on a non-empty location.*");
+        assertQuerySucceeds(format("CREATE TABLE test_create_table_like_copy4 (LIKE test_create_table_like_original INCLUDING PROPERTIES) WITH (format = '%s')", otherFormat));
     }
 
     private String getTablePropertiesString(String tableName)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This draft change supports creating an iceberg table using existing metadata and data. 

https://trino.io/docs/current/connector/delta-lake.html#creating-tables

TODO:  Add test cases

Syntax:

`CREATE TABLE iceberg.default.source (dummy bigint) WITH (location= 'hdfs://hadoop-master:9000/user/hive/warehouse/iceberg_src_1-d7f665f9ece54a99bd7046f89f754b28' );`

User has to provide a dummy column. The column will be ignored and the columns from the metadata will be used to create the table.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation
NA


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(X) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
