### PR TITLE
Cleanup naming and usage of array constructor

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayConstructor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayConstructor.java
@@ -65,13 +65,15 @@ import static java.util.Collections.nCopies;
 public final class ArrayConstructor
         extends SqlScalarFunction
 {
+    public static final String NAME = "$array";
+
     public static final ArrayConstructor ARRAY_CONSTRUCTOR = new ArrayConstructor();
 
     public ArrayConstructor()
     {
         super(FunctionMetadata.scalarBuilder()
                 .signature(Signature.builder()
-                        .name("array_constructor")
+                        .name(NAME)
                         .typeVariable("E")
                         .returnType(arrayType(new TypeSignature("E")))
                         .argumentType(new TypeSignature("E"))

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayFunctions.java
@@ -25,7 +25,7 @@ public final class ArrayFunctions
 {
     private ArrayFunctions() {}
 
-    @ScalarFunction(hidden = true)
+    @ScalarFunction(value = ArrayConstructor.NAME, hidden = true)
     @SqlType("array(unknown)")
     public static Block arrayConstructor()
     {

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/AggregationAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/AggregationAnalyzer.java
@@ -20,7 +20,7 @@ import io.trino.spi.StandardErrorCode;
 import io.trino.sql.planner.ScopeAware;
 import io.trino.sql.tree.ArithmeticBinaryExpression;
 import io.trino.sql.tree.ArithmeticUnaryExpression;
-import io.trino.sql.tree.ArrayConstructor;
+import io.trino.sql.tree.Array;
 import io.trino.sql.tree.AstVisitor;
 import io.trino.sql.tree.AtTimeZone;
 import io.trino.sql.tree.BetweenPredicate;
@@ -251,7 +251,7 @@ class AggregationAnalyzer
         }
 
         @Override
-        protected Boolean visitArrayConstructor(ArrayConstructor node, Void context)
+        protected Boolean visitArray(Array node, Void context)
         {
             return node.getValues().stream().allMatch(expression -> process(expression, context));
         }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -63,7 +63,7 @@ import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.TypeProvider;
 import io.trino.sql.tree.ArithmeticBinaryExpression;
 import io.trino.sql.tree.ArithmeticUnaryExpression;
-import io.trino.sql.tree.ArrayConstructor;
+import io.trino.sql.tree.Array;
 import io.trino.sql.tree.AtTimeZone;
 import io.trino.sql.tree.BetweenPredicate;
 import io.trino.sql.tree.BinaryLiteral;
@@ -243,7 +243,7 @@ import static io.trino.sql.analyzer.SemanticExceptions.missingAttributeException
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static io.trino.sql.analyzer.TypeSignatureTranslator.toTypeSignature;
-import static io.trino.sql.tree.ArrayConstructor.ARRAY_CONSTRUCTOR;
+import static io.trino.sql.tree.Array.ARRAY_CONSTRUCTOR;
 import static io.trino.sql.tree.DereferenceExpression.isQualifiedAllFieldsReference;
 import static io.trino.sql.tree.FrameBound.Type.CURRENT_ROW;
 import static io.trino.sql.tree.FrameBound.Type.FOLLOWING;
@@ -1013,7 +1013,7 @@ public class ExpressionAnalyzer
         }
 
         @Override
-        protected Type visitArrayConstructor(ArrayConstructor node, StackableAstVisitorContext<Context> context)
+        protected Type visitArray(Array node, StackableAstVisitorContext<Context> context)
         {
             Type type = coerceToSingleType(context, "All ARRAY elements", node.getValues());
             Type arrayType = plannerContext.getTypeManager().getParameterizedType(ARRAY.getName(), ImmutableList.of(TypeSignatureParameter.typeParameter(type.getTypeSignature())));

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -27,6 +27,7 @@ import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.OperatorNotFoundException;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.ResolvedFunction;
+import io.trino.operator.scalar.ArrayConstructor;
 import io.trino.operator.scalar.FormatFunction;
 import io.trino.security.AccessControl;
 import io.trino.security.SecurityContext;
@@ -243,7 +244,6 @@ import static io.trino.sql.analyzer.SemanticExceptions.missingAttributeException
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static io.trino.sql.analyzer.TypeSignatureTranslator.toTypeSignature;
-import static io.trino.sql.tree.Array.ARRAY_CONSTRUCTOR;
 import static io.trino.sql.tree.DereferenceExpression.isQualifiedAllFieldsReference;
 import static io.trino.sql.tree.FrameBound.Type.CURRENT_ROW;
 import static io.trino.sql.tree.FrameBound.Type.FOLLOWING;
@@ -1270,7 +1270,7 @@ public class ExpressionAnalyzer
                 throw new TrinoException(e::getErrorCode, extractLocation(node), e.getMessage(), e);
             }
 
-            if (function.getSignature().getName().equalsIgnoreCase(ARRAY_CONSTRUCTOR)) {
+            if (function.getSignature().getName().equalsIgnoreCase(ArrayConstructor.NAME)) {
                 // After optimization, array constructor is rewritten to a function call.
                 // For historic reasons array constructor is allowed to have 254 arguments
                 if (node.getArguments().size() > 254) {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/DesugarArrayConstructorRewriter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DesugarArrayConstructorRewriter.java
@@ -16,6 +16,7 @@ package io.trino.sql.planner;
 import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.metadata.Metadata;
+import io.trino.operator.scalar.ArrayConstructor;
 import io.trino.spi.type.Type;
 import io.trino.sql.tree.Array;
 import io.trino.sql.tree.Expression;
@@ -75,7 +76,7 @@ public final class DesugarArrayConstructorRewriter
             Array rewritten = treeRewriter.defaultRewrite(node, context);
             checkCondition(node.getValues().size() <= 254, TOO_MANY_ARGUMENTS, "Too many arguments for array constructor");
             return FunctionCallBuilder.resolve(session, metadata)
-                    .setName(QualifiedName.of(Array.ARRAY_CONSTRUCTOR))
+                    .setName(QualifiedName.of(ArrayConstructor.NAME))
                     .setArguments(getTypes(node.getValues()), rewritten.getValues())
                     .build();
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/DesugarArrayConstructorRewriter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DesugarArrayConstructorRewriter.java
@@ -17,7 +17,7 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.metadata.Metadata;
 import io.trino.spi.type.Type;
-import io.trino.sql.tree.ArrayConstructor;
+import io.trino.sql.tree.Array;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.ExpressionRewriter;
 import io.trino.sql.tree.ExpressionTreeRewriter;
@@ -70,12 +70,12 @@ public final class DesugarArrayConstructorRewriter
         }
 
         @Override
-        public Expression rewriteArrayConstructor(ArrayConstructor node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+        public Expression rewriteArray(Array node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
         {
-            ArrayConstructor rewritten = treeRewriter.defaultRewrite(node, context);
+            Array rewritten = treeRewriter.defaultRewrite(node, context);
             checkCondition(node.getValues().size() <= 254, TOO_MANY_ARGUMENTS, "Too many arguments for array constructor");
             return FunctionCallBuilder.resolve(session, metadata)
-                    .setName(QualifiedName.of(ArrayConstructor.ARRAY_CONSTRUCTOR))
+                    .setName(QualifiedName.of(Array.ARRAY_CONSTRUCTOR))
                     .setArguments(getTypes(node.getValues()), rewritten.getValues())
                     .build();
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionInterpreter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionInterpreter.java
@@ -24,6 +24,7 @@ import io.trino.execution.warnings.WarningCollector;
 import io.trino.likematcher.LikeMatcher;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.ResolvedFunction;
+import io.trino.operator.scalar.ArrayConstructor;
 import io.trino.operator.scalar.ArraySubscriptOperator;
 import io.trino.security.AccessControl;
 import io.trino.spi.TrinoException;
@@ -1265,7 +1266,7 @@ public class ExpressionInterpreter
                     checkCondition(node.getValues().size() <= 254, NOT_SUPPORTED, "Too many arguments for array constructor");
                     return visitFunctionCall(
                             FunctionCallBuilder.resolve(session, metadata)
-                                    .setName(QualifiedName.of(Array.ARRAY_CONSTRUCTOR))
+                                    .setName(QualifiedName.of(ArrayConstructor.NAME))
                                     .setArguments(types(node.getValues()), node.getValues())
                                     .build(),
                             context);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionInterpreter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionInterpreter.java
@@ -49,7 +49,7 @@ import io.trino.sql.planner.iterative.rule.DesugarCurrentPath;
 import io.trino.sql.planner.iterative.rule.DesugarCurrentUser;
 import io.trino.sql.tree.ArithmeticBinaryExpression;
 import io.trino.sql.tree.ArithmeticUnaryExpression;
-import io.trino.sql.tree.ArrayConstructor;
+import io.trino.sql.tree.Array;
 import io.trino.sql.tree.AstVisitor;
 import io.trino.sql.tree.BetweenPredicate;
 import io.trino.sql.tree.BindExpression;
@@ -1254,7 +1254,7 @@ public class ExpressionInterpreter
         }
 
         @Override
-        protected Object visitArrayConstructor(ArrayConstructor node, Object context)
+        protected Object visitArray(Array node, Object context)
         {
             Type elementType = ((ArrayType) type(node)).getElementType();
             BlockBuilder arrayBlockBuilder = elementType.createBlockBuilder(null, node.getValues().size());
@@ -1265,7 +1265,7 @@ public class ExpressionInterpreter
                     checkCondition(node.getValues().size() <= 254, NOT_SUPPORTED, "Too many arguments for array constructor");
                     return visitFunctionCall(
                             FunctionCallBuilder.resolve(session, metadata)
-                                    .setName(QualifiedName.of(ArrayConstructor.ARRAY_CONSTRUCTOR))
+                                    .setName(QualifiedName.of(Array.ARRAY_CONSTRUCTOR))
                                     .setArguments(types(node.getValues()), node.getValues())
                                     .build(),
                             context);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/GroupingOperationRewriter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/GroupingOperationRewriter.java
@@ -17,7 +17,7 @@ import io.trino.sql.analyzer.FieldId;
 import io.trino.sql.analyzer.RelationId;
 import io.trino.sql.analyzer.ResolvedField;
 import io.trino.sql.tree.ArithmeticBinaryExpression;
-import io.trino.sql.tree.ArrayConstructor;
+import io.trino.sql.tree.Array;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.GenericLiteral;
 import io.trino.sql.tree.GroupingOperation;
@@ -70,7 +70,7 @@ public final class GroupingOperationRewriter
 
         // It is necessary to add a 1 to the groupId because the underlying array is indexed starting at 1
         return new SubscriptExpression(
-                new ArrayConstructor(groupingResults),
+                new Array(groupingResults),
                 new ArithmeticBinaryExpression(ADD, groupIdSymbol.get().toSymbolReference(), new GenericLiteral("BIGINT", "1")));
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/sanity/SugarFreeChecker.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/sanity/SugarFreeChecker.java
@@ -22,7 +22,7 @@ import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.TypeAnalyzer;
 import io.trino.sql.planner.TypeProvider;
 import io.trino.sql.planner.plan.PlanNode;
-import io.trino.sql.tree.ArrayConstructor;
+import io.trino.sql.tree.Array;
 import io.trino.sql.tree.AtTimeZone;
 import io.trino.sql.tree.CurrentCatalog;
 import io.trino.sql.tree.CurrentPath;
@@ -112,7 +112,7 @@ public final class SugarFreeChecker
         }
 
         @Override
-        protected Void visitArrayConstructor(ArrayConstructor node, Builder<Symbol> context)
+        protected Void visitArray(Array node, Builder<Symbol> context)
         {
             throw createIllegalNodeException(node);
         }

--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
@@ -52,7 +52,7 @@ import io.trino.sql.analyzer.AnalyzerFactory;
 import io.trino.sql.parser.ParsingException;
 import io.trino.sql.parser.SqlParser;
 import io.trino.sql.tree.AllColumns;
-import io.trino.sql.tree.ArrayConstructor;
+import io.trino.sql.tree.Array;
 import io.trino.sql.tree.AstVisitor;
 import io.trino.sql.tree.BooleanLiteral;
 import io.trino.sql.tree.ColumnDefinition;
@@ -559,7 +559,7 @@ public final class ShowQueriesRewrite
 
             if (value instanceof List) {
                 List<?> list = (List<?>) value;
-                return new ArrayConstructor(list.stream()
+                return new Array(list.stream()
                         .map(Visitor::toExpression)
                         .collect(toList()));
             }

--- a/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
@@ -1780,11 +1780,11 @@ public class TestExpressionInterpreter
     {
         optimize("ARRAY[]");
         assertOptimizedEquals("ARRAY[(unbound_long + 0), (unbound_long + 1), (unbound_long + 2)]",
-                "array_constructor((unbound_long + 0), (unbound_long + 1), (unbound_long + 2))");
+                "\"$array\"((unbound_long + 0), (unbound_long + 1), (unbound_long + 2))");
         assertOptimizedEquals("ARRAY[(bound_long + 0), (unbound_long + 1), (bound_long + 2)]",
-                "array_constructor((bound_long + 0), (unbound_long + 1), (bound_long + 2))");
+                "\"$array\"((bound_long + 0), (unbound_long + 1), (bound_long + 2))");
         assertOptimizedEquals("ARRAY[(bound_long + 0), (unbound_long + 1), NULL]",
-                "array_constructor((bound_long + 0), (unbound_long + 1), NULL)");
+                "\"$array\"((bound_long + 0), (unbound_long + 1), NULL)");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestEqualityInference.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestEqualityInference.java
@@ -23,7 +23,7 @@ import io.trino.metadata.TestingFunctionResolution;
 import io.trino.operator.scalar.TryFunction;
 import io.trino.sql.ExpressionUtils;
 import io.trino.sql.tree.ArithmeticBinaryExpression;
-import io.trino.sql.tree.ArrayConstructor;
+import io.trino.sql.tree.Array;
 import io.trino.sql.tree.Cast;
 import io.trino.sql.tree.ComparisonExpression;
 import io.trino.sql.tree.Expression;
@@ -324,7 +324,7 @@ public class TestEqualityInference
                 new InPredicate(nameReference("b"), new InListExpression(ImmutableList.of(new NullLiteral()))),
                 new SearchedCaseExpression(ImmutableList.of(new WhenClause(new IsNotNullPredicate(nameReference("b")), new NullLiteral())), Optional.empty()),
                 new SimpleCaseExpression(nameReference("b"), ImmutableList.of(new WhenClause(number(1), new NullLiteral())), Optional.empty()),
-                new SubscriptExpression(new ArrayConstructor(ImmutableList.of(new NullLiteral())), nameReference("b")));
+                new SubscriptExpression(new Array(ImmutableList.of(new NullLiteral())), nameReference("b")));
 
         for (Expression candidate : candidates) {
             EqualityInference inference = EqualityInference.newInstance(

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestArraySortAfterArrayDistinct.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestArraySortAfterArrayDistinct.java
@@ -33,13 +33,13 @@ public class TestArraySortAfterArrayDistinct
     @Test
     public void testArrayDistinctAfterArraySort()
     {
-        test("ARRAY_DISTINCT(ARRAY_SORT(ARRAY['a']))", "ARRAY_SORT(ARRAY_DISTINCT(ARRAY['a']))");
+        test("ARRAY_DISTINCT(ARRAY_SORT(\"$array\"('a')))", "ARRAY_SORT(ARRAY_DISTINCT(\"$array\"('a')))");
     }
 
     @Test
     public void testArrayDistinctAfterArraySortWithLambda()
     {
-        test("ARRAY_DISTINCT(ARRAY_SORT(ARRAY['a'], (a, b) -> 1))", "ARRAY_SORT(ARRAY_DISTINCT(ARRAY['a']), (a, b) -> 1)");
+        test("ARRAY_DISTINCT(ARRAY_SORT(\"$array\"('a'), (a, b) -> 1))", "ARRAY_SORT(ARRAY_DISTINCT(\"$array\"('a')), (a, b) -> 1)");
     }
 
     private void test(String original, String rewritten)

--- a/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
@@ -20,7 +20,7 @@ import io.trino.sql.tree.AllColumns;
 import io.trino.sql.tree.AllRows;
 import io.trino.sql.tree.ArithmeticBinaryExpression;
 import io.trino.sql.tree.ArithmeticUnaryExpression;
-import io.trino.sql.tree.ArrayConstructor;
+import io.trino.sql.tree.Array;
 import io.trino.sql.tree.AstVisitor;
 import io.trino.sql.tree.AtTimeZone;
 import io.trino.sql.tree.BetweenPredicate;
@@ -296,7 +296,7 @@ public final class ExpressionFormatter
         }
 
         @Override
-        protected String visitArrayConstructor(ArrayConstructor node, Void context)
+        protected String visitArray(Array node, Void context)
         {
             ImmutableList.Builder<String> valueStrings = ImmutableList.builder();
             for (Expression value : node.getValues()) {

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -25,7 +25,7 @@ import io.trino.sql.tree.Analyze;
 import io.trino.sql.tree.AnchorPattern;
 import io.trino.sql.tree.ArithmeticBinaryExpression;
 import io.trino.sql.tree.ArithmeticUnaryExpression;
-import io.trino.sql.tree.ArrayConstructor;
+import io.trino.sql.tree.Array;
 import io.trino.sql.tree.AtTimeZone;
 import io.trino.sql.tree.BetweenPredicate;
 import io.trino.sql.tree.BinaryLiteral;
@@ -2152,7 +2152,7 @@ class AstBuilder
     @Override
     public Node visitArrayConstructor(SqlBaseParser.ArrayConstructorContext context)
     {
-        return new ArrayConstructor(getLocation(context), visit(context.expression(), Expression.class));
+        return new Array(getLocation(context), visit(context.expression(), Expression.class));
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Array.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Array.java
@@ -21,23 +21,23 @@ import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
-public class ArrayConstructor
+public class Array
         extends Expression
 {
     public static final String ARRAY_CONSTRUCTOR = "ARRAY_CONSTRUCTOR";
     private final List<Expression> values;
 
-    public ArrayConstructor(List<Expression> values)
+    public Array(List<Expression> values)
     {
         this(Optional.empty(), values);
     }
 
-    public ArrayConstructor(NodeLocation location, List<Expression> values)
+    public Array(NodeLocation location, List<Expression> values)
     {
         this(Optional.of(location), values);
     }
 
-    private ArrayConstructor(Optional<NodeLocation> location, List<Expression> values)
+    private Array(Optional<NodeLocation> location, List<Expression> values)
     {
         super(location);
         requireNonNull(values, "values is null");
@@ -52,7 +52,7 @@ public class ArrayConstructor
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context)
     {
-        return visitor.visitArrayConstructor(this, context);
+        return visitor.visitArray(this, context);
     }
 
     @Override
@@ -71,7 +71,7 @@ public class ArrayConstructor
             return false;
         }
 
-        ArrayConstructor that = (ArrayConstructor) o;
+        Array that = (Array) o;
         return Objects.equals(values, that.values);
     }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Array.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Array.java
@@ -24,7 +24,6 @@ import static java.util.Objects.requireNonNull;
 public class Array
         extends Expression
 {
-    public static final String ARRAY_CONSTRUCTOR = "ARRAY_CONSTRUCTOR";
     private final List<Expression> values;
 
     public Array(List<Expression> values)

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
@@ -417,7 +417,7 @@ public abstract class AstVisitor<R, C>
         return visitExpression(node, context);
     }
 
-    protected R visitArrayConstructor(ArrayConstructor node, C context)
+    protected R visitArray(Array node, C context)
     {
         return visitExpression(node, context);
     }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
@@ -69,7 +69,7 @@ public abstract class DefaultTraversalVisitor<C>
     }
 
     @Override
-    protected Void visitArrayConstructor(ArrayConstructor node, C context)
+    protected Void visitArray(Array node, C context)
     {
         for (Expression expression : node.getValues()) {
             process(expression, context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionRewriter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionRewriter.java
@@ -145,7 +145,7 @@ public class ExpressionRewriter<C>
         return rewriteExpression(node, context, treeRewriter);
     }
 
-    public Expression rewriteArrayConstructor(ArrayConstructor node, C context, ExpressionTreeRewriter<C> treeRewriter)
+    public Expression rewriteArray(Array node, C context, ExpressionTreeRewriter<C> treeRewriter)
     {
         return rewriteExpression(node, context, treeRewriter);
     }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionTreeRewriter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionTreeRewriter.java
@@ -136,10 +136,10 @@ public final class ExpressionTreeRewriter<C>
         }
 
         @Override
-        protected Expression visitArrayConstructor(ArrayConstructor node, Context<C> context)
+        protected Expression visitArray(Array node, Context<C> context)
         {
             if (!context.isDefaultRewrite()) {
-                Expression result = rewriter.rewriteArrayConstructor(node, context.get(), ExpressionTreeRewriter.this);
+                Expression result = rewriter.rewriteArray(node, context.get(), ExpressionTreeRewriter.this);
                 if (result != null) {
                     return result;
                 }
@@ -148,7 +148,7 @@ public final class ExpressionTreeRewriter<C>
             List<Expression> values = rewrite(node.getValues(), context);
 
             if (!sameElements(node.getValues(), values)) {
-                return new ArrayConstructor(values);
+                return new Array(values);
             }
 
             return node;

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -24,7 +24,7 @@ import io.trino.sql.tree.AllRows;
 import io.trino.sql.tree.Analyze;
 import io.trino.sql.tree.AnchorPattern;
 import io.trino.sql.tree.ArithmeticBinaryExpression;
-import io.trino.sql.tree.ArrayConstructor;
+import io.trino.sql.tree.Array;
 import io.trino.sql.tree.AtTimeZone;
 import io.trino.sql.tree.BetweenPredicate;
 import io.trino.sql.tree.BinaryLiteral;
@@ -418,20 +418,20 @@ public class TestSqlParser
     }
 
     @Test
-    public void testArrayConstructor()
+    public void testArray()
     {
-        assertExpression("ARRAY []", new ArrayConstructor(ImmutableList.of()));
-        assertExpression("ARRAY [1, 2]", new ArrayConstructor(ImmutableList.of(new LongLiteral("1"), new LongLiteral("2"))));
-        assertExpression("ARRAY [1e0, 2.5e0]", new ArrayConstructor(ImmutableList.of(new DoubleLiteral("1.0"), new DoubleLiteral("2.5"))));
-        assertExpression("ARRAY ['hi']", new ArrayConstructor(ImmutableList.of(new StringLiteral("hi"))));
-        assertExpression("ARRAY ['hi', 'hello']", new ArrayConstructor(ImmutableList.of(new StringLiteral("hi"), new StringLiteral("hello"))));
+        assertExpression("ARRAY []", new Array(ImmutableList.of()));
+        assertExpression("ARRAY [1, 2]", new Array(ImmutableList.of(new LongLiteral("1"), new LongLiteral("2"))));
+        assertExpression("ARRAY [1e0, 2.5e0]", new Array(ImmutableList.of(new DoubleLiteral("1.0"), new DoubleLiteral("2.5"))));
+        assertExpression("ARRAY ['hi']", new Array(ImmutableList.of(new StringLiteral("hi"))));
+        assertExpression("ARRAY ['hi', 'hello']", new Array(ImmutableList.of(new StringLiteral("hi"), new StringLiteral("hello"))));
     }
 
     @Test
     public void testArraySubscript()
     {
         assertExpression("ARRAY [1, 2][1]", new SubscriptExpression(
-                new ArrayConstructor(ImmutableList.of(new LongLiteral("1"), new LongLiteral("2"))),
+                new Array(ImmutableList.of(new LongLiteral("1"), new LongLiteral("2"))),
                 new LongLiteral("1")));
 
         assertExpression("CASE WHEN TRUE THEN ARRAY[1,2] END[1]", new SubscriptExpression(
@@ -439,7 +439,7 @@ public class TestSqlParser
                         ImmutableList.of(
                                 new WhenClause(
                                         new BooleanLiteral("true"),
-                                        new ArrayConstructor(ImmutableList.of(new LongLiteral("1"), new LongLiteral("2"))))),
+                                        new Array(ImmutableList.of(new LongLiteral("1"), new LongLiteral("2"))))),
                         Optional.empty()),
                 new LongLiteral("1")));
     }
@@ -1683,7 +1683,7 @@ public class TestSqlParser
                 new Property(
                         new Identifier("computed"),
                         new FunctionCall(QualifiedName.of("concat"), ImmutableList.of(new StringLiteral("ban"), new StringLiteral("ana")))),
-                new Property(new Identifier("a"), new ArrayConstructor(ImmutableList.of(new StringLiteral("v1"), new StringLiteral("v2")))));
+                new Property(new Identifier("a"), new Array(ImmutableList.of(new StringLiteral("v1"), new StringLiteral("v2")))));
 
         assertStatement("CREATE TABLE foo " +
                         "WITH ( string = 'bar', long = 42, computed = 'ban' || 'ana', a  = ARRAY[ 'v1', 'v2' ] ) " +
@@ -2017,7 +2017,7 @@ public class TestSqlParser
                         new Property(
                                 new Identifier("computed"),
                                 new FunctionCall(QualifiedName.of("concat"), ImmutableList.of(new StringLiteral("ban"), new StringLiteral("ana")))),
-                        new Property(new Identifier("a"), new ArrayConstructor(ImmutableList.of(new StringLiteral("v1"), new StringLiteral("v2")))))));
+                        new Property(new Identifier("a"), new Array(ImmutableList.of(new StringLiteral("v1"), new StringLiteral("v2")))))));
 
         assertStatement("EXPLAIN ANALYZE foo", new Explain(new Analyze(table, ImmutableList.of()), ImmutableList.of()));
         assertStatement("EXPLAIN ANALYZE ANALYZE foo", new ExplainAnalyze(new Analyze(table, ImmutableList.of()), false));
@@ -2777,7 +2777,7 @@ public class TestSqlParser
     public void testExecuteWithUsing()
     {
         assertStatement("EXECUTE myquery USING 1, 'abc', ARRAY ['hello']",
-                new Execute(identifier("myquery"), ImmutableList.of(new LongLiteral("1"), new StringLiteral("abc"), new ArrayConstructor(ImmutableList.of(new StringLiteral("hello"))))));
+                new Execute(identifier("myquery"), ImmutableList.of(new LongLiteral("1"), new StringLiteral("abc"), new Array(ImmutableList.of(new StringLiteral("hello"))))));
     }
 
     @Test
@@ -3328,7 +3328,7 @@ public class TestSqlParser
                         true, false, new ArrayList<>(), Optional.of("A simple materialized view")));
 
         List<Property> properties = ImmutableList.of(new Property(new Identifier("partitioned_by"),
-                new ArrayConstructor(ImmutableList.of(new StringLiteral("dateint")))));
+                new Array(ImmutableList.of(new StringLiteral("dateint")))));
 
         assertStatement("CREATE OR REPLACE MATERIALIZED VIEW catalog.schema.matview COMMENT 'A simple materialized view'" +
                         "WITH (partitioned_by = ARRAY ['dateint'])" +


### PR DESCRIPTION
In preparation for splitting the AST from the IR, SQL syntactic sugar needs to be removed from IR expressions.

## Release notes

(x) This is not user-visible or docs only and no release notes are required.

