### PR TITLE
Do not cache Hadoop LocatedFileStatus objects

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/BlockLocation.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/BlockLocation.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.fs;
+
+import com.google.common.collect.ImmutableList;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class BlockLocation
+{
+    private final List<String> hosts;
+    private final long offset;
+    private final long length;
+
+    public static List<BlockLocation> fromHiveBlockLocations(@Nullable org.apache.hadoop.fs.BlockLocation[] blockLocations)
+    {
+        if (blockLocations == null) {
+            return ImmutableList.of();
+        }
+
+        return Arrays.stream(blockLocations)
+                .map(BlockLocation::new)
+                .collect(toImmutableList());
+    }
+
+    public BlockLocation(org.apache.hadoop.fs.BlockLocation blockLocation)
+    {
+        requireNonNull(blockLocation, "blockLocation is null");
+        try {
+            this.hosts = ImmutableList.copyOf(blockLocation.getHosts());
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        this.offset = blockLocation.getOffset();
+        this.length = blockLocation.getLength();
+    }
+
+    public List<String> getHosts()
+    {
+        return hosts;
+    }
+
+    public long getOffset()
+    {
+        return offset;
+    }
+
+    public long getLength()
+    {
+        return length;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BlockLocation that = (BlockLocation) o;
+        return offset == that.offset
+                && length == that.length
+                && hosts.equals(that.hosts);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(hosts, offset, length);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("hosts", hosts)
+                .add("offset", offset)
+                .add("length", length)
+                .toString();
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/CachingDirectoryLister.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/CachingDirectoryLister.java
@@ -26,7 +26,6 @@ import io.trino.plugin.hive.metastore.Table;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.weakref.jmx.Managed;
@@ -89,28 +88,28 @@ public class CachingDirectoryLister
     }
 
     @Override
-    public RemoteIterator<LocatedFileStatus> list(FileSystem fs, Table table, Path path)
+    public RemoteIterator<TrinoFileStatus> list(FileSystem fs, Table table, Path path)
             throws IOException
     {
         if (!isCacheEnabledFor(table.getSchemaTableName())) {
-            return fs.listLocatedStatus(path);
+            return new TrinoFileStatusRemoteIterator(fs.listLocatedStatus(path));
         }
 
         return listInternal(fs, new DirectoryListingCacheKey(path, false));
     }
 
     @Override
-    public RemoteIterator<LocatedFileStatus> listFilesRecursively(FileSystem fs, Table table, Path path)
+    public RemoteIterator<TrinoFileStatus> listFilesRecursively(FileSystem fs, Table table, Path path)
             throws IOException
     {
         if (!isCacheEnabledFor(table.getSchemaTableName())) {
-            return fs.listFiles(path, true);
+            return new TrinoFileStatusRemoteIterator(fs.listFiles(path, true));
         }
 
         return listInternal(fs, new DirectoryListingCacheKey(path, true));
     }
 
-    private RemoteIterator<LocatedFileStatus> listInternal(FileSystem fs, DirectoryListingCacheKey cacheKey)
+    private RemoteIterator<TrinoFileStatus> listInternal(FileSystem fs, DirectoryListingCacheKey cacheKey)
             throws IOException
     {
         ValueHolder cachedValueHolder = uncheckedCacheGet(cache, cacheKey, ValueHolder::new);
@@ -121,13 +120,13 @@ public class CachingDirectoryLister
         return cachingRemoteIterator(cachedValueHolder, createListingRemoteIterator(fs, cacheKey), cacheKey);
     }
 
-    private static RemoteIterator<LocatedFileStatus> createListingRemoteIterator(FileSystem fs, DirectoryListingCacheKey cacheKey)
+    private static RemoteIterator<TrinoFileStatus> createListingRemoteIterator(FileSystem fs, DirectoryListingCacheKey cacheKey)
             throws IOException
     {
         if (cacheKey.isRecursiveFilesOnly()) {
-            return fs.listFiles(cacheKey.getPath(), true);
+            return new TrinoFileStatusRemoteIterator(fs.listFiles(cacheKey.getPath(), true));
         }
-        return fs.listLocatedStatus(cacheKey.getPath());
+        return new TrinoFileStatusRemoteIterator(fs.listLocatedStatus(cacheKey.getPath()));
     }
 
     @Override
@@ -152,11 +151,11 @@ public class CachingDirectoryLister
         }
     }
 
-    private RemoteIterator<LocatedFileStatus> cachingRemoteIterator(ValueHolder cachedValueHolder, RemoteIterator<LocatedFileStatus> iterator, DirectoryListingCacheKey key)
+    private RemoteIterator<TrinoFileStatus> cachingRemoteIterator(ValueHolder cachedValueHolder, RemoteIterator<TrinoFileStatus> iterator, DirectoryListingCacheKey key)
     {
         return new RemoteIterator<>()
         {
-            private final List<LocatedFileStatus> files = new ArrayList<>();
+            private final List<TrinoFileStatus> files = new ArrayList<>();
 
             @Override
             public boolean hasNext()
@@ -172,10 +171,10 @@ public class CachingDirectoryLister
             }
 
             @Override
-            public LocatedFileStatus next()
+            public TrinoFileStatus next()
                     throws IOException
             {
-                LocatedFileStatus next = iterator.next();
+                TrinoFileStatus next = iterator.next();
                 files.add(next);
                 return next;
             }
@@ -249,19 +248,19 @@ public class CachingDirectoryLister
      */
     private static class ValueHolder
     {
-        private final Optional<List<LocatedFileStatus>> files;
+        private final Optional<List<TrinoFileStatus>> files;
 
         public ValueHolder()
         {
             files = Optional.empty();
         }
 
-        public ValueHolder(List<LocatedFileStatus> files)
+        public ValueHolder(List<TrinoFileStatus> files)
         {
             this.files = Optional.of(ImmutableList.copyOf(requireNonNull(files, "files is null")));
         }
 
-        public Optional<List<LocatedFileStatus>> getFiles()
+        public Optional<List<TrinoFileStatus>> getFiles()
         {
             return files;
         }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/DirectoryLister.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/DirectoryLister.java
@@ -16,7 +16,6 @@ package io.trino.plugin.hive.fs;
 import io.trino.plugin.hive.TableInvalidationCallback;
 import io.trino.plugin.hive.metastore.Table;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 
@@ -25,9 +24,9 @@ import java.io.IOException;
 public interface DirectoryLister
         extends TableInvalidationCallback
 {
-    RemoteIterator<LocatedFileStatus> list(FileSystem fs, Table table, Path path)
+    RemoteIterator<TrinoFileStatus> list(FileSystem fs, Table table, Path path)
             throws IOException;
 
-    RemoteIterator<LocatedFileStatus> listFilesRecursively(FileSystem fs, Table table, Path path)
+    RemoteIterator<TrinoFileStatus> listFilesRecursively(FileSystem fs, Table table, Path path)
             throws IOException;
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/HiveFileIterator.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/HiveFileIterator.java
@@ -20,7 +20,6 @@ import io.trino.plugin.hive.NamenodeStats;
 import io.trino.plugin.hive.metastore.Table;
 import io.trino.spi.TrinoException;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 
@@ -37,7 +36,7 @@ import static java.util.Objects.requireNonNull;
 import static org.apache.hadoop.fs.Path.SEPARATOR_CHAR;
 
 public class HiveFileIterator
-        extends AbstractIterator<LocatedFileStatus>
+        extends AbstractIterator<TrinoFileStatus>
 {
     public enum NestedDirectoryPolicy
     {
@@ -53,7 +52,7 @@ public class HiveFileIterator
     private final NamenodeStats namenodeStats;
     private final NestedDirectoryPolicy nestedDirectoryPolicy;
     private final boolean ignoreAbsentPartitions;
-    private final Iterator<LocatedFileStatus> remoteIterator;
+    private final Iterator<TrinoFileStatus> remoteIterator;
 
     public HiveFileIterator(
             Table table,
@@ -75,10 +74,10 @@ public class HiveFileIterator
     }
 
     @Override
-    protected LocatedFileStatus computeNext()
+    protected TrinoFileStatus computeNext()
     {
         while (remoteIterator.hasNext()) {
-            LocatedFileStatus status = getLocatedFileStatus(remoteIterator);
+            TrinoFileStatus status = getLocatedFileStatus(remoteIterator);
 
             // Ignore hidden files and directories
             if (nestedDirectoryPolicy == RECURSE) {
@@ -108,7 +107,7 @@ public class HiveFileIterator
         return endOfData();
     }
 
-    private Iterator<LocatedFileStatus> getLocatedFileStatusRemoteIterator(Path path)
+    private Iterator<TrinoFileStatus> getLocatedFileStatusRemoteIterator(Path path)
     {
         try (TimeStat.BlockTimer ignored = namenodeStats.getListLocatedStatus().time()) {
             return new FileStatusIterator(table, path, fileSystem, directoryLister, namenodeStats, nestedDirectoryPolicy == RECURSE);
@@ -130,7 +129,7 @@ public class HiveFileIterator
         }
     }
 
-    private LocatedFileStatus getLocatedFileStatus(Iterator<LocatedFileStatus> iterator)
+    private TrinoFileStatus getLocatedFileStatus(Iterator<TrinoFileStatus> iterator)
     {
         try (TimeStat.BlockTimer ignored = namenodeStats.getRemoteIteratorNext().time()) {
             return iterator.next();
@@ -173,11 +172,11 @@ public class HiveFileIterator
     }
 
     private static class FileStatusIterator
-            implements Iterator<LocatedFileStatus>
+            implements Iterator<TrinoFileStatus>
     {
         private final Path path;
         private final NamenodeStats namenodeStats;
-        private final RemoteIterator<LocatedFileStatus> fileStatusIterator;
+        private final RemoteIterator<TrinoFileStatus> fileStatusIterator;
 
         private FileStatusIterator(Table table, Path path, FileSystem fileSystem, DirectoryLister directoryLister, NamenodeStats namenodeStats, boolean recursive)
         {
@@ -208,7 +207,7 @@ public class HiveFileIterator
         }
 
         @Override
-        public LocatedFileStatus next()
+        public TrinoFileStatus next()
         {
             try {
                 return fileStatusIterator.next();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/TransactionScopeCachingDirectoryLister.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/TransactionScopeCachingDirectoryLister.java
@@ -21,7 +21,6 @@ import io.trino.plugin.hive.metastore.Partition;
 import io.trino.plugin.hive.metastore.Storage;
 import io.trino.plugin.hive.metastore.Table;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 
@@ -67,20 +66,20 @@ public class TransactionScopeCachingDirectoryLister
     }
 
     @Override
-    public RemoteIterator<LocatedFileStatus> list(FileSystem fs, Table table, Path path)
+    public RemoteIterator<TrinoFileStatus> list(FileSystem fs, Table table, Path path)
             throws IOException
     {
         return listInternal(fs, table, new DirectoryListingCacheKey(path, false));
     }
 
     @Override
-    public RemoteIterator<LocatedFileStatus> listFilesRecursively(FileSystem fs, Table table, Path path)
+    public RemoteIterator<TrinoFileStatus> listFilesRecursively(FileSystem fs, Table table, Path path)
             throws IOException
     {
         return listInternal(fs, table, new DirectoryListingCacheKey(path, true));
     }
 
-    private RemoteIterator<LocatedFileStatus> listInternal(FileSystem fs, Table table, DirectoryListingCacheKey cacheKey)
+    private RemoteIterator<TrinoFileStatus> listInternal(FileSystem fs, Table table, DirectoryListingCacheKey cacheKey)
             throws IOException
     {
         FetchingValueHolder cachedValueHolder;
@@ -101,7 +100,7 @@ public class TransactionScopeCachingDirectoryLister
         return cachingRemoteIterator(cachedValueHolder, cacheKey);
     }
 
-    private RemoteIterator<LocatedFileStatus> createListingRemoteIterator(FileSystem fs, Table table, DirectoryListingCacheKey cacheKey)
+    private RemoteIterator<TrinoFileStatus> createListingRemoteIterator(FileSystem fs, Table table, DirectoryListingCacheKey cacheKey)
             throws IOException
     {
         if (cacheKey.isRecursiveFilesOnly()) {
@@ -134,7 +133,7 @@ public class TransactionScopeCachingDirectoryLister
         delegate.invalidate(partition);
     }
 
-    private RemoteIterator<LocatedFileStatus> cachingRemoteIterator(FetchingValueHolder cachedValueHolder, DirectoryListingCacheKey cacheKey)
+    private RemoteIterator<TrinoFileStatus> cachingRemoteIterator(FetchingValueHolder cachedValueHolder, DirectoryListingCacheKey cacheKey)
     {
         return new RemoteIterator<>()
         {
@@ -160,7 +159,7 @@ public class TransactionScopeCachingDirectoryLister
             }
 
             @Override
-            public LocatedFileStatus next()
+            public TrinoFileStatus next()
                     throws IOException
             {
                 // force cache entry weight update in case next file is cached
@@ -191,15 +190,15 @@ public class TransactionScopeCachingDirectoryLister
 
     private static class FetchingValueHolder
     {
-        private final List<LocatedFileStatus> cachedFiles = synchronizedList(new ArrayList<>());
+        private final List<TrinoFileStatus> cachedFiles = synchronizedList(new ArrayList<>());
         @GuardedBy("this")
         @Nullable
-        private RemoteIterator<LocatedFileStatus> fileIterator;
+        private RemoteIterator<TrinoFileStatus> fileIterator;
         @GuardedBy("this")
         @Nullable
         private Exception exception;
 
-        public FetchingValueHolder(RemoteIterator<LocatedFileStatus> fileIterator)
+        public FetchingValueHolder(RemoteIterator<TrinoFileStatus> fileIterator)
         {
             this.fileIterator = requireNonNull(fileIterator, "fileIterator is null");
         }
@@ -214,13 +213,13 @@ public class TransactionScopeCachingDirectoryLister
             return cachedFiles.size();
         }
 
-        public Iterator<LocatedFileStatus> getCachedFiles()
+        public Iterator<TrinoFileStatus> getCachedFiles()
         {
             checkState(isFullyCached());
             return cachedFiles.iterator();
         }
 
-        public Optional<LocatedFileStatus> getCachedFile(int index)
+        public Optional<TrinoFileStatus> getCachedFile(int index)
                 throws IOException
         {
             int filesSize = cachedFiles.size();
@@ -234,7 +233,7 @@ public class TransactionScopeCachingDirectoryLister
             return fetchNextCachedFile(index);
         }
 
-        private synchronized Optional<LocatedFileStatus> fetchNextCachedFile(int index)
+        private synchronized Optional<TrinoFileStatus> fetchNextCachedFile(int index)
                 throws IOException
         {
             if (exception != null) {
@@ -253,7 +252,7 @@ public class TransactionScopeCachingDirectoryLister
                     return Optional.empty();
                 }
 
-                LocatedFileStatus fileStatus = fileIterator.next();
+                TrinoFileStatus fileStatus = fileIterator.next();
                 cachedFiles.add(fileStatus);
                 return Optional.of(fileStatus);
             }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/TrinoFileStatus.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/TrinoFileStatus.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.fs;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class TrinoFileStatus
+        implements Comparable<TrinoFileStatus>
+{
+    private final List<BlockLocation> blockLocations;
+    private final Path path;
+    private final boolean isDirectory;
+    private final long length;
+    private final long modificationTime;
+
+    public TrinoFileStatus(LocatedFileStatus fileStatus)
+    {
+        this(BlockLocation.fromHiveBlockLocations(fileStatus.getBlockLocations()),
+                fileStatus.getPath(),
+                fileStatus.isDirectory(),
+                fileStatus.getLen(),
+                fileStatus.getModificationTime());
+    }
+
+    public TrinoFileStatus(List<BlockLocation> blockLocations, Path path, boolean isDirectory, long length, long modificationTime)
+    {
+        this.blockLocations = ImmutableList.copyOf(requireNonNull(blockLocations, "blockLocations is null"));
+        this.path = requireNonNull(path, "path is null");
+        this.isDirectory = isDirectory;
+        this.length = length;
+        this.modificationTime = modificationTime;
+    }
+
+    public List<BlockLocation> getBlockLocations()
+    {
+        return blockLocations;
+    }
+
+    public Path getPath()
+    {
+        return path;
+    }
+
+    public boolean isDirectory()
+    {
+        return isDirectory;
+    }
+
+    public long getLength()
+    {
+        return length;
+    }
+
+    public long getModificationTime()
+    {
+        return modificationTime;
+    }
+
+    @Override
+    public int compareTo(TrinoFileStatus other)
+    {
+        return path.compareTo(other.getPath());
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TrinoFileStatus that = (TrinoFileStatus) o;
+        return isDirectory == that.isDirectory
+                && length == that.length
+                && modificationTime == that.modificationTime
+                && blockLocations.equals(that.blockLocations)
+                && path.equals(that.path);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(blockLocations, path, isDirectory, length, modificationTime);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("blockLocations", blockLocations)
+                .add("path", path)
+                .add("isDirectory", isDirectory)
+                .add("length", length)
+                .add("modificationTime", modificationTime)
+                .toString();
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/TrinoFileStatusRemoteIterator.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/TrinoFileStatusRemoteIterator.java
@@ -13,19 +13,19 @@
  */
 package io.trino.plugin.hive.fs;
 
+import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.RemoteIterator;
 
 import java.io.IOException;
-import java.util.Iterator;
 
 import static java.util.Objects.requireNonNull;
 
-class SimpleRemoteIterator
+public class TrinoFileStatusRemoteIterator
         implements RemoteIterator<TrinoFileStatus>
 {
-    private final Iterator<TrinoFileStatus> iterator;
+    private final RemoteIterator<LocatedFileStatus> iterator;
 
-    public SimpleRemoteIterator(Iterator<TrinoFileStatus> iterator)
+    public TrinoFileStatusRemoteIterator(RemoteIterator<LocatedFileStatus> iterator)
     {
         this.iterator = requireNonNull(iterator, "iterator is null");
     }
@@ -41,6 +41,6 @@ class SimpleRemoteIterator
     public TrinoFileStatus next()
             throws IOException
     {
-        return iterator.next();
+        return new TrinoFileStatus(iterator.next());
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/InternalHiveSplitFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/InternalHiveSplitFactory.java
@@ -23,21 +23,19 @@ import io.trino.plugin.hive.HiveSplit.BucketConversion;
 import io.trino.plugin.hive.InternalHiveSplit;
 import io.trino.plugin.hive.InternalHiveSplit.InternalHiveBlock;
 import io.trino.plugin.hive.TableToPartitionMapping;
+import io.trino.plugin.hive.fs.BlockLocation;
+import io.trino.plugin.hive.fs.TrinoFileStatus;
 import io.trino.plugin.hive.s3select.S3SelectPushdown;
 import io.trino.spi.HostAddress;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
-import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.InputFormat;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -111,17 +109,17 @@ public class InternalHiveSplitFactory
         return partitionName;
     }
 
-    public Optional<InternalHiveSplit> createInternalHiveSplit(LocatedFileStatus status, OptionalInt readBucketNumber, OptionalInt tableBucketNumber, boolean splittable, Optional<AcidInfo> acidInfo)
+    public Optional<InternalHiveSplit> createInternalHiveSplit(TrinoFileStatus status, OptionalInt readBucketNumber, OptionalInt tableBucketNumber, boolean splittable, Optional<AcidInfo> acidInfo)
     {
         splittable = splittable &&
-                status.getLen() > minimumTargetSplitSizeInBytes &&
+                status.getLength() > minimumTargetSplitSizeInBytes &&
                 isSplittable(inputFormat, fileSystem, status.getPath());
         return createInternalHiveSplit(
                 status.getPath(),
                 status.getBlockLocations(),
                 0,
-                status.getLen(),
-                status.getLen(),
+                status.getLength(),
+                status.getLength(),
                 status.getModificationTime(),
                 readBucketNumber,
                 tableBucketNumber,
@@ -135,7 +133,7 @@ public class InternalHiveSplitFactory
         FileStatus file = fileSystem.getFileStatus(split.getPath());
         return createInternalHiveSplit(
                 split.getPath(),
-                fileSystem.getFileBlockLocations(file, split.getStart(), split.getLength()),
+                BlockLocation.fromHiveBlockLocations(fileSystem.getFileBlockLocations(file, split.getStart(), split.getLength())),
                 split.getStart(),
                 split.getLength(),
                 file.getLen(),
@@ -148,7 +146,7 @@ public class InternalHiveSplitFactory
 
     private Optional<InternalHiveSplit> createInternalHiveSplit(
             Path path,
-            BlockLocation[] blockLocations,
+            List<BlockLocation> blockLocations,
             long start,
             long length,
             // Estimated because, for example, encrypted S3 files may be padded, so reported size may not reflect actual size
@@ -263,20 +261,10 @@ public class InternalHiveSplitFactory
     private static List<HostAddress> getHostAddresses(BlockLocation blockLocation)
     {
         // Hadoop FileSystem returns "localhost" as a default
-        return Arrays.stream(getBlockHosts(blockLocation))
+        return blockLocation.getHosts().stream()
                 .map(HostAddress::fromString)
                 .filter(address -> !address.getHostText().equals("localhost"))
                 .collect(toImmutableList());
-    }
-
-    private static String[] getBlockHosts(BlockLocation blockLocation)
-    {
-        try {
-            return blockLocation.getHosts();
-        }
-        catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
     }
 
     private static Optional<Domain> getPathDomain(TupleDomain<HiveColumnHandle> effectivePredicate)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -34,6 +34,8 @@ import io.trino.plugin.base.metrics.LongCount;
 import io.trino.plugin.hive.LocationService.WriteInfo;
 import io.trino.plugin.hive.aws.athena.PartitionProjectionService;
 import io.trino.plugin.hive.fs.DirectoryLister;
+import io.trino.plugin.hive.fs.TrinoFileStatus;
+import io.trino.plugin.hive.fs.TrinoFileStatusRemoteIterator;
 import io.trino.plugin.hive.metastore.Column;
 import io.trino.plugin.hive.metastore.HiveColumnStatistics;
 import io.trino.plugin.hive.metastore.HiveMetastore;
@@ -132,7 +134,6 @@ import io.trino.testing.TestingNodeManager;
 import io.trino.type.BlockTypeOperators;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.hive.metastore.TableType;
@@ -6174,19 +6175,19 @@ public abstract class AbstractTestHive
         private final AtomicInteger listCount = new AtomicInteger();
 
         @Override
-        public RemoteIterator<LocatedFileStatus> list(FileSystem fs, Table table, Path path)
+        public RemoteIterator<TrinoFileStatus> list(FileSystem fs, Table table, Path path)
                 throws IOException
         {
             listCount.incrementAndGet();
-            return fs.listLocatedStatus(path);
+            return new TrinoFileStatusRemoteIterator(fs.listLocatedStatus(path));
         }
 
         @Override
-        public RemoteIterator<LocatedFileStatus> listFilesRecursively(FileSystem fs, Table table, Path path)
+        public RemoteIterator<TrinoFileStatus> listFilesRecursively(FileSystem fs, Table table, Path path)
                 throws IOException
         {
             listCount.incrementAndGet();
-            return fs.listFiles(path, true);
+            return new TrinoFileStatusRemoteIterator(fs.listFiles(path, true));
         }
 
         public int getListCount()

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
@@ -34,6 +34,7 @@ import io.trino.plugin.hive.AbstractTestHive.Transaction;
 import io.trino.plugin.hive.aws.athena.PartitionProjectionService;
 import io.trino.plugin.hive.fs.FileSystemDirectoryLister;
 import io.trino.plugin.hive.fs.HiveFileIterator;
+import io.trino.plugin.hive.fs.TrinoFileStatus;
 import io.trino.plugin.hive.metastore.Column;
 import io.trino.plugin.hive.metastore.Database;
 import io.trino.plugin.hive.metastore.ForwardingHiveMetastore;
@@ -71,7 +72,6 @@ import io.trino.testing.MaterializedResult;
 import io.trino.testing.TestingNodeManager;
 import io.trino.type.BlockTypeOperators;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem;
 import org.testng.annotations.AfterClass;
@@ -271,12 +271,14 @@ public abstract class AbstractTestHiveFileSystem
         return HiveFileSystemTestUtils.newTransaction(transactionManager);
     }
 
-    protected MaterializedResult readTable(SchemaTableName tableName) throws IOException
+    protected MaterializedResult readTable(SchemaTableName tableName)
+            throws IOException
     {
         return HiveFileSystemTestUtils.readTable(tableName, transactionManager, config, pageSourceProvider, splitManager);
     }
 
-    protected MaterializedResult filterTable(SchemaTableName tableName, List<ColumnHandle> projectedColumns) throws IOException
+    protected MaterializedResult filterTable(SchemaTableName tableName, List<ColumnHandle> projectedColumns)
+            throws IOException
     {
         return HiveFileSystemTestUtils.filterTable(tableName, projectedColumns, transactionManager, config, pageSourceProvider, splitManager);
     }
@@ -463,7 +465,7 @@ public abstract class AbstractTestHiveFileSystem
                 HiveFileIterator.NestedDirectoryPolicy.RECURSE,
                 false); // ignoreAbsentPartitions
 
-        List<Path> recursiveListing = Lists.newArrayList(Iterators.transform(recursiveIterator, LocatedFileStatus::getPath));
+        List<Path> recursiveListing = Lists.newArrayList(Iterators.transform(recursiveIterator, TrinoFileStatus::getPath));
         // Should not include directories, or files underneath hidden directories
         assertEqualsIgnoreOrder(recursiveListing, ImmutableList.of(nestedFile, baseFile));
 
@@ -475,7 +477,7 @@ public abstract class AbstractTestHiveFileSystem
                 new NamenodeStats(),
                 HiveFileIterator.NestedDirectoryPolicy.IGNORED,
                 false); // ignoreAbsentPartitions
-        List<Path> shallowListing = Lists.newArrayList(Iterators.transform(shallowIterator, LocatedFileStatus::getPath));
+        List<Path> shallowListing = Lists.newArrayList(Iterators.transform(shallowIterator, TrinoFileStatus::getPath));
         // Should not include any hidden files, folders, or nested files
         assertEqualsIgnoreOrder(shallowListing, ImmutableList.of(baseFile));
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestBackgroundHiveSplitLoader.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestBackgroundHiveSplitLoader.java
@@ -31,6 +31,7 @@ import io.trino.hdfs.authentication.NoHdfsAuthentication;
 import io.trino.plugin.hive.HiveColumnHandle.ColumnType;
 import io.trino.plugin.hive.fs.CachingDirectoryLister;
 import io.trino.plugin.hive.fs.DirectoryLister;
+import io.trino.plugin.hive.fs.TrinoFileStatus;
 import io.trino.plugin.hive.metastore.Column;
 import io.trino.plugin.hive.metastore.StorageFormat;
 import io.trino.plugin.hive.metastore.Table;
@@ -831,7 +832,7 @@ public class TestBackgroundHiveSplitLoader
     @Test
     public void testValidateFileBuckets()
     {
-        ListMultimap<Integer, LocatedFileStatus> bucketFiles = ArrayListMultimap.create();
+        ListMultimap<Integer, TrinoFileStatus> bucketFiles = ArrayListMultimap.create();
         bucketFiles.put(1, null);
         bucketFiles.put(3, null);
         bucketFiles.put(4, null);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/FileSystemDirectoryLister.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/FileSystemDirectoryLister.java
@@ -16,7 +16,6 @@ package io.trino.plugin.hive.fs;
 import io.trino.plugin.hive.metastore.Partition;
 import io.trino.plugin.hive.metastore.Table;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 
@@ -26,17 +25,17 @@ public class FileSystemDirectoryLister
         implements DirectoryLister
 {
     @Override
-    public RemoteIterator<LocatedFileStatus> list(FileSystem fs, Table table, Path path)
+    public RemoteIterator<TrinoFileStatus> list(FileSystem fs, Table table, Path path)
             throws IOException
     {
-        return fs.listLocatedStatus(path);
+        return new TrinoFileStatusRemoteIterator(fs.listLocatedStatus(path));
     }
 
     @Override
-    public RemoteIterator<LocatedFileStatus> listFilesRecursively(FileSystem fs, Table table, Path path)
+    public RemoteIterator<TrinoFileStatus> listFilesRecursively(FileSystem fs, Table table, Path path)
             throws IOException
     {
-        return fs.listFiles(path, true);
+        return new TrinoFileStatusRemoteIterator(fs.listFiles(path, true));
     }
 
     @Override


### PR DESCRIPTION
LocatedFileStatus objects contain much more fields than are required by Trino. It doesn't make sense
to cache them.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
