### PR TITLE
Support writing ARRAY and ROW types in BigQuery

### DIFF
--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConnectorTest.java
@@ -75,8 +75,6 @@ public class TestBigQueryConnectorTest
             case SUPPORTS_ADD_COLUMN:
             case SUPPORTS_RENAME_COLUMN:
             case SUPPORTS_NEGATIVE_DATE:
-            case SUPPORTS_ARRAY:
-            case SUPPORTS_ROW_TYPE:
                 return false;
             default:
                 return super.hasBehavior(connectorBehavior);
@@ -750,9 +748,10 @@ public class TestBigQueryConnectorTest
     @Override
     public void testInsertArray()
     {
-        // Override because base test expects failure when creating a table (not insert)
+        // Override because the connector disallows writing a NULL in ARRAY
         try (TestTable table = new TestTable(getQueryRunner()::execute, "test_insert_array_", "(a ARRAY<DOUBLE>, b ARRAY<BIGINT>)")) {
-            assertQueryFails("INSERT INTO " + table.getName() + " (a, b) VALUES (ARRAY[1.23E1], ARRAY[1.23E1])", "\\QUnsupported type: array(double)");
+            assertUpdate("INSERT INTO " + table.getName() + " (a, b) VALUES (ARRAY[1.23E1], ARRAY[1.23E1])", 1);
+            assertQuery("SELECT a[1], b[1] FROM " + table.getName(), "VALUES (12.3, 12)");
         }
     }
 


### PR DESCRIPTION
## Description

Support writing `ARRAY` and `ROW` types in BigQuery

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# BigQuery
* Support writing `array` and `row` columns. ({issue}`14418`)
```
