### PR TITLE
Update airlift units to 1.8

### DIFF
--- a/client/trino-cli/pom.xml
+++ b/client/trino-cli/pom.xml
@@ -33,6 +33,7 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
+            <version>1.7</version> <!-- JDK8 support dropped by version 1.8+ -->
         </dependency>
 
         <dependency>

--- a/client/trino-client/pom.xml
+++ b/client/trino-client/pom.xml
@@ -21,6 +21,7 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
+            <version>1.7</version> <!-- JDK8 support dropped by version 1.8+ -->
         </dependency>
 
         <dependency>
@@ -74,6 +75,13 @@
             <groupId>io.trino</groupId>
             <artifactId>trino-spi</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <!-- Exclude JDK 8 incompatible version -->
+                <exclusion>
+                    <groupId>io.airlift</groupId>
+                    <artifactId>units</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/client/trino-jdbc/pom.xml
+++ b/client/trino-jdbc/pom.xml
@@ -27,6 +27,7 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
+            <version>1.7</version> <!-- JDK8 support dropped by version 1.8+ -->
         </dependency>
 
         <dependency>
@@ -73,6 +74,13 @@
             <groupId>io.trino</groupId>
             <artifactId>trino-blackhole</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <!-- Exclude JDK 8 incompatible version -->
+                <exclusion>
+                    <groupId>io.airlift</groupId>
+                    <artifactId>units</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -84,6 +92,11 @@
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
+                <!-- Exclude JDK 8 incompatible version -->
+                <exclusion>
+                    <groupId>io.airlift</groupId>
+                    <artifactId>units</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -91,42 +104,91 @@
             <groupId>io.trino</groupId>
             <artifactId>trino-main</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <!-- Exclude JDK 8 incompatible version -->
+                <exclusion>
+                    <groupId>io.airlift</groupId>
+                    <artifactId>units</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-memory</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <!-- Exclude JDK 8 incompatible version -->
+                <exclusion>
+                    <groupId>io.airlift</groupId>
+                    <artifactId>units</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-parser</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <!-- Exclude JDK 8 incompatible version -->
+                <exclusion>
+                    <groupId>io.airlift</groupId>
+                    <artifactId>units</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-password-authenticators</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <!-- Exclude JDK 8 incompatible version -->
+                <exclusion>
+                    <groupId>io.airlift</groupId>
+                    <artifactId>units</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-spi</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <!-- Exclude JDK 8 incompatible version -->
+                <exclusion>
+                    <groupId>io.airlift</groupId>
+                    <artifactId>units</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-testing</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <!-- Exclude JDK 8 incompatible version -->
+                <exclusion>
+                    <groupId>io.airlift</groupId>
+                    <artifactId>units</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-tpch</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <!-- Exclude JDK 8 incompatible version -->
+                <exclusion>
+                    <groupId>io.airlift</groupId>
+                    <artifactId>units</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -879,7 +879,7 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>units</artifactId>
-                <version>1.7</version>
+                <version>1.8</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Description
Updates airlift units dependency to version 1.8, which now requires JDK11+. As a result, a minor improvement to reduce allocations during JSON serialization / deserialization was made possible.

Unfortunately, since Trino clients still currently support JDK 8- airlift units version 1.7 is still used in `trino-client`, `trino-cli`, and `trino-jdbc`.


## Non-technical explanation
No non-technical explanation should be necessary.


## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
