### PR TITLE
Fix MERGE when task_writer_count > 1

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchange.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchange.java
@@ -26,6 +26,7 @@ import io.trino.operator.PartitionFunction;
 import io.trino.operator.PrecomputedHashGenerator;
 import io.trino.spi.Page;
 import io.trino.spi.type.Type;
+import io.trino.sql.planner.MergePartitioningHandle;
 import io.trino.sql.planner.NodePartitioningManager;
 import io.trino.sql.planner.PartitioningHandle;
 import io.trino.sql.planner.SystemPartitioningHandle;
@@ -134,7 +135,8 @@ public class LocalExchange
                     physicalWrittenBytesSupplier,
                     writerMinSize);
         }
-        else if (partitioning.equals(FIXED_HASH_DISTRIBUTION) || partitioning.getCatalogHandle().isPresent()) {
+        else if (partitioning.equals(FIXED_HASH_DISTRIBUTION) || partitioning.getCatalogHandle().isPresent() ||
+                (partitioning.getConnectorHandle() instanceof MergePartitioningHandle)) {
             exchangerSupplier = () -> {
                 PartitionFunction partitionFunction = createPartitionFunction(
                         nodePartitioningManager,
@@ -224,12 +226,20 @@ public class LocalExchange
         // The same bucket function (with the same bucket count) as for node
         // partitioning must be used. This way rows within a single bucket
         // will be being processed by single thread.
-        int bucketCount = nodePartitioningManager.getBucketNodeMap(session, partitioning).getBucketCount();
+        int bucketCount = nodePartitioningManager.getBucketCount(session, partitioning);
         int[] bucketToPartition = new int[bucketCount];
+
         for (int bucket = 0; bucket < bucketCount; bucket++) {
             // mix the bucket bits so we don't use the same bucket number used to distribute between stages
             int hashedBucket = (int) XxHash64.hash(Long.reverse(bucket));
             bucketToPartition[bucket] = hashedBucket & (partitionCount - 1);
+        }
+
+        if (partitioning.getConnectorHandle() instanceof MergePartitioningHandle handle) {
+            return handle.getPartitionFunction(
+                    (scheme, types) -> nodePartitioningManager.getPartitionFunction(session, scheme, types, bucketToPartition),
+                    partitionChannelTypes,
+                    bucketToPartition);
         }
 
         return new BucketPartitionFunction(
@@ -358,7 +368,8 @@ public class LocalExchange
             bufferCount = defaultConcurrency;
             checkArgument(partitionChannels.isEmpty(), "Scaled writer exchange must not have partition channels");
         }
-        else if (partitioning.equals(FIXED_HASH_DISTRIBUTION) || partitioning.getCatalogHandle().isPresent()) {
+        else if (partitioning.equals(FIXED_HASH_DISTRIBUTION) || partitioning.getCatalogHandle().isPresent() ||
+                (partitioning.getConnectorHandle() instanceof MergePartitioningHandle)) {
             // partitioned exchange
             bufferCount = defaultConcurrency;
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/NodePartitioningManager.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/NodePartitioningManager.java
@@ -239,6 +239,15 @@ public class NodePartitioningManager
         return new BucketNodeMap(splitToBucket, createArbitraryBucketToNode(nodes, bucketCount));
     }
 
+    public int getBucketCount(Session session, PartitioningHandle partitioning)
+    {
+        if (partitioning.getConnectorHandle() instanceof MergePartitioningHandle) {
+            // TODO: can we always use this code path?
+            return getNodePartitioningMap(session, partitioning).getBucketToPartition().length;
+        }
+        return getBucketNodeMap(session, partitioning).getBucketCount();
+    }
+
     public int getNodeCount(Session session, PartitioningHandle partitioningHandle)
     {
         return getAllNodes(session, requiredCatalogHandle(partitioningHandle)).size();


### PR DESCRIPTION
## Description

Fix query failure for `MERGE` queries when `task_writer_count` is greater than one.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix query failure for `MERGE` queries when `task_writer_count` is greater than one. ({issue}`14306`)
```
