### PR TITLE
Fix sporadic fault tolerant query failures with CancellationException

### DIFF
--- a/core/trino-main/src/main/java/io/trino/exchange/LazyExchangeDataSource.java
+++ b/core/trino-main/src/main/java/io/trino/exchange/LazyExchangeDataSource.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
+import static com.google.common.util.concurrent.Futures.nonCancellationPropagating;
 import static java.util.Objects.requireNonNull;
 
 public class LazyExchangeDataSource
@@ -95,7 +96,7 @@ public class LazyExchangeDataSource
             return immediateVoidFuture();
         }
         if (!initializationFuture.isDone()) {
-            return initializationFuture;
+            return nonCancellationPropagating(initializationFuture);
         }
         ExchangeDataSource dataSource = delegate.get();
         if (dataSource == null) {

--- a/core/trino-main/src/test/java/io/trino/exchange/TestLazyExchangeDataSource.java
+++ b/core/trino-main/src/test/java/io/trino/exchange/TestLazyExchangeDataSource.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.exchange;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import io.trino.memory.context.SimpleLocalMemoryContext;
+import io.trino.metadata.ExchangeHandleResolver;
+import io.trino.operator.RetryPolicy;
+import io.trino.spi.QueryId;
+import io.trino.spi.exchange.ExchangeId;
+import org.testng.annotations.Test;
+
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestLazyExchangeDataSource
+{
+    @Test
+    public void testIsBlockedCancellationIsolationInInitializationPhase()
+    {
+        try (LazyExchangeDataSource source = new LazyExchangeDataSource(
+                new QueryId("query"),
+                new ExchangeId("exchange"),
+                (queryId, exchangeId, memoryContext, taskFailureListener, retryPolicy) -> {
+                    throw new UnsupportedOperationException();
+                },
+                new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), TestLazyExchangeDataSource.class.getSimpleName()),
+                (taskId, failure) -> {
+                    throw new UnsupportedOperationException();
+                },
+                RetryPolicy.NONE,
+                new ExchangeManagerRegistry(new ExchangeHandleResolver()))) {
+            ListenableFuture<Void> first = source.isBlocked();
+            ListenableFuture<Void> second = source.isBlocked();
+            assertThat(first)
+                    .isNotDone()
+                    .isNotCancelled();
+            assertThat(second)
+                    .isNotDone()
+                    .isNotCancelled();
+
+            first.cancel(true);
+            assertThat(first)
+                    .isDone()
+                    .isCancelled();
+            assertThat(second)
+                    .isNotDone()
+                    .isNotCancelled();
+
+            ListenableFuture<Void> third = source.isBlocked();
+            assertThat(third)
+                    .isNotDone()
+                    .isNotCancelled();
+        }
+    }
+}

--- a/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/TestFileSystemExchangeSource.java
+++ b/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/TestFileSystemExchangeSource.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.exchange.filesystem;
+
+import io.trino.plugin.exchange.filesystem.local.LocalFileSystemExchangeStorage;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestFileSystemExchangeSource
+{
+    @Test
+    public void testIsBlockedNonCancellable()
+    {
+        try (FileSystemExchangeSource source = new FileSystemExchangeSource(
+                new LocalFileSystemExchangeStorage(),
+                new FileSystemExchangeStats(),
+                1024,
+                2)) {
+            CompletableFuture<Void> first = source.isBlocked();
+            CompletableFuture<Void> second = source.isBlocked();
+            assertThat(first)
+                    .isNotDone()
+                    .isNotCancelled();
+            assertThat(second)
+                    .isNotDone()
+                    .isNotCancelled();
+
+            first.cancel(true);
+            assertThat(first)
+                    .isDone()
+                    .isCancelled();
+            assertThat(second)
+                    .isNotDone()
+                    .isNotCancelled();
+
+            CompletableFuture<Void> third = source.isBlocked();
+            assertThat(third)
+                    .isNotDone()
+                    .isNotCancelled();
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Trino client employs long pooling when fetching results from a Trino server. The client sends a request and the server waits for up to 1s for new query results to become available. On timeout the future returned by the Query#waitForResults is cancelled. The problem occurs when a subsequent request grabs an already cancelled future.

The problem is incredible rare to occur, as the feature is checked for "isDone" before returning. Yet a race condition is possible as the future is cancelled by a background thread what makes it possible for a new request to come in before the future is cancelled.


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

- Fix CancellationException related query failures when fault tolerant execution is enabled

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(X) Release notes are required, please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# Fault tolerant execution
* Fix CancellationException related query failures when fault tolerant execution is enabled
```
