### PR TITLE
Improve performance of Iceberg remove_orphan_files

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
@@ -404,8 +404,8 @@ public class TestIcebergMetadataFileOperations
                         .add(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM))
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH), 4)
                         .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM), 4)
-                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 24)
-                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 24)
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 6)
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 6)
                         .build());
 
         assertUpdate("DROP TABLE " + tableName);


### PR DESCRIPTION
## Description

Avoid reading manifests multiple times during the remove_orphan_files valid file set construction.

Fixes: https://github.com/trinodb/trino/issues/13691

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Reduce the file I/O required during remove_orphan_files

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Improve Iceberg `remove_orphan_files` performance. ({issue}`13691`)
```
