### PR TITLE
Report operator cpu and wall time distribution

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/OperatorContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OperatorContext.java
@@ -57,6 +57,7 @@ import static java.lang.Math.max;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Contains information about {@link Operator} execution.
@@ -510,9 +511,12 @@ public class OperatorContext
                 .orElseGet(() -> ImmutableList.of(getOperatorStats()));
     }
 
-    public static Metrics getOperatorMetrics(Metrics operatorMetrics, long inputPositions)
+    public static Metrics getOperatorMetrics(Metrics operatorMetrics, long inputPositions, double cpuTimeSeconds, double wallTimeSeconds)
     {
-        return operatorMetrics.mergeWith(new Metrics(ImmutableMap.of("Input distribution", TDigestHistogram.fromValue(inputPositions))));
+        return operatorMetrics.mergeWith(new Metrics(ImmutableMap.of(
+                "Input distribution", TDigestHistogram.fromValue(inputPositions),
+                "CPU time distribution (s)", TDigestHistogram.fromValue(cpuTimeSeconds),
+                "Wall time distribution (s)", TDigestHistogram.fromValue(wallTimeSeconds))));
     }
 
     public static Metrics getConnectorMetrics(Metrics connectorMetrics, long physicalInputReadTimeNanos)
@@ -566,7 +570,11 @@ public class OperatorContext
                 outputPositions.getTotalCount(),
 
                 dynamicFilterSplitsProcessed.get(),
-                getOperatorMetrics(metrics.get(), inputPositionsCount),
+                getOperatorMetrics(
+                        metrics.get(),
+                        inputPositionsCount,
+                        new Duration(addInputTiming.getCpuNanos() + getOutputTiming.getCpuNanos() + finishTiming.getCpuNanos(), NANOSECONDS).convertTo(SECONDS).getValue(),
+                        new Duration(addInputTiming.getWallNanos() + getOutputTiming.getWallNanos() + finishTiming.getWallNanos(), NANOSECONDS).convertTo(SECONDS).getValue()),
                 getConnectorMetrics(connectorMetrics.get(), physicalInputReadTimeNanos.get()),
 
                 DataSize.ofBytes(physicalWrittenDataSize.get()),

--- a/core/trino-main/src/main/java/io/trino/operator/OperatorContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OperatorContext.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.stats.CounterStat;
-import io.airlift.stats.TDigest;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.Session;
@@ -513,9 +512,7 @@ public class OperatorContext
 
     public static Metrics getOperatorMetrics(Metrics operatorMetrics, long inputPositions)
     {
-        TDigest digest = new TDigest();
-        digest.add(inputPositions);
-        return operatorMetrics.mergeWith(new Metrics(ImmutableMap.of("Input distribution", new TDigestHistogram(digest))));
+        return operatorMetrics.mergeWith(new Metrics(ImmutableMap.of("Input distribution", TDigestHistogram.fromValue(inputPositions))));
     }
 
     public static Metrics getConnectorMetrics(Metrics connectorMetrics, long physicalInputReadTimeNanos)

--- a/core/trino-main/src/main/java/io/trino/operator/OperatorContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OperatorContext.java
@@ -514,7 +514,7 @@ public class OperatorContext
     public static Metrics getOperatorMetrics(Metrics operatorMetrics, long inputPositions, double cpuTimeSeconds, double wallTimeSeconds)
     {
         return operatorMetrics.mergeWith(new Metrics(ImmutableMap.of(
-                "Input distribution", TDigestHistogram.fromValue(inputPositions),
+                "Input rows distribution", TDigestHistogram.fromValue(inputPositions),
                 "CPU time distribution (s)", TDigestHistogram.fromValue(cpuTimeSeconds),
                 "Wall time distribution (s)", TDigestHistogram.fromValue(wallTimeSeconds))));
     }

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorPipelineSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorPipelineSourceOperator.java
@@ -57,6 +57,7 @@ import static io.trino.operator.WorkProcessor.ProcessState.Type.FINISHED;
 import static io.trino.operator.project.MergePages.mergePages;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class WorkProcessorPipelineSourceOperator
         implements SourceOperator
@@ -342,7 +343,11 @@ public class WorkProcessorPipelineSourceOperator
                         context.outputPositions.get(),
 
                         context.dynamicFilterSplitsProcessed.get(),
-                        getOperatorMetrics(context.metrics.get(), context.inputPositions.get()),
+                        getOperatorMetrics(
+                                context.metrics.get(),
+                                context.inputPositions.get(),
+                                new Duration(context.operatorTiming.getCpuNanos(), NANOSECONDS).convertTo(SECONDS).getValue(),
+                                new Duration(context.operatorTiming.getWallNanos(), NANOSECONDS).convertTo(SECONDS).getValue()),
                         getConnectorMetrics(context.connectorMetrics.get(), context.readTimeNanos.get()),
 
                         DataSize.ofBytes(0),

--- a/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorOperatorAdapter.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorOperatorAdapter.java
@@ -65,13 +65,13 @@ public class TestWorkProcessorOperatorAdapter
         operator.getOutput();
         assertThat(operator.isFinished()).isFalse();
         assertThat(getOnlyElement(context.getNestedOperatorStats()).getMetrics().getMetrics())
-                .hasSize(2)
+                .hasSize(4)
                 .containsEntry("testOperatorMetric", new LongCount(1));
 
         operator.getOutput();
         assertThat(operator.isFinished()).isTrue();
         assertThat(getOnlyElement(context.getNestedOperatorStats()).getMetrics().getMetrics())
-                .hasSize(2)
+                .hasSize(4)
                 .containsEntry("testOperatorMetric", new LongCount(2));
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorPipelineSourceOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorPipelineSourceOperator.java
@@ -205,14 +205,14 @@ public class TestWorkProcessorPipelineSourceOperator
         assertEquals(operatorStats.get(2).getOutputDataSize().toBytes(), 45);
 
         assertThat(operatorStats.get(1).getMetrics().getMetrics())
-                .hasSize(2)
+                .hasSize(4)
                 .containsEntry("testOperatorMetric", new LongCount(1));
 
         // assert source operator stats are correct
         OperatorStats sourceOperatorStats = operatorStats.get(0);
 
         assertThat(sourceOperatorStats.getMetrics().getMetrics())
-                .hasSize(3)
+                .hasSize(5)
                 .containsEntry("testSourceMetric", new LongCount(1))
                 .containsEntry("testSourceClosed", new LongCount(1));
         assertEquals(sourceOperatorStats.getConnectorMetrics().getMetrics(), ImmutableMap.of(
@@ -250,7 +250,7 @@ public class TestWorkProcessorPipelineSourceOperator
         // assert pipeline metrics
         List<OperatorStats> operatorSummaries = pipelineStats.getOperatorSummaries();
         assertThat(operatorSummaries.get(0).getMetrics().getMetrics())
-                .hasSize(3)
+                .hasSize(5)
                 .containsEntry("testSourceMetric", new LongCount(1))
                 .containsEntry("testSourceClosed", new LongCount(1));
         assertEquals(operatorSummaries.get(0).getConnectorMetrics().getMetrics(), ImmutableMap.of(
@@ -258,7 +258,7 @@ public class TestWorkProcessorPipelineSourceOperator
                 "testSourceConnectorClosed", new LongCount(1),
                 "Physical input read time", new DurationTiming(new Duration(7, NANOSECONDS))));
         assertThat(operatorSummaries.get(1).getMetrics().getMetrics())
-                .hasSize(2)
+                .hasSize(4)
                 .containsEntry("testOperatorMetric", new LongCount(1));
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorSourceOperatorAdapter.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorSourceOperatorAdapter.java
@@ -74,7 +74,7 @@ public class TestWorkProcessorSourceOperatorAdapter
         operator.getOutput();
         assertThat(operator.isFinished()).isFalse();
         assertThat(getOnlyElement(context.getNestedOperatorStats()).getMetrics().getMetrics())
-                .hasSize(2)
+                .hasSize(4)
                 .containsEntry("testOperatorMetric", new LongCount(1));
         assertThat(getOnlyElement(context.getNestedOperatorStats()).getConnectorMetrics().getMetrics()).isEqualTo(ImmutableMap.of(
                 "testConnectorMetric", new LongCount(2),
@@ -83,7 +83,7 @@ public class TestWorkProcessorSourceOperatorAdapter
         operator.getOutput();
         assertThat(operator.isFinished()).isTrue();
         assertThat(getOnlyElement(context.getNestedOperatorStats()).getMetrics().getMetrics())
-                .hasSize(2)
+                .hasSize(4)
                 .containsEntry("testOperatorMetric", new LongCount(2));
         assertThat(getOnlyElement(context.getNestedOperatorStats()).getConnectorMetrics().getMetrics()).isEqualTo(ImmutableMap.of(
                 "testConnectorMetric", new LongCount(3),

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/metrics/TDigestHistogram.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/metrics/TDigestHistogram.java
@@ -38,6 +38,18 @@ public class TDigestHistogram
     @JsonDeserialize(converter = Base64ToTDigestConverter.class)
     private final TDigest digest;
 
+    public static TDigestHistogram fromValue(double value)
+    {
+        return fromValue(value, 1);
+    }
+
+    public static TDigestHistogram fromValue(double value, double weight)
+    {
+        TDigest digest = new TDigest();
+        digest.add(value, weight);
+        return new TDigestHistogram(digest);
+    }
+
     @JsonCreator
     public TDigestHistogram(TDigest digest)
     {

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/metrics/TestMetrics.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/metrics/TestMetrics.java
@@ -50,14 +50,8 @@ public class TestMetrics
     @Test
     public void testMergeHistogram()
     {
-        TDigest d1 = new TDigest();
-        d1.add(10.0, 1);
-
-        TDigest d2 = new TDigest();
-        d2.add(5.0, 2);
-
-        Metrics m1 = new Metrics(ImmutableMap.of("a", new TDigestHistogram(d1)));
-        Metrics m2 = new Metrics(ImmutableMap.of("a", new TDigestHistogram(d2)));
+        Metrics m1 = new Metrics(ImmutableMap.of("a", TDigestHistogram.fromValue(10.0, 1)));
+        Metrics m2 = new Metrics(ImmutableMap.of("a", TDigestHistogram.fromValue(5.0, 2)));
         TDigestHistogram merged = (TDigestHistogram) merge(m1, m2).getMetrics().get("a");
 
         assertThat(merged.getTotal()).isEqualTo(3L);

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractDistributedEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractDistributedEngineOnlyQueries.java
@@ -223,7 +223,9 @@ public abstract class AbstractDistributedEngineOnlyQueries
     {
         assertExplainAnalyze(
                 "EXPLAIN ANALYZE VERBOSE SELECT * FROM nation a",
-                "'Input distribution' = \\{count=.*, p01=.*, p05=.*, p10=.*, p25=.*, p50=.*, p75=.*, p90=.*, p95=.*, p99=.*, min=.*, max=.*}");
+                "'Input distribution' = \\{count=.*, p01=.*, p05=.*, p10=.*, p25=.*, p50=.*, p75=.*, p90=.*, p95=.*, p99=.*, min=.*, max=.*}",
+                "'CPU time distribution \\(s\\)' = \\{count=.*, p01=.*, p05=.*, p10=.*, p25=.*, p50=.*, p75=.*, p90=.*, p95=.*, p99=.*, min=.*, max=.*}",
+                "'Wall time distribution \\(s\\)' = \\{count=.*, p01=.*, p05=.*, p10=.*, p25=.*, p50=.*, p75=.*, p90=.*, p95=.*, p99=.*, min=.*, max=.*}");
     }
 
     @Test

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractDistributedEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractDistributedEngineOnlyQueries.java
@@ -223,7 +223,7 @@ public abstract class AbstractDistributedEngineOnlyQueries
     {
         assertExplainAnalyze(
                 "EXPLAIN ANALYZE VERBOSE SELECT * FROM nation a",
-                "'Input distribution' = \\{count=.*, p01=.*, p05=.*, p10=.*, p25=.*, p50=.*, p75=.*, p90=.*, p95=.*, p99=.*, min=.*, max=.*}",
+                "'Input rows distribution' = \\{count=.*, p01=.*, p05=.*, p10=.*, p25=.*, p50=.*, p75=.*, p90=.*, p95=.*, p99=.*, min=.*, max=.*}",
                 "'CPU time distribution \\(s\\)' = \\{count=.*, p01=.*, p05=.*, p10=.*, p25=.*, p50=.*, p75=.*, p90=.*, p95=.*, p99=.*, min=.*, max=.*}",
                 "'Wall time distribution \\(s\\)' = \\{count=.*, p01=.*, p05=.*, p10=.*, p25=.*, p50=.*, p75=.*, p90=.*, p95=.*, p99=.*, min=.*, max=.*}");
     }


### PR DESCRIPTION
    Example

         └─ TableScan[table = hive:tpch_sf10_orc:lineitem]
                Layout: [orderkey:bigint]
                Estimates: {rows: 59986052 (514.86MB), cpu: 514.86M, memory: 0B, network: 0B}
                CPU: 9.15s (92.31%), Scheduled: 51.59s (98.29%), Blocked: 0.00ns (0.00%), Output: 59986052 rows (514.86MB)
                connector metrics:
                  'OrcReaderCompressionFormat_ZLIB' = LongCount{total=1615733235}
                  'Physical input read time' = {duration=23.22s}
                metrics:
                  'CPU distribution' = {count=49.00, p01=0.00, p05=0.00, p10=0.00, p25=0.03, p50=0.28, p75=0.33, p90=0.36, p95=0.37, p99=0.46, min=0.00, max=0.46}
                  'Input distribution' = {count=49.00, p01=0.00, p05=0.00, p10=0.00, p25=0.00, p50=2165818.63, p75=2323301.00, p90=2323409.00, p95=2323438.00, p99=2323474.00, min=0.00, max=
                  'Wall time distribution' = {count=49.00, p01=0.04, p05=0.13, p10=0.16, p25=0.45, p50=1.36, p75=1.81, p90=1.87, p95=1.87, p99=1.88, min=0.04, max=1.88
