### PR TITLE
Add connector metric for parquet column index rows filtered

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
@@ -40,6 +40,7 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.RowBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.metrics.Metric;
+import io.trino.spi.metrics.Metrics;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.MapType;
 import io.trino.spi.type.RowType;
@@ -93,6 +94,7 @@ public class ParquetReader
     private static final int INITIAL_BATCH_SIZE = 1;
     private static final int BATCH_SIZE_GROWTH_FACTOR = 2;
     public static final String PARQUET_CODEC_METRIC_PREFIX = "ParquetReaderCompressionFormat_";
+    public static final String COLUMN_INDEX_ROWS_FILTERED = "ParquetColumnIndexRowsFiltered";
 
     private final Optional<String> fileCreatedBy;
     private final List<BlockMetaData> blocks;
@@ -134,6 +136,8 @@ public class ParquetReader
     private final Map<ColumnPath, ColumnDescriptor> paths = new HashMap<>();
     private final ParquetBlockFactory blockFactory;
     private final Map<String, Metric<?>> codecMetrics;
+
+    private long columnIndexRowsFiltered = -1;
 
     public ParquetReader(
             Optional<String> fileCreatedBy,
@@ -231,6 +235,8 @@ public class ParquetReader
                         totalDataSize += range.getLength();
                         ranges.put(new ChunkKey(columnId, rowGroup), range);
                     }
+                    // Initialize columnIndexRowsFiltered only when column indexes are found and used
+                    columnIndexRowsFiltered = 0;
                 }
                 // Update the metrics which records the codecs used along with data size
                 codecMetrics.merge(
@@ -324,6 +330,7 @@ public class ParquetReader
             if (columnIndexStore.get(currentRowGroup).isPresent()) {
                 currentGroupRowRanges = getRowRanges(filter.get(), currentRowGroup);
                 long rowCount = currentGroupRowRanges.rowCount();
+                columnIndexRowsFiltered += currentGroupRowCount - rowCount;
                 if (rowCount == 0) {
                     return false;
                 }
@@ -451,9 +458,15 @@ public class ParquetReader
         return columnChunk;
     }
 
-    public Map<String, Metric<?>> getCodecMetrics()
+    public Metrics getMetrics()
     {
-        return codecMetrics;
+        ImmutableMap.Builder<String, Metric<?>> metrics = ImmutableMap.<String, Metric<?>>builder()
+                .putAll(codecMetrics);
+        if (columnIndexRowsFiltered >= 0) {
+            metrics.put(COLUMN_INDEX_ROWS_FILTERED, new LongCount(columnIndexRowsFiltered));
+        }
+
+        return new Metrics(metrics.buildOrThrow());
     }
 
     private PageReader createPageReader(List<Slice> slices, ColumnChunkMetaData metadata, ColumnDescriptor columnDescriptor, OffsetIndex offsetIndex)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSource.java
@@ -128,7 +128,7 @@ public class ParquetPageSource
     @Override
     public Metrics getMetrics()
     {
-        return new Metrics(parquetReader.getCodecMetrics());
+        return parquetReader.getMetrics();
     }
 
     private Page getColumnAdaptationsPage(Page page)


### PR DESCRIPTION
## Description

Add connector metric for parquet column index rows filtered

## Non-technical explanation

Add metric for parquet column index rows filtered to EXPLAIN ANALYZE VERBOSE

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Delta
* Add metric for parquet column index rows filtered to EXPLAIN ANALYZE VERBOSE. ({issue}`14301`)
```
