### PR TITLE
Improve Pinot broker query failure message

### DIFF
--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotClient.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotClient.java
@@ -547,10 +547,13 @@ public class PinotClient
             if (response.getExceptionsSize() > 0 && response.getProcessingExceptions() != null && !response.getProcessingExceptions().isEmpty()) {
                 // Pinot is known to return exceptions with benign errorcodes like 200
                 // so we treat any exception as an error
+                String processingExceptionMessage = response.getProcessingExceptions().stream()
+                        .map(e -> "code: '%s' message: '%s'".formatted(e.getErrorCode(), e.getMessage()))
+                        .collect(joining(","));
                 throw new PinotException(
                         PINOT_EXCEPTION,
                         Optional.of(query.getQuery()),
-                        format("Query %s encountered exception %s", query.getQuery(), response.getProcessingExceptions().get(0)));
+                        format("Query %s encountered exception %s", query.getQuery(), processingExceptionMessage));
             }
             if (response.getNumServersQueried() == 0 || response.getNumServersResponded() == 0 || response.getNumServersQueried() > response.getNumServersResponded()) {
                 throw new PinotInsufficientServerResponseException(query, response.getNumServersResponded(), response.getNumServersQueried());

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/BasePinotIntegrationConnectorSmokeTest.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/BasePinotIntegrationConnectorSmokeTest.java
@@ -1312,7 +1312,7 @@ public abstract class BasePinotIntegrationConnectorSmokeTest
         // Pinot broker requests do not handle limits greater than Integer.MAX_VALUE
         // Note that -2147483648 is due to an integer overflow in Pinot: https://github.com/apache/pinot/issues/7242
         assertQueryFails("SELECT * FROM \"SELECT string_col, long_col FROM " + ALL_TYPES_TABLE + " LIMIT " + ((long) Integer.MAX_VALUE + 1) + "\"",
-                "Query select \"string_col\", \"long_col\" from alltypes limit -2147483648 encountered exception org.apache.pinot.common.response.broker.QueryProcessingException@\\w+ with query \"select \"string_col\", \"long_col\" from alltypes limit -2147483648\"");
+                "(?s)Query select \"string_col\", \"long_col\" from alltypes limit -2147483648 encountered exception .* with query \"select \"string_col\", \"long_col\" from alltypes limit -2147483648\"");
 
         List<String> tooManyBrokerRowsTableValues = new ArrayList<>();
         for (int i = 0; i < MAX_ROWS_PER_SPLIT_FOR_BROKER_QUERIES; i++) {


### PR DESCRIPTION
## Description

Currently, it provides unhelpful message. 
```
Caused by: io.trino.testing.QueryFailedException: Query select sum("regionkey") from nation encountered exception org.apache.pinot.common.response.broker.QueryProcessingException@7cddcbeb with query "select sum("regionkey") from nation"
	at io.trino.testing.AbstractTestingTrinoClient.execute(AbstractTestingTrinoClient.java:123)
	at io.trino.testing.DistributedQueryRunner.execute(DistributedQueryRunner.java:480)
	at io.trino.testing.QueryAssertions.assertQuery(QueryAssertions.java:147)
	... 17 more
	Suppressed: java.lang.Exception: SQL: SELECT sum(regionkey) FROM nation
		at io.trino.testing.DistributedQueryRunner.execute(DistributedQueryRunner.java:483)
		... 18 more
Caused by: io.trino.plugin.pinot.PinotException: Query select sum("regionkey") from nation encountered exception org.apache.pinot.common.response.broker.QueryProcessingException@7cddcbeb with query "select sum("regionkey") from nation"
	at io.trino.plugin.pinot.client.PinotClient.lambda$submitBrokerQueryJson$6(PinotClient.java:553)
	at io.trino.plugin.pinot.client.PinotClient.doWithRetries(PinotClient.java:621)
	at io.trino.plugin.pinot.client.PinotClient.submitBrokerQueryJson(PinotClient.java:533)
	at io.trino.plugin.pinot.client.PinotClient.createResultIterator(PinotClient.java:578)
	at io.trino.plugin.pinot.PinotBrokerPageSource.getNextPage(PinotBrokerPageSource.java:112)
	at io.trino.operator.TableScanOperator.getOutput(TableScanOperator.java:311)
	at io.trino.operator.Driver.processInternal(Driver.java:411)
	at io.trino.operator.Driver.lambda$process$10(Driver.java:314)
	at io.trino.operator.Driver.tryWithLock(Driver.java:706)
	at io.trino.operator.Driver.process(Driver.java:306)
	at io.trino.operator.Driver.processForDuration(Driver.java:277)
	at io.trino.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:736)
	at io.trino.execution.executor.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:164)
	at io.trino.execution.executor.TaskExecutor$TaskRunner.run(TaskExecutor.java:515)
	at io.trino.$gen.Trino_testversion____20220930_064644_189.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
