### PR TITLE
Handle expression FunctionCall OrderBy rewrites

### DIFF
--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionTreeRewriter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionTreeRewriter.java
@@ -492,14 +492,22 @@ public final class ExpressionTreeRewriter<C>
 
             List<Expression> arguments = rewrite(node.getArguments(), context);
 
+            Optional<OrderBy> orderBy = node.getOrderBy();
+            if (orderBy.isPresent()) {
+                OrderBy rewrittenOrderBy = rewriteOrderBy(orderBy.get(), context);
+                if (rewrittenOrderBy != orderBy.get()) {
+                    orderBy = Optional.of(rewrittenOrderBy);
+                }
+            }
+
             if (!sameElements(node.getArguments(), arguments) || !sameElements(window, node.getWindow())
-                    || !sameElements(filter, node.getFilter())) {
+                    || !sameElements(filter, node.getFilter()) || !sameElements(orderBy, node.getOrderBy())) {
                 return new FunctionCall(
                         node.getLocation(),
                         node.getName(),
                         window,
                         filter,
-                        node.getOrderBy().map(orderBy -> rewriteOrderBy(orderBy, context)),
+                        orderBy,
                         node.isDistinct(),
                         node.getNullTreatment(),
                         node.getProcessingMode(),


### PR DESCRIPTION
## Description
Fixes `ExpressionTreeRewriter` to handle `FunctionCall` nodes to not discard re-written embedded `OrderBy` nodes by performing the same checks as used for window and filter expressions.

This caused a bug that was fixed in https://github.com/prestodb/presto/pull/18372 for Presto, but I've been unable to induce the same bug here because some other code in Trino seems to make it such that rewritten `OrderBy` nodes never change. It's possible that there is some way to trigger the bug, but I haven't been able to find it- and consider this mostly a pre-emptive correctness refactor to ensure that the scenario is checked and handled in case it becomes relevant after some change in the future.


## Non-technical explanation
No non-technical explanation should be necessary, unless someone can identify a potential way to induce the potential bug fixed in this change.


## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
