### PR TITLE
Create a single projection for multiple column masks

### DIFF
--- a/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
@@ -1267,7 +1267,14 @@ public class AccessControlManager
                     .forEach(masks::add);
         }
 
-        return masks.build();
+        // Currently the use case of multiple masks on a single column is not supported, the reason being there's no guarantee about the order
+        // in which masks will be applied and whether the functions from different masks are compatible with each other.
+        List<ViewExpression> combinedMasks = masks.build();
+        if (combinedMasks.size() > 1) {
+            throw new TrinoException(NOT_SUPPORTED, format("Multiple masks on a single column is not supported: %s", columnName));
+        }
+
+        return combinedMasks;
     }
 
     private ConnectorAccessControl getConnectorAccessControl(TransactionId transactionId, String catalogName)

--- a/core/trino-main/src/test/java/io/trino/security/TestAccessControlManager.java
+++ b/core/trino-main/src/test/java/io/trino/security/TestAccessControlManager.java
@@ -209,6 +209,7 @@ public class TestAccessControlManager
         }
     }
 
+    // TODO: need to properly handle the ordering of multiple masks as they are not allowed currently
     @Test
     public void testColumnMaskOrdering()
     {
@@ -259,16 +260,16 @@ public class TestAccessControlManager
                 }
             })));
 
-            transaction(transactionManager, accessControlManager)
+            assertThatThrownBy(() -> transaction(transactionManager, accessControlManager)
                     .execute(transactionId -> {
-                        List<ViewExpression> masks = accessControlManager.getColumnMasks(
+                        accessControlManager.getColumnMasks(
                                 context(transactionId),
                                 new QualifiedObjectName(TEST_CATALOG_NAME, "schema", "table"),
                                 "column",
                                 BIGINT);
-                        assertEquals(masks.get(0).getExpression(), "connector mask");
-                        assertEquals(masks.get(1).getExpression(), "system mask");
-                    });
+                    }))
+                    .isInstanceOf(TrinoException.class)
+                    .hasMessageMatching("Multiple masks on a single column is not supported: column");
         }
     }
 


### PR DESCRIPTION
The current column masking behavior is problematic, if there are multiple column masks and some column is being masked itself as well as used as a condition for masking other columns. It's due to the masks being stacked with multiple [projections](https://github.com/trinodb/trino/blob/ab8337836910568f5c0e2690a391ea8f3a349ece/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java#L319). This creates a "chained masking" behavior, which is hardly anything users expect. The behavior is not predictable because it depends on the order of columns defined in the table.

The problem can be illustrated with examples below. Here's the DDL for table `t1`.
```
CREATE TABLE t1 (a int, b int);
```
Here's the original table content for `t1`
```
  a   |  b
------+------
    1 |    2
    3 |    4
```
Now let's use below file-based access control policy to do column masking for both column `a` and `b`.
```
{
    "tables": [
        {
            "catalog": "hive",
            "schema": "default",
            "table": "t1",
            "privileges": ["SELECT"],
            "columns": [
                {
                    "name": "a",
                    "mask": "IF (a <> 1, a)"
                },
                {
                    "name": "b",
                    "mask": "IF (a <> 1 OR a = 1, b)"
                }
            ]
        }
    ]
}

trino:default> select * from t1;
  a   |  b
------+------
 NULL | NULL
    3 |    4
```
The above result is wrong because the expected result is:
```
  a   |  b
------+------
 NULL |    2
    3 |    4
```

However, with a symmetric policy as below, we get expected result:
```
{
    "tables": [
        {
            "catalog": "hive",
            "schema": "default",
            "table": "t1",
            "privileges": ["SELECT"],
            "columns": [
                {
                    "name": "a",
                    "mask": "IF (b <> 2 OR b = 2, a)"
                },
                {
                    "name": "b",
                    "mask": "IF (b <> 2, b)"
                }
            ]
        }
    ]
}

trino:default> select * from t1;
  a   |  b
------+------
    1 | NULL
    3 |    4
```
The only reason for the latter example to (coincidentally) return the correct result is because column `a` is defined before column `b`.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide a user-friendly explanation, keep it brief if it isn't user-visible. -->
## Non-technical explanation



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(X) Release notes are required, with the following suggested text:
Fixed possible incorrect result issue when multiple column masks exist.

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
