### PR TITLE
Change default Accumulo metadata directory from presto to trino

### DIFF
--- a/docs/src/main/sphinx/connector/accumulo.rst
+++ b/docs/src/main/sphinx/connector/accumulo.rst
@@ -59,7 +59,7 @@ Property name                                    Default value          Required
 ``accumulo.zookeepers``                          (none)                 Yes        ZooKeeper connect string
 ``accumulo.username``                            (none)                 Yes        Accumulo user for Trino
 ``accumulo.password``                            (none)                 Yes        Accumulo password for user
-``accumulo.zookeeper.metadata.root``             ``/presto-accumulo``   No         Root znode for storing metadata. Only relevant if using default Metadata Manager
+``accumulo.zookeeper.metadata.root``             ``/trino-accumulo``    No         Root znode for storing metadata. Only relevant if using default Metadata Manager
 ``accumulo.cardinality.cache.size``              ``100000``             No         Sets the size of the index cardinality cache
 ``accumulo.cardinality.cache.expire.duration``   ``5m``                 No         Sets the expiration duration of the cardinality cache.
 ================================================ ====================== ========== =====================================================================================
@@ -617,7 +617,7 @@ follows:
     /metadata-root/schema/table
 
 Where ``metadata-root`` is the value of ``zookeeper.metadata.root`` in
-the config file (default is ``/presto-accumulo``), ``schema`` is the
+the config file (default is ``/trino-accumulo``), ``schema`` is the
 Trino schema (which is identical to the Accumulo namespace name), and
 ``table`` is the Trino table name (again, identical to Accumulo name).
 The data of the ``table`` ZooKeeper node is a serialized
@@ -666,12 +666,12 @@ when creating the external table.
      c      | date    |       | Accumulo column c:c. Indexed: true
 
 2. Using the ZooKeeper CLI, delete the corresponding znode.  Note this uses the default ZooKeeper
-metadata root of ``/presto-accumulo``
+metadata root of ``/trino-accumulo``
 
 .. code-block:: text
 
     $ zkCli.sh
-    [zk: localhost:2181(CONNECTED) 1] delete /presto-accumulo/foo/bar
+    [zk: localhost:2181(CONNECTED) 1] delete /trino-accumulo/foo/bar
 
 3. Re-create the table using the same DDL as before, but adding the ``external=true`` property.
 Note that if you had not previously defined the column_mapping, you need to add the property

--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/conf/AccumuloConfig.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/conf/AccumuloConfig.java
@@ -40,7 +40,7 @@ public class AccumuloConfig
     private String zooKeepers;
     private String username;
     private String password;
-    private String zkMetadataRoot = "/presto-accumulo";
+    private String zkMetadataRoot = "/trino-accumulo";
     private int cardinalityCacheSize = 100_000;
     private Duration cardinalityCacheExpiration = new Duration(5, TimeUnit.MINUTES);
 

--- a/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/AccumuloQueryRunner.java
+++ b/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/AccumuloQueryRunner.java
@@ -62,7 +62,7 @@ public final class AccumuloQueryRunner
                         .put(AccumuloConfig.ZOOKEEPERS, server.getZooKeepers())
                         .put(AccumuloConfig.USERNAME, server.getUser())
                         .put(AccumuloConfig.PASSWORD, server.getPassword())
-                        .put(AccumuloConfig.ZOOKEEPER_METADATA_ROOT, "/presto-accumulo-test")
+                        .put(AccumuloConfig.ZOOKEEPER_METADATA_ROOT, "/trino-accumulo-test")
                         .buildOrThrow();
 
         queryRunner.createCatalog("accumulo", "accumulo", accumuloProperties);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The `accumulo.zookeeper.metadata.root` property still defaults to `/presto-accumulo` to accommodate Bloomberg's `presto-accumulo` tools repository. This repository is [not maintained anymore](https://github.com/bloomberg/presto-accumulo), so we should change this default to `/trino-accumulo` for consistency. See [this PR](https://github.com/trinodb/trino/pull/13052) for additional context.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Update the default directory for Accumulo metadata to make more sense for use in Trino.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Accumulo connector
* Change default value for the `accumulo.zookeeper.metadata.root` catalog configuration property to `/trino-accumulo`. Existing
  Accumulo catalogs that use the Metadata Manager with the `/presto-accumulo` root directory must update their catalog
  configuration accordingly.
```
