### PR TITLE
Fix PREPARE statements with qualified names

### DIFF
--- a/core/trino-parser/pom.xml
+++ b/core/trino-parser/pom.xml
@@ -25,6 +25,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -15,6 +15,7 @@ package io.trino.sql;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.trino.sql.tree.AddColumn;
 import io.trino.sql.tree.AliasedRelation;
 import io.trino.sql.tree.AllColumns;
@@ -140,12 +141,10 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.common.collect.Iterables.transform;
 import static io.trino.sql.ExpressionFormatter.formatExpression;
 import static io.trino.sql.ExpressionFormatter.formatGroupBy;
 import static io.trino.sql.ExpressionFormatter.formatOrderBy;
@@ -154,6 +153,7 @@ import static io.trino.sql.ExpressionFormatter.formatStringLiteral;
 import static io.trino.sql.ExpressionFormatter.formatWindowSpecification;
 import static io.trino.sql.RowPatternFormatter.formatPattern;
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
 public final class SqlFormatter
@@ -179,11 +179,35 @@ public final class SqlFormatter
     private static class Formatter
             extends AstVisitor<Void, Integer>
     {
-        private final StringBuilder builder;
+        private static class SqlBuilder
+        {
+            private final StringBuilder builder;
+
+            public SqlBuilder(StringBuilder builder)
+            {
+                this.builder = requireNonNull(builder, "builder is null");
+            }
+
+            @CanIgnoreReturnValue
+            public SqlBuilder append(CharSequence value)
+            {
+                builder.append(value);
+                return this;
+            }
+
+            @CanIgnoreReturnValue
+            public SqlBuilder append(char c)
+            {
+                builder.append(c);
+                return this;
+            }
+        }
+
+        private final SqlBuilder builder;
 
         public Formatter(StringBuilder builder)
         {
-            this.builder = builder;
+            this.builder = new SqlBuilder(builder);
         }
 
         @Override
@@ -251,8 +275,8 @@ public final class SqlFormatter
                 builder.append(node.getCopartitioning().stream()
                         .map(tableList -> tableList.stream()
                                 .map(SqlFormatter::formatName)
-                                .collect(Collectors.joining(", ", "(", ")")))
-                        .collect(Collectors.joining(", ")));
+                                .collect(joining(", ", "(", ")")))
+                        .collect(joining(", ")));
             }
             builder.append(")");
         }
@@ -330,7 +354,7 @@ public final class SqlFormatter
                             }
                             return formattedField;
                         })
-                        .collect(Collectors.joining(", ", "DESCRIPTOR(", ")")));
+                        .collect(joining(", ", "DESCRIPTOR(", ")")));
             }
             else {
                 builder.append("CAST (NULL AS DESCRIPTOR)");
@@ -343,7 +367,7 @@ public final class SqlFormatter
         protected Void visitPrepare(Prepare node, Integer indent)
         {
             append(indent, "PREPARE ");
-            builder.append(node.getName());
+            builder.append(formatExpression(node.getName()));
             builder.append(" FROM");
             builder.append("\n");
             process(node.getStatement(), indent + 1);
@@ -354,7 +378,7 @@ public final class SqlFormatter
         protected Void visitDeallocate(Deallocate node, Integer indent)
         {
             append(indent, "DEALLOCATE PREPARE ");
-            builder.append(node.getName());
+            builder.append(formatExpression(node.getName()));
             return null;
         }
 
@@ -362,11 +386,13 @@ public final class SqlFormatter
         protected Void visitExecute(Execute node, Integer indent)
         {
             append(indent, "EXECUTE ");
-            builder.append(node.getName());
+            builder.append(formatExpression(node.getName()));
             List<Expression> parameters = node.getParameters();
             if (!parameters.isEmpty()) {
                 builder.append(" USING ");
-                Joiner.on(", ").appendTo(builder, parameters);
+                builder.append(parameters.stream()
+                        .map(ExpressionFormatter::formatExpression)
+                        .collect(joining(", ")));
             }
             return null;
         }
@@ -375,7 +401,7 @@ public final class SqlFormatter
         protected Void visitDescribeOutput(DescribeOutput node, Integer indent)
         {
             append(indent, "DESCRIBE OUTPUT ");
-            builder.append(node.getName());
+            builder.append(formatExpression(node.getName()));
             return null;
         }
 
@@ -383,7 +409,7 @@ public final class SqlFormatter
         protected Void visitDescribeInput(DescribeInput node, Integer indent)
         {
             append(indent, "DESCRIBE INPUT ");
-            builder.append(node.getName());
+            builder.append(formatExpression(node.getName()));
             return null;
         }
 
@@ -704,9 +730,9 @@ public final class SqlFormatter
             processRelationSuffix(node.getRelation(), indent);
 
             builder.append(" TABLESAMPLE ")
-                    .append(node.getType())
+                    .append(node.getType().name())
                     .append(" (")
-                    .append(node.getSamplePercentage())
+                    .append(formatExpression(node.getSamplePercentage()))
                     .append(')');
 
             return null;
@@ -813,11 +839,11 @@ public final class SqlFormatter
         protected Void visitMerge(Merge node, Integer indent)
         {
             builder.append("MERGE INTO ")
-                    .append(node.getTargetTable().getName());
+                    .append(formatName(node.getTargetTable().getName()));
 
             node.getTargetAlias().ifPresent(value -> builder
                     .append(' ')
-                    .append(value));
+                    .append(formatExpression(value)));
             builder.append("\n");
 
             append(indent + 1, "USING ");
@@ -843,14 +869,15 @@ public final class SqlFormatter
             append(indent + 1, "THEN INSERT ");
 
             if (!node.getColumns().isEmpty()) {
-                builder.append("(");
-                Joiner.on(", ").appendTo(builder, node.getColumns());
-                builder.append(")");
+                builder.append(node.getColumns().stream()
+                        .map(ExpressionFormatter::formatExpression)
+                        .collect(joining(", ", "(", ")")));
             }
 
-            builder.append("VALUES (");
-            Joiner.on(", ").appendTo(builder, transform(node.getValues(), ExpressionFormatter::formatExpression));
-            builder.append(")");
+            builder.append("VALUES ");
+            builder.append(node.getValues().stream()
+                    .map(ExpressionFormatter::formatExpression)
+                    .collect(joining(", ", "(", ")")));
 
             return null;
         }
@@ -865,7 +892,7 @@ public final class SqlFormatter
             for (MergeUpdate.Assignment assignment : node.getAssignments()) {
                 builder.append("\n");
                 append(indent + 1, first ? "  " : ", ");
-                builder.append(assignment.getTarget())
+                builder.append(formatExpression(assignment.getTarget()))
                         .append(" = ")
                         .append(formatExpression(assignment.getValue()));
                 first = false;
@@ -907,7 +934,7 @@ public final class SqlFormatter
 
             node.getSecurity().ifPresent(security -> builder
                     .append(" SECURITY ")
-                    .append(security));
+                    .append(security.name()));
 
             builder.append(" AS\n");
 
@@ -920,9 +947,9 @@ public final class SqlFormatter
         protected Void visitRenameView(RenameView node, Integer indent)
         {
             builder.append("ALTER VIEW ")
-                    .append(node.getSource())
+                    .append(formatName(node.getSource()))
                     .append(" RENAME TO ")
-                    .append(node.getTarget());
+                    .append(formatName(node.getTarget()));
 
             return null;
         }
@@ -934,9 +961,9 @@ public final class SqlFormatter
             if (node.isExists()) {
                 builder.append("IF EXISTS ");
             }
-            builder.append(node.getSource())
+            builder.append(formatName(node.getSource()))
                     .append(" RENAME TO ")
-                    .append(node.getTarget());
+                    .append(formatName(node.getTarget()));
 
             return null;
         }
@@ -1029,9 +1056,8 @@ public final class SqlFormatter
             }
 
             if (!options.isEmpty()) {
-                builder.append("(");
-                Joiner.on(", ").appendTo(builder, options);
-                builder.append(")");
+                builder.append(options.stream()
+                        .collect(joining(", ", "(", ")")));
             }
 
             builder.append("\n");
@@ -1078,7 +1104,7 @@ public final class SqlFormatter
 
             node.getCatalog().ifPresent(catalog -> builder
                     .append(" FROM ")
-                    .append(node.getCatalog().get()));
+                    .append(formatExpression(node.getCatalog().get())));
 
             node.getLikePattern().ifPresent(value -> builder
                     .append(" LIKE ")
@@ -1412,9 +1438,9 @@ public final class SqlFormatter
             if (node.isExists()) {
                 builder.append("IF EXISTS ");
             }
-            builder.append(node.getSource())
+            builder.append(formatName(node.getSource()))
                     .append(" RENAME TO ")
-                    .append(node.getTarget());
+                    .append(formatName(node.getTarget()));
 
             return null;
         }
@@ -1459,19 +1485,19 @@ public final class SqlFormatter
             switch (node.getType()) {
                 case TABLE:
                     builder.append("COMMENT ON TABLE ")
-                            .append(node.getName())
+                            .append(formatName(node.getName()))
                             .append(" IS ")
                             .append(comment);
                     break;
                 case VIEW:
                     builder.append("COMMENT ON VIEW ")
-                            .append(node.getName())
+                            .append(formatName(node.getName()))
                             .append(" IS ")
                             .append(comment);
                     break;
                 case COLUMN:
                     builder.append("COMMENT ON COLUMN ")
-                            .append(node.getName())
+                            .append(formatName(node.getName()))
                             .append(" IS ")
                             .append(comment);
                     break;
@@ -1487,14 +1513,14 @@ public final class SqlFormatter
             if (node.isTableExists()) {
                 builder.append("IF EXISTS ");
             }
-            builder.append(node.getTable())
+            builder.append(formatName(node.getTable()))
                     .append(" RENAME COLUMN ");
             if (node.isColumnExists()) {
                 builder.append("IF EXISTS ");
             }
-            builder.append(node.getSource())
+            builder.append(formatExpression(node.getSource()))
                     .append(" TO ")
-                    .append(node.getTarget());
+                    .append(formatExpression(node.getTarget()));
 
             return null;
         }
@@ -1552,7 +1578,7 @@ public final class SqlFormatter
             if (node.isTableExists()) {
                 builder.append("IF EXISTS ");
             }
-            builder.append(node.getName())
+            builder.append(formatName(node.getName()))
                     .append(" ADD COLUMN ");
             if (node.isColumnNotExists()) {
                 builder.append("IF NOT EXISTS ");
@@ -1595,7 +1621,7 @@ public final class SqlFormatter
         protected Void visitUpdate(Update node, Integer indent)
         {
             builder.append("UPDATE ")
-                    .append(node.getTable().getName())
+                    .append(formatName(node.getTable().getName()))
                     .append(" SET");
             int setCounter = node.getAssignments().size() - 1;
             for (UpdateAssignment assignment : node.getAssignments()) {
@@ -1649,7 +1675,7 @@ public final class SqlFormatter
         protected Void visitCallArgument(CallArgument node, Integer indent)
         {
             node.getName().ifPresent(name -> builder
-                    .append(name)
+                    .append(formatExpression(name))
                     .append(" => "));
             builder.append(formatExpression(node.getValue()));
 
@@ -1660,7 +1686,7 @@ public final class SqlFormatter
         protected Void visitCall(Call node, Integer indent)
         {
             builder.append("CALL ")
-                    .append(node.getName())
+                    .append(formatName(node.getName()))
                     .append("(");
             formatCallArguments(indent, node.getArguments());
             builder.append(")");
@@ -1742,23 +1768,23 @@ public final class SqlFormatter
         @Override
         protected Void visitCreateRole(CreateRole node, Integer indent)
         {
-            builder.append("CREATE ROLE ").append(node.getName());
+            builder.append("CREATE ROLE ").append(formatExpression(node.getName()));
             node.getGrantor().ifPresent(grantor -> builder
                     .append(" WITH ADMIN ")
                     .append(formatGrantor(grantor)));
             node.getCatalog().ifPresent(catalog -> builder
                     .append(" IN ")
-                    .append(catalog));
+                    .append(formatExpression(catalog)));
             return null;
         }
 
         @Override
         protected Void visitDropRole(DropRole node, Integer indent)
         {
-            builder.append("DROP ROLE ").append(node.getName());
+            builder.append("DROP ROLE ").append(formatExpression(node.getName()));
             node.getCatalog().ifPresent(catalog -> builder
                     .append(" IN ")
-                    .append(catalog));
+                    .append(formatExpression(catalog)));
             return null;
         }
 
@@ -1781,7 +1807,7 @@ public final class SqlFormatter
                     .append(formatGrantor(grantor)));
             node.getCatalog().ifPresent(catalog -> builder
                     .append(" IN ")
-                    .append(catalog));
+                    .append(formatExpression(catalog)));
             return null;
         }
 
@@ -1804,7 +1830,7 @@ public final class SqlFormatter
                     .append(formatGrantor(grantor)));
             node.getCatalog().ifPresent(catalog -> builder
                     .append(" IN ")
-                    .append(catalog));
+                    .append(formatExpression(catalog)));
             return null;
         }
 
@@ -1816,17 +1842,17 @@ public final class SqlFormatter
             switch (type) {
                 case ALL:
                 case NONE:
-                    builder.append(type);
+                    builder.append(type.name());
                     break;
                 case ROLE:
-                    builder.append(node.getRole().get());
+                    builder.append(formatExpression(node.getRole().get()));
                     break;
                 default:
                     throw new IllegalArgumentException("Unsupported type: " + type);
             }
             node.getCatalog().ifPresent(catalog -> builder
                     .append(" IN ")
-                    .append(catalog));
+                    .append(formatExpression(catalog)));
             return null;
         }
 
@@ -1841,7 +1867,7 @@ public final class SqlFormatter
 
             builder.append(" ON ");
             node.getType().ifPresent(type -> builder
-                    .append(type)
+                    .append(type.name())
                     .append(' '));
             builder.append(formatName(node.getName()))
                     .append(" TO ")
@@ -1867,7 +1893,7 @@ public final class SqlFormatter
 
             builder.append(" ON ");
             if (node.getType().isPresent()) {
-                builder.append(node.getType().get());
+                builder.append(node.getType().get().name());
                 builder.append(" ");
             }
             builder.append(formatName(node.getName()))
@@ -1892,9 +1918,9 @@ public final class SqlFormatter
 
             builder.append(" ON ");
             node.getType().ifPresent(type -> builder
-                    .append(type)
+                    .append(type.name())
                     .append(' '));
-            builder.append(node.getName())
+            builder.append(formatName(node.getName()))
                     .append(" FROM ")
                     .append(formatPrincipal(node.getGrantee()));
 
@@ -1911,7 +1937,7 @@ public final class SqlFormatter
                 if (node.getTable()) {
                     builder.append("TABLE ");
                 }
-                builder.append(tableName);
+                builder.append(formatName(tableName));
             });
 
             return null;
@@ -1927,7 +1953,7 @@ public final class SqlFormatter
             builder.append("ROLES");
             node.getCatalog().ifPresent(catalog -> builder
                     .append(" FROM ")
-                    .append(catalog));
+                    .append(formatExpression(catalog)));
 
             return null;
         }
@@ -1938,7 +1964,7 @@ public final class SqlFormatter
             builder.append("SHOW ROLE GRANTS");
             node.getCatalog().ifPresent(catalog -> builder
                     .append(" FROM ")
-                    .append(catalog));
+                    .append(formatExpression(catalog)));
             return null;
         }
 
@@ -1963,7 +1989,7 @@ public final class SqlFormatter
             // TODO: handle this properly
             if (relation instanceof Table) {
                 builder.append("TABLE ")
-                        .append(((Table) relation).getName())
+                        .append(formatName(((Table) relation).getName()))
                         .append('\n');
             }
             else {
@@ -1971,7 +1997,7 @@ public final class SqlFormatter
             }
         }
 
-        private StringBuilder append(int indent, String value)
+        private SqlBuilder append(int indent, String value)
         {
             return builder.append(indentString(indent))
                     .append(value);
@@ -2001,12 +2027,12 @@ public final class SqlFormatter
         }
     }
 
-    private static void appendAliasColumns(StringBuilder builder, List<Identifier> columns)
+    private static void appendAliasColumns(Formatter.SqlBuilder builder, List<Identifier> columns)
     {
         if ((columns != null) && (!columns.isEmpty())) {
             String formattedColumns = columns.stream()
                     .map(ExpressionFormatter::formatExpression)
-                    .collect(Collectors.joining(", "));
+                    .collect(joining(", "));
 
             builder.append(" (")
                     .append(formattedColumns)

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -168,10 +168,15 @@ public final class SqlFormatter
         return builder.toString();
     }
 
+    private static String formatName(Identifier identifier)
+    {
+        return ExpressionFormatter.formatExpression(identifier);
+    }
+
     static String formatName(QualifiedName name)
     {
         return name.getOriginalParts().stream()
-                .map(SqlFormatter::formatExpression)
+                .map(SqlFormatter::formatName)
                 .collect(joining("."));
     }
 
@@ -179,6 +184,13 @@ public final class SqlFormatter
     {
         return ExpressionFormatter.formatExpression(expression);
     }
+
+    /**
+     * @deprecated Use {@link #formatName(Identifier)} instead.
+     */
+    @Deprecated
+    @SuppressWarnings("unused")
+    private static void formatExpression(Identifier identifier) {}
 
     private static class Formatter
             extends AstVisitor<Void, Integer>
@@ -290,7 +302,7 @@ public final class SqlFormatter
             for (int i = 0; i < arguments.size(); i++) {
                 TableFunctionArgument argument = arguments.get(i);
                 if (argument.getName().isPresent()) {
-                    append(indent, formatExpression(argument.getName().get()));
+                    append(indent, formatName(argument.getName().get()));
                     builder.append(" => ");
                 }
                 else {
@@ -320,7 +332,7 @@ public final class SqlFormatter
             if (relation instanceof AliasedRelation) {
                 AliasedRelation aliasedRelation = (AliasedRelation) relation;
                 builder.append(" AS ")
-                        .append(formatExpression(aliasedRelation.getAlias()));
+                        .append(formatName(aliasedRelation.getAlias()));
                 appendAliasColumns(builder, aliasedRelation.getColumnNames());
             }
             if (node.getPartitionBy().isPresent()) {
@@ -352,7 +364,7 @@ public final class SqlFormatter
             if (node.getDescriptor().isPresent()) {
                 builder.append(node.getDescriptor().get().getFields().stream()
                         .map(field -> {
-                            String formattedField = formatExpression(field.getName());
+                            String formattedField = formatName(field.getName());
                             if (field.getType().isPresent()) {
                                 formattedField = formattedField + " " + formatExpression(field.getType().get());
                             }
@@ -371,7 +383,7 @@ public final class SqlFormatter
         protected Void visitPrepare(Prepare node, Integer indent)
         {
             append(indent, "PREPARE ");
-            builder.append(formatExpression(node.getName()));
+            builder.append(formatName(node.getName()));
             builder.append(" FROM");
             builder.append("\n");
             process(node.getStatement(), indent + 1);
@@ -382,7 +394,7 @@ public final class SqlFormatter
         protected Void visitDeallocate(Deallocate node, Integer indent)
         {
             append(indent, "DEALLOCATE PREPARE ");
-            builder.append(formatExpression(node.getName()));
+            builder.append(formatName(node.getName()));
             return null;
         }
 
@@ -390,7 +402,7 @@ public final class SqlFormatter
         protected Void visitExecute(Execute node, Integer indent)
         {
             append(indent, "EXECUTE ");
-            builder.append(formatExpression(node.getName()));
+            builder.append(formatName(node.getName()));
             List<Expression> parameters = node.getParameters();
             if (!parameters.isEmpty()) {
                 builder.append(" USING ");
@@ -405,7 +417,7 @@ public final class SqlFormatter
         protected Void visitDescribeOutput(DescribeOutput node, Integer indent)
         {
             append(indent, "DESCRIBE OUTPUT ");
-            builder.append(formatExpression(node.getName()));
+            builder.append(formatName(node.getName()));
             return null;
         }
 
@@ -413,7 +425,7 @@ public final class SqlFormatter
         protected Void visitDescribeInput(DescribeInput node, Integer indent)
         {
             append(indent, "DESCRIBE INPUT ");
-            builder.append(formatExpression(node.getName()));
+            builder.append(formatName(node.getName()));
             return null;
         }
 
@@ -429,7 +441,7 @@ public final class SqlFormatter
                 Iterator<WithQuery> queries = with.getQueries().iterator();
                 while (queries.hasNext()) {
                     WithQuery query = queries.next();
-                    append(indent, formatExpression(query.getName()));
+                    append(indent, formatName(query.getName()));
                     query.getColumnNames().ifPresent(columnNames -> appendAliasColumns(builder, columnNames));
                     builder.append(" AS ");
                     process(new TableSubquery(query.getQuery()), indent);
@@ -473,7 +485,7 @@ public final class SqlFormatter
             if (!node.getWindows().isEmpty()) {
                 append(indent, "WINDOW");
                 formatDefinitionList(node.getWindows().stream()
-                        .map(definition -> formatExpression(definition.getName()) + " AS " + formatWindowSpecification(definition.getWindow()))
+                        .map(definition -> formatName(definition.getName()) + " AS " + formatWindowSpecification(definition.getWindow()))
                         .collect(toImmutableList()), indent + 1);
             }
 
@@ -553,7 +565,7 @@ public final class SqlFormatter
             builder.append(formatExpression(node.getExpression()));
             node.getAlias().ifPresent(alias -> builder
                     .append(' ')
-                    .append(formatExpression(alias)));
+                    .append(formatName(alias)));
 
             return null;
         }
@@ -569,7 +581,7 @@ public final class SqlFormatter
             if (!node.getAliases().isEmpty()) {
                 builder.append(" AS (")
                         .append(Joiner.on(", ").join(node.getAliases().stream()
-                                .map(SqlFormatter::formatExpression)
+                                .map(SqlFormatter::formatName)
                                 .collect(toImmutableList())))
                         .append(")");
             }
@@ -647,7 +659,7 @@ public final class SqlFormatter
             processRelationSuffix(node.getRelation(), indent);
 
             builder.append(' ')
-                    .append(formatExpression(node.getAlias()));
+                    .append(formatName(node.getAlias()));
             appendAliasColumns(builder, node.getColumnNames());
 
             return null;
@@ -671,7 +683,7 @@ public final class SqlFormatter
             if (!node.getMeasures().isEmpty()) {
                 append(indent + 1, "MEASURES");
                 formatDefinitionList(node.getMeasures().stream()
-                        .map(measure -> formatExpression(measure.getExpression()) + " AS " + formatExpression(measure.getName()))
+                        .map(measure -> formatExpression(measure.getExpression()) + " AS " + formatName(measure.getName()))
                         .collect(toImmutableList()), indent + 2);
             }
 
@@ -714,13 +726,13 @@ public final class SqlFormatter
             if (!node.getSubsets().isEmpty()) {
                 append(indent + 1, "SUBSET");
                 formatDefinitionList(node.getSubsets().stream()
-                        .map(subset -> formatExpression(subset.getName()) + " = " + subset.getIdentifiers().stream()
-                                .map(SqlFormatter::formatExpression).collect(joining(", ", "(", ")")))
+                        .map(subset -> formatName(subset.getName()) + " = " + subset.getIdentifiers().stream()
+                                .map(SqlFormatter::formatName).collect(joining(", ", "(", ")")))
                         .collect(toImmutableList()), indent + 2);
             }
             append(indent + 1, "DEFINE");
             formatDefinitionList(node.getVariableDefinitions().stream()
-                    .map(variable -> formatExpression(variable.getName()) + " AS " + formatExpression(variable.getExpression()))
+                    .map(variable -> formatName(variable.getName()) + " AS " + formatExpression(variable.getExpression()))
                     .collect(toImmutableList()), indent + 2);
 
             builder.append(")");
@@ -847,7 +859,7 @@ public final class SqlFormatter
 
             node.getTargetAlias().ifPresent(value -> builder
                     .append(' ')
-                    .append(formatExpression(value)));
+                    .append(formatName(value)));
             builder.append("\n");
 
             append(indent + 1, "USING ");
@@ -874,7 +886,7 @@ public final class SqlFormatter
 
             if (!node.getColumns().isEmpty()) {
                 builder.append(node.getColumns().stream()
-                        .map(SqlFormatter::formatExpression)
+                        .map(SqlFormatter::formatName)
                         .collect(joining(", ", "(", ")")));
             }
 
@@ -896,7 +908,7 @@ public final class SqlFormatter
             for (MergeUpdate.Assignment assignment : node.getAssignments()) {
                 builder.append("\n");
                 append(indent + 1, first ? "  " : ", ");
-                builder.append(formatExpression(assignment.getTarget()))
+                builder.append(formatName(assignment.getTarget()))
                         .append(" = ")
                         .append(formatExpression(assignment.getValue()));
                 first = false;
@@ -1108,7 +1120,7 @@ public final class SqlFormatter
 
             node.getCatalog().ifPresent(catalog -> builder
                     .append(" FROM ")
-                    .append(formatExpression(node.getCatalog().get())));
+                    .append(formatName(node.getCatalog().get())));
 
             node.getLikePattern().ifPresent(value -> builder
                     .append(" LIKE ")
@@ -1266,7 +1278,7 @@ public final class SqlFormatter
             builder.append("ALTER SCHEMA ")
                     .append(formatName(node.getSource()))
                     .append(" RENAME TO ")
-                    .append(formatExpression(node.getTarget()));
+                    .append(formatName(node.getTarget()));
 
             return null;
         }
@@ -1293,7 +1305,7 @@ public final class SqlFormatter
 
             node.getColumnAliases().ifPresent(columnAliases -> {
                 String columnList = columnAliases.stream()
-                        .map(SqlFormatter::formatExpression)
+                        .map(SqlFormatter::formatName)
                         .collect(joining(", "));
                 builder.append(format("( %s )", columnList));
             });
@@ -1366,7 +1378,7 @@ public final class SqlFormatter
 
             String propertyList = properties.stream()
                     .map(element -> INDENT +
-                            formatExpression(element.getName()) + " = " +
+                            formatName(element.getName()) + " = " +
                             (element.isSetToDefault() ? "DEFAULT" : formatExpression(element.getNonDefaultValue())))
                     .collect(joining(",\n"));
 
@@ -1385,7 +1397,7 @@ public final class SqlFormatter
         private String formatColumnDefinition(ColumnDefinition column)
         {
             StringBuilder builder = new StringBuilder()
-                    .append(formatExpression(column.getName()))
+                    .append(formatName(column.getName()))
                     .append(" ").append(column.getType());
             if (!column.isNullable()) {
                 builder.append(" NOT NULL");
@@ -1474,7 +1486,7 @@ public final class SqlFormatter
         private String joinProperties(List<Property> properties)
         {
             return properties.stream()
-                    .map(element -> formatExpression(element.getName()) + " = " +
+                    .map(element -> formatName(element.getName()) + " = " +
                             (element.isSetToDefault() ? "DEFAULT" : formatExpression(element.getNonDefaultValue())))
                     .collect(joining(", "));
         }
@@ -1522,9 +1534,9 @@ public final class SqlFormatter
             if (node.isColumnExists()) {
                 builder.append("IF EXISTS ");
             }
-            builder.append(formatExpression(node.getSource()))
+            builder.append(formatName(node.getSource()))
                     .append(" TO ")
-                    .append(formatExpression(node.getTarget()));
+                    .append(formatName(node.getTarget()));
 
             return null;
         }
@@ -1541,7 +1553,7 @@ public final class SqlFormatter
             if (node.isColumnExists()) {
                 builder.append("IF EXISTS ");
             }
-            builder.append(formatExpression(node.getColumn()));
+            builder.append(formatName(node.getColumn()));
 
             return null;
         }
@@ -1552,7 +1564,7 @@ public final class SqlFormatter
             builder.append("ALTER TABLE ");
             builder.append(formatName(node.getTable().getName()));
             builder.append(" EXECUTE ");
-            builder.append(formatExpression(node.getProcedureName()));
+            builder.append(formatName(node.getProcedureName()));
             if (!node.getArguments().isEmpty()) {
                 builder.append("(");
                 formatCallArguments(indent, node.getArguments());
@@ -1679,7 +1691,7 @@ public final class SqlFormatter
         protected Void visitCallArgument(CallArgument node, Integer indent)
         {
             node.getName().ifPresent(name -> builder
-                    .append(formatExpression(name))
+                    .append(formatName(name))
                     .append(" => "));
             builder.append(formatExpression(node.getValue()));
 
@@ -1772,23 +1784,23 @@ public final class SqlFormatter
         @Override
         protected Void visitCreateRole(CreateRole node, Integer indent)
         {
-            builder.append("CREATE ROLE ").append(formatExpression(node.getName()));
+            builder.append("CREATE ROLE ").append(formatName(node.getName()));
             node.getGrantor().ifPresent(grantor -> builder
                     .append(" WITH ADMIN ")
                     .append(formatGrantor(grantor)));
             node.getCatalog().ifPresent(catalog -> builder
                     .append(" IN ")
-                    .append(formatExpression(catalog)));
+                    .append(formatName(catalog)));
             return null;
         }
 
         @Override
         protected Void visitDropRole(DropRole node, Integer indent)
         {
-            builder.append("DROP ROLE ").append(formatExpression(node.getName()));
+            builder.append("DROP ROLE ").append(formatName(node.getName()));
             node.getCatalog().ifPresent(catalog -> builder
                     .append(" IN ")
-                    .append(formatExpression(catalog)));
+                    .append(formatName(catalog)));
             return null;
         }
 
@@ -1811,7 +1823,7 @@ public final class SqlFormatter
                     .append(formatGrantor(grantor)));
             node.getCatalog().ifPresent(catalog -> builder
                     .append(" IN ")
-                    .append(formatExpression(catalog)));
+                    .append(formatName(catalog)));
             return null;
         }
 
@@ -1834,7 +1846,7 @@ public final class SqlFormatter
                     .append(formatGrantor(grantor)));
             node.getCatalog().ifPresent(catalog -> builder
                     .append(" IN ")
-                    .append(formatExpression(catalog)));
+                    .append(formatName(catalog)));
             return null;
         }
 
@@ -1849,14 +1861,14 @@ public final class SqlFormatter
                     builder.append(type.name());
                     break;
                 case ROLE:
-                    builder.append(formatExpression(node.getRole().get()));
+                    builder.append(formatName(node.getRole().get()));
                     break;
                 default:
                     throw new IllegalArgumentException("Unsupported type: " + type);
             }
             node.getCatalog().ifPresent(catalog -> builder
                     .append(" IN ")
-                    .append(formatExpression(catalog)));
+                    .append(formatName(catalog)));
             return null;
         }
 
@@ -1957,7 +1969,7 @@ public final class SqlFormatter
             builder.append("ROLES");
             node.getCatalog().ifPresent(catalog -> builder
                     .append(" FROM ")
-                    .append(formatExpression(catalog)));
+                    .append(formatName(catalog)));
 
             return null;
         }
@@ -1968,7 +1980,7 @@ public final class SqlFormatter
             builder.append("SHOW ROLE GRANTS");
             node.getCatalog().ifPresent(catalog -> builder
                     .append(" FROM ")
-                    .append(formatExpression(catalog)));
+                    .append(formatName(catalog)));
             return null;
         }
 
@@ -2035,7 +2047,7 @@ public final class SqlFormatter
     {
         if ((columns != null) && (!columns.isEmpty())) {
             String formattedColumns = columns.stream()
-                    .map(SqlFormatter::formatExpression)
+                    .map(SqlFormatter::formatName)
                     .collect(joining(", "));
 
             builder.append(" (")

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -145,7 +145,6 @@ import java.util.Optional;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static io.trino.sql.ExpressionFormatter.formatExpression;
 import static io.trino.sql.ExpressionFormatter.formatGroupBy;
 import static io.trino.sql.ExpressionFormatter.formatOrderBy;
 import static io.trino.sql.ExpressionFormatter.formatSkipTo;
@@ -172,8 +171,13 @@ public final class SqlFormatter
     static String formatName(QualifiedName name)
     {
         return name.getOriginalParts().stream()
-                .map(ExpressionFormatter::formatExpression)
+                .map(SqlFormatter::formatExpression)
                 .collect(joining("."));
+    }
+
+    private static String formatExpression(Expression expression)
+    {
+        return ExpressionFormatter.formatExpression(expression);
     }
 
     private static class Formatter
@@ -237,7 +241,7 @@ public final class SqlFormatter
         {
             builder.append("UNNEST(")
                     .append(node.getExpressions().stream()
-                            .map(ExpressionFormatter::formatExpression)
+                            .map(SqlFormatter::formatExpression)
                             .collect(joining(", ")))
                     .append(")");
             if (node.isWithOrdinality()) {
@@ -323,7 +327,7 @@ public final class SqlFormatter
                 builder.append("\n");
                 append(indent, "PARTITION BY ")
                         .append(node.getPartitionBy().get().stream()
-                                .map(ExpressionFormatter::formatExpression)
+                                .map(SqlFormatter::formatExpression)
                                 .collect(joining(", ")));
             }
             if (node.isPruneWhenEmpty()) {
@@ -391,7 +395,7 @@ public final class SqlFormatter
             if (!parameters.isEmpty()) {
                 builder.append(" USING ");
                 builder.append(parameters.stream()
-                        .map(ExpressionFormatter::formatExpression)
+                        .map(SqlFormatter::formatExpression)
                         .collect(joining(", ")));
             }
             return null;
@@ -565,7 +569,7 @@ public final class SqlFormatter
             if (!node.getAliases().isEmpty()) {
                 builder.append(" AS (")
                         .append(Joiner.on(", ").join(node.getAliases().stream()
-                                .map(ExpressionFormatter::formatExpression)
+                                .map(SqlFormatter::formatExpression)
                                 .collect(toImmutableList())))
                         .append(")");
             }
@@ -658,7 +662,7 @@ public final class SqlFormatter
             if (!node.getPartitionBy().isEmpty()) {
                 append(indent + 1, "PARTITION BY ")
                         .append(node.getPartitionBy().stream()
-                                .map(ExpressionFormatter::formatExpression)
+                                .map(SqlFormatter::formatExpression)
                                 .collect(joining(", ")))
                         .append("\n");
             }
@@ -711,7 +715,7 @@ public final class SqlFormatter
                 append(indent + 1, "SUBSET");
                 formatDefinitionList(node.getSubsets().stream()
                         .map(subset -> formatExpression(subset.getName()) + " = " + subset.getIdentifiers().stream()
-                                .map(ExpressionFormatter::formatExpression).collect(joining(", ", "(", ")")))
+                                .map(SqlFormatter::formatExpression).collect(joining(", ", "(", ")")))
                         .collect(toImmutableList()), indent + 2);
             }
             append(indent + 1, "DEFINE");
@@ -870,13 +874,13 @@ public final class SqlFormatter
 
             if (!node.getColumns().isEmpty()) {
                 builder.append(node.getColumns().stream()
-                        .map(ExpressionFormatter::formatExpression)
+                        .map(SqlFormatter::formatExpression)
                         .collect(joining(", ", "(", ")")));
             }
 
             builder.append("VALUES ");
             builder.append(node.getValues().stream()
-                    .map(ExpressionFormatter::formatExpression)
+                    .map(SqlFormatter::formatExpression)
                     .collect(joining(", ", "(", ")")));
 
             return null;
@@ -1289,7 +1293,7 @@ public final class SqlFormatter
 
             node.getColumnAliases().ifPresent(columnAliases -> {
                 String columnList = columnAliases.stream()
-                        .map(ExpressionFormatter::formatExpression)
+                        .map(SqlFormatter::formatExpression)
                         .collect(joining(", "));
                 builder.append(format("( %s )", columnList));
             });
@@ -1980,7 +1984,7 @@ public final class SqlFormatter
         public Void visitSetTimeZone(SetTimeZone node, Integer indent)
         {
             builder.append("SET TIME ZONE ");
-            builder.append(node.getTimeZone().map(ExpressionFormatter::formatExpression).orElse("LOCAL"));
+            builder.append(node.getTimeZone().map(SqlFormatter::formatExpression).orElse("LOCAL"));
             return null;
         }
 
@@ -2031,7 +2035,7 @@ public final class SqlFormatter
     {
         if ((columns != null) && (!columns.isEmpty())) {
             String formattedColumns = columns.stream()
-                    .map(ExpressionFormatter::formatExpression)
+                    .map(SqlFormatter::formatExpression)
                     .collect(joining(", "));
 
             builder.append(" (")


### PR DESCRIPTION
`SqlFormatter` internally was using `StringBuilder`, allowing any `Object` to be output, leveraging `Object.toString`. However, many things, especially identifiers and qualified names, require special processing. Identifiers are typically output with
`ExpressionFormatter.formatExpression` and qualified names with `formatName`.  Sometimes these formatting methods were skipped. Previously, such problems were identified one by one, but it seems they were still present in the code base in quite a number. This commit wraps the `StringBuilder` with a custom narrow interface, preventing accidental use of `Object.toString` within `SqlFormatter`.

Relates to

https://github.com/trinodb/trino/issues/9822 / https://github.com/trinodb/trino/pull/9823
https://github.com/trinodb/trino/issues/14196 / https://github.com/trinodb/trino/pull/14276
https://github.com/trinodb/trino/issues/5433