### PR TITLE
Add `register_table` procedure support for iceberg table

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -158,6 +158,9 @@ is used.
       materialized view definition. When the ``storage_schema`` materialized
       view property is specified, it takes precedence over this catalog property.
     - Empty
+  * - ``iceberg.register-table-procedure.enabled``
+    - Enable to allow user to call ``register_table`` procedure
+    - ``false``
 
 ORC format configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -747,6 +750,25 @@ Iceberg supports schema evolution, with safe column add, drop, reorder
 and rename operations, including in nested structures.
 Table partitioning can also be changed and the connector can still
 query data created before the partitioning change.
+
+Register table
+--------------
+The connector can register existing Iceberg tables with the catalog.
+
+An SQL procedure ``system.register_table`` allows the caller to register an existing Iceberg
+table in the metastore, using its existing metadata and data files::
+
+    CALL iceberg.system.register_table(schema_name => 'testdb', table_name => 'customer_orders', table_location => 'hdfs://hadoop-master:9000/user/hive/warehouse/customer_orders-581fad8517934af6be1857a903559d44')
+
+In addition, you can provide a file name to register a table
+with specific metadata. This may be used to register the table with
+some specific table state, or may be necessary if the connector cannot
+automatically figure out the metadata version to use::
+
+    CALL iceberg.system.register_table(schema_name => 'testdb', table_name => 'customer_orders', table_location => 'hdfs://hadoop-master:9000/user/hive/warehouse/customer_orders-581fad8517934af6be1857a903559d44', metadata_file_name => '00003-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json')
+
+To prevent unauthorized users from accessing data, this procedure is disabled by default.
+The procedure is enabled only when ``iceberg.register-table-procedure.enabled`` is set to ``true``.
 
 Migrating existing tables
 -------------------------

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -56,6 +56,7 @@ public class IcebergConfig
     private boolean tableStatisticsEnabled = true;
     private boolean extendedStatisticsEnabled;
     private boolean projectionPushdownEnabled = true;
+    private boolean registerTableProcedureEnabled;
     private Optional<String> hiveCatalogName = Optional.empty();
     private int formatVersion = FORMAT_VERSION_SUPPORT_MAX;
     private Duration expireSnapshotsMinRetention = new Duration(7, DAYS);
@@ -207,6 +208,19 @@ public class IcebergConfig
     public IcebergConfig setProjectionPushdownEnabled(boolean projectionPushdownEnabled)
     {
         this.projectionPushdownEnabled = projectionPushdownEnabled;
+        return this;
+    }
+
+    public boolean isRegisterTableProcedureEnabled()
+    {
+        return registerTableProcedureEnabled;
+    }
+
+    @Config("iceberg.register-table-procedure.enabled")
+    @ConfigDescription("Allow users to call the register_table procedure")
+    public IcebergConfig setRegisterTableProcedureEnabled(boolean registerTableProcedureEnabled)
+    {
+        this.registerTableProcedureEnabled = registerTableProcedureEnabled;
         return this;
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
@@ -28,6 +28,7 @@ import io.trino.plugin.hive.parquet.ParquetWriterConfig;
 import io.trino.plugin.iceberg.procedure.DropExtendedStatsTableProcedure;
 import io.trino.plugin.iceberg.procedure.ExpireSnapshotsTableProcedure;
 import io.trino.plugin.iceberg.procedure.OptimizeTableProcedure;
+import io.trino.plugin.iceberg.procedure.RegisterTableProcedure;
 import io.trino.plugin.iceberg.procedure.RemoveOrphanFilesTableProcedure;
 import io.trino.spi.connector.ConnectorNodePartitioningProvider;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
@@ -80,6 +81,7 @@ public class IcebergModule
 
         Multibinder<Procedure> procedures = newSetBinder(binder, Procedure.class);
         procedures.addBinding().toProvider(RollbackToSnapshotProcedure.class).in(Scopes.SINGLETON);
+        procedures.addBinding().toProvider(RegisterTableProcedure.class).in(Scopes.SINGLETON);
 
         Multibinder<TableProcedureMetadata> tableProcedures = newSetBinder(binder, TableProcedureMetadata.class);
         tableProcedures.addBinding().toProvider(OptimizeTableProcedure.class).in(Scopes.SINGLETON);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/TrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/TrinoCatalog.java
@@ -73,6 +73,8 @@ public interface TrinoCatalog
             String location,
             Map<String, String> properties);
 
+    void registerTable(ConnectorSession session, SchemaTableName tableName, String tableLocation, String metadataLocation);
+
     void dropTable(ConnectorSession session, SchemaTableName schemaTableName);
 
     void renameTable(ConnectorSession session, SchemaTableName from, SchemaTableName to);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -110,7 +110,9 @@ import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static org.apache.hadoop.hive.metastore.TableType.VIRTUAL_VIEW;
+import static org.apache.iceberg.BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE;
 import static org.apache.iceberg.BaseMetastoreTableOperations.METADATA_LOCATION_PROP;
+import static org.apache.iceberg.BaseMetastoreTableOperations.TABLE_TYPE_PROP;
 import static org.apache.iceberg.CatalogUtil.dropTableData;
 
 public class TrinoGlueCatalog
@@ -368,6 +370,17 @@ public class TrinoGlueCatalog
                 location,
                 properties,
                 Optional.of(session.getUser()));
+    }
+
+    @Override
+    public void registerTable(ConnectorSession session, SchemaTableName schemaTableName, String tableLocation, String metadataLocation)
+            throws TrinoException
+    {
+        TableInput tableInput = getTableInput(schemaTableName.getTableName(), Optional.of(session.getUser()), ImmutableMap.<String, String>builder()
+                .put(TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE.toUpperCase(ENGLISH))
+                .put(METADATA_LOCATION_PROP, metadataLocation)
+                .buildOrThrow());
+        createTable(schemaTableName.getSchemaName(), tableInput);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/RegisterTableProcedure.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/RegisterTableProcedure.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.procedure;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.filesystem.FileEntry;
+import io.trino.filesystem.FileIterator;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.plugin.iceberg.IcebergConfig;
+import io.trino.plugin.iceberg.catalog.TrinoCatalog;
+import io.trino.plugin.iceberg.catalog.TrinoCatalogFactory;
+import io.trino.spi.TrinoException;
+import io.trino.spi.classloader.ThreadContextClassLoader;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.procedure.Procedure;
+import org.apache.iceberg.TableMetadataParser;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.plugin.base.util.Procedures.checkProcedureArgument;
+import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_FILESYSTEM_ERROR;
+import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
+import static io.trino.plugin.iceberg.IcebergUtil.METADATA_FILE_EXTENSION;
+import static io.trino.plugin.iceberg.IcebergUtil.METADATA_FOLDER_NAME;
+import static io.trino.plugin.iceberg.IcebergUtil.parseVersion;
+import static io.trino.spi.StandardErrorCode.GENERIC_USER_ERROR;
+import static io.trino.spi.StandardErrorCode.PERMISSION_DENIED;
+import static io.trino.spi.StandardErrorCode.SCHEMA_NOT_FOUND;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.lang.String.format;
+import static java.lang.invoke.MethodHandles.lookup;
+import static java.util.Objects.requireNonNull;
+import static org.apache.iceberg.util.LocationUtil.stripTrailingSlash;
+
+public class RegisterTableProcedure
+        implements Provider<Procedure>
+{
+    private static final MethodHandle REGISTER_TABLE;
+
+    private static final String PROCEDURE_NAME = "register_table";
+    private static final String SYSTEM_SCHEMA = "system";
+
+    private static final String SCHEMA_NAME = "SCHEMA_NAME";
+    private static final String TABLE_NAME = "TABLE_NAME";
+    private static final String TABLE_LOCATION = "TABLE_LOCATION";
+    private static final String METADATA_FILE_NAME = "METADATA_FILE_NAME";
+
+    static {
+        try {
+            REGISTER_TABLE = lookup().unreflect(RegisterTableProcedure.class.getMethod("registerTable", ConnectorSession.class, String.class, String.class, String.class, String.class));
+        }
+        catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private final TrinoCatalogFactory catalogFactory;
+    private final TrinoFileSystemFactory fileSystemFactory;
+    private final ClassLoader classLoader;
+    private final boolean registerTableProcedureEnabled;
+
+    @Inject
+    public RegisterTableProcedure(TrinoCatalogFactory catalogFactory, TrinoFileSystemFactory fileSystemFactory, IcebergConfig icebergConfig)
+    {
+        this.catalogFactory = requireNonNull(catalogFactory, "catalogFactory is null");
+        this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
+        // this class is loaded by PluginClassLoader, and we need its reference to be stored
+        this.classLoader = getClass().getClassLoader();
+        this.registerTableProcedureEnabled = requireNonNull(icebergConfig, "icebergConfig is null").isRegisterTableProcedureEnabled();
+    }
+
+    @Override
+    public Procedure get()
+    {
+        return new Procedure(
+                SYSTEM_SCHEMA,
+                PROCEDURE_NAME,
+                ImmutableList.of(
+                        new Procedure.Argument(SCHEMA_NAME, VARCHAR),
+                        new Procedure.Argument(TABLE_NAME, VARCHAR),
+                        new Procedure.Argument(TABLE_LOCATION, VARCHAR),
+                        new Procedure.Argument(METADATA_FILE_NAME, VARCHAR, false, null)),
+                REGISTER_TABLE.bindTo(this));
+    }
+
+    public void registerTable(
+            ConnectorSession clientSession,
+            String schemaName,
+            String tableName,
+            String tableLocation,
+            String metadataFileName)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            doRegisterTable(
+                    clientSession,
+                    schemaName,
+                    tableName,
+                    tableLocation,
+                    Optional.ofNullable(metadataFileName));
+        }
+    }
+
+    private void doRegisterTable(
+            ConnectorSession clientSession,
+            String schemaName,
+            String tableName,
+            String tableLocation,
+            Optional<String> metadataFileName)
+    {
+        if (!registerTableProcedureEnabled) {
+            throw new TrinoException(PERMISSION_DENIED, "register_table procedure is disabled");
+        }
+        checkProcedureArgument(schemaName != null && !schemaName.isEmpty(), "schema_name cannot be null or empty");
+        checkProcedureArgument(tableName != null && !tableName.isEmpty(), "table_name cannot be null or empty");
+        checkProcedureArgument(tableLocation != null && !tableLocation.isEmpty(), "table_location cannot be null or empty");
+        metadataFileName.ifPresent(RegisterTableProcedure::validateMetadataFileName);
+
+        SchemaTableName schemaTableName = new SchemaTableName(schemaName, tableName);
+        TrinoCatalog catalog = catalogFactory.create(clientSession.getIdentity());
+        if (!catalog.namespaceExists(clientSession, schemaTableName.getSchemaName())) {
+            throw new TrinoException(SCHEMA_NOT_FOUND, format("Schema '%s' does not exist", schemaTableName.getSchemaName()));
+        }
+
+        TrinoFileSystem fileSystem = fileSystemFactory.create(clientSession);
+        String metadataLocation = getMetadataLocation(fileSystem, tableLocation, metadataFileName);
+        validateLocation(fileSystem, metadataLocation);
+        try {
+            // Try to read the metadata file. Invalid metadata file will throw the exception.
+            TableMetadataParser.read(fileSystem.toFileIo(), metadataLocation);
+        }
+        catch (RuntimeException e) {
+            throw new TrinoException(ICEBERG_INVALID_METADATA, metadataLocation + " is not a valid metadata file", e);
+        }
+
+        catalog.registerTable(clientSession, schemaTableName, tableLocation, metadataLocation);
+    }
+
+    private static void validateMetadataFileName(String fileName)
+    {
+        String metadataFileName = fileName.trim();
+        checkProcedureArgument(!metadataFileName.isEmpty(), "metadata_file_name cannot be empty when provided as an argument");
+        checkProcedureArgument(!metadataFileName.contains("/"), "%s is not a valid metadata file", metadataFileName);
+    }
+
+    /**
+     * Get the latest metadata file location present in location if metadataFileName is not provided, otherwise
+     * form the metadata file location using location and metadataFileName
+     */
+    private static String getMetadataLocation(TrinoFileSystem fileSystem, String location, Optional<String> metadataFileName)
+    {
+        return metadataFileName
+                .map(fileName -> format("%s/%s/%s", stripTrailingSlash(location), METADATA_FOLDER_NAME, fileName))
+                .orElseGet(() -> getLatestMetadataLocation(fileSystem, location));
+    }
+
+    public static String getLatestMetadataLocation(TrinoFileSystem fileSystem, String location)
+    {
+        List<String> latestMetadataLocations = new ArrayList<>();
+        String metadataDirectoryLocation = format("%s/%s", stripTrailingSlash(location), METADATA_FOLDER_NAME);
+        try {
+            int latestMetadataVersion = -1;
+            FileIterator fileIterator = fileSystem.listFiles(metadataDirectoryLocation);
+            while (fileIterator.hasNext()) {
+                FileEntry fileEntry = fileIterator.next();
+                if (fileEntry.path().contains(METADATA_FILE_EXTENSION)) {
+                    OptionalInt version = parseVersion(fileEntry.path());
+                    if (version.isPresent()) {
+                        int versionNumber = version.getAsInt();
+                        if (versionNumber > latestMetadataVersion) {
+                            latestMetadataVersion = versionNumber;
+                            latestMetadataLocations.clear();
+                            latestMetadataLocations.add(fileEntry.path());
+                        }
+                        else if (versionNumber == latestMetadataVersion) {
+                            latestMetadataLocations.add(fileEntry.path());
+                        }
+                    }
+                }
+            }
+            if (latestMetadataLocations.isEmpty()) {
+                throw new TrinoException(ICEBERG_INVALID_METADATA, "No versioned metadata file exists at location: " + metadataDirectoryLocation);
+            }
+            if (latestMetadataLocations.size() > 1) {
+                throw new TrinoException(ICEBERG_INVALID_METADATA, format(
+                        "More than one latest metadata file found at location: %s, latest metadata files are %s",
+                        metadataDirectoryLocation,
+                        latestMetadataLocations));
+            }
+        }
+        catch (IOException e) {
+            throw new TrinoException(ICEBERG_FILESYSTEM_ERROR, "Failed checking table's location: " + location, e);
+        }
+        return getOnlyElement(latestMetadataLocations);
+    }
+
+    private static void validateLocation(TrinoFileSystem fileSystem, String location)
+    {
+        try {
+            if (!fileSystem.newInputFile(location).exists()) {
+                throw new TrinoException(GENERIC_USER_ERROR, format("Location %s does not exist", location));
+            }
+        }
+        catch (IOException e) {
+            throw new TrinoException(ICEBERG_FILESYSTEM_ERROR, format("Invalid location: %s", location), e);
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
@@ -28,6 +28,7 @@ import java.util.stream.IntStream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
+import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newFixedThreadPool;
@@ -142,4 +143,182 @@ public abstract class BaseIcebergConnectorSmokeTest
             executor.awaitTermination(10, SECONDS);
         }
     }
+
+    @Test
+    public void testRegisterTableWithTableLocation()
+    {
+        String tableName = "test_register_table_with_table_location_" + randomTableSuffix();
+
+        assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean)", tableName));
+        assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
+        assertUpdate(format("INSERT INTO %s values(2, 'USA', false)", tableName), 1);
+
+        String tableLocation = getTableLocation(tableName);
+        // Drop table from hive metastore and use the same table name to register again with the metadata
+        dropTableFromMetastore(tableName);
+
+        assertUpdate("CALL system.register_table (CURRENT_SCHEMA, '" + tableName + "', '" + tableLocation + "')");
+
+        assertThat(query(format("SELECT * FROM %s", tableName)))
+                .matches("VALUES " +
+                        "ROW(INT '1', VARCHAR 'INDIA', BOOLEAN 'true'), " +
+                        "ROW(INT '2', VARCHAR 'USA', BOOLEAN 'false')");
+        assertUpdate(format("DROP TABLE %s", tableName));
+    }
+
+    @Test
+    public void testRegisterTableWithComments()
+    {
+        String tableName = "test_register_table_with_comments_" + randomTableSuffix();
+
+        assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean)", tableName));
+        assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
+        assertUpdate(format("COMMENT ON TABLE %s is 'my-table-comment'", tableName));
+        assertUpdate(format("COMMENT ON COLUMN %s.a is 'a-comment'", tableName));
+        assertUpdate(format("COMMENT ON COLUMN %s.b is 'b-comment'", tableName));
+        assertUpdate(format("COMMENT ON COLUMN %s.c is 'c-comment'", tableName));
+
+        String tableLocation = getTableLocation(tableName);
+        // Drop table from hive metastore and use the same table name to register again with the metadata
+        dropTableFromMetastore(tableName);
+
+        assertUpdate("CALL system.register_table (CURRENT_SCHEMA, '" + tableName + "', '" + tableLocation + "')");
+
+        assertThat(getTableComment(tableName)).isEqualTo("my-table-comment");
+        assertThat(getColumnComment(tableName, "a")).isEqualTo("a-comment");
+        assertThat(getColumnComment(tableName, "b")).isEqualTo("b-comment");
+        assertThat(getColumnComment(tableName, "c")).isEqualTo("c-comment");
+        assertUpdate(format("DROP TABLE %s", tableName));
+    }
+
+    @Test
+    public void testRegisterTableWithShowCreateTable()
+    {
+        String tableName = "test_register_table_with_show_create_table_" + randomTableSuffix();
+
+        assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean)", tableName));
+        assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
+
+        String tableLocation = getTableLocation(tableName);
+        String showCreateTableOld = (String) computeActual("SHOW CREATE TABLE " + tableName).getOnlyValue();
+        // Drop table from hive metastore and use the same table name to register again with the metadata
+        dropTableFromMetastore(tableName);
+
+        assertUpdate("CALL system.register_table (CURRENT_SCHEMA, '" + tableName + "', '" + tableLocation + "')");
+        String showCreateTableNew = (String) computeActual("SHOW CREATE TABLE " + tableName).getOnlyValue();
+
+        assertThat(showCreateTableOld).isEqualTo(showCreateTableNew);
+        assertUpdate(format("DROP TABLE %s", tableName));
+    }
+
+    @Test
+    public void testRegisterTableWithReInsert()
+    {
+        String tableName = "test_register_table_with_re_insert_" + randomTableSuffix();
+
+        assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean)", tableName));
+        assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
+        assertUpdate(format("INSERT INTO %s values(2, 'USA', false)", tableName), 1);
+
+        String tableLocation = getTableLocation(tableName);
+        // Drop table from hive metastore and use the same table name to register again with the metadata
+        dropTableFromMetastore(tableName);
+
+        assertUpdate("CALL system.register_table (CURRENT_SCHEMA, '" + tableName + "', '" + tableLocation + "')");
+        assertUpdate(format("INSERT INTO %s values(3, 'POLAND', true)", tableName), 1);
+
+        assertThat(query(format("SELECT * FROM %s", tableName)))
+                .matches("VALUES " +
+                        "ROW(INT '1', VARCHAR 'INDIA', BOOLEAN 'true'), " +
+                        "ROW(INT '2', VARCHAR 'USA', BOOLEAN 'false'), " +
+                        "ROW(INT '3', VARCHAR 'POLAND', BOOLEAN 'true')");
+        assertUpdate(format("DROP TABLE %s", tableName));
+    }
+
+    @Test
+    public void testRegisterTableWithDroppedTable()
+    {
+        String tableName = "test_register_table_with_dropped_table_" + randomTableSuffix();
+
+        assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean)", tableName));
+        assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
+
+        String tableLocation = getTableLocation(tableName);
+        String tableNameNew = tableName + "_new";
+        // Drop table to verify register_table call fails when no metadata can be found (table doesn't exist)
+        assertUpdate(format("DROP TABLE %s", tableName));
+
+        assertQueryFails(format("CALL system.register_table (CURRENT_SCHEMA, '%s', '%s')", tableNameNew, tableLocation),
+                ".*No versioned metadata file exists at location.*");
+    }
+
+    @Test
+    public void testRegisterTableWithDifferentTableName()
+    {
+        String tableName = "test_register_table_with_different_table_name_" + randomTableSuffix();
+
+        assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean)", tableName));
+        assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
+        assertUpdate(format("INSERT INTO %s values(2, 'USA', false)", tableName), 1);
+
+        String tableLocation = getTableLocation(tableName);
+        String tableNameNew = tableName + "_new";
+        // Drop table from glue metastore and use the same table name to register again with the metadata
+        dropTableFromMetastore(tableName);
+
+        assertUpdate(format("CALL system.register_table (CURRENT_SCHEMA, '%s', '%s')", tableNameNew, tableLocation));
+        assertUpdate(format("INSERT INTO %s values(3, 'POLAND', true)", tableNameNew), 1);
+
+        assertThat(query(format("SELECT * FROM %s", tableNameNew)))
+                .matches("VALUES " +
+                        "ROW(INT '1', VARCHAR 'INDIA', BOOLEAN 'true'), " +
+                        "ROW(INT '2', VARCHAR 'USA', BOOLEAN 'false'), " +
+                        "ROW(INT '3', VARCHAR 'POLAND', BOOLEAN 'true')");
+        assertUpdate(format("DROP TABLE %s", tableNameNew));
+    }
+
+    @Test
+    public void testRegisterTableWithMetadataFile()
+    {
+        String tableName = "test_register_table_with_metadata_file_" + randomTableSuffix();
+
+        assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean)", tableName));
+        assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
+        assertUpdate(format("INSERT INTO %s values(2, 'USA', false)", tableName), 1);
+
+        String tableLocation = getTableLocation(tableName);
+        String metadataLocation = getMetadataLocation(tableName);
+        String metadataFileName = metadataLocation.substring(metadataLocation.lastIndexOf("/") + 1);
+        // Drop table from hive metastore and use the same table name to register again with the metadata
+        dropTableFromMetastore(tableName);
+
+        assertUpdate("CALL iceberg.system.register_table (CURRENT_SCHEMA, '" + tableName + "', '" + tableLocation + "', '" + metadataFileName + "')");
+        assertUpdate(format("INSERT INTO %s values(3, 'POLAND', true)", tableName), 1);
+
+        assertThat(query(format("SELECT * FROM %s", tableName)))
+                .matches("VALUES " +
+                        "ROW(INT '1', VARCHAR 'INDIA', BOOLEAN 'true'), " +
+                        "ROW(INT '2', VARCHAR 'USA', BOOLEAN 'false'), " +
+                        "ROW(INT '3', VARCHAR 'POLAND', BOOLEAN 'true')");
+        assertUpdate(format("DROP TABLE %s", tableName));
+    }
+
+    private String getTableLocation(String tableName)
+    {
+        return (String) computeScalar("SELECT DISTINCT regexp_replace(\"$path\", '/[^/]*/[^/]*$', '') FROM " + tableName);
+    }
+
+    protected String getTableComment(String tableName)
+    {
+        return (String) computeScalar("SELECT comment FROM system.metadata.table_comments WHERE catalog_name = 'iceberg' AND schema_name = '" + getSession().getSchema().orElseThrow() + "' AND table_name = '" + tableName + "'");
+    }
+
+    protected String getColumnComment(String tableName, String columnName)
+    {
+        return (String) computeScalar("SELECT comment FROM information_schema.columns WHERE table_schema = '" + getSession().getSchema().orElseThrow() + "' AND table_name = '" + tableName + "' AND column_name = '" + columnName + "'");
+    }
+
+    protected abstract void dropTableFromMetastore(String tableName);
+
+    protected abstract String getMetadataLocation(String tableName);
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
@@ -58,7 +58,8 @@ public class TestIcebergConfig
                 .setDeleteSchemaLocationsFallback(false)
                 .setTargetMaxFileSize(DataSize.of(1, GIGABYTE))
                 .setMinimumAssignedSplitWeight(0.05)
-                .setMaterializedViewsStorageSchema(null));
+                .setMaterializedViewsStorageSchema(null)
+                .setRegisterTableProcedureEnabled(false));
     }
 
     @Test
@@ -83,6 +84,7 @@ public class TestIcebergConfig
                 .put("iceberg.target-max-file-size", "1MB")
                 .put("iceberg.minimum-assigned-split-weight", "0.01")
                 .put("iceberg.materialized-views.storage-schema", "mv_storage_schema")
+                .put("iceberg.register-table-procedure.enabled", "true")
                 .buildOrThrow();
 
         IcebergConfig expected = new IcebergConfig()
@@ -103,7 +105,8 @@ public class TestIcebergConfig
                 .setDeleteSchemaLocationsFallback(true)
                 .setTargetMaxFileSize(DataSize.of(1, MEGABYTE))
                 .setMinimumAssignedSplitWeight(0.01)
-                .setMaterializedViewsStorageSchema("mv_storage_schema");
+                .setMaterializedViewsStorageSchema("mv_storage_schema")
+                .setRegisterTableProcedureEnabled(true);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConnectorSmokeTest.java
@@ -13,15 +13,29 @@
  */
 package io.trino.plugin.iceberg;
 
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.testing.QueryRunner;
+import org.testng.annotations.AfterClass;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static io.trino.plugin.hive.metastore.file.FileHiveMetastore.createTestingFileHiveMetastore;
 import static org.apache.iceberg.FileFormat.ORC;
+import static org.assertj.core.api.Assertions.assertThat;
 
 // Redundant over TestIcebergOrcConnectorTest, but exists to exercise BaseConnectorSmokeTest
 // Some features like materialized views may be supported by Iceberg only.
 public class TestIcebergConnectorSmokeTest
         extends BaseIcebergConnectorSmokeTest
 {
+    private HiveMetastore metastore;
+    private File metastoreDir;
+
     public TestIcebergConnectorSmokeTest()
     {
         super(ORC);
@@ -31,8 +45,35 @@ public class TestIcebergConnectorSmokeTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
+        this.metastoreDir = Files.createTempDirectory("test_iceberg_table_smoke_test").toFile();
+        this.metastoreDir.deleteOnExit();
+        this.metastore = createTestingFileHiveMetastore(metastoreDir);
         return IcebergQueryRunner.builder()
                 .setInitialTables(REQUIRED_TPCH_TABLES)
+                .setMetastoreDirectory(metastoreDir)
+                .setIcebergProperties(ImmutableMap.of("iceberg.register-table-procedure.enabled", "true"))
                 .build();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+            throws IOException
+    {
+        deleteRecursively(metastoreDir.toPath(), ALLOW_INSECURE);
+    }
+
+    @Override
+    protected void dropTableFromMetastore(String tableName)
+    {
+        metastore.dropTable(getSession().getSchema().orElseThrow(), tableName, false);
+        assertThat(metastore.getTable(getSession().getSchema().orElseThrow(), tableName)).as("Table in metastore should be dropped").isEmpty();
+    }
+
+    @Override
+    protected String getMetadataLocation(String tableName)
+    {
+        return metastore
+                .getTable(getSession().getSchema().orElseThrow(), tableName).orElseThrow()
+                .getParameters().get("metadata_location");
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergDisabledRegisterTableProcedure.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergDisabledRegisterTableProcedure.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.testng.annotations.Test;
+
+public class TestIcebergDisabledRegisterTableProcedure
+        extends AbstractTestQueryFramework
+
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return IcebergQueryRunner.builder()
+                .build();
+    }
+
+    @Test
+    public void testDisabledRegisterTableProcedure()
+    {
+        assertQueryFails("CALL iceberg.system.register_table (CURRENT_SCHEMA, 'test_table', '/var/test/location/test_table/')",
+                "register_table procedure is disabled");
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergRegisterTableProcedure.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergRegisterTableProcedure.java
@@ -1,0 +1,417 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.filesystem.FileEntry;
+import io.trino.filesystem.FileIterator;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
+import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.TestingConnectorSession;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
+import static io.trino.plugin.hive.metastore.file.FileHiveMetastore.createTestingFileHiveMetastore;
+import static io.trino.plugin.iceberg.IcebergUtil.METADATA_FOLDER_NAME;
+import static io.trino.plugin.iceberg.procedure.RegisterTableProcedure.getLatestMetadataLocation;
+import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestIcebergRegisterTableProcedure
+        extends AbstractTestQueryFramework
+{
+    private HiveMetastore metastore;
+    private File metastoreDir;
+    private TrinoFileSystem fileSystem;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        metastoreDir = Files.createTempDirectory("test_iceberg_register_table").toFile();
+        metastoreDir.deleteOnExit();
+        metastore = createTestingFileHiveMetastore(metastoreDir);
+        fileSystem = new HdfsFileSystemFactory(HDFS_ENVIRONMENT).create(TestingConnectorSession.SESSION);
+        return IcebergQueryRunner.builder()
+                .setMetastoreDirectory(metastoreDir)
+                .setIcebergProperties(ImmutableMap.of("iceberg.register-table-procedure.enabled", "true"))
+                .build();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+            throws IOException
+    {
+        deleteRecursively(metastoreDir.toPath(), ALLOW_INSECURE);
+    }
+
+    @DataProvider
+    public static Object[][] fileFormats()
+    {
+        return Stream.of(IcebergFileFormat.values())
+                .map(icebergFileFormat -> new Object[] {icebergFileFormat})
+                .toArray(Object[][]::new);
+    }
+
+    @Test(dataProvider = "fileFormats")
+    public void testRegisterTableWithTableLocation(IcebergFileFormat icebergFileFormat)
+    {
+        String tableName = "test_register_table_with_table_location_" + icebergFileFormat.name().toLowerCase(ENGLISH) + "_" + randomTableSuffix();
+
+        assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean) with (format = '%s')", tableName, icebergFileFormat));
+        assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
+        assertUpdate(format("INSERT INTO %s values(2, 'USA', false)", tableName), 1);
+
+        String tableLocation = getTableLocation(tableName);
+        // Drop table from hive metastore and use the same table name to register again with the metadata
+        dropTableFromMetastore(tableName);
+
+        assertUpdate("CALL iceberg.system.register_table (CURRENT_SCHEMA, '" + tableName + "', '" + tableLocation + "')");
+
+        assertThat(query(format("SELECT * FROM %s", tableName)))
+                .matches("VALUES " +
+                        "ROW(INT '1', VARCHAR 'INDIA', BOOLEAN 'true'), " +
+                        "ROW(INT '2', VARCHAR 'USA', BOOLEAN 'false')");
+        assertUpdate(format("DROP TABLE %s", tableName));
+    }
+
+    @Test(dataProvider = "fileFormats")
+    public void testRegisterTableWithComments(IcebergFileFormat icebergFileFormat)
+    {
+        String tableName = "test_register_table_with_comments_" + icebergFileFormat.name().toLowerCase(ENGLISH) + "_" + randomTableSuffix();
+
+        assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean) with (format = '%s')", tableName, icebergFileFormat));
+        assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
+        assertUpdate(format("INSERT INTO %s values(2, 'USA', false)", tableName), 1);
+        assertUpdate(format("COMMENT ON TABLE %s is 'my-table-comment'", tableName));
+        assertUpdate(format("COMMENT ON COLUMN %s.a is 'a-comment'", tableName));
+        assertUpdate(format("COMMENT ON COLUMN %s.b is 'b-comment'", tableName));
+        assertUpdate(format("COMMENT ON COLUMN %s.c is 'c-comment'", tableName));
+
+        String tableLocation = getTableLocation(tableName);
+        // Drop table from hive metastore and use the same table name to register again with the metadata
+        dropTableFromMetastore(tableName);
+
+        assertUpdate("CALL iceberg.system.register_table (CURRENT_SCHEMA, '" + tableName + "', '" + tableLocation + "')");
+
+        assertThat(getTableComment(tableName)).isEqualTo("my-table-comment");
+        assertThat(getColumnComment(tableName, "a")).isEqualTo("a-comment");
+        assertThat(getColumnComment(tableName, "b")).isEqualTo("b-comment");
+        assertThat(getColumnComment(tableName, "c")).isEqualTo("c-comment");
+        assertUpdate(format("DROP TABLE %s", tableName));
+    }
+
+    @Test(dataProvider = "fileFormats")
+    public void testRegisterTableWithShowCreateTable(IcebergFileFormat icebergFileFormat)
+    {
+        String tableName = "test_register_table_with_show_create_table_" + icebergFileFormat.name().toLowerCase(ENGLISH) + "_" + randomTableSuffix();
+
+        assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean) with (format = '%s')", tableName, icebergFileFormat));
+        assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
+
+        String tableLocation = getTableLocation(tableName);
+        String showCreateTableOld = (String) computeActual("SHOW CREATE TABLE " + tableName).getOnlyValue();
+        // Drop table from hive metastore and use the same table name to register again with the metadata
+        dropTableFromMetastore(tableName);
+
+        assertUpdate("CALL system.register_table (CURRENT_SCHEMA, '" + tableName + "', '" + tableLocation + "')");
+        String showCreateTableNew = (String) computeActual("SHOW CREATE TABLE " + tableName).getOnlyValue();
+
+        assertThat(showCreateTableOld).isEqualTo(showCreateTableNew);
+        assertUpdate(format("DROP TABLE %s", tableName));
+    }
+
+    @Test(dataProvider = "fileFormats")
+    public void testRegisterTableWithReInsert(IcebergFileFormat icebergFileFormat)
+    {
+        String tableName = "test_register_table_with_re_insert_" + icebergFileFormat.name().toLowerCase(ENGLISH) + "_" + randomTableSuffix();
+
+        assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean) with (format = '%s')", tableName, icebergFileFormat));
+        assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
+        assertUpdate(format("INSERT INTO %s values(2, 'USA', false)", tableName), 1);
+
+        String tableLocation = getTableLocation(tableName);
+        // Drop table from hive metastore and use the same table name to register again with the metadata
+        dropTableFromMetastore(tableName);
+
+        assertUpdate("CALL system.register_table (CURRENT_SCHEMA, '" + tableName + "', '" + tableLocation + "')");
+        assertUpdate(format("INSERT INTO %s values(3, 'POLAND', true)", tableName), 1);
+
+        assertThat(query(format("SELECT * FROM %s", tableName)))
+                .matches("VALUES " +
+                        "ROW(INT '1', VARCHAR 'INDIA', BOOLEAN 'true'), " +
+                        "ROW(INT '2', VARCHAR 'USA', BOOLEAN 'false'), " +
+                        "ROW(INT '3', VARCHAR 'POLAND', BOOLEAN 'true')");
+        assertUpdate(format("DROP TABLE %s", tableName));
+    }
+
+    @Test(dataProvider = "fileFormats")
+    public void testRegisterTableWithDroppedTable(IcebergFileFormat icebergFileFormat)
+    {
+        String tableName = "test_register_table_with_dropped_table_" + icebergFileFormat.name().toLowerCase(ENGLISH) + "_" + randomTableSuffix();
+
+        assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean) with (format = '%s')", tableName, icebergFileFormat));
+        assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
+        assertUpdate(format("INSERT INTO %s values(2, 'USA', false)", tableName), 1);
+
+        String tableLocation = getTableLocation(tableName);
+        String tableNameNew = tableName + "_new";
+        // Drop table to verify register_table call fails when no metadata can be found (table doesn't exist)
+        assertUpdate(format("DROP TABLE %s", tableName));
+
+        assertQueryFails("CALL iceberg.system.register_table (CURRENT_SCHEMA, '" + tableNameNew + "', '" + tableLocation + "')",
+                ".*No versioned metadata file exists at location.*");
+    }
+
+    @Test(dataProvider = "fileFormats")
+    public void testRegisterTableWithDifferentTableName(IcebergFileFormat icebergFileFormat)
+    {
+        String tableName = "test_register_table_with_different_table_name_old_" + icebergFileFormat.name().toLowerCase(ENGLISH) + "_" + randomTableSuffix();
+
+        assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean) with (format = '%s')", tableName, icebergFileFormat));
+        assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
+        assertUpdate(format("INSERT INTO %s values(2, 'USA', false)", tableName), 1);
+
+        String tableLocation = getTableLocation(tableName);
+        String tableNameNew = tableName + "_new";
+        // Drop table from hive metastore and use the same table name to register again with the metadata
+        dropTableFromMetastore(tableName);
+
+        assertUpdate("CALL iceberg.system.register_table (CURRENT_SCHEMA, '" + tableNameNew + "', '" + tableLocation + "')");
+        assertUpdate(format("INSERT INTO %s values(3, 'POLAND', true)", tableNameNew), 1);
+
+        assertThat(query(format("SELECT * FROM %s", tableNameNew)))
+                .matches("VALUES " +
+                        "ROW(INT '1', VARCHAR 'INDIA', BOOLEAN 'true'), " +
+                        "ROW(INT '2', VARCHAR 'USA', BOOLEAN 'false'), " +
+                        "ROW(INT '3', VARCHAR 'POLAND', BOOLEAN 'true')");
+        assertUpdate(format("DROP TABLE %s", tableNameNew));
+    }
+
+    @Test(dataProvider = "fileFormats")
+    public void testRegisterTableWithMetadataFile(IcebergFileFormat icebergFileFormat)
+    {
+        String tableName = "test_register_table_with_metadata_file_" + icebergFileFormat.name().toLowerCase(ENGLISH) + "_" + randomTableSuffix();
+
+        assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean) with (format = '%s')", tableName, icebergFileFormat));
+        assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
+        assertUpdate(format("INSERT INTO %s values(2, 'USA', false)", tableName), 1);
+
+        String tableLocation = getTableLocation(tableName);
+        String metadataLocation = getLatestMetadataLocation(fileSystem, tableLocation);
+        String metadataFileName = metadataLocation.substring(metadataLocation.lastIndexOf("/") + 1);
+        // Drop table from hive metastore and use the same table name to register again with the metadata
+        dropTableFromMetastore(tableName);
+
+        assertUpdate("CALL iceberg.system.register_table (CURRENT_SCHEMA, '" + tableName + "', '" + tableLocation + "', '" + metadataFileName + "')");
+        assertUpdate(format("INSERT INTO %s values(3, 'POLAND', true)", tableName), 1);
+
+        assertThat(query(format("SELECT * FROM %s", tableName)))
+                .matches("VALUES " +
+                        "ROW(INT '1', VARCHAR 'INDIA', BOOLEAN 'true'), " +
+                        "ROW(INT '2', VARCHAR 'USA', BOOLEAN 'false'), " +
+                        "ROW(INT '3', VARCHAR 'POLAND', BOOLEAN 'true')");
+        assertUpdate(format("DROP TABLE %s", tableName));
+    }
+
+    @Test
+    public void testRegisterTableWithNoMetadataFile()
+            throws IOException
+    {
+        IcebergFileFormat icebergFileFormat = IcebergFileFormat.ORC;
+        String tableName = "test_register_table_with_no_metadata_file_" + icebergFileFormat.name().toLowerCase(ENGLISH) + "_" + randomTableSuffix();
+
+        assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean) with (format = '%s')", tableName, icebergFileFormat));
+        assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
+        assertUpdate(format("INSERT INTO %s values(2, 'USA', false)", tableName), 1);
+
+        String tableLocation = getTableLocation(tableName);
+        String tableNameNew = tableName + "_new";
+        // Delete files under metadata directory to verify register_table call fails
+        deleteRecursively(Path.of(tableLocation, METADATA_FOLDER_NAME), ALLOW_INSECURE);
+
+        assertQueryFails("CALL iceberg.system.register_table (CURRENT_SCHEMA, '" + tableNameNew + "', '" + tableLocation + "')",
+                ".*No versioned metadata file exists at location.*");
+        dropTableFromMetastore(tableName);
+        deleteRecursively(Path.of(tableLocation), ALLOW_INSECURE);
+    }
+
+    @Test
+    public void testRegisterTableWithInvalidMetadataFile()
+            throws IOException
+    {
+        String tableName = "test_register_table_with_invalid_metadata_file_" + randomTableSuffix();
+
+        assertUpdate(format("CREATE TABLE %s (a int, b varchar, c boolean)", tableName));
+        assertUpdate(format("INSERT INTO %s values(1, 'INDIA', true)", tableName), 1);
+        assertUpdate(format("INSERT INTO %s values(2, 'USA', false)", tableName), 1);
+
+        String tableLocation = getTableLocation(tableName);
+        String tableNameNew = tableName + "_new";
+        String metadataDirectoryLocation = format("%s/%s", tableLocation, METADATA_FOLDER_NAME);
+        FileIterator fileIterator = fileSystem.listFiles(metadataDirectoryLocation);
+        // Find one invalid metadata file inside metadata folder
+        String invalidMetadataFileName = "invalid-default.avro";
+        while (fileIterator.hasNext()) {
+            FileEntry fileEntry = fileIterator.next();
+            if (fileEntry.path().endsWith(".avro")) {
+                String file = fileEntry.path();
+                invalidMetadataFileName = file.substring(file.lastIndexOf("/") + 1);
+                break;
+            }
+        }
+
+        assertQueryFails("CALL iceberg.system.register_table (CURRENT_SCHEMA, '" + tableNameNew + "', '" + tableLocation + "', '" + invalidMetadataFileName + "')",
+                ".*is not a valid metadata file.*");
+        assertUpdate(format("DROP TABLE %s", tableName));
+    }
+
+    @Test
+    public void testRegisterTableWithNonExistingTableLocation()
+    {
+        String tableName = "test_register_table_with_non_existing_table_location_" + randomTableSuffix();
+        String tableLocation = "/test/iceberg/hive/warehouse/orders_5-581fad8517934af6be1857a903559d44";
+        assertQueryFails("CALL iceberg.system.register_table (CURRENT_SCHEMA, '" + tableName + "', '" + tableLocation + "')",
+                ".*No versioned metadata file exists at location.*");
+    }
+
+    @Test
+    public void testRegisterTableWithNonExistingMetadataFile()
+    {
+        String tableName = "test_register_table_with_non_existing_metadata_file_" + randomTableSuffix();
+        String nonExistingMetadataFileName = "00003-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json";
+        String tableLocation = "/test/iceberg/hive/warehouse/orders_5-581fad8517934af6be1857a903559d44";
+        assertQueryFails("CALL iceberg.system.register_table (CURRENT_SCHEMA, '" + tableName + "', '" + tableLocation + "', '" + nonExistingMetadataFileName + "')",
+                ".*Location (.*) does not exist.*");
+    }
+
+    @Test
+    public void testRegisterTableWithNonExistingSchema()
+    {
+        String tableLocation = "/test/iceberg/hive/orders_5-581fad8517934af6be1857a903559d44";
+        assertQueryFails("CALL iceberg.system.register_table ('invalid_schema', 'test_table', '" + tableLocation + "')",
+                ".*Schema '(.*)' does not exist.*");
+    }
+
+    @Test
+    public void testRegisterTableWithExistingTable()
+    {
+        String tableName = "test_register_table_with_existing_table_" + randomTableSuffix();
+
+        assertUpdate("CREATE TABLE " + tableName + " (a int, b varchar, c boolean)");
+        assertUpdate("INSERT INTO " + tableName + " values(1, 'INDIA', true)", 1);
+        String tableLocation = getTableLocation(tableName);
+
+        assertQueryFails("CALL iceberg.system.register_table (CURRENT_SCHEMA, '" + tableName + "', '" + tableLocation + "')",
+                ".*Table already exists.*");
+        assertUpdate(format("DROP TABLE %s", tableName));
+    }
+
+    @Test
+    public void testRegisterTableWithInvalidURIScheme()
+    {
+        String tableName = "test_register_table_with_invalid_uri_scheme_" + randomTableSuffix();
+        String nonExistedMetadataFileName = "00003-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json";
+        String tableLocation = "invalid://hadoop-master:9000/test/iceberg/hive/orders_5-581fad8517934af6be1857a903559d44";
+        assertQueryFails("CALL iceberg.system.register_table (CURRENT_SCHEMA, '" + tableName + "', '" + tableLocation + "', '" + nonExistedMetadataFileName + "')",
+                ".*Invalid location:.*");
+        assertQueryFails("CALL iceberg.system.register_table (CURRENT_SCHEMA, '" + tableName + "', '" + tableLocation + "')",
+                ".*Failed checking table's location:.*");
+    }
+
+    @Test
+    public void testRegisterTableWithInvalidParameter()
+    {
+        String tableName = "test_register_table_with_invalid_parameter_" + randomTableSuffix();
+        String tableLocation = "/test/iceberg/hive/table1/";
+
+        assertQueryFails(format("CALL iceberg.system.register_table (CURRENT_SCHEMA, '%s')", tableName),
+                ".*'TABLE_LOCATION' is missing.*");
+        assertQueryFails("CALL iceberg.system.register_table (CURRENT_SCHEMA)",
+                ".*'TABLE_NAME' is missing.*");
+        assertQueryFails("CALL iceberg.system.register_table ()",
+                ".*'SCHEMA_NAME' is missing.*");
+
+        assertQueryFails("CALL iceberg.system.register_table (null, null, null)",
+                ".*schema_name cannot be null or empty.*");
+        assertQueryFails("CALL iceberg.system.register_table (CURRENT_SCHEMA, null, null)",
+                ".*table_name cannot be null or empty.*");
+        assertQueryFails("CALL iceberg.system.register_table (CURRENT_SCHEMA, '" + tableName + "', null)",
+                ".*table_location cannot be null or empty.*");
+
+        assertQueryFails("CALL iceberg.system.register_table ('', '" + tableName + "', '" + tableLocation + "')",
+                ".*schema_name cannot be null or empty.*");
+        assertQueryFails("CALL iceberg.system.register_table (CURRENT_SCHEMA, '', '" + tableLocation + "')",
+                ".*table_name cannot be null or empty.*");
+        assertQueryFails("CALL iceberg.system.register_table (CURRENT_SCHEMA, '" + tableName + "', '')",
+                ".*table_location cannot be null or empty.*");
+        assertQueryFails("CALL iceberg.system.register_table (CURRENT_SCHEMA, '" + tableName + "', '" + tableLocation + "', '')",
+                ".*metadata_file_name cannot be empty when provided as an argument.*");
+    }
+
+    @Test
+    public void testRegisterTableWithInvalidMetadataFileName()
+    {
+        String tableName = "test_register_table_with_invalid_metadata_file_name_" + randomTableSuffix();
+        String tableLocation = "/test/iceberg/hive";
+
+        String[] invalidMetadataFileNames = {
+                "/",
+                "../",
+                "../../",
+                "../../somefile.metadata.json",
+        };
+
+        for (String invalidMetadataFileName : invalidMetadataFileNames) {
+            assertQueryFails("CALL iceberg.system.register_table (CURRENT_SCHEMA, '" + tableName + "', '" + tableLocation + "', '" + invalidMetadataFileName + "')",
+                    ".*is not a valid metadata file.*");
+        }
+    }
+
+    private String getTableLocation(String tableName)
+    {
+        return (String) computeScalar("SELECT DISTINCT regexp_replace(\"$path\", '/[^/]*/[^/]*$', '') FROM " + tableName);
+    }
+
+    private void dropTableFromMetastore(String tableName)
+    {
+        metastore.dropTable(getSession().getSchema().orElseThrow(), tableName, false);
+        assertThat(metastore.getTable(getSession().getSchema().orElseThrow(), tableName)).as("Table in metastore should be dropped").isEmpty();
+    }
+
+    private String getTableComment(String tableName)
+    {
+        return (String) computeScalar("SELECT comment FROM system.metadata.table_comments WHERE catalog_name = 'iceberg' AND schema_name = '" + getSession().getSchema().orElseThrow() + "' AND table_name = '" + tableName + "'");
+    }
+
+    private String getColumnComment(String tableName, String columnName)
+    {
+        return (String) computeScalar("SELECT comment FROM information_schema.columns WHERE table_schema = '" + getSession().getSchema().orElseThrow() + "' AND table_name = '" + tableName + "' AND column_name = '" + columnName + "'");
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergUtil.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergUtil.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import org.testng.annotations.Test;
+
+import java.util.OptionalInt;
+
+import static io.trino.plugin.iceberg.IcebergUtil.parseVersion;
+import static io.trino.testing.assertions.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestIcebergUtil
+{
+    @Test
+    public void testParseVersion()
+    {
+        assertEquals(parseVersion("hdfs://hadoop-master:9000/user/hive/warehouse/orders_5-581fad8517934af6be1857a903559d44/metadata/00000-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), OptionalInt.of(0));
+        assertEquals(parseVersion("hdfs://hadoop-master:9000/user/hive/warehouse/orders_5-581fad8517934af6be1857a903559d44/metadata/99999-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), OptionalInt.of(99999));
+        assertEquals(parseVersion("s3://krvikash-test/test_icerberg_util/orders_93p93eniuw-30fa27a68c734c2bafac881e905351a9/metadata/00010-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), OptionalInt.of(10));
+        assertEquals(parseVersion("/var/test/test_icerberg_util/orders_93p93eniuw-30fa27a68c734c2bafac881e905351a9/metadata/00011-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), OptionalInt.of(11));
+
+        assertThatThrownBy(() -> parseVersion("00010-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"))
+                .hasMessageMatching(".*Invalid metadata location: .*");
+        assertThatThrownBy(() -> parseVersion("hdfs://hadoop-master:9000/user/hive/warehouse/orders_5_581fad8517934af6be1857a903559d44"))
+                .hasMessageMatching(".*Invalid metadata location: .*");
+        assertThatThrownBy(() -> parseVersion("hdfs://hadoop-master:9000/user/hive/warehouse/orders_5-581fad8517934af6be1857a903559d44/metadata"))
+                .hasMessageMatching(".*Invalid metadata location:.*");
+        assertThatThrownBy(() -> parseVersion("s3://krvikash-test/test_icerberg_util/orders_93p93eniuw-30fa27a68c734c2bafac881e905351a9/metadata/00010_409702ba_4735_4645_8f14_09537cc0b2c8.metadata.json"))
+                .hasMessageMatching(".*Invalid metadata location:.*");
+        assertThatThrownBy(() -> parseVersion("orders_5_581fad8517934af6be1857a903559d44")).hasMessageMatching(".*Invalid metadata location:.*");
+
+        assertEquals(parseVersion("hdfs://hadoop-master:9000/user/hive/warehouse/orders_5-581fad8517934af6be1857a903559d44/metadata/00003_409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), OptionalInt.empty());
+        assertEquals(parseVersion("/var/test/test_icerberg_util/orders_93p93eniuw-30fa27a68c734c2bafac881e905351a9/metadata/-00010-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), OptionalInt.empty());
+    }
+}

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop/iceberg.properties
@@ -2,3 +2,4 @@ connector.name=iceberg
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
 iceberg.file-format=PARQUET
+iceberg.register-table-procedure.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg/iceberg.properties
@@ -1,2 +1,3 @@
 connector.name=iceberg
 hive.metastore.uri=thrift://hadoop-master:9083
+iceberg.register-table-procedure.enabled=true

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkDropTableCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkDropTableCompatibility.java
@@ -34,6 +34,7 @@ import static io.trino.tests.product.hive.Engine.SPARK;
 import static io.trino.tests.product.hive.Engine.TRINO;
 import static io.trino.tests.product.hive.util.TemporaryHiveTable.randomTableSuffix;
 import static io.trino.tests.product.iceberg.util.IcebergTestUtils.getTableLocation;
+import static io.trino.tests.product.iceberg.util.IcebergTestUtils.stripNamenodeURI;
 import static io.trino.tests.product.utils.QueryExecutors.onSpark;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
@@ -74,7 +75,7 @@ public class TestIcebergSparkDropTableCompatibility
         tableCreatorEngine.queryExecutor().executeQuery("CREATE TABLE " + tableName + "(col0 INT, col1 INT)");
         onTrino().executeQuery("INSERT INTO " + tableName + " VALUES (1, 2)");
 
-        String tableDirectory = getTableLocation(tableName);
+        String tableDirectory = stripNamenodeURI(getTableLocation(tableName));
         assertFileExistence(tableDirectory, true, "The table directory exists after creating the table");
         List<String> dataFilePaths = getDataFilePaths(tableName);
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/util/IcebergTestUtils.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/util/IcebergTestUtils.java
@@ -13,10 +13,8 @@
  */
 package io.trino.tests.product.iceberg.util;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.net.URI;
 
-import static com.google.common.base.Verify.verify;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 
 public final class IcebergTestUtils
@@ -25,13 +23,11 @@ public final class IcebergTestUtils
 
     public static String getTableLocation(String tableName)
     {
-        Pattern locationPattern = Pattern.compile(".*location = 'hdfs://hadoop-master:9000(.*?)'.*", Pattern.DOTALL);
-        Matcher m = locationPattern.matcher((String) onTrino().executeQuery("SHOW CREATE TABLE " + tableName).getOnlyValue());
-        if (m.find()) {
-            String location = m.group(1);
-            verify(!m.find(), "Unexpected second match");
-            return location;
-        }
-        throw new IllegalStateException("Location not found in SHOW CREATE TABLE result");
+        return (String) onTrino().executeQuery("SELECT DISTINCT regexp_replace(\"$path\", '/[^/]*/[^/]*$', '') FROM " + tableName).getOnlyValue();
+    }
+
+    public static String stripNamenodeURI(String location)
+    {
+        return URI.create(location).getPath();
     }
 }

--- a/testing/trino-server-dev/etc/catalog/iceberg.properties
+++ b/testing/trino-server-dev/etc/catalog/iceberg.properties
@@ -14,3 +14,4 @@ hive.hdfs.socks-proxy=localhost:1180
 
 # Fail-fast in development
 hive.metastore.thrift.client.max-retry-time=1s
+iceberg.register-table-procedure.enabled=true


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fixes https://github.com/trinodb/trino/issues/13552

Adding `register_table` procedure for iceberg connector to register table using existing metadata.

- Iceberg table will be created using provided table location
- Look for the latest metadata file ending with `.metadata.json` inside the `metadata` folder and use it for creating the table
- If provided location is invalid/does not exist then throw an exception
- If no metadata file exists inside provided table location then throw an exception
- If more than one metadata file exists with the latest sequence number then throw an exception
- `schema_name`, `table_name`, and `table_location` should be not-null and valid, Otherwise, the exception will be thrown
-  User can optionally provide the valid `metadata_file_location` (See the usage below)

Valid usages:
 - `register_table(schema_name => ..., table_name => ..., table_location => ...)`
 - `register_table(schema_name => ..., table_name => ..., table_location => ..., metadata_file_location => ...)`

 Sample Queries:
`CALL iceberg.system.register_table('default', 'src_22', 'hdfs://hadoop-master:9000/user/hive/warehouse/orders_5-581fad8517934af6be1857a903559d44');`
 
`CALL iceberg.system.register_table('default', 'src_22', 'hdfs://hadoop-master:9000/user/hive/warehouse/orders_5-581fad8517934af6be1857a903559d44', null);`

 `CALL iceberg.system.register_table('default', 'src_22', 'hdfs://hadoop-master:9000/user/hive/warehouse/orders_5-581fad8517934af6be1857a903559d44', '00003-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json');`

Test cases are added for success and failure scenarios in the following classes. 

- Flat File   -> `TestIcebergRegisterTableProcedure`
- AWS Glue, Minio, GCP -> `BaseIcebergConnectorSmokeTest`
- HDFS (Spark)  -> `TestIcebergSparkCompatibility`

Configuration:
By default `register_table` procedure is disabled. Enable procedure by setting `iceberg.register-table-procedure.enabled` to `true` in config.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

NA

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(X) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
