### PR TITLE
Fix drop view prepared statement fails when view qualified name requires quoting

### DIFF
--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -1004,7 +1004,7 @@ public final class SqlFormatter
             if (node.isExists()) {
                 builder.append("IF EXISTS ");
             }
-            builder.append(node.getName());
+            builder.append(formatName(node.getName()));
 
             return null;
         }

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -2664,6 +2664,16 @@ public class TestSqlParser
     }
 
     @Test
+    public void testPrepareDropView()
+    {
+        assertStatement("PREPARE statement1 FROM DROP VIEW IF EXISTS \"catalog-test\".\"test\".\"foo\"",
+                new Prepare(identifier("statement1"),
+                        new DropView(QualifiedName.of("catalog-test", "test", "foo"), true)));
+        assertStatementIsInvalid("PREPARE statement1 FROM DROP VIEW IF EXISTS catalog-test.test.foo")
+                .withMessage("line 1:52: mismatched input '-'. Expecting: '.', <EOF>");
+    }
+
+    @Test
     public void testPrepareWithParameters()
     {
         assertStatement("PREPARE myquery FROM SELECT ?, ? FROM foo",


### PR DESCRIPTION
…res quoting

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fix [#14196](https://github.com/trinodb/trino/issues/14196): 
The parser is throwing ParsingException for valid DROP VIEW IF EXISTS query. Although properly quoted, it seems the quotes aren't being considered.

For example:

This statement throws ParsingException
```
PREPARE statement1 FROM DROP VIEW IF EXISTS "catalog-test"."schema"."table"
```

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`14196`)
```
