### PR TITLE
Don't show unsupported AUTHORIZATION ROLE in Hive schema

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSharedFileMetastoreWithTableRedirections.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSharedFileMetastoreWithTableRedirections.java
@@ -84,7 +84,6 @@ public class TestDeltaLakeSharedFileMetastoreWithTableRedirections
     protected String getExpectedHiveCreateSchema(String catalogName)
     {
         String expectedHiveCreateSchema = "CREATE SCHEMA %s.%s\n" +
-                "AUTHORIZATION USER user\n" +
                 "WITH (\n" +
                 "   location = '%s/%s'\n" +
                 ")";

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -2551,12 +2551,7 @@ public class HiveMetadata
     {
         checkState(!isHiveSystemSchema(schemaName.getSchemaName()), "Schema is not accessible: %s", schemaName);
 
-        Optional<Database> database = metastore.getDatabase(schemaName.getSchemaName());
-        if (database.isPresent()) {
-            return database.flatMap(db -> db.getOwnerName().map(ownerName -> new TrinoPrincipal(db.getOwnerType().orElseThrow(), ownerName)));
-        }
-
-        throw new SchemaNotFoundException(schemaName.getSchemaName());
+        return accessControlMetadata.getSchemaOwner(session, schemaName.getSchemaName()).map(HivePrincipal::toTrinoPrincipal);
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -1221,6 +1221,15 @@ public class SemiTransactionalHiveMetastore
     }
 
     @Override
+    public Optional<HivePrincipal> getDatabaseOwner(String databaseName)
+    {
+        Database database = getDatabase(databaseName)
+                .orElseThrow(() -> new SchemaNotFoundException(databaseName));
+
+        return database.getOwnerName().map(ownerName -> new HivePrincipal(database.getOwnerType().orElseThrow(), ownerName));
+    }
+
+    @Override
     public synchronized Set<HivePrivilegeInfo> listTablePrivileges(String databaseName, String tableName, Optional<HivePrincipal> principal)
     {
         checkReadable();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/AccessControlMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/AccessControlMetadata.java
@@ -121,6 +121,14 @@ public interface AccessControlMetadata
     }
 
     /**
+     * Get the owner on the specified schema
+     */
+    default Optional<HivePrincipal> getSchemaOwner(ConnectorSession session, String schemaName)
+    {
+        return Optional.empty();
+    }
+
+    /**
      * Revokes the specified privilege on the specified schema from the specified user
      */
     default void revokeSchemaPrivileges(ConnectorSession session, String schemaName, Set<Privilege> privileges, HivePrincipal grantee, boolean grantOption)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControlMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControlMetadata.java
@@ -114,6 +114,12 @@ public class SqlStandardAccessControlMetadata
     }
 
     @Override
+    public Optional<HivePrincipal> getSchemaOwner(ConnectorSession session, String schemaName)
+    {
+        return metastore.getDatabaseOwner(schemaName);
+    }
+
+    @Override
     public void grantTablePrivileges(ConnectorSession session, SchemaTableName schemaTableName, Set<Privilege> privileges, HivePrincipal grantee, boolean grantOption)
     {
         String schemaName = schemaTableName.getSchemaName();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControlMetadataMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControlMetadataMetastore.java
@@ -41,6 +41,8 @@ public interface SqlStandardAccessControlMetadataMetastore
 
     Set<RoleGrant> listGrantedPrincipals(String role);
 
+    Optional<HivePrincipal> getDatabaseOwner(String databaseName);
+
     void revokeTablePrivileges(String databaseName, String tableName, HivePrincipal grantee, HivePrincipal grantor, Set<HivePrivilege> privileges, boolean grantOption);
 
     void grantTablePrivileges(String databaseName, String tableName, HivePrincipal grantee, HivePrincipal grantor, Set<HivePrivilege> privileges, boolean grantOption);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileBasedSecurity.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileBasedSecurity.java
@@ -27,6 +27,7 @@ import java.io.File;
 
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static io.trino.tpch.TpchTable.NATION;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestHiveFileBasedSecurity
@@ -67,6 +68,14 @@ public class TestHiveFileBasedSecurity
         assertThatThrownBy(() -> queryRunner.execute(bob, "SELECT * FROM nation"))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageMatching(".*Access Denied: Cannot select from table tpch.nation.*");
+    }
+
+    @Test
+    public void testShowCreateSchemaDoesNotContainAuthorization()
+    {
+        Session admin = getSession("hive");
+        assertThat((String) queryRunner.execute(admin, "SHOW CREATE SCHEMA tpch").getOnlyValue())
+                .doesNotContain("AUTHORIZATION");
     }
 
     private Session getSession(String user)

--- a/plugin/trino-hive/src/test/resources/io/trino/plugin/hive/security.json
+++ b/plugin/trino-hive/src/test/resources/io/trino/plugin/hive/security.json
@@ -10,7 +10,7 @@
   ],
   "schemas": [
     {
-      "owner": false
+      "owner": true
     }
   ]
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestSharedHiveMetastore.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestSharedHiveMetastore.java
@@ -122,7 +122,6 @@ public class TestSharedHiveMetastore
     protected String getExpectedHiveCreateSchema(String catalogName)
     {
         String expectedHiveCreateSchema = "CREATE SCHEMA %s.%s\n" +
-                "AUTHORIZATION USER user\n" +
                 "WITH (\n" +
                 "   location = 'file:%s/%s'\n" +
                 ")";


### PR DESCRIPTION
## Description

Don't show unsupported `AUTHORIZATION ROLE` property in `SHOW CREATE SCHEMA` result when the access control doesn't support roles in Hive connector.
Fixes #8817

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Don't show unsupported `AUTHORIZATION ROLE` property in `SHOW CREATE SCHEMA` result when the access control doesn't support roles. ({issue}`8817`)
```
