### PR TITLE
Support skip archive for Glue in Iceberg

### DIFF
--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -431,6 +431,7 @@
                                 <exclude>**/TestIcebergGlueCatalogAccessOperations.java</exclude>
                                 <exclude>**/TestIcebergGlueCatalogMaterializedViewTest.java</exclude>
                                 <exclude>**/TestIcebergGlueTableOperationsInsertFailure.java</exclude>
+                                <exclude>**/TestIcebergGlueCatalogSkipArchive.java</exclude>
                                 <exclude>**/TestIcebergGcsConnectorSmokeTest.java</exclude>
                             </excludes>
                         </configuration>
@@ -454,6 +455,7 @@
                                 <include>**/TestIcebergGlueCatalogAccessOperations.java</include>
                                 <include>**/TestIcebergGlueCatalogMaterializedViewTest.java</include>
                                 <include>**/TestIcebergGlueTableOperationsInsertFailure.java</include>
+                                <include>**/TestIcebergGlueCatalogSkipArchive.java</include>
                                 <include>**/TestIcebergGcsConnectorSmokeTest.java</include>
                             </includes>
                         </configuration>

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueClientProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueClientProvider.java
@@ -32,21 +32,24 @@ public class GlueClientProvider
     private final GlueMetastoreStats stats;
     private final AWSCredentialsProvider credentialsProvider;
     private final GlueHiveMetastoreConfig glueConfig; // TODO do not keep mutable config instance on a field
+    private final boolean skipArchive;
 
     @Inject
     public GlueClientProvider(
             GlueMetastoreStats stats,
             AWSCredentialsProvider credentialsProvider,
-            GlueHiveMetastoreConfig glueConfig)
+            GlueHiveMetastoreConfig glueConfig,
+            IcebergGlueCatalogConfig icebergGlueConfig)
     {
         this.stats = requireNonNull(stats, "stats is null");
         this.credentialsProvider = requireNonNull(credentialsProvider, "credentialsProvider is null");
         this.glueConfig = glueConfig;
+        this.skipArchive = icebergGlueConfig.isSkipArchive();
     }
 
     @Override
     public AWSGlueAsync get()
     {
-        return createAsyncGlueClient(glueConfig, credentialsProvider, Optional.empty(), stats.newRequestMetricsCollector());
+        return createAsyncGlueClient(glueConfig, credentialsProvider, Optional.of(new SkipArchiveRequestHandler(skipArchive)), stats.newRequestMetricsCollector());
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueClientProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueClientProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.glue;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.glue.AWSGlueAsync;
+import io.trino.plugin.hive.metastore.glue.GlueHiveMetastoreConfig;
+import io.trino.plugin.hive.metastore.glue.GlueMetastoreStats;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.util.Optional;
+
+import static io.trino.plugin.hive.metastore.glue.GlueHiveMetastore.createAsyncGlueClient;
+import static java.util.Objects.requireNonNull;
+
+public class GlueClientProvider
+        implements Provider<AWSGlueAsync>
+{
+    private final GlueMetastoreStats stats;
+    private final AWSCredentialsProvider credentialsProvider;
+    private final GlueHiveMetastoreConfig glueConfig; // TODO do not keep mutable config instance on a field
+
+    @Inject
+    public GlueClientProvider(
+            GlueMetastoreStats stats,
+            AWSCredentialsProvider credentialsProvider,
+            GlueHiveMetastoreConfig glueConfig)
+    {
+        this.stats = requireNonNull(stats, "stats is null");
+        this.credentialsProvider = requireNonNull(credentialsProvider, "credentialsProvider is null");
+        this.glueConfig = glueConfig;
+    }
+
+    @Override
+    public AWSGlueAsync get()
+    {
+        return createAsyncGlueClient(glueConfig, credentialsProvider, Optional.empty(), stats.newRequestMetricsCollector());
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergTableOperationsProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergTableOperationsProvider.java
@@ -13,10 +13,8 @@
  */
 package io.trino.plugin.iceberg.catalog.glue;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.glue.AWSGlueAsync;
 import io.trino.filesystem.TrinoFileSystemFactory;
-import io.trino.plugin.hive.metastore.glue.GlueHiveMetastoreConfig;
 import io.trino.plugin.hive.metastore.glue.GlueMetastoreStats;
 import io.trino.plugin.iceberg.catalog.IcebergTableOperations;
 import io.trino.plugin.iceberg.catalog.IcebergTableOperationsProvider;
@@ -27,7 +25,6 @@ import javax.inject.Inject;
 
 import java.util.Optional;
 
-import static io.trino.plugin.hive.metastore.glue.GlueHiveMetastore.createAsyncGlueClient;
 import static java.util.Objects.requireNonNull;
 
 public class GlueIcebergTableOperationsProvider
@@ -41,14 +38,11 @@ public class GlueIcebergTableOperationsProvider
     public GlueIcebergTableOperationsProvider(
             TrinoFileSystemFactory fileSystemFactory,
             GlueMetastoreStats stats,
-            GlueHiveMetastoreConfig glueConfig,
-            AWSCredentialsProvider credentialsProvider)
+            AWSGlueAsync glueClient)
     {
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.stats = requireNonNull(stats, "stats is null");
-        requireNonNull(glueConfig, "glueConfig is null");
-        requireNonNull(credentialsProvider, "credentialsProvider is null");
-        this.glueClient = createAsyncGlueClient(glueConfig, credentialsProvider, Optional.empty(), stats.newRequestMetricsCollector());
+        this.glueClient = requireNonNull(glueClient, "glueClient is null");
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/IcebergGlueCatalogConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/IcebergGlueCatalogConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.glue;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+
+public class IcebergGlueCatalogConfig
+{
+    private boolean skipArchive;
+
+    public boolean isSkipArchive()
+    {
+        return skipArchive;
+    }
+
+    @Config("iceberg.glue.skip-archive")
+    @ConfigDescription("Skip archiving an old table version when creating a new version in a commit")
+    public IcebergGlueCatalogConfig setSkipArchive(boolean skipArchive)
+    {
+        this.skipArchive = skipArchive;
+        return this;
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/IcebergGlueCatalogModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/IcebergGlueCatalogModule.java
@@ -34,6 +34,7 @@ public class IcebergGlueCatalogModule
     protected void setup(Binder binder)
     {
         configBinder(binder).bindConfig(GlueHiveMetastoreConfig.class);
+        configBinder(binder).bindConfig(IcebergGlueCatalogConfig.class);
         binder.bind(GlueMetastoreStats.class).in(Scopes.SINGLETON);
         binder.bind(AWSGlueAsync.class).toProvider(GlueClientProvider.class).in(Scopes.SINGLETON);
         newExporter(binder).export(GlueMetastoreStats.class).withGeneratedName();

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/IcebergGlueCatalogModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/IcebergGlueCatalogModule.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.iceberg.catalog.glue;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.glue.AWSGlueAsync;
 import com.google.inject.Binder;
 import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
@@ -34,6 +35,7 @@ public class IcebergGlueCatalogModule
     {
         configBinder(binder).bindConfig(GlueHiveMetastoreConfig.class);
         binder.bind(GlueMetastoreStats.class).in(Scopes.SINGLETON);
+        binder.bind(AWSGlueAsync.class).toProvider(GlueClientProvider.class).in(Scopes.SINGLETON);
         newExporter(binder).export(GlueMetastoreStats.class).withGeneratedName();
         binder.bind(AWSCredentialsProvider.class).toProvider(GlueCredentialsProvider.class).in(Scopes.SINGLETON);
         binder.bind(IcebergTableOperationsProvider.class).to(GlueIcebergTableOperationsProvider.class).in(Scopes.SINGLETON);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/SkipArchiveRequestHandler.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/SkipArchiveRequestHandler.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.glue;
+
+import com.amazonaws.AmazonWebServiceRequest;
+import com.amazonaws.handlers.RequestHandler2;
+import com.amazonaws.services.glue.model.CreateDatabaseRequest;
+import com.amazonaws.services.glue.model.CreateTableRequest;
+import com.amazonaws.services.glue.model.DeleteDatabaseRequest;
+import com.amazonaws.services.glue.model.DeleteTableRequest;
+import com.amazonaws.services.glue.model.GetDatabaseRequest;
+import com.amazonaws.services.glue.model.GetDatabasesRequest;
+import com.amazonaws.services.glue.model.GetTableRequest;
+import com.amazonaws.services.glue.model.GetTablesRequest;
+import com.amazonaws.services.glue.model.UpdateTableRequest;
+
+public class SkipArchiveRequestHandler
+        extends RequestHandler2
+{
+    private final boolean skipArchive;
+
+    public SkipArchiveRequestHandler(boolean skipArchive)
+    {
+        this.skipArchive = skipArchive;
+    }
+
+    @Override
+    public AmazonWebServiceRequest beforeExecution(AmazonWebServiceRequest request)
+    {
+        if (request instanceof UpdateTableRequest updateTableRequest) {
+            return updateTableRequest.withSkipArchive(skipArchive);
+        }
+        if (request instanceof CreateDatabaseRequest ||
+                request instanceof DeleteDatabaseRequest ||
+                request instanceof GetDatabasesRequest ||
+                request instanceof GetDatabaseRequest ||
+                request instanceof CreateTableRequest ||
+                request instanceof DeleteTableRequest ||
+                request instanceof GetTablesRequest ||
+                request instanceof GetTableRequest) {
+            return request;
+        }
+        throw new IllegalArgumentException("Unsupported request: " + request);
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalogFactory.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.iceberg.catalog.glue;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.glue.AWSGlueAsync;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.plugin.base.CatalogName;
@@ -33,7 +32,6 @@ import javax.inject.Inject;
 
 import java.util.Optional;
 
-import static io.trino.plugin.hive.metastore.glue.GlueHiveMetastore.createAsyncGlueClient;
 import static java.util.Objects.requireNonNull;
 
 public class TrinoGlueCatalogFactory
@@ -57,9 +55,9 @@ public class TrinoGlueCatalogFactory
             IcebergTableOperationsProvider tableOperationsProvider,
             NodeVersion nodeVersion,
             GlueHiveMetastoreConfig glueConfig,
-            AWSCredentialsProvider credentialsProvider,
             IcebergConfig icebergConfig,
-            GlueMetastoreStats stats)
+            GlueMetastoreStats stats,
+            AWSGlueAsync glueClient)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
@@ -67,8 +65,7 @@ public class TrinoGlueCatalogFactory
         this.tableOperationsProvider = requireNonNull(tableOperationsProvider, "tableOperationsProvider is null");
         this.trinoVersion = nodeVersion.toString();
         this.defaultSchemaLocation = glueConfig.getDefaultWarehouseDir();
-        requireNonNull(credentialsProvider, "credentialsProvider is null");
-        this.glueClient = createAsyncGlueClient(glueConfig, credentialsProvider, Optional.empty(), stats.newRequestMetricsCollector());
+        this.glueClient = requireNonNull(glueClient, "glueClient is null");
         this.isUniqueTableLocation = icebergConfig.isUniqueTableLocation();
         this.stats = requireNonNull(stats, "stats is null");
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.glue;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestIcebergGlueCatalogConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(IcebergGlueCatalogConfig.class)
+                .setSkipArchive(false));
+    }
+
+    @Test
+    public void testExplicitPropertyMapping()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("iceberg.glue.skip-archive", "true")
+                .buildOrThrow();
+
+        IcebergGlueCatalogConfig expected = new IcebergGlueCatalogConfig()
+                .setSkipArchive(true);
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogSkipArchive.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogSkipArchive.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.glue;
+
+import com.amazonaws.services.glue.AWSGlueAsync;
+import com.amazonaws.services.glue.AWSGlueAsyncClientBuilder;
+import com.amazonaws.services.glue.model.GetTableRequest;
+import com.amazonaws.services.glue.model.GetTableVersionsRequest;
+import com.amazonaws.services.glue.model.GetTableVersionsResult;
+import com.amazonaws.services.glue.model.Table;
+import com.amazonaws.services.glue.model.TableInput;
+import com.amazonaws.services.glue.model.TableVersion;
+import com.amazonaws.services.glue.model.UpdateTableRequest;
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.hive.metastore.glue.GlueMetastoreApiStats;
+import io.trino.plugin.iceberg.IcebergQueryRunner;
+import io.trino.plugin.iceberg.SchemaInitializer;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.sql.TestTable;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.plugin.hive.metastore.glue.AwsSdkUtil.getPaginatedResults;
+import static io.trino.plugin.iceberg.catalog.glue.GlueIcebergUtil.getTableInput;
+import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/*
+ * The test currently uses AWS Default Credential Provider Chain,
+ * See https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
+ * on ways to set your AWS credentials which will be needed to run this test.
+ */
+public class TestIcebergGlueCatalogSkipArchive
+        extends AbstractTestQueryFramework
+{
+    private final String schemaName = "test_iceberg_skip_archive_" + randomTableSuffix();
+    private AWSGlueAsync glueClient;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        glueClient = AWSGlueAsyncClientBuilder.defaultClient();
+        File schemaDirectory = Files.createTempDirectory("test_iceberg").toFile();
+        schemaDirectory.deleteOnExit();
+
+        return IcebergQueryRunner.builder()
+                .setIcebergProperties(
+                        ImmutableMap.<String, String>builder()
+                                .put("iceberg.catalog.type", "glue")
+                                .put("iceberg.glue.skip-archive", "true")
+                                .put("hive.metastore.glue.default-warehouse-dir", schemaDirectory.getAbsolutePath())
+                                .buildOrThrow())
+                .setSchemaInitializer(
+                        SchemaInitializer.builder()
+                                .withSchemaName(schemaName)
+                                .build())
+                .build();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void cleanup()
+    {
+        assertUpdate("DROP SCHEMA IF EXISTS " + schemaName);
+    }
+
+    @Test
+    public void testSkipArchive()
+    {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_skip_archive", "(col int)")) {
+            List<TableVersion> tableVersionsBeforeInsert = getTableVersions(schemaName, table.getName());
+            assertThat(tableVersionsBeforeInsert).hasSize(1);
+            String versionIdBeforeInsert = getOnlyElement(tableVersionsBeforeInsert).getVersionId();
+
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES 1", 1);
+
+            // Verify count of table versions isn't increased, but version id is changed
+            List<TableVersion> tableVersionsAfterInsert = getTableVersions(schemaName, table.getName());
+            assertThat(tableVersionsAfterInsert).hasSize(1);
+            String versionIdAfterInsert = getOnlyElement(tableVersionsAfterInsert).getVersionId();
+            assertThat(versionIdBeforeInsert).isNotEqualTo(versionIdAfterInsert);
+        }
+    }
+
+    @Test
+    public void testNotRemoveExistingArchive()
+    {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_remove_archive", "(col int)")) {
+            List<TableVersion> tableVersionsBeforeInsert = getTableVersions(schemaName, table.getName());
+            assertThat(tableVersionsBeforeInsert).hasSize(1);
+            TableVersion initialVersion = getOnlyElement(tableVersionsBeforeInsert);
+
+            // Add a new archive using Glue client
+            Table glueTable = glueClient.getTable(new GetTableRequest().withDatabaseName(schemaName).withName(table.getName())).getTable();
+            TableInput tableInput = getTableInput(table.getName(), Optional.empty(), glueTable.getParameters());
+            glueClient.updateTable(new UpdateTableRequest().withDatabaseName(schemaName).withTableInput(tableInput));
+            assertThat(getTableVersions(schemaName, table.getName())).hasSize(2);
+
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES 1", 1);
+
+            // Verify existing old table versions weren't removed
+            List<TableVersion> tableVersionsAfterInsert = getTableVersions(schemaName, table.getName());
+            assertThat(tableVersionsAfterInsert).hasSize(2).contains(initialVersion);
+        }
+    }
+
+    private List<TableVersion> getTableVersions(String databaseName, String tableName)
+    {
+        return getPaginatedResults(
+                glueClient::getTableVersions,
+                new GetTableVersionsRequest().withDatabaseName(databaseName).withTableName(tableName),
+                GetTableVersionsRequest::setNextToken,
+                GetTableVersionsResult::getNextToken,
+                new GlueMetastoreApiStats())
+                .map(GetTableVersionsResult::getTableVersions)
+                .flatMap(Collection::stream)
+                .collect(toImmutableList());
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestTrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestTrinoGlueCatalog.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.iceberg.catalog.glue;
 
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.services.glue.AWSGlueAsync;
 import com.amazonaws.services.glue.AWSGlueAsyncClientBuilder;
 import com.amazonaws.services.glue.model.CreateDatabaseRequest;
@@ -24,7 +23,6 @@ import io.airlift.log.Logger;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
 import io.trino.plugin.base.CatalogName;
-import io.trino.plugin.hive.metastore.glue.GlueHiveMetastoreConfig;
 import io.trino.plugin.hive.metastore.glue.GlueMetastoreStats;
 import io.trino.plugin.iceberg.CommitTaskData;
 import io.trino.plugin.iceberg.IcebergMetadata;
@@ -61,6 +59,7 @@ public class TestTrinoGlueCatalog
     protected TrinoCatalog createTrinoCatalog(boolean useUniqueTableLocations)
     {
         TrinoFileSystemFactory fileSystemFactory = new HdfsFileSystemFactory(HDFS_ENVIRONMENT);
+        AWSGlueAsync glueClient = AWSGlueAsyncClientBuilder.defaultClient();
         return new TrinoGlueCatalog(
                 new CatalogName("catalog_name"),
                 fileSystemFactory,
@@ -68,10 +67,9 @@ public class TestTrinoGlueCatalog
                 new GlueIcebergTableOperationsProvider(
                         fileSystemFactory,
                         new GlueMetastoreStats(),
-                        new GlueHiveMetastoreConfig(),
-                        DefaultAWSCredentialsProviderChain.getInstance()),
+                        glueClient),
                 "test",
-                AWSGlueAsyncClientBuilder.defaultClient(),
+                glueClient,
                 new GlueMetastoreStats(),
                 Optional.empty(),
                 useUniqueTableLocations);
@@ -133,6 +131,7 @@ public class TestTrinoGlueCatalog
         tmpDirectory.toFile().deleteOnExit();
 
         TrinoFileSystemFactory fileSystemFactory = new HdfsFileSystemFactory(HDFS_ENVIRONMENT);
+        AWSGlueAsync glueClient = AWSGlueAsyncClientBuilder.defaultClient();
         TrinoCatalog catalogWithDefaultLocation = new TrinoGlueCatalog(
                 new CatalogName("catalog_name"),
                 fileSystemFactory,
@@ -140,10 +139,9 @@ public class TestTrinoGlueCatalog
                 new GlueIcebergTableOperationsProvider(
                         fileSystemFactory,
                         new GlueMetastoreStats(),
-                        new GlueHiveMetastoreConfig(),
-                        DefaultAWSCredentialsProviderChain.getInstance()),
+                        glueClient),
                 "test",
-                AWSGlueAsyncClientBuilder.defaultClient(),
+                glueClient,
                 new GlueMetastoreStats(),
                 Optional.of(tmpDirectory.toAbsolutePath().toString()),
                 false);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestingIcebergGlueCatalogModule.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestingIcebergGlueCatalogModule.java
@@ -42,6 +42,7 @@ public class TestingIcebergGlueCatalogModule
     protected void setup(Binder binder)
     {
         configBinder(binder).bindConfig(GlueHiveMetastoreConfig.class);
+        configBinder(binder).bindConfig(IcebergGlueCatalogConfig.class);
         binder.bind(GlueMetastoreStats.class).in(Scopes.SINGLETON);
         newExporter(binder).export(GlueMetastoreStats.class).withGeneratedName();
         binder.bind(AWSGlueAsync.class).toProvider(GlueClientProvider.class).in(Scopes.SINGLETON);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestingIcebergGlueCatalogModule.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestingIcebergGlueCatalogModule.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.iceberg.catalog.glue;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.glue.AWSGlueAsync;
 import com.google.inject.Binder;
 import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
@@ -43,6 +44,7 @@ public class TestingIcebergGlueCatalogModule
         configBinder(binder).bindConfig(GlueHiveMetastoreConfig.class);
         binder.bind(GlueMetastoreStats.class).in(Scopes.SINGLETON);
         newExporter(binder).export(GlueMetastoreStats.class).withGeneratedName();
+        binder.bind(AWSGlueAsync.class).toProvider(GlueClientProvider.class).in(Scopes.SINGLETON);
         binder.bind(AWSCredentialsProvider.class).toProvider(GlueCredentialsProvider.class).in(Scopes.SINGLETON);
         binder.bind(IcebergTableOperationsProvider.class).to(TestingGlueIcebergTableOperationsProvider.class).in(Scopes.SINGLETON);
         binder.bind(TrinoCatalogFactory.class).to(TrinoGlueCatalogFactory.class).in(Scopes.SINGLETON);


### PR DESCRIPTION
## Description

`TestIcebergGlueCatalogSkipArchive.testSkipArchive` fails until updating IAM policy.
Fixes #13413

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Add support for skipping archive when committing a table in Glue when
  the `iceberg.glue.skip-archive` configuration property is set to true. ({issue}`13413`)
```
