### PR TITLE
Store uppercase metastore table type property for Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergTableOperations.java
@@ -46,6 +46,7 @@ import static io.trino.plugin.hive.util.HiveUtil.isIcebergTable;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
 import static io.trino.plugin.iceberg.catalog.glue.GlueIcebergUtil.getTableInput;
 import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE;
 import static org.apache.iceberg.BaseMetastoreTableOperations.METADATA_LOCATION_PROP;
@@ -103,7 +104,7 @@ public class GlueIcebergTableOperations
         verify(version == -1, "commitNewTable called on a table which already exists");
         String newMetadataLocation = writeNewMetadata(metadata, 0);
         TableInput tableInput = getTableInput(tableName, owner, ImmutableMap.<String, String>builder()
-                        .put(TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE)
+                        .put(TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE.toUpperCase(ENGLISH))
                         .put(METADATA_LOCATION_PROP, newMetadataLocation)
                         .buildOrThrow());
 
@@ -119,7 +120,7 @@ public class GlueIcebergTableOperations
     {
         String newMetadataLocation = writeNewMetadata(metadata, version + 1);
         TableInput tableInput = getTableInput(tableName, owner, ImmutableMap.<String, String>builder()
-                .put(TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE)
+                .put(TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE.toUpperCase(ENGLISH))
                 .put(METADATA_LOCATION_PROP, newMetadataLocation)
                 .put(PREVIOUS_METADATA_LOCATION_PROP, currentMetadataLocation)
                 .buildOrThrow());

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/AbstractMetastoreTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/AbstractMetastoreTableOperations.java
@@ -37,6 +37,7 @@ import static io.trino.plugin.hive.metastore.PrincipalPrivileges.NO_PRIVILEGES;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
 import static io.trino.plugin.iceberg.IcebergUtil.isIcebergTable;
 import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE;
 import static org.apache.iceberg.BaseMetastoreTableOperations.METADATA_LOCATION_PROP;
@@ -101,7 +102,7 @@ public abstract class AbstractMetastoreTableOperations
                 .withStorage(storage -> storage.setStorageFormat(STORAGE_FORMAT))
                 // This is a must-have property for the EXTERNAL_TABLE table type
                 .setParameter("EXTERNAL", "TRUE")
-                .setParameter(TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE)
+                .setParameter(TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE.toUpperCase(ENGLISH))
                 .setParameter(METADATA_LOCATION_PROP, newMetadataLocation);
         String tableComment = metadata.properties().get(TABLE_COMMENT);
         if (tableComment != null) {


### PR DESCRIPTION
## Description

This matches the Iceberg catalog implementations for compatibility with Iceberg:

* [HiveTableOperations](https://github.com/apache/iceberg/blob/41bfb9c1eb7309d45296e687ef465b881bc7d91b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java#L470)
* [GlueTableOperations](https://github.com/apache/iceberg/blob/731e5f0aa27b374d7affd8d3512654b2212048dc/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java#L289)

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg connector
* Store metastore `table_type` property value as uppercase for compatibility
  with other Iceberg catalog implementations. ({issue}`14384`)
```
