### PR TITLE
Retry pulling containers in Hive tests

### DIFF
--- a/plugin/trino-hive-hadoop2/bin/common.sh
+++ b/plugin/trino-hive-hadoop2/bin/common.sh
@@ -134,7 +134,7 @@ function start_docker_containers() {
 
     # pull docker images
     if [[ "${CONTINUOUS_INTEGRATION:-false}" == 'true' ]]; then
-        docker-compose ${compose_args} pull --quiet
+        retry docker-compose ${compose_args} pull --quiet
     fi
 
     # start containers


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Retry pulling hdp containers in tests. Should help in case of errors like:

```
+ docker-compose -f plugin/trino-hive-hadoop2/bin/../conf/docker-compose.yml pull --quiet

ERROR: for hadoop-master  b'Head "https://ghcr.io/v2/trinodb/testing/hdp3.1-hive/manifests/56": Get "https://ghcr.io/***?scope=repository%3Atrinodb%2Ftesting%2Fhdp3.1-hive%3Apull&service=ghcr.io": net/http: request canceled (Client.Timeout exceeded while awaiting headers)'
Head "https://ghcr.io/v2/trinodb/testing/hdp3.1-hive/manifests/56": Get "https://ghcr.io/***?scope=repository%3Atrinodb%2Ftesting%2Fhdp3.1-hive%3Apull&service=ghcr.io": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
Error: Process completed with exit code 1.
```

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Make tests more resilient to temporary GitHub issues.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
