### PR TITLE
Cleanup test table in CLI product test

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/cli/TestTrinoCli.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/cli/TestTrinoCli.java
@@ -409,20 +409,20 @@ public class TestTrinoCli
     {
         launchTrinoCliWithServerArgument();
         trino.waitForPrompt();
-        trino.getProcessInput().println("EXPLAIN ANALYZE CREATE TABLE iceberg.default.test_table AS SELECT * FROM hive.default.nation LIMIT 10;");
+        trino.getProcessInput().println("EXPLAIN ANALYZE CREATE TABLE iceberg.default.test_print_explain_analyze AS SELECT * FROM hive.default.nation LIMIT 10;");
         List<String> lines = trimLines(trino.readLinesUntilPrompt());
         // TODO once https://github.com/trinodb/trino/issues/14253 is done this should be assertThat(lines).contains("CREATE TABLE: 1 row", "Query Plan");
         assertThat(lines).contains("CREATE TABLE", "Query Plan");
         // TODO once https://github.com/trinodb/trino/issues/14253 is done this should be assertThat(lines).contains("INSERT: 1 row", "Query Plan");
-        trino.getProcessInput().println("EXPLAIN ANALYZE INSERT INTO iceberg.default.test_table VALUES(100, 'URUGUAY', 3, 'test comment');");
+        trino.getProcessInput().println("EXPLAIN ANALYZE INSERT INTO iceberg.default.test_print_explain_analyze VALUES(100, 'URUGUAY', 3, 'test comment');");
         lines = trimLines(trino.readLinesUntilPrompt());
         assertThat(lines).contains("INSERT", "Query Plan");
         // TODO once https://github.com/trinodb/trino/issues/14253 is done this should be assertThat(lines).contains("UPDATE: 1 row", "Query Plan");
-        trino.getProcessInput().println("EXPLAIN ANALYZE UPDATE iceberg.default.test_table SET n_comment = 'testValue 5' WHERE n_nationkey = 100;");
+        trino.getProcessInput().println("EXPLAIN ANALYZE UPDATE iceberg.default.test_print_explain_analyze SET n_comment = 'testValue 5' WHERE n_nationkey = 100;");
         lines = trimLines(trino.readLinesUntilPrompt());
         assertThat(lines).contains("UPDATE", "Query Plan");
         // TODO once https://github.com/trinodb/trino/issues/14253 is done this should be assertThat(lines).contains("DELETE: 1 row", "Query Plan");
-        trino.getProcessInput().println("EXPLAIN ANALYZE DELETE FROM iceberg.default.test_table WHERE n_nationkey = 100;");
+        trino.getProcessInput().println("EXPLAIN ANALYZE DELETE FROM iceberg.default.test_print_explain_analyze WHERE n_nationkey = 100;");
         lines = trimLines(trino.readLinesUntilPrompt());
         assertThat(lines).contains("DELETE", "Query Plan");
     }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/cli/TestTrinoCli.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/cli/TestTrinoCli.java
@@ -40,6 +40,7 @@ import static io.trino.tempto.process.CliProcess.trimLines;
 import static io.trino.tests.product.TestGroups.AUTHORIZATION;
 import static io.trino.tests.product.TestGroups.CLI;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.writeString;
@@ -425,6 +426,9 @@ public class TestTrinoCli
         trino.getProcessInput().println("EXPLAIN ANALYZE DELETE FROM iceberg.default.test_print_explain_analyze WHERE n_nationkey = 100;");
         lines = trimLines(trino.readLinesUntilPrompt());
         assertThat(lines).contains("DELETE", "Query Plan");
+
+        // cleanup
+        onTrino().executeQuery("DROP TABLE iceberg.default.test_print_explain_analyze");
     }
 
     private void launchTrinoCliWithServerArgument(String... arguments)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/cli/TestTrinoCli.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/cli/TestTrinoCli.java
@@ -96,10 +96,10 @@ public class TestTrinoCli
 
     @AfterTestWithContext
     @Override
-    public void stopPresto()
+    public void stopCli()
             throws InterruptedException
     {
-        super.stopPresto();
+        super.stopCli();
     }
 
     @Override

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/cli/TestTrinoLdapCli.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/cli/TestTrinoLdapCli.java
@@ -95,10 +95,10 @@ public class TestTrinoLdapCli
 
     @AfterTestWithContext
     @Override
-    public void stopPresto()
+    public void stopCli()
             throws InterruptedException
     {
-        super.stopPresto();
+        super.stopCli();
     }
 
     @Override

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/cli/TrinoCliLauncher.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/cli/TrinoCliLauncher.java
@@ -53,7 +53,7 @@ public class TrinoCliLauncher
         nationTableBatchLines = readLines(getResource("io/trino/tests/product/cli/batch_query.results"), UTF_8);
     }
 
-    protected void stopPresto()
+    protected void stopCli()
             throws InterruptedException
     {
         if (trino != null) {


### PR DESCRIPTION
If the table is left over, causes failure of `TestRoles`.
`TestRoles` should not assume there are no Iceberg tables in the
metastore, so this should be viewed as a quick-fix only.

Fixes master build failure occurring after https://github.com/trinodb/trino/pull/13907. 
That PR was green when being merged.