### PR TITLE
Fix escaping in metadata calls to SQL Server driver

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -345,8 +345,8 @@ public abstract class BaseJdbcClient
         RemoteTableName remoteTableName = tableHandle.getRequiredNamedRelation().getRemoteTableName();
         return metadata.getColumns(
                 remoteTableName.getCatalogName().orElse(null),
-                escapeNamePattern(remoteTableName.getSchemaName(), metadata.getSearchStringEscape()).orElse(null),
-                escapeNamePattern(remoteTableName.getTableName(), metadata.getSearchStringEscape()),
+                escapeObjectNameForMetadataQuery(remoteTableName.getSchemaName(), metadata.getSearchStringEscape()).orElse(null),
+                escapeObjectNameForMetadataQuery(remoteTableName.getTableName(), metadata.getSearchStringEscape()),
                 null);
     }
 
@@ -875,8 +875,8 @@ public abstract class BaseJdbcClient
         DatabaseMetaData metadata = connection.getMetaData();
         return metadata.getTables(
                 connection.getCatalog(),
-                escapeNamePattern(remoteSchemaName, metadata.getSearchStringEscape()).orElse(null),
-                escapeNamePattern(remoteTableName, metadata.getSearchStringEscape()).orElse(null),
+                escapeObjectNameForMetadataQuery(remoteSchemaName, metadata.getSearchStringEscape()).orElse(null),
+                escapeObjectNameForMetadataQuery(remoteTableName, metadata.getSearchStringEscape()).orElse(null),
                 getTableTypes().map(types -> types.toArray(String[]::new)).orElse(null));
     }
 
@@ -1137,12 +1137,12 @@ public abstract class BaseJdbcClient
         return "'" + value.replace("'", "''") + "'";
     }
 
-    protected static Optional<String> escapeNamePattern(Optional<String> name, String escape)
+    protected Optional<String> escapeObjectNameForMetadataQuery(Optional<String> name, String escape)
     {
-        return name.map(string -> escapeNamePattern(string, escape));
+        return name.map(string -> escapeObjectNameForMetadataQuery(string, escape));
     }
 
-    private static String escapeNamePattern(String name, String escape)
+    protected String escapeObjectNameForMetadataQuery(String name, String escape)
     {
         requireNonNull(name, "name is null");
         requireNonNull(escape, "escape is null");

--- a/plugin/trino-mariadb/src/main/java/io/trino/plugin/mariadb/MariaDbClient.java
+++ b/plugin/trino-mariadb/src/main/java/io/trino/plugin/mariadb/MariaDbClient.java
@@ -246,7 +246,7 @@ public class MariaDbClient
         return metadata.getTables(
                 schemaName.orElse(null),
                 null,
-                escapeNamePattern(tableName, metadata.getSearchStringEscape()).orElse(null),
+                escapeObjectNameForMetadataQuery(tableName, metadata.getSearchStringEscape()).orElse(null),
                 getTableTypes().map(types -> types.toArray(String[]::new)).orElse(null));
     }
 

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
@@ -313,7 +313,7 @@ public class MySqlClient
         return metadata.getTables(
                 schemaName.orElse(null),
                 null,
-                escapeNamePattern(tableName, metadata.getSearchStringEscape()).orElse(null),
+                escapeObjectNameForMetadataQuery(tableName, metadata.getSearchStringEscape()).orElse(null),
                 getTableTypes().map(types -> types.toArray(String[]::new)).orElse(null));
     }
 

--- a/plugin/trino-singlestore/src/main/java/io/trino/plugin/singlestore/SingleStoreClient.java
+++ b/plugin/trino-singlestore/src/main/java/io/trino/plugin/singlestore/SingleStoreClient.java
@@ -316,7 +316,7 @@ public class SingleStoreClient
         return metadata.getTables(
                 schemaName.orElse(null),
                 null,
-                escapeNamePattern(tableName, metadata.getSearchStringEscape()).orElse(null),
+                escapeObjectNameForMetadataQuery(tableName, metadata.getSearchStringEscape()).orElse(null),
                 getTableTypes().map(types -> types.toArray(String[]::new)).orElse(null));
     }
 

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConnectorTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConnectorTest.java
@@ -35,11 +35,15 @@ import static io.trino.plugin.sqlserver.SqlServerQueryRunner.createSqlServerQuer
 import static io.trino.plugin.sqlserver.SqlServerSessionProperties.BULK_COPY_FOR_WRITE;
 import static io.trino.plugin.sqlserver.SqlServerSessionProperties.BULK_COPY_FOR_WRITE_LOCK_DESTINATION_TABLE;
 import static io.trino.testing.DataProviders.cartesianProduct;
+import static io.trino.testing.DataProviders.toDataProvider;
 import static io.trino.testing.DataProviders.trueFalse;
 import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
 import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class TestSqlServerConnectorTest
         extends BaseSqlServerConnectorTest
@@ -151,6 +155,21 @@ public class TestSqlServerConnectorTest
         }
     }
 
+    // TODO move test to BaseConnectorTest
+    @Test(dataProvider = "testTableNameDataProvider")
+    public void testCreateAndDropTableWithSpecialCharacterName(String tableName)
+    {
+        String tableNameInSql = "\"" + tableName.replace("\"", "\"\"") + "\"";
+        // Until https://github.com/trinodb/trino/issues/17 the table name is effectively lowercase
+        tableName = tableName.toLowerCase(ENGLISH);
+        assertUpdate("CREATE TABLE " + tableNameInSql + " (a bigint, b double, c varchar(50))");
+        assertTrue(getQueryRunner().tableExists(getSession(), tableName));
+        assertTableColumnNames(tableNameInSql, "a", "b", "c");
+
+        assertUpdate("DROP TABLE " + tableNameInSql);
+        assertFalse(getQueryRunner().tableExists(getSession(), tableName));
+    }
+
     private int getTableOperationsCount(String operation, String table)
             throws SQLException
     {
@@ -194,5 +213,45 @@ public class TestSqlServerConnectorTest
                 {"timestamp(9)"},
                 {"timestamp(12)"}
         };
+    }
+
+    // TODO replace TableNameDataProvider and ColumnNameDataProvider with ObjectNameDataProvider
+    //  to one big single list of all special character cases, current list has additional special bracket cases,
+    //  please don't forget to use this list as base
+    @DataProvider
+    public Object[][] testTableNameDataProvider()
+    {
+        return testTableNameTestData().stream()
+                .collect(toDataProvider());
+    }
+
+    private List<String> testTableNameTestData()
+    {
+        return ImmutableList.<String>builder()
+                .add("lowercase")
+                .add("UPPERCASE")
+                .add("MixedCase")
+                .add("an_underscore")
+                .add("a-hyphen-minus") // ASCII '-' is HYPHEN-MINUS in Unicode
+                .add("a space")
+                .add("atrailingspace ")
+                .add(" aleadingspace")
+                .add("a.dot")
+                .add("a,comma")
+                .add("a:colon")
+                .add("a;semicolon")
+                .add("an@at")
+                .add("a\"quote")
+                .add("an'apostrophe")
+                .add("a`backtick`")
+                .add("a/slash`")
+                .add("a\\backslash`")
+                .add("adigit0")
+                .add("0startwithdigit")
+                .add("[brackets]")
+                .add("brackets[]inside")
+                .add("open[bracket")
+                .add("close]bracket")
+                .build();
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

I was able to rename table to contain special brackets:
`alter table test2 rename to "[test2]";`
`show tables;`
`  Table`
`----------`
 `[test2]`

But looks like we don't support to query such tables:
`select * from "[test2]";`
`uery 20220924_171606_00044_winm8 failed: Table 'dbo.[test2]' has no supported columns (all 0 columns are not supported)`

I checked that we cannot select tables with brackets in names because we didn't escape properly these table names:
because in metadata getColumns method, this parameter is used as SQL Like pattern and we should escape special characters

So I made a simple fix, by escaping brackets and now was I able to query such tables in trino:
`trino:dbo> SELECT * from sqlserver.dbo."[test3]";`
` column1 | column2`



<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
