### PR TITLE
Decrease a lock contention in PipelinedStageExecution

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedStageExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedStageExecution.java
@@ -237,13 +237,6 @@ public class PipelinedStageExecution
         }
     }
 
-    private synchronized boolean isFlushing()
-    {
-        // to transition to flushing, there must be at least one flushing task, and all others must be flushing or finished.
-        return !flushingTasks.isEmpty()
-                && allTasks.stream().allMatch(taskId -> finishedTasks.contains(taskId) || flushingTasks.contains(taskId));
-    }
-
     @Override
     public synchronized void schedulingComplete(PlanNodeId partitionedSource)
     {
@@ -387,6 +380,13 @@ public class PipelinedStageExecution
                 stateMachine.transitionToFinished();
             }
         }
+    }
+
+    private synchronized boolean isStageFlushing()
+    {
+        // to transition to flushing, there must be at least one flushing task, and all others must be flushing or finished.
+        return !flushingTasks.isEmpty()
+                && allTasks.stream().allMatch(taskId -> finishedTasks.contains(taskId) || flushingTasks.contains(taskId));
     }
 
     private ExecutionFailureInfo rewriteTransportFailure(ExecutionFailureInfo executionFailureInfo)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
We observed that there is a high lock contention on `io.trino.execution.scheduler.PipelinedStageExecution`'s monitor.
Lock contention before:

![new_master](https://user-images.githubusercontent.com/94364205/188837920-01944e21-8723-4fc3-a80f-0e4b9b3a9457.png)

Lock contention after:

![Screenshot 2022-09-30 at 11 53 50](https://user-images.githubusercontent.com/94364205/193244880-8572b383-424a-4816-b879-31e229dea6e1.png)

We measured the throughput (80 trino workers, 40 r5.4xlarge nodes, 64 concurrent queries) before/after

Throughput (queries/h) before:
**6000 queries / h**

Throughput (queries/h) after:
**6600 queries / h** (10% difference)


<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation
The Trino is able to process more queries within one hour.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(* ) Release notes are required, with the following suggested text:
Increase throughput when running highly concurrent workloads on big Trino clusters

