### PR TITLE
Remove READ and WRITE from type mapping headers

### DIFF
--- a/docs/src/main/sphinx/connector/memsql.rst
+++ b/docs/src/main/sphinx/connector/memsql.rst
@@ -124,8 +124,8 @@ writing data. Data types may not map the same way in both directions between
 Trino and the data source. Refer to the following sections for type mapping in
 each direction.
 
-Singlestore to Trino read type mapping
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Singlestore to Trino type mapping
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The connector maps Singlestore types to the corresponding Trino types following
 this table:
@@ -218,8 +218,8 @@ this table:
 
 No other types are supported.
 
-Trino to Singlestore write type mapping
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Trino to Singlestore type mapping
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The connector maps Trino types to the corresponding Singlestore types following
 this table:

--- a/docs/src/main/sphinx/connector/mysql.rst
+++ b/docs/src/main/sphinx/connector/mysql.rst
@@ -111,8 +111,8 @@ writing data. Data types may not map the same way in both directions between
 Trino and the data source. Refer to the following sections for type mapping in
 each direction.
 
-MySQL to Trino read type mapping
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+MySQL to Trino type mapping
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The connector maps MySQL types to the corresponding Trino types following
 this table:
@@ -196,8 +196,8 @@ this table:
 
 No other types are supported.
 
-Trino to MySQL write type mapping
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Trino to MySQL type mapping
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The connector maps Trino types to the corresponding MySQL types following
 this table:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Remove "Read" and "Write" from type mapping headers.

<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation

Remove misleading wording from type mapping headers.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
