### PR TITLE
Add Hudi connector to release notes template

### DIFF
--- a/docs/release-template.md
+++ b/docs/release-template.md
@@ -36,6 +36,8 @@
 
 ## Hive connector
 
+## Hudi connector
+
 ## Iceberg connector
 
 ## JMX connector


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

We've merged the Hudi connector, so we should add a release notes section for it moving forwards. This file doesn't functionally do anything, it's just for copy-pasting when creating release notes. It'll make my life easier.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Docs change.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text: