### PR TITLE
Expose stage buffer utilization distribution to event listener

### DIFF
--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -264,6 +264,13 @@
                                     <oldVisibility>public</oldVisibility>
                                     <newVisibility>private</newVisibility>
                                 </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.numberOfParametersChanged</code>
+                                    <old>method void io.trino.spi.eventlistener.QueryStatistics::&lt;init&gt;(java.time.Duration, java.time.Duration, java.time.Duration, java.time.Duration, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, long, long, long, long, long, long, long, long, long, long, long, long, long, long, long, double, double, java.util.List&lt;io.trino.spi.eventlistener.StageGcStatistics&gt;, int, boolean, java.util.List&lt;io.trino.spi.eventlistener.StageCpuDistribution&gt;, java.util.List&lt;java.lang.String&gt;, java.util.Optional&lt;java.lang.String&gt;)</old>
+                                    <new>method void io.trino.spi.eventlistener.QueryStatistics::&lt;init&gt;(java.time.Duration, java.time.Duration, java.time.Duration, java.time.Duration, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, long, long, long, long, long, long, long, long, long, long, long, long, long, long, long, double, double, java.util.List&lt;io.trino.spi.eventlistener.StageGcStatistics&gt;, int, boolean, java.util.List&lt;io.trino.spi.eventlistener.StageCpuDistribution&gt;, java.util.List&lt;java.util.Optional&lt;io.trino.spi.metrics.Distribution&lt;?&gt;&gt;&gt;, java.util.List&lt;java.lang.String&gt;, java.util.Optional&lt;java.lang.String&gt;)
+                                    </new>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryStatistics.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryStatistics.java
@@ -15,6 +15,7 @@ package io.trino.spi.eventlistener;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.metrics.Distribution;
 
 import java.time.Duration;
 import java.util.List;
@@ -67,6 +68,7 @@ public class QueryStatistics
     private final boolean complete;
 
     private final List<StageCpuDistribution> cpuTimeDistribution;
+    private final List<Optional<Distribution<?>>> stageOutputBufferUtilizationDistribution;
 
     /**
      * Operator summaries serialized to JSON. Serialization format and structure
@@ -116,6 +118,7 @@ public class QueryStatistics
             int completedSplits,
             boolean complete,
             List<StageCpuDistribution> cpuTimeDistribution,
+            List<Optional<Distribution<?>>> stageOutputBufferUtilizationDistribution,
             List<String> operatorSummaries,
             Optional<String> planNodeStatsAndCosts)
     {
@@ -154,6 +157,7 @@ public class QueryStatistics
         this.completedSplits = completedSplits;
         this.complete = complete;
         this.cpuTimeDistribution = requireNonNull(cpuTimeDistribution, "cpuTimeDistribution is null");
+        this.stageOutputBufferUtilizationDistribution = requireNonNull(stageOutputBufferUtilizationDistribution, "stageOutputBufferUtilizationDistribution is null");
         this.operatorSummaries = requireNonNull(operatorSummaries, "operatorSummaries is null");
         this.planNodeStatsAndCosts = requireNonNull(planNodeStatsAndCosts, "planNodeStatsAndCosts is null");
     }
@@ -366,6 +370,12 @@ public class QueryStatistics
     public List<StageCpuDistribution> getCpuTimeDistribution()
     {
         return cpuTimeDistribution;
+    }
+
+    @JsonProperty
+    public List<Optional<Distribution<?>>> getStageOutputBufferUtilizationDistribution()
+    {
+        return stageOutputBufferUtilizationDistribution;
     }
 
     @JsonProperty

--- a/plugin/trino-http-event-listener/pom.xml
+++ b/plugin/trino-http-event-listener/pom.xml
@@ -112,6 +112,12 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-plugin-toolkit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-testing-services</artifactId>
             <scope>test</scope>
         </dependency>

--- a/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpEventListener.java
+++ b/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpEventListener.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.json.JsonCodec;
 import io.trino.operator.RetryPolicy;
+import io.trino.plugin.base.metrics.TDigestHistogram;
 import io.trino.spi.eventlistener.EventListener;
 import io.trino.spi.eventlistener.QueryCompletedEvent;
 import io.trino.spi.eventlistener.QueryContext;
@@ -179,6 +180,7 @@ public class TestHttpEventListener
                 0,
                 true,
                 Collections.emptyList(),
+                List.of(Optional.of(TDigestHistogram.fromValue(42))),
                 Collections.emptyList(),
                 Optional.empty());
 

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerWithSplits.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerWithSplits.java
@@ -183,6 +183,8 @@ public class TestEventListenerWithSplits
         assertTrue(statistics.getWallTime().getSeconds() >= 0);
         assertTrue(statistics.getCpuTimeDistribution().size() > 0);
         assertTrue(statistics.getOperatorSummaries().size() > 0);
+        assertTrue(statistics.getStageOutputBufferUtilizationDistribution().size() > 0);
+        assertTrue(statistics.getStageOutputBufferUtilizationDistribution().stream().allMatch(Optional::isPresent));
     }
 
     @Test


### PR DESCRIPTION
This will allow to identify (with telemetry) which stages are bottlenecks.