### PR TITLE
Inline methods in generated codes

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/AccumulatorCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/AccumulatorCompiler.java
@@ -71,6 +71,7 @@ import static io.airlift.bytecode.expression.BytecodeExpressions.constantNull;
 import static io.airlift.bytecode.expression.BytecodeExpressions.constantString;
 import static io.airlift.bytecode.expression.BytecodeExpressions.invokeDynamic;
 import static io.airlift.bytecode.expression.BytecodeExpressions.invokeStatic;
+import static io.airlift.bytecode.expression.BytecodeExpressions.lessThan;
 import static io.airlift.bytecode.expression.BytecodeExpressions.newInstance;
 import static io.airlift.bytecode.expression.BytecodeExpressions.not;
 import static io.trino.sql.gen.Bootstrap.BOOTSTRAP_METHOD;
@@ -541,10 +542,7 @@ public final class AccumulatorCompiler
 
         ForLoop forLoop = new ForLoop()
                 .initialize(new BytecodeBlock().putVariable(positionVariable, 0))
-                .condition(new BytecodeBlock()
-                        .getVariable(positionVariable)
-                        .getVariable(rowsVariable)
-                        .invokeStatic(CompilerOperations.class, "lessThan", boolean.class, int.class, int.class))
+                .condition(lessThan(positionVariable, rowsVariable))
                 .update(new BytecodeBlock().incrementVariable(positionVariable, (byte) 1))
                 .body(loopBody);
 
@@ -755,10 +753,7 @@ public final class AccumulatorCompiler
 
         block.append(new ForLoop()
                 .initialize(positionVariable.set(constantInt(0)))
-                .condition(new BytecodeBlock()
-                        .append(positionVariable)
-                        .append(rowsVariable)
-                        .invokeStatic(CompilerOperations.class, "lessThan", boolean.class, int.class, int.class))
+                .condition(lessThan(positionVariable, rowsVariable))
                 .update(new BytecodeBlock().incrementVariable(positionVariable, (byte) 1))
                 .body(ifStatement));
 

--- a/core/trino-main/src/main/java/io/trino/sql/gen/CompilerOperations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/CompilerOperations.java
@@ -35,31 +35,6 @@ public final class CompilerOperations
         return value > 0;
     }
 
-    public static boolean and(boolean left, boolean right)
-    {
-        return left && right;
-    }
-
-    public static boolean or(boolean left, boolean right)
-    {
-        return left || right;
-    }
-
-    public static boolean not(boolean value)
-    {
-        return !value;
-    }
-
-    public static boolean lessThan(int left, int right)
-    {
-        return left < right;
-    }
-
-    public static boolean greaterThan(int left, int right)
-    {
-        return left > right;
-    }
-
     public static boolean in(Object value, Set<?> set)
     {
         return set.contains(value);

--- a/core/trino-main/src/main/java/io/trino/sql/gen/JoinCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/JoinCompiler.java
@@ -85,6 +85,7 @@ import static io.airlift.bytecode.expression.BytecodeExpressions.constantTrue;
 import static io.airlift.bytecode.expression.BytecodeExpressions.getStatic;
 import static io.airlift.bytecode.expression.BytecodeExpressions.invokeDynamic;
 import static io.airlift.bytecode.expression.BytecodeExpressions.invokeStatic;
+import static io.airlift.bytecode.expression.BytecodeExpressions.lessThan;
 import static io.airlift.bytecode.expression.BytecodeExpressions.newInstance;
 import static io.airlift.bytecode.expression.BytecodeExpressions.notEqual;
 import static io.airlift.bytecode.expression.BytecodeExpressions.setStatic;
@@ -300,10 +301,7 @@ public class JoinCompiler
             constructor.comment("for(blockIndex = 0; blockIndex < channel.size(); blockIndex++) { size += channel.get(i).getRetainedSizeInBytes() }")
                     .append(new ForLoop()
                             .initialize(blockIndex.set(constantInt(0)))
-                            .condition(new BytecodeBlock()
-                                    .append(blockIndex)
-                                    .append(channel.invoke("size", int.class))
-                                    .invokeStatic(CompilerOperations.class, "lessThan", boolean.class, int.class, int.class))
+                            .condition(lessThan(blockIndex, channel.invoke("size", int.class)))
                             .update(new BytecodeBlock().incrementVariable(blockIndex, (byte) 1))
                             .body(loopBody));
 


### PR DESCRIPTION
## Description

After we have introduced `BytecodeExpressions`, we can inline and remove
some of the static methods in `CompilerOperations`.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
