### PR TITLE
Bump jts to 1.19.0

### DIFF
--- a/lib/trino-geospatial-toolkit/pom.xml
+++ b/lib/trino-geospatial-toolkit/pom.xml
@@ -42,16 +42,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <optional>true</optional>

--- a/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/GeometryUtils.java
+++ b/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/GeometryUtils.java
@@ -23,35 +23,18 @@ import com.esri.core.geometry.Polygon;
 import com.esri.core.geometry.ogc.OGCGeometry;
 import com.esri.core.geometry.ogc.OGCPoint;
 import com.esri.core.geometry.ogc.OGCPolygon;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import io.trino.spi.TrinoException;
-import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.geojson.GeoJsonReader;
 import org.locationtech.jts.io.geojson.GeoJsonWriter;
 
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 
 public final class GeometryUtils
 {
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
-    private static final String TYPE_ATTRIBUTE = "type";
-    private static final String COORDINATES_ATTRIBUTE = "coordinates";
-    private static final Map<String, String> EMPTY_ATOMIC_GEOMETRY_JSON_OVERRIDE = ImmutableMap.of(
-            "LineString", "{\"type\":\"LineString\",\"coordinates\":[]}",
-            "Point", "{\"type\":\"Point\",\"coordinates\":[]}");
-    private static final Map<String, org.locationtech.jts.geom.Geometry> EMPTY_ATOMIC_GEOMETRY_OVERRIDE = ImmutableMap.of(
-            "Polygon", GEOMETRY_FACTORY.createPolygon(),
-            "Point", GEOMETRY_FACTORY.createPoint());
-
     private GeometryUtils() {}
 
     /**
@@ -187,71 +170,15 @@ public final class GeometryUtils
     public static org.locationtech.jts.geom.Geometry jtsGeometryFromJson(String json)
     {
         try {
-            org.locationtech.jts.geom.Geometry emptyGeoJsonOverride = getEmptyGeometryOverride(json);
-            if (emptyGeoJsonOverride != null) {
-                return emptyGeoJsonOverride;
-            }
             return new GeoJsonReader().read(json);
         }
-        catch (ParseException | IllegalArgumentException e) {
+        catch (ParseException e) {
             throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "Invalid GeoJSON: " + e.getMessage(), e);
         }
     }
 
-    /**
-     * Return an empty geometry in the cases in which the locationtech library
-     * doesn't when the coordinates attribute is an empty array. In particular,
-     * these two cases are handled by the underlying library as follows:
-     * {type:Point, coordinates:[]} -> POINT (0 0)
-     * {type:Polygon, coordinates[]} -> Exception during parsing
-     * To circumvent these inconsistencies, we catch this upfront and return
-     * the correct empty geometry.
-     * TODO: Remove if/when https://github.com/locationtech/jts/issues/684 is fixed.
-     */
-    private static org.locationtech.jts.geom.Geometry getEmptyGeometryOverride(String json)
-    {
-        try {
-            JsonNode jsonNode = OBJECT_MAPPER.readTree(json);
-            JsonNode typeNode = jsonNode.get(TYPE_ATTRIBUTE);
-            if (typeNode != null) {
-                org.locationtech.jts.geom.Geometry emptyGeometry = EMPTY_ATOMIC_GEOMETRY_OVERRIDE.get(typeNode.textValue());
-                if (emptyGeometry != null) {
-                    JsonNode coordinatesNode = jsonNode.get(COORDINATES_ATTRIBUTE);
-                    if (coordinatesNode != null && coordinatesNode.isArray() && coordinatesNode.isEmpty()) {
-                        return emptyGeometry;
-                    }
-                }
-            }
-        }
-        catch (JsonProcessingException e) {
-            // Ignore and have subsequent GeoJsonReader throw
-        }
-        return null;
-    }
-
     public static String jsonFromJtsGeometry(org.locationtech.jts.geom.Geometry geometry)
     {
-        String geoJsonOverride = getEmptyGeoJsonOverride(geometry);
-        if (geoJsonOverride != null) {
-            return geoJsonOverride;
-        }
-
         return new GeoJsonWriter().write(geometry);
-    }
-
-    /**
-     * Return GeoJSON with an empty coordinate array when the geometry is empty. This
-     * overrides the behavior of the locationtech library which returns invalid
-     * GeoJSON in these cases. For example, in the case of an empty point,
-     * locationtech would return:
-     * {type:Point, coordinates:, ...}
-     * TODO: Remove if/when https://github.com/locationtech/jts/issues/411 is fixed
-     */
-    private static String getEmptyGeoJsonOverride(org.locationtech.jts.geom.Geometry geometry)
-    {
-        if (geometry.isEmpty()) {
-            return EMPTY_ATOMIC_GEOMETRY_JSON_OVERRIDE.get(geometry.getGeometryType());
-        }
-        return null;
     }
 }

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestGeoFunctions.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestGeoFunctions.java
@@ -2236,22 +2236,19 @@ public class TestGeoFunctions
         assertValidGeometryJson(
                 "{\"type\":\"MultiLineString\", \"coordinates\":[[[0.0,0.0],[1,10]],[[10,10],[20,30]],[[123,123],[456,789]]]}",
                 "MULTILINESTRING ((0 0, 1 10), (10 10, 20 30), (123 123, 456 789))");
+        assertValidGeometryJson("{\"type\":\"FeatureCollection\",\"features\":[]}", "GEOMETRYCOLLECTION EMPTY");
+
+        // Valid JSON with invalid Geometry definition but return empty
+        assertValidGeometryJson("{\"type\":\"Point\"}", "POINT EMPTY");
+        assertValidGeometryJson("{\"type\":\"LineString\",\"coordinates\":null}", "LINESTRING EMPTY");
+        assertValidGeometryJson("{\"type\":\"MultiPoint\",\"invalidField\":[[10,10],[20,30]]}", "MULTIPOINT EMPTY");
+        assertValidGeometryJson("{\"type\":\"MultiPoint\",\"missingCoordinates\":[]}", "MULTIPOINT EMPTY");
 
         // Valid JSON with invalid Geometry definition
-        assertInvalidGeometryJson("{\"type\":\"Point\"}",
-                "Invalid GeoJSON: Could not parse Point from GeoJson string.");
-        assertInvalidGeometryJson("{\"type\":\"LineString\",\"coordinates\":null}",
-                "Invalid GeoJSON: Could not parse LineString from GeoJson string.");
         assertInvalidGeometryJson("{ \"data\": {\"type\":\"Point\",\"coordinates\":[0,0]}}",
                 "Invalid GeoJSON: Could not parse Geometry from Json string.  No 'type' property found.");
-        assertInvalidGeometryJson("{\"type\":\"MultiPoint\",\"invalidField\":[[10,10],[20,30]]}",
-                "Invalid GeoJSON: Could not parse MultiPoint from GeoJson string.");
         assertInvalidGeometryJson("{\"type\":\"Feature\",\"geometry\":[],\"property\":\"foo\"}",
-                "Invalid GeoJSON: Could not parse Geometry from GeoJson string.  Unsupported 'type':Feature");
-        assertInvalidGeometryJson("{\"type\":\"FeatureCollection\",\"features\":[]}",
-                "Invalid GeoJSON: Could not parse Geometry from GeoJson string.  Unsupported 'type':FeatureCollection");
-        assertInvalidGeometryJson("{\"type\":\"MultiPoint\",\"missingCoordinates\":[]}",
-                "Invalid GeoJSON: Could not parse MultiPoint from GeoJson string.");
+                "Invalid GeoJSON: Could not parse Feature from GeoJson string.");
         assertInvalidGeometryJson("{\"coordinates\":[[[0.0,0.0],[1,10]],[[10,10],[20,30]],[[123,123],[456,789]]]}",
                 "Invalid GeoJSON: Could not parse Geometry from Json string.  No 'type' property found.");
 

--- a/pom.xml
+++ b/pom.xml
@@ -1832,13 +1832,13 @@
             <dependency>
                 <groupId>org.locationtech.jts</groupId>
                 <artifactId>jts-core</artifactId>
-                <version>1.16.1</version>
+                <version>1.19.0</version>
             </dependency>
 
             <dependency>
                 <groupId>org.locationtech.jts.io</groupId>
                 <artifactId>jts-io-common</artifactId>
-                <version>1.16.1</version>
+                <version>1.19.0</version>
                 <exclusions>
                     <exclusion>
                         <groupId>junit</groupId>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Update jts to 1.19.0 and also remove the `getEmptyGeometryOverride` workaround, which has been fixed by upstream.

Closes #14343.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

No non-technical explanation should be necessary.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

