### PR TITLE
Do not wrap pass-through query in query PTF

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -73,6 +73,7 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.plugin.jdbc.CaseSensitivity.CASE_INSENSITIVE;
 import static io.trino.plugin.jdbc.CaseSensitivity.CASE_SENSITIVE;
 import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
+import static io.trino.plugin.jdbc.JdbcPassThroughQueryHandle.tableHandleForPassThroughQuery;
 import static io.trino.plugin.jdbc.JdbcWriteSessionProperties.isNonTransactionalInsert;
 import static io.trino.plugin.jdbc.PredicatePushdownController.DISABLE_PUSHDOWN;
 import static io.trino.plugin.jdbc.StandardColumnMappings.varcharReadFunction;
@@ -254,16 +255,7 @@ public abstract class BaseJdbcClient
             throw new TrinoException(JDBC_ERROR, "Failed to get table handle for prepared query. " + firstNonNull(e.getMessage(), e), e);
         }
 
-        return new JdbcTableHandle(
-                new JdbcQueryRelationHandle(preparedQuery),
-                TupleDomain.all(),
-                ImmutableList.of(),
-                Optional.empty(),
-                OptionalLong.empty(),
-                Optional.of(columns.build()),
-                // The query is opaque, so we don't know referenced tables
-                Optional.empty(),
-                0);
+        return tableHandleForPassThroughQuery(preparedQuery, columns.build());
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
@@ -65,6 +65,16 @@ public class DefaultQueryBuilder
             TupleDomain<ColumnHandle> tupleDomain,
             Optional<String> additionalPredicate)
     {
+        if (baseRelation instanceof JdbcPassThroughQueryHandle passThroughQueryHandle) {
+            verify(tupleDomain.isAll(), "Query pass-through handle cannot contain additional constraints");
+            verify(columnExpressions.isEmpty(), "Query pass-through handle cannot contain additional constraints");
+            verify(groupingSets.isEmpty(), "Query pass-through handle cannot contain additional grouping sets");
+            verify(additionalPredicate.isEmpty(), "Query pass-through handle cannot contain additional predicate");
+
+            // We don't want to wrap passed query
+            return passThroughQueryHandle.getPreparedQuery();
+        }
+
         if (!tupleDomain.isNone()) {
             Map<ColumnHandle, Domain> domains = tupleDomain.getDomains().orElseThrow();
             columns.stream()

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPassThroughQueryHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPassThroughQueryHandle.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.predicate.TupleDomain;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import static java.lang.String.format;
+
+public class JdbcPassThroughQueryHandle
+        extends JdbcRelationHandle
+{
+    private final PreparedQuery preparedQuery;
+
+    @JsonCreator
+    public JdbcPassThroughQueryHandle(PreparedQuery preparedQuery)
+    {
+        this.preparedQuery = preparedQuery;
+    }
+
+    @JsonProperty
+    public PreparedQuery getPreparedQuery()
+    {
+        return preparedQuery;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("PassThroughQuery[%s]", preparedQuery.getQuery());
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        JdbcPassThroughQueryHandle that = (JdbcPassThroughQueryHandle) o;
+        return preparedQuery.equals(that.preparedQuery);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(preparedQuery);
+    }
+
+    public static JdbcTableHandle tableHandleForPassThroughQuery(PreparedQuery preparedQuery, List<JdbcColumnHandle> columns)
+    {
+        return new JdbcTableHandle(
+                new JdbcPassThroughQueryHandle(preparedQuery),
+                TupleDomain.all(),
+                ImmutableList.of(),
+                Optional.empty(),
+                OptionalLong.empty(),
+                Optional.of(columns),
+                // The query is opaque, so we don't know referenced tables
+                Optional.empty(),
+                0);
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRelationHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRelationHandle.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonSubTypes({
         @JsonSubTypes.Type(value = JdbcNamedRelationHandle.class, name = "named"),
         @JsonSubTypes.Type(value = JdbcQueryRelationHandle.class, name = "query"),
+        @JsonSubTypes.Type(value = JdbcPassThroughQueryHandle.class, name = "pass_through"),
 })
 public abstract class JdbcRelationHandle
 {

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
@@ -1631,6 +1631,10 @@ public abstract class BaseJdbcConnectorTest
         assertQuery(
                 format("SELECT * FROM TABLE(system.query(query => 'SELECT name FROM %s.nation WHERE nationkey = 0'))", getSession().getSchema().orElseThrow()),
                 "VALUES 'ALGERIA'");
+
+        assertQuery(
+                format("SELECT * FROM TABLE(system.query(query => 'SELECT name FROM %s.nation WHERE regionkey = 0 AND nationkey > 14 ORDER BY name DESC'))", getSession().getSchema().orElseThrow()),
+                "VALUES 'MOZAMBIQUE', 'MOROCCO'");
     }
 
     @Test


### PR DESCRIPTION
This allows query on the remote side to use whole SQL syntax. Previously ORDER BY clause in a subquery could be rejected by some of the databases.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
