### PR TITLE
Minor fixes to InCodeGenerator

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/gen/CompilerOperations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/CompilerOperations.java
@@ -19,7 +19,6 @@ import javax.annotation.Nullable;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -58,11 +57,6 @@ public final class CompilerOperations
     public static boolean greaterThan(int left, int right)
     {
         return left > right;
-    }
-
-    public static boolean in(Object value, Set<?> set)
-    {
-        return set.contains(value);
     }
 
     public static boolean testMask(@Nullable Block masks, int index)

--- a/core/trino-main/src/main/java/io/trino/sql/gen/InCodeGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/InCodeGenerator.java
@@ -365,10 +365,9 @@ public class InCodeGenerator
 
     private static boolean isDeterminateConstant(RowExpression expression, MethodHandle isIndeterminateFunction)
     {
-        if (!(expression instanceof ConstantExpression)) {
+        if (!(expression instanceof ConstantExpression constantExpression)) {
             return false;
         }
-        ConstantExpression constantExpression = (ConstantExpression) expression;
         Object value = constantExpression.getValue();
         if (value == null) {
             return false;

--- a/core/trino-main/src/main/java/io/trino/sql/gen/InCodeGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/InCodeGenerator.java
@@ -177,7 +177,7 @@ public class InCodeGenerator
         SwitchBuilder switchBuilder = new SwitchBuilder().expression(expression);
 
         switch (switchGenerationCase) {
-            case DIRECT_SWITCH:
+            case DIRECT_SWITCH -> {
                 // A white-list is used to select types eligible for DIRECT_SWITCH.
                 // For these types, it's safe to not use Trino HASH_CODE and EQUAL operator.
                 for (Object constantValue : constantValues) {
@@ -192,8 +192,8 @@ public class InCodeGenerator
                                         .gotoLabel(defaultLabel)))
                         .append(expression.set(value.cast(int.class)))
                         .append(switchBuilder.build());
-                break;
-            case HASH_SWITCH:
+            }
+            case HASH_SWITCH -> {
                 for (Map.Entry<Integer, Collection<BytecodeNode>> bucket : hashBuckets.asMap().entrySet()) {
                     Collection<BytecodeNode> testValues = bucket.getValue();
                     BytecodeBlock caseBlock = buildInCase(
@@ -219,8 +219,8 @@ public class InCodeGenerator
                         .invokeStatic(Long.class, "hashCode", int.class, long.class)
                         .putVariable(expression)
                         .append(switchBuilder.build());
-                break;
-            case SET_CONTAINS:
+            }
+            case SET_CONTAINS -> {
                 Set<?> constantValuesSet = toFastutilHashSet(constantValues, type, hashCodeMethodHandle, equalsMethodHandle);
                 Binding constant = generatorContext.getCallSiteBinder().bind(constantValuesSet, constantValuesSet.getClass());
 
@@ -235,9 +235,8 @@ public class InCodeGenerator
                                         // TODO: use invokeVirtual on the set instead. This requires swapping the two elements in the stack
                                         .invokeStatic(FastutilSetHelper.class, "in", boolean.class, javaType.isPrimitive() ? javaType : Object.class, constantValuesSet.getClass()))
                                 .ifTrue(jump(match)));
-                break;
-            default:
-                throw new IllegalArgumentException("Not supported switch generation case: " + switchGenerationCase);
+            }
+            default -> throw new IllegalArgumentException("Not supported switch generation case: " + switchGenerationCase);
         }
 
         BytecodeBlock defaultCaseBlock = buildInCase(

--- a/core/trino-main/src/main/java/io/trino/sql/gen/InCodeGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/InCodeGenerator.java
@@ -29,7 +29,6 @@ import io.trino.spi.type.Type;
 import io.trino.sql.relational.ConstantExpression;
 import io.trino.sql.relational.RowExpression;
 import io.trino.sql.relational.SpecialForm;
-import io.trino.util.FastutilSetHelper;
 
 import java.lang.invoke.MethodHandle;
 import java.util.Collection;
@@ -228,12 +227,11 @@ public class InCodeGenerator
                         .comment("inListSet.contains(<stackValue>)")
                         .append(new IfStatement()
                                 .condition(new BytecodeBlock()
-                                        .comment("value")
-                                        .getVariable(value)
                                         .comment("set")
                                         .append(loadConstant(constant))
-                                        // TODO: use invokeVirtual on the set instead. This requires swapping the two elements in the stack
-                                        .invokeStatic(FastutilSetHelper.class, "in", boolean.class, javaType.isPrimitive() ? javaType : Object.class, constantValuesSet.getClass()))
+                                        .comment("value")
+                                        .getVariable(value)
+                                        .invokeVirtual(constantValuesSet.getClass(), "contains", boolean.class, javaType.isPrimitive() ? javaType : Object.class))
                                 .ifTrue(jump(match)));
             }
             default -> throw new IllegalArgumentException("Not supported switch generation case: " + switchGenerationCase);

--- a/core/trino-main/src/main/java/io/trino/util/FastutilSetHelper.java
+++ b/core/trino-main/src/main/java/io/trino/util/FastutilSetHelper.java
@@ -71,26 +71,6 @@ public final class FastutilSetHelper
         throw new UnsupportedOperationException("Unsupported native type in set: " + type.getJavaType() + " with type " + type.getTypeSignature());
     }
 
-    public static boolean in(boolean booleanValue, BooleanOpenHashSet set)
-    {
-        return set.contains(booleanValue);
-    }
-
-    public static boolean in(double doubleValue, DoubleOpenCustomHashSet set)
-    {
-        return set.contains(doubleValue);
-    }
-
-    public static boolean in(long longValue, LongOpenCustomHashSet set)
-    {
-        return set.contains(longValue);
-    }
-
-    public static boolean in(Object objectValue, ObjectOpenCustomHashSet<?> set)
-    {
-        return set.contains(objectValue);
-    }
-
     private static final class LongStrategy
             implements LongHash.Strategy
     {


### PR DESCRIPTION
- Use enhanced instanceof
- Use enhanced switch
- Inline isInteger
- Use invokeVirtual on the set

In addition, to make sure that these changes do not cause performance
regressions, I also benchmarked `BIGINT` with `inListCount={5, 1000,
10000}`.

Before
```
Benchmark                           (hitRate)  (inListCount)  (type)  Mode  Cnt    Score     Error  Units
BenchmarkInCodeGenerator.benchmark        0.0              5  bigint  avgt   12   99.942 ±  26.115  us/op
BenchmarkInCodeGenerator.benchmark        0.0           1000  bigint  avgt   12  170.274 ± 108.237  us/op
BenchmarkInCodeGenerator.benchmark        0.0          10000  bigint  avgt   12  242.052 ±  83.163  us/op
BenchmarkInCodeGenerator.benchmark       0.05              5  bigint  avgt   12  149.536 ±  42.432  us/op
BenchmarkInCodeGenerator.benchmark       0.05           1000  bigint  avgt   12  112.260 ±  32.969  us/op
BenchmarkInCodeGenerator.benchmark       0.05          10000  bigint  avgt   12  207.537 ± 110.180  us/op
BenchmarkInCodeGenerator.benchmark       0.50              5  bigint  avgt   12  176.636 ±  55.588  us/op
BenchmarkInCodeGenerator.benchmark       0.50           1000  bigint  avgt   12  263.002 ± 133.450  us/op
BenchmarkInCodeGenerator.benchmark       0.50          10000  bigint  avgt   12  269.707 ± 128.761  us/op
BenchmarkInCodeGenerator.benchmark        1.0              5  bigint  avgt   12  102.594 ±  24.347  us/op
BenchmarkInCodeGenerator.benchmark        1.0           1000  bigint  avgt   12  129.428 ±  68.642  us/op
BenchmarkInCodeGenerator.benchmark        1.0          10000  bigint  avgt   12  182.918 ±  24.591  us/op
```

After
```
Benchmark                           (hitRate)  (inListCount)  (type)  Mode  Cnt    Score     Error  Units
BenchmarkInCodeGenerator.benchmark        0.0              5  bigint  avgt   12   79.320 ±   3.186  us/op
BenchmarkInCodeGenerator.benchmark        0.0           1000  bigint  avgt   12   82.954 ±  14.446  us/op
BenchmarkInCodeGenerator.benchmark        0.0          10000  bigint  avgt   12  184.912 ± 101.167  us/op
BenchmarkInCodeGenerator.benchmark       0.05              5  bigint  avgt   12  171.468 ±  73.439  us/op
BenchmarkInCodeGenerator.benchmark       0.05           1000  bigint  avgt   12  260.507 ±  50.637  us/op
BenchmarkInCodeGenerator.benchmark       0.05          10000  bigint  avgt   12  161.067 ±  70.446  us/op
BenchmarkInCodeGenerator.benchmark       0.50              5  bigint  avgt   12  142.667 ±  20.598  us/op
BenchmarkInCodeGenerator.benchmark       0.50           1000  bigint  avgt   12  206.942 ±  67.317  us/op
BenchmarkInCodeGenerator.benchmark       0.50          10000  bigint  avgt   12  182.434 ±  23.918  us/op
BenchmarkInCodeGenerator.benchmark        1.0              5  bigint  avgt   12   78.913 ±   5.840  us/op
BenchmarkInCodeGenerator.benchmark        1.0           1000  bigint  avgt   12   63.445 ±   1.933  us/op
BenchmarkInCodeGenerator.benchmark        1.0          10000  bigint  avgt   12  115.853 ±  49.151  us/op
```

## Release notes

(x) This is not user-visible or docs only and no release notes are required.