### PR TITLE
Print stage output buffer utilization in EXPLAIN ANALYZE VERBOSE

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
@@ -520,15 +520,15 @@ public class PlanPrinter
         }
 
         builder.append(
-                new PlanPrinter(
-                        fragment.getRoot(),
-                        typeProvider,
-                        tableInfoSupplier,
-                        dynamicFilterDomainStats,
-                        valuePrinter,
-                        fragment.getStatsAndCosts(),
-                        planNodeStats,
-                        anonymizer).toText(verbose, 1))
+                        new PlanPrinter(
+                                fragment.getRoot(),
+                                typeProvider,
+                                tableInfoSupplier,
+                                dynamicFilterDomainStats,
+                                valuePrinter,
+                                fragment.getStatsAndCosts(),
+                                planNodeStats,
+                                anonymizer).toText(verbose, 1))
                 .append("\n");
 
         return builder.toString();
@@ -1780,12 +1780,12 @@ public class PlanPrinter
         private String formatOrderingScheme(OrderingScheme orderingScheme, int preSortedOrderPrefix)
         {
             List<String> orderBy = Stream.concat(
-                    orderingScheme.getOrderBy().stream()
-                            .limit(preSortedOrderPrefix)
-                            .map(symbol -> "<" + anonymizer.anonymize(symbol) + " " + orderingScheme.getOrdering(symbol) + ">"),
-                    orderingScheme.getOrderBy().stream()
-                            .skip(preSortedOrderPrefix)
-                            .map(symbol -> anonymizer.anonymize(symbol) + " " + orderingScheme.getOrdering(symbol)))
+                            orderingScheme.getOrderBy().stream()
+                                    .limit(preSortedOrderPrefix)
+                                    .map(symbol -> "<" + anonymizer.anonymize(symbol) + " " + orderingScheme.getOrdering(symbol) + ">"),
+                            orderingScheme.getOrderBy().stream()
+                                    .skip(preSortedOrderPrefix)
+                                    .map(symbol -> anonymizer.anonymize(symbol) + " " + orderingScheme.getOrdering(symbol)))
                     .collect(toImmutableList());
             return formatCollection(orderBy, Objects::toString);
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
@@ -34,6 +34,7 @@ import io.trino.execution.TableInfo;
 import io.trino.metadata.FunctionManager;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.TableHandle;
+import io.trino.plugin.base.metrics.TDigestHistogram;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.expression.FunctionName;
 import io.trino.spi.predicate.Domain;
@@ -483,6 +484,22 @@ public class PlanPrinter
                             formatDouble(sdAmongTasks),
                             formatPositions(stageStats.getOutputPositions()),
                             stageStats.getOutputDataSize()));
+            Optional<TDigestHistogram> outputBufferUtilization = stageInfo.get().getStageStats().getOutputBufferUtilization();
+            if (verbose && outputBufferUtilization.isPresent()) {
+                builder.append(indentString(1))
+                        .append(format("Output buffer utilization distribution (%%): {p01=%s, p05=%s, p10=%s, p25=%s, p50=%s, p75=%s, p90=%s, p95=%s, p99=%s, max=%s}\n",
+                                // scale ratio to percentages
+                                formatDouble(outputBufferUtilization.get().getP01() * 100),
+                                formatDouble(outputBufferUtilization.get().getP05() * 100),
+                                formatDouble(outputBufferUtilization.get().getP10() * 100),
+                                formatDouble(outputBufferUtilization.get().getP25() * 100),
+                                formatDouble(outputBufferUtilization.get().getP50() * 100),
+                                formatDouble(outputBufferUtilization.get().getP75() * 100),
+                                formatDouble(outputBufferUtilization.get().getP90() * 100),
+                                formatDouble(outputBufferUtilization.get().getP95() * 100),
+                                formatDouble(outputBufferUtilization.get().getP99() * 100),
+                                formatDouble(outputBufferUtilization.get().getMax() * 100)));
+            }
         }
 
         PartitioningScheme partitioningScheme = fragment.getPartitioningScheme();

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/TestDistributedFaultTolerantEngineOnlyQueries.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/TestDistributedFaultTolerantEngineOnlyQueries.java
@@ -62,6 +62,13 @@ public class TestDistributedFaultTolerantEngineOnlyQueries
 
     @Override
     @Test(enabled = false)
+    public void testExplainAnalyzeVerbose()
+    {
+        // Spooling exchange does not prove output buffer utilization histogram
+    }
+
+    @Override
+    @Test(enabled = false)
     public void testSelectiveLimit()
     {
         // FTE mode does not terminate query when limit is reached

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractDistributedEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractDistributedEngineOnlyQueries.java
@@ -225,7 +225,8 @@ public abstract class AbstractDistributedEngineOnlyQueries
                 "EXPLAIN ANALYZE VERBOSE SELECT * FROM nation a",
                 "'Input rows distribution' = \\{count=.*, p01=.*, p05=.*, p10=.*, p25=.*, p50=.*, p75=.*, p90=.*, p95=.*, p99=.*, min=.*, max=.*}",
                 "'CPU time distribution \\(s\\)' = \\{count=.*, p01=.*, p05=.*, p10=.*, p25=.*, p50=.*, p75=.*, p90=.*, p95=.*, p99=.*, min=.*, max=.*}",
-                "'Wall time distribution \\(s\\)' = \\{count=.*, p01=.*, p05=.*, p10=.*, p25=.*, p50=.*, p75=.*, p90=.*, p95=.*, p99=.*, min=.*, max=.*}");
+                "'Wall time distribution \\(s\\)' = \\{count=.*, p01=.*, p05=.*, p10=.*, p25=.*, p50=.*, p75=.*, p90=.*, p95=.*, p99=.*, min=.*, max=.*}",
+                "Output buffer utilization distribution \\(%\\): \\{p01=.*, p05=.*, p10=.*, p25=.*, p50=.*, p75=.*, p90=.*, p95=.*, p99=.*, max=.*}");
     }
 
     @Test


### PR DESCRIPTION
    Example
     Fragment 4 [SOURCE]
         CPU: 15.09s, Scheduled: 58.13s, Blocked 28.63s (Input: 0.00ns, Output: 28.63s), Input: 59986052 rows (514.86MB); per task: avg.: 59986052.00 std.dev.: 0.00, Output: 59986052 rows (
         Output buffer utilization distribution (%): {p01=0.00, p05=0.00, p10=0.00, p25=20.89, p50=74.91, p75=98.63, p90=106.80, p95=109.06, p99=119.41, max=126.03}
         ...