### PR TITLE
Avoid putting config object to field in BigQueryClientFactory

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
@@ -71,11 +71,11 @@ public class BigQueryClient
     private final ViewMaterializationCache materializationCache;
     private final boolean caseInsensitiveNameMatching;
 
-    public BigQueryClient(BigQuery bigQuery, BigQueryConfig config, ViewMaterializationCache materializationCache)
+    public BigQueryClient(BigQuery bigQuery, boolean caseInsensitiveNameMatching, ViewMaterializationCache materializationCache)
     {
         this.bigQuery = requireNonNull(bigQuery, "bigQuery is null");
         this.materializationCache = requireNonNull(materializationCache, "materializationCache is null");
-        this.caseInsensitiveNameMatching = config.isCaseInsensitiveNameMatching();
+        this.caseInsensitiveNameMatching = caseInsensitiveNameMatching;
     }
 
     public Optional<RemoteDatabaseObject> toRemoteDataset(String projectId, String datasetName)

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClientFactory.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClientFactory.java
@@ -35,8 +35,8 @@ public class BigQueryClientFactory
 {
     private final IdentityCacheMapping identityCacheMapping;
     private final BigQueryCredentialsSupplier credentialsSupplier;
-    @Deprecated // TODO do not keep mutable config instance on a field
-    private final BigQueryConfig bigQueryConfig;
+    private final Optional<String> parentProjectId;
+    private final boolean caseInsensitiveNameMatching;
     private final ViewMaterializationCache materializationCache;
     private final HeaderProvider headerProvider;
     private final NonEvictableCache<IdentityCacheMapping.IdentityCacheKey, BigQueryClient> clientCache;
@@ -51,7 +51,9 @@ public class BigQueryClientFactory
     {
         this.identityCacheMapping = requireNonNull(identityCacheMapping, "identityCacheMapping is null");
         this.credentialsSupplier = requireNonNull(credentialsSupplier, "credentialsSupplier is null");
-        this.bigQueryConfig = requireNonNull(bigQueryConfig, "bigQueryConfig is null");
+        requireNonNull(bigQueryConfig, "bigQueryConfig is null");
+        this.parentProjectId = bigQueryConfig.getParentProjectId();
+        this.caseInsensitiveNameMatching = bigQueryConfig.isCaseInsensitiveNameMatching();
         this.materializationCache = requireNonNull(materializationCache, "materializationCache is null");
         this.headerProvider = requireNonNull(headerProvider, "headerProvider is null");
 
@@ -70,13 +72,13 @@ public class BigQueryClientFactory
 
     protected BigQueryClient createBigQueryClient(ConnectorSession session)
     {
-        return new BigQueryClient(createBigQuery(session), bigQueryConfig, materializationCache);
+        return new BigQueryClient(createBigQuery(session), caseInsensitiveNameMatching, materializationCache);
     }
 
     protected BigQuery createBigQuery(ConnectorSession session)
     {
         Optional<Credentials> credentials = credentialsSupplier.getCredentials(session);
-        String billingProjectId = calculateBillingProjectId(bigQueryConfig.getParentProjectId(), credentials);
+        String billingProjectId = calculateBillingProjectId(parentProjectId, credentials);
         BigQueryOptions.Builder options = BigQueryOptions.newBuilder()
                 .setHeaderProvider(headerProvider)
                 .setProjectId(billingProjectId);


### PR DESCRIPTION
## Description

Avoid putting config object to field in `BigQueryClientFactory`

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
