### PR TITLE
remove old Kerberos ticket after relogin to make Kudu authentication work correctly

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/authentication/KerberosAuthentication.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/authentication/KerberosAuthentication.java
@@ -58,8 +58,11 @@ public class KerberosAuthentication
     public void attemptLogin(Subject subject)
     {
         try {
-            LoginContext loginContext = new LoginContext("", subject, null, configuration);
-            loginContext.login();
+            synchronized (subject.getPrivateCredentials()) {
+                subject.getPrivateCredentials().clear();
+                LoginContext loginContext = new LoginContext("", subject, null, configuration);
+                loginContext.login();
+            }
         }
         catch (LoginException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

A bugfix to make authentication work correctly on a Kerberized Kudu cluster. Old Kerberos tickets may be used to make Kudu connections, it may lead to Kudu `UnrecoverableException` being raised when query Kudu's data even though relogin recently. Besides, next ticket refresh time is calculated based on the ticket's `startTime` and `endTime`, a wrong result will lead to frequent access to the KDC. Remove old tickets after relogin can fix the issue.

This PR fixes #14372
fixes https://github.com/trinodb/trino/issues/14441

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Remove old Kerberos ticket to avoid authentication check failures when access Kerberized Kudu clusters.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix a bug in Kudu Kerberos ticket management. ({issue}`14372`)
```
