### PR TITLE
Pre-size projection BlockBuilder to the exact size needed

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/project/GeneratedPageProjection.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/GeneratedPageProjection.java
@@ -67,7 +67,7 @@ public class GeneratedPageProjection
     @Override
     public Work<Block> project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
     {
-        blockBuilder = blockBuilder.newBlockBuilderLike(null);
+        blockBuilder = blockBuilder.newBlockBuilderLike(selectedPositions.size(), null);
         try {
             return (Work<Block>) pageProjectionWorkFactory.invoke(blockBuilder, session, page, selectedPositions);
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Reduce projected page memory usage by pre-sizing the BlockBuilder to the exact needed size.
This is a follow up after https://github.com/trinodb/trino/pull/12512#pullrequestreview-1075208919

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Reduce projections memory usage

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
